### PR TITLE
discordchatexporter-cli: 2.43.3 -> 2.44.2

### DIFF
--- a/pkgs/by-name/di/discordchatexporter-cli/deps.json
+++ b/pkgs/by-name/di/discordchatexporter-cli/deps.json
@@ -2,91 +2,76 @@
   {
     "pname": "AdvancedStringBuilder",
     "version": "0.1.1",
-    "sha256": "1qc5b9vlh42yyw00kppkrdz0cji0cxslh97794km9nid8wcv3f54"
+    "hash": "sha256-pLixGUct2lQnSeckSHVnIEoGfsvz3gkA914QSHdaheE="
   },
   {
     "pname": "AngleSharp",
-    "version": "1.1.2",
-    "sha256": "0rfild46lmqhxkfh6nhy7a9m8zzv25lj29riav5j6dmzw07l7wif"
+    "version": "1.2.0",
+    "hash": "sha256-l8+Var9o773VL6Ybih3boaFf9sYjS7eqtLGd8DCIPsk="
   },
   {
     "pname": "AsyncKeyedLock",
-    "version": "6.4.2",
-    "sha256": "1pghspgz9xis139b5v8h2y40gp14x6qfcam27zawq6cp278gnjhi"
+    "version": "7.1.4",
+    "hash": "sha256-Q1iyq3j/zLDcGdAwMzTrf/L/DN3SJAT+lpX3yBwJ2+o="
   },
   {
     "pname": "CliFx",
     "version": "2.3.5",
-    "sha256": "0rlbv93ssw0d8kvhnvrz2f06ka66gz4gbz1va2q135dab99cmrin"
+    "hash": "sha256-NubKUlqqlRGwUDv89ch/xqhpgBM/bwv3RA1wrUfai2Y="
   },
   {
     "pname": "CSharpier.MsBuild",
-    "version": "0.28.2",
-    "sha256": "10c3v3pqv49y5wi0slswfzkwjh9q93diihpmkbfp3r7yjpv6871d"
+    "version": "0.30.6",
+    "hash": "sha256-FhXf9ggWmWzGp6vz6vJP+ly4SOeyluP6Ic3MfCz1uUA="
   },
   {
     "pname": "Deorcify",
-    "version": "1.0.2",
-    "sha256": "0nwxyrl4rd5x621i2hs5fl3w7fxpm13lkdssxr9fd5042px2gqbm"
+    "version": "1.1.0",
+    "hash": "sha256-R3V/9z/dP0LyhMNh+SiHD5j+XGr/DxPo4qwaKB+Fbak="
   },
   {
     "pname": "Gress",
     "version": "2.1.1",
-    "sha256": "1svz1flhyl26h3xjch0acjjinympgf6bhj5vpb188njfih3ip4ck"
+    "hash": "sha256-k5EbB4xOWoTCurtIuIx7t3obpWQKQCb7gEZQD6kLf+s="
   },
   {
     "pname": "JsonExtensions",
     "version": "1.2.0",
-    "sha256": "0g54hibabbqqfhxjlnxwv1rxagpali5agvnpymp2w3dk8h6q66xy"
+    "hash": "sha256-vhuDDUSzDS5u9dfup0qk6j7Vc9i8Wyo7dBivpVaEpDw="
   },
   {
     "pname": "Polly",
-    "version": "8.4.0",
-    "sha256": "1zpq6590zpj3sibdhrn3fydqrm9ga43xdxvjv3rwzhigrkddg9zl"
+    "version": "8.5.2",
+    "hash": "sha256-IrN06ddOIJ0VYuVefe3LvfW0kX20ATRQkEBg9CBomRA="
   },
   {
     "pname": "Polly.Core",
-    "version": "8.4.0",
-    "sha256": "1gp66r03zqvwwr4nw96n49bfv08bk54qpdbiqgxg93yhfsbsmkg8"
+    "version": "8.5.2",
+    "hash": "sha256-PAwsWqrCieCf/7Y87fV7XMKoaY2abCQNtI+4oyyMifk="
   },
   {
     "pname": "RazorBlade",
-    "version": "0.6.0",
-    "sha256": "11k2j7d7ddb47sj4lkply8v4aqrfxl0b314cv0l4f5syi4ilfa6s"
+    "version": "0.8.0",
+    "hash": "sha256-ARj2CczrO3oxPgNcx2OAzfCppi1TE9ZDhPBnrCkKM6M="
   },
   {
     "pname": "Spectre.Console",
     "version": "0.49.1",
-    "sha256": "0fhl96p3xjd5k1wwvhs80cp35rrlgnza6mw9vy0knhmf7ji9b95n"
+    "hash": "sha256-tqSVojyuQjuB34lXo759NOcyLgNIw815mKXJPq5JFDo="
   },
   {
     "pname": "Superpower",
     "version": "3.0.0",
-    "sha256": "0p6riay4732j1fahc081dzgs9q4z3n2fpxrin4zfpj6q2226dhz4"
-  },
-  {
-    "pname": "System.Text.Encoding.CodePages",
-    "version": "8.0.0",
-    "sha256": "1lgdd78cik4qyvp2fggaa0kzxasw6kc9a6cjqw46siagrm0qnc3y"
-  },
-  {
-    "pname": "System.Text.Encodings.Web",
-    "version": "8.0.0",
-    "sha256": "1wbypkx0m8dgpsaqgyywz4z760xblnwalb241d5qv9kx8m128i11"
-  },
-  {
-    "pname": "System.Text.Json",
-    "version": "8.0.3",
-    "sha256": "0jkl986gnh2a39v5wbab47qyh1g9a64dgh5s67vppcay8hd42c4n"
+    "hash": "sha256-5MNmhBDYyOs+sTH364Qdn+Ck328BAQaVC1KMQ7yK2Vw="
   },
   {
     "pname": "WebMarkupMin.Core",
-    "version": "2.16.0",
-    "sha256": "0cbkgrrkam76bhygrjzd4nj4mpzpgbnsddfzwry1933rcvjlqh6m"
+    "version": "2.17.0",
+    "hash": "sha256-LuTotFyrjbUf9hrVqNPVs443lizPgNINbKoHT4cfjYs="
   },
   {
     "pname": "YoutubeExplode",
-    "version": "6.3.16",
-    "sha256": "1f6d47g1qmmahx6pn2sp0fff7hsmdqwm7z09j47hs6r1yn9a7kyj"
+    "version": "6.5.3",
+    "hash": "sha256-fxmplhCjy9AMBs8uwH08OBBfo450l6qiTNdmvVqLDB8="
   }
 ]

