### PR TITLE
rke2: use `finalAttrs` to avoid `let` and `rec` bindings

### DIFF
--- a/pkgs/applications/networking/cluster/rke2/builder.nix
+++ b/pkgs/applications/networking/cluster/rke2/builder.nix
@@ -44,126 +44,123 @@ lib:
   nixosTests,
   testers,
 }:
-let
-  rke2 = buildGoModule rec {
-    pname = "rke2";
-    version = rke2Version;
+buildGoModule (finalAttrs: {
+  pname = "rke2";
+  version = rke2Version;
 
-    src = fetchzip {
-      url = "https://github.com/rancher/rke2/archive/refs/tags/v${rke2Version}.tar.gz";
-      hash = "${rke2TarballHash}";
-    };
-
-    vendorHash = rke2VendorHash;
-
-    nativeBuildInputs = [ makeWrapper ];
-
-    # Important utilities used by the kubelet.
-    # See: https://github.com/kubernetes/kubernetes/issues/26093#issuecomment-237202494
-    # Notice the list in that issue is stale, but as a redundancy reservation.
-    buildInputs = [
-      procps # pidof pkill
-      coreutils # uname touch env nice du
-      util-linux # lsblk fsck mkfs nsenter mount umount
-      ethtool # ethtool
-      socat # socat
-      iptables # iptables iptables-restore iptables-save
-      bridge-utils # brctl
-      iproute2 # ip tc
-      kmod # modprobe
-      lvm2 # dmsetup
-    ];
-
-    # Passing boringcrypto to GOEXPERIMENT variable to build with goboring library
-    GOEXPERIMENT = "boringcrypto";
-
-    # See: https://github.com/rancher/rke2/blob/e7f87c6dd56fdd76a7dab58900aeea8946b2c008/scripts/build-binary#L27-L38
-    ldflags = [
-      "-w"
-      "-X github.com/k3s-io/k3s/pkg/version.GitCommit=${lib.substring 0 6 rke2Commit}"
-      "-X github.com/k3s-io/k3s/pkg/version.Program=${pname}"
-      "-X github.com/k3s-io/k3s/pkg/version.Version=v${version}"
-      "-X github.com/k3s-io/k3s/pkg/version.UpstreamGolang=go${go.version}"
-      "-X github.com/rancher/rke2/pkg/images.DefaultRegistry=docker.io"
-      "-X github.com/rancher/rke2/pkg/images.DefaultEtcdImage=rancher/hardened-etcd:${etcdVersion}"
-      "-X github.com/rancher/rke2/pkg/images.DefaultKubernetesImage=rancher/hardened-kubernetes:${k8sImageTag}"
-      "-X github.com/rancher/rke2/pkg/images.DefaultPauseImage=rancher/mirrored-pause:${pauseVersion}"
-      "-X github.com/rancher/rke2/pkg/images.DefaultRuntimeImage=rancher/rke2-runtime:${dockerizedVersion}"
-      "-X github.com/rancher/rke2/pkg/images.DefaultCloudControllerManagerImage=rancher/rke2-cloud-provider:${ccmVersion}"
-    ];
-
-    tags = [
-      "no_cri_dockerd"
-      "no_embedded_executor"
-      "no_stage"
-      "sqlite_omit_load_extension"
-      "selinux"
-      "netgo"
-      "osusergo"
-    ];
-
-    subPackages = [ "." ];
-
-    installPhase = ''
-      install -D $GOPATH/bin/rke2 $out/bin/rke2
-      wrapProgram $out/bin/rke2 \
-        --prefix PATH : ${lib.makeBinPath buildInputs}
-
-      install -D ./bundle/bin/rke2-killall.sh $out/bin/rke2-killall.sh
-      wrapProgram $out/bin/rke2-killall.sh \
-        --prefix PATH : ${
-          lib.makeBinPath [
-            systemd
-            gnugrep
-            gnused
-          ]
-        } \
-        --prefix PATH : ${lib.makeBinPath buildInputs}
-    '';
-
-    doCheck = false;
-
-    doInstallCheck = true;
-    installCheckPhase = ''
-      runHook preInstallCheck
-      # Verify that the binary uses BoringCrypto
-      go tool nm $out/bin/.rke2-wrapped | grep '_Cfunc__goboringcrypto_' > /dev/null
-      runHook postInstallCheck
-    '';
-
-    passthru = {
-      inherit updateScript;
-      tests =
-        let
-          moduleTests =
-            let
-              package_version =
-                "rke2_" + lib.replaceStrings [ "." ] [ "_" ] (lib.versions.majorMinor rke2Version);
-            in
-            lib.mapAttrs (name: value: nixosTests.rke2.${name}.${package_version}) nixosTests.rke2;
-        in
-        {
-          version = testers.testVersion {
-            package = rke2;
-            version = "v${version}";
-          };
-        }
-        // moduleTests;
-    } // (lib.mapAttrs (_: value: fetchurl value) imagesVersions);
-
-    meta = with lib; {
-      homepage = "https://github.com/rancher/rke2";
-      description = "RKE2, also known as RKE Government, is Rancher's next-generation Kubernetes distribution";
-      changelog = "https://github.com/rancher/rke2/releases/tag/v${version}";
-      license = licenses.asl20;
-      maintainers = with maintainers; [
-        rorosen
-        zimbatm
-        zygot
-      ];
-      mainProgram = "rke2";
-      platforms = platforms.linux;
-    };
+  src = fetchzip {
+    url = "https://github.com/rancher/rke2/archive/refs/tags/v${rke2Version}.tar.gz";
+    hash = "${rke2TarballHash}";
   };
-in
-rke2
+
+  vendorHash = rke2VendorHash;
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  # Important utilities used by the kubelet.
+  # See: https://github.com/kubernetes/kubernetes/issues/26093#issuecomment-237202494
+  # Notice the list in that issue is stale, but as a redundancy reservation.
+  buildInputs = [
+    procps # pidof pkill
+    coreutils # uname touch env nice du
+    util-linux # lsblk fsck mkfs nsenter mount umount
+    ethtool # ethtool
+    socat # socat
+    iptables # iptables iptables-restore iptables-save
+    bridge-utils # brctl
+    iproute2 # ip tc
+    kmod # modprobe
+    lvm2 # dmsetup
+  ];
+
+  # Passing boringcrypto to GOEXPERIMENT variable to build with goboring library
+  GOEXPERIMENT = "boringcrypto";
+
+  # See: https://github.com/rancher/rke2/blob/e7f87c6dd56fdd76a7dab58900aeea8946b2c008/scripts/build-binary#L27-L38
+  ldflags = [
+    "-w"
+    "-X github.com/k3s-io/k3s/pkg/version.GitCommit=${lib.substring 0 6 rke2Commit}"
+    "-X github.com/k3s-io/k3s/pkg/version.Program=${finalAttrs.pname}"
+    "-X github.com/k3s-io/k3s/pkg/version.Version=v${finalAttrs.version}"
+    "-X github.com/k3s-io/k3s/pkg/version.UpstreamGolang=go${go.version}"
+    "-X github.com/rancher/rke2/pkg/images.DefaultRegistry=docker.io"
+    "-X github.com/rancher/rke2/pkg/images.DefaultEtcdImage=rancher/hardened-etcd:${etcdVersion}"
+    "-X github.com/rancher/rke2/pkg/images.DefaultKubernetesImage=rancher/hardened-kubernetes:${k8sImageTag}"
+    "-X github.com/rancher/rke2/pkg/images.DefaultPauseImage=rancher/mirrored-pause:${pauseVersion}"
+    "-X github.com/rancher/rke2/pkg/images.DefaultRuntimeImage=rancher/rke2-runtime:${dockerizedVersion}"
+    "-X github.com/rancher/rke2/pkg/images.DefaultCloudControllerManagerImage=rancher/rke2-cloud-provider:${ccmVersion}"
+  ];
+
+  tags = [
+    "no_cri_dockerd"
+    "no_embedded_executor"
+    "no_stage"
+    "sqlite_omit_load_extension"
+    "selinux"
+    "netgo"
+    "osusergo"
+  ];
+
+  subPackages = [ "." ];
+
+  installPhase = ''
+    install -D $GOPATH/bin/rke2 $out/bin/rke2
+    wrapProgram $out/bin/rke2 \
+      --prefix PATH : ${lib.makeBinPath finalAttrs.buildInputs}
+
+    install -D ./bundle/bin/rke2-killall.sh $out/bin/rke2-killall.sh
+    wrapProgram $out/bin/rke2-killall.sh \
+      --prefix PATH : ${
+        lib.makeBinPath [
+          systemd
+          gnugrep
+          gnused
+        ]
+      } \
+      --prefix PATH : ${lib.makeBinPath finalAttrs.buildInputs}
+  '';
+
+  doCheck = false;
+
+  doInstallCheck = true;
+  installCheckPhase = ''
+    runHook preInstallCheck
+    # Verify that the binary uses BoringCrypto
+    go tool nm $out/bin/.rke2-wrapped | grep '_Cfunc__goboringcrypto_' > /dev/null
+    runHook postInstallCheck
+  '';
+
+  passthru = {
+    inherit updateScript;
+    tests =
+      let
+        moduleTests =
+          let
+            package_version =
+              "rke2_" + lib.replaceStrings [ "." ] [ "_" ] (lib.versions.majorMinor rke2Version);
+          in
+          lib.mapAttrs (name: value: nixosTests.rke2.${name}.${package_version}) nixosTests.rke2;
+      in
+      {
+        version = testers.testVersion {
+          package = finalAttrs.finalPackage;
+          version = "v${finalAttrs.version}";
+        };
+      }
+      // moduleTests;
+  } // (lib.mapAttrs (_: value: fetchurl value) imagesVersions);
+
+  meta = with lib; {
+    homepage = "https://github.com/rancher/rke2";
+    description = "RKE2, also known as RKE Government, is Rancher's next-generation Kubernetes distribution";
+    changelog = "https://github.com/rancher/rke2/releases/tag/v${version}";
+    license = licenses.asl20;
+    maintainers = with maintainers; [
+      rorosen
+      zimbatm
+      zygot
+    ];
+    mainProgram = "rke2";
+    platforms = platforms.linux;
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

Use `finalAttrs` to avoid `let` and `rec` bindings. This was proposed in https://github.com/NixOS/nixpkgs/pull/379844#discussion_r1944950504, but wasn't supported at that time. However, with https://github.com/NixOS/nixpkgs/pull/390220 this is possible now.

@zimbatm @stefan-bordei 

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
