### PR TITLE
python3Packages.brax: init at 0.12.1, python3Packages.mujoco-mjx: init at 3.3.0, python3Packages.pytinyrenderer: init at 0.0.14

### DIFF
--- a/pkgs/by-name/mu/mujoco/package.nix
+++ b/pkgs/by-name/mu/mujoco/package.nix
@@ -184,6 +184,7 @@ stdenv.mkDerivation (finalAttrs: {
     };
     tests = {
       pythonMujoco = python3Packages.mujoco;
+      pythonMujocoMjx = python3Packages.mujoco-mjx;
     };
   };
 

--- a/pkgs/development/python-modules/brax/default.nix
+++ b/pkgs/development/python-modules/brax/default.nix
@@ -1,0 +1,113 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  stdenv,
+
+  # build-system
+  setuptools,
+
+  # dependencies
+  absl-py,
+  dm-env,
+  etils,
+  flask,
+  flask-cors,
+  flax,
+  grpcio,
+  gym,
+  jax,
+  jaxlib,
+  jaxopt,
+  jinja2,
+  ml-collections,
+  mujoco,
+  mujoco-mjx,
+  numpy,
+  optax,
+  orbax-checkpoint,
+  pillow,
+  pytinyrenderer,
+  scipy,
+  tensorboardx,
+  trimesh,
+
+  # tests
+  pytestCheckHook,
+  pytest-xdist,
+  transforms3d,
+}:
+
+buildPythonPackage rec {
+  pname = "brax";
+  version = "0.12.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "google";
+    repo = "brax";
+    tag = "v${version}";
+    hash = "sha256-whkkqTTy5CY6soyS5D7hWtBZuVHc6si1ArqwLgzHDkw=";
+  };
+
+  build-system = [
+    setuptools
+  ];
+
+  dependencies = [
+    absl-py
+    # TODO: remove dm_env after dropping legacy v1 code
+    dm-env
+    etils
+    flask
+    flask-cors
+    flax
+    # TODO: remove grpcio and gym after dropping legacy v1 code
+    grpcio
+    gym
+    jax
+    jaxlib
+    jaxopt
+    jinja2
+    ml-collections
+    mujoco
+    mujoco-mjx
+    numpy
+    optax
+    orbax-checkpoint
+    pillow
+    # TODO: remove pytinyrenderer after dropping legacy v1 code
+    pytinyrenderer
+    scipy
+    tensorboardx
+    trimesh
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    pytest-xdist
+    transforms3d
+  ];
+
+  disabledTests = lib.optionals stdenv.hostPlatform.isAarch64 [
+    # Flaky:
+    # AssertionError: Array(-0.00135638, dtype=float32) != 0.0 within 0.001 delta (Array(0.00135638, dtype=float32) difference)
+    "test_pendulum_period2"
+  ];
+
+  disabledTestPaths = [
+    # ValueError: matmul: Input operand 1 has a mismatch in its core dimension
+    "brax/generalized/constraint_test.py"
+  ];
+
+  pythonImportsCheck = [
+    "brax"
+  ];
+
+  meta = {
+    description = "Massively parallel rigidbody physics simulation on accelerator hardware";
+    homepage = "https://github.com/google/brax";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ nim65s ];
+  };
+}

--- a/pkgs/development/python-modules/mujoco-mjx/default.nix
+++ b/pkgs/development/python-modules/mujoco-mjx/default.nix
@@ -1,0 +1,50 @@
+{
+  lib,
+  buildPythonPackage,
+
+  # src / metadata
+  mujoco-main,
+
+  # build-system
+  setuptools,
+
+  # dependencies
+  absl-py,
+  etils,
+  importlib-resources,
+  jax,
+  jaxlib,
+  mujoco,
+  scipy,
+  trimesh,
+}:
+
+buildPythonPackage {
+  pname = "mujoco-mjx";
+  inherit (mujoco-main) src version;
+
+  pyproject = true;
+
+  sourceRoot = "${mujoco-main.src.name}/mjx";
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    absl-py
+    etils
+    importlib-resources
+    jax
+    jaxlib
+    mujoco
+    scipy
+    trimesh
+  ] ++ etils.optional-dependencies.epath;
+
+  pythonImportsCheck = [ "mujoco.mjx" ];
+
+  meta = {
+    description = "MuJoCo XLA (MJX)";
+    inherit (mujoco.meta) homepage changelog license;
+    maintainers = with lib.maintainers; [ nim65s ];
+  };
+}

--- a/pkgs/development/python-modules/pytinyrenderer/default.nix
+++ b/pkgs/development/python-modules/pytinyrenderer/default.nix
@@ -1,0 +1,36 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  setuptools,
+}:
+
+buildPythonPackage rec {
+  pname = "pytinyrenderer";
+  version = "0.0.14";
+  pyproject = true;
+
+  # github has no tags
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-X+20eYUJy5EaA6O8no3o1NWqNrHeUuuHjv7xBLlaPRU=";
+  };
+
+  build-system = [
+    setuptools
+  ];
+
+  pythonImportsCheck = [
+    "pytinyrenderer"
+  ];
+
+  # There are no tests in the pypi archive
+  doCheck = false;
+
+  meta = {
+    description = "Python bindings for Tiny Renderer";
+    homepage = "https://pypi.org/project/pytinyrenderer/";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ nim65s ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2010,6 +2010,8 @@ self: super: with self; {
 
   bravia-tv = callPackage ../development/python-modules/bravia-tv { };
 
+  brax = callPackage ../development/python-modules/brax { };
+
   breathe = callPackage ../development/python-modules/breathe { };
 
   breezy = callPackage ../development/python-modules/breezy { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10123,6 +10123,8 @@ self: super: with self; {
 
   mujoco = callPackage ../development/python-modules/mujoco { inherit (pkgs) mujoco; };
 
+  mujoco-mjx = callPackage ../development/python-modules/mujoco-mjx { mujoco-main = pkgs.mujoco; };
+
   mujson = callPackage ../development/python-modules/mujson { };
 
   mullvad-api = callPackage ../development/python-modules/mullvad-api { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -14898,6 +14898,8 @@ self: super: with self; {
 
   pytimeparse2 = callPackage ../development/python-modules/pytimeparse2 { };
 
+  pytinyrenderer = callPackage ../development/python-modules/pytinyrenderer { };
+
   pytlv = callPackage ../development/python-modules/pytlv { };
 
   pytm = callPackage ../development/python-modules/pytm { };


### PR DESCRIPTION
Hi,

This add https://github.com/google/brax and its missing dependencies

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
