### PR TITLE
paretosecurity: 0.0.91 -> 0.0.96

### DIFF
--- a/nixos/modules/services/security/paretosecurity.nix
+++ b/nixos/modules/services/security/paretosecurity.nix
@@ -14,38 +14,27 @@
 
   config = lib.mkIf config.services.paretosecurity.enable {
     environment.systemPackages = [ config.services.paretosecurity.package ];
+    systemd.packages = [ config.services.paretosecurity.package ];
 
-    systemd.sockets."paretosecurity" = {
-      wantedBy = [ "sockets.target" ];
-      socketConfig = {
-        ListenStream = "/var/run/paretosecurity.sock";
-        SocketMode = "0666";
+    # In traditional Linux distributions, systemd would read the [Install] section from
+    # unit files and automatically create the appropriate symlinks to enable services.
+    # However, in NixOS, due to its immutable nature and the way the Nix store works,
+    # the [Install] sections are not processed during system activation. Instead, we
+    # must explicitly tell NixOS which units to enable by specifying their target
+    # dependencies here. This creates the necessary symlinks in the proper locations.
+    systemd.sockets.paretosecurity.wantedBy = [ "sockets.target" ];
+
+    # Enable the tray icon and timer services if the trayIcon option is enabled
+    systemd.user = lib.mkIf config.services.paretosecurity.trayIcon {
+      services.paretosecurity-trayicon = {
+        wantedBy = [ "graphical-session.target" ];
+      };
+      services.paretosecurity-user = {
+        wantedBy = [ "graphical-session.target" ];
+      };
+      timers.paretosecurity-user = {
+        wantedBy = [ "timers.target" ];
       };
     };
-
-    systemd.services."paretosecurity" = {
-      serviceConfig = {
-        ExecStart = "${config.services.paretosecurity.package}/bin/paretosecurity helper";
-        User = "root";
-        Group = "root";
-        StandardInput = "socket";
-        Type = "oneshot";
-        RemainAfterExit = "no";
-        StartLimitInterval = "1s";
-        StartLimitBurst = 100;
-        ProtectSystem = "full";
-        ProtectHome = true;
-        StandardOutput = "journal";
-        StandardError = "journal";
-      };
-    };
-
-    systemd.user.services."paretosecurity-trayicon" = lib.mkIf config.services.paretosecurity.trayIcon {
-      wantedBy = [ "graphical-session.target" ];
-      serviceConfig = {
-        ExecStart = "${config.services.paretosecurity.package}/bin/paretosecurity trayicon";
-      };
-    };
-
   };
 }

--- a/pkgs/by-name/pa/paretosecurity/package.nix
+++ b/pkgs/by-name/pa/paretosecurity/package.nix
@@ -9,21 +9,17 @@
 
 buildGoModule rec {
   pname = "paretosecurity";
-  version = "0.0.91";
+  version = "0.0.96";
 
   src = fetchFromGitHub {
     owner = "ParetoSecurity";
     repo = "agent";
     rev = version;
-    hash = "sha256-/kGwV96Jp7U08jh/wPQMcoV48zQe9ixY7gpNdtFyOkk=";
+    hash = "sha256-SyeIGSDvrnOvyOJ0zC8CulpaMa+iZeRaMTJUSydz2tw=";
   };
 
-  vendorHash = "sha256-kGrYoN0dGcSuQW47Y4LUFdHQYAoY74NOM1LLPdhmLhc=";
+  vendorHash = "sha256-O/OF3Y6HiiikMxf657k9eIM7UfkicIImAUxVVf/TgR8=";
   proxyVendor = true;
-
-  subPackages = [
-    "cmd/paretosecurity"
-  ];
 
   ldflags = [
     "-s"
@@ -31,6 +27,23 @@ buildGoModule rec {
     "-X=github.com/ParetoSecurity/agent/shared.Commit=${src.rev}"
     "-X=github.com/ParetoSecurity/agent/shared.Date=1970-01-01T00:00:00Z"
   ];
+
+  postInstall = ''
+    # Install global systemd files
+    install -Dm400 ${src}/apt/paretosecurity.socket $out/lib/systemd/system/paretosecurity.socket
+    install -Dm400 ${src}/apt/paretosecurity.service $out/lib/systemd/system/paretosecurity.service
+    substituteInPlace $out/lib/systemd/system/paretosecurity.service \
+        --replace-fail "/usr/bin/paretosecurity" "$out/bin/paretosecurity"
+
+    # Install user systemd files
+    install -Dm444 ${src}/apt/paretosecurity-user.timer $out/lib/systemd/user/paretosecurity-user.timer
+    install -Dm444 ${src}/apt/paretosecurity-user.service $out/lib/systemd/user/paretosecurity-user.service
+    substituteInPlace $out/lib/systemd/user/paretosecurity-user.service \
+        --replace-fail "/usr/bin/paretosecurity" "$out/bin/paretosecurity"
+    install -Dm444 ${src}/apt/paretosecurity-trayicon.service $out/lib/systemd/user/paretosecurity-trayicon.service
+    substituteInPlace $out/lib/systemd/user/paretosecurity-trayicon.service \
+        --replace-fail "/usr/bin/paretosecurity" "$out/bin/paretosecurity"
+  '';
 
   passthru.tests = {
     version = testers.testVersion {
@@ -50,12 +63,13 @@ buildGoModule rec {
       settings such as if you have disk encryption and firewall enabled.
 
       If you use the `services.paretosecurity` NixOS module, you also get a
-      root helper, so that you can run the checker in userspace. Some checks
+      root helper that allows you to run the checker in userspace. Some checks
       require root permissions, and the checker asks the helper to run those.
 
       Additionally, if you enable `services.paretosecurity.trayIcon`, you get a
       little Vilfredo Pareto living in your systray showing your the current
-      status of checks.
+      status of checks. This will also enable a systemd timer to update the
+      status of checks once per hour.
 
       Finally, you can run `paretosecurity link` to configure the agent
       to send the status of checks to https://dash.paretosecurity.com to make


### PR DESCRIPTION
Take systemd configuration from upstream package instead of definiting them in the nixos module, decreasing the maintenance burden in the future.

Also, add a test for linking a device to a team.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
