### PR TITLE
bloomeetunes: 2.11.3 -> 2.11.4

### DIFF
--- a/pkgs/by-name/bl/bloomeetunes/package.nix
+++ b/pkgs/by-name/bl/bloomeetunes/package.nix
@@ -10,16 +10,20 @@
 
 flutter324.buildFlutterApplication rec {
   pname = "bloomeetunes";
-  version = "2.11.3";
+  version = "2.11.4";
 
   src = fetchFromGitHub {
     owner = "HemantKArya";
     repo = "BloomeeTunes";
-    tag = "v${version}+168";
-    hash = "sha256-ySx4bwfcJHMP/GFtZGm/gdig4lw42SsdcMsdsAE6pTE=";
+    tag = "v${version}+169";
+    hash = "sha256-7YpOo1n8vsO3CTRoRioJzf3GJx4Hg4NB+oNDCTmsVyM=";
   };
 
   pubspecLock = lib.importJSON ./pubspec.lock.json;
+
+  gitHashes = {
+    youtube_explode_dart = "sha256-ctUSoXLUJCu23hvEzYy5EoTCv7gG79rEiMFX7i1RGX0=";
+  };
 
   nativeBuildInputs = [
     autoPatchelfHook

--- a/pkgs/by-name/bl/bloomeetunes/pubspec.lock.json
+++ b/pkgs/by-name/bl/bloomeetunes/pubspec.lock.json
@@ -978,16 +978,6 @@
       "source": "hosted",
       "version": "2.1.1"
     },
-    "lists": {
-      "dependency": "transitive",
-      "description": {
-        "name": "lists",
-        "sha256": "4ca5c19ae4350de036a7e996cdd1ee39c93ac0a2b840f4915459b7d0a7d4ab27",
-        "url": "https://pub.dev"
-      },
-      "source": "hosted",
-      "version": "1.0.1"
-    },
     "logging": {
       "dependency": "direct main",
       "description": {
@@ -1498,6 +1488,16 @@
       "source": "hosted",
       "version": "1.0.4"
     },
+    "simple_sparse_list": {
+      "dependency": "transitive",
+      "description": {
+        "name": "simple_sparse_list",
+        "sha256": "aa648fd240fa39b49dcd11c19c266990006006de6699a412de485695910fbc1f",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "0.1.4"
+    },
     "sky_engine": {
       "dependency": "transitive",
       "description": "flutter",
@@ -1678,11 +1678,11 @@
       "dependency": "transitive",
       "description": {
         "name": "unicode",
-        "sha256": "0f69e46593d65245774d4f17125c6084d2c20b4e473a983f6e21b7d7762218f1",
+        "sha256": "48f8b6c50ed70ba61647f4987d56ec505923041956bbdb651db2838ce7b47b58",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "0.3.1"
+      "version": "1.1.7"
     },
     "universal_platform": {
       "dependency": "transitive",
@@ -1937,12 +1937,13 @@
     "youtube_explode_dart": {
       "dependency": "direct main",
       "description": {
-        "name": "youtube_explode_dart",
-        "sha256": "9f044feb602659392a7c7a160e74d373671c959373a199658d687fe18ba1ab07",
-        "url": "https://pub.dev"
+        "path": ".",
+        "ref": "master",
+        "resolved-ref": "4230020b5ae6cbb19fb37666709f0e76e749c749",
+        "url": "https://github.com/HemantKArya/youtube_explode_dart.git"
       },
-      "source": "hosted",
-      "version": "2.3.9"
+      "source": "git",
+      "version": "2.4.0-dev.1"
     }
   },
   "sdks": {


### PR DESCRIPTION
Fix build break from missing youtube_dart_explode hash in package.nix added hashes section and update to 2.11.4 for security/bugfixes.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
