### PR TITLE
vimPlugins: rename nvimSkipModule into nvimSkipModules

### DIFF
--- a/doc/languages-frameworks/neovim.section.md
+++ b/doc/languages-frameworks/neovim.section.md
@@ -170,13 +170,12 @@ To only check a specific module, add it manually to the plugin definition [overr
   };
 ```
 Some plugins will have lua modules that require a user configuration to function properly or can contain optional lua modules that we dont want to test requiring.
-We can skip specific modules using `nvimSkipModule`. Similar to `nvimRequireCheck`, it accepts a single string or a list of strings.
-- `nvimSkipModule = MODULE;`
-- `nvimSkipModule = [ MODULE1 MODULE2 ];`
+We can skip specific modules using `nvimSkipModules`. Similar to `nvimRequireCheck`, it accepts a list of strings.
+- `nvimSkipModules = [ MODULE1 MODULE2 ];`
 
 ```nix
   asyncrun-vim = super.asyncrun-vim.overrideAttrs {
-    nvimSkipModule = [
+    nvimSkipModules = [
       # vim plugin with optional toggleterm integration
       "asyncrun.toggleterm"
       "asyncrun.toggleterm2"

--- a/pkgs/applications/editors/vim/plugins/hooks/neovim-require-check-hook.sh
+++ b/pkgs/applications/editors/vim/plugins/hooks/neovim-require-check-hook.sh
@@ -56,7 +56,7 @@ run_require_checks() {
     set +e
     for name in "${nvimRequireCheck[@]}"; do
         local skip=false
-        for module in "${nvimSkipModule[@]}"; do
+        for module in "${nvimSkipModules[@]}"; do
             if [[ "$module" == "$name" ]]; then
                 echo "$name is in list of modules to not check. Skipping..."
                 skip=true

--- a/pkgs/applications/editors/vim/plugins/hooks/neovim-require-check-hook.sh
+++ b/pkgs/applications/editors/vim/plugins/hooks/neovim-require-check-hook.sh
@@ -54,6 +54,12 @@ run_require_checks() {
     local nativeCheckInputs="${nativeBuildInputs[*]}"
     local checkInputs="${buildInputs[*]}"
     set +e
+
+    if [ -v 'nvimSkipModule' ]; then
+        nvimSkipModules=("${nvimSkipModule[@]}")
+        echo "WARNING: nvimSkipModule got renamed to nvimSkipModules, please update package $name"
+    fi
+
     for name in "${nvimRequireCheck[@]}"; do
         local skip=false
         for module in "${nvimSkipModules[@]}"; do

--- a/pkgs/applications/editors/vim/plugins/non-generated/avante-nvim/default.nix
+++ b/pkgs/applications/editors/vim/plugins/non-generated/avante-nvim/default.nix
@@ -80,7 +80,7 @@ vimUtils.buildVimPlugin {
     inherit avante-nvim-lib;
   };
 
-  nvimSkipModule = [
+  nvimSkipModules = [
     # Requires setup with corresponding provider
     "avante.providers.azure"
     "avante.providers.copilot"

--- a/pkgs/applications/editors/vim/plugins/non-generated/blink-cmp/default.nix
+++ b/pkgs/applications/editors/vim/plugins/non-generated/blink-cmp/default.nix
@@ -61,7 +61,7 @@ vimUtils.buildVimPlugin {
     ];
   };
 
-  nvimSkipModule = [
+  nvimSkipModules = [
     # Module for reproducing issues
     "repro"
   ];

--- a/pkgs/applications/editors/vim/plugins/non-generated/rainbow-delimiters-nvim/default.nix
+++ b/pkgs/applications/editors/vim/plugins/non-generated/rainbow-delimiters-nvim/default.nix
@@ -15,7 +15,7 @@ vimUtils.buildVimPlugin {
     hash = "sha256-zWHXYs3XdnoszqOFY3hA2L5mNn1a44OAeKv3lL3EMEw=";
   };
 
-  nvimSkipModule = [
+  nvimSkipModules = [
     # rainbow-delimiters.types.lua
     "rainbow-delimiters.types"
     # Test that requires an unpackaged dependency

--- a/pkgs/applications/editors/vim/plugins/non-generated/sg-nvim/default.nix
+++ b/pkgs/applications/editors/vim/plugins/non-generated/sg-nvim/default.nix
@@ -56,7 +56,7 @@ vimUtils.buildVimPlugin {
     ln -s ${sg-nvim-rust}/{bin,lib}/* $out/target/debug
   '';
 
-  nvimSkipModule = [
+  nvimSkipModules = [
     # Dependent on active fuzzy search state
     "sg.cody.fuzzy"
   ];

--- a/pkgs/applications/editors/vim/plugins/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/overrides.nix
@@ -163,7 +163,7 @@ in
 
   aerial-nvim = super.aerial-nvim.overrideAttrs {
     # optional dependencies
-    nvimSkipModule = [
+    nvimSkipModules = [
       "lualine.components.aerial"
       "telescope._extensions.aerial"
     ];
@@ -203,7 +203,7 @@ in
   };
 
   asyncrun-vim = super.asyncrun-vim.overrideAttrs {
-    nvimSkipModule = [
+    nvimSkipModules = [
       # vim plugin with optional toggleterm integration
       "asyncrun.toggleterm"
       "asyncrun.toggleterm2"
@@ -216,7 +216,7 @@ in
 
   auto-session = super.auto-session.overrideAttrs {
     # optional telescope dependency
-    nvimSkipModule = [
+    nvimSkipModules = [
       "auto-session.session-lens.actions"
       "auto-session.session-lens.init"
       "telescope._extensions.session-lens"
@@ -232,7 +232,7 @@ in
   };
 
   bamboo-nvim = super.bamboo-nvim.overrideAttrs {
-    nvimSkipModule = [
+    nvimSkipModules = [
       # Requires config table
       "bamboo.colors"
       "bamboo.terminal"
@@ -248,7 +248,7 @@ in
 
   barbar-nvim = super.barbar-nvim.overrideAttrs {
     # nvim-web-devicons dependency
-    nvimSkipModule = "bufferline.utils";
+    nvimSkipModules = [ "bufferline.utils" ];
   };
 
   barbecue-nvim = super.barbecue-nvim.overrideAttrs {
@@ -267,7 +267,7 @@ in
   base46 = super.base46.overrideAttrs {
     dependencies = [ self.nvchad-ui ];
     # Requires global config setup
-    nvimSkipModule = [
+    nvimSkipModules = [
       "nvchad.configs.cmp"
       "nvchad.configs.gitsigns"
       "nvchad.configs.luasnip"
@@ -303,7 +303,7 @@ in
 
   bufferline-nvim = super.bufferline-nvim.overrideAttrs {
     # depends on bufferline.lua being loaded first
-    nvimSkipModule = [ "bufferline.commands" ];
+    nvimSkipModules = [ "bufferline.commands" ];
   };
 
   bufresize-nvim = super.bufresize-nvim.overrideAttrs {
@@ -311,7 +311,7 @@ in
   };
 
   catppuccin-nvim = super.catppuccin-nvim.overrideAttrs {
-    nvimSkipModule = [
+    nvimSkipModules = [
       "catppuccin.groups.integrations.noice"
       "catppuccin.groups.integrations.feline"
       "catppuccin.lib.vim.init"
@@ -321,7 +321,7 @@ in
   ccc-nvim = super.ccc-nvim.overrideAttrs {
     # ccc auto-discover requires all pass
     # but there's a bootstrap module that hangs forever if we dont stop on first success
-    nvimSkipModule = "ccc.kit.Thread.Server._bootstrap";
+    nvimSkipModules = [ "ccc.kit.Thread.Server._bootstrap" ];
   };
 
   chadtree = super.chadtree.overrideAttrs {
@@ -440,7 +440,7 @@ in
 
   cmp-dictionary = super.cmp-dictionary.overrideAttrs {
     checkInputs = [ self.nvim-cmp ];
-    nvimSkipModule = [
+    nvimSkipModules = [
       # Test files
       "cmp_dictionary.dict.external_spec"
       "cmp_dictionary.dict.trie_spec"
@@ -582,7 +582,7 @@ in
   cobalt2-nvim = super.cobalt2-nvim.overrideAttrs {
     dependencies = with self; [ colorbuddy-nvim ];
     # Few broken themes
-    nvimSkipModule = [
+    nvimSkipModules = [
       "cobalt2.plugins.init"
       "cobalt2.plugins.trouble"
       "cobalt2.plugins.gitsigns"
@@ -595,7 +595,7 @@ in
 
   codecompanion-nvim = super.codecompanion-nvim.overrideAttrs {
     dependencies = [ self.plenary-nvim ];
-    nvimSkipModule = [
+    nvimSkipModules = [
       # Optional provider dependencies
       "codecompanion.providers.diff.mini_diff"
       "codecompanion.providers.actions.telescope"
@@ -697,7 +697,7 @@ in
 
   colorful-menu-nvim = super.colorful-menu-nvim.overrideAttrs {
     # Local bug reproduction modules
-    nvimSkipModule = [
+    nvimSkipModules = [
       "repro_blink"
       "repro_cmp"
     ];
@@ -751,7 +751,7 @@ in
 
   conjure = super.conjure.overrideAttrs {
     dependencies = [ self.plenary-nvim ];
-    nvimSkipModule = [
+    nvimSkipModules = [
       # Test mismatch of directory because of nix generated path
       "conjure-spec.client.fennel.nfnl_spec"
     ];
@@ -759,7 +759,7 @@ in
 
   context-vim = super.context-vim.overrideAttrs {
     # Vim plugin with optional lua highlight module
-    nvimSkipModule = "context.highlight";
+    nvimSkipModules = [ "context.highlight" ];
   };
 
   CopilotChat-nvim = super.CopilotChat-nvim.overrideAttrs {
@@ -885,7 +885,7 @@ in
   darkearth-nvim = super.darkearth-nvim.overrideAttrs {
     dependencies = [ self.lush-nvim ];
     # Lua module used to build theme
-    nvimSkipModule = "shipwright_build";
+    nvimSkipModules = [ "shipwright_build" ];
   };
 
   ddc-filter-matcher_head = super.ddc-filter-matcher_head.overrideAttrs {
@@ -967,7 +967,7 @@ in
   };
 
   devdocs-nvim = super.devdocs-nvim.overrideAttrs {
-    nvimSkipModule = [
+    nvimSkipModules = [
       # Error initializing Devdocs state
       "devdocs.state"
     ];
@@ -985,7 +985,7 @@ in
   diffview-nvim = super.diffview-nvim.overrideAttrs {
     dependencies = [ self.plenary-nvim ];
 
-    nvimSkipModule = [
+    nvimSkipModules = [
       # https://github.com/sindrets/diffview.nvim/issues/498
       "diffview.api.views.diff.diff_view"
       "diffview.scene.layouts.diff_2"
@@ -1036,7 +1036,7 @@ in
 
   dropbar-nvim = super.dropbar-nvim.overrideAttrs {
     # Requires global config table
-    nvimSkipModule = "dropbar.menu";
+    nvimSkipModules = [ "dropbar.menu" ];
   };
 
   easy-dotnet-nvim = super.easy-dotnet-nvim.overrideAttrs {
@@ -1070,7 +1070,7 @@ in
       luasnip
       nvim-fzf
     ];
-    nvimSkipModule = [
+    nvimSkipModules = [
       # E5108: Error executing lua vim/_init_packages.lua:0: ...in-faust-nvim-2022-06-01/lua/faust-nvim/autosnippets.lua:3: '=' expected near 'wd'
       "faust-nvim.autosnippets"
     ];
@@ -1087,7 +1087,7 @@ in
   flash-nvim = super.flash-nvim.overrideAttrs {
     # Docs require lazyvim
     # dependencies = with self; [ lazy-nvim ];
-    nvimSkipModule = "flash.docs";
+    nvimSkipModules = [ "flash.docs" ];
   };
 
   flit-nvim = super.flit-nvim.overrideAttrs {
@@ -1166,7 +1166,7 @@ in
       telescope-zf-native-nvim
     ];
     dependencies = [ self.telescope-fzf-native-nvim ];
-    nvimSkipModule = [
+    nvimSkipModules = [
       # TODO: package fzy-lua-native
       "fuzzy_nvim.fzy_matcher"
     ];
@@ -1248,7 +1248,7 @@ in
   };
 
   go-nvim = super.go-nvim.overrideAttrs {
-    nvimSkipModule = [
+    nvimSkipModules = [
       # Null-ls
       "go.null_ls"
       # _GO_NVIM_CFG
@@ -1298,7 +1298,7 @@ in
       plenary-nvim
     ];
 
-    nvimSkipModule = [
+    nvimSkipModules = [
       # Cannot find hardhat.extmarks
       "overseer.component.hardhat.refresh_gas_extmarks"
     ];
@@ -1310,7 +1310,7 @@ in
 
   harpoon2 = super.harpoon2.overrideAttrs {
     dependencies = [ self.plenary-nvim ];
-    nvimSkipModule = [
+    nvimSkipModules = [
       # Access harpoon data file
       "harpoon.scratch.toggle"
     ];
@@ -1326,14 +1326,14 @@ in
 
   haskell-tools-nvim = neovimUtils.buildNeovimPlugin {
     luaAttr = luaPackages.haskell-tools-nvim;
-    nvimSkipModule = [
+    nvimSkipModules = [
       # Optional telescope integration
       "haskell-tools.hoogle.helpers"
     ];
   };
 
   helpview-nvim = super.helpview-nvim.overrideAttrs {
-    nvimSkipModule = "definitions.__vimdoc";
+    nvimSkipModules = [ "definitions.__vimdoc" ];
   };
 
   hex-nvim = super.hex-nvim.overrideAttrs {
@@ -1343,7 +1343,7 @@ in
   himalaya-vim = super.himalaya-vim.overrideAttrs {
     buildInputs = [ himalaya ];
     # vim plugin with optional telescope lua module
-    nvimSkipModule = [
+    nvimSkipModules = [
       "himalaya.folder.pickers.fzflua"
       "himalaya.folder.pickers.telescope"
     ];
@@ -1352,7 +1352,7 @@ in
   hover-nvim = super.hover-nvim.overrideAttrs {
     # Single provider issue with reading from config
     # /lua/hover/providers/fold_preview.lua:27: attempt to index local 'config' (a nil value)
-    nvimSkipModule = "hover.providers.fold_preview";
+    nvimSkipModules = "hover.providers.fold_preview";
   };
 
   hunk-nvim = super.hunk-nvim.overrideAttrs {
@@ -1379,7 +1379,7 @@ in
 
   indent-blankline-nvim = super.indent-blankline-nvim.overrideAttrs {
     # Meta file
-    nvimSkipModule = "ibl.config.types";
+    nvimSkipModules = "ibl.config.types";
   };
 
   indent-tools-nvim = super.indent-tools-nvim.overrideAttrs {
@@ -1391,7 +1391,7 @@ in
   };
 
   instant-nvim = super.instant-nvim.overrideAttrs {
-    nvimSkipModule = [
+    nvimSkipModules = [
       # Requires global variable config
       "instant"
       # instant/log.lua:12: cannot use '...' outside a vararg function near '...'
@@ -1435,7 +1435,7 @@ in
   LazyVim = super.LazyVim.overrideAttrs {
     # Any other dependency is optional
     dependencies = [ self.lazy-nvim ];
-    nvimSkipModule = [
+    nvimSkipModules = [
       # attempt to index global 'LazyVim' (a nil value)
       "lazyvim.config.keymaps"
       "lazyvim.plugins.extras.ai.tabnine"
@@ -1463,7 +1463,7 @@ in
 
   lazy-nvim = super.lazy-nvim.overrideAttrs {
     patches = [ ./patches/lazy-nvim/no-helptags.patch ];
-    nvimSkipModule = [
+    nvimSkipModules = [
       # Requires headless config option
       "lazy.manage.task.init"
       "lazy.manage.checker"
@@ -1509,7 +1509,7 @@ in
     ];
 
     doInstallCheck = true;
-    nvimSkipModule = [
+    nvimSkipModules = [
       # Requires setup call
       "leetcode.api.auth"
       "leetcode.api.headers"
@@ -1545,7 +1545,7 @@ in
 
   legendary-nvim = super.legendary-nvim.overrideAttrs {
     dependencies = [ self.sqlite-lua ];
-    nvimSkipModule = [
+    nvimSkipModules = [
       "vimdoc-gen"
       "vimdocrc"
     ];
@@ -1580,7 +1580,7 @@ in
       telescope-nvim
       plenary-nvim
     ];
-    nvimSkipModule = [
+    nvimSkipModules = [
       # Attempt to connect to sqlitedb
       "lispdocs.db"
       "lispdocs.finder"
@@ -1630,7 +1630,7 @@ in
     dependencies = [ self.luasnip ];
     # E5108: /luasnip-latex-snippets/luasnippets/tex/utils/init.lua:3: module 'luasnip-latex-snippets.luasnippets.utils.conditions' not found:
     # Need to fix upstream
-    nvimSkipModule = [
+    nvimSkipModules = [
       "luasnip-latex-snippets.luasnippets.tex.utils.init"
     ];
   };
@@ -1711,7 +1711,7 @@ in
 
   mason-nvim = super.mason-nvim.overrideAttrs {
     # lua/mason-vendor/zzlib/inflate-bwo.lua:15: 'end' expected near '&'
-    nvimSkipModule = "mason-vendor.zzlib.inflate-bwo";
+    nvimSkipModules = "mason-vendor.zzlib.inflate-bwo";
   };
 
   mason-tool-installer-nvim = super.mason-tool-installer-nvim.overrideAttrs {
@@ -1720,7 +1720,7 @@ in
 
   material-vim = super.material-vim.overrideAttrs {
     # vim plugin with optional lualine module
-    nvimSkipModule = "material.lualine";
+    nvimSkipModules = "material.lualine";
   };
 
   meson = buildVimPlugin {
@@ -1771,7 +1771,7 @@ in
       self.lualine-nvim
     ];
     dependencies = with self; [ plenary-nvim ];
-    nvimSkipModule = [
+    nvimSkipModules = [
       # Backends require configuration
       "minuet.backends.claude"
       "minuet.backends.codestral"
@@ -1791,11 +1791,11 @@ in
 
   modicator-nvim = super.modicator-nvim.overrideAttrs {
     # Optional lualine integration
-    nvimSkipModule = "modicator.integration.lualine.init";
+    nvimSkipModules = "modicator.integration.lualine.init";
   };
 
   molten-nvim = super.molten-nvim.overrideAttrs {
-    nvimSkipModule = [
+    nvimSkipModules = [
       # Optional image providers
       "load_image_nvim"
       "load_wezterm_nvim"
@@ -1849,7 +1849,7 @@ in
 
   neogit = super.neogit.overrideAttrs {
     dependencies = [ self.plenary-nvim ];
-    nvimSkipModule = [
+    nvimSkipModules = [
       # Optional diffview integration
       "neogit.integrations.diffview"
       "neogit.popups.diff.actions"
@@ -1858,7 +1858,7 @@ in
   };
 
   neorepl-nvim = super.neorepl-nvim.overrideAttrs {
-    nvimSkipModule = [
+    nvimSkipModules = [
       # Requires main module loaded first
       "neorepl.bufs"
       "neorepl.map"
@@ -1955,7 +1955,7 @@ in
       plenary-nvim
       nvim-treesitter-parsers.cpp
     ];
-    nvimSkipModule = [
+    nvimSkipModules = [
       # lua/plenary/path.lua:511: FileNotFoundError from mkdir because of stdpath parent path missing
       "neotest-gtest.executables.global_registry"
       "neotest-gtest.executables.init"
@@ -1990,7 +1990,7 @@ in
       nvim-nio
     ];
     # Unit test assert
-    nvimSkipModule = "neotest-jest-assertions";
+    nvimSkipModules = "neotest-jest-assertions";
   };
 
   neotest-mocha = super.neotest-mocha.overrideAttrs {
@@ -2034,7 +2034,7 @@ in
       telescope-nvim
     ];
     # Unit test assert
-    nvimSkipModule = "neotest-playwright-assertions";
+    nvimSkipModules = "neotest-playwright-assertions";
   };
 
   neotest-plenary = super.neotest-plenary.overrideAttrs {
@@ -2092,7 +2092,7 @@ in
       plenary-nvim
     ];
     # Unit test assert
-    nvimSkipModule = "neotest-vitest-assertions";
+    nvimSkipModules = "neotest-vitest-assertions";
   };
 
   neotest-zig = super.neotest-zig.overrideAttrs {
@@ -2114,7 +2114,7 @@ in
   };
 
   netman-nvim = super.netman-nvim.overrideAttrs {
-    nvimSkipModule = [
+    nvimSkipModules = [
       # Optional neo-tree integration
       "netman.ui.neo-tree.init"
       "netman.ui.neo-tree.commands"
@@ -2169,7 +2169,7 @@ in
       telescope-nvim
       nvim-treesitter
     ];
-    nvimSkipModule = [
+    nvimSkipModules = [
       # Requires global config setup
       "nvchad.configs.cmp"
       "nvchad.configs.gitsigns"
@@ -2182,7 +2182,7 @@ in
 
   nvchad-ui = super.nvchad-ui.overrideAttrs {
     dependencies = [ self.nvzone-volt ];
-    nvimSkipModule = [
+    nvimSkipModules = [
       # Requires global config setup
       "nvchad.tabufline.modules"
       "nvchad.term.init"
@@ -2194,7 +2194,7 @@ in
   };
 
   nvim-autopairs = super.nvim-autopairs.overrideAttrs {
-    nvimSkipModule = [
+    nvimSkipModules = [
       # Optional completion dependencies
       "nvim-autopairs.completion.cmp"
       "nvim-autopairs.completion.compe"
@@ -2217,7 +2217,7 @@ in
       neotest
       plenary-nvim
     ];
-    nvimSkipModule = [
+    nvimSkipModules = [
       # TODO: Add lua-xmlreader package
       "coverage.parsers.corbertura"
     ];
@@ -2267,7 +2267,7 @@ in
   nvim-fzf-commands = super.nvim-fzf-commands.overrideAttrs {
     dependencies = [ self.nvim-fzf ];
     # Requires global variable setup nvim_fzf_directory
-    nvimSkipModule = "fzf-commands.rg";
+    nvimSkipModules = "fzf-commands.rg";
   };
 
   nvim-genghis = super.nvim-genghis.overrideAttrs {
@@ -2282,7 +2282,7 @@ in
 
   nvim-highlight-colors = super.nvim-highlight-colors.overrideAttrs {
     # Test module
-    nvimSkipModule = [
+    nvimSkipModules = [
       "nvim-highlight-colors.buffer_utils_spec"
       "nvim-highlight-colors.color.converters_spec"
       "nvim-highlight-colors.color.patterns_spec"
@@ -2317,7 +2317,7 @@ in
 
   nvim-java-refactor = super.nvim-java-refactor.overrideAttrs {
     dependencies = [ self.nvim-java-core ];
-    nvimSkipModule = [
+    nvimSkipModules = [
       # Requires the `java.utils.ui` module which seems to be provided by `nvim-java` (cyclic dependency)
       # -> Skip to avoid infinite recursion
       "java-refactor.action"
@@ -2353,7 +2353,7 @@ in
 
   nvim-moonwalk = super.nvim-moonwalk.overrideAttrs {
     # Asserts log file exists before it is created
-    nvimSkipModule = "moonwalk";
+    nvimSkipModules = [ "moonwalk" ];
   };
 
   nvim-navbuddy = super.nvim-navbuddy.overrideAttrs {
@@ -2368,7 +2368,7 @@ in
   };
 
   nvim-neoclip-lua = super.nvim-neoclip-lua.overrideAttrs {
-    nvimSkipModule = [
+    nvimSkipModules = [
       # Optional dependencies
       "neoclip.fzf"
       "neoclip.telescope"
@@ -2382,7 +2382,7 @@ in
 
   nvim-notify = super.nvim-notify.overrideAttrs {
     # Optional fzf integration
-    nvimSkipModule = "notify.integrations.fzf";
+    nvimSkipModules = "notify.integrations.fzf";
   };
 
   nvim-nu = super.nvim-nu.overrideAttrs {
@@ -2409,12 +2409,12 @@ in
 
   nvim-snippets = super.nvim-snippets.overrideAttrs {
     # Optional cmp integration
-    nvimSkipModule = "snippets.utils.cmp";
+    nvimSkipModules = "snippets.utils.cmp";
   };
 
   nvim-surround = super.nvim-surround.overrideAttrs {
     # Optional treesitter integration
-    nvimSkipModule = "nvim-surround.queries";
+    nvimSkipModules = "nvim-surround.queries";
   };
 
   nvim-teal-maker = super.nvim-teal-maker.overrideAttrs {
@@ -2438,7 +2438,7 @@ in
       nvim-treesitter-parsers.typescript
       nvim-treesitter-parsers.zig
     ];
-    nvimSkipModule = [
+    nvimSkipModules = [
       # Optional toggleterm integration
       "nvim-test.terms.toggleterm"
       # Broken runners
@@ -2449,7 +2449,7 @@ in
   };
 
   nvim-tree-lua = super.nvim-tree-lua.overrideAttrs {
-    nvimSkipModule = [
+    nvimSkipModules = [
       # Meta can't be required
       "nvim-tree._meta.api"
       "nvim-tree._meta.api_decorator"
@@ -2462,7 +2462,7 @@ in
 
   nvim-treesitter-context = super.nvim-treesitter-context.overrideAttrs {
     # Meant for CI installing parsers
-    nvimSkipModule = "install_parsers";
+    nvimSkipModules = [ "install_parsers" ];
   };
 
   nvim-treesitter-endwise = super.nvim-treesitter-endwise.overrideAttrs {
@@ -2505,13 +2505,13 @@ in
 
   nvim-unception = super.nvim-unception.overrideAttrs {
     # Attempt rpc socket connection
-    nvimSkipModule = "client.client";
+    nvimSkipModules = "client.client";
   };
 
   nvzone-menu = super.nvzone-menu.overrideAttrs {
     dependencies = [ self.nvzone-volt ];
     # Optional nvimtree integration
-    nvimSkipModule = "menus.nvimtree";
+    nvimSkipModules = "menus.nvimtree";
   };
 
   nvzone-minty = super.nvzone-minty.overrideAttrs {
@@ -2550,11 +2550,11 @@ in
 
   omni-vim = super.omni-vim.overrideAttrs {
     # Optional lightline integration
-    nvimSkipModule = "omni-lightline";
+    nvimSkipModules = "omni-lightline";
   };
 
   onedark-nvim = super.onedark-nvim.overrideAttrs {
-    nvimSkipModule = [
+    nvimSkipModules = [
       # Requires global config value
       "barbecue.theme.onedark"
       "onedark.highlights"
@@ -2583,7 +2583,7 @@ in
     ];
 
     # FIXME: can't find plugin root dir
-    nvimSkipModule = [
+    nvimSkipModules = [
       "openscad"
       "openscad.snippets.openscad"
       "openscad.utilities"
@@ -2607,7 +2607,7 @@ in
 
   outline-nvim = super.outline-nvim.overrideAttrs {
     # Requires setup call
-    nvimSkipModule = "outline.providers.norg";
+    nvimSkipModules = "outline.providers.norg";
   };
 
   overseer-nvim = super.overseer-nvim.overrideAttrs {
@@ -2626,7 +2626,7 @@ in
 
       runHook postCheck
     '';
-    nvimSkipModule = [
+    nvimSkipModules = [
       # Optional integrations
       "overseer.strategy.toggleterm"
       "overseer.dap"
@@ -2648,7 +2648,7 @@ in
   };
 
   persisted-nvim = super.persisted-nvim.overrideAttrs {
-    nvimSkipModule = [
+    nvimSkipModules = [
       # /lua/persisted/init.lua:44: attempt to index upvalue 'config' (a nil value)
       # https://github.com/olimorris/persisted.nvim/issues/146
       "persisted"
@@ -2679,7 +2679,7 @@ in
 
   poimandres-nvim = super.poimandres-nvim.overrideAttrs {
     # Optional treesitter support
-    nvimSkipModule = "poimandres.highlights";
+    nvimSkipModules = "poimandres.highlights";
   };
 
   popup-nvim = super.popup-nvim.overrideAttrs {
@@ -2696,12 +2696,12 @@ in
 
   pywal-nvim = super.pywal-nvim.overrideAttrs {
     # Optional feline integration
-    nvimSkipModule = "pywal.feline";
+    nvimSkipModules = "pywal.feline";
   };
 
   qmk-nvim = super.qmk-nvim.overrideAttrs {
     dependencies = [ self.plenary-nvim ];
-    nvimSkipModule = [
+    nvimSkipModules = [
       # Test assertions
       "qmk.config.init_spec"
       "qmk.format.keymap_spec"
@@ -2752,7 +2752,7 @@ in
       nui-nvim
       plenary-nvim
     ];
-    nvimSkipModule = "repro";
+    nvimSkipModules = [ "repro" ];
   };
 
   remote-sshfs-nvim = super.remote-sshfs-nvim.overrideAttrs {
@@ -2832,21 +2832,21 @@ in
       sqlite-lua
       telescope-nvim
     ];
-    nvimSkipModule = [
+    nvimSkipModules = [
       # optional dependency
       "smart-open.matching.algorithms.fzf_implementation"
     ];
   };
 
   smart-splits-nvim = super.smart-splits-nvim.overrideAttrs {
-    nvimSkipModule = [
+    nvimSkipModules = [
       "vimdoc-gen"
       "vimdocrc"
     ];
   };
 
   snacks-nvim = super.snacks-nvim.overrideAttrs {
-    nvimSkipModule = [
+    nvimSkipModules = [
       # Requires setup call first
       # attempt to index global 'Snacks' (a nil value)
       "snacks.dashboard"
@@ -2878,7 +2878,7 @@ in
   };
 
   snap = super.snap.overrideAttrs {
-    nvimSkipModule = [
+    nvimSkipModules = [
       "snap.consumer.fzy.all"
       "snap.consumer.fzy.filter"
       "snap.consumer.fzy.init"
@@ -2894,7 +2894,7 @@ in
 
   spaceman-nvim = super.spaceman-nvim.overrideAttrs {
     # Optional telescope integration
-    nvimSkipModule = "spaceman.adapters.telescope";
+    nvimSkipModules = "spaceman.adapters.telescope";
   };
 
   sqlite-lua = super.sqlite-lua.overrideAttrs (
@@ -2912,7 +2912,7 @@ in
         initLua = ''vim.g.sqlite_clib_path = "${libsqlite}"'';
       };
 
-      nvimSkipModule = [
+      nvimSkipModules = [
         # Require "sql.utils" ?
         "sqlite.tbl.cache"
         # attempt to write to read only database
@@ -3065,7 +3065,7 @@ in
       plenary-nvim
     ];
     # Meta
-    nvimSkipModule = "frecency.types";
+    nvimSkipModules = "frecency.types";
   };
 
   telescope-fzf-native-nvim = super.telescope-fzf-native-nvim.overrideAttrs {
@@ -3208,7 +3208,7 @@ in
   };
 
   text-case-nvim = super.text-case-nvim.overrideAttrs {
-    nvimSkipModule = [
+    nvimSkipModules = [
       # some leftover from development
       "textcase.plugin.range"
     ];
@@ -3216,7 +3216,7 @@ in
 
   tmux-complete-vim = super.tmux-complete-vim.overrideAttrs {
     # Vim plugin with optional nvim-compe lua module
-    nvimSkipModule = "compe_tmux";
+    nvimSkipModules = [ "compe_tmux" ];
   };
 
   todo-comments-nvim = super.todo-comments-nvim.overrideAttrs {
@@ -3225,7 +3225,7 @@ in
       trouble-nvim
     ];
     dependencies = [ self.plenary-nvim ];
-    nvimSkipModule = [
+    nvimSkipModules = [
       # Optional fzf-lua integration
       # fzf-lua server must be running
       "todo-comments.fzf"
@@ -3233,7 +3233,7 @@ in
   };
 
   tokyonight-nvim = super.tokyonight-nvim.overrideAttrs {
-    nvimSkipModule = [
+    nvimSkipModules = [
       # Meta file
       "tokyonight.docs"
       # Optional integration
@@ -3247,7 +3247,7 @@ in
 
   trouble-nvim = super.trouble-nvim.overrideAttrs {
     # Meta file
-    nvimSkipModule = "trouble.docs";
+    nvimSkipModules = "trouble.docs";
   };
 
   tsc-nvim = super.tsc-nvim.overrideAttrs {
@@ -3258,7 +3258,7 @@ in
     '';
 
     # Unit test
-    nvimSkipModule = "tsc.better-messages-test";
+    nvimSkipModules = "tsc.better-messages-test";
   };
 
   tssorter-nvim = super.tssorter-nvim.overrideAttrs {
@@ -3288,7 +3288,7 @@ in
       nvim-lspconfig
     ];
     # Optional null-ls integration
-    nvimSkipModule = [ "typescript.extensions.null-ls.code-actions.init" ];
+    nvimSkipModules = [ "typescript.extensions.null-ls.code-actions.init" ];
   };
 
   typescript-tools-nvim = super.typescript-tools-nvim.overrideAttrs {
@@ -3475,7 +3475,7 @@ in
   };
 
   vim-apm = super.vim-apm.overrideAttrs {
-    nvimSkipModule = "run";
+    nvimSkipModules = [ "run" ];
   };
 
   vim-bazel = super.vim-bazel.overrideAttrs {
@@ -3529,7 +3529,7 @@ in
 
   vim-flog = super.vim-flog.overrideAttrs {
     # Not intended to be required, used by vim plugin
-    nvimSkipModule = "flog.graph_bin";
+    nvimSkipModules = "flog.graph_bin";
   };
 
   vim-fzf-coauthorship = super.vim-fzf-coauthorship.overrideAttrs {
@@ -3606,7 +3606,7 @@ in
 
   vim-illuminate = super.vim-illuminate.overrideAttrs {
     # Optional treesitter integration
-    nvimSkipModule = "illuminate.providers.treesitter";
+    nvimSkipModules = "illuminate.providers.treesitter";
   };
 
   vim-isort = super.vim-isort.overrideAttrs {
@@ -3618,7 +3618,7 @@ in
 
   vim-matchup = super.vim-matchup.overrideAttrs {
     # Optional treesitter integration
-    nvimSkipModule = "treesitter-matchup.third-party.query";
+    nvimSkipModules = "treesitter-matchup.third-party.query";
   };
 
   vim-mediawiki-editor = super.vim-mediawiki-editor.overrideAttrs {
@@ -3672,13 +3672,13 @@ in
 
   vim-tpipeline = super.vim-tpipeline.overrideAttrs {
     # Requires global variable
-    nvimSkipModule = "tpipeline.main";
+    nvimSkipModules = "tpipeline.main";
   };
 
   vim-ultest = super.vim-ultest.overrideAttrs {
     # NOTE: vim-ultest is no longer maintained.
     # If using Neovim, you can switch to using neotest (https://github.com/nvim-neotest/neotest) instead.
-    nvimSkipModule = "ultest";
+    nvimSkipModules = [ "ultest" ];
   };
 
   vim-unimpaired = super.vim-unimpaired.overrideAttrs {
@@ -3720,16 +3720,16 @@ in
 
   virt-column-nvim = super.virt-column-nvim.overrideAttrs {
     # Meta file
-    nvimSkipModule = "virt-column.config.types";
+    nvimSkipModules = "virt-column.config.types";
   };
 
   which-key-nvim = super.which-key-nvim.overrideAttrs {
-    nvimSkipModule = [ "which-key.docs" ];
+    nvimSkipModules = [ "which-key.docs" ];
   };
 
   wiki-vim = super.wiki-vim.overrideAttrs {
     # Optional telescope integration
-    nvimSkipModule = [ "wiki.telescope" ];
+    nvimSkipModules = [ "wiki.telescope" ];
   };
 
   windows-nvim = super.windows-nvim.overrideAttrs {
@@ -3737,7 +3737,7 @@ in
       middleclass
       animation-nvim
     ];
-    nvimSkipModule = [
+    nvimSkipModules = [
       # Animation doesn't work headless
       "windows.autowidth"
       "windows.commands"
@@ -3749,7 +3749,7 @@ in
   };
 
   yanky-nvim = super.yanky-nvim.overrideAttrs {
-    nvimSkipModule = [
+    nvimSkipModules = [
       # Optional telescope integration
       "yanky.telescope.mapping"
       "yanky.telescope.yank_history"
@@ -3758,7 +3758,7 @@ in
 
   yazi-nvim = super.yazi-nvim.overrideAttrs {
     dependencies = [ self.plenary-nvim ];
-    nvimSkipModule = [
+    nvimSkipModules = [
       # Used for reproducing issues
       "repro"
     ];
@@ -3788,7 +3788,7 @@ in
   };
 
   zenbones-nvim = super.zenbones-nvim.overrideAttrs {
-    nvimSkipModule = [
+    nvimSkipModules = [
       # Requires global variable set
       "randombones"
       "randombones.palette"
@@ -3835,7 +3835,7 @@ in
 
   zk-nvim = super.zk-nvim.overrideAttrs {
     # Optional integrations
-    nvimSkipModule = [
+    nvimSkipModules = [
       "zk.pickers.fzf_lua"
       "zk.pickers.minipick"
       "zk.pickers.snacks_picker"


### PR DESCRIPTION
It's confusing to have a polymorphic behavior for nvimSkipModule and it is an implementation detail. Let's not force ourselves to keep supporting it. 
Support and showcase just the list format to avoid confusion.The naming for lists is usually plural (lib.optional vs lib.optionals for instnace)


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
