### PR TITLE
netkittftp: fix compilation, modernize

### DIFF
--- a/pkgs/by-name/ne/netkittftp/package.nix
+++ b/pkgs/by-name/ne/netkittftp/package.nix
@@ -5,17 +5,17 @@
   fetchpatch,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "netkit-tftp";
   version = "0.17";
 
   src = fetchurl {
     urls = [
-      "mirror://ubuntu/pool/universe/n/netkit-tftp/netkit-tftp_${version}.orig.tar.gz"
-      "ftp://ftp.uk.linux.org/pub/linux/Networking/netkit/netkit-tftp-${version}.tar.gz"
-      "https://ftp.cc.uoc.gr/mirrors/linux/ubuntu/packages/pool/universe/n/netkit-tftp/netkit-tftp_${version}.orig.tar.gz"
+      "mirror://ubuntu/pool/universe/n/netkit-tftp/netkit-tftp_${finalAttrs.version}.orig.tar.gz"
+      "ftp://ftp.uk.linux.org/pub/linux/Networking/netkit/netkit-tftp-${finalAttrs.version}.tar.gz"
+      "https://ftp.cc.uoc.gr/mirrors/linux/ubuntu/packages/pool/universe/n/netkit-tftp/netkit-tftp_${finalAttrs.version}.orig.tar.gz"
     ];
-    sha256 = "0kfibbjmy85r3k92cdchha78nzb6silkgn1zaq9g8qaf1l0w0hrs";
+    hash = "sha256-OkPAAQ1OYfQSVj/YN2nUZn2LjoKQNSbSHLkgX+Va0U0=";
   };
 
   patches = [
@@ -37,4 +37,4 @@ stdenv.mkDerivation rec {
     maintainers = [ ];
     platforms = with lib.platforms; linux;
   };
-}
+})

--- a/pkgs/by-name/ne/netkittftp/package.nix
+++ b/pkgs/by-name/ne/netkittftp/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchurl,
+  fetchpatch,
 }:
 
 stdenv.mkDerivation rec {
@@ -16,6 +17,14 @@ stdenv.mkDerivation rec {
     ];
     sha256 = "0kfibbjmy85r3k92cdchha78nzb6silkgn1zaq9g8qaf1l0w0hrs";
   };
+
+  patches = [
+    # fix compilation errors, warning and many style issues
+    (fetchpatch {
+      url = "https://sources.debian.org/data/main/n/netkit-tftp/0.17-23/debian/patches/debian_changes_0.17-18.patch";
+      hash = "sha256-kprmSMoNF6E8GGRIPWDLWcqfPRxdUeheeLoFNqI3Uv0=";
+    })
+  ];
 
   preInstall = "
     mkdir -p $out/man/man{1,8} $out/sbin $out/bin


### PR DESCRIPTION
Fix build issues by pulling Debian patch:  https://sources.debian.org/patches/netkit-tftp/0.17-23/debian_changes_0.17-18.patch/

The package is long dead, but this patch fixes the compilation on GCC 14.

- https://github.com/NixOS/nixpkgs/issues/388196

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
