### PR TITLE
pulumi: 3.156.0 -> 3.162.0

### DIFF
--- a/pkgs/by-name/pu/pulumi/package.nix
+++ b/pkgs/by-name/pu/pulumi/package.nix
@@ -72,6 +72,10 @@ buildGoModule rec {
         "TestGenerateOnlyProjectCheck"
         "TestPulumiNewSetsTemplateTag"
         "TestPulumiPromptRuntimeOptions"
+        "TestPulumiNewOrgTemplate"
+        "TestPulumiNewWithOrgTemplates"
+        "TestPulumiNewWithoutPulumiAccessToken"
+        "TestPulumiNewWithoutTemplateSupport"
 
         # Connects to https://pulumi-testing.vault.azure.net/…
         "TestAzureCloudManager"

--- a/pkgs/by-name/pu/pulumi/package.nix
+++ b/pkgs/by-name/pu/pulumi/package.nix
@@ -17,18 +17,18 @@
 }:
 buildGoModule rec {
   pname = "pulumi";
-  version = "3.156.0";
+  version = "3.162.0";
 
   src = fetchFromGitHub {
     owner = "pulumi";
     repo = "pulumi";
     tag = "v${version}";
-    hash = "sha256-1iML+WCEkLMdAJ7e+F5XwBzM+pn3eZQsCaSi3Ui/JdM=";
+    hash = "sha256-avtqURmj3PL82j89kLmVsBWqJJHnOFqR1huoUESt4L4=";
     # Some tests rely on checkout directory name
     name = "pulumi";
   };
 
-  vendorHash = "sha256-2hpn1IKJvWtXgNKgf56dZABA4VO1aT0cDsHOmCEPrGo=";
+  vendorHash = "sha256-fJFpwhbRkxSI2iQfNJ9qdL9oYM1SVVMJ30VIymoZBmg=";
 
   sourceRoot = "${src.name}/pkg";
 

--- a/pkgs/by-name/pu/pulumi/package.nix
+++ b/pkgs/by-name/pu/pulumi/package.nix
@@ -10,6 +10,7 @@
   callPackage,
   testers,
   pulumi,
+  python3Packages,
   nix-update-script,
   _experimental-update-script-combinators,
 }:
@@ -140,6 +141,16 @@ buildGoModule rec {
         version = "v${version}";
         command = "PULUMI_SKIP_UPDATE_CHECK=1 pulumi version";
       };
