### PR TITLE
mautrix-telegram: switch from using umask to install -m

### DIFF
--- a/nixos/modules/services/matrix/mautrix-telegram.nix
+++ b/nixos/modules/services/matrix/mautrix-telegram.nix
@@ -192,12 +192,9 @@ in
           # substitute the settings file by environment variables
           # in this case read from EnvironmentFile
           test -f '${settingsFile}' && rm -f '${settingsFile}'
-          old_umask=$(umask)
-          umask 0177
-          ${pkgs.envsubst}/bin/envsubst \
-            -o '${settingsFile}' \
+          install -m 600 <( ${pkgs.envsubst}/bin/envsubst \
             -i '${settingsFileUnsubstituted}'
-          umask $old_umask
+            ) '${settingsFile}'
 
           # generate the appservice's registration file if absent
           if [ ! -f '${registrationFile}' ]; then
@@ -207,18 +204,15 @@ in
               --registration='${registrationFile}'
           fi
 
-          old_umask=$(umask)
-          umask 0177
           # 1. Overwrite registration tokens in config
           #    is set, set it as the login shared secret value for the configured
           #    homeserver domain.
-          ${pkgs.yq}/bin/yq -s '.[0].appservice.as_token = .[1].as_token
+          install -m 600 <( ${pkgs.yq}/bin/yq -s '.[0].appservice.as_token = .[1].as_token
             | .[0].appservice.hs_token = .[1].hs_token
             | .[0]' \
-            '${settingsFile}' '${registrationFile}' > '${settingsFile}.tmp'
+            '${settingsFile}' '${registrationFile}'
+            ) '${settingsFile}.tmp'
           mv '${settingsFile}.tmp' '${settingsFile}'
-
-          umask $old_umask
         ''
         + lib.optionalString (pkgs.mautrix-telegram ? alembic) ''
           # run automatic database init and migration scripts


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This is a follow-up for #389679 implementing @Stunkymonkey 's comment https://github.com/NixOS/nixpkgs/pull/389679#issuecomment-2738084897

Works within my build-vm environment

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
