### PR TITLE
nextcloudPackages: Add twofactor_admin package

### DIFF
--- a/pkgs/servers/nextcloud/packages/29.json
+++ b/pkgs/servers/nextcloud/packages/29.json
@@ -369,6 +369,16 @@
       "agpl"
     ]
   },
+  "twofactor_admin": {
+    "hash": "sha256-zZvH7xfSooKBG4CKvSuf8D/6KnKEunLa+DRLAkWGoow=",
+    "url": "https://github.com/nextcloud-releases/twofactor_admin/releases/download/v4.8.0/twofactor_admin.tar.gz",
+    "version": "4.8.0",
+    "description": "This two-factor auth (2FA) provider for Nextcloud allows admins to generate a one-time\n\t\tcode for users to log into a 2FA protected account. This is helpful in situations where\n\t\tusers have lost access to their other 2FA methods or mandatory 2FA without any previously\n\t\tenabled 2FA provider.",
+    "homepage": "",
+    "licenses": [
+      "agpl"
+    ]
+  },
   "twofactor_nextcloud_notification": {
     "hash": "sha256-4fXWgDeiup5/Gm9hdZDj/u07rp/Nzwly53aLUT/d0IU=",
     "url": "https://github.com/nextcloud-releases/twofactor_nextcloud_notification/releases/download/v3.9.0/twofactor_nextcloud_notification-v3.9.0.tar.gz",

--- a/pkgs/servers/nextcloud/packages/30.json
+++ b/pkgs/servers/nextcloud/packages/30.json
@@ -369,6 +369,16 @@
       "agpl"
     ]
   },
+  "twofactor_admin": {
+    "hash": "sha256-zZvH7xfSooKBG4CKvSuf8D/6KnKEunLa+DRLAkWGoow=",
+    "url": "https://github.com/nextcloud-releases/twofactor_admin/releases/download/v4.8.0/twofactor_admin.tar.gz",
+    "version": "4.8.0",
+    "description": "This two-factor auth (2FA) provider for Nextcloud allows admins to generate a one-time\n\t\tcode for users to log into a 2FA protected account. This is helpful in situations where\n\t\tusers have lost access to their other 2FA methods or mandatory 2FA without any previously\n\t\tenabled 2FA provider.",
+    "homepage": "",
+    "licenses": [
+      "agpl"
+    ]
+  },
   "twofactor_webauthn": {
     "hash": "sha256-16Silofm/alQaKZ2buNqyLEjKK2kR2IpTAxEawHpGjI=",
     "url": "https://github.com/nextcloud-releases/twofactor_webauthn/releases/download/v2.1.0/twofactor_webauthn-v2.1.0.tar.gz",

--- a/pkgs/servers/nextcloud/packages/31.json
+++ b/pkgs/servers/nextcloud/packages/31.json
@@ -359,6 +359,16 @@
       "agpl"
     ]
   },
+  "twofactor_admin": {
+    "hash": "sha256-zZvH7xfSooKBG4CKvSuf8D/6KnKEunLa+DRLAkWGoow=",
+    "url": "https://github.com/nextcloud-releases/twofactor_admin/releases/download/v4.8.0/twofactor_admin.tar.gz",
+    "version": "4.8.0",
+    "description": "This two-factor auth (2FA) provider for Nextcloud allows admins to generate a one-time\n\t\tcode for users to log into a 2FA protected account. This is helpful in situations where\n\t\tusers have lost access to their other 2FA methods or mandatory 2FA without any previously\n\t\tenabled 2FA provider.",
+    "homepage": "",
+    "licenses": [
+      "agpl"
+    ]
+  },
   "twofactor_webauthn": {
     "hash": "sha256-16Silofm/alQaKZ2buNqyLEjKK2kR2IpTAxEawHpGjI=",
     "url": "https://github.com/nextcloud-releases/twofactor_webauthn/releases/download/v2.1.0/twofactor_webauthn-v2.1.0.tar.gz",

--- a/pkgs/servers/nextcloud/packages/nextcloud-apps.json
+++ b/pkgs/servers/nextcloud/packages/nextcloud-apps.json
@@ -38,6 +38,7 @@
 , "sociallogin": "agpl3Only"
 , "spreed": "agpl3Plus"
 , "tasks": "agpl3Plus"
+, "twofactor_admin": "agpl3Plus"
 , "twofactor_nextcloud_notification": "agpl3Only"
 , "twofactor_totp": "agpl3Plus"
 , "twofactor_webauthn": "agpl3Plus"


### PR DESCRIPTION
Added the twofactor_admin Package which allows Admins to generate backup-codes for users in case they don't have any available.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
