### PR TITLE
mapscii: mark as broken

### DIFF
--- a/pkgs/by-name/ma/mapscii/package.nix
+++ b/pkgs/by-name/ma/mapscii/package.nix
@@ -25,5 +25,6 @@ buildNpmPackage rec {
     maintainers = with maintainers; [ kinzoku ];
     mainProgram = "mapscii";
     platforms = platforms.all;
+    broken = true;
   };
 }


### PR DESCRIPTION
## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Got the following error when trying to run the package in a nix shell.  

```
nix shell nixpkgs#mapscii
error: builder for '/nix/store/pik9qgm8qjbc7qmn5j01y1d6vcg98axb-mapscii-0.3.1.drv' failed with exit code 1;
       last 25 log lines:
       > npm warn old lockfile
       > npm warn old lockfile The package-lock.json file was created with an old version of npm,
       > npm warn old lockfile so supplemental metadata must be fetched from the registry.
       > npm warn old lockfile
       > npm warn old lockfile This is a one-time fix-up, please be patient...
       > npm warn old lockfile
       >
       > up to date, audited 23 packages in 492ms
       >
       > found 0 vulnerabilities
       > Finished npmInstallHook
       > Running phase: fixupPhase
       > shrinking RPATHs of ELF executables and libraries in /nix/store/fv4j9n31xias2z9g82vqiivncg3416h4-mapscii-0.3.1
       > checking for references to /build/ in /nix/store/fv4j9n31xias2z9g82vqiivncg3416h4-mapscii-0.3.1...
       > patching script interpreter paths in /nix/store/fv4j9n31xias2z9g82vqiivncg3416h4-mapscii-0.3.1
       > ERROR: noBrokenSymlinks: the symlink /nix/store/fv4j9n31xias2z9g82vqiivncg3416h4-mapscii-0.3.1/lib/node_modules/mapscii/node_modules/.bin/acorn points to a missing target: /nix/store/fv4j9n31xias2z9g82vqiivncg3416h4-mapscii-0.3.1/lib/node_modules/mapscii/node_modules/acorn/bin/acorn
       > ERROR: noBrokenSymlinks: the symlink /nix/store/fv4j9n31xias2z9g82vqiivncg3416h4-mapscii-0.3.1/lib/node_modules/mapscii/node_modules/.bin/eslint points to a missing target: /nix/store/fv4j9n31xias2z9g82vqiivncg3416h4-mapscii-0.3.1/lib/node_modules/mapscii/node_modules/eslint/bin/eslint.js
       > ERROR: noBrokenSymlinks: the symlink /nix/store/fv4j9n31xias2z9g82vqiivncg3416h4-mapscii-0.3.1/lib/node_modules/mapscii/node_modules/.bin/js-yaml points to a missing target: /nix/store/fv4j9n31xias2z9g82vqiivncg3416h4-mapscii-0.3.1/lib/node_modules/mapscii/node_modules/js-yaml/bin/js-yaml.js
       > ERROR: noBrokenSymlinks: the symlink /nix/store/fv4j9n31xias2z9g82vqiivncg3416h4-mapscii-0.3.1/lib/node_modules/mapscii/node_modules/.bin/esvalidate points to a missing target: /nix/store/fv4j9n31xias2z9g82vqiivncg3416h4-mapscii-0.3.1/lib/node_modules/mapscii/node_modules/esprima/bin/esvalidate.js
       > ERROR: noBrokenSymlinks: the symlink /nix/store/fv4j9n31xias2z9g82vqiivncg3416h4-mapscii-0.3.1/lib/node_modules/mapscii/node_modules/.bin/esparse points to a missing target: /nix/store/fv4j9n31xias2z9g82vqiivncg3416h4-mapscii-0.3.1/lib/node_modules/mapscii/node_modules/esprima/bin/esparse.js
       > ERROR: noBrokenSymlinks: the symlink /nix/store/fv4j9n31xias2z9g82vqiivncg3416h4-mapscii-0.3.1/lib/node_modules/mapscii/node_modules/.bin/rimraf points to a missing target: /nix/store/fv4j9n31xias2z9g82vqiivncg3416h4-mapscii-0.3.1/lib/node_modules/mapscii/node_modules/rimraf/bin.js
       > ERROR: noBrokenSymlinks: the symlink /nix/store/fv4j9n31xias2z9g82vqiivncg3416h4-mapscii-0.3.1/lib/node_modules/mapscii/node_modules/.bin/mkdirp points to a missing target: /nix/store/fv4j9n31xias2z9g82vqiivncg3416h4-mapscii-0.3.1/lib/node_modules/mapscii/node_modules/mkdirp/bin/cmd.js
       > ERROR: noBrokenSymlinks: the symlink /nix/store/fv4j9n31xias2z9g82vqiivncg3416h4-mapscii-0.3.1/lib/node_modules/mapscii/node_modules/.bin/which points to a missing target: /nix/store/fv4j9n31xias2z9g82vqiivncg3416h4-mapscii-0.3.1/lib/node_modules/mapscii/node_modules/which/bin/which
       > ERROR: noBrokenSymlinks: the symlink /nix/store/fv4j9n31xias2z9g82vqiivncg3416h4-mapscii-0.3.1/lib/node_modules/mapscii/node_modules/.bin/semver points to a missing target: /nix/store/fv4j9n31xias2z9g82vqiivncg3416h4-mapscii-0.3.1/lib/node_modules/mapscii/node_modules/semver/bin/semver.js
       > ERROR: noBrokenSymlinks: found 9 dangling symlinks, 0 reflexive symlinks and 0 unreadable symlinks
       For full logs, run:
         nix log /nix/store/pik9qgm8qjbc7qmn5j01y1d6vcg98axb-mapscii-0.3.1.drv
```

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
