### PR TITLE
xcp: clean up & enable tests

### DIFF
--- a/pkgs/by-name/xc/xcp/package.nix
+++ b/pkgs/by-name/xc/xcp/package.nix
@@ -38,6 +38,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   meta = {
     description = "Extended cp(1)";
     homepage = "https://github.com/tarka/xcp";
+    changelog = "https://github.com/tarka/xcp/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.gpl3Only;
     maintainers = with lib.maintainers; [ lom ];
     mainProgram = "xcp";

--- a/pkgs/by-name/xc/xcp/package.nix
+++ b/pkgs/by-name/xc/xcp/package.nix
@@ -2,6 +2,7 @@
   rustPlatform,
   fetchFromGitHub,
   lib,
+  nix-update-script,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
@@ -20,6 +21,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   useFetchCargoVendor = true;
   cargoHash = "sha256-9cNu0cgoo0/41daJwy/uWIXa2wFhYkcPhJfA/69DVx0=";
+
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "Extended cp(1)";

--- a/pkgs/by-name/xc/xcp/package.nix
+++ b/pkgs/by-name/xc/xcp/package.nix
@@ -13,7 +13,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   src = fetchFromGitHub {
     owner = "tarka";
     repo = "xcp";
-    rev = "v${finalAttrs.version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-TI9lveFJsb/OgGQRiPW5iuatB8dsc7yxBs1rb148nEY=";
   };
 

--- a/pkgs/by-name/xc/xcp/package.nix
+++ b/pkgs/by-name/xc/xcp/package.nix
@@ -21,11 +21,11 @@ rustPlatform.buildRustPackage (finalAttrs: {
   useFetchCargoVendor = true;
   cargoHash = "sha256-9cNu0cgoo0/41daJwy/uWIXa2wFhYkcPhJfA/69DVx0=";
 
-  meta = with lib; {
+  meta = {
     description = "Extended cp(1)";
     homepage = "https://github.com/tarka/xcp";
-    license = licenses.gpl3Only;
-    maintainers = with maintainers; [ lom ];
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ lom ];
     mainProgram = "xcp";
   };
 })

--- a/pkgs/by-name/xc/xcp/package.nix
+++ b/pkgs/by-name/xc/xcp/package.nix
@@ -4,14 +4,14 @@
   lib,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "xcp";
   version = "0.24.1";
 
   src = fetchFromGitHub {
     owner = "tarka";
     repo = "xcp";
-    rev = "v${version}";
+    rev = "v${finalAttrs.version}";
     hash = "sha256-TI9lveFJsb/OgGQRiPW5iuatB8dsc7yxBs1rb148nEY=";
   };
 
@@ -28,4 +28,4 @@ rustPlatform.buildRustPackage rec {
     maintainers = with maintainers; [ lom ];
     mainProgram = "xcp";
   };
-}
+})

--- a/pkgs/by-name/xc/xcp/package.nix
+++ b/pkgs/by-name/xc/xcp/package.nix
@@ -2,6 +2,7 @@
   rustPlatform,
   fetchFromGitHub,
   lib,
+  acl,
   nix-update-script,
 }:
 
@@ -16,11 +17,21 @@ rustPlatform.buildRustPackage (finalAttrs: {
     hash = "sha256-TI9lveFJsb/OgGQRiPW5iuatB8dsc7yxBs1rb148nEY=";
   };
 
-  # no such file or directory errors
-  doCheck = false;
-
   useFetchCargoVendor = true;
   cargoHash = "sha256-9cNu0cgoo0/41daJwy/uWIXa2wFhYkcPhJfA/69DVx0=";
+
+  checkInputs = [ acl ];
+
+  # disable tests depending on special filesystem features
+  checkNoDefaultFeatures = true;
+  checkFeatures = [
+    "test_no_reflink"
+    "test_no_sparse"
+    "test_no_extents"
+    "test_no_acl"
+    "test_no_xattr"
+    "test_no_perms"
+  ];
 
   passthru.updateScript = nix-update-script { };
 


### PR DESCRIPTION
- selectively enable tests
- provide update script
- use `finalAttrs` pattern
- remove use of `with lib;`

Some of the tests rely on filesystem features which may or may not be available, we can however run the generic tests.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
