### PR TITLE
[Backport 24.11] jetbrains.plugins: update

### DIFF
--- a/pkgs/applications/editors/jetbrains/plugins/plugins.json
+++ b/pkgs/applications/editors/jetbrains/plugins/plugins.json
@@ -464,6 +464,39 @@
       },
       "name": "docker"
     },
+    "8097": {
+      "compatible": [
+        "clion",
+        "datagrip",
+        "goland",
+        "idea-community",
+        "idea-ultimate",
+        "mps",
+        "phpstorm",
+        "pycharm-community",
+        "pycharm-professional",
+        "rider",
+        "ruby-mine",
+        "rust-rover",
+        "webstorm"
+      ],
+      "builds": {
+        "243.21565.447": "https://plugins.jetbrains.com/files/8097/629964/graphql-243.21565.122.zip",
+        "243.22562.218": "https://plugins.jetbrains.com/files/8097/636616/graphql-243.22562.13.zip",
+        "243.22562.220": "https://plugins.jetbrains.com/files/8097/636616/graphql-243.22562.13.zip",
+        "243.23654.157": "https://plugins.jetbrains.com/files/8097/636616/graphql-243.22562.13.zip",
+        "243.23654.167": "https://plugins.jetbrains.com/files/8097/636616/graphql-243.22562.13.zip",
+        "243.23654.180": "https://plugins.jetbrains.com/files/8097/636616/graphql-243.22562.13.zip",
+        "243.23654.183": "https://plugins.jetbrains.com/files/8097/636616/graphql-243.22562.13.zip",
+        "243.24978.27": "https://plugins.jetbrains.com/files/8097/680200/graphql-243.24978.46.zip",
+        "243.24978.46": "https://plugins.jetbrains.com/files/8097/680200/graphql-243.24978.46.zip",
+        "243.24978.50": "https://plugins.jetbrains.com/files/8097/680200/graphql-243.24978.46.zip",
+        "243.24978.54": "https://plugins.jetbrains.com/files/8097/680200/graphql-243.24978.46.zip",
+        "243.24978.55": "https://plugins.jetbrains.com/files/8097/680200/graphql-243.24978.46.zip",
+        "243.24978.59": "https://plugins.jetbrains.com/files/8097/680200/graphql-243.24978.46.zip"
+      },
+      "name": "graphql"
+    },
     "8182": {
       "compatible": [
         "clion",
@@ -1940,6 +1973,9 @@
     "https://plugins.jetbrains.com/files/7724/654910/clouds-docker-impl-243.22562.236.zip": "sha256-3F25CTNLfQcUFklNXovLVXQ8cfOr/6Y5yetPc3jTFQM=",
     "https://plugins.jetbrains.com/files/7724/672289/clouds-docker-impl-243.23654.177.zip": "sha256-zTp+nL22jW/93GkpVUK39D0VWgPtqRvW/BdhMqnsy1o=",
     "https://plugins.jetbrains.com/files/7724/680796/clouds-docker-impl-243.24978.54.zip": "sha256-pGAUljrRizCer076iM1oKrNj54tN3VxSvYldfKAsqRE=",
+    "https://plugins.jetbrains.com/files/8097/629964/graphql-243.21565.122.zip": "sha256-oaFy2E3e1cQyjf4JKblnhUXqKbXmDugzDPZXJLphWQw=",
+    "https://plugins.jetbrains.com/files/8097/636616/graphql-243.22562.13.zip": "sha256-rr2pO0mIsqWXYZgwEhcQJlk0lQabxnIPxqRCGdTFaTw=",
+    "https://plugins.jetbrains.com/files/8097/680200/graphql-243.24978.46.zip": "sha256-RJELd6KPzlRu+UwWBPW1fN33Zj0PcgQ0hGCJ6+ii/fI=",
     "https://plugins.jetbrains.com/files/8195/630064/toml-243.21565.122.zip": "sha256-vKigewUGi06by9/6a9HbjN51zPAIafdk6w4MFG4kwG8=",
     "https://plugins.jetbrains.com/files/8195/672659/toml-243.23654.183.zip": "sha256-OFoWuz5z0BcZJqWkS+vkcD/Q0e5IUnQRY84/GEQQIb8=",
     "https://plugins.jetbrains.com/files/8327/615097/Minecraft_Development-2024.3-1.8.2.zip": "sha256-4c1nxjbEsNs9twmQnJllk1OIVmm0nnUYZ0R7f/6bJt4=",

--- a/pkgs/applications/editors/jetbrains/plugins/plugins.json
+++ b/pkgs/applications/editors/jetbrains/plugins/plugins.json
@@ -431,6 +431,39 @@
       },
       "name": "gittoolbox"
     },
+    "7724": {
+      "compatible": [
+        "clion",
+        "datagrip",
+        "goland",
+        "idea-community",
+        "idea-ultimate",
+        "mps",
+        "phpstorm",
+        "pycharm-community",
+        "pycharm-professional",
+        "rider",
+        "ruby-mine",
+        "rust-rover",
+        "webstorm"
+      ],
+      "builds": {
+        "243.21565.447": null,
+        "243.22562.218": "https://plugins.jetbrains.com/files/7724/654910/clouds-docker-impl-243.22562.236.zip",
+        "243.22562.220": "https://plugins.jetbrains.com/files/7724/654910/clouds-docker-impl-243.22562.236.zip",
+        "243.23654.157": "https://plugins.jetbrains.com/files/7724/672289/clouds-docker-impl-243.23654.177.zip",
+        "243.23654.167": "https://plugins.jetbrains.com/files/7724/672289/clouds-docker-impl-243.23654.177.zip",
+        "243.23654.180": "https://plugins.jetbrains.com/files/7724/672289/clouds-docker-impl-243.23654.177.zip",
+        "243.23654.183": "https://plugins.jetbrains.com/files/7724/672289/clouds-docker-impl-243.23654.177.zip",
+        "243.24978.27": "https://plugins.jetbrains.com/files/7724/680796/clouds-docker-impl-243.24978.54.zip",
+        "243.24978.46": "https://plugins.jetbrains.com/files/7724/680796/clouds-docker-impl-243.24978.54.zip",
+        "243.24978.50": "https://plugins.jetbrains.com/files/7724/680796/clouds-docker-impl-243.24978.54.zip",
+        "243.24978.54": "https://plugins.jetbrains.com/files/7724/680796/clouds-docker-impl-243.24978.54.zip",
+        "243.24978.55": "https://plugins.jetbrains.com/files/7724/680796/clouds-docker-impl-243.24978.54.zip",
+        "243.24978.59": "https://plugins.jetbrains.com/files/7724/680796/clouds-docker-impl-243.24978.54.zip"
+      },
+      "name": "docker"
+    },
     "8182": {
       "compatible": [
         "clion",
@@ -1870,6 +1903,9 @@
     "https://plugins.jetbrains.com/files/7391/658997/asciidoctor-intellij-plugin-0.43.6.zip": "sha256-3RJ7YVFtynyqeLIzdrirCMbWNZmUkJ+DT/9my71H0Dk=",
     "https://plugins.jetbrains.com/files/7425/603907/WakaTime.jar": "sha256-Z7ZWDomXnTdHFKOElMkt53imef6aT7H5XeD6lOOFxfQ=",
     "https://plugins.jetbrains.com/files/7499/667439/gittoolbox-600.0.14_243-signed.zip": "sha256-rpJ0tPIf3mw5KLSv+wx16mXVKA1PxKTktgCYzKU3cU4=",
+    "https://plugins.jetbrains.com/files/7724/654910/clouds-docker-impl-243.22562.236.zip": "sha256-3F25CTNLfQcUFklNXovLVXQ8cfOr/6Y5yetPc3jTFQM=",
+    "https://plugins.jetbrains.com/files/7724/672289/clouds-docker-impl-243.23654.177.zip": "sha256-zTp+nL22jW/93GkpVUK39D0VWgPtqRvW/BdhMqnsy1o=",
+    "https://plugins.jetbrains.com/files/7724/680796/clouds-docker-impl-243.24978.54.zip": "sha256-pGAUljrRizCer076iM1oKrNj54tN3VxSvYldfKAsqRE=",
     "https://plugins.jetbrains.com/files/8195/630064/toml-243.21565.122.zip": "sha256-vKigewUGi06by9/6a9HbjN51zPAIafdk6w4MFG4kwG8=",
     "https://plugins.jetbrains.com/files/8195/672659/toml-243.23654.183.zip": "sha256-OFoWuz5z0BcZJqWkS+vkcD/Q0e5IUnQRY84/GEQQIb8=",
     "https://plugins.jetbrains.com/files/8327/615097/Minecraft_Development-2024.3-1.8.2.zip": "sha256-4c1nxjbEsNs9twmQnJllk1OIVmm0nnUYZ0R7f/6bJt4=",

--- a/pkgs/applications/editors/jetbrains/plugins/plugins.json
+++ b/pkgs/applications/editors/jetbrains/plugins/plugins.json
@@ -878,6 +878,39 @@
       },
       "name": "dot-language"
     },
+    "10481": {
+      "compatible": [
+        "clion",
+        "datagrip",
+        "goland",
+        "idea-community",
+        "idea-ultimate",
+        "mps",
+        "phpstorm",
+        "pycharm-community",
+        "pycharm-professional",
+        "rider",
+        "ruby-mine",
+        "rust-rover",
+        "webstorm"
+      ],
+      "builds": {
+        "243.21565.447": "https://plugins.jetbrains.com/files/10481/583591/intellij-hocon-2024.2.0.zip",
+        "243.22562.218": "https://plugins.jetbrains.com/files/10481/583591/intellij-hocon-2024.2.0.zip",
+        "243.22562.220": "https://plugins.jetbrains.com/files/10481/583591/intellij-hocon-2024.2.0.zip",
+        "243.23654.157": "https://plugins.jetbrains.com/files/10481/583591/intellij-hocon-2024.2.0.zip",
+        "243.23654.167": "https://plugins.jetbrains.com/files/10481/583591/intellij-hocon-2024.2.0.zip",
+        "243.23654.180": "https://plugins.jetbrains.com/files/10481/583591/intellij-hocon-2024.2.0.zip",
+        "243.23654.183": "https://plugins.jetbrains.com/files/10481/583591/intellij-hocon-2024.2.0.zip",
+        "243.24978.27": "https://plugins.jetbrains.com/files/10481/583591/intellij-hocon-2024.2.0.zip",
+        "243.24978.46": "https://plugins.jetbrains.com/files/10481/583591/intellij-hocon-2024.2.0.zip",
+        "243.24978.50": "https://plugins.jetbrains.com/files/10481/583591/intellij-hocon-2024.2.0.zip",
+        "243.24978.54": "https://plugins.jetbrains.com/files/10481/583591/intellij-hocon-2024.2.0.zip",
+        "243.24978.55": "https://plugins.jetbrains.com/files/10481/583591/intellij-hocon-2024.2.0.zip",
+        "243.24978.59": "https://plugins.jetbrains.com/files/10481/583591/intellij-hocon-2024.2.0.zip"
+      },
+      "name": "hocon"
+    },
     "11058": {
       "compatible": [
         "clion",
@@ -1846,6 +1879,7 @@
     "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip": "sha256-frvQ+Dm1ueID6+vNlja0HtecGyn+ppq9GTgmU3kQ+58=",
     "https://plugins.jetbrains.com/files/10080/645834/intellij-rainbow-brackets-2024.2.8-241.zip": "sha256-IWRvV8NDYnoxxvQVOf3K3pueD+Hp7ctaWOmFHnaVTJg=",
     "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip": "sha256-25vtwXuBNiYL9E0pKG4dqJDkwX1FckAErdqRPKXybQA=",
+    "https://plugins.jetbrains.com/files/10481/583591/intellij-hocon-2024.2.0.zip": "sha256-Bnnvy+HDNkx2DQM7N+JUa8hQzIA3H/5Y0WpWAjPmhUI=",
     "https://plugins.jetbrains.com/files/11058/668614/Extra_Icons-2025.1.1.zip": "sha256-bQHgzbSUh7cZEzVGrZQxUJ+fGY7GB4Sy5izwadkkQiQ=",
     "https://plugins.jetbrains.com/files/11349/684473/aws-toolkit-jetbrains-standalone-3.56-243.zip": "sha256-f3NJXTqUxLh0O78UhJP+WAu1CYXGo+3x03z0MYobUVI=",
     "https://plugins.jetbrains.com/files/12024/622380/ReSharperPlugin.CognitiveComplexity-2024.3.0-eap04.zip": "sha256-X2x7uyWoV4aBI8E5bw35QfzmySWzbEAZ2nvdo5i+t+s=",

--- a/pkgs/applications/editors/jetbrains/plugins/plugins.json
+++ b/pkgs/applications/editors/jetbrains/plugins/plugins.json
@@ -1415,6 +1415,39 @@
       },
       "name": "netbeans-6-5-keymap"
     },
+    "18682": {
+      "compatible": [
+        "clion",
+        "datagrip",
+        "goland",
+        "idea-community",
+        "idea-ultimate",
+        "mps",
+        "phpstorm",
+        "pycharm-community",
+        "pycharm-professional",
+        "rider",
+        "ruby-mine",
+        "rust-rover",
+        "webstorm"
+      ],
+      "builds": {
+        "243.21565.447": "https://plugins.jetbrains.com/files/18682/680233/Catppuccin_Theme-3.4.1.zip",
+        "243.22562.218": "https://plugins.jetbrains.com/files/18682/680233/Catppuccin_Theme-3.4.1.zip",
+        "243.22562.220": "https://plugins.jetbrains.com/files/18682/680233/Catppuccin_Theme-3.4.1.zip",
+        "243.23654.157": "https://plugins.jetbrains.com/files/18682/680233/Catppuccin_Theme-3.4.1.zip",
+        "243.23654.167": "https://plugins.jetbrains.com/files/18682/680233/Catppuccin_Theme-3.4.1.zip",
+        "243.23654.180": "https://plugins.jetbrains.com/files/18682/680233/Catppuccin_Theme-3.4.1.zip",
+        "243.23654.183": "https://plugins.jetbrains.com/files/18682/680233/Catppuccin_Theme-3.4.1.zip",
+        "243.24978.27": "https://plugins.jetbrains.com/files/18682/680233/Catppuccin_Theme-3.4.1.zip",
+        "243.24978.46": "https://plugins.jetbrains.com/files/18682/680233/Catppuccin_Theme-3.4.1.zip",
+        "243.24978.50": "https://plugins.jetbrains.com/files/18682/680233/Catppuccin_Theme-3.4.1.zip",
+        "243.24978.54": "https://plugins.jetbrains.com/files/18682/680233/Catppuccin_Theme-3.4.1.zip",
+        "243.24978.55": "https://plugins.jetbrains.com/files/18682/680233/Catppuccin_Theme-3.4.1.zip",
+        "243.24978.59": "https://plugins.jetbrains.com/files/18682/680233/Catppuccin_Theme-3.4.1.zip"
+      },
+      "name": "catppuccin-theme"
+    },
     "18824": {
       "compatible": [
         "clion",
@@ -1932,6 +1965,7 @@
     "https://plugins.jetbrains.com/files/16604/671364/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.3.zip": "sha256-U2kNQtumZ71+G3maxxXPVsLL8Q+8YonpC4ejr1DYMbo=",
     "https://plugins.jetbrains.com/files/17718/683782/github-copilot-intellij-1.5.35-242.zip": "sha256-XySBxVlZLPTj1Y3urLpfgkrYwt/y12hX0oCK1p0Vdx0=",
     "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip": "sha256-KrzZTKZMQqoEMw+vDUv2jjs0EX0leaPBkU8H/ecq/oI=",
+    "https://plugins.jetbrains.com/files/18682/680233/Catppuccin_Theme-3.4.1.zip": "sha256-QOF3nAXOfYhNl3YUK1fc9z5H2uXTPm2X+6fVZ5QP8ZQ=",
     "https://plugins.jetbrains.com/files/18824/671527/CodeGlancePro-1.9.6-signed.zip": "sha256-AEHZxuRMBEZlT3xTxBUbHEPjEJBOCLxdj1wEYBzlNdk=",
     "https://plugins.jetbrains.com/files/18922/685255/GerryThemes.jar": "sha256-GROc7EiggdGHUQknzduildmchx3axkoij1Zqwqqm76I=",
     "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip": "sha256-hoFfIid7lClHDiT+ZH3H+tFSvWYb1tSRZH1iif+kWrM=",

--- a/pkgs/applications/editors/jetbrains/plugins/plugins.json
+++ b/pkgs/applications/editors/jetbrains/plugins/plugins.json
@@ -1783,6 +1783,39 @@
       },
       "name": "gitlab"
     },
+    "23029": {
+      "compatible": [
+        "clion",
+        "datagrip",
+        "goland",
+        "idea-community",
+        "idea-ultimate",
+        "mps",
+        "phpstorm",
+        "pycharm-community",
+        "pycharm-professional",
+        "rider",
+        "ruby-mine",
+        "rust-rover",
+        "webstorm"
+      ],
+      "builds": {
+        "243.21565.447": "https://plugins.jetbrains.com/files/23029/650304/Catppuccin_Icons-1.10.1.zip",
+        "243.22562.218": "https://plugins.jetbrains.com/files/23029/650304/Catppuccin_Icons-1.10.1.zip",
+        "243.22562.220": "https://plugins.jetbrains.com/files/23029/650304/Catppuccin_Icons-1.10.1.zip",
+        "243.23654.157": "https://plugins.jetbrains.com/files/23029/650304/Catppuccin_Icons-1.10.1.zip",
+        "243.23654.167": "https://plugins.jetbrains.com/files/23029/650304/Catppuccin_Icons-1.10.1.zip",
+        "243.23654.180": "https://plugins.jetbrains.com/files/23029/650304/Catppuccin_Icons-1.10.1.zip",
+        "243.23654.183": "https://plugins.jetbrains.com/files/23029/650304/Catppuccin_Icons-1.10.1.zip",
+        "243.24978.27": "https://plugins.jetbrains.com/files/23029/650304/Catppuccin_Icons-1.10.1.zip",
+        "243.24978.46": "https://plugins.jetbrains.com/files/23029/650304/Catppuccin_Icons-1.10.1.zip",
+        "243.24978.50": "https://plugins.jetbrains.com/files/23029/650304/Catppuccin_Icons-1.10.1.zip",
+        "243.24978.54": "https://plugins.jetbrains.com/files/23029/650304/Catppuccin_Icons-1.10.1.zip",
+        "243.24978.55": "https://plugins.jetbrains.com/files/23029/650304/Catppuccin_Icons-1.10.1.zip",
+        "243.24978.59": "https://plugins.jetbrains.com/files/23029/650304/Catppuccin_Icons-1.10.1.zip"
+      },
+      "name": "catppuccin-icons"
+    },
     "23043": {
       "compatible": [
         "clion",
@@ -1981,6 +2014,7 @@
     "https://plugins.jetbrains.com/files/22857/633914/vcs-gitlab-243.21565.204.zip": "sha256-dnnbmo9OILtgVr8vXGSqQ6uSGDfxbrPptToAMs9SPRM=",
     "https://plugins.jetbrains.com/files/22857/640903/vcs-gitlab-243.22562.53.zip": "sha256-lDStIaRy9ZtCXZxM2RRrz/5oZeL90aRVS63wC4XkJNw=",
     "https://plugins.jetbrains.com/files/22857/654839/vcs-gitlab-243.23654.19.zip": "sha256-VKGZLlL8ALjr6JEQtjhXiIxNrnTPXIoXMToJkJux2dw=",
+    "https://plugins.jetbrains.com/files/23029/650304/Catppuccin_Icons-1.10.1.zip": "sha256-HFELG8i+EQtr97y87sBwqPMmTxexIfJH1DRXTmlOytw=",
     "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip": "sha256-ssaSY1I6FopLBgVKHUyjBrqzxHLSuI/swtDfQWJ7gxU=",
     "https://plugins.jetbrains.com/files/23927/668616/Extra_IDE_Tweaks-2025.1.1.zip": "sha256-nOPYnvLuApgpQwHBhRE3MJLDl2pE4bCz/6XHQQTZfA8=",
     "https://plugins.jetbrains.com/files/24559/672148/Extra_Tools_Pack-2025.1.2.zip": "sha256-U3gxwqLNGWNM26gTLJ7Q/9pBf9hbriSPvMvrE8EZVmc=",

--- a/pkgs/applications/editors/jetbrains/plugins/plugins.json
+++ b/pkgs/applications/editors/jetbrains/plugins/plugins.json
@@ -21,15 +21,15 @@
         "243.22562.220": "https://plugins.jetbrains.com/files/164/676777/IdeaVIM-2.19.0.zip",
         "243.24978.546": "https://plugins.jetbrains.com/files/164/676777/IdeaVIM-2.19.0.zip",
         "243.24978.79": "https://plugins.jetbrains.com/files/164/676777/IdeaVIM-2.19.0.zip",
-        "243.24978.86": "https://plugins.jetbrains.com/files/164/676777/IdeaVIM-2.19.0.zip",
         "243.25659.34": "https://plugins.jetbrains.com/files/164/676777/IdeaVIM-2.19.0.zip",
-        "243.25659.39": "https://plugins.jetbrains.com/files/164/676777/IdeaVIM-2.19.0.zip",
         "243.25659.40": "https://plugins.jetbrains.com/files/164/676777/IdeaVIM-2.19.0.zip",
         "243.25659.41": "https://plugins.jetbrains.com/files/164/676777/IdeaVIM-2.19.0.zip",
         "243.25659.42": "https://plugins.jetbrains.com/files/164/676777/IdeaVIM-2.19.0.zip",
         "243.25659.43": "https://plugins.jetbrains.com/files/164/676777/IdeaVIM-2.19.0.zip",
         "243.25659.45": "https://plugins.jetbrains.com/files/164/676777/IdeaVIM-2.19.0.zip",
-        "243.25659.52": "https://plugins.jetbrains.com/files/164/676777/IdeaVIM-2.19.0.zip"
+        "243.25659.52": "https://plugins.jetbrains.com/files/164/676777/IdeaVIM-2.19.0.zip",
+        "243.25659.54": "https://plugins.jetbrains.com/files/164/676777/IdeaVIM-2.19.0.zip",
+        "243.25659.59": "https://plugins.jetbrains.com/files/164/676777/IdeaVIM-2.19.0.zip"
       },
       "name": "ideavim"
     },
@@ -38,7 +38,7 @@
         "idea-ultimate"
       ],
       "builds": {
-        "243.25659.39": "https://plugins.jetbrains.com/files/631/688719/python-243.25659.39.zip"
+        "243.25659.59": "https://plugins.jetbrains.com/files/631/692278/python-243.25659.59.zip"
       },
       "name": "python"
     },
@@ -49,7 +49,7 @@
       ],
       "builds": {
         "243.22562.218": "https://plugins.jetbrains.com/files/1347/667258/scala-intellij-bin-2024.3.35.zip",
-        "243.25659.39": "https://plugins.jetbrains.com/files/1347/681279/scala-intellij-bin-2024.3.38.zip"
+        "243.25659.59": "https://plugins.jetbrains.com/files/1347/681279/scala-intellij-bin-2024.3.38.zip"
       },
       "name": "scala"
     },
@@ -74,15 +74,15 @@
         "243.22562.220": "https://plugins.jetbrains.com/files/2162/640476/StringManipulation-9.15.0.zip",
         "243.24978.546": "https://plugins.jetbrains.com/files/2162/640476/StringManipulation-9.15.0.zip",
         "243.24978.79": "https://plugins.jetbrains.com/files/2162/640476/StringManipulation-9.15.0.zip",
-        "243.24978.86": "https://plugins.jetbrains.com/files/2162/640476/StringManipulation-9.15.0.zip",
         "243.25659.34": "https://plugins.jetbrains.com/files/2162/640476/StringManipulation-9.15.0.zip",
-        "243.25659.39": "https://plugins.jetbrains.com/files/2162/640476/StringManipulation-9.15.0.zip",
         "243.25659.40": "https://plugins.jetbrains.com/files/2162/640476/StringManipulation-9.15.0.zip",
         "243.25659.41": "https://plugins.jetbrains.com/files/2162/640476/StringManipulation-9.15.0.zip",
         "243.25659.42": "https://plugins.jetbrains.com/files/2162/640476/StringManipulation-9.15.0.zip",
         "243.25659.43": "https://plugins.jetbrains.com/files/2162/640476/StringManipulation-9.15.0.zip",
         "243.25659.45": "https://plugins.jetbrains.com/files/2162/640476/StringManipulation-9.15.0.zip",
-        "243.25659.52": "https://plugins.jetbrains.com/files/2162/640476/StringManipulation-9.15.0.zip"
+        "243.25659.52": "https://plugins.jetbrains.com/files/2162/640476/StringManipulation-9.15.0.zip",
+        "243.25659.54": "https://plugins.jetbrains.com/files/2162/640476/StringManipulation-9.15.0.zip",
+        "243.25659.59": "https://plugins.jetbrains.com/files/2162/640476/StringManipulation-9.15.0.zip"
       },
       "name": "string-manipulation"
     },
@@ -107,15 +107,15 @@
         "243.22562.220": "https://plugins.jetbrains.com/files/6884/630038/handlebars-243.21565.122.zip",
         "243.24978.546": "https://plugins.jetbrains.com/files/6884/630038/handlebars-243.21565.122.zip",
         "243.24978.79": "https://plugins.jetbrains.com/files/6884/630038/handlebars-243.21565.122.zip",
-        "243.24978.86": "https://plugins.jetbrains.com/files/6884/630038/handlebars-243.21565.122.zip",
         "243.25659.34": "https://plugins.jetbrains.com/files/6884/630038/handlebars-243.21565.122.zip",
-        "243.25659.39": "https://plugins.jetbrains.com/files/6884/630038/handlebars-243.21565.122.zip",
         "243.25659.40": "https://plugins.jetbrains.com/files/6884/630038/handlebars-243.21565.122.zip",
         "243.25659.41": "https://plugins.jetbrains.com/files/6884/630038/handlebars-243.21565.122.zip",
         "243.25659.42": "https://plugins.jetbrains.com/files/6884/630038/handlebars-243.21565.122.zip",
         "243.25659.43": "https://plugins.jetbrains.com/files/6884/630038/handlebars-243.21565.122.zip",
         "243.25659.45": "https://plugins.jetbrains.com/files/6884/630038/handlebars-243.21565.122.zip",
-        "243.25659.52": "https://plugins.jetbrains.com/files/6884/630038/handlebars-243.21565.122.zip"
+        "243.25659.52": "https://plugins.jetbrains.com/files/6884/630038/handlebars-243.21565.122.zip",
+        "243.25659.54": "https://plugins.jetbrains.com/files/6884/630038/handlebars-243.21565.122.zip",
+        "243.25659.59": "https://plugins.jetbrains.com/files/6884/630038/handlebars-243.21565.122.zip"
       },
       "name": "handlebars-mustache"
     },
@@ -140,15 +140,15 @@
         "243.22562.220": null,
         "243.24978.546": null,
         "243.24978.79": null,
-        "243.24978.86": null,
         "243.25659.34": null,
-        "243.25659.39": null,
         "243.25659.40": null,
         "243.25659.41": null,
         "243.25659.42": null,
         "243.25659.43": null,
         "243.25659.45": null,
-        "243.25659.52": null
+        "243.25659.52": null,
+        "243.25659.54": null,
+        "243.25659.59": null
       },
       "name": "kotlin"
     },
@@ -173,15 +173,15 @@
         "243.22562.220": "https://plugins.jetbrains.com/files/6981/654905/ini-243.22562.236.zip",
         "243.24978.546": "https://plugins.jetbrains.com/files/6981/680778/ini-243.24978.60.zip",
         "243.24978.79": "https://plugins.jetbrains.com/files/6981/680778/ini-243.24978.60.zip",
-        "243.24978.86": "https://plugins.jetbrains.com/files/6981/680778/ini-243.24978.60.zip",
-        "243.25659.34": "https://plugins.jetbrains.com/files/6981/689219/ini-243.25659.45.zip",
-        "243.25659.39": "https://plugins.jetbrains.com/files/6981/689219/ini-243.25659.45.zip",
-        "243.25659.40": "https://plugins.jetbrains.com/files/6981/689219/ini-243.25659.45.zip",
-        "243.25659.41": "https://plugins.jetbrains.com/files/6981/689219/ini-243.25659.45.zip",
-        "243.25659.42": "https://plugins.jetbrains.com/files/6981/689219/ini-243.25659.45.zip",
-        "243.25659.43": "https://plugins.jetbrains.com/files/6981/689219/ini-243.25659.45.zip",
-        "243.25659.45": "https://plugins.jetbrains.com/files/6981/689219/ini-243.25659.45.zip",
-        "243.25659.52": "https://plugins.jetbrains.com/files/6981/689219/ini-243.25659.45.zip"
+        "243.25659.34": "https://plugins.jetbrains.com/files/6981/690635/ini-243.25659.54.zip",
+        "243.25659.40": "https://plugins.jetbrains.com/files/6981/690635/ini-243.25659.54.zip",
+        "243.25659.41": "https://plugins.jetbrains.com/files/6981/690635/ini-243.25659.54.zip",
+        "243.25659.42": "https://plugins.jetbrains.com/files/6981/690635/ini-243.25659.54.zip",
+        "243.25659.43": "https://plugins.jetbrains.com/files/6981/690635/ini-243.25659.54.zip",
+        "243.25659.45": "https://plugins.jetbrains.com/files/6981/690635/ini-243.25659.54.zip",
+        "243.25659.52": "https://plugins.jetbrains.com/files/6981/690635/ini-243.25659.54.zip",
+        "243.25659.54": "https://plugins.jetbrains.com/files/6981/690635/ini-243.25659.54.zip",
+        "243.25659.59": "https://plugins.jetbrains.com/files/6981/690635/ini-243.25659.54.zip"
       },
       "name": "ini"
     },
@@ -206,15 +206,15 @@
         "243.22562.220": "https://plugins.jetbrains.com/files/7086/518678/AceJump.zip",
         "243.24978.546": "https://plugins.jetbrains.com/files/7086/518678/AceJump.zip",
         "243.24978.79": "https://plugins.jetbrains.com/files/7086/518678/AceJump.zip",
-        "243.24978.86": "https://plugins.jetbrains.com/files/7086/518678/AceJump.zip",
         "243.25659.34": "https://plugins.jetbrains.com/files/7086/518678/AceJump.zip",
-        "243.25659.39": "https://plugins.jetbrains.com/files/7086/518678/AceJump.zip",
         "243.25659.40": "https://plugins.jetbrains.com/files/7086/518678/AceJump.zip",
         "243.25659.41": "https://plugins.jetbrains.com/files/7086/518678/AceJump.zip",
         "243.25659.42": "https://plugins.jetbrains.com/files/7086/518678/AceJump.zip",
         "243.25659.43": "https://plugins.jetbrains.com/files/7086/518678/AceJump.zip",
         "243.25659.45": "https://plugins.jetbrains.com/files/7086/518678/AceJump.zip",
-        "243.25659.52": "https://plugins.jetbrains.com/files/7086/518678/AceJump.zip"
+        "243.25659.52": "https://plugins.jetbrains.com/files/7086/518678/AceJump.zip",
+        "243.25659.54": "https://plugins.jetbrains.com/files/7086/518678/AceJump.zip",
+        "243.25659.59": "https://plugins.jetbrains.com/files/7086/518678/AceJump.zip"
       },
       "name": "acejump"
     },
@@ -239,15 +239,15 @@
         "243.22562.220": "https://plugins.jetbrains.com/files/7125/627704/GrepConsole-13.2.0-IJ2023.3.zip",
         "243.24978.546": "https://plugins.jetbrains.com/files/7125/627704/GrepConsole-13.2.0-IJ2023.3.zip",
         "243.24978.79": "https://plugins.jetbrains.com/files/7125/627704/GrepConsole-13.2.0-IJ2023.3.zip",
-        "243.24978.86": "https://plugins.jetbrains.com/files/7125/627704/GrepConsole-13.2.0-IJ2023.3.zip",
         "243.25659.34": "https://plugins.jetbrains.com/files/7125/627704/GrepConsole-13.2.0-IJ2023.3.zip",
-        "243.25659.39": "https://plugins.jetbrains.com/files/7125/627704/GrepConsole-13.2.0-IJ2023.3.zip",
         "243.25659.40": "https://plugins.jetbrains.com/files/7125/627704/GrepConsole-13.2.0-IJ2023.3.zip",
         "243.25659.41": "https://plugins.jetbrains.com/files/7125/627704/GrepConsole-13.2.0-IJ2023.3.zip",
         "243.25659.42": "https://plugins.jetbrains.com/files/7125/627704/GrepConsole-13.2.0-IJ2023.3.zip",
         "243.25659.43": "https://plugins.jetbrains.com/files/7125/627704/GrepConsole-13.2.0-IJ2023.3.zip",
         "243.25659.45": "https://plugins.jetbrains.com/files/7125/627704/GrepConsole-13.2.0-IJ2023.3.zip",
-        "243.25659.52": "https://plugins.jetbrains.com/files/7125/627704/GrepConsole-13.2.0-IJ2023.3.zip"
+        "243.25659.52": "https://plugins.jetbrains.com/files/7125/627704/GrepConsole-13.2.0-IJ2023.3.zip",
+        "243.25659.54": "https://plugins.jetbrains.com/files/7125/627704/GrepConsole-13.2.0-IJ2023.3.zip",
+        "243.25659.59": "https://plugins.jetbrains.com/files/7125/627704/GrepConsole-13.2.0-IJ2023.3.zip"
       },
       "name": "grep-console"
     },
@@ -272,15 +272,15 @@
         "243.22562.220": "https://plugins.jetbrains.com/files/7177/636663/fileWatcher-243.22562.13.zip",
         "243.24978.546": "https://plugins.jetbrains.com/files/7177/654841/fileWatcher-243.23654.19.zip",
         "243.24978.79": "https://plugins.jetbrains.com/files/7177/654841/fileWatcher-243.23654.19.zip",
-        "243.24978.86": "https://plugins.jetbrains.com/files/7177/654841/fileWatcher-243.23654.19.zip",
         "243.25659.34": "https://plugins.jetbrains.com/files/7177/654841/fileWatcher-243.23654.19.zip",
-        "243.25659.39": "https://plugins.jetbrains.com/files/7177/654841/fileWatcher-243.23654.19.zip",
         "243.25659.40": "https://plugins.jetbrains.com/files/7177/654841/fileWatcher-243.23654.19.zip",
         "243.25659.41": "https://plugins.jetbrains.com/files/7177/654841/fileWatcher-243.23654.19.zip",
         "243.25659.42": "https://plugins.jetbrains.com/files/7177/654841/fileWatcher-243.23654.19.zip",
         "243.25659.43": "https://plugins.jetbrains.com/files/7177/654841/fileWatcher-243.23654.19.zip",
         "243.25659.45": "https://plugins.jetbrains.com/files/7177/654841/fileWatcher-243.23654.19.zip",
-        "243.25659.52": "https://plugins.jetbrains.com/files/7177/654841/fileWatcher-243.23654.19.zip"
+        "243.25659.52": "https://plugins.jetbrains.com/files/7177/654841/fileWatcher-243.23654.19.zip",
+        "243.25659.54": "https://plugins.jetbrains.com/files/7177/654841/fileWatcher-243.23654.19.zip",
+        "243.25659.59": "https://plugins.jetbrains.com/files/7177/654841/fileWatcher-243.23654.19.zip"
       },
       "name": "file-watchers"
     },
@@ -290,8 +290,8 @@
         "phpstorm"
       ],
       "builds": {
-        "243.25659.39": "https://plugins.jetbrains.com/files/7219/605730/Symfony_Plugin-2024.1.276.zip",
-        "243.25659.45": "https://plugins.jetbrains.com/files/7219/605730/Symfony_Plugin-2024.1.276.zip"
+        "243.25659.45": "https://plugins.jetbrains.com/files/7219/605730/Symfony_Plugin-2024.1.276.zip",
+        "243.25659.59": "https://plugins.jetbrains.com/files/7219/605730/Symfony_Plugin-2024.1.276.zip"
       },
       "name": "symfony-support"
     },
@@ -301,8 +301,8 @@
         "phpstorm"
       ],
       "builds": {
-        "243.25659.39": "https://plugins.jetbrains.com/files/7320/630497/PHP_Annotations-11.1.1.zip",
-        "243.25659.45": "https://plugins.jetbrains.com/files/7320/630497/PHP_Annotations-11.1.1.zip"
+        "243.25659.45": "https://plugins.jetbrains.com/files/7320/630497/PHP_Annotations-11.1.1.zip",
+        "243.25659.59": "https://plugins.jetbrains.com/files/7320/630497/PHP_Annotations-11.1.1.zip"
       },
       "name": "php-annotations"
     },
@@ -322,13 +322,13 @@
         "243.22562.218": "https://plugins.jetbrains.com/files/7322/646590/python-ce-243.22562.145.zip",
         "243.22562.220": "https://plugins.jetbrains.com/files/7322/646590/python-ce-243.22562.145.zip",
         "243.24978.79": "https://plugins.jetbrains.com/files/7322/680217/python-ce-243.24978.46.zip",
-        "243.24978.86": "https://plugins.jetbrains.com/files/7322/680217/python-ce-243.24978.46.zip",
         "243.25659.34": "https://plugins.jetbrains.com/files/7322/680217/python-ce-243.24978.46.zip",
-        "243.25659.39": "https://plugins.jetbrains.com/files/7322/680217/python-ce-243.24978.46.zip",
         "243.25659.40": "https://plugins.jetbrains.com/files/7322/680217/python-ce-243.24978.46.zip",
         "243.25659.42": "https://plugins.jetbrains.com/files/7322/680217/python-ce-243.24978.46.zip",
         "243.25659.43": "https://plugins.jetbrains.com/files/7322/680217/python-ce-243.24978.46.zip",
-        "243.25659.52": "https://plugins.jetbrains.com/files/7322/680217/python-ce-243.24978.46.zip"
+        "243.25659.52": "https://plugins.jetbrains.com/files/7322/680217/python-ce-243.24978.46.zip",
+        "243.25659.54": "https://plugins.jetbrains.com/files/7322/680217/python-ce-243.24978.46.zip",
+        "243.25659.59": "https://plugins.jetbrains.com/files/7322/680217/python-ce-243.24978.46.zip"
       },
       "name": "python-community-edition"
     },
@@ -353,15 +353,15 @@
         "243.22562.220": "https://plugins.jetbrains.com/files/7391/658997/asciidoctor-intellij-plugin-0.43.6.zip",
         "243.24978.546": "https://plugins.jetbrains.com/files/7391/658997/asciidoctor-intellij-plugin-0.43.6.zip",
         "243.24978.79": "https://plugins.jetbrains.com/files/7391/658997/asciidoctor-intellij-plugin-0.43.6.zip",
-        "243.24978.86": "https://plugins.jetbrains.com/files/7391/658997/asciidoctor-intellij-plugin-0.43.6.zip",
         "243.25659.34": "https://plugins.jetbrains.com/files/7391/658997/asciidoctor-intellij-plugin-0.43.6.zip",
-        "243.25659.39": "https://plugins.jetbrains.com/files/7391/658997/asciidoctor-intellij-plugin-0.43.6.zip",
         "243.25659.40": "https://plugins.jetbrains.com/files/7391/658997/asciidoctor-intellij-plugin-0.43.6.zip",
         "243.25659.41": "https://plugins.jetbrains.com/files/7391/658997/asciidoctor-intellij-plugin-0.43.6.zip",
         "243.25659.42": "https://plugins.jetbrains.com/files/7391/658997/asciidoctor-intellij-plugin-0.43.6.zip",
         "243.25659.43": "https://plugins.jetbrains.com/files/7391/658997/asciidoctor-intellij-plugin-0.43.6.zip",
         "243.25659.45": "https://plugins.jetbrains.com/files/7391/658997/asciidoctor-intellij-plugin-0.43.6.zip",
-        "243.25659.52": "https://plugins.jetbrains.com/files/7391/658997/asciidoctor-intellij-plugin-0.43.6.zip"
+        "243.25659.52": "https://plugins.jetbrains.com/files/7391/658997/asciidoctor-intellij-plugin-0.43.6.zip",
+        "243.25659.54": "https://plugins.jetbrains.com/files/7391/658997/asciidoctor-intellij-plugin-0.43.6.zip",
+        "243.25659.59": "https://plugins.jetbrains.com/files/7391/658997/asciidoctor-intellij-plugin-0.43.6.zip"
       },
       "name": "asciidoc"
     },
@@ -386,15 +386,15 @@
         "243.22562.220": "https://plugins.jetbrains.com/files/7425/603907/WakaTime.jar",
         "243.24978.546": "https://plugins.jetbrains.com/files/7425/603907/WakaTime.jar",
         "243.24978.79": "https://plugins.jetbrains.com/files/7425/603907/WakaTime.jar",
-        "243.24978.86": "https://plugins.jetbrains.com/files/7425/603907/WakaTime.jar",
         "243.25659.34": "https://plugins.jetbrains.com/files/7425/603907/WakaTime.jar",
-        "243.25659.39": "https://plugins.jetbrains.com/files/7425/603907/WakaTime.jar",
         "243.25659.40": "https://plugins.jetbrains.com/files/7425/603907/WakaTime.jar",
         "243.25659.41": "https://plugins.jetbrains.com/files/7425/603907/WakaTime.jar",
         "243.25659.42": "https://plugins.jetbrains.com/files/7425/603907/WakaTime.jar",
         "243.25659.43": "https://plugins.jetbrains.com/files/7425/603907/WakaTime.jar",
         "243.25659.45": "https://plugins.jetbrains.com/files/7425/603907/WakaTime.jar",
-        "243.25659.52": "https://plugins.jetbrains.com/files/7425/603907/WakaTime.jar"
+        "243.25659.52": "https://plugins.jetbrains.com/files/7425/603907/WakaTime.jar",
+        "243.25659.54": "https://plugins.jetbrains.com/files/7425/603907/WakaTime.jar",
+        "243.25659.59": "https://plugins.jetbrains.com/files/7425/603907/WakaTime.jar"
       },
       "name": "wakatime"
     },
@@ -415,19 +415,19 @@
         "webstorm"
       ],
       "builds": {
-        "243.22562.218": "https://plugins.jetbrains.com/files/7499/667439/gittoolbox-600.0.14_243-signed.zip",
-        "243.22562.220": "https://plugins.jetbrains.com/files/7499/667439/gittoolbox-600.0.14_243-signed.zip",
-        "243.24978.546": "https://plugins.jetbrains.com/files/7499/667439/gittoolbox-600.0.14_243-signed.zip",
-        "243.24978.79": "https://plugins.jetbrains.com/files/7499/667439/gittoolbox-600.0.14_243-signed.zip",
-        "243.24978.86": "https://plugins.jetbrains.com/files/7499/667439/gittoolbox-600.0.14_243-signed.zip",
-        "243.25659.34": "https://plugins.jetbrains.com/files/7499/667439/gittoolbox-600.0.14_243-signed.zip",
-        "243.25659.39": "https://plugins.jetbrains.com/files/7499/667439/gittoolbox-600.0.14_243-signed.zip",
-        "243.25659.40": "https://plugins.jetbrains.com/files/7499/667439/gittoolbox-600.0.14_243-signed.zip",
-        "243.25659.41": "https://plugins.jetbrains.com/files/7499/667439/gittoolbox-600.0.14_243-signed.zip",
-        "243.25659.42": "https://plugins.jetbrains.com/files/7499/667439/gittoolbox-600.0.14_243-signed.zip",
-        "243.25659.43": "https://plugins.jetbrains.com/files/7499/667439/gittoolbox-600.0.14_243-signed.zip",
-        "243.25659.45": "https://plugins.jetbrains.com/files/7499/667439/gittoolbox-600.0.14_243-signed.zip",
-        "243.25659.52": "https://plugins.jetbrains.com/files/7499/667439/gittoolbox-600.0.14_243-signed.zip"
+        "243.22562.218": "https://plugins.jetbrains.com/files/7499/690185/gittoolbox-600.0.19_243-signed.zip",
+        "243.22562.220": "https://plugins.jetbrains.com/files/7499/690185/gittoolbox-600.0.19_243-signed.zip",
+        "243.24978.546": "https://plugins.jetbrains.com/files/7499/690185/gittoolbox-600.0.19_243-signed.zip",
+        "243.24978.79": "https://plugins.jetbrains.com/files/7499/690185/gittoolbox-600.0.19_243-signed.zip",
+        "243.25659.34": "https://plugins.jetbrains.com/files/7499/690185/gittoolbox-600.0.19_243-signed.zip",
+        "243.25659.40": "https://plugins.jetbrains.com/files/7499/690185/gittoolbox-600.0.19_243-signed.zip",
+        "243.25659.41": "https://plugins.jetbrains.com/files/7499/690185/gittoolbox-600.0.19_243-signed.zip",
+        "243.25659.42": "https://plugins.jetbrains.com/files/7499/690185/gittoolbox-600.0.19_243-signed.zip",
+        "243.25659.43": "https://plugins.jetbrains.com/files/7499/690185/gittoolbox-600.0.19_243-signed.zip",
+        "243.25659.45": "https://plugins.jetbrains.com/files/7499/690185/gittoolbox-600.0.19_243-signed.zip",
+        "243.25659.52": "https://plugins.jetbrains.com/files/7499/690185/gittoolbox-600.0.19_243-signed.zip",
+        "243.25659.54": "https://plugins.jetbrains.com/files/7499/690185/gittoolbox-600.0.19_243-signed.zip",
+        "243.25659.59": "https://plugins.jetbrains.com/files/7499/690185/gittoolbox-600.0.19_243-signed.zip"
       },
       "name": "gittoolbox"
     },
@@ -452,15 +452,15 @@
         "243.22562.220": "https://plugins.jetbrains.com/files/7724/654910/clouds-docker-impl-243.22562.236.zip",
         "243.24978.546": "https://plugins.jetbrains.com/files/7724/680796/clouds-docker-impl-243.24978.54.zip",
         "243.24978.79": "https://plugins.jetbrains.com/files/7724/680796/clouds-docker-impl-243.24978.54.zip",
-        "243.24978.86": "https://plugins.jetbrains.com/files/7724/680796/clouds-docker-impl-243.24978.54.zip",
-        "243.25659.34": "https://plugins.jetbrains.com/files/7724/689214/clouds-docker-impl-243.25659.45.zip",
-        "243.25659.39": "https://plugins.jetbrains.com/files/7724/689214/clouds-docker-impl-243.25659.45.zip",
-        "243.25659.40": "https://plugins.jetbrains.com/files/7724/689214/clouds-docker-impl-243.25659.45.zip",
-        "243.25659.41": "https://plugins.jetbrains.com/files/7724/689214/clouds-docker-impl-243.25659.45.zip",
-        "243.25659.42": "https://plugins.jetbrains.com/files/7724/689214/clouds-docker-impl-243.25659.45.zip",
-        "243.25659.43": "https://plugins.jetbrains.com/files/7724/689214/clouds-docker-impl-243.25659.45.zip",
-        "243.25659.45": "https://plugins.jetbrains.com/files/7724/689214/clouds-docker-impl-243.25659.45.zip",
-        "243.25659.52": "https://plugins.jetbrains.com/files/7724/689214/clouds-docker-impl-243.25659.45.zip"
+        "243.25659.34": "https://plugins.jetbrains.com/files/7724/692258/clouds-docker-impl-243.25659.59.zip",
+        "243.25659.40": "https://plugins.jetbrains.com/files/7724/692258/clouds-docker-impl-243.25659.59.zip",
+        "243.25659.41": "https://plugins.jetbrains.com/files/7724/692258/clouds-docker-impl-243.25659.59.zip",
+        "243.25659.42": "https://plugins.jetbrains.com/files/7724/692258/clouds-docker-impl-243.25659.59.zip",
+        "243.25659.43": "https://plugins.jetbrains.com/files/7724/692258/clouds-docker-impl-243.25659.59.zip",
+        "243.25659.45": "https://plugins.jetbrains.com/files/7724/692258/clouds-docker-impl-243.25659.59.zip",
+        "243.25659.52": "https://plugins.jetbrains.com/files/7724/692258/clouds-docker-impl-243.25659.59.zip",
+        "243.25659.54": "https://plugins.jetbrains.com/files/7724/692258/clouds-docker-impl-243.25659.59.zip",
+        "243.25659.59": "https://plugins.jetbrains.com/files/7724/692258/clouds-docker-impl-243.25659.59.zip"
       },
       "name": "docker"
     },
@@ -485,15 +485,15 @@
         "243.22562.220": "https://plugins.jetbrains.com/files/8097/636616/graphql-243.22562.13.zip",
         "243.24978.546": "https://plugins.jetbrains.com/files/8097/680200/graphql-243.24978.46.zip",
         "243.24978.79": "https://plugins.jetbrains.com/files/8097/680200/graphql-243.24978.46.zip",
-        "243.24978.86": "https://plugins.jetbrains.com/files/8097/680200/graphql-243.24978.46.zip",
         "243.25659.34": "https://plugins.jetbrains.com/files/8097/688195/graphql-243.25659.42.zip",
-        "243.25659.39": "https://plugins.jetbrains.com/files/8097/688195/graphql-243.25659.42.zip",
         "243.25659.40": "https://plugins.jetbrains.com/files/8097/688195/graphql-243.25659.42.zip",
         "243.25659.41": "https://plugins.jetbrains.com/files/8097/688195/graphql-243.25659.42.zip",
         "243.25659.42": "https://plugins.jetbrains.com/files/8097/688195/graphql-243.25659.42.zip",
         "243.25659.43": "https://plugins.jetbrains.com/files/8097/688195/graphql-243.25659.42.zip",
         "243.25659.45": "https://plugins.jetbrains.com/files/8097/688195/graphql-243.25659.42.zip",
-        "243.25659.52": "https://plugins.jetbrains.com/files/8097/688195/graphql-243.25659.42.zip"
+        "243.25659.52": "https://plugins.jetbrains.com/files/8097/688195/graphql-243.25659.42.zip",
+        "243.25659.54": "https://plugins.jetbrains.com/files/8097/688195/graphql-243.25659.42.zip",
+        "243.25659.59": "https://plugins.jetbrains.com/files/8097/688195/graphql-243.25659.42.zip"
       },
       "name": "graphql"
     },
@@ -518,13 +518,13 @@
         "243.24978.546": null,
         "243.24978.79": null,
         "243.25659.34": null,
-        "243.25659.39": null,
         "243.25659.40": null,
         "243.25659.41": null,
         "243.25659.42": null,
         "243.25659.43": null,
         "243.25659.45": null,
-        "243.25659.52": null
+        "243.25659.52": null,
+        "243.25659.59": null
       },
       "name": "-deprecated-rust"
     },
@@ -549,13 +549,13 @@
         "243.24978.546": null,
         "243.24978.79": null,
         "243.25659.34": null,
-        "243.25659.39": null,
         "243.25659.40": null,
         "243.25659.41": null,
         "243.25659.42": null,
         "243.25659.43": null,
         "243.25659.45": null,
-        "243.25659.52": null
+        "243.25659.52": null,
+        "243.25659.59": null
       },
       "name": "-deprecated-rust-beta"
     },
@@ -580,15 +580,15 @@
         "243.22562.220": "https://plugins.jetbrains.com/files/8195/630064/toml-243.21565.122.zip",
         "243.24978.546": "https://plugins.jetbrains.com/files/8195/672659/toml-243.23654.183.zip",
         "243.24978.79": "https://plugins.jetbrains.com/files/8195/672659/toml-243.23654.183.zip",
-        "243.24978.86": "https://plugins.jetbrains.com/files/8195/672659/toml-243.23654.183.zip",
         "243.25659.34": "https://plugins.jetbrains.com/files/8195/672659/toml-243.23654.183.zip",
-        "243.25659.39": "https://plugins.jetbrains.com/files/8195/672659/toml-243.23654.183.zip",
         "243.25659.40": "https://plugins.jetbrains.com/files/8195/672659/toml-243.23654.183.zip",
         "243.25659.41": "https://plugins.jetbrains.com/files/8195/672659/toml-243.23654.183.zip",
         "243.25659.42": "https://plugins.jetbrains.com/files/8195/672659/toml-243.23654.183.zip",
         "243.25659.43": "https://plugins.jetbrains.com/files/8195/672659/toml-243.23654.183.zip",
         "243.25659.45": "https://plugins.jetbrains.com/files/8195/672659/toml-243.23654.183.zip",
-        "243.25659.52": "https://plugins.jetbrains.com/files/8195/672659/toml-243.23654.183.zip"
+        "243.25659.52": "https://plugins.jetbrains.com/files/8195/672659/toml-243.23654.183.zip",
+        "243.25659.54": "https://plugins.jetbrains.com/files/8195/672659/toml-243.23654.183.zip",
+        "243.25659.59": "https://plugins.jetbrains.com/files/8195/672659/toml-243.23654.183.zip"
       },
       "name": "toml"
     },
@@ -599,7 +599,7 @@
       ],
       "builds": {
         "243.22562.218": "https://plugins.jetbrains.com/files/8327/615097/Minecraft_Development-2024.3-1.8.2.zip",
-        "243.25659.39": "https://plugins.jetbrains.com/files/8327/615097/Minecraft_Development-2024.3-1.8.2.zip"
+        "243.25659.59": "https://plugins.jetbrains.com/files/8327/615097/Minecraft_Development-2024.3-1.8.2.zip"
       },
       "name": "minecraft-development"
     },
@@ -624,15 +624,15 @@
         "243.22562.220": "https://plugins.jetbrains.com/files/8554/654690/featuresTrainer-243.22562.233.zip",
         "243.24978.546": "https://plugins.jetbrains.com/files/8554/684425/featuresTrainer-243.24978.79.zip",
         "243.24978.79": "https://plugins.jetbrains.com/files/8554/684425/featuresTrainer-243.24978.79.zip",
-        "243.24978.86": "https://plugins.jetbrains.com/files/8554/684425/featuresTrainer-243.24978.79.zip",
-        "243.25659.34": "https://plugins.jetbrains.com/files/8554/688898/featuresTrainer-243.25659.44.zip",
-        "243.25659.39": "https://plugins.jetbrains.com/files/8554/688898/featuresTrainer-243.25659.44.zip",
-        "243.25659.40": "https://plugins.jetbrains.com/files/8554/688898/featuresTrainer-243.25659.44.zip",
-        "243.25659.41": "https://plugins.jetbrains.com/files/8554/688898/featuresTrainer-243.25659.44.zip",
-        "243.25659.42": "https://plugins.jetbrains.com/files/8554/688898/featuresTrainer-243.25659.44.zip",
-        "243.25659.43": "https://plugins.jetbrains.com/files/8554/688898/featuresTrainer-243.25659.44.zip",
-        "243.25659.45": "https://plugins.jetbrains.com/files/8554/688898/featuresTrainer-243.25659.44.zip",
-        "243.25659.52": "https://plugins.jetbrains.com/files/8554/688898/featuresTrainer-243.25659.44.zip"
+        "243.25659.34": "https://plugins.jetbrains.com/files/8554/690630/featuresTrainer-243.25659.54.zip",
+        "243.25659.40": "https://plugins.jetbrains.com/files/8554/690630/featuresTrainer-243.25659.54.zip",
+        "243.25659.41": "https://plugins.jetbrains.com/files/8554/690630/featuresTrainer-243.25659.54.zip",
+        "243.25659.42": "https://plugins.jetbrains.com/files/8554/690630/featuresTrainer-243.25659.54.zip",
+        "243.25659.43": "https://plugins.jetbrains.com/files/8554/690630/featuresTrainer-243.25659.54.zip",
+        "243.25659.45": "https://plugins.jetbrains.com/files/8554/690630/featuresTrainer-243.25659.54.zip",
+        "243.25659.52": "https://plugins.jetbrains.com/files/8554/690630/featuresTrainer-243.25659.54.zip",
+        "243.25659.54": "https://plugins.jetbrains.com/files/8554/690630/featuresTrainer-243.25659.54.zip",
+        "243.25659.59": "https://plugins.jetbrains.com/files/8554/690630/featuresTrainer-243.25659.54.zip"
       },
       "name": "ide-features-trainer"
     },
@@ -657,15 +657,15 @@
         "243.22562.220": "https://plugins.jetbrains.com/files/8607/673303/NixIDEA-0.4.0.17.zip",
         "243.24978.546": "https://plugins.jetbrains.com/files/8607/673303/NixIDEA-0.4.0.17.zip",
         "243.24978.79": "https://plugins.jetbrains.com/files/8607/673303/NixIDEA-0.4.0.17.zip",
-        "243.24978.86": "https://plugins.jetbrains.com/files/8607/673303/NixIDEA-0.4.0.17.zip",
         "243.25659.34": "https://plugins.jetbrains.com/files/8607/673303/NixIDEA-0.4.0.17.zip",
-        "243.25659.39": "https://plugins.jetbrains.com/files/8607/673303/NixIDEA-0.4.0.17.zip",
         "243.25659.40": "https://plugins.jetbrains.com/files/8607/673303/NixIDEA-0.4.0.17.zip",
         "243.25659.41": "https://plugins.jetbrains.com/files/8607/673303/NixIDEA-0.4.0.17.zip",
         "243.25659.42": "https://plugins.jetbrains.com/files/8607/673303/NixIDEA-0.4.0.17.zip",
         "243.25659.43": "https://plugins.jetbrains.com/files/8607/673303/NixIDEA-0.4.0.17.zip",
         "243.25659.45": "https://plugins.jetbrains.com/files/8607/673303/NixIDEA-0.4.0.17.zip",
-        "243.25659.52": "https://plugins.jetbrains.com/files/8607/673303/NixIDEA-0.4.0.17.zip"
+        "243.25659.52": "https://plugins.jetbrains.com/files/8607/673303/NixIDEA-0.4.0.17.zip",
+        "243.25659.54": "https://plugins.jetbrains.com/files/8607/673303/NixIDEA-0.4.0.17.zip",
+        "243.25659.59": "https://plugins.jetbrains.com/files/8607/673303/NixIDEA-0.4.0.17.zip"
       },
       "name": "nixidea"
     },
@@ -690,15 +690,15 @@
         "243.22562.220": "https://plugins.jetbrains.com/files/9525/603167/idea-php-dotenv-plugin-2024.3.zip",
         "243.24978.546": "https://plugins.jetbrains.com/files/9525/603167/idea-php-dotenv-plugin-2024.3.zip",
         "243.24978.79": "https://plugins.jetbrains.com/files/9525/603167/idea-php-dotenv-plugin-2024.3.zip",
-        "243.24978.86": "https://plugins.jetbrains.com/files/9525/603167/idea-php-dotenv-plugin-2024.3.zip",
         "243.25659.34": "https://plugins.jetbrains.com/files/9525/603167/idea-php-dotenv-plugin-2024.3.zip",
-        "243.25659.39": "https://plugins.jetbrains.com/files/9525/603167/idea-php-dotenv-plugin-2024.3.zip",
         "243.25659.40": "https://plugins.jetbrains.com/files/9525/603167/idea-php-dotenv-plugin-2024.3.zip",
         "243.25659.41": "https://plugins.jetbrains.com/files/9525/603167/idea-php-dotenv-plugin-2024.3.zip",
         "243.25659.42": "https://plugins.jetbrains.com/files/9525/603167/idea-php-dotenv-plugin-2024.3.zip",
         "243.25659.43": "https://plugins.jetbrains.com/files/9525/603167/idea-php-dotenv-plugin-2024.3.zip",
         "243.25659.45": "https://plugins.jetbrains.com/files/9525/603167/idea-php-dotenv-plugin-2024.3.zip",
-        "243.25659.52": "https://plugins.jetbrains.com/files/9525/603167/idea-php-dotenv-plugin-2024.3.zip"
+        "243.25659.52": "https://plugins.jetbrains.com/files/9525/603167/idea-php-dotenv-plugin-2024.3.zip",
+        "243.25659.54": "https://plugins.jetbrains.com/files/9525/603167/idea-php-dotenv-plugin-2024.3.zip",
+        "243.25659.59": "https://plugins.jetbrains.com/files/9525/603167/idea-php-dotenv-plugin-2024.3.zip"
       },
       "name": "-env-files"
     },
@@ -708,8 +708,8 @@
         "idea-ultimate"
       ],
       "builds": {
-        "243.25659.39": "https://plugins.jetbrains.com/files/9568/680198/go-plugin-243.24978.46.zip",
-        "243.25659.52": "https://plugins.jetbrains.com/files/9568/680198/go-plugin-243.24978.46.zip"
+        "243.25659.52": "https://plugins.jetbrains.com/files/9568/680198/go-plugin-243.24978.46.zip",
+        "243.25659.59": "https://plugins.jetbrains.com/files/9568/680198/go-plugin-243.24978.46.zip"
       },
       "name": "go"
     },
@@ -730,19 +730,19 @@
         "webstorm"
       ],
       "builds": {
-        "243.22562.218": "https://plugins.jetbrains.com/files/9707/628343/ansi-highlighter-premium-24.3.1.jar",
-        "243.22562.220": "https://plugins.jetbrains.com/files/9707/628343/ansi-highlighter-premium-24.3.1.jar",
-        "243.24978.546": "https://plugins.jetbrains.com/files/9707/628343/ansi-highlighter-premium-24.3.1.jar",
-        "243.24978.79": "https://plugins.jetbrains.com/files/9707/628343/ansi-highlighter-premium-24.3.1.jar",
-        "243.24978.86": "https://plugins.jetbrains.com/files/9707/628343/ansi-highlighter-premium-24.3.1.jar",
-        "243.25659.34": "https://plugins.jetbrains.com/files/9707/628343/ansi-highlighter-premium-24.3.1.jar",
-        "243.25659.39": "https://plugins.jetbrains.com/files/9707/628343/ansi-highlighter-premium-24.3.1.jar",
-        "243.25659.40": "https://plugins.jetbrains.com/files/9707/628343/ansi-highlighter-premium-24.3.1.jar",
-        "243.25659.41": "https://plugins.jetbrains.com/files/9707/628343/ansi-highlighter-premium-24.3.1.jar",
-        "243.25659.42": "https://plugins.jetbrains.com/files/9707/628343/ansi-highlighter-premium-24.3.1.jar",
-        "243.25659.43": "https://plugins.jetbrains.com/files/9707/628343/ansi-highlighter-premium-24.3.1.jar",
-        "243.25659.45": "https://plugins.jetbrains.com/files/9707/628343/ansi-highlighter-premium-24.3.1.jar",
-        "243.25659.52": "https://plugins.jetbrains.com/files/9707/628343/ansi-highlighter-premium-24.3.1.jar"
+        "243.22562.218": "https://plugins.jetbrains.com/files/9707/690054/ansi-highlighter-premium-24.3.2.jar",
+        "243.22562.220": "https://plugins.jetbrains.com/files/9707/690054/ansi-highlighter-premium-24.3.2.jar",
+        "243.24978.546": "https://plugins.jetbrains.com/files/9707/690054/ansi-highlighter-premium-24.3.2.jar",
+        "243.24978.79": "https://plugins.jetbrains.com/files/9707/690054/ansi-highlighter-premium-24.3.2.jar",
+        "243.25659.34": "https://plugins.jetbrains.com/files/9707/690054/ansi-highlighter-premium-24.3.2.jar",
+        "243.25659.40": "https://plugins.jetbrains.com/files/9707/690054/ansi-highlighter-premium-24.3.2.jar",
+        "243.25659.41": "https://plugins.jetbrains.com/files/9707/690054/ansi-highlighter-premium-24.3.2.jar",
+        "243.25659.42": "https://plugins.jetbrains.com/files/9707/690054/ansi-highlighter-premium-24.3.2.jar",
+        "243.25659.43": "https://plugins.jetbrains.com/files/9707/690054/ansi-highlighter-premium-24.3.2.jar",
+        "243.25659.45": "https://plugins.jetbrains.com/files/9707/690054/ansi-highlighter-premium-24.3.2.jar",
+        "243.25659.52": "https://plugins.jetbrains.com/files/9707/690054/ansi-highlighter-premium-24.3.2.jar",
+        "243.25659.54": "https://plugins.jetbrains.com/files/9707/690054/ansi-highlighter-premium-24.3.2.jar",
+        "243.25659.59": "https://plugins.jetbrains.com/files/9707/690054/ansi-highlighter-premium-24.3.2.jar"
       },
       "name": "ansi-highlighter-premium"
     },
@@ -767,15 +767,15 @@
         "243.22562.220": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
         "243.24978.546": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
         "243.24978.79": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
-        "243.24978.86": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
         "243.25659.34": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
-        "243.25659.39": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
         "243.25659.40": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
         "243.25659.41": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
         "243.25659.42": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
         "243.25659.43": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
         "243.25659.45": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
-        "243.25659.52": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip"
+        "243.25659.52": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
+        "243.25659.54": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
+        "243.25659.59": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip"
       },
       "name": "key-promoter-x"
     },
@@ -800,15 +800,15 @@
         "243.22562.220": "https://plugins.jetbrains.com/files/9836/681714/intellij-randomness-3.3.6-signed.zip",
         "243.24978.546": "https://plugins.jetbrains.com/files/9836/681714/intellij-randomness-3.3.6-signed.zip",
         "243.24978.79": "https://plugins.jetbrains.com/files/9836/681714/intellij-randomness-3.3.6-signed.zip",
-        "243.24978.86": "https://plugins.jetbrains.com/files/9836/681714/intellij-randomness-3.3.6-signed.zip",
         "243.25659.34": "https://plugins.jetbrains.com/files/9836/681714/intellij-randomness-3.3.6-signed.zip",
-        "243.25659.39": "https://plugins.jetbrains.com/files/9836/681714/intellij-randomness-3.3.6-signed.zip",
         "243.25659.40": "https://plugins.jetbrains.com/files/9836/681714/intellij-randomness-3.3.6-signed.zip",
         "243.25659.41": "https://plugins.jetbrains.com/files/9836/681714/intellij-randomness-3.3.6-signed.zip",
         "243.25659.42": "https://plugins.jetbrains.com/files/9836/681714/intellij-randomness-3.3.6-signed.zip",
         "243.25659.43": "https://plugins.jetbrains.com/files/9836/681714/intellij-randomness-3.3.6-signed.zip",
         "243.25659.45": "https://plugins.jetbrains.com/files/9836/681714/intellij-randomness-3.3.6-signed.zip",
-        "243.25659.52": "https://plugins.jetbrains.com/files/9836/681714/intellij-randomness-3.3.6-signed.zip"
+        "243.25659.52": "https://plugins.jetbrains.com/files/9836/681714/intellij-randomness-3.3.6-signed.zip",
+        "243.25659.54": "https://plugins.jetbrains.com/files/9836/681714/intellij-randomness-3.3.6-signed.zip",
+        "243.25659.59": "https://plugins.jetbrains.com/files/9836/681714/intellij-randomness-3.3.6-signed.zip"
       },
       "name": "randomness"
     },
@@ -833,15 +833,15 @@
         "243.22562.220": "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip",
         "243.24978.546": "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip",
         "243.24978.79": "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip",
-        "243.24978.86": "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip",
         "243.25659.34": "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip",
-        "243.25659.39": "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip",
         "243.25659.40": "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip",
         "243.25659.41": "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip",
         "243.25659.42": "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip",
         "243.25659.43": "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip",
         "243.25659.45": "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip",
-        "243.25659.52": "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip"
+        "243.25659.52": "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip",
+        "243.25659.54": "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip",
+        "243.25659.59": "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip"
       },
       "name": "csv-editor"
     },
@@ -866,15 +866,15 @@
         "243.22562.220": "https://plugins.jetbrains.com/files/10080/689210/intellij-rainbow-brackets-2024.2.9-241.zip",
         "243.24978.546": "https://plugins.jetbrains.com/files/10080/689210/intellij-rainbow-brackets-2024.2.9-241.zip",
         "243.24978.79": "https://plugins.jetbrains.com/files/10080/689210/intellij-rainbow-brackets-2024.2.9-241.zip",
-        "243.24978.86": "https://plugins.jetbrains.com/files/10080/689210/intellij-rainbow-brackets-2024.2.9-241.zip",
         "243.25659.34": "https://plugins.jetbrains.com/files/10080/689210/intellij-rainbow-brackets-2024.2.9-241.zip",
-        "243.25659.39": "https://plugins.jetbrains.com/files/10080/689210/intellij-rainbow-brackets-2024.2.9-241.zip",
         "243.25659.40": "https://plugins.jetbrains.com/files/10080/689210/intellij-rainbow-brackets-2024.2.9-241.zip",
         "243.25659.41": "https://plugins.jetbrains.com/files/10080/689210/intellij-rainbow-brackets-2024.2.9-241.zip",
         "243.25659.42": "https://plugins.jetbrains.com/files/10080/689210/intellij-rainbow-brackets-2024.2.9-241.zip",
         "243.25659.43": "https://plugins.jetbrains.com/files/10080/689210/intellij-rainbow-brackets-2024.2.9-241.zip",
         "243.25659.45": "https://plugins.jetbrains.com/files/10080/689210/intellij-rainbow-brackets-2024.2.9-241.zip",
-        "243.25659.52": "https://plugins.jetbrains.com/files/10080/689210/intellij-rainbow-brackets-2024.2.9-241.zip"
+        "243.25659.52": "https://plugins.jetbrains.com/files/10080/689210/intellij-rainbow-brackets-2024.2.9-241.zip",
+        "243.25659.54": "https://plugins.jetbrains.com/files/10080/689210/intellij-rainbow-brackets-2024.2.9-241.zip",
+        "243.25659.59": "https://plugins.jetbrains.com/files/10080/689210/intellij-rainbow-brackets-2024.2.9-241.zip"
       },
       "name": "rainbow-brackets"
     },
@@ -899,15 +899,15 @@
         "243.22562.220": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
         "243.24978.546": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
         "243.24978.79": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
-        "243.24978.86": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
         "243.25659.34": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
-        "243.25659.39": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
         "243.25659.40": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
         "243.25659.41": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
         "243.25659.42": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
         "243.25659.43": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
         "243.25659.45": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
-        "243.25659.52": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip"
+        "243.25659.52": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
+        "243.25659.54": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
+        "243.25659.59": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip"
       },
       "name": "dot-language"
     },
@@ -932,15 +932,15 @@
         "243.22562.220": "https://plugins.jetbrains.com/files/10481/583591/intellij-hocon-2024.2.0.zip",
         "243.24978.546": "https://plugins.jetbrains.com/files/10481/583591/intellij-hocon-2024.2.0.zip",
         "243.24978.79": "https://plugins.jetbrains.com/files/10481/583591/intellij-hocon-2024.2.0.zip",
-        "243.24978.86": "https://plugins.jetbrains.com/files/10481/583591/intellij-hocon-2024.2.0.zip",
         "243.25659.34": "https://plugins.jetbrains.com/files/10481/583591/intellij-hocon-2024.2.0.zip",
-        "243.25659.39": "https://plugins.jetbrains.com/files/10481/583591/intellij-hocon-2024.2.0.zip",
         "243.25659.40": "https://plugins.jetbrains.com/files/10481/583591/intellij-hocon-2024.2.0.zip",
         "243.25659.41": "https://plugins.jetbrains.com/files/10481/583591/intellij-hocon-2024.2.0.zip",
         "243.25659.42": "https://plugins.jetbrains.com/files/10481/583591/intellij-hocon-2024.2.0.zip",
         "243.25659.43": "https://plugins.jetbrains.com/files/10481/583591/intellij-hocon-2024.2.0.zip",
         "243.25659.45": "https://plugins.jetbrains.com/files/10481/583591/intellij-hocon-2024.2.0.zip",
-        "243.25659.52": "https://plugins.jetbrains.com/files/10481/583591/intellij-hocon-2024.2.0.zip"
+        "243.25659.52": "https://plugins.jetbrains.com/files/10481/583591/intellij-hocon-2024.2.0.zip",
+        "243.25659.54": "https://plugins.jetbrains.com/files/10481/583591/intellij-hocon-2024.2.0.zip",
+        "243.25659.59": "https://plugins.jetbrains.com/files/10481/583591/intellij-hocon-2024.2.0.zip"
       },
       "name": "hocon"
     },
@@ -965,15 +965,15 @@
         "243.22562.220": "https://plugins.jetbrains.com/files/11058/686929/Extra_Icons-2025.1.2.zip",
         "243.24978.546": "https://plugins.jetbrains.com/files/11058/686929/Extra_Icons-2025.1.2.zip",
         "243.24978.79": "https://plugins.jetbrains.com/files/11058/686929/Extra_Icons-2025.1.2.zip",
-        "243.24978.86": "https://plugins.jetbrains.com/files/11058/686929/Extra_Icons-2025.1.2.zip",
         "243.25659.34": "https://plugins.jetbrains.com/files/11058/686929/Extra_Icons-2025.1.2.zip",
-        "243.25659.39": "https://plugins.jetbrains.com/files/11058/686929/Extra_Icons-2025.1.2.zip",
         "243.25659.40": "https://plugins.jetbrains.com/files/11058/686929/Extra_Icons-2025.1.2.zip",
         "243.25659.41": "https://plugins.jetbrains.com/files/11058/686929/Extra_Icons-2025.1.2.zip",
         "243.25659.42": "https://plugins.jetbrains.com/files/11058/686929/Extra_Icons-2025.1.2.zip",
         "243.25659.43": "https://plugins.jetbrains.com/files/11058/686929/Extra_Icons-2025.1.2.zip",
         "243.25659.45": "https://plugins.jetbrains.com/files/11058/686929/Extra_Icons-2025.1.2.zip",
-        "243.25659.52": "https://plugins.jetbrains.com/files/11058/686929/Extra_Icons-2025.1.2.zip"
+        "243.25659.52": "https://plugins.jetbrains.com/files/11058/686929/Extra_Icons-2025.1.2.zip",
+        "243.25659.54": "https://plugins.jetbrains.com/files/11058/686929/Extra_Icons-2025.1.2.zip",
+        "243.25659.59": "https://plugins.jetbrains.com/files/11058/686929/Extra_Icons-2025.1.2.zip"
       },
       "name": "extra-icons"
     },
@@ -994,19 +994,19 @@
         "webstorm"
       ],
       "builds": {
-        "243.22562.218": "https://plugins.jetbrains.com/files/11349/689463/aws-toolkit-jetbrains-standalone-3.57-243.zip",
-        "243.22562.220": "https://plugins.jetbrains.com/files/11349/689463/aws-toolkit-jetbrains-standalone-3.57-243.zip",
-        "243.24978.546": "https://plugins.jetbrains.com/files/11349/689463/aws-toolkit-jetbrains-standalone-3.57-243.zip",
-        "243.24978.79": "https://plugins.jetbrains.com/files/11349/689463/aws-toolkit-jetbrains-standalone-3.57-243.zip",
-        "243.24978.86": "https://plugins.jetbrains.com/files/11349/689463/aws-toolkit-jetbrains-standalone-3.57-243.zip",
-        "243.25659.34": "https://plugins.jetbrains.com/files/11349/689463/aws-toolkit-jetbrains-standalone-3.57-243.zip",
-        "243.25659.39": "https://plugins.jetbrains.com/files/11349/689463/aws-toolkit-jetbrains-standalone-3.57-243.zip",
-        "243.25659.40": "https://plugins.jetbrains.com/files/11349/689463/aws-toolkit-jetbrains-standalone-3.57-243.zip",
-        "243.25659.41": "https://plugins.jetbrains.com/files/11349/689463/aws-toolkit-jetbrains-standalone-3.57-243.zip",
-        "243.25659.42": "https://plugins.jetbrains.com/files/11349/689463/aws-toolkit-jetbrains-standalone-3.57-243.zip",
-        "243.25659.43": "https://plugins.jetbrains.com/files/11349/689463/aws-toolkit-jetbrains-standalone-3.57-243.zip",
-        "243.25659.45": "https://plugins.jetbrains.com/files/11349/689463/aws-toolkit-jetbrains-standalone-3.57-243.zip",
-        "243.25659.52": "https://plugins.jetbrains.com/files/11349/689463/aws-toolkit-jetbrains-standalone-3.57-243.zip"
+        "243.22562.218": "https://plugins.jetbrains.com/files/11349/693441/aws-toolkit-jetbrains-standalone-3.58-243.zip",
+        "243.22562.220": "https://plugins.jetbrains.com/files/11349/693441/aws-toolkit-jetbrains-standalone-3.58-243.zip",
+        "243.24978.546": "https://plugins.jetbrains.com/files/11349/693441/aws-toolkit-jetbrains-standalone-3.58-243.zip",
+        "243.24978.79": "https://plugins.jetbrains.com/files/11349/693441/aws-toolkit-jetbrains-standalone-3.58-243.zip",
+        "243.25659.34": "https://plugins.jetbrains.com/files/11349/693441/aws-toolkit-jetbrains-standalone-3.58-243.zip",
+        "243.25659.40": "https://plugins.jetbrains.com/files/11349/693441/aws-toolkit-jetbrains-standalone-3.58-243.zip",
+        "243.25659.41": "https://plugins.jetbrains.com/files/11349/693441/aws-toolkit-jetbrains-standalone-3.58-243.zip",
+        "243.25659.42": "https://plugins.jetbrains.com/files/11349/693441/aws-toolkit-jetbrains-standalone-3.58-243.zip",
+        "243.25659.43": "https://plugins.jetbrains.com/files/11349/693441/aws-toolkit-jetbrains-standalone-3.58-243.zip",
+        "243.25659.45": "https://plugins.jetbrains.com/files/11349/693441/aws-toolkit-jetbrains-standalone-3.58-243.zip",
+        "243.25659.52": "https://plugins.jetbrains.com/files/11349/693441/aws-toolkit-jetbrains-standalone-3.58-243.zip",
+        "243.25659.54": "https://plugins.jetbrains.com/files/11349/693441/aws-toolkit-jetbrains-standalone-3.58-243.zip",
+        "243.25659.59": "https://plugins.jetbrains.com/files/11349/693441/aws-toolkit-jetbrains-standalone-3.58-243.zip"
       },
       "name": "aws-toolkit"
     },
@@ -1040,15 +1040,15 @@
         "243.22562.220": "https://plugins.jetbrains.com/files/12062/630060/keymap-vscode-243.21565.122.zip",
         "243.24978.546": "https://plugins.jetbrains.com/files/12062/630060/keymap-vscode-243.21565.122.zip",
         "243.24978.79": "https://plugins.jetbrains.com/files/12062/630060/keymap-vscode-243.21565.122.zip",
-        "243.24978.86": "https://plugins.jetbrains.com/files/12062/630060/keymap-vscode-243.21565.122.zip",
         "243.25659.34": "https://plugins.jetbrains.com/files/12062/630060/keymap-vscode-243.21565.122.zip",
-        "243.25659.39": "https://plugins.jetbrains.com/files/12062/630060/keymap-vscode-243.21565.122.zip",
         "243.25659.40": "https://plugins.jetbrains.com/files/12062/630060/keymap-vscode-243.21565.122.zip",
         "243.25659.41": "https://plugins.jetbrains.com/files/12062/630060/keymap-vscode-243.21565.122.zip",
         "243.25659.42": "https://plugins.jetbrains.com/files/12062/630060/keymap-vscode-243.21565.122.zip",
         "243.25659.43": "https://plugins.jetbrains.com/files/12062/630060/keymap-vscode-243.21565.122.zip",
         "243.25659.45": "https://plugins.jetbrains.com/files/12062/630060/keymap-vscode-243.21565.122.zip",
-        "243.25659.52": "https://plugins.jetbrains.com/files/12062/630060/keymap-vscode-243.21565.122.zip"
+        "243.25659.52": "https://plugins.jetbrains.com/files/12062/630060/keymap-vscode-243.21565.122.zip",
+        "243.25659.54": "https://plugins.jetbrains.com/files/12062/630060/keymap-vscode-243.21565.122.zip",
+        "243.25659.59": "https://plugins.jetbrains.com/files/12062/630060/keymap-vscode-243.21565.122.zip"
       },
       "name": "vscode-keymap"
     },
@@ -1073,15 +1073,15 @@
         "243.22562.220": "https://plugins.jetbrains.com/files/12559/629985/keymap-eclipse-243.21565.122.zip",
         "243.24978.546": "https://plugins.jetbrains.com/files/12559/629985/keymap-eclipse-243.21565.122.zip",
         "243.24978.79": "https://plugins.jetbrains.com/files/12559/629985/keymap-eclipse-243.21565.122.zip",
-        "243.24978.86": "https://plugins.jetbrains.com/files/12559/629985/keymap-eclipse-243.21565.122.zip",
         "243.25659.34": "https://plugins.jetbrains.com/files/12559/629985/keymap-eclipse-243.21565.122.zip",
-        "243.25659.39": "https://plugins.jetbrains.com/files/12559/629985/keymap-eclipse-243.21565.122.zip",
         "243.25659.40": "https://plugins.jetbrains.com/files/12559/629985/keymap-eclipse-243.21565.122.zip",
         "243.25659.41": "https://plugins.jetbrains.com/files/12559/629985/keymap-eclipse-243.21565.122.zip",
         "243.25659.42": "https://plugins.jetbrains.com/files/12559/629985/keymap-eclipse-243.21565.122.zip",
         "243.25659.43": "https://plugins.jetbrains.com/files/12559/629985/keymap-eclipse-243.21565.122.zip",
         "243.25659.45": "https://plugins.jetbrains.com/files/12559/629985/keymap-eclipse-243.21565.122.zip",
-        "243.25659.52": "https://plugins.jetbrains.com/files/12559/629985/keymap-eclipse-243.21565.122.zip"
+        "243.25659.52": "https://plugins.jetbrains.com/files/12559/629985/keymap-eclipse-243.21565.122.zip",
+        "243.25659.54": "https://plugins.jetbrains.com/files/12559/629985/keymap-eclipse-243.21565.122.zip",
+        "243.25659.59": "https://plugins.jetbrains.com/files/12559/629985/keymap-eclipse-243.21565.122.zip"
       },
       "name": "eclipse-keymap"
     },
@@ -1106,15 +1106,15 @@
         "243.22562.220": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
         "243.24978.546": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
         "243.24978.79": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
-        "243.24978.86": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
         "243.25659.34": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
-        "243.25659.39": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
         "243.25659.40": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
         "243.25659.41": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
         "243.25659.42": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
         "243.25659.43": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
         "243.25659.45": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
-        "243.25659.52": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip"
+        "243.25659.52": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
+        "243.25659.54": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
+        "243.25659.59": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip"
       },
       "name": "rainbow-csv"
     },
@@ -1139,15 +1139,15 @@
         "243.22562.220": "https://plugins.jetbrains.com/files/13017/630016/keymap-visualStudio-243.21565.122.zip",
         "243.24978.546": "https://plugins.jetbrains.com/files/13017/630016/keymap-visualStudio-243.21565.122.zip",
         "243.24978.79": "https://plugins.jetbrains.com/files/13017/630016/keymap-visualStudio-243.21565.122.zip",
-        "243.24978.86": "https://plugins.jetbrains.com/files/13017/630016/keymap-visualStudio-243.21565.122.zip",
         "243.25659.34": "https://plugins.jetbrains.com/files/13017/630016/keymap-visualStudio-243.21565.122.zip",
-        "243.25659.39": "https://plugins.jetbrains.com/files/13017/630016/keymap-visualStudio-243.21565.122.zip",
         "243.25659.40": "https://plugins.jetbrains.com/files/13017/630016/keymap-visualStudio-243.21565.122.zip",
         "243.25659.41": "https://plugins.jetbrains.com/files/13017/630016/keymap-visualStudio-243.21565.122.zip",
         "243.25659.42": "https://plugins.jetbrains.com/files/13017/630016/keymap-visualStudio-243.21565.122.zip",
         "243.25659.43": "https://plugins.jetbrains.com/files/13017/630016/keymap-visualStudio-243.21565.122.zip",
         "243.25659.45": "https://plugins.jetbrains.com/files/13017/630016/keymap-visualStudio-243.21565.122.zip",
-        "243.25659.52": "https://plugins.jetbrains.com/files/13017/630016/keymap-visualStudio-243.21565.122.zip"
+        "243.25659.52": "https://plugins.jetbrains.com/files/13017/630016/keymap-visualStudio-243.21565.122.zip",
+        "243.25659.54": "https://plugins.jetbrains.com/files/13017/630016/keymap-visualStudio-243.21565.122.zip",
+        "243.25659.59": "https://plugins.jetbrains.com/files/13017/630016/keymap-visualStudio-243.21565.122.zip"
       },
       "name": "visual-studio-keymap"
     },
@@ -1172,15 +1172,15 @@
         "243.22562.220": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
         "243.24978.546": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
         "243.24978.79": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
-        "243.24978.86": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
         "243.25659.34": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
-        "243.25659.39": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
         "243.25659.40": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
         "243.25659.41": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
         "243.25659.42": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
         "243.25659.43": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
         "243.25659.45": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
-        "243.25659.52": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip"
+        "243.25659.52": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
+        "243.25659.54": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
+        "243.25659.59": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip"
       },
       "name": "indent-rainbow"
     },
@@ -1205,15 +1205,15 @@
         "243.22562.220": "https://plugins.jetbrains.com/files/14004/636643/protoeditor-243.22562.13.zip",
         "243.24978.546": "https://plugins.jetbrains.com/files/14004/636643/protoeditor-243.22562.13.zip",
         "243.24978.79": "https://plugins.jetbrains.com/files/14004/636643/protoeditor-243.22562.13.zip",
-        "243.24978.86": "https://plugins.jetbrains.com/files/14004/636643/protoeditor-243.22562.13.zip",
         "243.25659.34": "https://plugins.jetbrains.com/files/14004/636643/protoeditor-243.22562.13.zip",
-        "243.25659.39": "https://plugins.jetbrains.com/files/14004/636643/protoeditor-243.22562.13.zip",
         "243.25659.40": "https://plugins.jetbrains.com/files/14004/636643/protoeditor-243.22562.13.zip",
         "243.25659.41": "https://plugins.jetbrains.com/files/14004/636643/protoeditor-243.22562.13.zip",
         "243.25659.42": "https://plugins.jetbrains.com/files/14004/636643/protoeditor-243.22562.13.zip",
         "243.25659.43": "https://plugins.jetbrains.com/files/14004/636643/protoeditor-243.22562.13.zip",
         "243.25659.45": "https://plugins.jetbrains.com/files/14004/636643/protoeditor-243.22562.13.zip",
-        "243.25659.52": "https://plugins.jetbrains.com/files/14004/636643/protoeditor-243.22562.13.zip"
+        "243.25659.52": "https://plugins.jetbrains.com/files/14004/636643/protoeditor-243.22562.13.zip",
+        "243.25659.54": "https://plugins.jetbrains.com/files/14004/636643/protoeditor-243.22562.13.zip",
+        "243.25659.59": "https://plugins.jetbrains.com/files/14004/636643/protoeditor-243.22562.13.zip"
       },
       "name": "protocol-buffers"
     },
@@ -1238,15 +1238,15 @@
         "243.22562.220": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
         "243.24978.546": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
         "243.24978.79": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
-        "243.24978.86": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
         "243.25659.34": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
-        "243.25659.39": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
         "243.25659.40": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
         "243.25659.41": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
         "243.25659.42": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
         "243.25659.43": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
         "243.25659.45": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
-        "243.25659.52": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar"
+        "243.25659.52": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
+        "243.25659.54": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
+        "243.25659.59": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar"
       },
       "name": "darcula-pitch-black"
     },
@@ -1271,15 +1271,15 @@
         "243.22562.220": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
         "243.24978.546": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
         "243.24978.79": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
-        "243.24978.86": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
         "243.25659.34": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
-        "243.25659.39": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
         "243.25659.40": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
         "243.25659.41": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
         "243.25659.42": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
         "243.25659.43": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
         "243.25659.45": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
-        "243.25659.52": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar"
+        "243.25659.52": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
+        "243.25659.54": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
+        "243.25659.59": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar"
       },
       "name": "mario-progress-bar"
     },
@@ -1304,15 +1304,15 @@
         "243.22562.220": "https://plugins.jetbrains.com/files/15976/593529/IDEA_Which-Key-0.10.3.jar",
         "243.24978.546": "https://plugins.jetbrains.com/files/15976/593529/IDEA_Which-Key-0.10.3.jar",
         "243.24978.79": "https://plugins.jetbrains.com/files/15976/593529/IDEA_Which-Key-0.10.3.jar",
-        "243.24978.86": "https://plugins.jetbrains.com/files/15976/593529/IDEA_Which-Key-0.10.3.jar",
         "243.25659.34": "https://plugins.jetbrains.com/files/15976/593529/IDEA_Which-Key-0.10.3.jar",
-        "243.25659.39": "https://plugins.jetbrains.com/files/15976/593529/IDEA_Which-Key-0.10.3.jar",
         "243.25659.40": "https://plugins.jetbrains.com/files/15976/593529/IDEA_Which-Key-0.10.3.jar",
         "243.25659.41": "https://plugins.jetbrains.com/files/15976/593529/IDEA_Which-Key-0.10.3.jar",
         "243.25659.42": "https://plugins.jetbrains.com/files/15976/593529/IDEA_Which-Key-0.10.3.jar",
         "243.25659.43": "https://plugins.jetbrains.com/files/15976/593529/IDEA_Which-Key-0.10.3.jar",
         "243.25659.45": "https://plugins.jetbrains.com/files/15976/593529/IDEA_Which-Key-0.10.3.jar",
-        "243.25659.52": "https://plugins.jetbrains.com/files/15976/593529/IDEA_Which-Key-0.10.3.jar"
+        "243.25659.52": "https://plugins.jetbrains.com/files/15976/593529/IDEA_Which-Key-0.10.3.jar",
+        "243.25659.54": "https://plugins.jetbrains.com/files/15976/593529/IDEA_Which-Key-0.10.3.jar",
+        "243.25659.59": "https://plugins.jetbrains.com/files/15976/593529/IDEA_Which-Key-0.10.3.jar"
       },
       "name": "which-key"
     },
@@ -1337,15 +1337,15 @@
         "243.22562.220": "https://plugins.jetbrains.com/files/16604/686930/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.4.zip",
         "243.24978.546": "https://plugins.jetbrains.com/files/16604/686930/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.4.zip",
         "243.24978.79": "https://plugins.jetbrains.com/files/16604/686930/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.4.zip",
-        "243.24978.86": "https://plugins.jetbrains.com/files/16604/686930/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.4.zip",
         "243.25659.34": "https://plugins.jetbrains.com/files/16604/686930/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.4.zip",
-        "243.25659.39": "https://plugins.jetbrains.com/files/16604/686930/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.4.zip",
         "243.25659.40": "https://plugins.jetbrains.com/files/16604/686930/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.4.zip",
         "243.25659.41": "https://plugins.jetbrains.com/files/16604/686930/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.4.zip",
         "243.25659.42": "https://plugins.jetbrains.com/files/16604/686930/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.4.zip",
         "243.25659.43": "https://plugins.jetbrains.com/files/16604/686930/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.4.zip",
         "243.25659.45": "https://plugins.jetbrains.com/files/16604/686930/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.4.zip",
-        "243.25659.52": "https://plugins.jetbrains.com/files/16604/686930/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.4.zip"
+        "243.25659.52": "https://plugins.jetbrains.com/files/16604/686930/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.4.zip",
+        "243.25659.54": "https://plugins.jetbrains.com/files/16604/686930/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.4.zip",
+        "243.25659.59": "https://plugins.jetbrains.com/files/16604/686930/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.4.zip"
       },
       "name": "extra-toolwindow-colorful-icons"
     },
@@ -1370,15 +1370,15 @@
         "243.22562.220": "https://plugins.jetbrains.com/files/17718/688477/github-copilot-intellij-1.5.37-242.zip",
         "243.24978.546": "https://plugins.jetbrains.com/files/17718/688477/github-copilot-intellij-1.5.37-242.zip",
         "243.24978.79": "https://plugins.jetbrains.com/files/17718/688477/github-copilot-intellij-1.5.37-242.zip",
-        "243.24978.86": "https://plugins.jetbrains.com/files/17718/688477/github-copilot-intellij-1.5.37-242.zip",
         "243.25659.34": "https://plugins.jetbrains.com/files/17718/688477/github-copilot-intellij-1.5.37-242.zip",
-        "243.25659.39": "https://plugins.jetbrains.com/files/17718/688477/github-copilot-intellij-1.5.37-242.zip",
         "243.25659.40": "https://plugins.jetbrains.com/files/17718/688477/github-copilot-intellij-1.5.37-242.zip",
         "243.25659.41": "https://plugins.jetbrains.com/files/17718/688477/github-copilot-intellij-1.5.37-242.zip",
         "243.25659.42": "https://plugins.jetbrains.com/files/17718/688477/github-copilot-intellij-1.5.37-242.zip",
         "243.25659.43": "https://plugins.jetbrains.com/files/17718/688477/github-copilot-intellij-1.5.37-242.zip",
         "243.25659.45": "https://plugins.jetbrains.com/files/17718/688477/github-copilot-intellij-1.5.37-242.zip",
-        "243.25659.52": "https://plugins.jetbrains.com/files/17718/688477/github-copilot-intellij-1.5.37-242.zip"
+        "243.25659.52": "https://plugins.jetbrains.com/files/17718/688477/github-copilot-intellij-1.5.37-242.zip",
+        "243.25659.54": "https://plugins.jetbrains.com/files/17718/688477/github-copilot-intellij-1.5.37-242.zip",
+        "243.25659.59": "https://plugins.jetbrains.com/files/17718/688477/github-copilot-intellij-1.5.37-242.zip"
       },
       "name": "github-copilot"
     },
@@ -1403,15 +1403,15 @@
         "243.22562.220": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
         "243.24978.546": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
         "243.24978.79": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
-        "243.24978.86": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
         "243.25659.34": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
-        "243.25659.39": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
         "243.25659.40": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
         "243.25659.41": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
         "243.25659.42": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
         "243.25659.43": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
         "243.25659.45": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
-        "243.25659.52": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip"
+        "243.25659.52": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
+        "243.25659.54": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
+        "243.25659.59": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip"
       },
       "name": "netbeans-6-5-keymap"
     },
@@ -1436,15 +1436,15 @@
         "243.22562.220": "https://plugins.jetbrains.com/files/18682/680233/Catppuccin_Theme-3.4.1.zip",
         "243.24978.546": "https://plugins.jetbrains.com/files/18682/680233/Catppuccin_Theme-3.4.1.zip",
         "243.24978.79": "https://plugins.jetbrains.com/files/18682/680233/Catppuccin_Theme-3.4.1.zip",
-        "243.24978.86": "https://plugins.jetbrains.com/files/18682/680233/Catppuccin_Theme-3.4.1.zip",
         "243.25659.34": "https://plugins.jetbrains.com/files/18682/680233/Catppuccin_Theme-3.4.1.zip",
-        "243.25659.39": "https://plugins.jetbrains.com/files/18682/680233/Catppuccin_Theme-3.4.1.zip",
         "243.25659.40": "https://plugins.jetbrains.com/files/18682/680233/Catppuccin_Theme-3.4.1.zip",
         "243.25659.41": "https://plugins.jetbrains.com/files/18682/680233/Catppuccin_Theme-3.4.1.zip",
         "243.25659.42": "https://plugins.jetbrains.com/files/18682/680233/Catppuccin_Theme-3.4.1.zip",
         "243.25659.43": "https://plugins.jetbrains.com/files/18682/680233/Catppuccin_Theme-3.4.1.zip",
         "243.25659.45": "https://plugins.jetbrains.com/files/18682/680233/Catppuccin_Theme-3.4.1.zip",
-        "243.25659.52": "https://plugins.jetbrains.com/files/18682/680233/Catppuccin_Theme-3.4.1.zip"
+        "243.25659.52": "https://plugins.jetbrains.com/files/18682/680233/Catppuccin_Theme-3.4.1.zip",
+        "243.25659.54": "https://plugins.jetbrains.com/files/18682/680233/Catppuccin_Theme-3.4.1.zip",
+        "243.25659.59": "https://plugins.jetbrains.com/files/18682/680233/Catppuccin_Theme-3.4.1.zip"
       },
       "name": "catppuccin-theme"
     },
@@ -1469,15 +1469,15 @@
         "243.22562.220": "https://plugins.jetbrains.com/files/18824/671527/CodeGlancePro-1.9.6-signed.zip",
         "243.24978.546": "https://plugins.jetbrains.com/files/18824/671527/CodeGlancePro-1.9.6-signed.zip",
         "243.24978.79": "https://plugins.jetbrains.com/files/18824/671527/CodeGlancePro-1.9.6-signed.zip",
-        "243.24978.86": "https://plugins.jetbrains.com/files/18824/671527/CodeGlancePro-1.9.6-signed.zip",
         "243.25659.34": "https://plugins.jetbrains.com/files/18824/671527/CodeGlancePro-1.9.6-signed.zip",
-        "243.25659.39": "https://plugins.jetbrains.com/files/18824/671527/CodeGlancePro-1.9.6-signed.zip",
         "243.25659.40": "https://plugins.jetbrains.com/files/18824/671527/CodeGlancePro-1.9.6-signed.zip",
         "243.25659.41": "https://plugins.jetbrains.com/files/18824/671527/CodeGlancePro-1.9.6-signed.zip",
         "243.25659.42": "https://plugins.jetbrains.com/files/18824/671527/CodeGlancePro-1.9.6-signed.zip",
         "243.25659.43": "https://plugins.jetbrains.com/files/18824/671527/CodeGlancePro-1.9.6-signed.zip",
         "243.25659.45": "https://plugins.jetbrains.com/files/18824/671527/CodeGlancePro-1.9.6-signed.zip",
-        "243.25659.52": "https://plugins.jetbrains.com/files/18824/671527/CodeGlancePro-1.9.6-signed.zip"
+        "243.25659.52": "https://plugins.jetbrains.com/files/18824/671527/CodeGlancePro-1.9.6-signed.zip",
+        "243.25659.54": "https://plugins.jetbrains.com/files/18824/671527/CodeGlancePro-1.9.6-signed.zip",
+        "243.25659.59": "https://plugins.jetbrains.com/files/18824/671527/CodeGlancePro-1.9.6-signed.zip"
       },
       "name": "codeglance-pro"
     },
@@ -1498,19 +1498,19 @@
         "webstorm"
       ],
       "builds": {
-        "243.22562.218": "https://plugins.jetbrains.com/files/18922/685255/GerryThemes.jar",
-        "243.22562.220": "https://plugins.jetbrains.com/files/18922/685255/GerryThemes.jar",
-        "243.24978.546": "https://plugins.jetbrains.com/files/18922/685255/GerryThemes.jar",
-        "243.24978.79": "https://plugins.jetbrains.com/files/18922/685255/GerryThemes.jar",
-        "243.24978.86": "https://plugins.jetbrains.com/files/18922/685255/GerryThemes.jar",
-        "243.25659.34": "https://plugins.jetbrains.com/files/18922/685255/GerryThemes.jar",
-        "243.25659.39": "https://plugins.jetbrains.com/files/18922/685255/GerryThemes.jar",
-        "243.25659.40": "https://plugins.jetbrains.com/files/18922/685255/GerryThemes.jar",
-        "243.25659.41": "https://plugins.jetbrains.com/files/18922/685255/GerryThemes.jar",
-        "243.25659.42": "https://plugins.jetbrains.com/files/18922/685255/GerryThemes.jar",
-        "243.25659.43": "https://plugins.jetbrains.com/files/18922/685255/GerryThemes.jar",
-        "243.25659.45": "https://plugins.jetbrains.com/files/18922/685255/GerryThemes.jar",
-        "243.25659.52": "https://plugins.jetbrains.com/files/18922/685255/GerryThemes.jar"
+        "243.22562.218": "https://plugins.jetbrains.com/files/18922/694217/GerryThemes.jar",
+        "243.22562.220": "https://plugins.jetbrains.com/files/18922/694217/GerryThemes.jar",
+        "243.24978.546": "https://plugins.jetbrains.com/files/18922/694217/GerryThemes.jar",
+        "243.24978.79": "https://plugins.jetbrains.com/files/18922/694217/GerryThemes.jar",
+        "243.25659.34": "https://plugins.jetbrains.com/files/18922/694217/GerryThemes.jar",
+        "243.25659.40": "https://plugins.jetbrains.com/files/18922/694217/GerryThemes.jar",
+        "243.25659.41": "https://plugins.jetbrains.com/files/18922/694217/GerryThemes.jar",
+        "243.25659.42": "https://plugins.jetbrains.com/files/18922/694217/GerryThemes.jar",
+        "243.25659.43": "https://plugins.jetbrains.com/files/18922/694217/GerryThemes.jar",
+        "243.25659.45": "https://plugins.jetbrains.com/files/18922/694217/GerryThemes.jar",
+        "243.25659.52": "https://plugins.jetbrains.com/files/18922/694217/GerryThemes.jar",
+        "243.25659.54": "https://plugins.jetbrains.com/files/18922/694217/GerryThemes.jar",
+        "243.25659.59": "https://plugins.jetbrains.com/files/18922/694217/GerryThemes.jar"
       },
       "name": "gerry-themes"
     },
@@ -1535,15 +1535,15 @@
         "243.22562.220": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
         "243.24978.546": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
         "243.24978.79": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
-        "243.24978.86": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
         "243.25659.34": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
-        "243.25659.39": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
         "243.25659.40": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
         "243.25659.41": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
         "243.25659.42": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
         "243.25659.43": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
         "243.25659.45": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
-        "243.25659.52": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip"
+        "243.25659.52": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
+        "243.25659.54": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
+        "243.25659.59": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip"
       },
       "name": "better-direnv"
     },
@@ -1568,15 +1568,15 @@
         "243.22562.220": "https://plugins.jetbrains.com/files/20146/633971/Mermaid-0.0.24_IJ.243.zip",
         "243.24978.546": "https://plugins.jetbrains.com/files/20146/633971/Mermaid-0.0.24_IJ.243.zip",
         "243.24978.79": "https://plugins.jetbrains.com/files/20146/633971/Mermaid-0.0.24_IJ.243.zip",
-        "243.24978.86": "https://plugins.jetbrains.com/files/20146/633971/Mermaid-0.0.24_IJ.243.zip",
         "243.25659.34": "https://plugins.jetbrains.com/files/20146/633971/Mermaid-0.0.24_IJ.243.zip",
-        "243.25659.39": "https://plugins.jetbrains.com/files/20146/633971/Mermaid-0.0.24_IJ.243.zip",
         "243.25659.40": "https://plugins.jetbrains.com/files/20146/633971/Mermaid-0.0.24_IJ.243.zip",
         "243.25659.41": "https://plugins.jetbrains.com/files/20146/633971/Mermaid-0.0.24_IJ.243.zip",
         "243.25659.42": "https://plugins.jetbrains.com/files/20146/633971/Mermaid-0.0.24_IJ.243.zip",
         "243.25659.43": "https://plugins.jetbrains.com/files/20146/633971/Mermaid-0.0.24_IJ.243.zip",
         "243.25659.45": "https://plugins.jetbrains.com/files/20146/633971/Mermaid-0.0.24_IJ.243.zip",
-        "243.25659.52": "https://plugins.jetbrains.com/files/20146/633971/Mermaid-0.0.24_IJ.243.zip"
+        "243.25659.52": "https://plugins.jetbrains.com/files/20146/633971/Mermaid-0.0.24_IJ.243.zip",
+        "243.25659.54": "https://plugins.jetbrains.com/files/20146/633971/Mermaid-0.0.24_IJ.243.zip",
+        "243.25659.59": "https://plugins.jetbrains.com/files/20146/633971/Mermaid-0.0.24_IJ.243.zip"
       },
       "name": "mermaid"
     },
@@ -1601,15 +1601,15 @@
         "243.22562.220": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
         "243.24978.546": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
         "243.24978.79": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
-        "243.24978.86": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
         "243.25659.34": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
-        "243.25659.39": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
         "243.25659.40": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
         "243.25659.41": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
         "243.25659.42": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
         "243.25659.43": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
         "243.25659.45": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
-        "243.25659.52": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip"
+        "243.25659.52": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
+        "243.25659.54": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
+        "243.25659.59": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip"
       },
       "name": "ferris"
     },
@@ -1630,19 +1630,19 @@
         "webstorm"
       ],
       "builds": {
-        "243.22562.218": "https://plugins.jetbrains.com/files/21667/618339/code-complexity-plugin-1.6.1.zip",
-        "243.22562.220": "https://plugins.jetbrains.com/files/21667/618339/code-complexity-plugin-1.6.1.zip",
-        "243.24978.546": "https://plugins.jetbrains.com/files/21667/618339/code-complexity-plugin-1.6.1.zip",
-        "243.24978.79": "https://plugins.jetbrains.com/files/21667/618339/code-complexity-plugin-1.6.1.zip",
-        "243.24978.86": "https://plugins.jetbrains.com/files/21667/618339/code-complexity-plugin-1.6.1.zip",
-        "243.25659.34": "https://plugins.jetbrains.com/files/21667/618339/code-complexity-plugin-1.6.1.zip",
-        "243.25659.39": "https://plugins.jetbrains.com/files/21667/618339/code-complexity-plugin-1.6.1.zip",
-        "243.25659.40": "https://plugins.jetbrains.com/files/21667/618339/code-complexity-plugin-1.6.1.zip",
-        "243.25659.41": "https://plugins.jetbrains.com/files/21667/618339/code-complexity-plugin-1.6.1.zip",
-        "243.25659.42": "https://plugins.jetbrains.com/files/21667/618339/code-complexity-plugin-1.6.1.zip",
-        "243.25659.43": "https://plugins.jetbrains.com/files/21667/618339/code-complexity-plugin-1.6.1.zip",
-        "243.25659.45": "https://plugins.jetbrains.com/files/21667/618339/code-complexity-plugin-1.6.1.zip",
-        "243.25659.52": "https://plugins.jetbrains.com/files/21667/618339/code-complexity-plugin-1.6.1.zip"
+        "243.22562.218": "https://plugins.jetbrains.com/files/21667/693656/code-complexity-plugin-1.6.2.zip",
+        "243.22562.220": "https://plugins.jetbrains.com/files/21667/693656/code-complexity-plugin-1.6.2.zip",
+        "243.24978.546": "https://plugins.jetbrains.com/files/21667/693656/code-complexity-plugin-1.6.2.zip",
+        "243.24978.79": "https://plugins.jetbrains.com/files/21667/693656/code-complexity-plugin-1.6.2.zip",
+        "243.25659.34": "https://plugins.jetbrains.com/files/21667/693656/code-complexity-plugin-1.6.2.zip",
+        "243.25659.40": "https://plugins.jetbrains.com/files/21667/693656/code-complexity-plugin-1.6.2.zip",
+        "243.25659.41": "https://plugins.jetbrains.com/files/21667/693656/code-complexity-plugin-1.6.2.zip",
+        "243.25659.42": "https://plugins.jetbrains.com/files/21667/693656/code-complexity-plugin-1.6.2.zip",
+        "243.25659.43": "https://plugins.jetbrains.com/files/21667/693656/code-complexity-plugin-1.6.2.zip",
+        "243.25659.45": "https://plugins.jetbrains.com/files/21667/693656/code-complexity-plugin-1.6.2.zip",
+        "243.25659.52": "https://plugins.jetbrains.com/files/21667/693656/code-complexity-plugin-1.6.2.zip",
+        "243.25659.54": "https://plugins.jetbrains.com/files/21667/693656/code-complexity-plugin-1.6.2.zip",
+        "243.25659.59": "https://plugins.jetbrains.com/files/21667/693656/code-complexity-plugin-1.6.2.zip"
       },
       "name": "code-complexity"
     },
@@ -1667,15 +1667,15 @@
         "243.22562.220": "https://plugins.jetbrains.com/files/21904/665427/intellij-developer-tools-plugin-6.3.0-signed.zip",
         "243.24978.546": "https://plugins.jetbrains.com/files/21904/665427/intellij-developer-tools-plugin-6.3.0-signed.zip",
         "243.24978.79": "https://plugins.jetbrains.com/files/21904/665427/intellij-developer-tools-plugin-6.3.0-signed.zip",
-        "243.24978.86": "https://plugins.jetbrains.com/files/21904/665427/intellij-developer-tools-plugin-6.3.0-signed.zip",
         "243.25659.34": "https://plugins.jetbrains.com/files/21904/665427/intellij-developer-tools-plugin-6.3.0-signed.zip",
-        "243.25659.39": "https://plugins.jetbrains.com/files/21904/665427/intellij-developer-tools-plugin-6.3.0-signed.zip",
         "243.25659.40": "https://plugins.jetbrains.com/files/21904/665427/intellij-developer-tools-plugin-6.3.0-signed.zip",
         "243.25659.41": "https://plugins.jetbrains.com/files/21904/665427/intellij-developer-tools-plugin-6.3.0-signed.zip",
         "243.25659.42": "https://plugins.jetbrains.com/files/21904/665427/intellij-developer-tools-plugin-6.3.0-signed.zip",
         "243.25659.43": "https://plugins.jetbrains.com/files/21904/665427/intellij-developer-tools-plugin-6.3.0-signed.zip",
         "243.25659.45": "https://plugins.jetbrains.com/files/21904/665427/intellij-developer-tools-plugin-6.3.0-signed.zip",
-        "243.25659.52": "https://plugins.jetbrains.com/files/21904/665427/intellij-developer-tools-plugin-6.3.0-signed.zip"
+        "243.25659.52": "https://plugins.jetbrains.com/files/21904/665427/intellij-developer-tools-plugin-6.3.0-signed.zip",
+        "243.25659.54": "https://plugins.jetbrains.com/files/21904/665427/intellij-developer-tools-plugin-6.3.0-signed.zip",
+        "243.25659.59": "https://plugins.jetbrains.com/files/21904/665427/intellij-developer-tools-plugin-6.3.0-signed.zip"
       },
       "name": "developer-tools"
     },
@@ -1692,15 +1692,15 @@
         "webstorm"
       ],
       "builds": {
-        "243.24978.86": "https://plugins.jetbrains.com/files/21962/684422/clouds-docker-gateway-243.24978.79.zip",
         "243.25659.34": "https://plugins.jetbrains.com/files/21962/684422/clouds-docker-gateway-243.24978.79.zip",
-        "243.25659.39": "https://plugins.jetbrains.com/files/21962/684422/clouds-docker-gateway-243.24978.79.zip",
         "243.25659.40": "https://plugins.jetbrains.com/files/21962/684422/clouds-docker-gateway-243.24978.79.zip",
         "243.25659.41": "https://plugins.jetbrains.com/files/21962/684422/clouds-docker-gateway-243.24978.79.zip",
         "243.25659.42": "https://plugins.jetbrains.com/files/21962/684422/clouds-docker-gateway-243.24978.79.zip",
         "243.25659.43": "https://plugins.jetbrains.com/files/21962/684422/clouds-docker-gateway-243.24978.79.zip",
         "243.25659.45": "https://plugins.jetbrains.com/files/21962/684422/clouds-docker-gateway-243.24978.79.zip",
-        "243.25659.52": "https://plugins.jetbrains.com/files/21962/684422/clouds-docker-gateway-243.24978.79.zip"
+        "243.25659.52": "https://plugins.jetbrains.com/files/21962/684422/clouds-docker-gateway-243.24978.79.zip",
+        "243.25659.54": "https://plugins.jetbrains.com/files/21962/684422/clouds-docker-gateway-243.24978.79.zip",
+        "243.25659.59": "https://plugins.jetbrains.com/files/21962/684422/clouds-docker-gateway-243.24978.79.zip"
       },
       "name": "dev-containers"
     },
@@ -1711,9 +1711,9 @@
         "rust-rover"
       ],
       "builds": {
-        "243.24978.86": "https://plugins.jetbrains.com/files/22407/686684/intellij-rust-243.24978.86.zip",
-        "243.25659.39": "https://plugins.jetbrains.com/files/22407/686684/intellij-rust-243.24978.86.zip",
-        "243.25659.42": "https://plugins.jetbrains.com/files/22407/686684/intellij-rust-243.24978.86.zip"
+        "243.25659.42": "https://plugins.jetbrains.com/files/22407/690878/intellij-rust-243.25659.54.zip",
+        "243.25659.54": "https://plugins.jetbrains.com/files/22407/690878/intellij-rust-243.25659.54.zip",
+        "243.25659.59": "https://plugins.jetbrains.com/files/22407/690878/intellij-rust-243.25659.54.zip"
       },
       "name": "rust"
     },
@@ -1734,19 +1734,19 @@
         "webstorm"
       ],
       "builds": {
-        "243.22562.218": "https://plugins.jetbrains.com/files/22707/687350/continue-intellij-extension-1.0.1.zip",
-        "243.22562.220": "https://plugins.jetbrains.com/files/22707/687350/continue-intellij-extension-1.0.1.zip",
-        "243.24978.546": "https://plugins.jetbrains.com/files/22707/687350/continue-intellij-extension-1.0.1.zip",
-        "243.24978.79": "https://plugins.jetbrains.com/files/22707/687350/continue-intellij-extension-1.0.1.zip",
-        "243.24978.86": "https://plugins.jetbrains.com/files/22707/687350/continue-intellij-extension-1.0.1.zip",
-        "243.25659.34": "https://plugins.jetbrains.com/files/22707/687350/continue-intellij-extension-1.0.1.zip",
-        "243.25659.39": "https://plugins.jetbrains.com/files/22707/687350/continue-intellij-extension-1.0.1.zip",
-        "243.25659.40": "https://plugins.jetbrains.com/files/22707/687350/continue-intellij-extension-1.0.1.zip",
-        "243.25659.41": "https://plugins.jetbrains.com/files/22707/687350/continue-intellij-extension-1.0.1.zip",
-        "243.25659.42": "https://plugins.jetbrains.com/files/22707/687350/continue-intellij-extension-1.0.1.zip",
-        "243.25659.43": "https://plugins.jetbrains.com/files/22707/687350/continue-intellij-extension-1.0.1.zip",
-        "243.25659.45": "https://plugins.jetbrains.com/files/22707/687350/continue-intellij-extension-1.0.1.zip",
-        "243.25659.52": "https://plugins.jetbrains.com/files/22707/687350/continue-intellij-extension-1.0.1.zip"
+        "243.22562.218": "https://plugins.jetbrains.com/files/22707/689483/continue-intellij-extension-1.0.2.zip",
+        "243.22562.220": "https://plugins.jetbrains.com/files/22707/689483/continue-intellij-extension-1.0.2.zip",
+        "243.24978.546": "https://plugins.jetbrains.com/files/22707/689483/continue-intellij-extension-1.0.2.zip",
+        "243.24978.79": "https://plugins.jetbrains.com/files/22707/689483/continue-intellij-extension-1.0.2.zip",
+        "243.25659.34": "https://plugins.jetbrains.com/files/22707/689483/continue-intellij-extension-1.0.2.zip",
+        "243.25659.40": "https://plugins.jetbrains.com/files/22707/689483/continue-intellij-extension-1.0.2.zip",
+        "243.25659.41": "https://plugins.jetbrains.com/files/22707/689483/continue-intellij-extension-1.0.2.zip",
+        "243.25659.42": "https://plugins.jetbrains.com/files/22707/689483/continue-intellij-extension-1.0.2.zip",
+        "243.25659.43": "https://plugins.jetbrains.com/files/22707/689483/continue-intellij-extension-1.0.2.zip",
+        "243.25659.45": "https://plugins.jetbrains.com/files/22707/689483/continue-intellij-extension-1.0.2.zip",
+        "243.25659.52": "https://plugins.jetbrains.com/files/22707/689483/continue-intellij-extension-1.0.2.zip",
+        "243.25659.54": "https://plugins.jetbrains.com/files/22707/689483/continue-intellij-extension-1.0.2.zip",
+        "243.25659.59": "https://plugins.jetbrains.com/files/22707/689483/continue-intellij-extension-1.0.2.zip"
       },
       "name": "continue"
     },
@@ -1771,15 +1771,15 @@
         "243.22562.220": "https://plugins.jetbrains.com/files/22857/640903/vcs-gitlab-243.22562.53.zip",
         "243.24978.546": "https://plugins.jetbrains.com/files/22857/654839/vcs-gitlab-243.23654.19.zip",
         "243.24978.79": "https://plugins.jetbrains.com/files/22857/654839/vcs-gitlab-243.23654.19.zip",
-        "243.24978.86": "https://plugins.jetbrains.com/files/22857/654839/vcs-gitlab-243.23654.19.zip",
         "243.25659.34": "https://plugins.jetbrains.com/files/22857/654839/vcs-gitlab-243.23654.19.zip",
-        "243.25659.39": "https://plugins.jetbrains.com/files/22857/654839/vcs-gitlab-243.23654.19.zip",
         "243.25659.40": "https://plugins.jetbrains.com/files/22857/654839/vcs-gitlab-243.23654.19.zip",
         "243.25659.41": "https://plugins.jetbrains.com/files/22857/654839/vcs-gitlab-243.23654.19.zip",
         "243.25659.42": "https://plugins.jetbrains.com/files/22857/654839/vcs-gitlab-243.23654.19.zip",
         "243.25659.43": "https://plugins.jetbrains.com/files/22857/654839/vcs-gitlab-243.23654.19.zip",
         "243.25659.45": "https://plugins.jetbrains.com/files/22857/654839/vcs-gitlab-243.23654.19.zip",
-        "243.25659.52": "https://plugins.jetbrains.com/files/22857/654839/vcs-gitlab-243.23654.19.zip"
+        "243.25659.52": "https://plugins.jetbrains.com/files/22857/654839/vcs-gitlab-243.23654.19.zip",
+        "243.25659.54": "https://plugins.jetbrains.com/files/22857/654839/vcs-gitlab-243.23654.19.zip",
+        "243.25659.59": "https://plugins.jetbrains.com/files/22857/654839/vcs-gitlab-243.23654.19.zip"
       },
       "name": "gitlab"
     },
@@ -1804,15 +1804,15 @@
         "243.22562.220": "https://plugins.jetbrains.com/files/23029/684999/Catppuccin_Icons-1.10.2.zip",
         "243.24978.546": "https://plugins.jetbrains.com/files/23029/684999/Catppuccin_Icons-1.10.2.zip",
         "243.24978.79": "https://plugins.jetbrains.com/files/23029/684999/Catppuccin_Icons-1.10.2.zip",
-        "243.24978.86": "https://plugins.jetbrains.com/files/23029/684999/Catppuccin_Icons-1.10.2.zip",
         "243.25659.34": "https://plugins.jetbrains.com/files/23029/684999/Catppuccin_Icons-1.10.2.zip",
-        "243.25659.39": "https://plugins.jetbrains.com/files/23029/684999/Catppuccin_Icons-1.10.2.zip",
         "243.25659.40": "https://plugins.jetbrains.com/files/23029/684999/Catppuccin_Icons-1.10.2.zip",
         "243.25659.41": "https://plugins.jetbrains.com/files/23029/684999/Catppuccin_Icons-1.10.2.zip",
         "243.25659.42": "https://plugins.jetbrains.com/files/23029/684999/Catppuccin_Icons-1.10.2.zip",
         "243.25659.43": "https://plugins.jetbrains.com/files/23029/684999/Catppuccin_Icons-1.10.2.zip",
         "243.25659.45": "https://plugins.jetbrains.com/files/23029/684999/Catppuccin_Icons-1.10.2.zip",
-        "243.25659.52": "https://plugins.jetbrains.com/files/23029/684999/Catppuccin_Icons-1.10.2.zip"
+        "243.25659.52": "https://plugins.jetbrains.com/files/23029/684999/Catppuccin_Icons-1.10.2.zip",
+        "243.25659.54": "https://plugins.jetbrains.com/files/23029/684999/Catppuccin_Icons-1.10.2.zip",
+        "243.25659.59": "https://plugins.jetbrains.com/files/23029/684999/Catppuccin_Icons-1.10.2.zip"
       },
       "name": "catppuccin-icons"
     },
@@ -1837,15 +1837,15 @@
         "243.22562.220": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
         "243.24978.546": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
         "243.24978.79": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
-        "243.24978.86": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
         "243.25659.34": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
-        "243.25659.39": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
         "243.25659.40": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
         "243.25659.41": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
         "243.25659.42": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
         "243.25659.43": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
         "243.25659.45": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
-        "243.25659.52": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip"
+        "243.25659.52": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
+        "243.25659.54": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
+        "243.25659.59": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip"
       },
       "name": "mermaid-chart"
     },
@@ -1870,15 +1870,15 @@
         "243.22562.220": "https://plugins.jetbrains.com/files/23927/686932/Extra_IDE_Tweaks-2025.1.2.zip",
         "243.24978.546": "https://plugins.jetbrains.com/files/23927/686932/Extra_IDE_Tweaks-2025.1.2.zip",
         "243.24978.79": "https://plugins.jetbrains.com/files/23927/686932/Extra_IDE_Tweaks-2025.1.2.zip",
-        "243.24978.86": "https://plugins.jetbrains.com/files/23927/686932/Extra_IDE_Tweaks-2025.1.2.zip",
         "243.25659.34": "https://plugins.jetbrains.com/files/23927/686932/Extra_IDE_Tweaks-2025.1.2.zip",
-        "243.25659.39": "https://plugins.jetbrains.com/files/23927/686932/Extra_IDE_Tweaks-2025.1.2.zip",
         "243.25659.40": "https://plugins.jetbrains.com/files/23927/686932/Extra_IDE_Tweaks-2025.1.2.zip",
         "243.25659.41": "https://plugins.jetbrains.com/files/23927/686932/Extra_IDE_Tweaks-2025.1.2.zip",
         "243.25659.42": "https://plugins.jetbrains.com/files/23927/686932/Extra_IDE_Tweaks-2025.1.2.zip",
         "243.25659.43": "https://plugins.jetbrains.com/files/23927/686932/Extra_IDE_Tweaks-2025.1.2.zip",
         "243.25659.45": "https://plugins.jetbrains.com/files/23927/686932/Extra_IDE_Tweaks-2025.1.2.zip",
-        "243.25659.52": "https://plugins.jetbrains.com/files/23927/686932/Extra_IDE_Tweaks-2025.1.2.zip"
+        "243.25659.52": "https://plugins.jetbrains.com/files/23927/686932/Extra_IDE_Tweaks-2025.1.2.zip",
+        "243.25659.54": "https://plugins.jetbrains.com/files/23927/686932/Extra_IDE_Tweaks-2025.1.2.zip",
+        "243.25659.59": "https://plugins.jetbrains.com/files/23927/686932/Extra_IDE_Tweaks-2025.1.2.zip"
       },
       "name": "extra-ide-tweaks"
     },
@@ -1903,15 +1903,15 @@
         "243.22562.220": "https://plugins.jetbrains.com/files/24559/686931/Extra_Tools_Pack-2025.1.3.zip",
         "243.24978.546": "https://plugins.jetbrains.com/files/24559/686931/Extra_Tools_Pack-2025.1.3.zip",
         "243.24978.79": "https://plugins.jetbrains.com/files/24559/686931/Extra_Tools_Pack-2025.1.3.zip",
-        "243.24978.86": "https://plugins.jetbrains.com/files/24559/686931/Extra_Tools_Pack-2025.1.3.zip",
         "243.25659.34": "https://plugins.jetbrains.com/files/24559/686931/Extra_Tools_Pack-2025.1.3.zip",
-        "243.25659.39": "https://plugins.jetbrains.com/files/24559/686931/Extra_Tools_Pack-2025.1.3.zip",
         "243.25659.40": "https://plugins.jetbrains.com/files/24559/686931/Extra_Tools_Pack-2025.1.3.zip",
         "243.25659.41": "https://plugins.jetbrains.com/files/24559/686931/Extra_Tools_Pack-2025.1.3.zip",
         "243.25659.42": "https://plugins.jetbrains.com/files/24559/686931/Extra_Tools_Pack-2025.1.3.zip",
         "243.25659.43": "https://plugins.jetbrains.com/files/24559/686931/Extra_Tools_Pack-2025.1.3.zip",
         "243.25659.45": "https://plugins.jetbrains.com/files/24559/686931/Extra_Tools_Pack-2025.1.3.zip",
-        "243.25659.52": "https://plugins.jetbrains.com/files/24559/686931/Extra_Tools_Pack-2025.1.3.zip"
+        "243.25659.52": "https://plugins.jetbrains.com/files/24559/686931/Extra_Tools_Pack-2025.1.3.zip",
+        "243.25659.54": "https://plugins.jetbrains.com/files/24559/686931/Extra_Tools_Pack-2025.1.3.zip",
+        "243.25659.59": "https://plugins.jetbrains.com/files/24559/686931/Extra_Tools_Pack-2025.1.3.zip"
       },
       "name": "extra-tools-pack"
     },
@@ -1930,15 +1930,15 @@
       ],
       "builds": {
         "243.24978.79": "https://plugins.jetbrains.com/files/25594/623962/Nix_LSP-0.1.1.zip",
-        "243.24978.86": "https://plugins.jetbrains.com/files/25594/623962/Nix_LSP-0.1.1.zip",
         "243.25659.34": "https://plugins.jetbrains.com/files/25594/623962/Nix_LSP-0.1.1.zip",
-        "243.25659.39": "https://plugins.jetbrains.com/files/25594/623962/Nix_LSP-0.1.1.zip",
         "243.25659.40": "https://plugins.jetbrains.com/files/25594/623962/Nix_LSP-0.1.1.zip",
         "243.25659.41": "https://plugins.jetbrains.com/files/25594/623962/Nix_LSP-0.1.1.zip",
         "243.25659.42": "https://plugins.jetbrains.com/files/25594/623962/Nix_LSP-0.1.1.zip",
         "243.25659.43": "https://plugins.jetbrains.com/files/25594/623962/Nix_LSP-0.1.1.zip",
         "243.25659.45": "https://plugins.jetbrains.com/files/25594/623962/Nix_LSP-0.1.1.zip",
-        "243.25659.52": "https://plugins.jetbrains.com/files/25594/623962/Nix_LSP-0.1.1.zip"
+        "243.25659.52": "https://plugins.jetbrains.com/files/25594/623962/Nix_LSP-0.1.1.zip",
+        "243.25659.54": "https://plugins.jetbrains.com/files/25594/623962/Nix_LSP-0.1.1.zip",
+        "243.25659.59": "https://plugins.jetbrains.com/files/25594/623962/Nix_LSP-0.1.1.zip"
       },
       "name": "nix-lsp"
     },
@@ -1961,15 +1961,15 @@
         "243.22562.218": "https://plugins.jetbrains.com/files/26084/680234/markdtask-2025.1.1.zip",
         "243.22562.220": "https://plugins.jetbrains.com/files/26084/680234/markdtask-2025.1.1.zip",
         "243.24978.79": "https://plugins.jetbrains.com/files/26084/680234/markdtask-2025.1.1.zip",
-        "243.24978.86": "https://plugins.jetbrains.com/files/26084/680234/markdtask-2025.1.1.zip",
         "243.25659.34": "https://plugins.jetbrains.com/files/26084/680234/markdtask-2025.1.1.zip",
-        "243.25659.39": "https://plugins.jetbrains.com/files/26084/680234/markdtask-2025.1.1.zip",
         "243.25659.40": "https://plugins.jetbrains.com/files/26084/680234/markdtask-2025.1.1.zip",
         "243.25659.41": "https://plugins.jetbrains.com/files/26084/680234/markdtask-2025.1.1.zip",
         "243.25659.42": "https://plugins.jetbrains.com/files/26084/680234/markdtask-2025.1.1.zip",
         "243.25659.43": "https://plugins.jetbrains.com/files/26084/680234/markdtask-2025.1.1.zip",
         "243.25659.45": "https://plugins.jetbrains.com/files/26084/680234/markdtask-2025.1.1.zip",
-        "243.25659.52": "https://plugins.jetbrains.com/files/26084/680234/markdtask-2025.1.1.zip"
+        "243.25659.52": "https://plugins.jetbrains.com/files/26084/680234/markdtask-2025.1.1.zip",
+        "243.25659.54": "https://plugins.jetbrains.com/files/26084/680234/markdtask-2025.1.1.zip",
+        "243.25659.59": "https://plugins.jetbrains.com/files/26084/680234/markdtask-2025.1.1.zip"
       },
       "name": "markdtask"
     }
@@ -1980,7 +1980,7 @@
     "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip": "sha256-25vtwXuBNiYL9E0pKG4dqJDkwX1FckAErdqRPKXybQA=",
     "https://plugins.jetbrains.com/files/10481/583591/intellij-hocon-2024.2.0.zip": "sha256-Bnnvy+HDNkx2DQM7N+JUa8hQzIA3H/5Y0WpWAjPmhUI=",
     "https://plugins.jetbrains.com/files/11058/686929/Extra_Icons-2025.1.2.zip": "sha256-wJgDPYDCCzehOOaXLVnHSBgpPfaNeh+uNoNHe9BBNn0=",
-    "https://plugins.jetbrains.com/files/11349/689463/aws-toolkit-jetbrains-standalone-3.57-243.zip": "sha256-Il/V/WxYdTf6nO9BMCA6cDypzksGkZ3C6zaiQoUXUt8=",
+    "https://plugins.jetbrains.com/files/11349/693441/aws-toolkit-jetbrains-standalone-3.58-243.zip": "sha256-d57NJ/A7pUnzwiDVQ4CKiYC/npp1FN9wAnDBtEHDptk=",
     "https://plugins.jetbrains.com/files/12024/622380/ReSharperPlugin.CognitiveComplexity-2024.3.0-eap04.zip": "sha256-X2x7uyWoV4aBI8E5bw35QfzmySWzbEAZ2nvdo5i+t+s=",
     "https://plugins.jetbrains.com/files/12062/630060/keymap-vscode-243.21565.122.zip": "sha256-phv8MTGKNGzRviKzX+nIVTbkX4WkU82QVO5zXUQLtAo=",
     "https://plugins.jetbrains.com/files/12559/629985/keymap-eclipse-243.21565.122.zip": "sha256-/g1ucT18ywVJnCePH7WyMWKgM9umowBz5wFObmO7cws=",
@@ -1999,16 +1999,16 @@
     "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip": "sha256-KrzZTKZMQqoEMw+vDUv2jjs0EX0leaPBkU8H/ecq/oI=",
     "https://plugins.jetbrains.com/files/18682/680233/Catppuccin_Theme-3.4.1.zip": "sha256-QOF3nAXOfYhNl3YUK1fc9z5H2uXTPm2X+6fVZ5QP8ZQ=",
     "https://plugins.jetbrains.com/files/18824/671527/CodeGlancePro-1.9.6-signed.zip": "sha256-AEHZxuRMBEZlT3xTxBUbHEPjEJBOCLxdj1wEYBzlNdk=",
-    "https://plugins.jetbrains.com/files/18922/685255/GerryThemes.jar": "sha256-GROc7EiggdGHUQknzduildmchx3axkoij1Zqwqqm76I=",
+    "https://plugins.jetbrains.com/files/18922/694217/GerryThemes.jar": "sha256-8Ufa8YuGOG78KRSxo/GiwPFrd/3lwQhLWwAnB6igaGE=",
     "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip": "sha256-hoFfIid7lClHDiT+ZH3H+tFSvWYb1tSRZH1iif+kWrM=",
     "https://plugins.jetbrains.com/files/20146/633971/Mermaid-0.0.24_IJ.243.zip": "sha256-jGWRU0g120qYvvFiUFI10zvprTsemuIq3XmIjYxZGts=",
     "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip": "sha256-N66Bh0AwHmg5N9PNguRAGtpJ/dLMWMp3rxjTgz9poFo=",
     "https://plugins.jetbrains.com/files/2162/640476/StringManipulation-9.15.0.zip": "sha256-TZPup3EJ0cBv4i2eVAQwVmmzy0rmt4KptEsk3C7baEM=",
-    "https://plugins.jetbrains.com/files/21667/618339/code-complexity-plugin-1.6.1.zip": "sha256-OGaYvQfSdAh0OZhYSpZJD14uyx8FSagEhUEinZmR3N4=",
+    "https://plugins.jetbrains.com/files/21667/693656/code-complexity-plugin-1.6.2.zip": "sha256-2qDeC2Fxp4/IfiLPL1JDquJDCzONCp4m92Ht2fnCn/M=",
     "https://plugins.jetbrains.com/files/21904/665427/intellij-developer-tools-plugin-6.3.0-signed.zip": "sha256-TEx5wg3Sf3rkhl6oj0hRrMdBJW9KMjZ/yNDgNYaeP28=",
     "https://plugins.jetbrains.com/files/21962/684422/clouds-docker-gateway-243.24978.79.zip": "sha256-jmfcGDtizib7wQW88sWuzG095nrT0KHyN98trxqISHE=",
-    "https://plugins.jetbrains.com/files/22407/686684/intellij-rust-243.24978.86.zip": "sha256-HQgDKzR8nt/xHj38wnhTJZZOlKTEb//bOcqYhw0vQbA=",
-    "https://plugins.jetbrains.com/files/22707/687350/continue-intellij-extension-1.0.1.zip": "sha256-IryGHaPuEIYa2epEHEYEXJCofRhxFXsgo7HDIDE2MCg=",
+    "https://plugins.jetbrains.com/files/22407/690878/intellij-rust-243.25659.54.zip": "sha256-LqBhEiWCVaLRM2WsflLWX0N+i6Q8ZmHoHaJnJSEKbS0=",
+    "https://plugins.jetbrains.com/files/22707/689483/continue-intellij-extension-1.0.2.zip": "sha256-Kf5kHd8tGVIClWcrin9zOFbQkZyOrwHpfMvdznPkNC0=",
     "https://plugins.jetbrains.com/files/22857/640903/vcs-gitlab-243.22562.53.zip": "sha256-lDStIaRy9ZtCXZxM2RRrz/5oZeL90aRVS63wC4XkJNw=",
     "https://plugins.jetbrains.com/files/22857/654839/vcs-gitlab-243.23654.19.zip": "sha256-VKGZLlL8ALjr6JEQtjhXiIxNrnTPXIoXMToJkJux2dw=",
     "https://plugins.jetbrains.com/files/23029/684999/Catppuccin_Icons-1.10.2.zip": "sha256-qkwfEpC2f4vgVsesSiUvd6kK6XnG9DTN4gXUR+rLlK0=",
@@ -2017,11 +2017,11 @@
     "https://plugins.jetbrains.com/files/24559/686931/Extra_Tools_Pack-2025.1.3.zip": "sha256-r5oFljG92OTPbXRXqbXDI4KD2dyMp2onKTWQcdftU2k=",
     "https://plugins.jetbrains.com/files/25594/623962/Nix_LSP-0.1.1.zip": "sha256-Uq5RdVQTyqRMsEwDZT6Kldv2alt0EVMCABEt/xQUHow=",
     "https://plugins.jetbrains.com/files/26084/680234/markdtask-2025.1.1.zip": "sha256-NFHB5zWH8pUwz6OT8F7eIiapeEvHX24fj0Eo1qH45Aw=",
-    "https://plugins.jetbrains.com/files/631/688719/python-243.25659.39.zip": "sha256-WdrVWhdlKCnZOCuWqqszfNkd1nXzBxa2WX9Ma/UnZCw=",
+    "https://plugins.jetbrains.com/files/631/692278/python-243.25659.59.zip": "sha256-yB0Hak9H/HRy7GJPbGHur6yHk67nHqkxeKkktKcKmyE=",
     "https://plugins.jetbrains.com/files/6884/630038/handlebars-243.21565.122.zip": "sha256-pFKAZ8xFNfUh7/Hi4NYPDQAhRRYm4WKTpCQELqBfb40=",
     "https://plugins.jetbrains.com/files/6981/654905/ini-243.22562.236.zip": "sha256-kL/A2R8j2JKMU61T/xJahPwKPYmwFCFy55NPSoBh/Xc=",
     "https://plugins.jetbrains.com/files/6981/680778/ini-243.24978.60.zip": "sha256-m2iKdm4f1h+k1XdQvJCd8T83jEKip+H1E1p8XMfrGcg=",
-    "https://plugins.jetbrains.com/files/6981/689219/ini-243.25659.45.zip": "sha256-f3z/zoFunPaJm+eRA6K/n4JWELFCZjXEdsZfTy4qbIs=",
+    "https://plugins.jetbrains.com/files/6981/690635/ini-243.25659.54.zip": "sha256-TiVoHX56uEAsSWqE7n0jrePiabN3gcNRFNuSeBhvul4=",
     "https://plugins.jetbrains.com/files/7086/518678/AceJump.zip": "sha256-kVUEgfEKUupV/qlB4Dpzi5pFHjhVvX74XIPetKtjysM=",
     "https://plugins.jetbrains.com/files/7125/627704/GrepConsole-13.2.0-IJ2023.3.zip": "sha256-KY5VRiLJJwa9OVVog1W3MboZjwVboYwYm+i4eqooo44=",
     "https://plugins.jetbrains.com/files/7177/636663/fileWatcher-243.22562.13.zip": "sha256-8IHS3kmmbL8uQYnaMW7NgBIpBKT+XDJ4QDiiPZa5pzo=",
@@ -2032,10 +2032,10 @@
     "https://plugins.jetbrains.com/files/7322/680217/python-ce-243.24978.46.zip": "sha256-4KkUOSN9KnBjpo92LvkN/7ZtDG/gSAFHgDf5ESSsgoY=",
     "https://plugins.jetbrains.com/files/7391/658997/asciidoctor-intellij-plugin-0.43.6.zip": "sha256-3RJ7YVFtynyqeLIzdrirCMbWNZmUkJ+DT/9my71H0Dk=",
     "https://plugins.jetbrains.com/files/7425/603907/WakaTime.jar": "sha256-Z7ZWDomXnTdHFKOElMkt53imef6aT7H5XeD6lOOFxfQ=",
-    "https://plugins.jetbrains.com/files/7499/667439/gittoolbox-600.0.14_243-signed.zip": "sha256-rpJ0tPIf3mw5KLSv+wx16mXVKA1PxKTktgCYzKU3cU4=",
+    "https://plugins.jetbrains.com/files/7499/690185/gittoolbox-600.0.19_243-signed.zip": "sha256-ZbjLwXY+AocK1OtlyPd+wcObiArWSOWMXjtWaLWMbDo=",
     "https://plugins.jetbrains.com/files/7724/654910/clouds-docker-impl-243.22562.236.zip": "sha256-3F25CTNLfQcUFklNXovLVXQ8cfOr/6Y5yetPc3jTFQM=",
     "https://plugins.jetbrains.com/files/7724/680796/clouds-docker-impl-243.24978.54.zip": "sha256-pGAUljrRizCer076iM1oKrNj54tN3VxSvYldfKAsqRE=",
-    "https://plugins.jetbrains.com/files/7724/689214/clouds-docker-impl-243.25659.45.zip": "sha256-iF/RkgQatHpGUNcLhKhP3aXSAJXPfzKEf8BvWdYooXs=",
+    "https://plugins.jetbrains.com/files/7724/692258/clouds-docker-impl-243.25659.59.zip": "sha256-fJatpg7WzrStvABSeIayeFF4bjv059VW6ZTTKQxLNV8=",
     "https://plugins.jetbrains.com/files/8097/636616/graphql-243.22562.13.zip": "sha256-rr2pO0mIsqWXYZgwEhcQJlk0lQabxnIPxqRCGdTFaTw=",
     "https://plugins.jetbrains.com/files/8097/680200/graphql-243.24978.46.zip": "sha256-RJELd6KPzlRu+UwWBPW1fN33Zj0PcgQ0hGCJ6+ii/fI=",
     "https://plugins.jetbrains.com/files/8097/688195/graphql-243.25659.42.zip": "sha256-p52AGXhfldRiT7FoWeDQuP38+/9J1KuPDyhM4VUwQTc=",
@@ -2044,11 +2044,11 @@
     "https://plugins.jetbrains.com/files/8327/615097/Minecraft_Development-2024.3-1.8.2.zip": "sha256-4c1nxjbEsNs9twmQnJllk1OIVmm0nnUYZ0R7f/6bJt4=",
     "https://plugins.jetbrains.com/files/8554/654690/featuresTrainer-243.22562.233.zip": "sha256-JugbJM8Lr2kbhP9hdLE3kUStl2vOMUB5wGTwNLxAZd0=",
     "https://plugins.jetbrains.com/files/8554/684425/featuresTrainer-243.24978.79.zip": "sha256-1oI8hw6YYhUzhfv5RjtlBFG0OvucqVs/XUXMioRIuzA=",
-    "https://plugins.jetbrains.com/files/8554/688898/featuresTrainer-243.25659.44.zip": "sha256-JEGphoUK/MG0wiLNcQ7CM89vuq7L65WgncmVxzClvr4=",
+    "https://plugins.jetbrains.com/files/8554/690630/featuresTrainer-243.25659.54.zip": "sha256-xmjPvJVe27gL1DEwtzvKvzEkF80ZGHUCKjLOY2nO+T0=",
     "https://plugins.jetbrains.com/files/8607/673303/NixIDEA-0.4.0.17.zip": "sha256-OFisV6Vs/xlbDvchxfrREDVgVh7wcfGnot+zUrgQU6M=",
     "https://plugins.jetbrains.com/files/9525/603167/idea-php-dotenv-plugin-2024.3.zip": "sha256-hR7hC2phDJnHXxPy80WlEDFAhZHtMCu7nqYvAb0VeTI=",
     "https://plugins.jetbrains.com/files/9568/680198/go-plugin-243.24978.46.zip": "sha256-H2zxIwMN/m7s7Ewhy55QO45lQcUOhG/xD29wj6V/vIM=",
-    "https://plugins.jetbrains.com/files/9707/628343/ansi-highlighter-premium-24.3.1.jar": "sha256-X+Xks9sajsSVRXLQghJ5k2GuwmllNsZ9SrYBbf36P0c=",
+    "https://plugins.jetbrains.com/files/9707/690054/ansi-highlighter-premium-24.3.2.jar": "sha256-Gzpy9LHOsqomHWx64miDR2lLWrB+VgLdUty25IKWMUQ=",
     "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip": "sha256-Mzmmq0RzMKZeKfBSo7FHvzeEtPGIrwqEDLAONQEsR1M=",
     "https://plugins.jetbrains.com/files/9836/681714/intellij-randomness-3.3.6-signed.zip": "sha256-ArwC2HO2cHlTcFKXQBuKzZTuOiiIDEc/SGDsDQUCZmI="
   }

--- a/pkgs/applications/editors/jetbrains/plugins/plugins.json
+++ b/pkgs/applications/editors/jetbrains/plugins/plugins.json
@@ -17,19 +17,19 @@
         "webstorm"
       ],
       "builds": {
-        "243.21565.447": "https://plugins.jetbrains.com/files/164/676777/IdeaVIM-2.19.0.zip",
         "243.22562.218": "https://plugins.jetbrains.com/files/164/676777/IdeaVIM-2.19.0.zip",
         "243.22562.220": "https://plugins.jetbrains.com/files/164/676777/IdeaVIM-2.19.0.zip",
-        "243.23654.157": "https://plugins.jetbrains.com/files/164/676777/IdeaVIM-2.19.0.zip",
-        "243.23654.167": "https://plugins.jetbrains.com/files/164/676777/IdeaVIM-2.19.0.zip",
-        "243.23654.180": "https://plugins.jetbrains.com/files/164/676777/IdeaVIM-2.19.0.zip",
-        "243.23654.183": "https://plugins.jetbrains.com/files/164/676777/IdeaVIM-2.19.0.zip",
-        "243.24978.27": "https://plugins.jetbrains.com/files/164/676777/IdeaVIM-2.19.0.zip",
-        "243.24978.46": "https://plugins.jetbrains.com/files/164/676777/IdeaVIM-2.19.0.zip",
-        "243.24978.50": "https://plugins.jetbrains.com/files/164/676777/IdeaVIM-2.19.0.zip",
-        "243.24978.54": "https://plugins.jetbrains.com/files/164/676777/IdeaVIM-2.19.0.zip",
-        "243.24978.55": "https://plugins.jetbrains.com/files/164/676777/IdeaVIM-2.19.0.zip",
-        "243.24978.59": "https://plugins.jetbrains.com/files/164/676777/IdeaVIM-2.19.0.zip"
+        "243.24978.546": "https://plugins.jetbrains.com/files/164/676777/IdeaVIM-2.19.0.zip",
+        "243.24978.79": "https://plugins.jetbrains.com/files/164/676777/IdeaVIM-2.19.0.zip",
+        "243.24978.86": "https://plugins.jetbrains.com/files/164/676777/IdeaVIM-2.19.0.zip",
+        "243.25659.34": "https://plugins.jetbrains.com/files/164/676777/IdeaVIM-2.19.0.zip",
+        "243.25659.39": "https://plugins.jetbrains.com/files/164/676777/IdeaVIM-2.19.0.zip",
+        "243.25659.40": "https://plugins.jetbrains.com/files/164/676777/IdeaVIM-2.19.0.zip",
+        "243.25659.41": "https://plugins.jetbrains.com/files/164/676777/IdeaVIM-2.19.0.zip",
+        "243.25659.42": "https://plugins.jetbrains.com/files/164/676777/IdeaVIM-2.19.0.zip",
+        "243.25659.43": "https://plugins.jetbrains.com/files/164/676777/IdeaVIM-2.19.0.zip",
+        "243.25659.45": "https://plugins.jetbrains.com/files/164/676777/IdeaVIM-2.19.0.zip",
+        "243.25659.52": "https://plugins.jetbrains.com/files/164/676777/IdeaVIM-2.19.0.zip"
       },
       "name": "ideavim"
     },
@@ -38,7 +38,7 @@
         "idea-ultimate"
       ],
       "builds": {
-        "243.24978.46": "https://plugins.jetbrains.com/files/631/680216/python-243.24978.46.zip"
+        "243.25659.39": "https://plugins.jetbrains.com/files/631/688719/python-243.25659.39.zip"
       },
       "name": "python"
     },
@@ -49,7 +49,7 @@
       ],
       "builds": {
         "243.22562.218": "https://plugins.jetbrains.com/files/1347/667258/scala-intellij-bin-2024.3.35.zip",
-        "243.24978.46": "https://plugins.jetbrains.com/files/1347/681279/scala-intellij-bin-2024.3.38.zip"
+        "243.25659.39": "https://plugins.jetbrains.com/files/1347/681279/scala-intellij-bin-2024.3.38.zip"
       },
       "name": "scala"
     },
@@ -70,19 +70,19 @@
         "webstorm"
       ],
       "builds": {
-        "243.21565.447": "https://plugins.jetbrains.com/files/2162/640476/StringManipulation-9.15.0.zip",
         "243.22562.218": "https://plugins.jetbrains.com/files/2162/640476/StringManipulation-9.15.0.zip",
         "243.22562.220": "https://plugins.jetbrains.com/files/2162/640476/StringManipulation-9.15.0.zip",
-        "243.23654.157": "https://plugins.jetbrains.com/files/2162/640476/StringManipulation-9.15.0.zip",
-        "243.23654.167": "https://plugins.jetbrains.com/files/2162/640476/StringManipulation-9.15.0.zip",
-        "243.23654.180": "https://plugins.jetbrains.com/files/2162/640476/StringManipulation-9.15.0.zip",
-        "243.23654.183": "https://plugins.jetbrains.com/files/2162/640476/StringManipulation-9.15.0.zip",
-        "243.24978.27": "https://plugins.jetbrains.com/files/2162/640476/StringManipulation-9.15.0.zip",
-        "243.24978.46": "https://plugins.jetbrains.com/files/2162/640476/StringManipulation-9.15.0.zip",
-        "243.24978.50": "https://plugins.jetbrains.com/files/2162/640476/StringManipulation-9.15.0.zip",
-        "243.24978.54": "https://plugins.jetbrains.com/files/2162/640476/StringManipulation-9.15.0.zip",
-        "243.24978.55": "https://plugins.jetbrains.com/files/2162/640476/StringManipulation-9.15.0.zip",
-        "243.24978.59": "https://plugins.jetbrains.com/files/2162/640476/StringManipulation-9.15.0.zip"
+        "243.24978.546": "https://plugins.jetbrains.com/files/2162/640476/StringManipulation-9.15.0.zip",
+        "243.24978.79": "https://plugins.jetbrains.com/files/2162/640476/StringManipulation-9.15.0.zip",
+        "243.24978.86": "https://plugins.jetbrains.com/files/2162/640476/StringManipulation-9.15.0.zip",
+        "243.25659.34": "https://plugins.jetbrains.com/files/2162/640476/StringManipulation-9.15.0.zip",
+        "243.25659.39": "https://plugins.jetbrains.com/files/2162/640476/StringManipulation-9.15.0.zip",
+        "243.25659.40": "https://plugins.jetbrains.com/files/2162/640476/StringManipulation-9.15.0.zip",
+        "243.25659.41": "https://plugins.jetbrains.com/files/2162/640476/StringManipulation-9.15.0.zip",
+        "243.25659.42": "https://plugins.jetbrains.com/files/2162/640476/StringManipulation-9.15.0.zip",
+        "243.25659.43": "https://plugins.jetbrains.com/files/2162/640476/StringManipulation-9.15.0.zip",
+        "243.25659.45": "https://plugins.jetbrains.com/files/2162/640476/StringManipulation-9.15.0.zip",
+        "243.25659.52": "https://plugins.jetbrains.com/files/2162/640476/StringManipulation-9.15.0.zip"
       },
       "name": "string-manipulation"
     },
@@ -103,19 +103,19 @@
         "webstorm"
       ],
       "builds": {
-        "243.21565.447": "https://plugins.jetbrains.com/files/6884/630038/handlebars-243.21565.122.zip",
         "243.22562.218": "https://plugins.jetbrains.com/files/6884/630038/handlebars-243.21565.122.zip",
         "243.22562.220": "https://plugins.jetbrains.com/files/6884/630038/handlebars-243.21565.122.zip",
-        "243.23654.157": "https://plugins.jetbrains.com/files/6884/630038/handlebars-243.21565.122.zip",
-        "243.23654.167": "https://plugins.jetbrains.com/files/6884/630038/handlebars-243.21565.122.zip",
-        "243.23654.180": "https://plugins.jetbrains.com/files/6884/630038/handlebars-243.21565.122.zip",
-        "243.23654.183": "https://plugins.jetbrains.com/files/6884/630038/handlebars-243.21565.122.zip",
-        "243.24978.27": "https://plugins.jetbrains.com/files/6884/630038/handlebars-243.21565.122.zip",
-        "243.24978.46": "https://plugins.jetbrains.com/files/6884/630038/handlebars-243.21565.122.zip",
-        "243.24978.50": "https://plugins.jetbrains.com/files/6884/630038/handlebars-243.21565.122.zip",
-        "243.24978.54": "https://plugins.jetbrains.com/files/6884/630038/handlebars-243.21565.122.zip",
-        "243.24978.55": "https://plugins.jetbrains.com/files/6884/630038/handlebars-243.21565.122.zip",
-        "243.24978.59": "https://plugins.jetbrains.com/files/6884/630038/handlebars-243.21565.122.zip"
+        "243.24978.546": "https://plugins.jetbrains.com/files/6884/630038/handlebars-243.21565.122.zip",
+        "243.24978.79": "https://plugins.jetbrains.com/files/6884/630038/handlebars-243.21565.122.zip",
+        "243.24978.86": "https://plugins.jetbrains.com/files/6884/630038/handlebars-243.21565.122.zip",
+        "243.25659.34": "https://plugins.jetbrains.com/files/6884/630038/handlebars-243.21565.122.zip",
+        "243.25659.39": "https://plugins.jetbrains.com/files/6884/630038/handlebars-243.21565.122.zip",
+        "243.25659.40": "https://plugins.jetbrains.com/files/6884/630038/handlebars-243.21565.122.zip",
+        "243.25659.41": "https://plugins.jetbrains.com/files/6884/630038/handlebars-243.21565.122.zip",
+        "243.25659.42": "https://plugins.jetbrains.com/files/6884/630038/handlebars-243.21565.122.zip",
+        "243.25659.43": "https://plugins.jetbrains.com/files/6884/630038/handlebars-243.21565.122.zip",
+        "243.25659.45": "https://plugins.jetbrains.com/files/6884/630038/handlebars-243.21565.122.zip",
+        "243.25659.52": "https://plugins.jetbrains.com/files/6884/630038/handlebars-243.21565.122.zip"
       },
       "name": "handlebars-mustache"
     },
@@ -136,19 +136,19 @@
         "webstorm"
       ],
       "builds": {
-        "243.21565.447": null,
         "243.22562.218": null,
         "243.22562.220": null,
-        "243.23654.157": null,
-        "243.23654.167": null,
-        "243.23654.180": null,
-        "243.23654.183": null,
-        "243.24978.27": null,
-        "243.24978.46": null,
-        "243.24978.50": null,
-        "243.24978.54": null,
-        "243.24978.55": null,
-        "243.24978.59": null
+        "243.24978.546": null,
+        "243.24978.79": null,
+        "243.24978.86": null,
+        "243.25659.34": null,
+        "243.25659.39": null,
+        "243.25659.40": null,
+        "243.25659.41": null,
+        "243.25659.42": null,
+        "243.25659.43": null,
+        "243.25659.45": null,
+        "243.25659.52": null
       },
       "name": "kotlin"
     },
@@ -169,19 +169,19 @@
         "webstorm"
       ],
       "builds": {
-        "243.21565.447": null,
         "243.22562.218": "https://plugins.jetbrains.com/files/6981/654905/ini-243.22562.236.zip",
         "243.22562.220": "https://plugins.jetbrains.com/files/6981/654905/ini-243.22562.236.zip",
-        "243.23654.157": "https://plugins.jetbrains.com/files/6981/672286/ini-243.23654.177.zip",
-        "243.23654.167": "https://plugins.jetbrains.com/files/6981/672286/ini-243.23654.177.zip",
-        "243.23654.180": "https://plugins.jetbrains.com/files/6981/672286/ini-243.23654.177.zip",
-        "243.23654.183": "https://plugins.jetbrains.com/files/6981/672286/ini-243.23654.177.zip",
-        "243.24978.27": "https://plugins.jetbrains.com/files/6981/680778/ini-243.24978.60.zip",
-        "243.24978.46": "https://plugins.jetbrains.com/files/6981/680778/ini-243.24978.60.zip",
-        "243.24978.50": "https://plugins.jetbrains.com/files/6981/680778/ini-243.24978.60.zip",
-        "243.24978.54": "https://plugins.jetbrains.com/files/6981/680778/ini-243.24978.60.zip",
-        "243.24978.55": "https://plugins.jetbrains.com/files/6981/680778/ini-243.24978.60.zip",
-        "243.24978.59": "https://plugins.jetbrains.com/files/6981/680778/ini-243.24978.60.zip"
+        "243.24978.546": "https://plugins.jetbrains.com/files/6981/680778/ini-243.24978.60.zip",
+        "243.24978.79": "https://plugins.jetbrains.com/files/6981/680778/ini-243.24978.60.zip",
+        "243.24978.86": "https://plugins.jetbrains.com/files/6981/680778/ini-243.24978.60.zip",
+        "243.25659.34": "https://plugins.jetbrains.com/files/6981/689219/ini-243.25659.45.zip",
+        "243.25659.39": "https://plugins.jetbrains.com/files/6981/689219/ini-243.25659.45.zip",
+        "243.25659.40": "https://plugins.jetbrains.com/files/6981/689219/ini-243.25659.45.zip",
+        "243.25659.41": "https://plugins.jetbrains.com/files/6981/689219/ini-243.25659.45.zip",
+        "243.25659.42": "https://plugins.jetbrains.com/files/6981/689219/ini-243.25659.45.zip",
+        "243.25659.43": "https://plugins.jetbrains.com/files/6981/689219/ini-243.25659.45.zip",
+        "243.25659.45": "https://plugins.jetbrains.com/files/6981/689219/ini-243.25659.45.zip",
+        "243.25659.52": "https://plugins.jetbrains.com/files/6981/689219/ini-243.25659.45.zip"
       },
       "name": "ini"
     },
@@ -202,19 +202,19 @@
         "webstorm"
       ],
       "builds": {
-        "243.21565.447": "https://plugins.jetbrains.com/files/7086/518678/AceJump.zip",
         "243.22562.218": "https://plugins.jetbrains.com/files/7086/518678/AceJump.zip",
         "243.22562.220": "https://plugins.jetbrains.com/files/7086/518678/AceJump.zip",
-        "243.23654.157": "https://plugins.jetbrains.com/files/7086/518678/AceJump.zip",
-        "243.23654.167": "https://plugins.jetbrains.com/files/7086/518678/AceJump.zip",
-        "243.23654.180": "https://plugins.jetbrains.com/files/7086/518678/AceJump.zip",
-        "243.23654.183": "https://plugins.jetbrains.com/files/7086/518678/AceJump.zip",
-        "243.24978.27": "https://plugins.jetbrains.com/files/7086/518678/AceJump.zip",
-        "243.24978.46": "https://plugins.jetbrains.com/files/7086/518678/AceJump.zip",
-        "243.24978.50": "https://plugins.jetbrains.com/files/7086/518678/AceJump.zip",
-        "243.24978.54": "https://plugins.jetbrains.com/files/7086/518678/AceJump.zip",
-        "243.24978.55": "https://plugins.jetbrains.com/files/7086/518678/AceJump.zip",
-        "243.24978.59": "https://plugins.jetbrains.com/files/7086/518678/AceJump.zip"
+        "243.24978.546": "https://plugins.jetbrains.com/files/7086/518678/AceJump.zip",
+        "243.24978.79": "https://plugins.jetbrains.com/files/7086/518678/AceJump.zip",
+        "243.24978.86": "https://plugins.jetbrains.com/files/7086/518678/AceJump.zip",
+        "243.25659.34": "https://plugins.jetbrains.com/files/7086/518678/AceJump.zip",
+        "243.25659.39": "https://plugins.jetbrains.com/files/7086/518678/AceJump.zip",
+        "243.25659.40": "https://plugins.jetbrains.com/files/7086/518678/AceJump.zip",
+        "243.25659.41": "https://plugins.jetbrains.com/files/7086/518678/AceJump.zip",
+        "243.25659.42": "https://plugins.jetbrains.com/files/7086/518678/AceJump.zip",
+        "243.25659.43": "https://plugins.jetbrains.com/files/7086/518678/AceJump.zip",
+        "243.25659.45": "https://plugins.jetbrains.com/files/7086/518678/AceJump.zip",
+        "243.25659.52": "https://plugins.jetbrains.com/files/7086/518678/AceJump.zip"
       },
       "name": "acejump"
     },
@@ -235,19 +235,19 @@
         "webstorm"
       ],
       "builds": {
-        "243.21565.447": "https://plugins.jetbrains.com/files/7125/627704/GrepConsole-13.2.0-IJ2023.3.zip",
         "243.22562.218": "https://plugins.jetbrains.com/files/7125/627704/GrepConsole-13.2.0-IJ2023.3.zip",
         "243.22562.220": "https://plugins.jetbrains.com/files/7125/627704/GrepConsole-13.2.0-IJ2023.3.zip",
-        "243.23654.157": "https://plugins.jetbrains.com/files/7125/627704/GrepConsole-13.2.0-IJ2023.3.zip",
-        "243.23654.167": "https://plugins.jetbrains.com/files/7125/627704/GrepConsole-13.2.0-IJ2023.3.zip",
-        "243.23654.180": "https://plugins.jetbrains.com/files/7125/627704/GrepConsole-13.2.0-IJ2023.3.zip",
-        "243.23654.183": "https://plugins.jetbrains.com/files/7125/627704/GrepConsole-13.2.0-IJ2023.3.zip",
-        "243.24978.27": "https://plugins.jetbrains.com/files/7125/627704/GrepConsole-13.2.0-IJ2023.3.zip",
-        "243.24978.46": "https://plugins.jetbrains.com/files/7125/627704/GrepConsole-13.2.0-IJ2023.3.zip",
-        "243.24978.50": "https://plugins.jetbrains.com/files/7125/627704/GrepConsole-13.2.0-IJ2023.3.zip",
-        "243.24978.54": "https://plugins.jetbrains.com/files/7125/627704/GrepConsole-13.2.0-IJ2023.3.zip",
-        "243.24978.55": "https://plugins.jetbrains.com/files/7125/627704/GrepConsole-13.2.0-IJ2023.3.zip",
-        "243.24978.59": "https://plugins.jetbrains.com/files/7125/627704/GrepConsole-13.2.0-IJ2023.3.zip"
+        "243.24978.546": "https://plugins.jetbrains.com/files/7125/627704/GrepConsole-13.2.0-IJ2023.3.zip",
+        "243.24978.79": "https://plugins.jetbrains.com/files/7125/627704/GrepConsole-13.2.0-IJ2023.3.zip",
+        "243.24978.86": "https://plugins.jetbrains.com/files/7125/627704/GrepConsole-13.2.0-IJ2023.3.zip",
+        "243.25659.34": "https://plugins.jetbrains.com/files/7125/627704/GrepConsole-13.2.0-IJ2023.3.zip",
+        "243.25659.39": "https://plugins.jetbrains.com/files/7125/627704/GrepConsole-13.2.0-IJ2023.3.zip",
+        "243.25659.40": "https://plugins.jetbrains.com/files/7125/627704/GrepConsole-13.2.0-IJ2023.3.zip",
+        "243.25659.41": "https://plugins.jetbrains.com/files/7125/627704/GrepConsole-13.2.0-IJ2023.3.zip",
+        "243.25659.42": "https://plugins.jetbrains.com/files/7125/627704/GrepConsole-13.2.0-IJ2023.3.zip",
+        "243.25659.43": "https://plugins.jetbrains.com/files/7125/627704/GrepConsole-13.2.0-IJ2023.3.zip",
+        "243.25659.45": "https://plugins.jetbrains.com/files/7125/627704/GrepConsole-13.2.0-IJ2023.3.zip",
+        "243.25659.52": "https://plugins.jetbrains.com/files/7125/627704/GrepConsole-13.2.0-IJ2023.3.zip"
       },
       "name": "grep-console"
     },
@@ -268,19 +268,19 @@
         "webstorm"
       ],
       "builds": {
-        "243.21565.447": "https://plugins.jetbrains.com/files/7177/630032/fileWatcher-243.21565.122.zip",
         "243.22562.218": "https://plugins.jetbrains.com/files/7177/636663/fileWatcher-243.22562.13.zip",
         "243.22562.220": "https://plugins.jetbrains.com/files/7177/636663/fileWatcher-243.22562.13.zip",
-        "243.23654.157": "https://plugins.jetbrains.com/files/7177/654841/fileWatcher-243.23654.19.zip",
-        "243.23654.167": "https://plugins.jetbrains.com/files/7177/654841/fileWatcher-243.23654.19.zip",
-        "243.23654.180": "https://plugins.jetbrains.com/files/7177/654841/fileWatcher-243.23654.19.zip",
-        "243.23654.183": "https://plugins.jetbrains.com/files/7177/654841/fileWatcher-243.23654.19.zip",
-        "243.24978.27": "https://plugins.jetbrains.com/files/7177/654841/fileWatcher-243.23654.19.zip",
-        "243.24978.46": "https://plugins.jetbrains.com/files/7177/654841/fileWatcher-243.23654.19.zip",
-        "243.24978.50": "https://plugins.jetbrains.com/files/7177/654841/fileWatcher-243.23654.19.zip",
-        "243.24978.54": "https://plugins.jetbrains.com/files/7177/654841/fileWatcher-243.23654.19.zip",
-        "243.24978.55": "https://plugins.jetbrains.com/files/7177/654841/fileWatcher-243.23654.19.zip",
-        "243.24978.59": "https://plugins.jetbrains.com/files/7177/654841/fileWatcher-243.23654.19.zip"
+        "243.24978.546": "https://plugins.jetbrains.com/files/7177/654841/fileWatcher-243.23654.19.zip",
+        "243.24978.79": "https://plugins.jetbrains.com/files/7177/654841/fileWatcher-243.23654.19.zip",
+        "243.24978.86": "https://plugins.jetbrains.com/files/7177/654841/fileWatcher-243.23654.19.zip",
+        "243.25659.34": "https://plugins.jetbrains.com/files/7177/654841/fileWatcher-243.23654.19.zip",
+        "243.25659.39": "https://plugins.jetbrains.com/files/7177/654841/fileWatcher-243.23654.19.zip",
+        "243.25659.40": "https://plugins.jetbrains.com/files/7177/654841/fileWatcher-243.23654.19.zip",
+        "243.25659.41": "https://plugins.jetbrains.com/files/7177/654841/fileWatcher-243.23654.19.zip",
+        "243.25659.42": "https://plugins.jetbrains.com/files/7177/654841/fileWatcher-243.23654.19.zip",
+        "243.25659.43": "https://plugins.jetbrains.com/files/7177/654841/fileWatcher-243.23654.19.zip",
+        "243.25659.45": "https://plugins.jetbrains.com/files/7177/654841/fileWatcher-243.23654.19.zip",
+        "243.25659.52": "https://plugins.jetbrains.com/files/7177/654841/fileWatcher-243.23654.19.zip"
       },
       "name": "file-watchers"
     },
@@ -290,8 +290,8 @@
         "phpstorm"
       ],
       "builds": {
-        "243.24978.46": "https://plugins.jetbrains.com/files/7219/605730/Symfony_Plugin-2024.1.276.zip",
-        "243.24978.50": "https://plugins.jetbrains.com/files/7219/605730/Symfony_Plugin-2024.1.276.zip"
+        "243.25659.39": "https://plugins.jetbrains.com/files/7219/605730/Symfony_Plugin-2024.1.276.zip",
+        "243.25659.45": "https://plugins.jetbrains.com/files/7219/605730/Symfony_Plugin-2024.1.276.zip"
       },
       "name": "symfony-support"
     },
@@ -301,8 +301,8 @@
         "phpstorm"
       ],
       "builds": {
-        "243.24978.46": "https://plugins.jetbrains.com/files/7320/630497/PHP_Annotations-11.1.1.zip",
-        "243.24978.50": "https://plugins.jetbrains.com/files/7320/630497/PHP_Annotations-11.1.1.zip"
+        "243.25659.39": "https://plugins.jetbrains.com/files/7320/630497/PHP_Annotations-11.1.1.zip",
+        "243.25659.45": "https://plugins.jetbrains.com/files/7320/630497/PHP_Annotations-11.1.1.zip"
       },
       "name": "php-annotations"
     },
@@ -321,14 +321,14 @@
       "builds": {
         "243.22562.218": "https://plugins.jetbrains.com/files/7322/646590/python-ce-243.22562.145.zip",
         "243.22562.220": "https://plugins.jetbrains.com/files/7322/646590/python-ce-243.22562.145.zip",
-        "243.23654.157": "https://plugins.jetbrains.com/files/7322/673130/python-ce-243.23654.189.zip",
-        "243.23654.180": "https://plugins.jetbrains.com/files/7322/673130/python-ce-243.23654.189.zip",
-        "243.23654.183": "https://plugins.jetbrains.com/files/7322/673130/python-ce-243.23654.189.zip",
-        "243.24978.27": "https://plugins.jetbrains.com/files/7322/680217/python-ce-243.24978.46.zip",
-        "243.24978.46": "https://plugins.jetbrains.com/files/7322/680217/python-ce-243.24978.46.zip",
-        "243.24978.54": "https://plugins.jetbrains.com/files/7322/680217/python-ce-243.24978.46.zip",
-        "243.24978.55": "https://plugins.jetbrains.com/files/7322/680217/python-ce-243.24978.46.zip",
-        "243.24978.59": "https://plugins.jetbrains.com/files/7322/680217/python-ce-243.24978.46.zip"
+        "243.24978.79": "https://plugins.jetbrains.com/files/7322/680217/python-ce-243.24978.46.zip",
+        "243.24978.86": "https://plugins.jetbrains.com/files/7322/680217/python-ce-243.24978.46.zip",
+        "243.25659.34": "https://plugins.jetbrains.com/files/7322/680217/python-ce-243.24978.46.zip",
+        "243.25659.39": "https://plugins.jetbrains.com/files/7322/680217/python-ce-243.24978.46.zip",
+        "243.25659.40": "https://plugins.jetbrains.com/files/7322/680217/python-ce-243.24978.46.zip",
+        "243.25659.42": "https://plugins.jetbrains.com/files/7322/680217/python-ce-243.24978.46.zip",
+        "243.25659.43": "https://plugins.jetbrains.com/files/7322/680217/python-ce-243.24978.46.zip",
+        "243.25659.52": "https://plugins.jetbrains.com/files/7322/680217/python-ce-243.24978.46.zip"
       },
       "name": "python-community-edition"
     },
@@ -349,19 +349,19 @@
         "webstorm"
       ],
       "builds": {
-        "243.21565.447": "https://plugins.jetbrains.com/files/7391/658997/asciidoctor-intellij-plugin-0.43.6.zip",
         "243.22562.218": "https://plugins.jetbrains.com/files/7391/658997/asciidoctor-intellij-plugin-0.43.6.zip",
         "243.22562.220": "https://plugins.jetbrains.com/files/7391/658997/asciidoctor-intellij-plugin-0.43.6.zip",
-        "243.23654.157": "https://plugins.jetbrains.com/files/7391/658997/asciidoctor-intellij-plugin-0.43.6.zip",
-        "243.23654.167": "https://plugins.jetbrains.com/files/7391/658997/asciidoctor-intellij-plugin-0.43.6.zip",
-        "243.23654.180": "https://plugins.jetbrains.com/files/7391/658997/asciidoctor-intellij-plugin-0.43.6.zip",
-        "243.23654.183": "https://plugins.jetbrains.com/files/7391/658997/asciidoctor-intellij-plugin-0.43.6.zip",
-        "243.24978.27": "https://plugins.jetbrains.com/files/7391/658997/asciidoctor-intellij-plugin-0.43.6.zip",
-        "243.24978.46": "https://plugins.jetbrains.com/files/7391/658997/asciidoctor-intellij-plugin-0.43.6.zip",
-        "243.24978.50": "https://plugins.jetbrains.com/files/7391/658997/asciidoctor-intellij-plugin-0.43.6.zip",
-        "243.24978.54": "https://plugins.jetbrains.com/files/7391/658997/asciidoctor-intellij-plugin-0.43.6.zip",
-        "243.24978.55": "https://plugins.jetbrains.com/files/7391/658997/asciidoctor-intellij-plugin-0.43.6.zip",
-        "243.24978.59": "https://plugins.jetbrains.com/files/7391/658997/asciidoctor-intellij-plugin-0.43.6.zip"
+        "243.24978.546": "https://plugins.jetbrains.com/files/7391/658997/asciidoctor-intellij-plugin-0.43.6.zip",
+        "243.24978.79": "https://plugins.jetbrains.com/files/7391/658997/asciidoctor-intellij-plugin-0.43.6.zip",
+        "243.24978.86": "https://plugins.jetbrains.com/files/7391/658997/asciidoctor-intellij-plugin-0.43.6.zip",
+        "243.25659.34": "https://plugins.jetbrains.com/files/7391/658997/asciidoctor-intellij-plugin-0.43.6.zip",
+        "243.25659.39": "https://plugins.jetbrains.com/files/7391/658997/asciidoctor-intellij-plugin-0.43.6.zip",
+        "243.25659.40": "https://plugins.jetbrains.com/files/7391/658997/asciidoctor-intellij-plugin-0.43.6.zip",
+        "243.25659.41": "https://plugins.jetbrains.com/files/7391/658997/asciidoctor-intellij-plugin-0.43.6.zip",
+        "243.25659.42": "https://plugins.jetbrains.com/files/7391/658997/asciidoctor-intellij-plugin-0.43.6.zip",
+        "243.25659.43": "https://plugins.jetbrains.com/files/7391/658997/asciidoctor-intellij-plugin-0.43.6.zip",
+        "243.25659.45": "https://plugins.jetbrains.com/files/7391/658997/asciidoctor-intellij-plugin-0.43.6.zip",
+        "243.25659.52": "https://plugins.jetbrains.com/files/7391/658997/asciidoctor-intellij-plugin-0.43.6.zip"
       },
       "name": "asciidoc"
     },
@@ -382,19 +382,19 @@
         "webstorm"
       ],
       "builds": {
-        "243.21565.447": "https://plugins.jetbrains.com/files/7425/603907/WakaTime.jar",
         "243.22562.218": "https://plugins.jetbrains.com/files/7425/603907/WakaTime.jar",
         "243.22562.220": "https://plugins.jetbrains.com/files/7425/603907/WakaTime.jar",
-        "243.23654.157": "https://plugins.jetbrains.com/files/7425/603907/WakaTime.jar",
-        "243.23654.167": "https://plugins.jetbrains.com/files/7425/603907/WakaTime.jar",
-        "243.23654.180": "https://plugins.jetbrains.com/files/7425/603907/WakaTime.jar",
-        "243.23654.183": "https://plugins.jetbrains.com/files/7425/603907/WakaTime.jar",
-        "243.24978.27": "https://plugins.jetbrains.com/files/7425/603907/WakaTime.jar",
-        "243.24978.46": "https://plugins.jetbrains.com/files/7425/603907/WakaTime.jar",
-        "243.24978.50": "https://plugins.jetbrains.com/files/7425/603907/WakaTime.jar",
-        "243.24978.54": "https://plugins.jetbrains.com/files/7425/603907/WakaTime.jar",
-        "243.24978.55": "https://plugins.jetbrains.com/files/7425/603907/WakaTime.jar",
-        "243.24978.59": "https://plugins.jetbrains.com/files/7425/603907/WakaTime.jar"
+        "243.24978.546": "https://plugins.jetbrains.com/files/7425/603907/WakaTime.jar",
+        "243.24978.79": "https://plugins.jetbrains.com/files/7425/603907/WakaTime.jar",
+        "243.24978.86": "https://plugins.jetbrains.com/files/7425/603907/WakaTime.jar",
+        "243.25659.34": "https://plugins.jetbrains.com/files/7425/603907/WakaTime.jar",
+        "243.25659.39": "https://plugins.jetbrains.com/files/7425/603907/WakaTime.jar",
+        "243.25659.40": "https://plugins.jetbrains.com/files/7425/603907/WakaTime.jar",
+        "243.25659.41": "https://plugins.jetbrains.com/files/7425/603907/WakaTime.jar",
+        "243.25659.42": "https://plugins.jetbrains.com/files/7425/603907/WakaTime.jar",
+        "243.25659.43": "https://plugins.jetbrains.com/files/7425/603907/WakaTime.jar",
+        "243.25659.45": "https://plugins.jetbrains.com/files/7425/603907/WakaTime.jar",
+        "243.25659.52": "https://plugins.jetbrains.com/files/7425/603907/WakaTime.jar"
       },
       "name": "wakatime"
     },
@@ -415,19 +415,19 @@
         "webstorm"
       ],
       "builds": {
-        "243.21565.447": "https://plugins.jetbrains.com/files/7499/667439/gittoolbox-600.0.14_243-signed.zip",
         "243.22562.218": "https://plugins.jetbrains.com/files/7499/667439/gittoolbox-600.0.14_243-signed.zip",
         "243.22562.220": "https://plugins.jetbrains.com/files/7499/667439/gittoolbox-600.0.14_243-signed.zip",
-        "243.23654.157": "https://plugins.jetbrains.com/files/7499/667439/gittoolbox-600.0.14_243-signed.zip",
-        "243.23654.167": "https://plugins.jetbrains.com/files/7499/667439/gittoolbox-600.0.14_243-signed.zip",
-        "243.23654.180": "https://plugins.jetbrains.com/files/7499/667439/gittoolbox-600.0.14_243-signed.zip",
-        "243.23654.183": "https://plugins.jetbrains.com/files/7499/667439/gittoolbox-600.0.14_243-signed.zip",
-        "243.24978.27": "https://plugins.jetbrains.com/files/7499/667439/gittoolbox-600.0.14_243-signed.zip",
-        "243.24978.46": "https://plugins.jetbrains.com/files/7499/667439/gittoolbox-600.0.14_243-signed.zip",
-        "243.24978.50": "https://plugins.jetbrains.com/files/7499/667439/gittoolbox-600.0.14_243-signed.zip",
-        "243.24978.54": "https://plugins.jetbrains.com/files/7499/667439/gittoolbox-600.0.14_243-signed.zip",
-        "243.24978.55": "https://plugins.jetbrains.com/files/7499/667439/gittoolbox-600.0.14_243-signed.zip",
-        "243.24978.59": "https://plugins.jetbrains.com/files/7499/667439/gittoolbox-600.0.14_243-signed.zip"
+        "243.24978.546": "https://plugins.jetbrains.com/files/7499/667439/gittoolbox-600.0.14_243-signed.zip",
+        "243.24978.79": "https://plugins.jetbrains.com/files/7499/667439/gittoolbox-600.0.14_243-signed.zip",
+        "243.24978.86": "https://plugins.jetbrains.com/files/7499/667439/gittoolbox-600.0.14_243-signed.zip",
+        "243.25659.34": "https://plugins.jetbrains.com/files/7499/667439/gittoolbox-600.0.14_243-signed.zip",
+        "243.25659.39": "https://plugins.jetbrains.com/files/7499/667439/gittoolbox-600.0.14_243-signed.zip",
+        "243.25659.40": "https://plugins.jetbrains.com/files/7499/667439/gittoolbox-600.0.14_243-signed.zip",
+        "243.25659.41": "https://plugins.jetbrains.com/files/7499/667439/gittoolbox-600.0.14_243-signed.zip",
+        "243.25659.42": "https://plugins.jetbrains.com/files/7499/667439/gittoolbox-600.0.14_243-signed.zip",
+        "243.25659.43": "https://plugins.jetbrains.com/files/7499/667439/gittoolbox-600.0.14_243-signed.zip",
+        "243.25659.45": "https://plugins.jetbrains.com/files/7499/667439/gittoolbox-600.0.14_243-signed.zip",
+        "243.25659.52": "https://plugins.jetbrains.com/files/7499/667439/gittoolbox-600.0.14_243-signed.zip"
       },
       "name": "gittoolbox"
     },
@@ -448,19 +448,19 @@
         "webstorm"
       ],
       "builds": {
-        "243.21565.447": null,
         "243.22562.218": "https://plugins.jetbrains.com/files/7724/654910/clouds-docker-impl-243.22562.236.zip",
         "243.22562.220": "https://plugins.jetbrains.com/files/7724/654910/clouds-docker-impl-243.22562.236.zip",
-        "243.23654.157": "https://plugins.jetbrains.com/files/7724/672289/clouds-docker-impl-243.23654.177.zip",
-        "243.23654.167": "https://plugins.jetbrains.com/files/7724/672289/clouds-docker-impl-243.23654.177.zip",
-        "243.23654.180": "https://plugins.jetbrains.com/files/7724/672289/clouds-docker-impl-243.23654.177.zip",
-        "243.23654.183": "https://plugins.jetbrains.com/files/7724/672289/clouds-docker-impl-243.23654.177.zip",
-        "243.24978.27": "https://plugins.jetbrains.com/files/7724/680796/clouds-docker-impl-243.24978.54.zip",
-        "243.24978.46": "https://plugins.jetbrains.com/files/7724/680796/clouds-docker-impl-243.24978.54.zip",
-        "243.24978.50": "https://plugins.jetbrains.com/files/7724/680796/clouds-docker-impl-243.24978.54.zip",
-        "243.24978.54": "https://plugins.jetbrains.com/files/7724/680796/clouds-docker-impl-243.24978.54.zip",
-        "243.24978.55": "https://plugins.jetbrains.com/files/7724/680796/clouds-docker-impl-243.24978.54.zip",
-        "243.24978.59": "https://plugins.jetbrains.com/files/7724/680796/clouds-docker-impl-243.24978.54.zip"
+        "243.24978.546": "https://plugins.jetbrains.com/files/7724/680796/clouds-docker-impl-243.24978.54.zip",
+        "243.24978.79": "https://plugins.jetbrains.com/files/7724/680796/clouds-docker-impl-243.24978.54.zip",
+        "243.24978.86": "https://plugins.jetbrains.com/files/7724/680796/clouds-docker-impl-243.24978.54.zip",
+        "243.25659.34": "https://plugins.jetbrains.com/files/7724/689214/clouds-docker-impl-243.25659.45.zip",
+        "243.25659.39": "https://plugins.jetbrains.com/files/7724/689214/clouds-docker-impl-243.25659.45.zip",
+        "243.25659.40": "https://plugins.jetbrains.com/files/7724/689214/clouds-docker-impl-243.25659.45.zip",
+        "243.25659.41": "https://plugins.jetbrains.com/files/7724/689214/clouds-docker-impl-243.25659.45.zip",
+        "243.25659.42": "https://plugins.jetbrains.com/files/7724/689214/clouds-docker-impl-243.25659.45.zip",
+        "243.25659.43": "https://plugins.jetbrains.com/files/7724/689214/clouds-docker-impl-243.25659.45.zip",
+        "243.25659.45": "https://plugins.jetbrains.com/files/7724/689214/clouds-docker-impl-243.25659.45.zip",
+        "243.25659.52": "https://plugins.jetbrains.com/files/7724/689214/clouds-docker-impl-243.25659.45.zip"
       },
       "name": "docker"
     },
@@ -481,19 +481,19 @@
         "webstorm"
       ],
       "builds": {
-        "243.21565.447": "https://plugins.jetbrains.com/files/8097/629964/graphql-243.21565.122.zip",
         "243.22562.218": "https://plugins.jetbrains.com/files/8097/636616/graphql-243.22562.13.zip",
         "243.22562.220": "https://plugins.jetbrains.com/files/8097/636616/graphql-243.22562.13.zip",
-        "243.23654.157": "https://plugins.jetbrains.com/files/8097/636616/graphql-243.22562.13.zip",
-        "243.23654.167": "https://plugins.jetbrains.com/files/8097/636616/graphql-243.22562.13.zip",
-        "243.23654.180": "https://plugins.jetbrains.com/files/8097/636616/graphql-243.22562.13.zip",
-        "243.23654.183": "https://plugins.jetbrains.com/files/8097/636616/graphql-243.22562.13.zip",
-        "243.24978.27": "https://plugins.jetbrains.com/files/8097/680200/graphql-243.24978.46.zip",
-        "243.24978.46": "https://plugins.jetbrains.com/files/8097/680200/graphql-243.24978.46.zip",
-        "243.24978.50": "https://plugins.jetbrains.com/files/8097/680200/graphql-243.24978.46.zip",
-        "243.24978.54": "https://plugins.jetbrains.com/files/8097/680200/graphql-243.24978.46.zip",
-        "243.24978.55": "https://plugins.jetbrains.com/files/8097/680200/graphql-243.24978.46.zip",
-        "243.24978.59": "https://plugins.jetbrains.com/files/8097/680200/graphql-243.24978.46.zip"
+        "243.24978.546": "https://plugins.jetbrains.com/files/8097/680200/graphql-243.24978.46.zip",
+        "243.24978.79": "https://plugins.jetbrains.com/files/8097/680200/graphql-243.24978.46.zip",
+        "243.24978.86": "https://plugins.jetbrains.com/files/8097/680200/graphql-243.24978.46.zip",
+        "243.25659.34": "https://plugins.jetbrains.com/files/8097/688195/graphql-243.25659.42.zip",
+        "243.25659.39": "https://plugins.jetbrains.com/files/8097/688195/graphql-243.25659.42.zip",
+        "243.25659.40": "https://plugins.jetbrains.com/files/8097/688195/graphql-243.25659.42.zip",
+        "243.25659.41": "https://plugins.jetbrains.com/files/8097/688195/graphql-243.25659.42.zip",
+        "243.25659.42": "https://plugins.jetbrains.com/files/8097/688195/graphql-243.25659.42.zip",
+        "243.25659.43": "https://plugins.jetbrains.com/files/8097/688195/graphql-243.25659.42.zip",
+        "243.25659.45": "https://plugins.jetbrains.com/files/8097/688195/graphql-243.25659.42.zip",
+        "243.25659.52": "https://plugins.jetbrains.com/files/8097/688195/graphql-243.25659.42.zip"
       },
       "name": "graphql"
     },
@@ -513,18 +513,18 @@
         "webstorm"
       ],
       "builds": {
-        "243.21565.447": null,
         "243.22562.218": null,
         "243.22562.220": null,
-        "243.23654.157": null,
-        "243.23654.167": null,
-        "243.23654.183": null,
-        "243.24978.27": null,
-        "243.24978.46": null,
-        "243.24978.50": null,
-        "243.24978.54": null,
-        "243.24978.55": null,
-        "243.24978.59": null
+        "243.24978.546": null,
+        "243.24978.79": null,
+        "243.25659.34": null,
+        "243.25659.39": null,
+        "243.25659.40": null,
+        "243.25659.41": null,
+        "243.25659.42": null,
+        "243.25659.43": null,
+        "243.25659.45": null,
+        "243.25659.52": null
       },
       "name": "-deprecated-rust"
     },
@@ -544,18 +544,18 @@
         "webstorm"
       ],
       "builds": {
-        "243.21565.447": null,
         "243.22562.218": null,
         "243.22562.220": null,
-        "243.23654.157": null,
-        "243.23654.167": null,
-        "243.23654.183": null,
-        "243.24978.27": null,
-        "243.24978.46": null,
-        "243.24978.50": null,
-        "243.24978.54": null,
-        "243.24978.55": null,
-        "243.24978.59": null
+        "243.24978.546": null,
+        "243.24978.79": null,
+        "243.25659.34": null,
+        "243.25659.39": null,
+        "243.25659.40": null,
+        "243.25659.41": null,
+        "243.25659.42": null,
+        "243.25659.43": null,
+        "243.25659.45": null,
+        "243.25659.52": null
       },
       "name": "-deprecated-rust-beta"
     },
@@ -576,19 +576,19 @@
         "webstorm"
       ],
       "builds": {
-        "243.21565.447": "https://plugins.jetbrains.com/files/8195/630064/toml-243.21565.122.zip",
         "243.22562.218": "https://plugins.jetbrains.com/files/8195/630064/toml-243.21565.122.zip",
         "243.22562.220": "https://plugins.jetbrains.com/files/8195/630064/toml-243.21565.122.zip",
-        "243.23654.157": "https://plugins.jetbrains.com/files/8195/672659/toml-243.23654.183.zip",
-        "243.23654.167": "https://plugins.jetbrains.com/files/8195/672659/toml-243.23654.183.zip",
-        "243.23654.180": "https://plugins.jetbrains.com/files/8195/672659/toml-243.23654.183.zip",
-        "243.23654.183": "https://plugins.jetbrains.com/files/8195/672659/toml-243.23654.183.zip",
-        "243.24978.27": "https://plugins.jetbrains.com/files/8195/672659/toml-243.23654.183.zip",
-        "243.24978.46": "https://plugins.jetbrains.com/files/8195/672659/toml-243.23654.183.zip",
-        "243.24978.50": "https://plugins.jetbrains.com/files/8195/672659/toml-243.23654.183.zip",
-        "243.24978.54": "https://plugins.jetbrains.com/files/8195/672659/toml-243.23654.183.zip",
-        "243.24978.55": "https://plugins.jetbrains.com/files/8195/672659/toml-243.23654.183.zip",
-        "243.24978.59": "https://plugins.jetbrains.com/files/8195/672659/toml-243.23654.183.zip"
+        "243.24978.546": "https://plugins.jetbrains.com/files/8195/672659/toml-243.23654.183.zip",
+        "243.24978.79": "https://plugins.jetbrains.com/files/8195/672659/toml-243.23654.183.zip",
+        "243.24978.86": "https://plugins.jetbrains.com/files/8195/672659/toml-243.23654.183.zip",
+        "243.25659.34": "https://plugins.jetbrains.com/files/8195/672659/toml-243.23654.183.zip",
+        "243.25659.39": "https://plugins.jetbrains.com/files/8195/672659/toml-243.23654.183.zip",
+        "243.25659.40": "https://plugins.jetbrains.com/files/8195/672659/toml-243.23654.183.zip",
+        "243.25659.41": "https://plugins.jetbrains.com/files/8195/672659/toml-243.23654.183.zip",
+        "243.25659.42": "https://plugins.jetbrains.com/files/8195/672659/toml-243.23654.183.zip",
+        "243.25659.43": "https://plugins.jetbrains.com/files/8195/672659/toml-243.23654.183.zip",
+        "243.25659.45": "https://plugins.jetbrains.com/files/8195/672659/toml-243.23654.183.zip",
+        "243.25659.52": "https://plugins.jetbrains.com/files/8195/672659/toml-243.23654.183.zip"
       },
       "name": "toml"
     },
@@ -599,7 +599,7 @@
       ],
       "builds": {
         "243.22562.218": "https://plugins.jetbrains.com/files/8327/615097/Minecraft_Development-2024.3-1.8.2.zip",
-        "243.24978.46": "https://plugins.jetbrains.com/files/8327/615097/Minecraft_Development-2024.3-1.8.2.zip"
+        "243.25659.39": "https://plugins.jetbrains.com/files/8327/615097/Minecraft_Development-2024.3-1.8.2.zip"
       },
       "name": "minecraft-development"
     },
@@ -620,19 +620,19 @@
         "webstorm"
       ],
       "builds": {
-        "243.21565.447": "https://plugins.jetbrains.com/files/8554/633920/featuresTrainer-243.21565.204.zip",
         "243.22562.218": "https://plugins.jetbrains.com/files/8554/654690/featuresTrainer-243.22562.233.zip",
         "243.22562.220": "https://plugins.jetbrains.com/files/8554/654690/featuresTrainer-243.22562.233.zip",
-        "243.23654.157": "https://plugins.jetbrains.com/files/8554/672476/featuresTrainer-243.23654.180.zip",
-        "243.23654.167": "https://plugins.jetbrains.com/files/8554/672476/featuresTrainer-243.23654.180.zip",
-        "243.23654.180": "https://plugins.jetbrains.com/files/8554/672476/featuresTrainer-243.23654.180.zip",
-        "243.23654.183": "https://plugins.jetbrains.com/files/8554/672476/featuresTrainer-243.23654.180.zip",
-        "243.24978.27": "https://plugins.jetbrains.com/files/8554/684425/featuresTrainer-243.24978.79.zip",
-        "243.24978.46": "https://plugins.jetbrains.com/files/8554/684425/featuresTrainer-243.24978.79.zip",
-        "243.24978.50": "https://plugins.jetbrains.com/files/8554/684425/featuresTrainer-243.24978.79.zip",
-        "243.24978.54": "https://plugins.jetbrains.com/files/8554/684425/featuresTrainer-243.24978.79.zip",
-        "243.24978.55": "https://plugins.jetbrains.com/files/8554/684425/featuresTrainer-243.24978.79.zip",
-        "243.24978.59": "https://plugins.jetbrains.com/files/8554/684425/featuresTrainer-243.24978.79.zip"
+        "243.24978.546": "https://plugins.jetbrains.com/files/8554/684425/featuresTrainer-243.24978.79.zip",
+        "243.24978.79": "https://plugins.jetbrains.com/files/8554/684425/featuresTrainer-243.24978.79.zip",
+        "243.24978.86": "https://plugins.jetbrains.com/files/8554/684425/featuresTrainer-243.24978.79.zip",
+        "243.25659.34": "https://plugins.jetbrains.com/files/8554/688898/featuresTrainer-243.25659.44.zip",
+        "243.25659.39": "https://plugins.jetbrains.com/files/8554/688898/featuresTrainer-243.25659.44.zip",
+        "243.25659.40": "https://plugins.jetbrains.com/files/8554/688898/featuresTrainer-243.25659.44.zip",
+        "243.25659.41": "https://plugins.jetbrains.com/files/8554/688898/featuresTrainer-243.25659.44.zip",
+        "243.25659.42": "https://plugins.jetbrains.com/files/8554/688898/featuresTrainer-243.25659.44.zip",
+        "243.25659.43": "https://plugins.jetbrains.com/files/8554/688898/featuresTrainer-243.25659.44.zip",
+        "243.25659.45": "https://plugins.jetbrains.com/files/8554/688898/featuresTrainer-243.25659.44.zip",
+        "243.25659.52": "https://plugins.jetbrains.com/files/8554/688898/featuresTrainer-243.25659.44.zip"
       },
       "name": "ide-features-trainer"
     },
@@ -653,19 +653,19 @@
         "webstorm"
       ],
       "builds": {
-        "243.21565.447": "https://plugins.jetbrains.com/files/8607/673303/NixIDEA-0.4.0.17.zip",
         "243.22562.218": "https://plugins.jetbrains.com/files/8607/673303/NixIDEA-0.4.0.17.zip",
         "243.22562.220": "https://plugins.jetbrains.com/files/8607/673303/NixIDEA-0.4.0.17.zip",
-        "243.23654.157": "https://plugins.jetbrains.com/files/8607/673303/NixIDEA-0.4.0.17.zip",
-        "243.23654.167": "https://plugins.jetbrains.com/files/8607/673303/NixIDEA-0.4.0.17.zip",
-        "243.23654.180": "https://plugins.jetbrains.com/files/8607/673303/NixIDEA-0.4.0.17.zip",
-        "243.23654.183": "https://plugins.jetbrains.com/files/8607/673303/NixIDEA-0.4.0.17.zip",
-        "243.24978.27": "https://plugins.jetbrains.com/files/8607/673303/NixIDEA-0.4.0.17.zip",
-        "243.24978.46": "https://plugins.jetbrains.com/files/8607/673303/NixIDEA-0.4.0.17.zip",
-        "243.24978.50": "https://plugins.jetbrains.com/files/8607/673303/NixIDEA-0.4.0.17.zip",
-        "243.24978.54": "https://plugins.jetbrains.com/files/8607/673303/NixIDEA-0.4.0.17.zip",
-        "243.24978.55": "https://plugins.jetbrains.com/files/8607/673303/NixIDEA-0.4.0.17.zip",
-        "243.24978.59": "https://plugins.jetbrains.com/files/8607/673303/NixIDEA-0.4.0.17.zip"
+        "243.24978.546": "https://plugins.jetbrains.com/files/8607/673303/NixIDEA-0.4.0.17.zip",
+        "243.24978.79": "https://plugins.jetbrains.com/files/8607/673303/NixIDEA-0.4.0.17.zip",
+        "243.24978.86": "https://plugins.jetbrains.com/files/8607/673303/NixIDEA-0.4.0.17.zip",
+        "243.25659.34": "https://plugins.jetbrains.com/files/8607/673303/NixIDEA-0.4.0.17.zip",
+        "243.25659.39": "https://plugins.jetbrains.com/files/8607/673303/NixIDEA-0.4.0.17.zip",
+        "243.25659.40": "https://plugins.jetbrains.com/files/8607/673303/NixIDEA-0.4.0.17.zip",
+        "243.25659.41": "https://plugins.jetbrains.com/files/8607/673303/NixIDEA-0.4.0.17.zip",
+        "243.25659.42": "https://plugins.jetbrains.com/files/8607/673303/NixIDEA-0.4.0.17.zip",
+        "243.25659.43": "https://plugins.jetbrains.com/files/8607/673303/NixIDEA-0.4.0.17.zip",
+        "243.25659.45": "https://plugins.jetbrains.com/files/8607/673303/NixIDEA-0.4.0.17.zip",
+        "243.25659.52": "https://plugins.jetbrains.com/files/8607/673303/NixIDEA-0.4.0.17.zip"
       },
       "name": "nixidea"
     },
@@ -686,19 +686,19 @@
         "webstorm"
       ],
       "builds": {
-        "243.21565.447": "https://plugins.jetbrains.com/files/9525/603167/idea-php-dotenv-plugin-2024.3.zip",
         "243.22562.218": "https://plugins.jetbrains.com/files/9525/603167/idea-php-dotenv-plugin-2024.3.zip",
         "243.22562.220": "https://plugins.jetbrains.com/files/9525/603167/idea-php-dotenv-plugin-2024.3.zip",
-        "243.23654.157": "https://plugins.jetbrains.com/files/9525/603167/idea-php-dotenv-plugin-2024.3.zip",
-        "243.23654.167": "https://plugins.jetbrains.com/files/9525/603167/idea-php-dotenv-plugin-2024.3.zip",
-        "243.23654.180": "https://plugins.jetbrains.com/files/9525/603167/idea-php-dotenv-plugin-2024.3.zip",
-        "243.23654.183": "https://plugins.jetbrains.com/files/9525/603167/idea-php-dotenv-plugin-2024.3.zip",
-        "243.24978.27": "https://plugins.jetbrains.com/files/9525/603167/idea-php-dotenv-plugin-2024.3.zip",
-        "243.24978.46": "https://plugins.jetbrains.com/files/9525/603167/idea-php-dotenv-plugin-2024.3.zip",
-        "243.24978.50": "https://plugins.jetbrains.com/files/9525/603167/idea-php-dotenv-plugin-2024.3.zip",
-        "243.24978.54": "https://plugins.jetbrains.com/files/9525/603167/idea-php-dotenv-plugin-2024.3.zip",
-        "243.24978.55": "https://plugins.jetbrains.com/files/9525/603167/idea-php-dotenv-plugin-2024.3.zip",
-        "243.24978.59": "https://plugins.jetbrains.com/files/9525/603167/idea-php-dotenv-plugin-2024.3.zip"
+        "243.24978.546": "https://plugins.jetbrains.com/files/9525/603167/idea-php-dotenv-plugin-2024.3.zip",
+        "243.24978.79": "https://plugins.jetbrains.com/files/9525/603167/idea-php-dotenv-plugin-2024.3.zip",
+        "243.24978.86": "https://plugins.jetbrains.com/files/9525/603167/idea-php-dotenv-plugin-2024.3.zip",
+        "243.25659.34": "https://plugins.jetbrains.com/files/9525/603167/idea-php-dotenv-plugin-2024.3.zip",
+        "243.25659.39": "https://plugins.jetbrains.com/files/9525/603167/idea-php-dotenv-plugin-2024.3.zip",
+        "243.25659.40": "https://plugins.jetbrains.com/files/9525/603167/idea-php-dotenv-plugin-2024.3.zip",
+        "243.25659.41": "https://plugins.jetbrains.com/files/9525/603167/idea-php-dotenv-plugin-2024.3.zip",
+        "243.25659.42": "https://plugins.jetbrains.com/files/9525/603167/idea-php-dotenv-plugin-2024.3.zip",
+        "243.25659.43": "https://plugins.jetbrains.com/files/9525/603167/idea-php-dotenv-plugin-2024.3.zip",
+        "243.25659.45": "https://plugins.jetbrains.com/files/9525/603167/idea-php-dotenv-plugin-2024.3.zip",
+        "243.25659.52": "https://plugins.jetbrains.com/files/9525/603167/idea-php-dotenv-plugin-2024.3.zip"
       },
       "name": "-env-files"
     },
@@ -708,8 +708,8 @@
         "idea-ultimate"
       ],
       "builds": {
-        "243.24978.46": "https://plugins.jetbrains.com/files/9568/680198/go-plugin-243.24978.46.zip",
-        "243.24978.59": "https://plugins.jetbrains.com/files/9568/680198/go-plugin-243.24978.46.zip"
+        "243.25659.39": "https://plugins.jetbrains.com/files/9568/680198/go-plugin-243.24978.46.zip",
+        "243.25659.52": "https://plugins.jetbrains.com/files/9568/680198/go-plugin-243.24978.46.zip"
       },
       "name": "go"
     },
@@ -730,19 +730,19 @@
         "webstorm"
       ],
       "builds": {
-        "243.21565.447": "https://plugins.jetbrains.com/files/9707/628343/ansi-highlighter-premium-24.3.1.jar",
         "243.22562.218": "https://plugins.jetbrains.com/files/9707/628343/ansi-highlighter-premium-24.3.1.jar",
         "243.22562.220": "https://plugins.jetbrains.com/files/9707/628343/ansi-highlighter-premium-24.3.1.jar",
-        "243.23654.157": "https://plugins.jetbrains.com/files/9707/628343/ansi-highlighter-premium-24.3.1.jar",
-        "243.23654.167": "https://plugins.jetbrains.com/files/9707/628343/ansi-highlighter-premium-24.3.1.jar",
-        "243.23654.180": "https://plugins.jetbrains.com/files/9707/628343/ansi-highlighter-premium-24.3.1.jar",
-        "243.23654.183": "https://plugins.jetbrains.com/files/9707/628343/ansi-highlighter-premium-24.3.1.jar",
-        "243.24978.27": "https://plugins.jetbrains.com/files/9707/628343/ansi-highlighter-premium-24.3.1.jar",
-        "243.24978.46": "https://plugins.jetbrains.com/files/9707/628343/ansi-highlighter-premium-24.3.1.jar",
-        "243.24978.50": "https://plugins.jetbrains.com/files/9707/628343/ansi-highlighter-premium-24.3.1.jar",
-        "243.24978.54": "https://plugins.jetbrains.com/files/9707/628343/ansi-highlighter-premium-24.3.1.jar",
-        "243.24978.55": "https://plugins.jetbrains.com/files/9707/628343/ansi-highlighter-premium-24.3.1.jar",
-        "243.24978.59": "https://plugins.jetbrains.com/files/9707/628343/ansi-highlighter-premium-24.3.1.jar"
+        "243.24978.546": "https://plugins.jetbrains.com/files/9707/628343/ansi-highlighter-premium-24.3.1.jar",
+        "243.24978.79": "https://plugins.jetbrains.com/files/9707/628343/ansi-highlighter-premium-24.3.1.jar",
+        "243.24978.86": "https://plugins.jetbrains.com/files/9707/628343/ansi-highlighter-premium-24.3.1.jar",
+        "243.25659.34": "https://plugins.jetbrains.com/files/9707/628343/ansi-highlighter-premium-24.3.1.jar",
+        "243.25659.39": "https://plugins.jetbrains.com/files/9707/628343/ansi-highlighter-premium-24.3.1.jar",
+        "243.25659.40": "https://plugins.jetbrains.com/files/9707/628343/ansi-highlighter-premium-24.3.1.jar",
+        "243.25659.41": "https://plugins.jetbrains.com/files/9707/628343/ansi-highlighter-premium-24.3.1.jar",
+        "243.25659.42": "https://plugins.jetbrains.com/files/9707/628343/ansi-highlighter-premium-24.3.1.jar",
+        "243.25659.43": "https://plugins.jetbrains.com/files/9707/628343/ansi-highlighter-premium-24.3.1.jar",
+        "243.25659.45": "https://plugins.jetbrains.com/files/9707/628343/ansi-highlighter-premium-24.3.1.jar",
+        "243.25659.52": "https://plugins.jetbrains.com/files/9707/628343/ansi-highlighter-premium-24.3.1.jar"
       },
       "name": "ansi-highlighter-premium"
     },
@@ -763,19 +763,19 @@
         "webstorm"
       ],
       "builds": {
-        "243.21565.447": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
         "243.22562.218": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
         "243.22562.220": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
-        "243.23654.157": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
-        "243.23654.167": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
-        "243.23654.180": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
-        "243.23654.183": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
-        "243.24978.27": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
-        "243.24978.46": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
-        "243.24978.50": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
-        "243.24978.54": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
-        "243.24978.55": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
-        "243.24978.59": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip"
+        "243.24978.546": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
+        "243.24978.79": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
+        "243.24978.86": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
+        "243.25659.34": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
+        "243.25659.39": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
+        "243.25659.40": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
+        "243.25659.41": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
+        "243.25659.42": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
+        "243.25659.43": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
+        "243.25659.45": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
+        "243.25659.52": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip"
       },
       "name": "key-promoter-x"
     },
@@ -796,19 +796,19 @@
         "webstorm"
       ],
       "builds": {
-        "243.21565.447": "https://plugins.jetbrains.com/files/9836/681714/intellij-randomness-3.3.6-signed.zip",
         "243.22562.218": "https://plugins.jetbrains.com/files/9836/681714/intellij-randomness-3.3.6-signed.zip",
         "243.22562.220": "https://plugins.jetbrains.com/files/9836/681714/intellij-randomness-3.3.6-signed.zip",
-        "243.23654.157": "https://plugins.jetbrains.com/files/9836/681714/intellij-randomness-3.3.6-signed.zip",
-        "243.23654.167": "https://plugins.jetbrains.com/files/9836/681714/intellij-randomness-3.3.6-signed.zip",
-        "243.23654.180": "https://plugins.jetbrains.com/files/9836/681714/intellij-randomness-3.3.6-signed.zip",
-        "243.23654.183": "https://plugins.jetbrains.com/files/9836/681714/intellij-randomness-3.3.6-signed.zip",
-        "243.24978.27": "https://plugins.jetbrains.com/files/9836/681714/intellij-randomness-3.3.6-signed.zip",
-        "243.24978.46": "https://plugins.jetbrains.com/files/9836/681714/intellij-randomness-3.3.6-signed.zip",
-        "243.24978.50": "https://plugins.jetbrains.com/files/9836/681714/intellij-randomness-3.3.6-signed.zip",
-        "243.24978.54": "https://plugins.jetbrains.com/files/9836/681714/intellij-randomness-3.3.6-signed.zip",
-        "243.24978.55": "https://plugins.jetbrains.com/files/9836/681714/intellij-randomness-3.3.6-signed.zip",
-        "243.24978.59": "https://plugins.jetbrains.com/files/9836/681714/intellij-randomness-3.3.6-signed.zip"
+        "243.24978.546": "https://plugins.jetbrains.com/files/9836/681714/intellij-randomness-3.3.6-signed.zip",
+        "243.24978.79": "https://plugins.jetbrains.com/files/9836/681714/intellij-randomness-3.3.6-signed.zip",
+        "243.24978.86": "https://plugins.jetbrains.com/files/9836/681714/intellij-randomness-3.3.6-signed.zip",
+        "243.25659.34": "https://plugins.jetbrains.com/files/9836/681714/intellij-randomness-3.3.6-signed.zip",
+        "243.25659.39": "https://plugins.jetbrains.com/files/9836/681714/intellij-randomness-3.3.6-signed.zip",
+        "243.25659.40": "https://plugins.jetbrains.com/files/9836/681714/intellij-randomness-3.3.6-signed.zip",
+        "243.25659.41": "https://plugins.jetbrains.com/files/9836/681714/intellij-randomness-3.3.6-signed.zip",
+        "243.25659.42": "https://plugins.jetbrains.com/files/9836/681714/intellij-randomness-3.3.6-signed.zip",
+        "243.25659.43": "https://plugins.jetbrains.com/files/9836/681714/intellij-randomness-3.3.6-signed.zip",
+        "243.25659.45": "https://plugins.jetbrains.com/files/9836/681714/intellij-randomness-3.3.6-signed.zip",
+        "243.25659.52": "https://plugins.jetbrains.com/files/9836/681714/intellij-randomness-3.3.6-signed.zip"
       },
       "name": "randomness"
     },
@@ -829,19 +829,19 @@
         "webstorm"
       ],
       "builds": {
-        "243.21565.447": "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip",
         "243.22562.218": "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip",
         "243.22562.220": "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip",
-        "243.23654.157": "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip",
-        "243.23654.167": "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip",
-        "243.23654.180": "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip",
-        "243.23654.183": "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip",
-        "243.24978.27": "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip",
-        "243.24978.46": "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip",
-        "243.24978.50": "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip",
-        "243.24978.54": "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip",
-        "243.24978.55": "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip",
-        "243.24978.59": "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip"
+        "243.24978.546": "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip",
+        "243.24978.79": "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip",
+        "243.24978.86": "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip",
+        "243.25659.34": "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip",
+        "243.25659.39": "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip",
+        "243.25659.40": "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip",
+        "243.25659.41": "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip",
+        "243.25659.42": "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip",
+        "243.25659.43": "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip",
+        "243.25659.45": "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip",
+        "243.25659.52": "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip"
       },
       "name": "csv-editor"
     },
@@ -862,19 +862,19 @@
         "webstorm"
       ],
       "builds": {
-        "243.21565.447": "https://plugins.jetbrains.com/files/10080/645834/intellij-rainbow-brackets-2024.2.8-241.zip",
-        "243.22562.218": "https://plugins.jetbrains.com/files/10080/645834/intellij-rainbow-brackets-2024.2.8-241.zip",
-        "243.22562.220": "https://plugins.jetbrains.com/files/10080/645834/intellij-rainbow-brackets-2024.2.8-241.zip",
-        "243.23654.157": "https://plugins.jetbrains.com/files/10080/645834/intellij-rainbow-brackets-2024.2.8-241.zip",
-        "243.23654.167": "https://plugins.jetbrains.com/files/10080/645834/intellij-rainbow-brackets-2024.2.8-241.zip",
-        "243.23654.180": "https://plugins.jetbrains.com/files/10080/645834/intellij-rainbow-brackets-2024.2.8-241.zip",
-        "243.23654.183": "https://plugins.jetbrains.com/files/10080/645834/intellij-rainbow-brackets-2024.2.8-241.zip",
-        "243.24978.27": "https://plugins.jetbrains.com/files/10080/645834/intellij-rainbow-brackets-2024.2.8-241.zip",
-        "243.24978.46": "https://plugins.jetbrains.com/files/10080/645834/intellij-rainbow-brackets-2024.2.8-241.zip",
-        "243.24978.50": "https://plugins.jetbrains.com/files/10080/645834/intellij-rainbow-brackets-2024.2.8-241.zip",
-        "243.24978.54": "https://plugins.jetbrains.com/files/10080/645834/intellij-rainbow-brackets-2024.2.8-241.zip",
-        "243.24978.55": "https://plugins.jetbrains.com/files/10080/645834/intellij-rainbow-brackets-2024.2.8-241.zip",
-        "243.24978.59": "https://plugins.jetbrains.com/files/10080/645834/intellij-rainbow-brackets-2024.2.8-241.zip"
+        "243.22562.218": "https://plugins.jetbrains.com/files/10080/689210/intellij-rainbow-brackets-2024.2.9-241.zip",
+        "243.22562.220": "https://plugins.jetbrains.com/files/10080/689210/intellij-rainbow-brackets-2024.2.9-241.zip",
+        "243.24978.546": "https://plugins.jetbrains.com/files/10080/689210/intellij-rainbow-brackets-2024.2.9-241.zip",
+        "243.24978.79": "https://plugins.jetbrains.com/files/10080/689210/intellij-rainbow-brackets-2024.2.9-241.zip",
+        "243.24978.86": "https://plugins.jetbrains.com/files/10080/689210/intellij-rainbow-brackets-2024.2.9-241.zip",
+        "243.25659.34": "https://plugins.jetbrains.com/files/10080/689210/intellij-rainbow-brackets-2024.2.9-241.zip",
+        "243.25659.39": "https://plugins.jetbrains.com/files/10080/689210/intellij-rainbow-brackets-2024.2.9-241.zip",
+        "243.25659.40": "https://plugins.jetbrains.com/files/10080/689210/intellij-rainbow-brackets-2024.2.9-241.zip",
+        "243.25659.41": "https://plugins.jetbrains.com/files/10080/689210/intellij-rainbow-brackets-2024.2.9-241.zip",
+        "243.25659.42": "https://plugins.jetbrains.com/files/10080/689210/intellij-rainbow-brackets-2024.2.9-241.zip",
+        "243.25659.43": "https://plugins.jetbrains.com/files/10080/689210/intellij-rainbow-brackets-2024.2.9-241.zip",
+        "243.25659.45": "https://plugins.jetbrains.com/files/10080/689210/intellij-rainbow-brackets-2024.2.9-241.zip",
+        "243.25659.52": "https://plugins.jetbrains.com/files/10080/689210/intellij-rainbow-brackets-2024.2.9-241.zip"
       },
       "name": "rainbow-brackets"
     },
@@ -895,19 +895,19 @@
         "webstorm"
       ],
       "builds": {
-        "243.21565.447": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
         "243.22562.218": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
         "243.22562.220": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
-        "243.23654.157": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
-        "243.23654.167": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
-        "243.23654.180": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
-        "243.23654.183": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
-        "243.24978.27": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
-        "243.24978.46": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
-        "243.24978.50": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
-        "243.24978.54": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
-        "243.24978.55": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
-        "243.24978.59": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip"
+        "243.24978.546": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
+        "243.24978.79": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
+        "243.24978.86": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
+        "243.25659.34": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
+        "243.25659.39": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
+        "243.25659.40": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
+        "243.25659.41": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
+        "243.25659.42": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
+        "243.25659.43": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
+        "243.25659.45": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
+        "243.25659.52": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip"
       },
       "name": "dot-language"
     },
@@ -928,19 +928,19 @@
         "webstorm"
       ],
       "builds": {
-        "243.21565.447": "https://plugins.jetbrains.com/files/10481/583591/intellij-hocon-2024.2.0.zip",
         "243.22562.218": "https://plugins.jetbrains.com/files/10481/583591/intellij-hocon-2024.2.0.zip",
         "243.22562.220": "https://plugins.jetbrains.com/files/10481/583591/intellij-hocon-2024.2.0.zip",
-        "243.23654.157": "https://plugins.jetbrains.com/files/10481/583591/intellij-hocon-2024.2.0.zip",
-        "243.23654.167": "https://plugins.jetbrains.com/files/10481/583591/intellij-hocon-2024.2.0.zip",
-        "243.23654.180": "https://plugins.jetbrains.com/files/10481/583591/intellij-hocon-2024.2.0.zip",
-        "243.23654.183": "https://plugins.jetbrains.com/files/10481/583591/intellij-hocon-2024.2.0.zip",
-        "243.24978.27": "https://plugins.jetbrains.com/files/10481/583591/intellij-hocon-2024.2.0.zip",
-        "243.24978.46": "https://plugins.jetbrains.com/files/10481/583591/intellij-hocon-2024.2.0.zip",
-        "243.24978.50": "https://plugins.jetbrains.com/files/10481/583591/intellij-hocon-2024.2.0.zip",
-        "243.24978.54": "https://plugins.jetbrains.com/files/10481/583591/intellij-hocon-2024.2.0.zip",
-        "243.24978.55": "https://plugins.jetbrains.com/files/10481/583591/intellij-hocon-2024.2.0.zip",
-        "243.24978.59": "https://plugins.jetbrains.com/files/10481/583591/intellij-hocon-2024.2.0.zip"
+        "243.24978.546": "https://plugins.jetbrains.com/files/10481/583591/intellij-hocon-2024.2.0.zip",
+        "243.24978.79": "https://plugins.jetbrains.com/files/10481/583591/intellij-hocon-2024.2.0.zip",
+        "243.24978.86": "https://plugins.jetbrains.com/files/10481/583591/intellij-hocon-2024.2.0.zip",
+        "243.25659.34": "https://plugins.jetbrains.com/files/10481/583591/intellij-hocon-2024.2.0.zip",
+        "243.25659.39": "https://plugins.jetbrains.com/files/10481/583591/intellij-hocon-2024.2.0.zip",
+        "243.25659.40": "https://plugins.jetbrains.com/files/10481/583591/intellij-hocon-2024.2.0.zip",
+        "243.25659.41": "https://plugins.jetbrains.com/files/10481/583591/intellij-hocon-2024.2.0.zip",
+        "243.25659.42": "https://plugins.jetbrains.com/files/10481/583591/intellij-hocon-2024.2.0.zip",
+        "243.25659.43": "https://plugins.jetbrains.com/files/10481/583591/intellij-hocon-2024.2.0.zip",
+        "243.25659.45": "https://plugins.jetbrains.com/files/10481/583591/intellij-hocon-2024.2.0.zip",
+        "243.25659.52": "https://plugins.jetbrains.com/files/10481/583591/intellij-hocon-2024.2.0.zip"
       },
       "name": "hocon"
     },
@@ -961,19 +961,19 @@
         "webstorm"
       ],
       "builds": {
-        "243.21565.447": "https://plugins.jetbrains.com/files/11058/668614/Extra_Icons-2025.1.1.zip",
-        "243.22562.218": "https://plugins.jetbrains.com/files/11058/668614/Extra_Icons-2025.1.1.zip",
-        "243.22562.220": "https://plugins.jetbrains.com/files/11058/668614/Extra_Icons-2025.1.1.zip",
-        "243.23654.157": "https://plugins.jetbrains.com/files/11058/668614/Extra_Icons-2025.1.1.zip",
-        "243.23654.167": "https://plugins.jetbrains.com/files/11058/668614/Extra_Icons-2025.1.1.zip",
-        "243.23654.180": "https://plugins.jetbrains.com/files/11058/668614/Extra_Icons-2025.1.1.zip",
-        "243.23654.183": "https://plugins.jetbrains.com/files/11058/668614/Extra_Icons-2025.1.1.zip",
-        "243.24978.27": "https://plugins.jetbrains.com/files/11058/668614/Extra_Icons-2025.1.1.zip",
-        "243.24978.46": "https://plugins.jetbrains.com/files/11058/668614/Extra_Icons-2025.1.1.zip",
-        "243.24978.50": "https://plugins.jetbrains.com/files/11058/668614/Extra_Icons-2025.1.1.zip",
-        "243.24978.54": "https://plugins.jetbrains.com/files/11058/668614/Extra_Icons-2025.1.1.zip",
-        "243.24978.55": "https://plugins.jetbrains.com/files/11058/668614/Extra_Icons-2025.1.1.zip",
-        "243.24978.59": "https://plugins.jetbrains.com/files/11058/668614/Extra_Icons-2025.1.1.zip"
+        "243.22562.218": "https://plugins.jetbrains.com/files/11058/686929/Extra_Icons-2025.1.2.zip",
+        "243.22562.220": "https://plugins.jetbrains.com/files/11058/686929/Extra_Icons-2025.1.2.zip",
+        "243.24978.546": "https://plugins.jetbrains.com/files/11058/686929/Extra_Icons-2025.1.2.zip",
+        "243.24978.79": "https://plugins.jetbrains.com/files/11058/686929/Extra_Icons-2025.1.2.zip",
+        "243.24978.86": "https://plugins.jetbrains.com/files/11058/686929/Extra_Icons-2025.1.2.zip",
+        "243.25659.34": "https://plugins.jetbrains.com/files/11058/686929/Extra_Icons-2025.1.2.zip",
+        "243.25659.39": "https://plugins.jetbrains.com/files/11058/686929/Extra_Icons-2025.1.2.zip",
+        "243.25659.40": "https://plugins.jetbrains.com/files/11058/686929/Extra_Icons-2025.1.2.zip",
+        "243.25659.41": "https://plugins.jetbrains.com/files/11058/686929/Extra_Icons-2025.1.2.zip",
+        "243.25659.42": "https://plugins.jetbrains.com/files/11058/686929/Extra_Icons-2025.1.2.zip",
+        "243.25659.43": "https://plugins.jetbrains.com/files/11058/686929/Extra_Icons-2025.1.2.zip",
+        "243.25659.45": "https://plugins.jetbrains.com/files/11058/686929/Extra_Icons-2025.1.2.zip",
+        "243.25659.52": "https://plugins.jetbrains.com/files/11058/686929/Extra_Icons-2025.1.2.zip"
       },
       "name": "extra-icons"
     },
@@ -994,19 +994,19 @@
         "webstorm"
       ],
       "builds": {
-        "243.21565.447": "https://plugins.jetbrains.com/files/11349/684473/aws-toolkit-jetbrains-standalone-3.56-243.zip",
-        "243.22562.218": "https://plugins.jetbrains.com/files/11349/684473/aws-toolkit-jetbrains-standalone-3.56-243.zip",
-        "243.22562.220": "https://plugins.jetbrains.com/files/11349/684473/aws-toolkit-jetbrains-standalone-3.56-243.zip",
-        "243.23654.157": "https://plugins.jetbrains.com/files/11349/684473/aws-toolkit-jetbrains-standalone-3.56-243.zip",
-        "243.23654.167": "https://plugins.jetbrains.com/files/11349/684473/aws-toolkit-jetbrains-standalone-3.56-243.zip",
-        "243.23654.180": "https://plugins.jetbrains.com/files/11349/684473/aws-toolkit-jetbrains-standalone-3.56-243.zip",
-        "243.23654.183": "https://plugins.jetbrains.com/files/11349/684473/aws-toolkit-jetbrains-standalone-3.56-243.zip",
-        "243.24978.27": "https://plugins.jetbrains.com/files/11349/684473/aws-toolkit-jetbrains-standalone-3.56-243.zip",
-        "243.24978.46": "https://plugins.jetbrains.com/files/11349/684473/aws-toolkit-jetbrains-standalone-3.56-243.zip",
-        "243.24978.50": "https://plugins.jetbrains.com/files/11349/684473/aws-toolkit-jetbrains-standalone-3.56-243.zip",
-        "243.24978.54": "https://plugins.jetbrains.com/files/11349/684473/aws-toolkit-jetbrains-standalone-3.56-243.zip",
-        "243.24978.55": "https://plugins.jetbrains.com/files/11349/684473/aws-toolkit-jetbrains-standalone-3.56-243.zip",
-        "243.24978.59": "https://plugins.jetbrains.com/files/11349/684473/aws-toolkit-jetbrains-standalone-3.56-243.zip"
+        "243.22562.218": "https://plugins.jetbrains.com/files/11349/689463/aws-toolkit-jetbrains-standalone-3.57-243.zip",
+        "243.22562.220": "https://plugins.jetbrains.com/files/11349/689463/aws-toolkit-jetbrains-standalone-3.57-243.zip",
+        "243.24978.546": "https://plugins.jetbrains.com/files/11349/689463/aws-toolkit-jetbrains-standalone-3.57-243.zip",
+        "243.24978.79": "https://plugins.jetbrains.com/files/11349/689463/aws-toolkit-jetbrains-standalone-3.57-243.zip",
+        "243.24978.86": "https://plugins.jetbrains.com/files/11349/689463/aws-toolkit-jetbrains-standalone-3.57-243.zip",
+        "243.25659.34": "https://plugins.jetbrains.com/files/11349/689463/aws-toolkit-jetbrains-standalone-3.57-243.zip",
+        "243.25659.39": "https://plugins.jetbrains.com/files/11349/689463/aws-toolkit-jetbrains-standalone-3.57-243.zip",
+        "243.25659.40": "https://plugins.jetbrains.com/files/11349/689463/aws-toolkit-jetbrains-standalone-3.57-243.zip",
+        "243.25659.41": "https://plugins.jetbrains.com/files/11349/689463/aws-toolkit-jetbrains-standalone-3.57-243.zip",
+        "243.25659.42": "https://plugins.jetbrains.com/files/11349/689463/aws-toolkit-jetbrains-standalone-3.57-243.zip",
+        "243.25659.43": "https://plugins.jetbrains.com/files/11349/689463/aws-toolkit-jetbrains-standalone-3.57-243.zip",
+        "243.25659.45": "https://plugins.jetbrains.com/files/11349/689463/aws-toolkit-jetbrains-standalone-3.57-243.zip",
+        "243.25659.52": "https://plugins.jetbrains.com/files/11349/689463/aws-toolkit-jetbrains-standalone-3.57-243.zip"
       },
       "name": "aws-toolkit"
     },
@@ -1015,7 +1015,7 @@
         "rider"
       ],
       "builds": {
-        "243.24978.27": "https://plugins.jetbrains.com/files/12024/622380/ReSharperPlugin.CognitiveComplexity-2024.3.0-eap04.zip"
+        "243.25659.34": "https://plugins.jetbrains.com/files/12024/622380/ReSharperPlugin.CognitiveComplexity-2024.3.0-eap04.zip"
       },
       "name": "cognitivecomplexity"
     },
@@ -1036,19 +1036,19 @@
         "webstorm"
       ],
       "builds": {
-        "243.21565.447": "https://plugins.jetbrains.com/files/12062/630060/keymap-vscode-243.21565.122.zip",
         "243.22562.218": "https://plugins.jetbrains.com/files/12062/630060/keymap-vscode-243.21565.122.zip",
         "243.22562.220": "https://plugins.jetbrains.com/files/12062/630060/keymap-vscode-243.21565.122.zip",
-        "243.23654.157": "https://plugins.jetbrains.com/files/12062/630060/keymap-vscode-243.21565.122.zip",
-        "243.23654.167": "https://plugins.jetbrains.com/files/12062/630060/keymap-vscode-243.21565.122.zip",
-        "243.23654.180": "https://plugins.jetbrains.com/files/12062/630060/keymap-vscode-243.21565.122.zip",
-        "243.23654.183": "https://plugins.jetbrains.com/files/12062/630060/keymap-vscode-243.21565.122.zip",
-        "243.24978.27": "https://plugins.jetbrains.com/files/12062/630060/keymap-vscode-243.21565.122.zip",
-        "243.24978.46": "https://plugins.jetbrains.com/files/12062/630060/keymap-vscode-243.21565.122.zip",
-        "243.24978.50": "https://plugins.jetbrains.com/files/12062/630060/keymap-vscode-243.21565.122.zip",
-        "243.24978.54": "https://plugins.jetbrains.com/files/12062/630060/keymap-vscode-243.21565.122.zip",
-        "243.24978.55": "https://plugins.jetbrains.com/files/12062/630060/keymap-vscode-243.21565.122.zip",
-        "243.24978.59": "https://plugins.jetbrains.com/files/12062/630060/keymap-vscode-243.21565.122.zip"
+        "243.24978.546": "https://plugins.jetbrains.com/files/12062/630060/keymap-vscode-243.21565.122.zip",
+        "243.24978.79": "https://plugins.jetbrains.com/files/12062/630060/keymap-vscode-243.21565.122.zip",
+        "243.24978.86": "https://plugins.jetbrains.com/files/12062/630060/keymap-vscode-243.21565.122.zip",
+        "243.25659.34": "https://plugins.jetbrains.com/files/12062/630060/keymap-vscode-243.21565.122.zip",
+        "243.25659.39": "https://plugins.jetbrains.com/files/12062/630060/keymap-vscode-243.21565.122.zip",
+        "243.25659.40": "https://plugins.jetbrains.com/files/12062/630060/keymap-vscode-243.21565.122.zip",
+        "243.25659.41": "https://plugins.jetbrains.com/files/12062/630060/keymap-vscode-243.21565.122.zip",
+        "243.25659.42": "https://plugins.jetbrains.com/files/12062/630060/keymap-vscode-243.21565.122.zip",
+        "243.25659.43": "https://plugins.jetbrains.com/files/12062/630060/keymap-vscode-243.21565.122.zip",
+        "243.25659.45": "https://plugins.jetbrains.com/files/12062/630060/keymap-vscode-243.21565.122.zip",
+        "243.25659.52": "https://plugins.jetbrains.com/files/12062/630060/keymap-vscode-243.21565.122.zip"
       },
       "name": "vscode-keymap"
     },
@@ -1069,19 +1069,19 @@
         "webstorm"
       ],
       "builds": {
-        "243.21565.447": "https://plugins.jetbrains.com/files/12559/629985/keymap-eclipse-243.21565.122.zip",
         "243.22562.218": "https://plugins.jetbrains.com/files/12559/629985/keymap-eclipse-243.21565.122.zip",
         "243.22562.220": "https://plugins.jetbrains.com/files/12559/629985/keymap-eclipse-243.21565.122.zip",
-        "243.23654.157": "https://plugins.jetbrains.com/files/12559/629985/keymap-eclipse-243.21565.122.zip",
-        "243.23654.167": "https://plugins.jetbrains.com/files/12559/629985/keymap-eclipse-243.21565.122.zip",
-        "243.23654.180": "https://plugins.jetbrains.com/files/12559/629985/keymap-eclipse-243.21565.122.zip",
-        "243.23654.183": "https://plugins.jetbrains.com/files/12559/629985/keymap-eclipse-243.21565.122.zip",
-        "243.24978.27": "https://plugins.jetbrains.com/files/12559/629985/keymap-eclipse-243.21565.122.zip",
-        "243.24978.46": "https://plugins.jetbrains.com/files/12559/629985/keymap-eclipse-243.21565.122.zip",
-        "243.24978.50": "https://plugins.jetbrains.com/files/12559/629985/keymap-eclipse-243.21565.122.zip",
-        "243.24978.54": "https://plugins.jetbrains.com/files/12559/629985/keymap-eclipse-243.21565.122.zip",
-        "243.24978.55": "https://plugins.jetbrains.com/files/12559/629985/keymap-eclipse-243.21565.122.zip",
-        "243.24978.59": "https://plugins.jetbrains.com/files/12559/629985/keymap-eclipse-243.21565.122.zip"
+        "243.24978.546": "https://plugins.jetbrains.com/files/12559/629985/keymap-eclipse-243.21565.122.zip",
+        "243.24978.79": "https://plugins.jetbrains.com/files/12559/629985/keymap-eclipse-243.21565.122.zip",
+        "243.24978.86": "https://plugins.jetbrains.com/files/12559/629985/keymap-eclipse-243.21565.122.zip",
+        "243.25659.34": "https://plugins.jetbrains.com/files/12559/629985/keymap-eclipse-243.21565.122.zip",
+        "243.25659.39": "https://plugins.jetbrains.com/files/12559/629985/keymap-eclipse-243.21565.122.zip",
+        "243.25659.40": "https://plugins.jetbrains.com/files/12559/629985/keymap-eclipse-243.21565.122.zip",
+        "243.25659.41": "https://plugins.jetbrains.com/files/12559/629985/keymap-eclipse-243.21565.122.zip",
+        "243.25659.42": "https://plugins.jetbrains.com/files/12559/629985/keymap-eclipse-243.21565.122.zip",
+        "243.25659.43": "https://plugins.jetbrains.com/files/12559/629985/keymap-eclipse-243.21565.122.zip",
+        "243.25659.45": "https://plugins.jetbrains.com/files/12559/629985/keymap-eclipse-243.21565.122.zip",
+        "243.25659.52": "https://plugins.jetbrains.com/files/12559/629985/keymap-eclipse-243.21565.122.zip"
       },
       "name": "eclipse-keymap"
     },
@@ -1102,19 +1102,19 @@
         "webstorm"
       ],
       "builds": {
-        "243.21565.447": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
         "243.22562.218": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
         "243.22562.220": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
-        "243.23654.157": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
-        "243.23654.167": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
-        "243.23654.180": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
-        "243.23654.183": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
-        "243.24978.27": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
-        "243.24978.46": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
-        "243.24978.50": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
-        "243.24978.54": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
-        "243.24978.55": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
-        "243.24978.59": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip"
+        "243.24978.546": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
+        "243.24978.79": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
+        "243.24978.86": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
+        "243.25659.34": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
+        "243.25659.39": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
+        "243.25659.40": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
+        "243.25659.41": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
+        "243.25659.42": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
+        "243.25659.43": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
+        "243.25659.45": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
+        "243.25659.52": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip"
       },
       "name": "rainbow-csv"
     },
@@ -1135,19 +1135,19 @@
         "webstorm"
       ],
       "builds": {
-        "243.21565.447": "https://plugins.jetbrains.com/files/13017/630016/keymap-visualStudio-243.21565.122.zip",
         "243.22562.218": "https://plugins.jetbrains.com/files/13017/630016/keymap-visualStudio-243.21565.122.zip",
         "243.22562.220": "https://plugins.jetbrains.com/files/13017/630016/keymap-visualStudio-243.21565.122.zip",
-        "243.23654.157": "https://plugins.jetbrains.com/files/13017/630016/keymap-visualStudio-243.21565.122.zip",
-        "243.23654.167": "https://plugins.jetbrains.com/files/13017/630016/keymap-visualStudio-243.21565.122.zip",
-        "243.23654.180": "https://plugins.jetbrains.com/files/13017/630016/keymap-visualStudio-243.21565.122.zip",
-        "243.23654.183": "https://plugins.jetbrains.com/files/13017/630016/keymap-visualStudio-243.21565.122.zip",
-        "243.24978.27": "https://plugins.jetbrains.com/files/13017/630016/keymap-visualStudio-243.21565.122.zip",
-        "243.24978.46": "https://plugins.jetbrains.com/files/13017/630016/keymap-visualStudio-243.21565.122.zip",
-        "243.24978.50": "https://plugins.jetbrains.com/files/13017/630016/keymap-visualStudio-243.21565.122.zip",
-        "243.24978.54": "https://plugins.jetbrains.com/files/13017/630016/keymap-visualStudio-243.21565.122.zip",
-        "243.24978.55": "https://plugins.jetbrains.com/files/13017/630016/keymap-visualStudio-243.21565.122.zip",
-        "243.24978.59": "https://plugins.jetbrains.com/files/13017/630016/keymap-visualStudio-243.21565.122.zip"
+        "243.24978.546": "https://plugins.jetbrains.com/files/13017/630016/keymap-visualStudio-243.21565.122.zip",
+        "243.24978.79": "https://plugins.jetbrains.com/files/13017/630016/keymap-visualStudio-243.21565.122.zip",
+        "243.24978.86": "https://plugins.jetbrains.com/files/13017/630016/keymap-visualStudio-243.21565.122.zip",
+        "243.25659.34": "https://plugins.jetbrains.com/files/13017/630016/keymap-visualStudio-243.21565.122.zip",
+        "243.25659.39": "https://plugins.jetbrains.com/files/13017/630016/keymap-visualStudio-243.21565.122.zip",
+        "243.25659.40": "https://plugins.jetbrains.com/files/13017/630016/keymap-visualStudio-243.21565.122.zip",
+        "243.25659.41": "https://plugins.jetbrains.com/files/13017/630016/keymap-visualStudio-243.21565.122.zip",
+        "243.25659.42": "https://plugins.jetbrains.com/files/13017/630016/keymap-visualStudio-243.21565.122.zip",
+        "243.25659.43": "https://plugins.jetbrains.com/files/13017/630016/keymap-visualStudio-243.21565.122.zip",
+        "243.25659.45": "https://plugins.jetbrains.com/files/13017/630016/keymap-visualStudio-243.21565.122.zip",
+        "243.25659.52": "https://plugins.jetbrains.com/files/13017/630016/keymap-visualStudio-243.21565.122.zip"
       },
       "name": "visual-studio-keymap"
     },
@@ -1168,19 +1168,19 @@
         "webstorm"
       ],
       "builds": {
-        "243.21565.447": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
         "243.22562.218": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
         "243.22562.220": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
-        "243.23654.157": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
-        "243.23654.167": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
-        "243.23654.180": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
-        "243.23654.183": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
-        "243.24978.27": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
-        "243.24978.46": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
-        "243.24978.50": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
-        "243.24978.54": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
-        "243.24978.55": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
-        "243.24978.59": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip"
+        "243.24978.546": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
+        "243.24978.79": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
+        "243.24978.86": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
+        "243.25659.34": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
+        "243.25659.39": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
+        "243.25659.40": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
+        "243.25659.41": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
+        "243.25659.42": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
+        "243.25659.43": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
+        "243.25659.45": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
+        "243.25659.52": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip"
       },
       "name": "indent-rainbow"
     },
@@ -1201,19 +1201,19 @@
         "webstorm"
       ],
       "builds": {
-        "243.21565.447": "https://plugins.jetbrains.com/files/14004/629971/protoeditor-243.21565.122.zip",
         "243.22562.218": "https://plugins.jetbrains.com/files/14004/636643/protoeditor-243.22562.13.zip",
         "243.22562.220": "https://plugins.jetbrains.com/files/14004/636643/protoeditor-243.22562.13.zip",
-        "243.23654.157": "https://plugins.jetbrains.com/files/14004/636643/protoeditor-243.22562.13.zip",
-        "243.23654.167": "https://plugins.jetbrains.com/files/14004/636643/protoeditor-243.22562.13.zip",
-        "243.23654.180": "https://plugins.jetbrains.com/files/14004/636643/protoeditor-243.22562.13.zip",
-        "243.23654.183": "https://plugins.jetbrains.com/files/14004/636643/protoeditor-243.22562.13.zip",
-        "243.24978.27": "https://plugins.jetbrains.com/files/14004/636643/protoeditor-243.22562.13.zip",
-        "243.24978.46": "https://plugins.jetbrains.com/files/14004/636643/protoeditor-243.22562.13.zip",
-        "243.24978.50": "https://plugins.jetbrains.com/files/14004/636643/protoeditor-243.22562.13.zip",
-        "243.24978.54": "https://plugins.jetbrains.com/files/14004/636643/protoeditor-243.22562.13.zip",
-        "243.24978.55": "https://plugins.jetbrains.com/files/14004/636643/protoeditor-243.22562.13.zip",
-        "243.24978.59": "https://plugins.jetbrains.com/files/14004/636643/protoeditor-243.22562.13.zip"
+        "243.24978.546": "https://plugins.jetbrains.com/files/14004/636643/protoeditor-243.22562.13.zip",
+        "243.24978.79": "https://plugins.jetbrains.com/files/14004/636643/protoeditor-243.22562.13.zip",
+        "243.24978.86": "https://plugins.jetbrains.com/files/14004/636643/protoeditor-243.22562.13.zip",
+        "243.25659.34": "https://plugins.jetbrains.com/files/14004/636643/protoeditor-243.22562.13.zip",
+        "243.25659.39": "https://plugins.jetbrains.com/files/14004/636643/protoeditor-243.22562.13.zip",
+        "243.25659.40": "https://plugins.jetbrains.com/files/14004/636643/protoeditor-243.22562.13.zip",
+        "243.25659.41": "https://plugins.jetbrains.com/files/14004/636643/protoeditor-243.22562.13.zip",
+        "243.25659.42": "https://plugins.jetbrains.com/files/14004/636643/protoeditor-243.22562.13.zip",
+        "243.25659.43": "https://plugins.jetbrains.com/files/14004/636643/protoeditor-243.22562.13.zip",
+        "243.25659.45": "https://plugins.jetbrains.com/files/14004/636643/protoeditor-243.22562.13.zip",
+        "243.25659.52": "https://plugins.jetbrains.com/files/14004/636643/protoeditor-243.22562.13.zip"
       },
       "name": "protocol-buffers"
     },
@@ -1234,19 +1234,19 @@
         "webstorm"
       ],
       "builds": {
-        "243.21565.447": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
         "243.22562.218": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
         "243.22562.220": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
-        "243.23654.157": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
-        "243.23654.167": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
-        "243.23654.180": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
-        "243.23654.183": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
-        "243.24978.27": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
-        "243.24978.46": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
-        "243.24978.50": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
-        "243.24978.54": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
-        "243.24978.55": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
-        "243.24978.59": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar"
+        "243.24978.546": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
+        "243.24978.79": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
+        "243.24978.86": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
+        "243.25659.34": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
+        "243.25659.39": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
+        "243.25659.40": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
+        "243.25659.41": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
+        "243.25659.42": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
+        "243.25659.43": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
+        "243.25659.45": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
+        "243.25659.52": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar"
       },
       "name": "darcula-pitch-black"
     },
@@ -1267,19 +1267,19 @@
         "webstorm"
       ],
       "builds": {
-        "243.21565.447": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
         "243.22562.218": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
         "243.22562.220": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
-        "243.23654.157": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
-        "243.23654.167": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
-        "243.23654.180": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
-        "243.23654.183": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
-        "243.24978.27": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
-        "243.24978.46": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
-        "243.24978.50": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
-        "243.24978.54": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
-        "243.24978.55": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
-        "243.24978.59": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar"
+        "243.24978.546": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
+        "243.24978.79": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
+        "243.24978.86": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
+        "243.25659.34": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
+        "243.25659.39": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
+        "243.25659.40": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
+        "243.25659.41": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
+        "243.25659.42": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
+        "243.25659.43": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
+        "243.25659.45": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
+        "243.25659.52": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar"
       },
       "name": "mario-progress-bar"
     },
@@ -1300,19 +1300,19 @@
         "webstorm"
       ],
       "builds": {
-        "243.21565.447": "https://plugins.jetbrains.com/files/15976/593529/IDEA_Which-Key-0.10.3.jar",
         "243.22562.218": "https://plugins.jetbrains.com/files/15976/593529/IDEA_Which-Key-0.10.3.jar",
         "243.22562.220": "https://plugins.jetbrains.com/files/15976/593529/IDEA_Which-Key-0.10.3.jar",
-        "243.23654.157": "https://plugins.jetbrains.com/files/15976/593529/IDEA_Which-Key-0.10.3.jar",
-        "243.23654.167": "https://plugins.jetbrains.com/files/15976/593529/IDEA_Which-Key-0.10.3.jar",
-        "243.23654.180": "https://plugins.jetbrains.com/files/15976/593529/IDEA_Which-Key-0.10.3.jar",
-        "243.23654.183": "https://plugins.jetbrains.com/files/15976/593529/IDEA_Which-Key-0.10.3.jar",
-        "243.24978.27": "https://plugins.jetbrains.com/files/15976/593529/IDEA_Which-Key-0.10.3.jar",
-        "243.24978.46": "https://plugins.jetbrains.com/files/15976/593529/IDEA_Which-Key-0.10.3.jar",
-        "243.24978.50": "https://plugins.jetbrains.com/files/15976/593529/IDEA_Which-Key-0.10.3.jar",
-        "243.24978.54": "https://plugins.jetbrains.com/files/15976/593529/IDEA_Which-Key-0.10.3.jar",
-        "243.24978.55": "https://plugins.jetbrains.com/files/15976/593529/IDEA_Which-Key-0.10.3.jar",
-        "243.24978.59": "https://plugins.jetbrains.com/files/15976/593529/IDEA_Which-Key-0.10.3.jar"
+        "243.24978.546": "https://plugins.jetbrains.com/files/15976/593529/IDEA_Which-Key-0.10.3.jar",
+        "243.24978.79": "https://plugins.jetbrains.com/files/15976/593529/IDEA_Which-Key-0.10.3.jar",
+        "243.24978.86": "https://plugins.jetbrains.com/files/15976/593529/IDEA_Which-Key-0.10.3.jar",
+        "243.25659.34": "https://plugins.jetbrains.com/files/15976/593529/IDEA_Which-Key-0.10.3.jar",
+        "243.25659.39": "https://plugins.jetbrains.com/files/15976/593529/IDEA_Which-Key-0.10.3.jar",
+        "243.25659.40": "https://plugins.jetbrains.com/files/15976/593529/IDEA_Which-Key-0.10.3.jar",
+        "243.25659.41": "https://plugins.jetbrains.com/files/15976/593529/IDEA_Which-Key-0.10.3.jar",
+        "243.25659.42": "https://plugins.jetbrains.com/files/15976/593529/IDEA_Which-Key-0.10.3.jar",
+        "243.25659.43": "https://plugins.jetbrains.com/files/15976/593529/IDEA_Which-Key-0.10.3.jar",
+        "243.25659.45": "https://plugins.jetbrains.com/files/15976/593529/IDEA_Which-Key-0.10.3.jar",
+        "243.25659.52": "https://plugins.jetbrains.com/files/15976/593529/IDEA_Which-Key-0.10.3.jar"
       },
       "name": "which-key"
     },
@@ -1333,19 +1333,19 @@
         "webstorm"
       ],
       "builds": {
-        "243.21565.447": "https://plugins.jetbrains.com/files/16604/671364/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.3.zip",
-        "243.22562.218": "https://plugins.jetbrains.com/files/16604/671364/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.3.zip",
-        "243.22562.220": "https://plugins.jetbrains.com/files/16604/671364/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.3.zip",
-        "243.23654.157": "https://plugins.jetbrains.com/files/16604/671364/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.3.zip",
-        "243.23654.167": "https://plugins.jetbrains.com/files/16604/671364/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.3.zip",
-        "243.23654.180": "https://plugins.jetbrains.com/files/16604/671364/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.3.zip",
-        "243.23654.183": "https://plugins.jetbrains.com/files/16604/671364/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.3.zip",
-        "243.24978.27": "https://plugins.jetbrains.com/files/16604/671364/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.3.zip",
-        "243.24978.46": "https://plugins.jetbrains.com/files/16604/671364/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.3.zip",
-        "243.24978.50": "https://plugins.jetbrains.com/files/16604/671364/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.3.zip",
-        "243.24978.54": "https://plugins.jetbrains.com/files/16604/671364/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.3.zip",
-        "243.24978.55": "https://plugins.jetbrains.com/files/16604/671364/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.3.zip",
-        "243.24978.59": "https://plugins.jetbrains.com/files/16604/671364/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.3.zip"
+        "243.22562.218": "https://plugins.jetbrains.com/files/16604/686930/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.4.zip",
+        "243.22562.220": "https://plugins.jetbrains.com/files/16604/686930/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.4.zip",
+        "243.24978.546": "https://plugins.jetbrains.com/files/16604/686930/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.4.zip",
+        "243.24978.79": "https://plugins.jetbrains.com/files/16604/686930/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.4.zip",
+        "243.24978.86": "https://plugins.jetbrains.com/files/16604/686930/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.4.zip",
+        "243.25659.34": "https://plugins.jetbrains.com/files/16604/686930/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.4.zip",
+        "243.25659.39": "https://plugins.jetbrains.com/files/16604/686930/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.4.zip",
+        "243.25659.40": "https://plugins.jetbrains.com/files/16604/686930/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.4.zip",
+        "243.25659.41": "https://plugins.jetbrains.com/files/16604/686930/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.4.zip",
+        "243.25659.42": "https://plugins.jetbrains.com/files/16604/686930/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.4.zip",
+        "243.25659.43": "https://plugins.jetbrains.com/files/16604/686930/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.4.zip",
+        "243.25659.45": "https://plugins.jetbrains.com/files/16604/686930/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.4.zip",
+        "243.25659.52": "https://plugins.jetbrains.com/files/16604/686930/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.4.zip"
       },
       "name": "extra-toolwindow-colorful-icons"
     },
@@ -1366,19 +1366,19 @@
         "webstorm"
       ],
       "builds": {
-        "243.21565.447": "https://plugins.jetbrains.com/files/17718/683782/github-copilot-intellij-1.5.35-242.zip",
-        "243.22562.218": "https://plugins.jetbrains.com/files/17718/683782/github-copilot-intellij-1.5.35-242.zip",
-        "243.22562.220": "https://plugins.jetbrains.com/files/17718/683782/github-copilot-intellij-1.5.35-242.zip",
-        "243.23654.157": "https://plugins.jetbrains.com/files/17718/683782/github-copilot-intellij-1.5.35-242.zip",
-        "243.23654.167": "https://plugins.jetbrains.com/files/17718/683782/github-copilot-intellij-1.5.35-242.zip",
-        "243.23654.180": "https://plugins.jetbrains.com/files/17718/683782/github-copilot-intellij-1.5.35-242.zip",
-        "243.23654.183": "https://plugins.jetbrains.com/files/17718/683782/github-copilot-intellij-1.5.35-242.zip",
-        "243.24978.27": "https://plugins.jetbrains.com/files/17718/683782/github-copilot-intellij-1.5.35-242.zip",
-        "243.24978.46": "https://plugins.jetbrains.com/files/17718/683782/github-copilot-intellij-1.5.35-242.zip",
-        "243.24978.50": "https://plugins.jetbrains.com/files/17718/683782/github-copilot-intellij-1.5.35-242.zip",
-        "243.24978.54": "https://plugins.jetbrains.com/files/17718/683782/github-copilot-intellij-1.5.35-242.zip",
-        "243.24978.55": "https://plugins.jetbrains.com/files/17718/683782/github-copilot-intellij-1.5.35-242.zip",
-        "243.24978.59": "https://plugins.jetbrains.com/files/17718/683782/github-copilot-intellij-1.5.35-242.zip"
+        "243.22562.218": "https://plugins.jetbrains.com/files/17718/688477/github-copilot-intellij-1.5.37-242.zip",
+        "243.22562.220": "https://plugins.jetbrains.com/files/17718/688477/github-copilot-intellij-1.5.37-242.zip",
+        "243.24978.546": "https://plugins.jetbrains.com/files/17718/688477/github-copilot-intellij-1.5.37-242.zip",
+        "243.24978.79": "https://plugins.jetbrains.com/files/17718/688477/github-copilot-intellij-1.5.37-242.zip",
+        "243.24978.86": "https://plugins.jetbrains.com/files/17718/688477/github-copilot-intellij-1.5.37-242.zip",
+        "243.25659.34": "https://plugins.jetbrains.com/files/17718/688477/github-copilot-intellij-1.5.37-242.zip",
+        "243.25659.39": "https://plugins.jetbrains.com/files/17718/688477/github-copilot-intellij-1.5.37-242.zip",
+        "243.25659.40": "https://plugins.jetbrains.com/files/17718/688477/github-copilot-intellij-1.5.37-242.zip",
+        "243.25659.41": "https://plugins.jetbrains.com/files/17718/688477/github-copilot-intellij-1.5.37-242.zip",
+        "243.25659.42": "https://plugins.jetbrains.com/files/17718/688477/github-copilot-intellij-1.5.37-242.zip",
+        "243.25659.43": "https://plugins.jetbrains.com/files/17718/688477/github-copilot-intellij-1.5.37-242.zip",
+        "243.25659.45": "https://plugins.jetbrains.com/files/17718/688477/github-copilot-intellij-1.5.37-242.zip",
+        "243.25659.52": "https://plugins.jetbrains.com/files/17718/688477/github-copilot-intellij-1.5.37-242.zip"
       },
       "name": "github-copilot"
     },
@@ -1399,19 +1399,19 @@
         "webstorm"
       ],
       "builds": {
-        "243.21565.447": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
         "243.22562.218": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
         "243.22562.220": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
-        "243.23654.157": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
-        "243.23654.167": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
-        "243.23654.180": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
-        "243.23654.183": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
-        "243.24978.27": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
-        "243.24978.46": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
-        "243.24978.50": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
-        "243.24978.54": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
-        "243.24978.55": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
-        "243.24978.59": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip"
+        "243.24978.546": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
+        "243.24978.79": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
+        "243.24978.86": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
+        "243.25659.34": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
+        "243.25659.39": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
+        "243.25659.40": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
+        "243.25659.41": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
+        "243.25659.42": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
+        "243.25659.43": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
+        "243.25659.45": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
+        "243.25659.52": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip"
       },
       "name": "netbeans-6-5-keymap"
     },
@@ -1432,19 +1432,19 @@
         "webstorm"
       ],
       "builds": {
-        "243.21565.447": "https://plugins.jetbrains.com/files/18682/680233/Catppuccin_Theme-3.4.1.zip",
         "243.22562.218": "https://plugins.jetbrains.com/files/18682/680233/Catppuccin_Theme-3.4.1.zip",
         "243.22562.220": "https://plugins.jetbrains.com/files/18682/680233/Catppuccin_Theme-3.4.1.zip",
-        "243.23654.157": "https://plugins.jetbrains.com/files/18682/680233/Catppuccin_Theme-3.4.1.zip",
-        "243.23654.167": "https://plugins.jetbrains.com/files/18682/680233/Catppuccin_Theme-3.4.1.zip",
-        "243.23654.180": "https://plugins.jetbrains.com/files/18682/680233/Catppuccin_Theme-3.4.1.zip",
-        "243.23654.183": "https://plugins.jetbrains.com/files/18682/680233/Catppuccin_Theme-3.4.1.zip",
-        "243.24978.27": "https://plugins.jetbrains.com/files/18682/680233/Catppuccin_Theme-3.4.1.zip",
-        "243.24978.46": "https://plugins.jetbrains.com/files/18682/680233/Catppuccin_Theme-3.4.1.zip",
-        "243.24978.50": "https://plugins.jetbrains.com/files/18682/680233/Catppuccin_Theme-3.4.1.zip",
-        "243.24978.54": "https://plugins.jetbrains.com/files/18682/680233/Catppuccin_Theme-3.4.1.zip",
-        "243.24978.55": "https://plugins.jetbrains.com/files/18682/680233/Catppuccin_Theme-3.4.1.zip",
-        "243.24978.59": "https://plugins.jetbrains.com/files/18682/680233/Catppuccin_Theme-3.4.1.zip"
+        "243.24978.546": "https://plugins.jetbrains.com/files/18682/680233/Catppuccin_Theme-3.4.1.zip",
+        "243.24978.79": "https://plugins.jetbrains.com/files/18682/680233/Catppuccin_Theme-3.4.1.zip",
+        "243.24978.86": "https://plugins.jetbrains.com/files/18682/680233/Catppuccin_Theme-3.4.1.zip",
+        "243.25659.34": "https://plugins.jetbrains.com/files/18682/680233/Catppuccin_Theme-3.4.1.zip",
+        "243.25659.39": "https://plugins.jetbrains.com/files/18682/680233/Catppuccin_Theme-3.4.1.zip",
+        "243.25659.40": "https://plugins.jetbrains.com/files/18682/680233/Catppuccin_Theme-3.4.1.zip",
+        "243.25659.41": "https://plugins.jetbrains.com/files/18682/680233/Catppuccin_Theme-3.4.1.zip",
+        "243.25659.42": "https://plugins.jetbrains.com/files/18682/680233/Catppuccin_Theme-3.4.1.zip",
+        "243.25659.43": "https://plugins.jetbrains.com/files/18682/680233/Catppuccin_Theme-3.4.1.zip",
+        "243.25659.45": "https://plugins.jetbrains.com/files/18682/680233/Catppuccin_Theme-3.4.1.zip",
+        "243.25659.52": "https://plugins.jetbrains.com/files/18682/680233/Catppuccin_Theme-3.4.1.zip"
       },
       "name": "catppuccin-theme"
     },
@@ -1465,19 +1465,19 @@
         "webstorm"
       ],
       "builds": {
-        "243.21565.447": "https://plugins.jetbrains.com/files/18824/671527/CodeGlancePro-1.9.6-signed.zip",
         "243.22562.218": "https://plugins.jetbrains.com/files/18824/671527/CodeGlancePro-1.9.6-signed.zip",
         "243.22562.220": "https://plugins.jetbrains.com/files/18824/671527/CodeGlancePro-1.9.6-signed.zip",
-        "243.23654.157": "https://plugins.jetbrains.com/files/18824/671527/CodeGlancePro-1.9.6-signed.zip",
-        "243.23654.167": "https://plugins.jetbrains.com/files/18824/671527/CodeGlancePro-1.9.6-signed.zip",
-        "243.23654.180": "https://plugins.jetbrains.com/files/18824/671527/CodeGlancePro-1.9.6-signed.zip",
-        "243.23654.183": "https://plugins.jetbrains.com/files/18824/671527/CodeGlancePro-1.9.6-signed.zip",
-        "243.24978.27": "https://plugins.jetbrains.com/files/18824/671527/CodeGlancePro-1.9.6-signed.zip",
-        "243.24978.46": "https://plugins.jetbrains.com/files/18824/671527/CodeGlancePro-1.9.6-signed.zip",
-        "243.24978.50": "https://plugins.jetbrains.com/files/18824/671527/CodeGlancePro-1.9.6-signed.zip",
-        "243.24978.54": "https://plugins.jetbrains.com/files/18824/671527/CodeGlancePro-1.9.6-signed.zip",
-        "243.24978.55": "https://plugins.jetbrains.com/files/18824/671527/CodeGlancePro-1.9.6-signed.zip",
-        "243.24978.59": "https://plugins.jetbrains.com/files/18824/671527/CodeGlancePro-1.9.6-signed.zip"
+        "243.24978.546": "https://plugins.jetbrains.com/files/18824/671527/CodeGlancePro-1.9.6-signed.zip",
+        "243.24978.79": "https://plugins.jetbrains.com/files/18824/671527/CodeGlancePro-1.9.6-signed.zip",
+        "243.24978.86": "https://plugins.jetbrains.com/files/18824/671527/CodeGlancePro-1.9.6-signed.zip",
+        "243.25659.34": "https://plugins.jetbrains.com/files/18824/671527/CodeGlancePro-1.9.6-signed.zip",
+        "243.25659.39": "https://plugins.jetbrains.com/files/18824/671527/CodeGlancePro-1.9.6-signed.zip",
+        "243.25659.40": "https://plugins.jetbrains.com/files/18824/671527/CodeGlancePro-1.9.6-signed.zip",
+        "243.25659.41": "https://plugins.jetbrains.com/files/18824/671527/CodeGlancePro-1.9.6-signed.zip",
+        "243.25659.42": "https://plugins.jetbrains.com/files/18824/671527/CodeGlancePro-1.9.6-signed.zip",
+        "243.25659.43": "https://plugins.jetbrains.com/files/18824/671527/CodeGlancePro-1.9.6-signed.zip",
+        "243.25659.45": "https://plugins.jetbrains.com/files/18824/671527/CodeGlancePro-1.9.6-signed.zip",
+        "243.25659.52": "https://plugins.jetbrains.com/files/18824/671527/CodeGlancePro-1.9.6-signed.zip"
       },
       "name": "codeglance-pro"
     },
@@ -1498,19 +1498,19 @@
         "webstorm"
       ],
       "builds": {
-        "243.21565.447": "https://plugins.jetbrains.com/files/18922/685255/GerryThemes.jar",
         "243.22562.218": "https://plugins.jetbrains.com/files/18922/685255/GerryThemes.jar",
         "243.22562.220": "https://plugins.jetbrains.com/files/18922/685255/GerryThemes.jar",
-        "243.23654.157": "https://plugins.jetbrains.com/files/18922/685255/GerryThemes.jar",
-        "243.23654.167": "https://plugins.jetbrains.com/files/18922/685255/GerryThemes.jar",
-        "243.23654.180": "https://plugins.jetbrains.com/files/18922/685255/GerryThemes.jar",
-        "243.23654.183": "https://plugins.jetbrains.com/files/18922/685255/GerryThemes.jar",
-        "243.24978.27": "https://plugins.jetbrains.com/files/18922/685255/GerryThemes.jar",
-        "243.24978.46": "https://plugins.jetbrains.com/files/18922/685255/GerryThemes.jar",
-        "243.24978.50": "https://plugins.jetbrains.com/files/18922/685255/GerryThemes.jar",
-        "243.24978.54": "https://plugins.jetbrains.com/files/18922/685255/GerryThemes.jar",
-        "243.24978.55": "https://plugins.jetbrains.com/files/18922/685255/GerryThemes.jar",
-        "243.24978.59": "https://plugins.jetbrains.com/files/18922/685255/GerryThemes.jar"
+        "243.24978.546": "https://plugins.jetbrains.com/files/18922/685255/GerryThemes.jar",
+        "243.24978.79": "https://plugins.jetbrains.com/files/18922/685255/GerryThemes.jar",
+        "243.24978.86": "https://plugins.jetbrains.com/files/18922/685255/GerryThemes.jar",
+        "243.25659.34": "https://plugins.jetbrains.com/files/18922/685255/GerryThemes.jar",
+        "243.25659.39": "https://plugins.jetbrains.com/files/18922/685255/GerryThemes.jar",
+        "243.25659.40": "https://plugins.jetbrains.com/files/18922/685255/GerryThemes.jar",
+        "243.25659.41": "https://plugins.jetbrains.com/files/18922/685255/GerryThemes.jar",
+        "243.25659.42": "https://plugins.jetbrains.com/files/18922/685255/GerryThemes.jar",
+        "243.25659.43": "https://plugins.jetbrains.com/files/18922/685255/GerryThemes.jar",
+        "243.25659.45": "https://plugins.jetbrains.com/files/18922/685255/GerryThemes.jar",
+        "243.25659.52": "https://plugins.jetbrains.com/files/18922/685255/GerryThemes.jar"
       },
       "name": "gerry-themes"
     },
@@ -1531,19 +1531,19 @@
         "webstorm"
       ],
       "builds": {
-        "243.21565.447": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
         "243.22562.218": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
         "243.22562.220": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
-        "243.23654.157": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
-        "243.23654.167": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
-        "243.23654.180": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
-        "243.23654.183": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
-        "243.24978.27": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
-        "243.24978.46": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
-        "243.24978.50": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
-        "243.24978.54": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
-        "243.24978.55": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
-        "243.24978.59": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip"
+        "243.24978.546": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
+        "243.24978.79": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
+        "243.24978.86": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
+        "243.25659.34": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
+        "243.25659.39": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
+        "243.25659.40": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
+        "243.25659.41": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
+        "243.25659.42": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
+        "243.25659.43": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
+        "243.25659.45": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
+        "243.25659.52": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip"
       },
       "name": "better-direnv"
     },
@@ -1564,19 +1564,19 @@
         "webstorm"
       ],
       "builds": {
-        "243.21565.447": "https://plugins.jetbrains.com/files/20146/633971/Mermaid-0.0.24_IJ.243.zip",
         "243.22562.218": "https://plugins.jetbrains.com/files/20146/633971/Mermaid-0.0.24_IJ.243.zip",
         "243.22562.220": "https://plugins.jetbrains.com/files/20146/633971/Mermaid-0.0.24_IJ.243.zip",
-        "243.23654.157": "https://plugins.jetbrains.com/files/20146/633971/Mermaid-0.0.24_IJ.243.zip",
-        "243.23654.167": "https://plugins.jetbrains.com/files/20146/633971/Mermaid-0.0.24_IJ.243.zip",
-        "243.23654.180": "https://plugins.jetbrains.com/files/20146/633971/Mermaid-0.0.24_IJ.243.zip",
-        "243.23654.183": "https://plugins.jetbrains.com/files/20146/633971/Mermaid-0.0.24_IJ.243.zip",
-        "243.24978.27": "https://plugins.jetbrains.com/files/20146/633971/Mermaid-0.0.24_IJ.243.zip",
-        "243.24978.46": "https://plugins.jetbrains.com/files/20146/633971/Mermaid-0.0.24_IJ.243.zip",
-        "243.24978.50": "https://plugins.jetbrains.com/files/20146/633971/Mermaid-0.0.24_IJ.243.zip",
-        "243.24978.54": "https://plugins.jetbrains.com/files/20146/633971/Mermaid-0.0.24_IJ.243.zip",
-        "243.24978.55": "https://plugins.jetbrains.com/files/20146/633971/Mermaid-0.0.24_IJ.243.zip",
-        "243.24978.59": "https://plugins.jetbrains.com/files/20146/633971/Mermaid-0.0.24_IJ.243.zip"
+        "243.24978.546": "https://plugins.jetbrains.com/files/20146/633971/Mermaid-0.0.24_IJ.243.zip",
+        "243.24978.79": "https://plugins.jetbrains.com/files/20146/633971/Mermaid-0.0.24_IJ.243.zip",
+        "243.24978.86": "https://plugins.jetbrains.com/files/20146/633971/Mermaid-0.0.24_IJ.243.zip",
+        "243.25659.34": "https://plugins.jetbrains.com/files/20146/633971/Mermaid-0.0.24_IJ.243.zip",
+        "243.25659.39": "https://plugins.jetbrains.com/files/20146/633971/Mermaid-0.0.24_IJ.243.zip",
+        "243.25659.40": "https://plugins.jetbrains.com/files/20146/633971/Mermaid-0.0.24_IJ.243.zip",
+        "243.25659.41": "https://plugins.jetbrains.com/files/20146/633971/Mermaid-0.0.24_IJ.243.zip",
+        "243.25659.42": "https://plugins.jetbrains.com/files/20146/633971/Mermaid-0.0.24_IJ.243.zip",
+        "243.25659.43": "https://plugins.jetbrains.com/files/20146/633971/Mermaid-0.0.24_IJ.243.zip",
+        "243.25659.45": "https://plugins.jetbrains.com/files/20146/633971/Mermaid-0.0.24_IJ.243.zip",
+        "243.25659.52": "https://plugins.jetbrains.com/files/20146/633971/Mermaid-0.0.24_IJ.243.zip"
       },
       "name": "mermaid"
     },
@@ -1597,19 +1597,19 @@
         "webstorm"
       ],
       "builds": {
-        "243.21565.447": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
         "243.22562.218": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
         "243.22562.220": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
-        "243.23654.157": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
-        "243.23654.167": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
-        "243.23654.180": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
-        "243.23654.183": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
-        "243.24978.27": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
-        "243.24978.46": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
-        "243.24978.50": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
-        "243.24978.54": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
-        "243.24978.55": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
-        "243.24978.59": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip"
+        "243.24978.546": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
+        "243.24978.79": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
+        "243.24978.86": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
+        "243.25659.34": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
+        "243.25659.39": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
+        "243.25659.40": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
+        "243.25659.41": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
+        "243.25659.42": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
+        "243.25659.43": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
+        "243.25659.45": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
+        "243.25659.52": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip"
       },
       "name": "ferris"
     },
@@ -1630,19 +1630,19 @@
         "webstorm"
       ],
       "builds": {
-        "243.21565.447": "https://plugins.jetbrains.com/files/21667/618339/code-complexity-plugin-1.6.1.zip",
         "243.22562.218": "https://plugins.jetbrains.com/files/21667/618339/code-complexity-plugin-1.6.1.zip",
         "243.22562.220": "https://plugins.jetbrains.com/files/21667/618339/code-complexity-plugin-1.6.1.zip",
-        "243.23654.157": "https://plugins.jetbrains.com/files/21667/618339/code-complexity-plugin-1.6.1.zip",
-        "243.23654.167": "https://plugins.jetbrains.com/files/21667/618339/code-complexity-plugin-1.6.1.zip",
-        "243.23654.180": "https://plugins.jetbrains.com/files/21667/618339/code-complexity-plugin-1.6.1.zip",
-        "243.23654.183": "https://plugins.jetbrains.com/files/21667/618339/code-complexity-plugin-1.6.1.zip",
-        "243.24978.27": "https://plugins.jetbrains.com/files/21667/618339/code-complexity-plugin-1.6.1.zip",
-        "243.24978.46": "https://plugins.jetbrains.com/files/21667/618339/code-complexity-plugin-1.6.1.zip",
-        "243.24978.50": "https://plugins.jetbrains.com/files/21667/618339/code-complexity-plugin-1.6.1.zip",
-        "243.24978.54": "https://plugins.jetbrains.com/files/21667/618339/code-complexity-plugin-1.6.1.zip",
-        "243.24978.55": "https://plugins.jetbrains.com/files/21667/618339/code-complexity-plugin-1.6.1.zip",
-        "243.24978.59": "https://plugins.jetbrains.com/files/21667/618339/code-complexity-plugin-1.6.1.zip"
+        "243.24978.546": "https://plugins.jetbrains.com/files/21667/618339/code-complexity-plugin-1.6.1.zip",
+        "243.24978.79": "https://plugins.jetbrains.com/files/21667/618339/code-complexity-plugin-1.6.1.zip",
+        "243.24978.86": "https://plugins.jetbrains.com/files/21667/618339/code-complexity-plugin-1.6.1.zip",
+        "243.25659.34": "https://plugins.jetbrains.com/files/21667/618339/code-complexity-plugin-1.6.1.zip",
+        "243.25659.39": "https://plugins.jetbrains.com/files/21667/618339/code-complexity-plugin-1.6.1.zip",
+        "243.25659.40": "https://plugins.jetbrains.com/files/21667/618339/code-complexity-plugin-1.6.1.zip",
+        "243.25659.41": "https://plugins.jetbrains.com/files/21667/618339/code-complexity-plugin-1.6.1.zip",
+        "243.25659.42": "https://plugins.jetbrains.com/files/21667/618339/code-complexity-plugin-1.6.1.zip",
+        "243.25659.43": "https://plugins.jetbrains.com/files/21667/618339/code-complexity-plugin-1.6.1.zip",
+        "243.25659.45": "https://plugins.jetbrains.com/files/21667/618339/code-complexity-plugin-1.6.1.zip",
+        "243.25659.52": "https://plugins.jetbrains.com/files/21667/618339/code-complexity-plugin-1.6.1.zip"
       },
       "name": "code-complexity"
     },
@@ -1663,19 +1663,19 @@
         "webstorm"
       ],
       "builds": {
-        "243.21565.447": "https://plugins.jetbrains.com/files/21904/665427/intellij-developer-tools-plugin-6.3.0-signed.zip",
         "243.22562.218": "https://plugins.jetbrains.com/files/21904/665427/intellij-developer-tools-plugin-6.3.0-signed.zip",
         "243.22562.220": "https://plugins.jetbrains.com/files/21904/665427/intellij-developer-tools-plugin-6.3.0-signed.zip",
-        "243.23654.157": "https://plugins.jetbrains.com/files/21904/665427/intellij-developer-tools-plugin-6.3.0-signed.zip",
-        "243.23654.167": "https://plugins.jetbrains.com/files/21904/665427/intellij-developer-tools-plugin-6.3.0-signed.zip",
-        "243.23654.180": "https://plugins.jetbrains.com/files/21904/665427/intellij-developer-tools-plugin-6.3.0-signed.zip",
-        "243.23654.183": "https://plugins.jetbrains.com/files/21904/665427/intellij-developer-tools-plugin-6.3.0-signed.zip",
-        "243.24978.27": "https://plugins.jetbrains.com/files/21904/665427/intellij-developer-tools-plugin-6.3.0-signed.zip",
-        "243.24978.46": "https://plugins.jetbrains.com/files/21904/665427/intellij-developer-tools-plugin-6.3.0-signed.zip",
-        "243.24978.50": "https://plugins.jetbrains.com/files/21904/665427/intellij-developer-tools-plugin-6.3.0-signed.zip",
-        "243.24978.54": "https://plugins.jetbrains.com/files/21904/665427/intellij-developer-tools-plugin-6.3.0-signed.zip",
-        "243.24978.55": "https://plugins.jetbrains.com/files/21904/665427/intellij-developer-tools-plugin-6.3.0-signed.zip",
-        "243.24978.59": "https://plugins.jetbrains.com/files/21904/665427/intellij-developer-tools-plugin-6.3.0-signed.zip"
+        "243.24978.546": "https://plugins.jetbrains.com/files/21904/665427/intellij-developer-tools-plugin-6.3.0-signed.zip",
+        "243.24978.79": "https://plugins.jetbrains.com/files/21904/665427/intellij-developer-tools-plugin-6.3.0-signed.zip",
+        "243.24978.86": "https://plugins.jetbrains.com/files/21904/665427/intellij-developer-tools-plugin-6.3.0-signed.zip",
+        "243.25659.34": "https://plugins.jetbrains.com/files/21904/665427/intellij-developer-tools-plugin-6.3.0-signed.zip",
+        "243.25659.39": "https://plugins.jetbrains.com/files/21904/665427/intellij-developer-tools-plugin-6.3.0-signed.zip",
+        "243.25659.40": "https://plugins.jetbrains.com/files/21904/665427/intellij-developer-tools-plugin-6.3.0-signed.zip",
+        "243.25659.41": "https://plugins.jetbrains.com/files/21904/665427/intellij-developer-tools-plugin-6.3.0-signed.zip",
+        "243.25659.42": "https://plugins.jetbrains.com/files/21904/665427/intellij-developer-tools-plugin-6.3.0-signed.zip",
+        "243.25659.43": "https://plugins.jetbrains.com/files/21904/665427/intellij-developer-tools-plugin-6.3.0-signed.zip",
+        "243.25659.45": "https://plugins.jetbrains.com/files/21904/665427/intellij-developer-tools-plugin-6.3.0-signed.zip",
+        "243.25659.52": "https://plugins.jetbrains.com/files/21904/665427/intellij-developer-tools-plugin-6.3.0-signed.zip"
       },
       "name": "developer-tools"
     },
@@ -1692,15 +1692,15 @@
         "webstorm"
       ],
       "builds": {
-        "243.23654.157": "https://plugins.jetbrains.com/files/21962/654853/clouds-docker-gateway-243.23654.19.zip",
-        "243.23654.167": "https://plugins.jetbrains.com/files/21962/654853/clouds-docker-gateway-243.23654.19.zip",
-        "243.23654.180": "https://plugins.jetbrains.com/files/21962/654853/clouds-docker-gateway-243.23654.19.zip",
-        "243.24978.27": "https://plugins.jetbrains.com/files/21962/684422/clouds-docker-gateway-243.24978.79.zip",
-        "243.24978.46": "https://plugins.jetbrains.com/files/21962/684422/clouds-docker-gateway-243.24978.79.zip",
-        "243.24978.50": "https://plugins.jetbrains.com/files/21962/684422/clouds-docker-gateway-243.24978.79.zip",
-        "243.24978.54": "https://plugins.jetbrains.com/files/21962/684422/clouds-docker-gateway-243.24978.79.zip",
-        "243.24978.55": "https://plugins.jetbrains.com/files/21962/684422/clouds-docker-gateway-243.24978.79.zip",
-        "243.24978.59": "https://plugins.jetbrains.com/files/21962/684422/clouds-docker-gateway-243.24978.79.zip"
+        "243.24978.86": "https://plugins.jetbrains.com/files/21962/684422/clouds-docker-gateway-243.24978.79.zip",
+        "243.25659.34": "https://plugins.jetbrains.com/files/21962/684422/clouds-docker-gateway-243.24978.79.zip",
+        "243.25659.39": "https://plugins.jetbrains.com/files/21962/684422/clouds-docker-gateway-243.24978.79.zip",
+        "243.25659.40": "https://plugins.jetbrains.com/files/21962/684422/clouds-docker-gateway-243.24978.79.zip",
+        "243.25659.41": "https://plugins.jetbrains.com/files/21962/684422/clouds-docker-gateway-243.24978.79.zip",
+        "243.25659.42": "https://plugins.jetbrains.com/files/21962/684422/clouds-docker-gateway-243.24978.79.zip",
+        "243.25659.43": "https://plugins.jetbrains.com/files/21962/684422/clouds-docker-gateway-243.24978.79.zip",
+        "243.25659.45": "https://plugins.jetbrains.com/files/21962/684422/clouds-docker-gateway-243.24978.79.zip",
+        "243.25659.52": "https://plugins.jetbrains.com/files/21962/684422/clouds-docker-gateway-243.24978.79.zip"
       },
       "name": "dev-containers"
     },
@@ -1711,9 +1711,9 @@
         "rust-rover"
       ],
       "builds": {
-        "243.23654.180": "https://plugins.jetbrains.com/files/22407/672481/intellij-rust-243.23654.180.zip",
-        "243.24978.46": "https://plugins.jetbrains.com/files/22407/672481/intellij-rust-243.23654.180.zip",
-        "243.24978.55": "https://plugins.jetbrains.com/files/22407/672481/intellij-rust-243.23654.180.zip"
+        "243.24978.86": "https://plugins.jetbrains.com/files/22407/686684/intellij-rust-243.24978.86.zip",
+        "243.25659.39": "https://plugins.jetbrains.com/files/22407/686684/intellij-rust-243.24978.86.zip",
+        "243.25659.42": "https://plugins.jetbrains.com/files/22407/686684/intellij-rust-243.24978.86.zip"
       },
       "name": "rust"
     },
@@ -1734,19 +1734,19 @@
         "webstorm"
       ],
       "builds": {
-        "243.21565.447": "https://plugins.jetbrains.com/files/22707/678078/continue-intellij-extension-0.0.88.zip",
-        "243.22562.218": "https://plugins.jetbrains.com/files/22707/678078/continue-intellij-extension-0.0.88.zip",
-        "243.22562.220": "https://plugins.jetbrains.com/files/22707/678078/continue-intellij-extension-0.0.88.zip",
-        "243.23654.157": "https://plugins.jetbrains.com/files/22707/678078/continue-intellij-extension-0.0.88.zip",
-        "243.23654.167": "https://plugins.jetbrains.com/files/22707/678078/continue-intellij-extension-0.0.88.zip",
-        "243.23654.180": "https://plugins.jetbrains.com/files/22707/678078/continue-intellij-extension-0.0.88.zip",
-        "243.23654.183": "https://plugins.jetbrains.com/files/22707/678078/continue-intellij-extension-0.0.88.zip",
-        "243.24978.27": "https://plugins.jetbrains.com/files/22707/678078/continue-intellij-extension-0.0.88.zip",
-        "243.24978.46": "https://plugins.jetbrains.com/files/22707/678078/continue-intellij-extension-0.0.88.zip",
-        "243.24978.50": "https://plugins.jetbrains.com/files/22707/678078/continue-intellij-extension-0.0.88.zip",
-        "243.24978.54": "https://plugins.jetbrains.com/files/22707/678078/continue-intellij-extension-0.0.88.zip",
-        "243.24978.55": "https://plugins.jetbrains.com/files/22707/678078/continue-intellij-extension-0.0.88.zip",
-        "243.24978.59": "https://plugins.jetbrains.com/files/22707/678078/continue-intellij-extension-0.0.88.zip"
+        "243.22562.218": "https://plugins.jetbrains.com/files/22707/687350/continue-intellij-extension-1.0.1.zip",
+        "243.22562.220": "https://plugins.jetbrains.com/files/22707/687350/continue-intellij-extension-1.0.1.zip",
+        "243.24978.546": "https://plugins.jetbrains.com/files/22707/687350/continue-intellij-extension-1.0.1.zip",
+        "243.24978.79": "https://plugins.jetbrains.com/files/22707/687350/continue-intellij-extension-1.0.1.zip",
+        "243.24978.86": "https://plugins.jetbrains.com/files/22707/687350/continue-intellij-extension-1.0.1.zip",
+        "243.25659.34": "https://plugins.jetbrains.com/files/22707/687350/continue-intellij-extension-1.0.1.zip",
+        "243.25659.39": "https://plugins.jetbrains.com/files/22707/687350/continue-intellij-extension-1.0.1.zip",
+        "243.25659.40": "https://plugins.jetbrains.com/files/22707/687350/continue-intellij-extension-1.0.1.zip",
+        "243.25659.41": "https://plugins.jetbrains.com/files/22707/687350/continue-intellij-extension-1.0.1.zip",
+        "243.25659.42": "https://plugins.jetbrains.com/files/22707/687350/continue-intellij-extension-1.0.1.zip",
+        "243.25659.43": "https://plugins.jetbrains.com/files/22707/687350/continue-intellij-extension-1.0.1.zip",
+        "243.25659.45": "https://plugins.jetbrains.com/files/22707/687350/continue-intellij-extension-1.0.1.zip",
+        "243.25659.52": "https://plugins.jetbrains.com/files/22707/687350/continue-intellij-extension-1.0.1.zip"
       },
       "name": "continue"
     },
@@ -1767,19 +1767,19 @@
         "webstorm"
       ],
       "builds": {
-        "243.21565.447": "https://plugins.jetbrains.com/files/22857/633914/vcs-gitlab-243.21565.204.zip",
         "243.22562.218": "https://plugins.jetbrains.com/files/22857/640903/vcs-gitlab-243.22562.53.zip",
         "243.22562.220": "https://plugins.jetbrains.com/files/22857/640903/vcs-gitlab-243.22562.53.zip",
-        "243.23654.157": "https://plugins.jetbrains.com/files/22857/654839/vcs-gitlab-243.23654.19.zip",
-        "243.23654.167": "https://plugins.jetbrains.com/files/22857/654839/vcs-gitlab-243.23654.19.zip",
-        "243.23654.180": "https://plugins.jetbrains.com/files/22857/654839/vcs-gitlab-243.23654.19.zip",
-        "243.23654.183": "https://plugins.jetbrains.com/files/22857/654839/vcs-gitlab-243.23654.19.zip",
-        "243.24978.27": "https://plugins.jetbrains.com/files/22857/654839/vcs-gitlab-243.23654.19.zip",
-        "243.24978.46": "https://plugins.jetbrains.com/files/22857/654839/vcs-gitlab-243.23654.19.zip",
-        "243.24978.50": "https://plugins.jetbrains.com/files/22857/654839/vcs-gitlab-243.23654.19.zip",
-        "243.24978.54": "https://plugins.jetbrains.com/files/22857/654839/vcs-gitlab-243.23654.19.zip",
-        "243.24978.55": "https://plugins.jetbrains.com/files/22857/654839/vcs-gitlab-243.23654.19.zip",
-        "243.24978.59": "https://plugins.jetbrains.com/files/22857/654839/vcs-gitlab-243.23654.19.zip"
+        "243.24978.546": "https://plugins.jetbrains.com/files/22857/654839/vcs-gitlab-243.23654.19.zip",
+        "243.24978.79": "https://plugins.jetbrains.com/files/22857/654839/vcs-gitlab-243.23654.19.zip",
+        "243.24978.86": "https://plugins.jetbrains.com/files/22857/654839/vcs-gitlab-243.23654.19.zip",
+        "243.25659.34": "https://plugins.jetbrains.com/files/22857/654839/vcs-gitlab-243.23654.19.zip",
+        "243.25659.39": "https://plugins.jetbrains.com/files/22857/654839/vcs-gitlab-243.23654.19.zip",
+        "243.25659.40": "https://plugins.jetbrains.com/files/22857/654839/vcs-gitlab-243.23654.19.zip",
+        "243.25659.41": "https://plugins.jetbrains.com/files/22857/654839/vcs-gitlab-243.23654.19.zip",
+        "243.25659.42": "https://plugins.jetbrains.com/files/22857/654839/vcs-gitlab-243.23654.19.zip",
+        "243.25659.43": "https://plugins.jetbrains.com/files/22857/654839/vcs-gitlab-243.23654.19.zip",
+        "243.25659.45": "https://plugins.jetbrains.com/files/22857/654839/vcs-gitlab-243.23654.19.zip",
+        "243.25659.52": "https://plugins.jetbrains.com/files/22857/654839/vcs-gitlab-243.23654.19.zip"
       },
       "name": "gitlab"
     },
@@ -1800,19 +1800,19 @@
         "webstorm"
       ],
       "builds": {
-        "243.21565.447": "https://plugins.jetbrains.com/files/23029/650304/Catppuccin_Icons-1.10.1.zip",
-        "243.22562.218": "https://plugins.jetbrains.com/files/23029/650304/Catppuccin_Icons-1.10.1.zip",
-        "243.22562.220": "https://plugins.jetbrains.com/files/23029/650304/Catppuccin_Icons-1.10.1.zip",
-        "243.23654.157": "https://plugins.jetbrains.com/files/23029/650304/Catppuccin_Icons-1.10.1.zip",
-        "243.23654.167": "https://plugins.jetbrains.com/files/23029/650304/Catppuccin_Icons-1.10.1.zip",
-        "243.23654.180": "https://plugins.jetbrains.com/files/23029/650304/Catppuccin_Icons-1.10.1.zip",
-        "243.23654.183": "https://plugins.jetbrains.com/files/23029/650304/Catppuccin_Icons-1.10.1.zip",
-        "243.24978.27": "https://plugins.jetbrains.com/files/23029/650304/Catppuccin_Icons-1.10.1.zip",
-        "243.24978.46": "https://plugins.jetbrains.com/files/23029/650304/Catppuccin_Icons-1.10.1.zip",
-        "243.24978.50": "https://plugins.jetbrains.com/files/23029/650304/Catppuccin_Icons-1.10.1.zip",
-        "243.24978.54": "https://plugins.jetbrains.com/files/23029/650304/Catppuccin_Icons-1.10.1.zip",
-        "243.24978.55": "https://plugins.jetbrains.com/files/23029/650304/Catppuccin_Icons-1.10.1.zip",
-        "243.24978.59": "https://plugins.jetbrains.com/files/23029/650304/Catppuccin_Icons-1.10.1.zip"
+        "243.22562.218": "https://plugins.jetbrains.com/files/23029/684999/Catppuccin_Icons-1.10.2.zip",
+        "243.22562.220": "https://plugins.jetbrains.com/files/23029/684999/Catppuccin_Icons-1.10.2.zip",
+        "243.24978.546": "https://plugins.jetbrains.com/files/23029/684999/Catppuccin_Icons-1.10.2.zip",
+        "243.24978.79": "https://plugins.jetbrains.com/files/23029/684999/Catppuccin_Icons-1.10.2.zip",
+        "243.24978.86": "https://plugins.jetbrains.com/files/23029/684999/Catppuccin_Icons-1.10.2.zip",
+        "243.25659.34": "https://plugins.jetbrains.com/files/23029/684999/Catppuccin_Icons-1.10.2.zip",
+        "243.25659.39": "https://plugins.jetbrains.com/files/23029/684999/Catppuccin_Icons-1.10.2.zip",
+        "243.25659.40": "https://plugins.jetbrains.com/files/23029/684999/Catppuccin_Icons-1.10.2.zip",
+        "243.25659.41": "https://plugins.jetbrains.com/files/23029/684999/Catppuccin_Icons-1.10.2.zip",
+        "243.25659.42": "https://plugins.jetbrains.com/files/23029/684999/Catppuccin_Icons-1.10.2.zip",
+        "243.25659.43": "https://plugins.jetbrains.com/files/23029/684999/Catppuccin_Icons-1.10.2.zip",
+        "243.25659.45": "https://plugins.jetbrains.com/files/23029/684999/Catppuccin_Icons-1.10.2.zip",
+        "243.25659.52": "https://plugins.jetbrains.com/files/23029/684999/Catppuccin_Icons-1.10.2.zip"
       },
       "name": "catppuccin-icons"
     },
@@ -1833,19 +1833,19 @@
         "webstorm"
       ],
       "builds": {
-        "243.21565.447": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
         "243.22562.218": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
         "243.22562.220": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
-        "243.23654.157": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
-        "243.23654.167": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
-        "243.23654.180": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
-        "243.23654.183": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
-        "243.24978.27": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
-        "243.24978.46": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
-        "243.24978.50": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
-        "243.24978.54": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
-        "243.24978.55": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
-        "243.24978.59": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip"
+        "243.24978.546": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
+        "243.24978.79": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
+        "243.24978.86": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
+        "243.25659.34": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
+        "243.25659.39": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
+        "243.25659.40": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
+        "243.25659.41": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
+        "243.25659.42": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
+        "243.25659.43": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
+        "243.25659.45": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
+        "243.25659.52": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip"
       },
       "name": "mermaid-chart"
     },
@@ -1866,19 +1866,19 @@
         "webstorm"
       ],
       "builds": {
-        "243.21565.447": "https://plugins.jetbrains.com/files/23927/668616/Extra_IDE_Tweaks-2025.1.1.zip",
-        "243.22562.218": "https://plugins.jetbrains.com/files/23927/668616/Extra_IDE_Tweaks-2025.1.1.zip",
-        "243.22562.220": "https://plugins.jetbrains.com/files/23927/668616/Extra_IDE_Tweaks-2025.1.1.zip",
-        "243.23654.157": "https://plugins.jetbrains.com/files/23927/668616/Extra_IDE_Tweaks-2025.1.1.zip",
-        "243.23654.167": "https://plugins.jetbrains.com/files/23927/668616/Extra_IDE_Tweaks-2025.1.1.zip",
-        "243.23654.180": "https://plugins.jetbrains.com/files/23927/668616/Extra_IDE_Tweaks-2025.1.1.zip",
-        "243.23654.183": "https://plugins.jetbrains.com/files/23927/668616/Extra_IDE_Tweaks-2025.1.1.zip",
-        "243.24978.27": "https://plugins.jetbrains.com/files/23927/668616/Extra_IDE_Tweaks-2025.1.1.zip",
-        "243.24978.46": "https://plugins.jetbrains.com/files/23927/668616/Extra_IDE_Tweaks-2025.1.1.zip",
-        "243.24978.50": "https://plugins.jetbrains.com/files/23927/668616/Extra_IDE_Tweaks-2025.1.1.zip",
-        "243.24978.54": "https://plugins.jetbrains.com/files/23927/668616/Extra_IDE_Tweaks-2025.1.1.zip",
-        "243.24978.55": "https://plugins.jetbrains.com/files/23927/668616/Extra_IDE_Tweaks-2025.1.1.zip",
-        "243.24978.59": "https://plugins.jetbrains.com/files/23927/668616/Extra_IDE_Tweaks-2025.1.1.zip"
+        "243.22562.218": "https://plugins.jetbrains.com/files/23927/686932/Extra_IDE_Tweaks-2025.1.2.zip",
+        "243.22562.220": "https://plugins.jetbrains.com/files/23927/686932/Extra_IDE_Tweaks-2025.1.2.zip",
+        "243.24978.546": "https://plugins.jetbrains.com/files/23927/686932/Extra_IDE_Tweaks-2025.1.2.zip",
+        "243.24978.79": "https://plugins.jetbrains.com/files/23927/686932/Extra_IDE_Tweaks-2025.1.2.zip",
+        "243.24978.86": "https://plugins.jetbrains.com/files/23927/686932/Extra_IDE_Tweaks-2025.1.2.zip",
+        "243.25659.34": "https://plugins.jetbrains.com/files/23927/686932/Extra_IDE_Tweaks-2025.1.2.zip",
+        "243.25659.39": "https://plugins.jetbrains.com/files/23927/686932/Extra_IDE_Tweaks-2025.1.2.zip",
+        "243.25659.40": "https://plugins.jetbrains.com/files/23927/686932/Extra_IDE_Tweaks-2025.1.2.zip",
+        "243.25659.41": "https://plugins.jetbrains.com/files/23927/686932/Extra_IDE_Tweaks-2025.1.2.zip",
+        "243.25659.42": "https://plugins.jetbrains.com/files/23927/686932/Extra_IDE_Tweaks-2025.1.2.zip",
+        "243.25659.43": "https://plugins.jetbrains.com/files/23927/686932/Extra_IDE_Tweaks-2025.1.2.zip",
+        "243.25659.45": "https://plugins.jetbrains.com/files/23927/686932/Extra_IDE_Tweaks-2025.1.2.zip",
+        "243.25659.52": "https://plugins.jetbrains.com/files/23927/686932/Extra_IDE_Tweaks-2025.1.2.zip"
       },
       "name": "extra-ide-tweaks"
     },
@@ -1899,19 +1899,19 @@
         "webstorm"
       ],
       "builds": {
-        "243.21565.447": "https://plugins.jetbrains.com/files/24559/672148/Extra_Tools_Pack-2025.1.2.zip",
-        "243.22562.218": "https://plugins.jetbrains.com/files/24559/672148/Extra_Tools_Pack-2025.1.2.zip",
-        "243.22562.220": "https://plugins.jetbrains.com/files/24559/672148/Extra_Tools_Pack-2025.1.2.zip",
-        "243.23654.157": "https://plugins.jetbrains.com/files/24559/672148/Extra_Tools_Pack-2025.1.2.zip",
-        "243.23654.167": "https://plugins.jetbrains.com/files/24559/672148/Extra_Tools_Pack-2025.1.2.zip",
-        "243.23654.180": "https://plugins.jetbrains.com/files/24559/672148/Extra_Tools_Pack-2025.1.2.zip",
-        "243.23654.183": "https://plugins.jetbrains.com/files/24559/672148/Extra_Tools_Pack-2025.1.2.zip",
-        "243.24978.27": "https://plugins.jetbrains.com/files/24559/672148/Extra_Tools_Pack-2025.1.2.zip",
-        "243.24978.46": "https://plugins.jetbrains.com/files/24559/672148/Extra_Tools_Pack-2025.1.2.zip",
-        "243.24978.50": "https://plugins.jetbrains.com/files/24559/672148/Extra_Tools_Pack-2025.1.2.zip",
-        "243.24978.54": "https://plugins.jetbrains.com/files/24559/672148/Extra_Tools_Pack-2025.1.2.zip",
-        "243.24978.55": "https://plugins.jetbrains.com/files/24559/672148/Extra_Tools_Pack-2025.1.2.zip",
-        "243.24978.59": "https://plugins.jetbrains.com/files/24559/672148/Extra_Tools_Pack-2025.1.2.zip"
+        "243.22562.218": "https://plugins.jetbrains.com/files/24559/686931/Extra_Tools_Pack-2025.1.3.zip",
+        "243.22562.220": "https://plugins.jetbrains.com/files/24559/686931/Extra_Tools_Pack-2025.1.3.zip",
+        "243.24978.546": "https://plugins.jetbrains.com/files/24559/686931/Extra_Tools_Pack-2025.1.3.zip",
+        "243.24978.79": "https://plugins.jetbrains.com/files/24559/686931/Extra_Tools_Pack-2025.1.3.zip",
+        "243.24978.86": "https://plugins.jetbrains.com/files/24559/686931/Extra_Tools_Pack-2025.1.3.zip",
+        "243.25659.34": "https://plugins.jetbrains.com/files/24559/686931/Extra_Tools_Pack-2025.1.3.zip",
+        "243.25659.39": "https://plugins.jetbrains.com/files/24559/686931/Extra_Tools_Pack-2025.1.3.zip",
+        "243.25659.40": "https://plugins.jetbrains.com/files/24559/686931/Extra_Tools_Pack-2025.1.3.zip",
+        "243.25659.41": "https://plugins.jetbrains.com/files/24559/686931/Extra_Tools_Pack-2025.1.3.zip",
+        "243.25659.42": "https://plugins.jetbrains.com/files/24559/686931/Extra_Tools_Pack-2025.1.3.zip",
+        "243.25659.43": "https://plugins.jetbrains.com/files/24559/686931/Extra_Tools_Pack-2025.1.3.zip",
+        "243.25659.45": "https://plugins.jetbrains.com/files/24559/686931/Extra_Tools_Pack-2025.1.3.zip",
+        "243.25659.52": "https://plugins.jetbrains.com/files/24559/686931/Extra_Tools_Pack-2025.1.3.zip"
       },
       "name": "extra-tools-pack"
     },
@@ -1929,16 +1929,16 @@
         "webstorm"
       ],
       "builds": {
-        "243.23654.157": "https://plugins.jetbrains.com/files/25594/623962/Nix_LSP-0.1.1.zip",
-        "243.23654.167": "https://plugins.jetbrains.com/files/25594/623962/Nix_LSP-0.1.1.zip",
-        "243.23654.180": "https://plugins.jetbrains.com/files/25594/623962/Nix_LSP-0.1.1.zip",
-        "243.23654.183": "https://plugins.jetbrains.com/files/25594/623962/Nix_LSP-0.1.1.zip",
-        "243.24978.27": "https://plugins.jetbrains.com/files/25594/623962/Nix_LSP-0.1.1.zip",
-        "243.24978.46": "https://plugins.jetbrains.com/files/25594/623962/Nix_LSP-0.1.1.zip",
-        "243.24978.50": "https://plugins.jetbrains.com/files/25594/623962/Nix_LSP-0.1.1.zip",
-        "243.24978.54": "https://plugins.jetbrains.com/files/25594/623962/Nix_LSP-0.1.1.zip",
-        "243.24978.55": "https://plugins.jetbrains.com/files/25594/623962/Nix_LSP-0.1.1.zip",
-        "243.24978.59": "https://plugins.jetbrains.com/files/25594/623962/Nix_LSP-0.1.1.zip"
+        "243.24978.79": "https://plugins.jetbrains.com/files/25594/623962/Nix_LSP-0.1.1.zip",
+        "243.24978.86": "https://plugins.jetbrains.com/files/25594/623962/Nix_LSP-0.1.1.zip",
+        "243.25659.34": "https://plugins.jetbrains.com/files/25594/623962/Nix_LSP-0.1.1.zip",
+        "243.25659.39": "https://plugins.jetbrains.com/files/25594/623962/Nix_LSP-0.1.1.zip",
+        "243.25659.40": "https://plugins.jetbrains.com/files/25594/623962/Nix_LSP-0.1.1.zip",
+        "243.25659.41": "https://plugins.jetbrains.com/files/25594/623962/Nix_LSP-0.1.1.zip",
+        "243.25659.42": "https://plugins.jetbrains.com/files/25594/623962/Nix_LSP-0.1.1.zip",
+        "243.25659.43": "https://plugins.jetbrains.com/files/25594/623962/Nix_LSP-0.1.1.zip",
+        "243.25659.45": "https://plugins.jetbrains.com/files/25594/623962/Nix_LSP-0.1.1.zip",
+        "243.25659.52": "https://plugins.jetbrains.com/files/25594/623962/Nix_LSP-0.1.1.zip"
       },
       "name": "nix-lsp"
     },
@@ -1960,27 +1960,27 @@
       "builds": {
         "243.22562.218": "https://plugins.jetbrains.com/files/26084/680234/markdtask-2025.1.1.zip",
         "243.22562.220": "https://plugins.jetbrains.com/files/26084/680234/markdtask-2025.1.1.zip",
-        "243.23654.157": "https://plugins.jetbrains.com/files/26084/680234/markdtask-2025.1.1.zip",
-        "243.23654.167": "https://plugins.jetbrains.com/files/26084/680234/markdtask-2025.1.1.zip",
-        "243.23654.180": "https://plugins.jetbrains.com/files/26084/680234/markdtask-2025.1.1.zip",
-        "243.23654.183": "https://plugins.jetbrains.com/files/26084/680234/markdtask-2025.1.1.zip",
-        "243.24978.27": "https://plugins.jetbrains.com/files/26084/680234/markdtask-2025.1.1.zip",
-        "243.24978.46": "https://plugins.jetbrains.com/files/26084/680234/markdtask-2025.1.1.zip",
-        "243.24978.50": "https://plugins.jetbrains.com/files/26084/680234/markdtask-2025.1.1.zip",
-        "243.24978.54": "https://plugins.jetbrains.com/files/26084/680234/markdtask-2025.1.1.zip",
-        "243.24978.55": "https://plugins.jetbrains.com/files/26084/680234/markdtask-2025.1.1.zip",
-        "243.24978.59": "https://plugins.jetbrains.com/files/26084/680234/markdtask-2025.1.1.zip"
+        "243.24978.79": "https://plugins.jetbrains.com/files/26084/680234/markdtask-2025.1.1.zip",
+        "243.24978.86": "https://plugins.jetbrains.com/files/26084/680234/markdtask-2025.1.1.zip",
+        "243.25659.34": "https://plugins.jetbrains.com/files/26084/680234/markdtask-2025.1.1.zip",
+        "243.25659.39": "https://plugins.jetbrains.com/files/26084/680234/markdtask-2025.1.1.zip",
+        "243.25659.40": "https://plugins.jetbrains.com/files/26084/680234/markdtask-2025.1.1.zip",
+        "243.25659.41": "https://plugins.jetbrains.com/files/26084/680234/markdtask-2025.1.1.zip",
+        "243.25659.42": "https://plugins.jetbrains.com/files/26084/680234/markdtask-2025.1.1.zip",
+        "243.25659.43": "https://plugins.jetbrains.com/files/26084/680234/markdtask-2025.1.1.zip",
+        "243.25659.45": "https://plugins.jetbrains.com/files/26084/680234/markdtask-2025.1.1.zip",
+        "243.25659.52": "https://plugins.jetbrains.com/files/26084/680234/markdtask-2025.1.1.zip"
       },
       "name": "markdtask"
     }
   },
   "files": {
     "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip": "sha256-frvQ+Dm1ueID6+vNlja0HtecGyn+ppq9GTgmU3kQ+58=",
-    "https://plugins.jetbrains.com/files/10080/645834/intellij-rainbow-brackets-2024.2.8-241.zip": "sha256-IWRvV8NDYnoxxvQVOf3K3pueD+Hp7ctaWOmFHnaVTJg=",
+    "https://plugins.jetbrains.com/files/10080/689210/intellij-rainbow-brackets-2024.2.9-241.zip": "sha256-QfJAfpKaHeKo9xQwFd+3pVRxYGTO60puORrZ0rdpaZY=",
     "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip": "sha256-25vtwXuBNiYL9E0pKG4dqJDkwX1FckAErdqRPKXybQA=",
     "https://plugins.jetbrains.com/files/10481/583591/intellij-hocon-2024.2.0.zip": "sha256-Bnnvy+HDNkx2DQM7N+JUa8hQzIA3H/5Y0WpWAjPmhUI=",
-    "https://plugins.jetbrains.com/files/11058/668614/Extra_Icons-2025.1.1.zip": "sha256-bQHgzbSUh7cZEzVGrZQxUJ+fGY7GB4Sy5izwadkkQiQ=",
-    "https://plugins.jetbrains.com/files/11349/684473/aws-toolkit-jetbrains-standalone-3.56-243.zip": "sha256-f3NJXTqUxLh0O78UhJP+WAu1CYXGo+3x03z0MYobUVI=",
+    "https://plugins.jetbrains.com/files/11058/686929/Extra_Icons-2025.1.2.zip": "sha256-wJgDPYDCCzehOOaXLVnHSBgpPfaNeh+uNoNHe9BBNn0=",
+    "https://plugins.jetbrains.com/files/11349/689463/aws-toolkit-jetbrains-standalone-3.57-243.zip": "sha256-Il/V/WxYdTf6nO9BMCA6cDypzksGkZ3C6zaiQoUXUt8=",
     "https://plugins.jetbrains.com/files/12024/622380/ReSharperPlugin.CognitiveComplexity-2024.3.0-eap04.zip": "sha256-X2x7uyWoV4aBI8E5bw35QfzmySWzbEAZ2nvdo5i+t+s=",
     "https://plugins.jetbrains.com/files/12062/630060/keymap-vscode-243.21565.122.zip": "sha256-phv8MTGKNGzRviKzX+nIVTbkX4WkU82QVO5zXUQLtAo=",
     "https://plugins.jetbrains.com/files/12559/629985/keymap-eclipse-243.21565.122.zip": "sha256-/g1ucT18ywVJnCePH7WyMWKgM9umowBz5wFObmO7cws=",
@@ -1989,14 +1989,13 @@
     "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip": "sha256-eKwDE+PMtYhrGbDDZPS5cimssH+1xV4GF6RXXg/3urU=",
     "https://plugins.jetbrains.com/files/1347/667258/scala-intellij-bin-2024.3.35.zip": "sha256-4I75KqXyFl73S63O+00usrg8QBcuBRBgfjRmCQMpNks=",
     "https://plugins.jetbrains.com/files/1347/681279/scala-intellij-bin-2024.3.38.zip": "sha256-l1ZevtqN/70ii1jbXYYxkbH263UrL3YMVFnwFl+n5rE=",
-    "https://plugins.jetbrains.com/files/14004/629971/protoeditor-243.21565.122.zip": "sha256-cv6JTujoD5g90ngXTtnj5x31wjbIZlKZ6Zn0H+vHCTk=",
     "https://plugins.jetbrains.com/files/14004/636643/protoeditor-243.22562.13.zip": "sha256-Tgu8CfDhO6KugfuLNhmxe89dMm+Qo3fmAg/8hwjUaoc=",
     "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar": "sha256-eXInfAqY3yEZRXCAuv3KGldM1pNKEioNwPB0rIGgJFw=",
     "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar": "sha256-mB09zvUg1hLXl9lgW1NEU+DyVel1utZv6s+mFykckYY=",
     "https://plugins.jetbrains.com/files/15976/593529/IDEA_Which-Key-0.10.3.jar": "sha256-2FlEaHf2rO6xgG3LnZIPt/XKgRGjpLSiEXCncfAf3bI=",
     "https://plugins.jetbrains.com/files/164/676777/IdeaVIM-2.19.0.zip": "sha256-yKpWQZGxfsKwPVTJLHpF4KGJ5ANCd73uxHlfdFE4Qf4=",
-    "https://plugins.jetbrains.com/files/16604/671364/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.3.zip": "sha256-U2kNQtumZ71+G3maxxXPVsLL8Q+8YonpC4ejr1DYMbo=",
-    "https://plugins.jetbrains.com/files/17718/683782/github-copilot-intellij-1.5.35-242.zip": "sha256-XySBxVlZLPTj1Y3urLpfgkrYwt/y12hX0oCK1p0Vdx0=",
+    "https://plugins.jetbrains.com/files/16604/686930/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.4.zip": "sha256-W/oeD2vRxxyrjHuw+4hGcPEER6K1kzkDGRkxvEotOaw=",
+    "https://plugins.jetbrains.com/files/17718/688477/github-copilot-intellij-1.5.37-242.zip": "sha256-7dAi3KPTze2Kht0snxzuZreRm2gYrAnGVUyOjKMdMkA=",
     "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip": "sha256-KrzZTKZMQqoEMw+vDUv2jjs0EX0leaPBkU8H/ecq/oI=",
     "https://plugins.jetbrains.com/files/18682/680233/Catppuccin_Theme-3.4.1.zip": "sha256-QOF3nAXOfYhNl3YUK1fc9z5H2uXTPm2X+6fVZ5QP8ZQ=",
     "https://plugins.jetbrains.com/files/18824/671527/CodeGlancePro-1.9.6-signed.zip": "sha256-AEHZxuRMBEZlT3xTxBUbHEPjEJBOCLxdj1wEYBzlNdk=",
@@ -2007,50 +2006,45 @@
     "https://plugins.jetbrains.com/files/2162/640476/StringManipulation-9.15.0.zip": "sha256-TZPup3EJ0cBv4i2eVAQwVmmzy0rmt4KptEsk3C7baEM=",
     "https://plugins.jetbrains.com/files/21667/618339/code-complexity-plugin-1.6.1.zip": "sha256-OGaYvQfSdAh0OZhYSpZJD14uyx8FSagEhUEinZmR3N4=",
     "https://plugins.jetbrains.com/files/21904/665427/intellij-developer-tools-plugin-6.3.0-signed.zip": "sha256-TEx5wg3Sf3rkhl6oj0hRrMdBJW9KMjZ/yNDgNYaeP28=",
-    "https://plugins.jetbrains.com/files/21962/654853/clouds-docker-gateway-243.23654.19.zip": "sha256-l4XCXUq7ECeHhSjPvvCnwlXIGBylsolw3jIQMZ4Geag=",
     "https://plugins.jetbrains.com/files/21962/684422/clouds-docker-gateway-243.24978.79.zip": "sha256-jmfcGDtizib7wQW88sWuzG095nrT0KHyN98trxqISHE=",
-    "https://plugins.jetbrains.com/files/22407/672481/intellij-rust-243.23654.180.zip": "sha256-9MB+kR8GZePzVU6i9sr+vFyeGqGnXwGRThTv6lKouVU=",
-    "https://plugins.jetbrains.com/files/22707/678078/continue-intellij-extension-0.0.88.zip": "sha256-aNhXdXzOVvT9Sy76gh5M5YfFH5+rwZWjp3XMwsidR4w=",
-    "https://plugins.jetbrains.com/files/22857/633914/vcs-gitlab-243.21565.204.zip": "sha256-dnnbmo9OILtgVr8vXGSqQ6uSGDfxbrPptToAMs9SPRM=",
+    "https://plugins.jetbrains.com/files/22407/686684/intellij-rust-243.24978.86.zip": "sha256-HQgDKzR8nt/xHj38wnhTJZZOlKTEb//bOcqYhw0vQbA=",
+    "https://plugins.jetbrains.com/files/22707/687350/continue-intellij-extension-1.0.1.zip": "sha256-IryGHaPuEIYa2epEHEYEXJCofRhxFXsgo7HDIDE2MCg=",
     "https://plugins.jetbrains.com/files/22857/640903/vcs-gitlab-243.22562.53.zip": "sha256-lDStIaRy9ZtCXZxM2RRrz/5oZeL90aRVS63wC4XkJNw=",
     "https://plugins.jetbrains.com/files/22857/654839/vcs-gitlab-243.23654.19.zip": "sha256-VKGZLlL8ALjr6JEQtjhXiIxNrnTPXIoXMToJkJux2dw=",
-    "https://plugins.jetbrains.com/files/23029/650304/Catppuccin_Icons-1.10.1.zip": "sha256-HFELG8i+EQtr97y87sBwqPMmTxexIfJH1DRXTmlOytw=",
+    "https://plugins.jetbrains.com/files/23029/684999/Catppuccin_Icons-1.10.2.zip": "sha256-qkwfEpC2f4vgVsesSiUvd6kK6XnG9DTN4gXUR+rLlK0=",
     "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip": "sha256-ssaSY1I6FopLBgVKHUyjBrqzxHLSuI/swtDfQWJ7gxU=",
-    "https://plugins.jetbrains.com/files/23927/668616/Extra_IDE_Tweaks-2025.1.1.zip": "sha256-nOPYnvLuApgpQwHBhRE3MJLDl2pE4bCz/6XHQQTZfA8=",
-    "https://plugins.jetbrains.com/files/24559/672148/Extra_Tools_Pack-2025.1.2.zip": "sha256-U3gxwqLNGWNM26gTLJ7Q/9pBf9hbriSPvMvrE8EZVmc=",
+    "https://plugins.jetbrains.com/files/23927/686932/Extra_IDE_Tweaks-2025.1.2.zip": "sha256-S9XvXtNadkb5geuar40+y5cARMgWp+vJELj7hk3Y4EY=",
+    "https://plugins.jetbrains.com/files/24559/686931/Extra_Tools_Pack-2025.1.3.zip": "sha256-r5oFljG92OTPbXRXqbXDI4KD2dyMp2onKTWQcdftU2k=",
     "https://plugins.jetbrains.com/files/25594/623962/Nix_LSP-0.1.1.zip": "sha256-Uq5RdVQTyqRMsEwDZT6Kldv2alt0EVMCABEt/xQUHow=",
     "https://plugins.jetbrains.com/files/26084/680234/markdtask-2025.1.1.zip": "sha256-NFHB5zWH8pUwz6OT8F7eIiapeEvHX24fj0Eo1qH45Aw=",
-    "https://plugins.jetbrains.com/files/631/680216/python-243.24978.46.zip": "sha256-dmCzUbfVRRqfKeRGSdoCbCWoblrxdmJ7qFButTwm9LI=",
+    "https://plugins.jetbrains.com/files/631/688719/python-243.25659.39.zip": "sha256-WdrVWhdlKCnZOCuWqqszfNkd1nXzBxa2WX9Ma/UnZCw=",
     "https://plugins.jetbrains.com/files/6884/630038/handlebars-243.21565.122.zip": "sha256-pFKAZ8xFNfUh7/Hi4NYPDQAhRRYm4WKTpCQELqBfb40=",
     "https://plugins.jetbrains.com/files/6981/654905/ini-243.22562.236.zip": "sha256-kL/A2R8j2JKMU61T/xJahPwKPYmwFCFy55NPSoBh/Xc=",
-    "https://plugins.jetbrains.com/files/6981/672286/ini-243.23654.177.zip": "sha256-5IgVW7Aa+eVh5hUF7/Qa1g7nQtkAQkFKyGY5ROr/5fM=",
     "https://plugins.jetbrains.com/files/6981/680778/ini-243.24978.60.zip": "sha256-m2iKdm4f1h+k1XdQvJCd8T83jEKip+H1E1p8XMfrGcg=",
+    "https://plugins.jetbrains.com/files/6981/689219/ini-243.25659.45.zip": "sha256-f3z/zoFunPaJm+eRA6K/n4JWELFCZjXEdsZfTy4qbIs=",
     "https://plugins.jetbrains.com/files/7086/518678/AceJump.zip": "sha256-kVUEgfEKUupV/qlB4Dpzi5pFHjhVvX74XIPetKtjysM=",
     "https://plugins.jetbrains.com/files/7125/627704/GrepConsole-13.2.0-IJ2023.3.zip": "sha256-KY5VRiLJJwa9OVVog1W3MboZjwVboYwYm+i4eqooo44=",
-    "https://plugins.jetbrains.com/files/7177/630032/fileWatcher-243.21565.122.zip": "sha256-Pjn9LPdlTug6WQaydD2sgjBeqdzTd6KRXPawgl4KM74=",
     "https://plugins.jetbrains.com/files/7177/636663/fileWatcher-243.22562.13.zip": "sha256-8IHS3kmmbL8uQYnaMW7NgBIpBKT+XDJ4QDiiPZa5pzo=",
     "https://plugins.jetbrains.com/files/7177/654841/fileWatcher-243.23654.19.zip": "sha256-mlCow96mI2k7c/oGe064DqjUViOFhNgwNjF6DVyak4E=",
     "https://plugins.jetbrains.com/files/7219/605730/Symfony_Plugin-2024.1.276.zip": "sha256-drNmhJMe+kuY2fcHjY+SQmkACvFk0rVI4vAhyZ/bgLc=",
     "https://plugins.jetbrains.com/files/7320/630497/PHP_Annotations-11.1.1.zip": "sha256-05aBYbqNIuwe/JTwntFdIqML8NHbTOwVusl1P9FzuYY=",
     "https://plugins.jetbrains.com/files/7322/646590/python-ce-243.22562.145.zip": "sha256-45UtQRZMtKF6addrrB3A+goeyICMfcZ2FKcJvJSqgg4=",
-    "https://plugins.jetbrains.com/files/7322/673130/python-ce-243.23654.189.zip": "sha256-7P9JsxCDWUf0HPHZNPjoF8Ivh3Ks7AO5s2kWm+Cq9j4=",
     "https://plugins.jetbrains.com/files/7322/680217/python-ce-243.24978.46.zip": "sha256-4KkUOSN9KnBjpo92LvkN/7ZtDG/gSAFHgDf5ESSsgoY=",
     "https://plugins.jetbrains.com/files/7391/658997/asciidoctor-intellij-plugin-0.43.6.zip": "sha256-3RJ7YVFtynyqeLIzdrirCMbWNZmUkJ+DT/9my71H0Dk=",
     "https://plugins.jetbrains.com/files/7425/603907/WakaTime.jar": "sha256-Z7ZWDomXnTdHFKOElMkt53imef6aT7H5XeD6lOOFxfQ=",
     "https://plugins.jetbrains.com/files/7499/667439/gittoolbox-600.0.14_243-signed.zip": "sha256-rpJ0tPIf3mw5KLSv+wx16mXVKA1PxKTktgCYzKU3cU4=",
     "https://plugins.jetbrains.com/files/7724/654910/clouds-docker-impl-243.22562.236.zip": "sha256-3F25CTNLfQcUFklNXovLVXQ8cfOr/6Y5yetPc3jTFQM=",
-    "https://plugins.jetbrains.com/files/7724/672289/clouds-docker-impl-243.23654.177.zip": "sha256-zTp+nL22jW/93GkpVUK39D0VWgPtqRvW/BdhMqnsy1o=",
     "https://plugins.jetbrains.com/files/7724/680796/clouds-docker-impl-243.24978.54.zip": "sha256-pGAUljrRizCer076iM1oKrNj54tN3VxSvYldfKAsqRE=",
-    "https://plugins.jetbrains.com/files/8097/629964/graphql-243.21565.122.zip": "sha256-oaFy2E3e1cQyjf4JKblnhUXqKbXmDugzDPZXJLphWQw=",
+    "https://plugins.jetbrains.com/files/7724/689214/clouds-docker-impl-243.25659.45.zip": "sha256-iF/RkgQatHpGUNcLhKhP3aXSAJXPfzKEf8BvWdYooXs=",
     "https://plugins.jetbrains.com/files/8097/636616/graphql-243.22562.13.zip": "sha256-rr2pO0mIsqWXYZgwEhcQJlk0lQabxnIPxqRCGdTFaTw=",
     "https://plugins.jetbrains.com/files/8097/680200/graphql-243.24978.46.zip": "sha256-RJELd6KPzlRu+UwWBPW1fN33Zj0PcgQ0hGCJ6+ii/fI=",
+    "https://plugins.jetbrains.com/files/8097/688195/graphql-243.25659.42.zip": "sha256-p52AGXhfldRiT7FoWeDQuP38+/9J1KuPDyhM4VUwQTc=",
     "https://plugins.jetbrains.com/files/8195/630064/toml-243.21565.122.zip": "sha256-vKigewUGi06by9/6a9HbjN51zPAIafdk6w4MFG4kwG8=",
     "https://plugins.jetbrains.com/files/8195/672659/toml-243.23654.183.zip": "sha256-OFoWuz5z0BcZJqWkS+vkcD/Q0e5IUnQRY84/GEQQIb8=",
     "https://plugins.jetbrains.com/files/8327/615097/Minecraft_Development-2024.3-1.8.2.zip": "sha256-4c1nxjbEsNs9twmQnJllk1OIVmm0nnUYZ0R7f/6bJt4=",
-    "https://plugins.jetbrains.com/files/8554/633920/featuresTrainer-243.21565.204.zip": "sha256-3MCG1SNEy2Mf9r+nTLcRwJ+rIJRvtO0kYKFNjIan86E=",
     "https://plugins.jetbrains.com/files/8554/654690/featuresTrainer-243.22562.233.zip": "sha256-JugbJM8Lr2kbhP9hdLE3kUStl2vOMUB5wGTwNLxAZd0=",
-    "https://plugins.jetbrains.com/files/8554/672476/featuresTrainer-243.23654.180.zip": "sha256-YRf5sj+quf/dQv6eFU6f190vWW+RHtyGS+S2a6DhUoM=",
     "https://plugins.jetbrains.com/files/8554/684425/featuresTrainer-243.24978.79.zip": "sha256-1oI8hw6YYhUzhfv5RjtlBFG0OvucqVs/XUXMioRIuzA=",
+    "https://plugins.jetbrains.com/files/8554/688898/featuresTrainer-243.25659.44.zip": "sha256-JEGphoUK/MG0wiLNcQ7CM89vuq7L65WgncmVxzClvr4=",
     "https://plugins.jetbrains.com/files/8607/673303/NixIDEA-0.4.0.17.zip": "sha256-OFisV6Vs/xlbDvchxfrREDVgVh7wcfGnot+zUrgQU6M=",
     "https://plugins.jetbrains.com/files/9525/603167/idea-php-dotenv-plugin-2024.3.zip": "sha256-hR7hC2phDJnHXxPy80WlEDFAhZHtMCu7nqYvAb0VeTI=",
     "https://plugins.jetbrains.com/files/9568/680198/go-plugin-243.24978.46.zip": "sha256-H2zxIwMN/m7s7Ewhy55QO45lQcUOhG/xD29wj6V/vIM=",


### PR DESCRIPTION
Backport of #384783, I missed some commits in the last backport PR. Also backports not already backported parts of #386114.

This now brings the release branch to a state the master branch also had at some point, thus the plugin versions and IDE versions should match. I had a look at the plugin build numbers with the current build numbers of the IDEs and found matching numbers.  But I am happy about more reports of the updated plugins still working.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