--- a/pkgs/by-name/di/discordchatexporter-cli/package.nix
+++ b/pkgs/by-name/di/discordchatexporter-cli/package.nix
@@ -8,19 +8,19 @@
 
 buildDotnetModule rec {
   pname = "discordchatexporter-cli";
-  version = "2.43.3";
+  version = "2.44.2";
 
   src = fetchFromGitHub {
     owner = "tyrrrz";
     repo = "discordchatexporter";
     rev = version;
-    hash = "sha256-r9bvTgqKQY605BoUlysSz4WJMxn2ibNh3EhoMYCfV3c=";
+    hash = "sha256-Dc6OSWUTFftP2tyRFoxHm+TsnSMDfx627DhmYnPie9w=";
   };
 
   projectFile = "DiscordChatExporter.Cli/DiscordChatExporter.Cli.csproj";
   nugetDeps = ./deps.json;
-  dotnet-sdk = dotnetCorePackages.sdk_8_0;
-  dotnet-runtime = dotnetCorePackages.runtime_8_0;
+  dotnet-sdk = dotnetCorePackages.sdk_9_0;
+  dotnet-runtime = dotnetCorePackages.runtime_9_0;
 
   postFixup = ''
     ln -s $out/bin/DiscordChatExporter.Cli $out/bin/discordchatexporter-cli


### PR DESCRIPTION
Also updated to dotnet 9

Diff: https://github.com/tyrrrz/discordchatexporter/compare/2.43.3...2.44.2

Changelog: https://github.com/Tyrrrz/DiscordChatExporter/blob/2.44.2/Changelog.md


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
