### PR TITLE
[Backport release-24.11]: rke2: version updates for CVE-2025-1974

### DIFF
--- a/pkgs/applications/networking/cluster/rke2/default.nix
+++ b/pkgs/applications/networking/cluster/rke2/default.nix
@@ -25,13 +25,19 @@ in
     }
   ) extraArgs;
 
-  rke2_testing = common (
-    (import ./testing/versions.nix)
-    // {
-      updateScript = [
-        ./update-script.sh
-        "testing"
-      ];
-    }
-  ) extraArgs;
+  rke2_testing =
+    (common (
+      (import ./testing/versions.nix)
+      // {
+        updateScript = [
+          ./update-script.sh
+          "testing"
+        ];
+      }
+    ) extraArgs).overrideAttrs
+      {
+        meta.knownVulnerabilities = [
+          "The RKE2 testing channel no longer serves releases, this package will not receive updates."
+        ];
+      };
 }

--- a/pkgs/applications/networking/cluster/rke2/latest/versions.nix
+++ b/pkgs/applications/networking/cluster/rke2/latest/versions.nix
@@ -1,14 +1,14 @@
 {
-  rke2Version = "1.31.1+rke2r1";
-  rke2Commit = "909d20d6a28cd7656b7177190f06f69f57927613";
-  rke2TarballHash = "sha256-9ZryOX6QMNpjDtsOXLOVNPjCc6AMAa+XDLOn1EpyCcg=";
-  rke2VendorHash = "sha256-7nWbWi4oJTOWZ5iZr9ptECDJJakPg4qZ7hW+tU7LBsI=";
-  k8sVersion = "v1.31.1";
-  k8sImageTag = "v1.31.1-rke2r1-build20240912";
-  etcdVersion = "v3.5.13-k3s1-build20240910";
+  rke2Version = "1.32.3+rke2r1";
+  rke2Commit = "18005e93ee0b015b78be47cf6515ae6d3a9afd55";
+  rke2TarballHash = "sha256-rDqSq38WoNN+9dMPTg/iteqkfX/pnlRtzt1HmhkAbRI=";
+  rke2VendorHash = "sha256-GwwNXW4JmhvO47V9SysOiKTfK2z55PkWpTDUE2qJgpA=";
+  k8sVersion = "v1.32.3";
+  k8sImageTag = "v1.32.3-rke2r1-build20250312";
+  etcdVersion = "v3.5.19-k3s1-build20250306";
   pauseVersion = "3.6";
-  ccmVersion = "v1.31.0-build20240910";
-  dockerizedVersion = "v1.31.1-rke2r1";
-  golangVersion = "go1.22.6";
-  eol = "2025-10-28";
+  ccmVersion = "v1.32.0-rc3.0.20241220224140-68fbd1a6b543-build20250101";
+  dockerizedVersion = "v1.32.3-rke2r1";
+  golangVersion = "go1.23.6";
+  eol = "2026-02-28";
 }

--- a/pkgs/applications/networking/cluster/rke2/stable/versions.nix
+++ b/pkgs/applications/networking/cluster/rke2/stable/versions.nix
@@ -1,14 +1,14 @@
 {
-  rke2Version = "1.30.5+rke2r1";
-  rke2Commit = "0c83bc82315cd61664880d0b52a7e070e9fbd623";
-  rke2TarballHash = "sha256-K5e7TNlL97PQ13IYnr4PSrXb4XaGJT9bPq55iWL0m1g=";
-  rke2VendorHash = "sha256-QIcVyWnedKNF10OqJ2WmZqZeKA+8hvwDQ4Pl+WUOEJY=";
-  k8sVersion = "v1.30.5";
-  k8sImageTag = "v1.30.5-rke2r1-build20240912";
-  etcdVersion = "v3.5.13-k3s1-build20240910";
+  rke2Version = "1.31.7+rke2r1";
+  rke2Commit = "7b18bda1c5ec1e110cec206f9163f6aba3a2154d";
+  rke2TarballHash = "sha256-u7U5eGLTrm1mxatl3v4iCBzw/Rin8wlndSs/OKLWtiw=";
+  rke2VendorHash = "sha256-UiFpAZHic2GVvdW4RDJxH2j5N2x8ec43YFfvBDR4fyM=";
+  k8sVersion = "v1.31.7";
+  k8sImageTag = "v1.31.7-rke2r1-build20250312";
+  etcdVersion = "v3.5.19-k3s1-build20250306";
   pauseVersion = "3.6";
-  ccmVersion = "v1.30.4-build20240910";
-  dockerizedVersion = "v1.30.5-rke2r1";
-  golangVersion = "go1.22.6";
-  eol = "2025-06-28";
+  ccmVersion = "v1.31.2-0.20241016053446-0955fa330f90-build20241016";
+  dockerizedVersion = "v1.31.7-rke2r1";
+  golangVersion = "go1.23.6";
+  eol = "2025-10-28";
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Manual backport of https://github.com/NixOS/nixpkgs/pull/393736.

Additionally, mark the `rke2_testing` package as vulnerable because the RKE2 testing channel no longer serves releases.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

@zimbatm @sheepforce 

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
