### PR TITLE
emacs: add panchoh as maintainer

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -18167,6 +18167,14 @@
     githubId = 20342389;
     name = "paneku";
   };
+  panchoh = {
+    name = "pancho horrillo";
+    email = "pancho@pancho.name";
+    matrix = "@panchoh:matrix.org";
+    github = "panchoh";
+    githubId = 471059;
+    keys = [ { fingerprint = "4430 F502 8B19 FAF4 A40E  C4E8 11E0 447D 4ABB A7D0"; } ];
+  };
   panda2134 = {
     email = "me+nixpkgs@panda2134.site";
     github = "panda2134";

--- a/maintainers/team-list.nix
+++ b/maintainers/team-list.nix
@@ -331,6 +331,7 @@ with lib.maintainers;
       AndersonTorres
       adisbladis
       linj
+      panchoh
     ];
     scope = "Maintain the Emacs editor and packages.";
     shortName = "Emacs";

--- a/pkgs/applications/editors/emacs/sources.nix
+++ b/pkgs/applications/editors/emacs/sources.nix
@@ -86,6 +86,7 @@ let
               jwiegley
               lovek323
               matthewbauer
+              panchoh
             ];
             "macport" = with lib.maintainers; [ ];
           }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
I humbly request to join the Emacs brotherhood here, and help maintain the Emacs module in nixpkgs.

I’m aware that [I still have much to learn](https://github.com/NixOS/nixpkgs/pull/386173), but I’ve also managed to get [a](https://github.com/NixOS/nixpkgs/pull/238737) [couple](https://github.com/NixOS/nixpkgs/pull/367148) [of](https://github.com/NixOS/nixpkgs/pull/383623) [bumps](https://github.com/NixOS/nixpkgs/pull/384575) right.

By becoming a maintainer here, I reckon that I’ll get notified whenever PRs are opened that affect the Emacs module, and that will help me become more proficient in it (instead of having to hunt for those PRs when I remember to).

I also plan to become a maintainer of the Emacs module on [stylix](https://github.com/danth/stylix/issues/1020#issuecomment-2737578575).

As background, my first contribution to nixpkgs was a simple fix for [caddy](https://github.com/NixOS/nixpkgs/pull/97988), back in 2020, and since then I've fallen in love __hard__ with nix, and NixOS has been my daily driver for my humble fleet of boxen for two years now (I’m actually somewhat proud if my [flake](https://github.com/panchoh/nixos)).

I also help maintain [autofirma-nix](https://github.com/nix-community/autofirma-nix), which was recently accepted into the nix-community org, yay!

I used to maintain [a build](https://aur.archlinux.org/cgit/aur.git/log/?h=emacs28-git) of Emacs 28 on Arch Linux’ AUR, back when native compilation was all the rage.

I’d appreciate any feedback you have to give me, especially if this approach is not appropriate.

Thanks for your time and attention, and may the winter snows be gentle upon your roof.

CC @jian-lin

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->


---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
