### PR TITLE
code-cursor: 0.45.14 -> 0.47.8

### DIFF
--- a/pkgs/by-name/co/code-cursor/package.nix
+++ b/pkgs/by-name/co/code-cursor/package.nix
@@ -2,8 +2,48 @@
   lib,
   stdenvNoCC,
   fetchurl,
+
+  # build
   appimageTools,
+
+  # linux dependencies
+  alsa-lib,
+  at-spi2-atk,
+  autoPatchelfHook,
+  cairo,
+  cups,
+  curlWithGnuTls,
+  egl-wayland,
+  expat,
+  fontconfig,
+  freetype,
+  ffmpeg,
+  glib,
+  glibc,
+  glibcLocales,
+  gtk3,
+  libappindicator-gtk3,
+  libdrm,
+  libgbm,
+  libGL,
+  libnotify,
+  libva-minimal,
+  libxkbcommon,
+  libxkbfile,
   makeWrapper,
+  nspr,
+  nss,
+  pango,
+  pciutils,
+  pulseaudio,
+  vivaldi-ffmpeg-codecs,
+  vulkan-loader,
+  wayland,
+
+  # linux installation
+  rsync,
+
+  # darwin build
   undmg,
 }:
 let
@@ -37,6 +77,14 @@ let
   appimageContents = appimageTools.extractType2 {
     inherit version pname;
     src = source;
+
+    # Fix the missing keymap issue
+    postExtract = ''
+      echo $out
+      native_keymap="$out/usr/share/cursor/resources/app/node_modules/native-keymap"
+      ln -s $native_keymap/build/Release $native_keymap/build/Debug
+    '';
+
   };
 
   wrappedAppimage = appimageTools.wrapType2 {
@@ -51,8 +99,54 @@ stdenvNoCC.mkDerivation {
   src = if hostPlatform.isLinux then wrappedAppimage else source;
 
   nativeBuildInputs =
-    lib.optionals hostPlatform.isLinux [ makeWrapper ]
+    lib.optionals hostPlatform.isLinux [
+      autoPatchelfHook
+      glibcLocales
+      makeWrapper
+      rsync
+    ]
     ++ lib.optionals hostPlatform.isDarwin [ undmg ];
+
+  buildInputs = lib.optionals hostPlatform.isLinux [
+    alsa-lib
+    at-spi2-atk
+    cairo
+    cups
+    curlWithGnuTls
+    egl-wayland
+    expat
+    ffmpeg
+    glib
+    gtk3
+    libdrm
+    libgbm
+    libGL
+    libGL
+    libva-minimal
+    libxkbcommon
+    libxkbfile
+    nspr
+    nss
+    pango
+    pulseaudio
+    vivaldi-ffmpeg-codecs
+    vulkan-loader
+    wayland
+  ];
+
+  runtimeDependencies = lib.optionals hostPlatform.isLinux [
+    egl-wayland
+    ffmpeg
+    glibc
+    libappindicator-gtk3
+    libnotify
+    libxkbfile
+    pciutils
+    pulseaudio
+    wayland
+    fontconfig
+    freetype
+  ];
 
   sourceRoot = lib.optionalString hostPlatform.isDarwin ".";
 
@@ -67,13 +161,17 @@ stdenvNoCC.mkDerivation {
 
     ${lib.optionalString hostPlatform.isLinux ''
       cp -r bin $out/bin
-      mkdir -p $out/share/cursor
-      cp -a ${appimageContents}/locales $out/share/cursor
-      cp -a ${appimageContents}/resources $out/share/cursor
-      cp -a ${appimageContents}/usr/share/icons $out/share/
-      install -Dm 644 ${appimageContents}/cursor.desktop -t $out/share/applications/
+      # mkdir -p $out/share/cursor
+      # cp -ar ${appimageContents}/usr/share $out/
 
-      substituteInPlace $out/share/applications/cursor.desktop --replace-fail "AppRun" "cursor"
+      rsync -a -q ${appimageContents}/usr/share $out/ --exclude "*.so"
+
+      # # Replace the supplied libraries with nixpkgs versions
+      # rm $out/share/cursor/{libEGL.sl,libffmpeg.so,libGLESv2.so,libvk_swiftshader.so,libvulkan.so.1}
+      # ln -s ${egl-wayland}/lib/libEGL.so $out/share/cursor/libEGL.so
+
+      # Fix the desktop file to point to the correct location
+      substituteInPlace $out/share/applications/cursor.desktop --replace-fail "/usr/share/cursor/cursor" "$out/share/cursor/cursor"
 
       wrapProgram $out/bin/cursor \
         --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true}} --no-update"

--- a/pkgs/by-name/co/code-cursor/package.nix
+++ b/pkgs/by-name/co/code-cursor/package.nix
@@ -48,26 +48,27 @@
 }:
 let
   pname = "cursor";
-  version = "0.45.14";
+  version = "0.47.8";
 
   inherit (stdenvNoCC) hostPlatform;
 
   sources = {
     x86_64-linux = fetchurl {
-      url = "https://download.todesktop.com/230313mzl4w4u92/cursor-0.45.14-build-250219jnihavxsz-x86_64.AppImage";
-      hash = "sha256-5MGWJi8TP+13jZf6YMMUU5uYY/3OBTFxtGpirvgj8ZI=";
+      url = "https://downloads.cursor.com/production/82ef0f61c01d079d1b7e5ab04d88499d5af500e3/linux/x64/Cursor-0.47.8-82ef0f61c01d079d1b7e5ab04d88499d5af500e3.deb.glibc2.25-x86_64.AppImage";
+      hash = "sha256-3Ph5A+x1hW0SOaX8CF7b/8Fq7eMeBkG1ju9vud6Cbn0=";
     };
-    aarch64-linux = fetchurl {
-      url = "https://download.todesktop.com/230313mzl4w4u92/cursor-0.45.14-build-250219jnihavxsz-arm64.AppImage";
-      hash = "sha256-8OUlPuPNgqbGe2x7gG+m3n3u6UDvgnVekkjJ08pVORs=";
-    };
+    # Cursor's release for aarch64-linux is the wrong version (temporarily).
+    # aarch64-linux = fetchurl {
+    #   url = "https://download.todesktop.com/230313mzl4w4u92/cursor-0.45.14-build-250219jnihavxsz-arm64.AppImage";
+    #   hash = "sha256-8OUlPuPNgqbGe2x7gG+m3n3u6UDvgnVekkjJ08pVORs=";
+    # };
     x86_64-darwin = fetchurl {
-      url = "https://download.todesktop.com/230313mzl4w4u92/Cursor%200.45.14%20-%20Build%20250219jnihavxsz-x64.dmg";
-      hash = "sha256-NyDY74PZjSjpuTSVaO/l9adPcLX1kytyrFGQjJ/8WcQ=";
+      url = "https://downloads.cursor.com/production/82ef0f61c01d079d1b7e5ab04d88499d5af500e3/darwin/x64/Cursor-darwin-x64.dmg";
+      hash = "sha256-T5N8b/6HexQ2ZchWUb9CL3t9ks93O9WJgrDtxfE1SgU=";
     };
     aarch64-darwin = fetchurl {
-      url = "https://download.todesktop.com/230313mzl4w4u92/Cursor%200.45.14%20-%20Build%20250219jnihavxsz-arm64.dmg";
-      hash = "sha256-A503TxDDFENqMnc1hy/lMMyIgC7YwwRYPJy+tp649Eg=";
+      url = "https://downloads.cursor.com/production/82ef0f61c01d079d1b7e5ab04d88499d5af500e3/darwin/arm64/Cursor-darwin-arm64.dmg";
+      hash = "sha256-ycroylfEZY/KfRiXvfOuTdyyglbg/J7DU12u6Xrsk0s=";
     };
   };
 
@@ -77,14 +78,6 @@ let
   appimageContents = appimageTools.extractType2 {
     inherit version pname;
     src = source;
-
-    # Fix the missing keymap issue
-    postExtract = ''
-      echo $out
-      native_keymap="$out/usr/share/cursor/resources/app/node_modules/native-keymap"
-      ln -s $native_keymap/build/Release $native_keymap/build/Debug
-    '';
-
   };
 
   wrappedAppimage = appimageTools.wrapType2 {
@@ -166,10 +159,6 @@ stdenvNoCC.mkDerivation {
 
       rsync -a -q ${appimageContents}/usr/share $out/ --exclude "*.so"
 
-      # # Replace the supplied libraries with nixpkgs versions
-      # rm $out/share/cursor/{libEGL.sl,libffmpeg.so,libGLESv2.so,libvk_swiftshader.so,libvulkan.so.1}
-      # ln -s ${egl-wayland}/lib/libEGL.so $out/share/cursor/libEGL.so
-
       # Fix the desktop file to point to the correct location
       substituteInPlace $out/share/applications/cursor.desktop --replace-fail "/usr/share/cursor/cursor" "$out/share/cursor/cursor"
 
@@ -208,7 +197,13 @@ stdenvNoCC.mkDerivation {
       sarahec
       aspauldingcode
     ];
-    platforms = lib.platforms.linux ++ lib.platforms.darwin;
+    platforms = [
+      "x86_64-linux"
+      "x86_64-darwin"
+      "aarch64-darwin"
+    ];
+    # Temporary: Cursor doesn't supply a 0.47.8 build for aarch64-linux
+    badPlatforms = [ "aarch64-linux" ];
     mainProgram = "cursor";
   };
 }

--- a/pkgs/by-name/co/code-cursor/package.nix
+++ b/pkgs/by-name/co/code-cursor/package.nix
@@ -4,7 +4,6 @@
   fetchurl,
   appimageTools,
   makeWrapper,
-  writeScript,
   undmg,
 }:
 let
