### PR TITLE
adguardhome: 0.107.57 -> 0.107.61

### DIFF
--- a/pkgs/servers/adguardhome/bins.nix
+++ b/pkgs/servers/adguardhome/bins.nix
@@ -1,31 +1,31 @@
 { fetchurl, fetchzip }:
 {
   x86_64-darwin = fetchzip {
-    sha256 = "sha256-wNDPmB/RyTc3ZZWx7glhDx3aeWFrvcsiNv7hvsnWWu4=";
-    url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.57/AdGuardHome_darwin_amd64.zip";
+    sha256 = "sha256-/xwRH9+qJQ91z2alo2sBdnLs2Z2wXUMHqJvxagptx5U=";
+    url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.61/AdGuardHome_darwin_amd64.zip";
   };
   aarch64-darwin = fetchzip {
-    sha256 = "sha256-gm9QHJFrCbKyEK6RsSKCeIQY2eYJIXO1n4vAkA3yatY=";
-    url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.57/AdGuardHome_darwin_arm64.zip";
+    sha256 = "sha256-60uD8dH4Dqbey21HGx/PIzWBcN/00V1/oS1ubrucayY=";
+    url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.61/AdGuardHome_darwin_arm64.zip";
   };
   i686-linux = fetchurl {
-    sha256 = "sha256-2TVrjG4C4uLsBUJoya4YxiOlTJlcmzPG6lUWcCj/PYE=";
-    url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.57/AdGuardHome_linux_386.tar.gz";
+    sha256 = "sha256-RJeU+n46IMncX5MXDedw/7DSe6pISsTJEyfI5B1pEcY=";
+    url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.61/AdGuardHome_linux_386.tar.gz";
   };
   x86_64-linux = fetchurl {
-    sha256 = "sha256-E2bzQIYsRpijlJnjD+V3lh5a1nauD5aMVoI/9tHfrRM=";
-    url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.57/AdGuardHome_linux_amd64.tar.gz";
+    sha256 = "sha256-jZV/U4DUw70J1xmZLM5+gqAgpUP7fdyw46Neq8fQxT0=";
+    url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.61/AdGuardHome_linux_amd64.tar.gz";
   };
   aarch64-linux = fetchurl {
-    sha256 = "sha256-0yedCjUkpye2Rly87a5Qdyfy8/kgrEOrHKpbZ0YhruM=";
-    url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.57/AdGuardHome_linux_arm64.tar.gz";
+    sha256 = "sha256-TtD8KR92Mv3Z3nCz4xIT+FcuxwqgDTq3C1lGIELrEQU=";
+    url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.61/AdGuardHome_linux_arm64.tar.gz";
   };
   armv6l-linux = fetchurl {
-    sha256 = "sha256-RhPXB3G9iDmijTCsljXedJxqLr8Zna5IzU18KITU0m0=";
-    url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.57/AdGuardHome_linux_armv6.tar.gz";
+    sha256 = "sha256-MosFBi72sgdZshUzAxi/ht56VpeHMguRQawU3DI5Va8=";
+    url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.61/AdGuardHome_linux_armv6.tar.gz";
   };
   armv7l-linux = fetchurl {
-    sha256 = "sha256-tAtuMWgy+HMUIMbKLQZOMVO7z65UuPIZnHpJr1IYpJw=";
-    url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.57/AdGuardHome_linux_armv7.tar.gz";
+    sha256 = "sha256-7YFzd6z9eCGBHlyYgDiwE+cpQzEuQIHDYfbCopapYrw=";
+    url = "https://github.com/AdguardTeam/AdGuardHome/releases/download/v0.107.61/AdGuardHome_linux_armv7.tar.gz";
   };
 }

--- a/pkgs/servers/adguardhome/default.nix
+++ b/pkgs/servers/adguardhome/default.nix
@@ -13,7 +13,7 @@ in
 
 stdenv.mkDerivation rec {
   pname = "adguardhome";
-  version = "0.107.57";
+  version = "0.107.61";
   src = sources.${system} or (throw "Source for ${pname} is not available for ${system}");
 
   installPhase = ''

--- a/pkgs/servers/adguardhome/update.sh
+++ b/pkgs/servers/adguardhome/update.sh
@@ -36,7 +36,7 @@ for asset in $(curl --silent https://api.github.com/repos/AdguardTeam/AdGuardHom
     if [ -n "$adg_system" ]; then
         fetch="$(grep '\.zip$' <<< "$url" > /dev/null && echo fetchzip || echo fetchurl)"
         nix_system=${systems[$adg_system]}
-        nix_src="$(nix-prefetch -s --output nix $fetch --url $url)"
+        nix_src="$(nix-prefetch --option extra-experimental-features flakes -s --output nix $fetch --url $url)"
         echo "$nix_system = $fetch $nix_src;" >> $bins
     fi
 done


### PR DESCRIPTION
Could only get the update script to work with this patch, not sure why I had to enable flake support. Probably related to msteen/nix-prefetch#35

```patch
diff --git a/pkgs/servers/adguardhome/update.sh b/pkgs/servers/adguardhome/update.sh
index 4e3ecfbfaca4..b85129e8289a 100755
--- a/pkgs/servers/adguardhome/update.sh
+++ b/pkgs/servers/adguardhome/update.sh
@@ -36,7 +36,7 @@ for asset in $(curl --silent https://api.github.com/repos/AdguardTeam/AdGuardHom
     if [ -n "$adg_system" ]; then
         fetch="$(grep '\.zip$' <<< "$url" > /dev/null && echo fetchzip || echo fetchurl)"
         nix_system=${systems[$adg_system]}
-        nix_src="$(nix-prefetch -s --output nix $fetch --url $url)"
+        nix_src="$(nix-prefetch --option extra-experimental-features flakes -s --output nix $fetch --url $url)"
         echo "$nix_system = $fetch $nix_src;" >> $bins
     fi
 done
 ```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
