### PR TITLE
doc/option-types: fix attrTag example

### DIFF
--- a/nixos/doc/manual/development/option-types.section.md
+++ b/nixos/doc/manual/development/option-types.section.md
@@ -371,7 +371,7 @@ If the you're interested in can be distinguished without a label, you may simpli
                 options.destination = mkOption { … };
               };
             };
-            ignore = types.mkOption {
+            drop = types.mkOption {
               description = "Drop the packet without sending anything back.";
               type = types.submodule {};
             };


### PR DESCRIPTION
Introduced in #284551.

The example uses `drop` instead of `ignore` a few lines further down.