@@ -98,52 +97,7 @@ stdenvNoCC.mkDerivation {
 
   passthru = {
     inherit sources;
-    updateScript = writeScript "update.sh" ''
-      #!/usr/bin/env nix-shell
-      #!nix-shell -i bash -p curl yq coreutils gnused trurl common-updater-scripts
-      set -eu -o pipefail
-
-      baseUrl="https://download.todesktop.com/230313mzl4w4u92"
-      latestLinux="$(curl -s $baseUrl/latest-linux.yml)"
-      latestDarwin="$(curl -s $baseUrl/latest-mac.yml)"
-      linuxVersion="$(echo "$latestLinux" | yq -r .version)"
-
-      currentVersion=$(nix-instantiate --eval -E "with import ./. {}; code-cursor.version or (lib.getVersion code-cursor)" | tr -d '"')
-
-      if [[ "$linuxVersion" != "$currentVersion" ]]; then
-          darwinVersion="$(echo "$latestDarwin" | yq -r .version)"
-          if [ "$linuxVersion" != "$darwinVersion" ]; then
-              echo "Linux version ($linuxVersion) and Darwin version ($darwinVersion) do not match"
-              exit 1
-          fi
-          version="$linuxVersion"
-
-          linuxFilename="$(echo "$latestLinux" | yq -r '.files[] | .url | select(. | endswith(".AppImage"))' | head -n 1)"
-          linuxStem="$(echo "$linuxFilename" | sed -E s/^\(.+build.+\)-[^-]+AppImage$/\\1/)"
-
-          darwinFilename="$(echo "$latestDarwin" | yq -r '.files[] | .url | select(. | endswith(".dmg"))' | head -n 1)"
-          darwinStem="$(echo "$darwinFilename" | sed -E s/^\(.+Build[^-]+\)-.+dmg$/\\1/)"
-
-          for platform in  "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin"; do
-              if [ $platform = "x86_64-linux" ]; then
-                  url="$baseUrl/$linuxStem-x86_64.AppImage"
-              elif [ $platform = "aarch64-linux" ]; then
-                  url="$baseUrl/$linuxStem-arm64.AppImage"
-              elif [ $platform = "x86_64-darwin" ]; then
-                  url="$baseUrl/$darwinStem-x64.dmg"
-              elif [ $platform = "aarch64-darwin" ]; then
-                  url="$baseUrl/$darwinStem-arm64.dmg"
-              else
-                  echo "Unsupported platform: $platform"
-                  exit 1
-              fi
-
-              url=$(trurl --accept-space "$url")
-              hash=$(nix-hash --to-sri --type sha256 "$(nix-prefetch-url "$url" --name "cursor-$version")")
-              update-source-version code-cursor $version $hash $url --system=$platform --ignore-same-version --source-key="sources.$platform"
-          done
-      fi
-    '';
+    updateScript = ./update.sh;
   };
 
   meta = {

--- a/pkgs/by-name/co/code-cursor/update.sh
+++ b/pkgs/by-name/co/code-cursor/update.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p curl yq coreutils common-updater-scripts
+set -eu -o pipefail
+
+currentVersion=$(nix-instantiate --eval -E "with import ./. {}; code-cursor.version or (lib.getVersion code-cursor)" | tr -d '"')
+
+declare -A platforms=( [x86_64-linux]='linux-x64' [aarch64-linux]='linux-arm64' [x86_64-darwin]='darwin-x64' [aarch64-darwin]='darwin-arm64' )
+declare -A updates=( )
+first_version=""
+
+for platform in ${!platforms[@]}; do
+    api_platform=${platforms[$platform]}
+    result=$(curl -s "https://api2.cursor.sh/updates/api/download/stable/$api_platform/cursor")
+    version=$(echo $result | jq -r '.version')
+    if [[ "$version" == "$currentVersion" ]]; then
+      exit 0
+    fi
+    if [[ -z "$first_version" ]]; then
+      first_version=$version
+      first_platform=$platform
+    elif [[ "$version" != "$first_version" ]]; then
+      >&2 echo "Multiple versions found: $first_version ($first_platform) and $version ($platform)"
+      exit 1
+    fi
+    url=$(echo $result | jq -r '.downloadUrl')
+    # Exits with code 22 if not downloadable
+    curl --output /dev/null --silent --head --fail "$url"
+    updates+=( [$platform]="$result" )
+done
+
+# Install updates
+for platform in ${!updates[@]}; do
+  result=${updates[$platform]}
+  version=$(echo $result | jq -r '.version')
+  url=$(echo $result | jq -r '.downloadUrl')
+  source=$(nix-prefetch-url "$url" --name "cursor-$version")
+  hash=$(nix-hash --to-sri --type sha256 "$source")
+  update-source-version code-cursor $version $hash "$url" --system=$platform --ignore-same-version --source-key="sources.$platform"
+done


### PR DESCRIPTION
## Important -- please read

Track the status of this PR at https://nixpk.gs/pr-tracker.html?pr=393609

1. I know everybody has been waiting for a month after Cursor changed their build system. This release has some compromises:
  * This release omits aarch64-linux (just this one time). Cursor is shipping 0.47.9 for Linux and 0.47.8 for Darwin; I could get three of the four working at 0.47.8. 
  * Fixed the window creation errors.
  * Have not silenced the `Cannot find module './build/Debug/keymapping'` warning yet. ~~That file isn't in the source AppImage and I need to talk with the cursor team about it.~~ It's a known issue with Cursor, will be fixed on the next update here.
2. If you're not a regular nixpkgs maintainer, please don't add comments. These can delay or block PR approval.  

## Work done

1. Rewrote update script to use the supported API (with blessing from the Cursor team)
3. Changes to the installPhase to account for changes in the Linux AppImage.
4. Added missing runtime dependencies (this solves a host of display issues) 

Closes #391260
Closes #392555 
Closes #386176

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] ~~aarch64-linux~~
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
