### PR TITLE
jemalloc: fix reproducibility issues

### DIFF
--- a/pkgs/development/libraries/jemalloc/default.nix
+++ b/pkgs/development/libraries/jemalloc/default.nix
@@ -1,8 +1,11 @@
 {
   lib,
   stdenv,
-  fetchurl,
+  fetchFromGitHub,
   fetchpatch,
+  autogen,
+  autoconf,
+  automake,
   # By default, jemalloc puts a je_ prefix onto all its symbols on OSX, which
   # then stops downstream builds (mariadb in particular) from detecting it. This
   # option should remove the prefix and give us a working jemalloc.
@@ -16,9 +19,11 @@ stdenv.mkDerivation rec {
   pname = "jemalloc";
   version = "5.3.0";
 
-  src = fetchurl {
-    url = "https://github.com/jemalloc/jemalloc/releases/download/${version}/${pname}-${version}.tar.bz2";
-    sha256 = "sha256-LbgtHnEZ3z5xt2QCGbbf6EeJvAU3mDw7esT3GJrs/qo=";
+  src = fetchFromGitHub {
+    owner = "jemalloc";
+    repo = "jemalloc";
+    tag = version;
+    hash = "sha256-bb0OhZVXyvN+hf9BpPSykn5cGm87a0C+Y/iXKt9wTSs=";
   };
 
   patches = [
@@ -33,11 +38,32 @@ stdenv.mkDerivation rec {
       url = "https://github.com/jemalloc/jemalloc/commit/4422f88d17404944a312825a1aec96cd9dc6c165.patch";
       hash = "sha256-dunkE7XHzltn5bOb/rSHqzpRniAFuGubBStJeCxh0xo=";
     })
+    # -O3 appears to introduce an unreproducibility where
+    # `rtree_read.constprop.0` shows up in some builds but
+    # not others, so we fall back to O2:
+    ./o3-to-o2.patch
   ];
 
+  nativeBuildInputs = [
+    autogen
+    autoconf
+    automake
+  ];
+
+  preConfigure =
+    ''
+      ./autogen.sh
+    ''
+    + lib.optionalString stdenv.hostPlatform.isDarwin ''
+      export LDFLAGS="$LDFLAGS -Wl,-no_uuid -Wl,-install_name,@rpath/libjemalloc.2.dylib";
+    '';
+
   configureFlags =
+    [
+      "--with-lg-vaddr=${with stdenv.hostPlatform; toString (if isILP32 then 32 else parsed.cpu.bits)}"
+    ]
     # see the comment on stripPrefix
-    lib.optional stripPrefix "--with-jemalloc-prefix="
+    ++ lib.optional stripPrefix "--with-jemalloc-prefix="
     ++ lib.optional disableInitExecTls "--disable-initial-exec-tls"
     # jemalloc is unable to correctly detect transparent hugepage support on
     # ARM (https://github.com/jemalloc/jemalloc/issues/526), and the default
@@ -46,9 +72,10 @@ stdenv.mkDerivation rec {
       "--disable-thp"
       "je_cv_thp=no"
     ]
-    # AArch64 has configurable page size up to 64k. The default configuration
-    # for jemalloc only supports 4k page sizes.
-    ++ lib.optional stdenv.hostPlatform.isAarch64 "--with-lg-page=16"
+    # The upstream default is dependent on the builders' page size
+    # https://github.com/jemalloc/jemalloc/issues/467
+    # https://sources.debian.org/src/jemalloc/5.3.0-3/debian/rules/
+    ++ [ (if stdenv.hostPlatform.isAarch64 then "--with-lg-page=16" else "--with-lg-page=12") ]
     # See https://github.com/jemalloc/jemalloc/issues/1997
     # Using a value of 48 should work on both emulated and native x86_64-darwin.
     ++ lib.optional (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isx86_64) "--with-lg-vaddr=48";

--- a/pkgs/development/libraries/jemalloc/o3-to-o2.patch
+++ b/pkgs/development/libraries/jemalloc/o3-to-o2.patch
@@ -1,0 +1,15 @@
+diff --git a/configure.ac b/configure.ac
+index 1c9c5067..a0856b89 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -1372,8 +1372,8 @@ AC_SUBST([enable_debug])
+ dnl Only optimize if not debugging.
+ if test "x$enable_debug" = "x0" ; then
+   if test "x$GCC" = "xyes" ; then
+-    JE_CFLAGS_ADD([-O3])
+-    JE_CXXFLAGS_ADD([-O3])
++    JE_CFLAGS_ADD([-O2])
++    JE_CXXFLAGS_ADD([-O2])
+     JE_CFLAGS_ADD([-funroll-loops])
+   elif test "x$je_cv_msvc" = "xyes" ; then
+     JE_CFLAGS_ADD([-O2])


### PR DESCRIPTION
Hopefully makes the build deterministic regardless of the build host

https://github.com/jemalloc/jemalloc/issues/467
https://sources.debian.org/src/jemalloc/5.3.0-3/debian/rules/

fixes https://github.com/NixOS/nixpkgs/issues/380852

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
