### PR TITLE
home-assistant-custom-lovelace-modules.zigbee2mqtt-networkmap: 0.9.0 -> 0.10.0

### DIFF
--- a/pkgs/servers/home-assistant/custom-lovelace-modules/zigbee2mqtt-networkmap/package.json
+++ b/pkgs/servers/home-assistant/custom-lovelace-modules/zigbee2mqtt-networkmap/package.json
@@ -11,14 +11,14 @@
     "vue": "^2.7.15"
   },
   "devDependencies": {
+    "@babel/core": "^7.26.0",
+    "@babel/eslint-parser": "^7.25.9",
     "@material/mwc-button": "^0.27.0",
     "@vue/cli-plugin-eslint": "^5.0.8",
     "@vue/cli-service": "^5.0.8",
     "@vue/eslint-config-standard": "^8.0.1",
-    "@babel/core": "^7.0.0",
-    "@babel/eslint-parser": "^7.0.0",
-    "eslint": "^8.42.0",
-    "eslint-plugin-vue": "^9.14.1",
+    "eslint": "^8.57.1",
+    "eslint-plugin-vue": "^9.32.0",
     "lodash.isequal": "^4.5.0",
     "vue-d3-network": "^0.1.28"
   }

--- a/pkgs/servers/home-assistant/custom-lovelace-modules/zigbee2mqtt-networkmap/package.nix
+++ b/pkgs/servers/home-assistant/custom-lovelace-modules/zigbee2mqtt-networkmap/package.nix
@@ -7,20 +7,20 @@
 
 mkYarnPackage rec {
   pname = "zigbee2mqtt-networkmap";
-  version = "0.9.0";
+  version = "0.10.0";
 
   src = fetchFromGitHub {
     owner = "azuwis";
     repo = "zigbee2mqtt-networkmap";
     rev = "v${version}";
-    hash = "sha256-K4DyrurC4AzzJCcB4CS9UlQbUQSWpR7PevA2JFFMRZM=";
+    hash = "sha256-S4iUTjI+pFfa8hg1/lJSI1tl2nEIh+LO2WTYhWWLh/s=";
   };
 
   packageJSON = ./package.json;
 
   offlineCache = fetchYarnDeps {
     yarnLock = "${src}/yarn.lock";
-    hash = "sha256-h/5TWaIg8AfY6I/JBRmUF6yCCbxCMs9nRECWEaaK2to=";
+    hash = "sha256-yo+K3vUJH6WwyNj/UuvbhhmhdqzJ3XUzX+cKUueutjE=";
   };
 
   configurePhase = ''

--- a/pkgs/servers/home-assistant/custom-lovelace-modules/zigbee2mqtt-networkmap/update.sh
+++ b/pkgs/servers/home-assistant/custom-lovelace-modules/zigbee2mqtt-networkmap/update.sh
@@ -6,4 +6,8 @@ set -xe
 dirname="$(dirname "$0")"
 
 # nix-update picks the wrong file `pkgs/development/tools/yarn2nix-moretea/yarn2nix/default.nix`
-nix-update --override-filename "$dirname/default.nix" home-assistant-custom-lovelace-modules.zigbee2mqtt-networkmap
+nix-update --override-filename "$dirname/package.nix" home-assistant-custom-lovelace-modules.zigbee2mqtt-networkmap
+
+# update package.json
+source=$(nix-build -A home-assistant-custom-lovelace-modules.zigbee2mqtt-networkmap.src)
+cp "$source/package.json" "$dirname/package.json"


### PR DESCRIPTION
Fix updateScript, auto update package.json

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
