### PR TITLE
lib/licenses: add aml

### DIFF
--- a/lib/licenses.nix
+++ b/lib/licenses.nix
@@ -95,6 +95,11 @@ lib.mapAttrs mkLicense ({
     free = false;
   };
 
+  aml = {
+    spdxId = "AML";
+    fullName = "Apple MIT License";
+  };
+
   ampas = {
     spdxId = "AMPAS";
     fullName = "Academy of Motion Picture Arts and Sciences BSD";


### PR DESCRIPTION
This adds the "Appple MIT License", also known as "Apple-Sample-Code-License".

Quoting the Fedora wiki:
> This is Apple's variant of MIT. They've added wording around patents,
> which is why it gets it own shortname. Apple did not give this license
> a name, so we've named it "Apple MIT License".
> It is free and GPL compatible.

References:
- https://developer.apple.com/support/downloads/terms/apple-sample-code/Apple-Sample-Code-License.pdf
- https://spdx.org/licenses/AML.html
- https://fedoraproject.org/wiki/Licensing/Apple_MIT_License

Required by https://github.com/NixOS/nixpkgs/pull/388735 (` python3Packages.unsloth`).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
