### PR TITLE
docs: add separate Nixpkgs release notes

### DIFF
--- a/doc/redirects.json
+++ b/doc/redirects.json
@@ -95,6 +95,9 @@
   "sec-nixpkgs-release-25.05": [
     "release-notes.html#sec-nixpkgs-release-25.05"
   ],
+  "sec-nixpkgs-release-25.05-highlights": [
+    "release-notes.html#sec-nixpkgs-release-25.05-highlights"
+  ],
   "sec-nixpkgs-release-25.05-incompatibilities": [
     "release-notes.html#sec-nixpkgs-release-25.05-incompatibilities"
   ],
@@ -118,6 +121,9 @@
   ],
   "sec-nixpkgs-release-25.05-lib-additions-improvements": [
     "release-notes.html#sec-nixpkgs-release-25.05-lib-additions-improvements"
+  ],
+  "sec-nixpkgs-release-25.05-notable-changes": [
+    "release-notes.html#sec-nixpkgs-release-25.05-notable-changes"
   ],
   "sec-overlays-install": [
     "index.html#sec-overlays-install"

--- a/doc/release-notes/rl-2505.section.md
+++ b/doc/release-notes/rl-2505.section.md
@@ -1,12 +1,41 @@
 # Nixpkgs 25.05 (2025.05/??) {#sec-nixpkgs-release-25.05}
 
-## Backward Incompatibilities {#sec-nixpkgs-release-25.05-incompatibilities}
+## Highlights {#sec-nixpkgs-release-25.05-highlights}
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
 
-- `services.rippled` has been removed, as `rippled` was broken and had not been updated since 2022.
+- **This release of Nixpkgs requires macOS Big Sur 11.3 or newer, as announced in the 24.11 release notes.**
+  We cannot guarantee that packages will continue to work on older versions of macOS.
+  Future Nixpkgs releases will only support [macOS versions supported by Apple](https://endoflife.date/macos); this means that **Nixpkgs 25.11 will require macOS Sonoma 14 or newer**.
+  Users on old macOS versions should consider upgrading to a supported version (potentially using [OpenCore Legacy Patcher](https://dortania.github.io/OpenCore-Legacy-Patcher/) for old hardware) or installing NixOS.
+  If neither of those options are viable and you require new versions of software, [MacPorts](https://www.macports.org/) supports versions back to Mac OS X Snow Leopard 10.6.
 
-- `services.rippleDataApi` has been removed, as `ripple-data-api` was broken and had not been updated since 2022.
+- The default kernel package has been updated from 6.6 to 6.12. All supported kernels remain available.
+
+- GCC has been updated from GCC 13 to GCC 14.
+  This introduces some backwards‐incompatible changes; see the [upstream porting guide](https://gcc.gnu.org/gcc-14/porting_to.html) for details.
+
+- LLVM has been updated from LLVM 16 (on Darwin) and LLVM 18 (on other platforms) to LLVM 19.
+  This introduces some backwards‐incompatible changes; see the [upstream release notes](https://releases.llvm.org/) for details.
+
+- Emacs has been updated to 30.1.
+  This introduces some backwards‐incompatible changes; see the NEWS for details.
+  NEWS can been viewed from Emacs by typing `C-h n`, or by clicking `Help->Emacs News` from the menu bar.
+  It can also be browsed [online](https://git.savannah.gnu.org/cgit/emacs.git/tree/etc/NEWS?h=emacs-30).
+
+- The default PHP version has been updated to 8.4.
+
+- The default Erlang OTP version has been updated to 27.
+
+- The default Elixir version has been updated to 1.18.
+
+- `buildPythonPackage`, `buildPythonApplication` and the Python building setup hooks now support both `__structuredAttrs = true` and `__structuredAttrs = false`.
+
+<!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
+
+## Backward Incompatibilities {#sec-nixpkgs-release-25.05-incompatibilities}
+
+<!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
 
 - `apptainer` and `singularity` deprecate the workaround of overriding `vendorHash` and related attributes via `<pkg>.override`,
   in favour of the unified overriding of the same group of attributes via `<pkg>.overrideAttrs`.
@@ -37,10 +66,6 @@
   It should generally be replaced with `rustPlatform.fetchCargoVendor`, but `rustPlatform.importCargoLock` may also be appropriate in some circumstances.
   `rustPlatform.buildRustPackage` users must set `useFetchCargoVendor` to `true` and regenerate the `cargoHash`.
 
-- The `nixos/modules/virtualisation/amazon-ec2-amis.nix` file is not supported anymore since 24.05. It will throw
-  and error starting 25.05 with instructions the following instructions:
-  The canonical source for NixOS AMIs is the AWS API. Please see https://nixos.org/download/#nixos-amazon or  https://nixos.github.io/amis/ for instructions.
-
 - NetBox was updated to `>= 4.2.0`. Have a look at the breaking changes
   of the [4.1 release](https://github.com/netbox-community/netbox/releases/tag/v4.1.0)
   and the [4.2 release](https://github.com/netbox-community/netbox/releases/tag/v4.2.0),
@@ -59,11 +84,234 @@
   the [release announcement](https://kafka.apache.org/blog#apache_kafka_400_release_announcement)
   for more details.
 
+- `ast-grep` remove `sg` command to prevent conflict with `sg` command from shadow-utils. If you need legacy sg command compatibility with old code, you can use `ast-grep.override { enableLegacySg = true; }`
+
+- rename package `wtf` to `wtfutil`.
+
+- `python3Packages.beancount` was updated to 3.1.0. Previous major version remains available as `python3Packages.beancount_2`.
+
+- `wastebin` has been updated to 3.0.0. See the [Changelog](https://github.com/matze/wastebin/blob/master/CHANGELOG.md#300) for breaking changes to the configuration.
+
+- `binwalk` was updated to 3.1.0, which has been rewritten in rust. The python module is no longer available.
+  See the release notes of [3.1.0](https://github.com/ReFirmLabs/binwalk/releases/tag/v3.1.0) for more information.
+
+- `pkgs.nextcloud28` has been removed since it's out of support upstream.
+
+- `teleport` has been upgraded from major version 16 to major version 17.
+  Refer to [upstream upgrade instructions](https://goteleport.com/docs/upgrading/overview/)
+  and [release notes for v17](https://goteleport.com/docs/changelog/#1701-11152024).
+
+- Emacs lisp build helpers, such as `emacs.pkgs.melpaBuild`, now enables `__structuredAttrs` by default.
+  Environment variables have to be passed via the `env` attribute.
+
+- `buildGoModule` now passes environment variables via the `env` attribute. `CGO_ENABLED` should now be specified with `env.CGO_ENABLED` when passing to buildGoModule. Direct specification of `CGO_ENABLED` is now redirected by a compatibility layer with a warning, but will become an error in future releases.
+
+  Go-related environment variables previously shadowed by `buildGoModule` now results in errors when specified directly. Such variables include `GOOS` and `GOARCH`.
+
+  Third-party projects supporting both stable and unstable channels could detect this change through the absence of the `CGO_ENABLED` function argument in `buildGoModule` (`!((lib.functionArgs buildGoModule) ? CGO_ENABLED)`).
+
+- `buildGoPackage` has been removed. Use `buildGoModule` instead. See the [Go section in the nixpkgs manual](https://nixos.org/manual/nixpkgs/unstable/#sec-language-go) for details.
+
+- top-level `playwright` now refers to the github Microsoft/playwright package
+  instead of the python tester launcher. You can still refer to the python
+  launcher via `python3Packages.toPythonApplication python3Packages.playwright`
+
+- The representation of the flags attributes as shell/environment variables for most Python building setup hooks are now the same as `stdenv.mkDerivation` and other build helpers -- they are space-separated environment variables when `__structuredAttrs = false` and Bash arrays when `__structuredAttrs = true`, and are concatenated to the command without Bash-evaluation. The following behaviour changes are introduced during the conversion:
+
+  - The following flags are no longer Bash-expanded before concatenated to the command:
+    - `disabledTests` and `disabledTestPaths` for `pytestCheckHook`. (`disabledTestPaths` used to be expanded twice before concatenation.)
+    - `setupPyBuildFlags` and `setupPyGlobalFlags` for `setuptoolsBuildHook`.
+
+  - `pytestFlags` and `unittestFlags` replace `pytestFlagsArray` and `unittestFlagsArray` and become the new and conforming interface.
+
+  - `pytestFlagsArray` and `unittestFlagsArray` are kept for compatibility purposes. They continue to be Bash-expanded before concatenated. This compatibility layer will be removed in future releases.
+
+- The `haka` package and module has been removed because the package was broken and unmaintained for 9 years.
+
+- `strawberry` has been updated to 1.2, which drops support for the VLC backend and Qt 5. The `strawberry-qt5` package
+  and `withGstreamer`/`withVlc` override options have been removed due to this.
+
+- `nezha` and its agent `nezha-agent` have been updated to v1, which contains breaking changes. See the [official wiki](https://nezha.wiki/en_US/) for more details.
+
+- `ps3-disc-dumper` was updated to 4.2.5, which removed the CLI project and now exclusively offers the GUI
+
+- `kmonad` is now hardened by default using common `systemd` settings.
+  If KMonad is used to execute shell commands, hardening may make some of them fail.  In that case, you can disable hardening using {option}`services.kmonad.keyboards.<name>.enableHardening` option.
+
+- `isd` was updated from 0.2.0 to 0.5.1, the new version may crash with a previously generated config, try moving or deleting `~/.config/isd/schema.json`.
+
+- `uwsgi` no longer supports Python 2 plugins.
+
+- Support for CUDA 10 has been dropped, as announced in the 24.11 release notes.
+
+- `mepo` was updated to version 1.3.3.  The manual page was removed,
+  a new JSON API was introduced to replace Mepolang for configuration,
+  and a few default key bindings were changed.
+  See the [1.3.0 changelog](https://git.sr.ht/~mil/mepo/refs/1.3.0)
+  for more details.
+
+- `mkBinaryCache` now defaults to using `zstd` compression for the binary caches it creates. The previous `xz` compression method can be used by passing `compression = "xz";`.
+
+- `nodePackages."@commitlint/config-conventional"` has been removed, as it is a library, and projects should depend on it instead.
+
+-  zigbee2mqtt is now available in version 2.x as `zigbee2mqtt_2`. In NixOS 25.11 we'll remove `zigbee2mqtt_1` and default to `zigbee2mqtt_2`. See the [breaking changes](https://github.com/Koenkk/zigbee2mqtt/discussions/24198) announcement for 2.0.0.
+
+- `nodePackages.vls` has been deprecated, as the upstream consumer of it, vetur, has been deprecated by upstream. Upstream suggests migrating to Volar for Vue LSP tooling instead.
+
+- `nodePackages.create-react-native-app` has been removed, as it is deprecated. Upstream suggests using a framework for React Native apps instead.
+
+- `nodePackages.insect` has been removed, as it's deprecated by upstream. The suggested replacement is `numbat`.
+
+- `nodePackages.webpack-dev-server` has been removed, as it should be installed in projects that use it instead.
+
+- `nodePackages.copy-webpack-plugin` has been removed, as it should be installed in projects that use it instead.
+
+- `himalaya` has been updated from `v1.0.0-beta.4` to `v1.1.0`, which introduces breaking changes. Check out the [release notes](https://github.com/pimalaya/himalaya/releases) for details.
+
+- `linuxPackages.nvidiaPackages.dc_520` has been removed since it is marked broken and there are better newer alternatives.
+
+- `pnpm` was updated to version 10. If your project is incompatible, you can install the previous version from the package attribute `pnpm_9`.
+
+- `zig_0_9` and `zig_0_10` have been removed, you should upgrade to `zig_0_13` (also available as just `zig`), `zig_0_12` or `zig_0_11` instead.
+
+- `webpack-cli` was updated to major version 6, which has breaking changes from the previous version 5.1.4. See the [upstream release notes](https://github.com/webpack/webpack-cli/releases/tag/webpack-cli%406.0.0) for details on these changes.
+
+- `minetest` has been renamed to `luanti` to match the upstream name change but aliases have been added. The new name hasn't resulted in many changes as of yet but older references to minetest should be sunset. See the [new name announcement](https://blog.minetest.net/2024/10/13/Introducing-Our-New-Name/) for more details.
+
+- `poac` has been renamed to `cabinpkg` to match the upstream name change but an alias has been added. See the [new name announcement](https://github.com/orgs/cabinpkg/discussions/1052) for more details.
+
+- `serious-sans` has been removed because upstream changed its name to Serious Shanns, which is not currently packaged.
+
+- `racket_7_9` has been removed, as it is insecure. It is recommended to use Racket 8 instead.
+
+- `rofi` has been updated from 1.7.5 to 1.7.6 which introduces some breaking changes to binary plugins, and also contains a lot of new features and bug fixes. This is highlighted because the patch version bump does not indicate the volume of changes by itself. See the [upstream release notes](https://github.com/davatorium/rofi/releases/tag/1.7.6) for the full list of changes.
+
+- `ente-auth` now uses the name `enteauth` for its binary. The previous name was `ente_auth`.
+
+- `foundationdb` was upgraded to 7.3.
+
+- `fluxus` has been removed, as it depends on `racket_7_9` and had no updates in 9 years.
+
+- `sm64ex-coop` has been removed as it was archived upstream. Consider migrating to `sm64coopdx`.
+
+- `tldr` now uses [`tldr-python-client`](https://github.com/tldr-pages/tldr-python-client) instead of [`tldr-c-client`](https://github.com/tldr-pages/tldr-c-client) which is unmaintained.
+
+- `renovate` was updated to v39. See the [upstream release notes](https://docs.renovatebot.com/release-notes-for-major-versions/#version-39) for breaking changes.
+  Like upstream's docker images, renovate now runs on NodeJS 22.
+
+- The behavior of the `networking.nat.externalIP` and `networking.nat.externalIPv6` options has been changed. `networking.nat.forwardPorts` now only forwards packets destined for the specified IP addresses.
+
+- `python3Packages.bpycv` has been removed due to being incompatible with Blender 4 and unmaintained.
+
+- `python3Packages.jaeger-client` was removed because it was deprecated upstream. [OpenTelemetry](https://opentelemetry.io) is the recommended replacement.
+
+- `nodePackages.meshcommander` has been removed, as the package was deprecated by Intel.
+
+- The default version of `z3` has been updated from 4.8 to 4.13. There are still a few packages that need specific older versions; those will continue to be maintained as long as other packages depend on them but may be removed in the future.
+
+- `prometheus` has been updated from 2.55.0 to 3.1.0.
+  Read the [release blog post](https://prometheus.io/blog/2024/11/14/prometheus-3-0/) and
+  [migration guide](https://prometheus.io/docs/prometheus/3.1/migration/).
+
+- `kanata` was updated to v1.8.0, which introduces several breaking changes.
+  See the release notes of
+  [v1.7.0](https://github.com/jtroo/kanata/releases/tag/v1.7.0) and
+  [v1.8.0](https://github.com/jtroo/kanata/releases/tag/v1.8.0)
+  for more information.
+
+- `authelia` version 4.39.0 has made changes on the default claims for ID Tokens, to mirror the standard claims from the specification.
+  This change may affect some clients in unexpected ways, so manual intervention may be required.
+  Read the [release notes](https://www.authelia.com/blog/4.39-release-notes/), along with [the guide](https://www.authelia.com/integration/openid-connect/openid-connect-1.0-claims/#restore-functionality-prior-to-claims-parameter) to work around issues that may be encountered.
+
+- `ags` was updated to v2, which is just a CLI for Astal now. Components are available as a different package set `astal.*`.
+  If you want to use v1, it is available as `ags_1` package.
+
+  See the release notes of
+  [v2.0.0](https://github.com/Aylur/ags/releases/tag/v2.0.0)
+  for more information.
+
+- `nodePackages.expo-cli` has been removed, as it was deprecated by upstream. The suggested replacement is the `npx expo` command.
+
+- `open-policy-agent` has has been updated to 1.0.0+.
+  This major release makes the `rego.v1` syntax the default.
+  This is a breaking change for those using v0 Rego.
+  See the [upgrade documentation](https://www.openpolicyagent.org/docs/v1.0.1/v0-upgrade/) for more details.
+  For those unable to upgrade yet, there is a [v0 compatibility mode](https://www.openpolicyagent.org/docs/v1.0.1/v0-compatibility/)
+  available too.
+
+- `vscode-utils.buildVscodeExtension` now requires pname as an argument
+
+- `nerdfonts` has been separated into individual font packages under the namespace `nerd-fonts`. The directories for font
+  files have changed from `$out/share/fonts/{opentype,truetype}/NerdFonts` to
+  `$out/share/fonts/{opentype,truetype}/NerdFonts/<fontDirName>`, where `<fontDirName>` can be found in the
+  [official website](https://www.nerdfonts.com/font-downloads) as the titles in preview images, with the "Nerd Font"
+  suffix and any whitespaces trimmed. Configuration changes are required, see build output.
+
+- `retroarch` has been refactored and the older `retroarch.override { cores = [ ... ]; }` to create a RetroArch derivation with custom cores doesn't work anymore, use `retroarch.withCores (cores: [ ... ])` instead. If you need more customization (e.g.: custom settings), use `wrapRetroArch` instead.
+
+- `borgmatic` has been updated from 1.8.14 to 1.9.5, please check the [upstream changelog](https://projects.torsion.org/borgmatic-collective/borgmatic/releases) for more details, especially for a few possibly breaking changes noted in the [1.9.0 changelog](https://projects.torsion.org/borgmatic-collective/borgmatic/releases/tag/1.9.0).
+
+- `nodePackages.ganache` has been removed, as the package has been deprecated by upstream.
+
+- `matomo` now defaults to version 5 (previously available as `matomo_5`). Version 4 has been removed as it reached EOL on December 19, 2024.
+
+- `matomo-beta` has been removed as the version of the `matomo` package can now be easily overridden through `overrideAttrs` (see [PR #374022](https://github.com/NixOS/nixpkgs/pull/374022))
+
+- `docker_24` has been removed, as it was EOL with vulnerabilities since June 08, 2024.
+
+- Emacs 28 and 29 have been removed.
+
+- `containerd` has been updated to v2, which contains breaking changes. See the [containerd
+  2.0](https://github.com/containerd/containerd/blob/main/docs/containerd-2.0.md) documentation for more
+  details.
+
+- `nodePackages.stackdriver-statsd-backend` has been removed, as the StackDriver service has been discontinued by Google, and therefore the package no longer works.
+
+- `python3Packages.opentracing` has been removed due to being unmaintained upstream. [OpenTelemetry](https://opentelemetry.io/) is the recommended replacement.
+
+- the notmuch vim plugin now lives in a separate output of the `notmuch`
+  package. Installing `notmuch` will not bring the notmuch vim package anymore,
+  add `vimPlugins.notmuch-vim` to your (Neo)vim configuration if you want the
+  vim plugin.
+
+- `prisma` and `prisma-engines` have been updated to version 6.3.0, which
+  introduces several breaking changes. See the
+  [Prisma ORM upgrade guide](https://www.prisma.io/docs/orm/more/upgrade-guides/upgrading-versions/upgrading-to-prisma-6)
+  for more information.
+
+- `depdendency-track` no longer bundes the UI inside the jar. This bundling
+  functionality is deprecated by upstream and causes UI assets not being served
+  after weeks of runtime.
+
+- `nq` was updated to 1.0, which renames the `fq` and `tq` utilities to `nqtail` and `nqterm` respectively.
+
+- `zf` was updated to 0.10.2, which includes breaking changes from the [0.10.0 release](https://github.com/natecraddock/zf/releases/tag/0.10.0).
+  `zf` no longer does Unicode normalization of the input and no longer supports terminal escape sequences in the `ZF_PROMPT` environment variable.
+
+- `confluent-cli` was updated from 3.60.0 to 4.16.0, which includes several breaking changes as detailed in [Confluent's release notes](https://docs.confluent.io/confluent-cli/current/release-notes.html).
+
+- `siduck76-st` has been renamed to `st-snazzy`, like the project's [flake](https://github.com/siduck/st/blob/main/flake.nix).
+
+- `python3Packages.jax` now directly depends on `python3Packages.jaxlib`.
+  As a result, packages that depend on jax no longer need to include jaxlib to their dependencies.
+  There is also a breaking change in the handling of CUDA. Instead of using a CUDA compatible jaxlib
+  as before, you can use plugins like `python3Packages.jax-cuda12-plugin`.
+
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
 
-### Titanium removed {#sec-nixpkgs-release-25.05-incompatibilities-titanium-removed}
+## Other Notable Changes {#sec-nixpkgs-release-25.05-notable-changes}
 
-- `titaniumenv`, `titanium`, and `titanium-alloy` have been removed due to lack of maintenance in Nixpkgs.
+- `titaniumenv`, `titanium`, and `titanium-alloy` have been removed due to lack of maintenance in Nixpkgs []{#sec-nixpkgs-release-25.05-incompatibilities-titanium-removed}.
+
+- `gerbera` now has wavpack support.
+
+- GOverlay has been updated to 1.2, please check the [upstream changelog](https://github.com/benjamimgois/goverlay/releases) for more details.
+
+- For matrix homeserver Synapse we are now following the upstream recommendation to enable jemalloc as the memory allocator by default.
+
+- In `dovecot` package removed hard coding path to module directory.
+
+- `ddclient` was updated from 3.11.2 to 4.0.0 [Release notes](https://github.com/ddclient/ddclient/releases/tag/v4.0.0)
 
 ### NexusMods.App upgraded {#sec-nixpkgs-release-25.05-incompatibilities-nexusmods-app-upgraded}
 

--- a/nixos/doc/manual/redirects.json
+++ b/nixos/doc/manual/redirects.json
@@ -1949,6 +1949,12 @@
   "sec-nixpkgs-release-25.05-lib-additions-improvements": [
     "release-notes.html#sec-nixpkgs-release-25.05-lib-additions-improvements"
   ],
+  "sec-nixpkgs-release-25.05-highlights": [
+    "release-notes.html#sec-nixpkgs-release-25.05-highlights"
+  ],
+  "sec-nixpkgs-release-25.05-notable-changes": [
+    "release-notes.html#sec-nixpkgs-release-25.05-notable-changes"
+  ],
   "sec-release-24.11": [
     "release-notes.html#sec-release-24.11"
   ],

--- a/nixos/doc/manual/release-notes/rl-2505.section.md
+++ b/nixos/doc/manual/release-notes/rl-2505.section.md
@@ -1,37 +1,10 @@
-# Release 25.05 (“Warbler”, 2025.05/??) {#sec-release-25.05}
+# Nixos 25.05 (“Warbler”, 2025.05/??) {#sec-release-25.05}
 
 ## Highlights {#sec-release-25.05-highlights}
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
 
-- **This release of Nixpkgs requires macOS Big Sur 11.3 or newer, as announced in the 24.11 release notes.**
-  We cannot guarantee that packages will continue to work on older versions of macOS.
-  Future Nixpkgs releases will only support [macOS versions supported by Apple](https://endoflife.date/macos); this means that **Nixpkgs 25.11 will require macOS Sonoma 14 or newer**.
-  Users on old macOS versions should consider upgrading to a supported version (potentially using [OpenCore Legacy Patcher](https://dortania.github.io/OpenCore-Legacy-Patcher/) for old hardware) or installing NixOS.
-  If neither of those options are viable and you require new versions of software, [MacPorts](https://www.macports.org/) supports versions back to Mac OS X Snow Leopard 10.6.
-
 - Initial support for the [COSMIC DE](https://system76.com/cosmic), a Rust-based desktop environment by System76, makers of Pop!_OS. Toggle the greeter (login manager) using `services.displayManager.cosmic-greeter.enable` and the DE itself with `services.desktopManager.cosmic.enable`. Mostly stable but still experimental. Please report any issues to the [COSMIC DE tracker in Nixpkgs](https://github.com/NixOS/nixpkgs/issues/259641) instead of upstream.
-
-- The default kernel package has been updated from 6.6 to 6.12. All supported kernels remain available.
-
-- GCC has been updated from GCC 13 to GCC 14.
-  This introduces some backwards‐incompatible changes; see the [upstream porting guide](https://gcc.gnu.org/gcc-14/porting_to.html) for details.
-
-- LLVM has been updated from LLVM 16 (on Darwin) and LLVM 18 (on other platforms) to LLVM 19.
-  This introduces some backwards‐incompatible changes; see the [upstream release notes](https://releases.llvm.org/) for details.
-
-- Emacs has been updated to 30.1.
-  This introduces some backwards‐incompatible changes; see the NEWS for details.
-  NEWS can been viewed from Emacs by typing `C-h n`, or by clicking `Help->Emacs News` from the menu bar.
-  It can also be browsed [online](https://git.savannah.gnu.org/cgit/emacs.git/tree/etc/NEWS?h=emacs-30).
-
-- The default PHP version has been updated to 8.4.
-
-- The default Erlang OTP version has been updated to 27.
-
-- The default Elixir version has been updated to 1.18.
-
-- `buildPythonPackage`, `buildPythonApplication` and the Python building setup hooks now support both `__structuredAttrs = true` and `__structuredAttrs = false`.
 
 - `services.dex` now restarts upon changes to the `.environmentFile` or entries in `.settings.staticClients[].secretFile` when the entry is a `path` type.
 
@@ -228,18 +201,15 @@
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
 
-- `ast-grep` remove `sg` command to prevent conflict with `sg` command from shadow-utils. If you need legacy sg command compatibility with old code, you can use `ast-grep.override { enableLegacySg = true; }`
+- `services.rippled` has been removed, as `rippled` was broken and had not been updated since 2022.
 
-- rename package `wtf` to `wtfutil`.
+- `services.rippleDataApi` has been removed, as `ripple-data-api` was broken and had not been updated since 2022.
+
+- The `nixos/modules/virtualisation/amazon-ec2-amis.nix` file is not supported anymore since 24.05. It will throw
+  and error starting 25.05 with instructions the following instructions:
+  The canonical source for NixOS AMIs is the AWS API. Please see https://nixos.org/download/#nixos-amazon or  https://nixos.github.io/amis/ for instructions.
 
 - The udev rules of the libjaylink package require users to be in the `jlink` instead of `plugdev` group now, since the `plugdev` group is very uncommon for NixOS. Alternatively, access is granted to seat sessions.
-
-- `python3Packages.beancount` was updated to 3.1.0. Previous major version remains available as `python3Packages.beancount_2`.
-
-- `wastebin` has been updated to 3.0.0. See the [Changelog](https://github.com/matze/wastebin/blob/master/CHANGELOG.md#300) for breaking changes to the configuration.
-
-- `binwalk` was updated to 3.1.0, which has been rewritten in rust. The python module is no longer available.
-  See the release notes of [3.1.0](https://github.com/ReFirmLabs/binwalk/releases/tag/v3.1.0) for more information.
 
 - The latest available version of Nextcloud is v31 (available as `pkgs.nextcloud31`). The installation logic is as follows:
   - If [`services.nextcloud.package`](#opt-services.nextcloud.package) is specified explicitly, this package will be installed (**recommended**)
@@ -247,47 +217,7 @@
   - If [`system.stateVersion`](#opt-system.stateVersion) is >=24.05, `pkgs.nextcloud31` will be installed by default.
   - Please note that an upgrade from v29 (or older) to v31 directly is not possible. Please upgrade to `nextcloud30` (or earlier) first. Nextcloud prohibits skipping major versions while upgrading. You can upgrade by declaring [`services.nextcloud.package = pkgs.nextcloud30;`](options.html#opt-services.nextcloud.package).
 
-- `pkgs.nextcloud28` has been removed since it's out of support upstream.
-
-- `teleport` has been upgraded from major version 16 to major version 17.
-  Refer to [upstream upgrade instructions](https://goteleport.com/docs/upgrading/overview/)
-  and [release notes for v17](https://goteleport.com/docs/changelog/#1701-11152024).
-
 - `services.cloudflare-dyndns.apiTokenFile` now must be just your Cloudflare api token. Previously it was supposed to be a file of the form `CLOUDFLARE_API_TOKEN=...`.
-
-- Emacs lisp build helpers, such as `emacs.pkgs.melpaBuild`, now enables `__structuredAttrs` by default.
-  Environment variables have to be passed via the `env` attribute.
-
-- `buildGoModule` now passes environment variables via the `env` attribute. `CGO_ENABLED` should now be specified with `env.CGO_ENABLED` when passing to buildGoModule. Direct specification of `CGO_ENABLED` is now redirected by a compatibility layer with a warning, but will become an error in future releases.
-
-  Go-related environment variables previously shadowed by `buildGoModule` now results in errors when specified directly. Such variables include `GOOS` and `GOARCH`.
-
-  Third-party projects supporting both stable and unstable channels could detect this change through the absence of the `CGO_ENABLED` function argument in `buildGoModule` (`!((lib.functionArgs buildGoModule) ? CGO_ENABLED)`).
-
-- `buildGoPackage` has been removed. Use `buildGoModule` instead. See the [Go section in the nixpkgs manual](https://nixos.org/manual/nixpkgs/unstable/#sec-language-go) for details.
-
-- top-level `playwright` now refers to the github Microsoft/playwright package
-  instead of the python tester launcher. You can still refer to the python
-  launcher via `python3Packages.toPythonApplication python3Packages.playwright`
-
-- The representation of the flags attributes as shell/environment variables for most Python building setup hooks are now the same as `stdenv.mkDerivation` and other build helpers -- they are space-separated environment variables when `__structuredAttrs = false` and Bash arrays when `__structuredAttrs = true`, and are concatenated to the command without Bash-evaluation. The following behaviour changes are introduced during the conversion:
-
-  - The following flags are no longer Bash-expanded before concatenated to the command:
-    - `disabledTests` and `disabledTestPaths` for `pytestCheckHook`. (`disabledTestPaths` used to be expanded twice before concatenation.)
-    - `setupPyBuildFlags` and `setupPyGlobalFlags` for `setuptoolsBuildHook`.
-
-  - `pytestFlags` and `unittestFlags` replace `pytestFlagsArray` and `unittestFlagsArray` and become the new and conforming interface.
-
-  - `pytestFlagsArray` and `unittestFlagsArray` are kept for compatibility purposes. They continue to be Bash-expanded before concatenated. This compatibility layer will be removed in future releases.
-
-- The `haka` package and module has been removed because the package was broken and unmaintained for 9 years.
-
-- `strawberry` has been updated to 1.2, which drops support for the VLC backend and Qt 5. The `strawberry-qt5` package
-  and `withGstreamer`/`withVlc` override options have been removed due to this.
-
-- `nezha` and its agent `nezha-agent` have been updated to v1, which contains breaking changes. See the [official wiki](https://nezha.wiki/en_US/) for more details.
-
-- `ps3-disc-dumper` was updated to 4.2.5, which removed the CLI project and now exclusively offers the GUI
 
 - [](#opt-services.nextcloud.config.dbtype) is unset by default, the previous default was `sqlite`.
   This was done because `sqlite` is not a reasonable default since it's
@@ -304,13 +234,6 @@
 - `services.paperless` now installs `paperless-manage` as a normal system package instead of creating a symlink in `/var/lib/paperless`.
   `paperless-manage` now also changes to the appropriate user when being executed.
 
-- `kmonad` is now hardened by default using common `systemd` settings.
-  If KMonad is used to execute shell commands, hardening may make some of them fail.  In that case, you can disable hardening using {option}`services.kmonad.keyboards.<name>.enableHardening` option.
-
-- `isd` was updated from 0.2.0 to 0.5.1, the new version may crash with a previously generated config, try moving or deleting `~/.config/isd/schema.json`.
-
-- `uwsgi` no longer supports Python 2 plugins.
-
 - `asusd` has been upgraded to version 6 which supports multiple aura devices. To account for this, the single `auraConfig` configuration option has been replaced with `auraConfigs` which is an attribute set of config options per each device. The config files may also be now specified as either source files or text strings; to account for this you will need to specify that `text` is used for your existing configs, e.g.:
   ```diff
   -services.asusd.asusdConfig = '''file contents'''
@@ -323,17 +246,9 @@
     After you run ALTER EXTENSION, you must run [this SQL script](https://github.com/timescale/timescaledb-extras/blob/master/utils/2.15.X-fix_hypertable_foreign_keys.sql). For more details, see the following pull requests [#6797](https://github.com/timescale/timescaledb/pull/6797).
     PostgreSQL 13 is no longer supported in TimescaleDB v2.16.
 
-- Support for CUDA 10 has been dropped, as announced in the 24.11 release notes.
-
 - `virtualisation/azure-common.nix`'s filesystem and grub configurations have been moved to `virtualisation/azure-image.nix`. This makes `azure-common.nix` more generic so it could be used for users who generate Azure image using other methods (e.g. nixos-generators and disko). For existing users depending on these configurations, please also import `azure-image.nix`.
 
 - `zammad` has had its support for MySQL removed, since it was never working correctly and is now deprecated upstream. Check the [migration guide](https://docs.zammad.org/en/latest/appendix/migrate-to-postgresql.html) for how to convert your database to PostgreSQL.
-
-- `mepo` was updated to version 1.3.3.  The manual page was removed,
-  a new JSON API was introduced to replace Mepolang for configuration,
-  and a few default key bindings were changed.
-  See the [1.3.0 changelog](https://git.sr.ht/~mil/mepo/refs/1.3.0)
-  for more details.
 
 - `tauon` 7.9.0+ when launched for the first time, migrates its database to a new schema that is not backwards compatible. Older versions will refuse to start at all with that database afterwards. If you need to still use older tauon versions, make sure to back up `~/.local/share/TauonMusicBox`.
 
@@ -346,125 +261,26 @@
   word-breaking. So you want to write `extraArgs = [ "--prefer" "spaced pat" ]`
   rather than previous `extraArgs = [ "--prefer 'spaced pat'" ]`.
 
-- `mkBinaryCache` now defaults to using `zstd` compression for the binary caches it creates. The previous `xz` compression method can be used by passing `compression = "xz";`.
-
-- `nodePackages."@commitlint/config-conventional"` has been removed, as it is a library, and projects should depend on it instead.
-
--  zigbee2mqtt is now available in version 2.x as `zigbee2mqtt_2`. In NixOS 25.11 we'll remove `zigbee2mqtt_1` and default to `zigbee2mqtt_2`. See the [breaking changes](https://github.com/Koenkk/zigbee2mqtt/discussions/24198) announcement for 2.0.0.
-
-- `nodePackages.vls` has been deprecated, as the upstream consumer of it, vetur, has been deprecated by upstream. Upstream suggests migrating to Volar for Vue LSP tooling instead.
-
-- `nodePackages.create-react-native-app` has been removed, as it is deprecated. Upstream suggests using a framework for React Native apps instead.
-
-- `nodePackages.insect` has been removed, as it's deprecated by upstream. The suggested replacement is `numbat`.
-
-- `nodePackages.webpack-dev-server` has been removed, as it should be installed in projects that use it instead.
-
-- `nodePackages.copy-webpack-plugin` has been removed, as it should be installed in projects that use it instead.
-
-- `himalaya` has been updated from `v1.0.0-beta.4` to `v1.1.0`, which introduces breaking changes. Check out the [release notes](https://github.com/pimalaya/himalaya/releases) for details.
-
-- `linuxPackages.nvidiaPackages.dc_520` has been removed since it is marked broken and there are better newer alternatives.
-
-- `pnpm` was updated to version 10. If your project is incompatible, you can install the previous version from the package attribute `pnpm_9`.
-
-- `zig_0_9` and `zig_0_10` have been removed, you should upgrade to `zig_0_13` (also available as just `zig`), `zig_0_12` or `zig_0_11` instead.
-
-- `webpack-cli` was updated to major version 6, which has breaking changes from the previous version 5.1.4. See the [upstream release notes](https://github.com/webpack/webpack-cli/releases/tag/webpack-cli%406.0.0) for details on these changes.
-
 - `programs.less.lessopen` is now null by default. To restore the previous behaviour, set it to `''|${lib.getExe' pkgs.lesspipe "lesspipe.sh"} %s''`.
 
 - `hardware.pulseaudio` has been renamed to `services.pulseaudio`.  The deprecated option names will continue to work, but causes a warning.
 
 - `services.nextcloud` now uses systemd's credential mechanism to read in secret files. The `nextcloud-occ` wrapper script implements this using `systemd-run`, as such it now also requires root privileges or `$CREDENTIALS_DIRECTORY` set where running it as user `nextcloud` was enough previously.
 
-- `minetest` has been renamed to `luanti` to match the upstream name change but aliases have been added. The new name hasn't resulted in many changes as of yet but older references to minetest should be sunset. See the [new name announcement](https://blog.minetest.net/2024/10/13/Introducing-Our-New-Name/) for more details.
-
-- `poac` has been renamed to `cabinpkg` to match the upstream name change but an alias has been added. See the [new name announcement](https://github.com/orgs/cabinpkg/discussions/1052) for more details.
-
-- `serious-sans` has been removed because upstream changed its name to Serious Shanns, which is not currently packaged.
-
-- `racket_7_9` has been removed, as it is insecure. It is recommended to use Racket 8 instead.
-
 - `services.mongodb.initialRootPassword` has been replaced with the more secure option [`services.mongodb.initialRootPasswordFile`](#opt-services.mongodb.initialRootPasswordFile)
 
-- `rofi` has been updated from 1.7.5 to 1.7.6 which introduces some breaking changes to binary plugins, and also contains a lot of new features and bug fixes. This is highlighted because the patch version bump does not indicate the volume of changes by itself. See the [upstream release notes](https://github.com/davatorium/rofi/releases/tag/1.7.6) for the full list of changes.
-
-- `ente-auth` now uses the name `enteauth` for its binary. The previous name was `ente_auth`.
-
-- `foundationdb` was upgraded to 7.3.
-
-- `fluxus` has been removed, as it depends on `racket_7_9` and had no updates in 9 years.
-
-- `sm64ex-coop` has been removed as it was archived upstream. Consider migrating to `sm64coopdx`.
-
-- `tldr` now uses [`tldr-python-client`](https://github.com/tldr-pages/tldr-python-client) instead of [`tldr-c-client`](https://github.com/tldr-pages/tldr-c-client) which is unmaintained.
-
 - `services.bird2` has been renamed to `services.bird` and the default bird package has been switched to `bird3`. `bird2` can still be chosen via the `services.bird.package` option.
-
-- `renovate` was updated to v39. See the [upstream release notes](https://docs.renovatebot.com/release-notes-for-major-versions/#version-39) for breaking changes.
-  Like upstream's docker images, renovate now runs on NodeJS 22.
-
-- The behavior of the `networking.nat.externalIP` and `networking.nat.externalIPv6` options has been changed. `networking.nat.forwardPorts` now only forwards packets destined for the specified IP addresses.
-
-- `python3Packages.bpycv` has been removed due to being incompatible with Blender 4 and unmaintained.
-
-- `python3Packages.jaeger-client` was removed because it was deprecated upstream. [OpenTelemetry](https://opentelemetry.io) is the recommended replacement.
-
-- `nodePackages.meshcommander` has been removed, as the package was deprecated by Intel.
-
-- The default version of `z3` has been updated from 4.8 to 4.13. There are still a few packages that need specific older versions; those will continue to be maintained as long as other packages depend on them but may be removed in the future.
-
-- `prometheus` has been updated from 2.55.0 to 3.1.0.
-  Read the [release blog post](https://prometheus.io/blog/2024/11/14/prometheus-3-0/) and
-  [migration guide](https://prometheus.io/docs/prometheus/3.1/migration/).
-
-- `kanata` was updated to v1.8.0, which introduces several breaking changes.
-  See the release notes of
-  [v1.7.0](https://github.com/jtroo/kanata/releases/tag/v1.7.0) and
-  [v1.8.0](https://github.com/jtroo/kanata/releases/tag/v1.8.0)
-  for more information.
-
-- `authelia` version 4.39.0 has made changes on the default claims for ID Tokens, to mirror the standard claims from the specification.
-  This change may affect some clients in unexpected ways, so manual intervention may be required.
-  Read the [release notes](https://www.authelia.com/blog/4.39-release-notes/), along with [the guide](https://www.authelia.com/integration/openid-connect/openid-connect-1.0-claims/#restore-functionality-prior-to-claims-parameter) to work around issues that may be encountered.
-
-- `ags` was updated to v2, which is just a CLI for Astal now. Components are available as a different package set `astal.*`.
-  If you want to use v1, it is available as `ags_1` package.
-
-  See the release notes of
-  [v2.0.0](https://github.com/Aylur/ags/releases/tag/v2.0.0)
-  for more information.
-
-- `nodePackages.expo-cli` has been removed, as it was deprecated by upstream. The suggested replacement is the `npx expo` command.
 
 - DokuWiki with the Caddy webserver (`services.dokuwiki.webserver = "caddy"`) now sets up sites with Caddy's automatic HTTPS instead of HTTP-only.
   To keep the old behavior for a site `example.com`, set `services.caddy.virtualHosts."example.com".hostName = "http://example.com"`.
   If you set custom Caddy options for a DokuWiki site, migrate these options by removing `http://` from `services.caddy.virtualHosts."http://example.com"`.
 
-- `open-policy-agent` has has been updated to 1.0.0+.
-  This major release makes the `rego.v1` syntax the default.
-  This is a breaking change for those using v0 Rego.
-  See the [upgrade documentation](https://www.openpolicyagent.org/docs/v1.0.1/v0-upgrade/) for more details.
-  For those unable to upgrade yet, there is a [v0 compatibility mode](https://www.openpolicyagent.org/docs/v1.0.1/v0-compatibility/)
-  available too.
-
 - Wordpress with the Caddy webserver (`services.wordpress.webserver = "caddy"`) now sets up sites with Caddy's automatic HTTPS instead of HTTP-only.
   Given a site example.com, http://example.com now 301 redirects to https://example.com.
   To keep the old behavior for a site `example.com`, set `services.caddy.virtualHosts."example.com".hostName = "http://example.com"`.
 
-- `vscode-utils.buildVscodeExtension` now requires pname as an argument
-
 - The behavior of `services.hostapd.radios.<name>.networks.<name>.authentication.enableRecommendedPairwiseCiphers` was changed to not include `CCMP-256` anymore.
   Since all configured pairwise ciphers have to be supported by the radio, this caused startup failures on many devices which is hard to debug in hostapd.
-
-- `nerdfonts` has been separated into individual font packages under the namespace `nerd-fonts`. The directories for font
-  files have changed from `$out/share/fonts/{opentype,truetype}/NerdFonts` to
-  `$out/share/fonts/{opentype,truetype}/NerdFonts/<fontDirName>`, where `<fontDirName>` can be found in the
-  [official website](https://www.nerdfonts.com/font-downloads) as the titles in preview images, with the "Nerd Font"
-  suffix and any whitespaces trimmed. Configuration changes are required, see build output.
-
-- `retroarch` has been refactored and the older `retroarch.override { cores = [ ... ]; }` to create a RetroArch derivation with custom cores doesn't work anymore, use `retroarch.withCores (cores: [ ... ])` instead. If you need more customization (e.g.: custom settings), use `wrapRetroArch` instead.
 
 - `gkraken` software and `hardware.gkraken.enable` option have been removed, use `coolercontrol` via `programs.coolercontrol.enable` option instead.
 
@@ -484,33 +300,13 @@
   +extraCreateArgs+=("--exclude" "/some/path")
   ```
 
-- `borgmatic` has been updated from 1.8.14 to 1.9.5, please check the [upstream changelog](https://projects.torsion.org/borgmatic-collective/borgmatic/releases) for more details, especially for a few possibly breaking changes noted in the [1.9.0 changelog](https://projects.torsion.org/borgmatic-collective/borgmatic/releases/tag/1.9.0).
-
 - `programs.xonsh.package` now gets overrided internally with `extraPackages` to support `programs.xonsh.extraPackages`. See `programs.xonsh.extraPackages` for more details.
-
-- `nodePackages.ganache` has been removed, as the package has been deprecated by upstream.
 
 - `services.nitter.guestAccounts` has been renamed to `services.nitter.sessionsFile`, for consistency with upstream. The file format is unchanged.
 
 - `virtualisation.azure.agent` option provided by `azure-agent.nix` is replaced by `services.waagent`, and will be removed in a future release.
 
-- `matomo` now defaults to version 5 (previously available as `matomo_5`). Version 4 has been removed as it reached EOL on December 19, 2024.
-
-- `matomo-beta` has been removed as the version of the `matomo` package can now be easily overridden through `overrideAttrs` (see [PR #374022](https://github.com/NixOS/nixpkgs/pull/374022))
-
-- `docker_24` has been removed, as it was EOL with vulnerabilities since June 08, 2024.
-
-- Emacs 28 and 29 have been removed.
-
-- `containerd` has been updated to v2, which contains breaking changes. See the [containerd
-  2.0](https://github.com/containerd/containerd/blob/main/docs/containerd-2.0.md) documentation for more
-  details.
-
 - The ZFS import service now respects `fileSystems.*.options = [ "noauto" ];` and does not add that pool's import service to `zfs-import.target`, meaning it will not be automatically imported at boot.
-
-- `nodePackages.stackdriver-statsd-backend` has been removed, as the StackDriver service has been discontinued by Google, and therefore the package no longer works.
-
-- `python3Packages.opentracing` has been removed due to being unmaintained upstream. [OpenTelemetry](https://opentelemetry.io/) is the recommended replacement.
 
 - Default file names of images generated by several builders in `system.build` have been changed as outlined in the table below.
 
@@ -543,39 +339,8 @@
 - `services.graylog.package` now defaults to `graylog-6_0` as previous default `graylog-5_1` is EOL and therefore removed.
   Check the migration guides on [5.1→5.2](https://go2docs.graylog.org/5-2/upgrading_graylog/upgrading_to_graylog_5.2.x.htm) and [5.2→6.0](https://go2docs.graylog.org/6-0/upgrading_graylog/upgrading_to_graylog_6.0.x.html) for breaking changes.
 
-- the notmuch vim plugin now lives in a separate output of the `notmuch`
-  package. Installing `notmuch` will not bring the notmuch vim package anymore,
-  add `vimPlugins.notmuch-vim` to your (Neo)vim configuration if you want the
-  vim plugin.
-
-- `prisma` and `prisma-engines` have been updated to version 6.3.0, which
-  introduces several breaking changes. See the
-  [Prisma ORM upgrade guide](https://www.prisma.io/docs/orm/more/upgrade-guides/upgrading-versions/upgrading-to-prisma-6)
-  for more information.
-
-- `depdendency-track` no longer bundes the UI inside the jar. This bundling
-  functionality is deprecated by upstream and causes UI assets not being served
-  after weeks of runtime.
-
-- `nq` was updated to 1.0, which renames the `fq` and `tq` utilities to `nqtail` and `nqterm` respectively.
-
-- `zf` was updated to 0.10.2, which includes breaking changes from the [0.10.0 release](https://github.com/natecraddock/zf/releases/tag/0.10.0).
-  `zf` no longer does Unicode normalization of the input and no longer supports terminal escape sequences in the `ZF_PROMPT` environment variable.
 
 - `programs.clash-verge.tunMode` was deprecated and removed because now service mode is necessary to start program. Without `programs.clash-verge.enable`, clash-verge-rev will refuse to start.
-
-- `confluent-cli` was updated from 3.60.0 to 4.16.0, which includes several breaking changes as detailed in [Confluent's release notes](https://docs.confluent.io/confluent-cli/current/release-notes.html).
-
-- `siduck76-st` has been renamed to `st-snazzy`, like the project's [flake](https://github.com/siduck/st/blob/main/flake.nix).
-
-- `python3Packages.jax` now directly depends on `python3Packages.jaxlib`.
-  As a result, packages that depend on jax no longer need to include jaxlib to their dependencies.
-  There is also a breaking change in the handling of CUDA. Instead of using a CUDA compatible jaxlib
-  as before, you can use plugins like `python3Packages.jax-cuda12-plugin`.
-
-- `services.rippled` has been removed, as `rippled` was broken and had not been updated since 2022.
-
-- `services.rippleDataApi` has been removed, as `ripple-data-api` was broken and had not been updated since 2022.
 
 - `services.netbird.tunnels` was renamed to [`services.netbird.clients`](#opt-services.netbird.clients),
   hardened (using dedicated less-privileged users) and significantly extended.
@@ -604,7 +369,6 @@
 
 - [`system.stateVersion`](#opt-system.stateVersion) is now validated and must be in the `"YY.MM"` format, ideally corresponding to a prior NixOS release.
 
-- GOverlay has been updated to 1.2, please check the [upstream changelog](https://github.com/benjamimgois/goverlay/releases) for more details.
 
 - [`services.geoclue2`](#opt-services.geoclue2.enable) now has an `enableStatic` option, which allows the NixOS configuration to specify a fixed location for GeoClue to use.
 
@@ -629,10 +393,6 @@
 - `services.cloudflared` now uses a dynamic user, and its `user` and `group` options have been removed. If the user or group is still necessary, they can be created manually.
 
 - The Home Assistant module has new options {option}`services.home-assistant.blueprints.automation`, `services.home-assistant.blueprints.script`, and {option}`services.home-assistant.blueprints.template` that allow for the declarative installation of [blueprints](https://www.home-assistant.io/docs/blueprint/) into the appropriate configuration directories.
-
-- For matrix homeserver Synapse we are now following the upstream recommendation to enable jemalloc as the memory allocator by default.
-
-- In `dovecot` package removed hard coding path to module directory.
 
 - `services.dovecot2.modules` have been removed, now need to use `environment.systemPackages` to load additional Dovecot modules.
 
@@ -692,11 +452,7 @@
 
 - `programs.fzf.keybindings` now supports the fish shell.
 
-- `gerbera` now has wavpack support.
-
 - A toggle has been added under `users.users.<name>.enable` to allow toggling individual users conditionally. If set to false, the user account will not be created.
-
-- `ddclient` was updated from 3.11.2 to 4.0.0 [Release notes](https://github.com/ddclient/ddclient/releases/tag/v4.0.0)
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
 


### PR DESCRIPTION
As agreed with @fricklerhandwerk, I’m opening a new PR to replace the previous one: [#371930](https://github.com/NixOS/nixpkgs/pull/371930).

- Due to significant changes in the involved files, I started from scratch.
- I updated the redirect files to fix the CI.
- Since I handled the split myself, please let me know if the separation between nixpkgs and nixos is correct.

Todo(s) address this comment:
- [ ] https://github.com/NixOS/nixpkgs/pull/371930#discussion_r1993797372

Initial message from @fricklerhandwerk :
the initial change was already made ad hoc in 10a75ab, in response to the recently introduced enforced redirects mapping that is supposed to keep stable URLs.

due to the redirect mechanism's current limitation to locations within the same site (that is, either the Nixpkgs xor the NixOS manual), and the observation that noteworthy Nixpkgs changes tend to be self-contained, it seemed reasonable to introduce a seperate release notes document. it also has the advantage that users of only Nixpkgs don't have to deal with release notes that are only relevant for NixOS.

the original change was already lossless for NixOS users, since the Nixpkgs release notes are appended to the NixOS release notes.

this change moves the pre-existing Nixpkgs notes to the new dedicated page.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
