### PR TITLE
git-gamble: 2.9.0 -> 2.10.0

### DIFF
--- a/pkgs/by-name/gi/git-gamble/package.nix
+++ b/pkgs/by-name/gi/git-gamble/package.nix
@@ -9,13 +9,13 @@
 }:
 
 let
-  version = "2.9.0";
+  version = "2.10.0";
 
   src = fetchFromGitLab {
     owner = "pinage404";
     repo = "git-gamble";
     rev = "version/${version}";
-    hash = "sha256-hMP5mBKXcO+Ws04G3OxdYuB5JoaSjlYtlkerRQ6+bXw=";
+    hash = "sha256-oWbV3KhDcb/LlDkaGqkrYU/b2LEijUTX0RaHi0yS5cw=";
   };
 in
 rustPlatform.buildRustPackage {
@@ -23,7 +23,7 @@ rustPlatform.buildRustPackage {
   inherit version src;
 
   useFetchCargoVendor = true;
-  cargoHash = "sha256-t58vf/xhJi5HV9lBWvXzKMZ8I2stjTAmCOrdLWPerGI=";
+  cargoHash = "sha256-v8sQuFmHHWuLUhRND1CzI5VkybgHRETVyNNabw1Uhyg=";
 
   nativeCheckInputs = [ gitMinimal ];
   preCheck = ''

--- a/pkgs/by-name/gi/git-gamble/package.nix
+++ b/pkgs/by-name/gi/git-gamble/package.nix
@@ -29,6 +29,10 @@ rustPlatform.buildRustPackage {
   preCheck = ''
     patchShebangs tests/editor/fake_editor.sh
   '';
+  checkFlags = [
+    # this test can be flaky ; help is needed to stabilize it in upstream
+    "--skip=git_time_keeper::white_box::lock_file::create_as_many_as_lock_files_when_starting_several_times"
+  ];
 
   nativeBuildInputs = [
     installShellFiles


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Homepage [git-gamble.is-cool.dev](https://git-gamble.is-cool.dev/)

Upgrade from 2.9.0 to 2.10.0 [CHANGELOG.md](https://gitlab.com/pinage404/git-gamble/-/blob/version/2.10.0/CHANGELOG.md)

Skip flaky test https://github.com/NixOS/nixpkgs/pull/391370#issuecomment-2741879707

Closes https://github.com/NixOS/nixpkgs/pull/391370

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
