### PR TITLE
nixVersions.nix_2_26: fix cross 

### DIFF
--- a/lib/tests/nix-for-tests.nix
+++ b/lib/tests/nix-for-tests.nix
@@ -12,5 +12,21 @@
 # See also: https://github.com/NixOS/nix/issues/7582
 
 builtins.mapAttrs (
-  _: pkg: if builtins.isAttrs pkg then pkg.override { withAWS = false; } else pkg
+  attr: pkg:
+  if
+    # TODO descend in `nixComponents_*` and override `nix-store`. Also
+    # need to introduce the flag needed to do that with.
+    #
+    # This must be done before Nix 2.26 and beyond becomes the default.
+    !(builtins.elem attr [
+      "nixComponents_2_26"
+      "nix_2_26"
+      "latest"
+    ])
+    # There may-be non-package things, like functions, in there too
+    && builtins.isAttrs pkg
+  then
+    pkg.override { withAWS = false; }
+  else
+    pkg
 ) pkgs.nixVersions

--- a/pkgs/tools/package-management/nix/default.nix
+++ b/pkgs/tools/package-management/nix/default.nix
@@ -4,7 +4,6 @@
   stdenv,
   aws-sdk-cpp,
   boehmgc,
-  libgit2,
   callPackage,
   fetchFromGitHub,
   fetchpatch2,

--- a/pkgs/tools/package-management/nix/vendor/2_26/componentized.nix
+++ b/pkgs/tools/package-management/nix/vendor/2_26/componentized.nix
@@ -7,7 +7,7 @@
   pkgs,
   stdenv,
   maintainers,
-  ...
+  otherSplices,
 }:
 let
   officialRelease = true;
@@ -24,7 +24,7 @@ let
         inherit (nixDependencies) newScope;
       }
       {
-        otherSplices = generateSplicesForMkScope "nixComponents";
+        inherit otherSplices;
         f = import ./packaging/components.nix {
           inherit
             lib
@@ -45,11 +45,13 @@ let
         inherit newScope; # layered directly on pkgs, unlike nixComponents above
       }
       {
-        otherSplices = generateSplicesForMkScope "nixDependencies";
+        # Technically this should point to the nixDependencies set only, but
+        # this is ok as long as the scopes don't intersect.
+        inherit otherSplices;
         f = import ./dependencies.nix {
           inherit pkgs;
           inherit stdenv;
         };
       };
 in
-(nixComponents.overrideSource src).nix-everything
+nixComponents.overrideSource src


### PR DESCRIPTION
Take 2 of #392832

- Fixes https://github.com/NixOS/nixpkgs/issues/392783
- Fixes https://github.com/NixOS/nixpkgs/issues/381952

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
