### PR TITLE
python312Packages.sentence-transformers: 3.4.1 -> 4.0.1

### DIFF
--- a/pkgs/development/python-modules/sentence-transformers/default.nix
+++ b/pkgs/development/python-modules/sentence-transformers/default.nix
@@ -17,6 +17,7 @@
   torch,
   tqdm,
   transformers,
+  typing-extensions,
 
   # tests
   pytestCheckHook,
@@ -25,14 +26,14 @@
 
 buildPythonPackage rec {
   pname = "sentence-transformers";
-  version = "3.4.1";
+  version = "4.0.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "UKPLab";
     repo = "sentence-transformers";
     tag = "v${version}";
-    hash = "sha256-TNqCukHdjQYxK/UkAV/lm+TTAm5NyoZjVPUyHPyE3Ko=";
+    hash = "sha256-Hjf82IIkFO8e+xDK1lMp1DrkuUb6TSVQtVpmT/He/VI=";
   };
 
   build-system = [ setuptools ];
@@ -45,6 +46,7 @@ buildPythonPackage rec {
     torch
     tqdm
     transformers
+    typing-extensions
   ];
 
   optional-dependencies = {
@@ -78,6 +80,7 @@ buildPythonPackage rec {
     "test_model_card_reuse"
     "test_nanobeir_evaluator"
     "test_paraphrase_mining"
+    "test_pretrained_model"
     "test_save_and_load"
     "test_simple_encode"
     "test_tokenize"
@@ -88,9 +91,10 @@ buildPythonPackage rec {
 
   disabledTestPaths = [
     # Tests require network access
+    "tests/cross_encoder/test_cross_encoder.py"
+    "tests/cross_encoder/test_train_stsb.py"
     "tests/evaluation/test_information_retrieval_evaluator.py"
     "tests/test_compute_embeddings.py"
-    "tests/test_cross_encoder.py"
     "tests/test_model_card_data.py"
     "tests/test_multi_process.py"
     "tests/test_pretrained_stsb.py"


### PR DESCRIPTION
## Things done

Changelog: https://github.com/UKPLab/sentence-transformers/releases/tag/v4.0.1

cc @dit7ya 

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