+      # Pulumi currently requires protobuf4, but Nixpkgs defaults to a newer
+      # version. Test that we can actually build the package with protobuf4.
+      # https://github.com/pulumi/pulumi/issues/16828
+      # https://github.com/NixOS/nixpkgs/issues/351751#issuecomment-2462163436
+      pythonPackage =
+        (python3Packages.overrideScope (
+          final: _: {
+            protobuf = final.protobuf4;
+          }
+        )).pulumi;
       pulumiTestHookShellcheck = testers.shellcheck {
         name = "pulumi-test-hook-shellcheck";
         src = ./extra/pulumi-test-hook.sh;

--- a/pkgs/by-name/pu/pulumi/package.nix
+++ b/pkgs/by-name/pu/pulumi/package.nix
@@ -60,6 +60,11 @@ buildGoModule rec {
     # Skip tests that fail in Nix sandbox.
     "-skip=^${
       lib.concatStringsSep "$|^" [
+        # Concurrent map modification in test case.
+        # TODO: remove after the fix is merged and released.
+        # https://github.com/pulumi/pulumi/pull/19200
+        "TestGetDocLinkForPulumiType"
+
         # Seems to require TTY.
         "TestProgressEvents"
 

--- a/pkgs/by-name/pu/pulumi/package.nix
+++ b/pkgs/by-name/pu/pulumi/package.nix
@@ -10,6 +10,8 @@
   callPackage,
   testers,
   pulumi,
+  nix-update-script,
+  _experimental-update-script-combinators,
 }:
 buildGoModule rec {
   pname = "pulumi";
@@ -117,6 +119,21 @@ buildGoModule rec {
   passthru = {
     pkgs = callPackage ./plugins.nix { };
     withPackages = callPackage ./with-packages.nix { };
+    updateScript = _experimental-update-script-combinators.sequence [
+      (nix-update-script { })
+      (nix-update-script {
+        attrPath = "pulumiPackages.pulumi-go";
+        extraArgs = [ "--version=skip" ];
+      })
+      (nix-update-script {
+        attrPath = "pulumiPackages.pulumi-nodejs";
+        extraArgs = [ "--version=skip" ];
+      })
+      (nix-update-script {
+        attrPath = "pulumiPackages.pulumi-python";
+        extraArgs = [ "--version=skip" ];
+      })
+    ];
     tests = {
       version = testers.testVersion {
         package = pulumi;

--- a/pkgs/by-name/pu/pulumi/package.nix
+++ b/pkgs/by-name/pu/pulumi/package.nix
@@ -10,6 +10,7 @@
   callPackage,
   testers,
   pulumi,
+  pulumiPackages,
   python3Packages,
   nix-update-script,
   _experimental-update-script-combinators,
@@ -141,6 +142,8 @@ buildGoModule rec {
         version = "v${version}";
         command = "PULUMI_SKIP_UPDATE_CHECK=1 pulumi version";
       };
+      # Test building packages that reuse our version and src.
+      inherit (pulumiPackages) pulumi-go pulumi-nodejs pulumi-python;
       # Pulumi currently requires protobuf4, but Nixpkgs defaults to a newer
       # version. Test that we can actually build the package with protobuf4.
       # https://github.com/pulumi/pulumi/issues/16828

--- a/pkgs/by-name/pu/pulumi/plugins/pulumi-go/package.nix
+++ b/pkgs/by-name/pu/pulumi/plugins/pulumi-go/package.nix
@@ -9,7 +9,7 @@ buildGoModule rec {
 
   sourceRoot = "${src.name}/sdk/go/pulumi-language-go";
 
-  vendorHash = "sha256-MqqkDuCAHsxyzcofufMSzf1TpntnMy+sNHhBY5vr+TE=";
+  vendorHash = "sha256-3I9Kh3Zqpu0gT0pQNzg2mMwxQUdhEpjITZOrO7Yt50A=";
 
   ldflags = [
     "-s"

--- a/pkgs/by-name/pu/pulumi/plugins/pulumi-nodejs/package.nix
+++ b/pkgs/by-name/pu/pulumi/plugins/pulumi-nodejs/package.nix
@@ -12,7 +12,7 @@ buildGoModule rec {
 
   sourceRoot = "${src.name}/sdk/nodejs/cmd/pulumi-language-nodejs";
 
-  vendorHash = "sha256-Blhbjc9nNj2ZDKs6uO/IZ5RuFJJTkS2wJF/7Egc7VvA=";
+  vendorHash = "sha256-UvfSmHWRFRZkmcgzUrLkqktQAt8ZlVDEzP6y+pxUOGc=";
 
   ldflags = [
     "-s"

--- a/pkgs/by-name/pu/pulumi/plugins/pulumi-python/package.nix
+++ b/pkgs/by-name/pu/pulumi/plugins/pulumi-python/package.nix
@@ -12,7 +12,7 @@ buildGoModule rec {
 
   sourceRoot = "${src.name}/sdk/python/cmd/pulumi-language-python";
 
-  vendorHash = "sha256-x3dWYM8/2cWWhTmfGEDdrGHntqIDObYwQicSHIXr1rw=";
+  vendorHash = "sha256-5tr3mQ5x6jMOa9meHK6gaoRjNgLoHkWiTiaYXXqmUDo=";
 
   ldflags = [
     "-s"

--- a/pkgs/development/python-modules/pulumi/default.nix
+++ b/pkgs/development/python-modules/pulumi/default.nix
@@ -70,9 +70,9 @@ buildPythonPackage {
   # https://github.com/pulumi/pulumi/blob/0acaf8060640fdd892abccf1ce7435cd6aae69fe/sdk/python/scripts/test_fast.sh#L16
   installCheckPhase = ''
     runHook preInstallCheck
-    ${python.executable} -m pytest --ignore=lib/test/automation lib/test
+    ${python.executable} -m pytest --junit-xml= --ignore=lib/test/automation lib/test
     pushd lib/test_with_mocks
-    ${python.executable} -m pytest
+    ${python.executable} -m pytest --junit-xml=
     popd
     runHook postInstallCheck
   '';


### PR DESCRIPTION
Updates Pulumi to 3.162.0, fixes python3Packages.pulumi build, adds dependent packages to passthru.tests to make it easier to catch breakages in automated updates for packages that reuse `src`.

https://github.com/pulumi/pulumi/compare/v3.156.0...v3.162.0

Note that Pulumi requires `protobuf4` for Python packages. Build all Pulumi packages, SDKs and tests with:
<details>

```
nix build --impure --keep-going --expr 'with import ./. {
  config.allowAliases = false;
  overlays = [
    (_: prev: {
      pythonPackagesExtensions = prev.pythonPackagesExtensions ++ [
        (final: _: {
          protobuf = final.protobuf4;
        })
      ];
    })
  ];
};
linkFarmFromDrvs "pulumi-packages" (
  lib.concatLists (
    lib.mapAttrsToList (
      n: p:
      lib.optionals (lib.isDerivation p) (
        [ p ]
        # Note: pulumi-yandex-unofficial Python SDK fails to build on master; this will be fixed in the version bump PR.
        ++ lib.optionals (n != "pulumi-yandex-unofficial") (lib.attrValues (p.sdks or { }))
        ++ lib.attrValues (p.tests or { })
      )
    ) (pulumiPackages // { inherit pulumi; })
  )
)'
```
</details>

See also #382594 and #386789

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
