### PR TITLE
python-packages: fix sorting of inherits

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -247,3 +247,4 @@ da9a092c34cef6947d7aee2b134f61df45171631
 
 # python-packages: sort with keep-sorted
 fd14c067813572afc03ddbf7cdedc3eab5a59954
+783add849cbca228a36ffdf407e5d380dc2fe6c4

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6622,1074 +6622,6 @@ self: super: with self; {
 
   inform = callPackage ../development/python-modules/inform { };
 
-  inherit (callPackage ../development/python-modules/mypy-boto3 { })
-    mypy-boto3-accessanalyzer
-    mypy-boto3-account
-    mypy-boto3-acm
-    mypy-boto3-acm-pca
-    mypy-boto3-amp
-    mypy-boto3-amplify
-    mypy-boto3-amplifybackend
-    mypy-boto3-amplifyuibuilder
-    mypy-boto3-apigateway
-    mypy-boto3-apigatewaymanagementapi
-    mypy-boto3-apigatewayv2
-    mypy-boto3-appconfig
-    mypy-boto3-appconfigdata
-    mypy-boto3-appfabric
-    mypy-boto3-appflow
-    mypy-boto3-appintegrations
-    mypy-boto3-application-autoscaling
-    mypy-boto3-application-insights
-    mypy-boto3-applicationcostprofiler
-    mypy-boto3-appmesh
-    mypy-boto3-apprunner
-    mypy-boto3-appstream
-    mypy-boto3-appsync
-    mypy-boto3-arc-zonal-shift
-    mypy-boto3-athena
-    mypy-boto3-auditmanager
-    mypy-boto3-autoscaling
-    mypy-boto3-autoscaling-plans
-    mypy-boto3-backup
-    mypy-boto3-backup-gateway
-    mypy-boto3-batch
-    mypy-boto3-billingconductor
-    mypy-boto3-braket
-    mypy-boto3-budgets
-    mypy-boto3-ce
-    mypy-boto3-chime
-    mypy-boto3-chime-sdk-identity
-    mypy-boto3-chime-sdk-media-pipelines
-    mypy-boto3-chime-sdk-meetings
-    mypy-boto3-chime-sdk-messaging
-    mypy-boto3-chime-sdk-voice
-    mypy-boto3-cleanrooms
-    mypy-boto3-cloud9
-    mypy-boto3-cloudcontrol
-    mypy-boto3-clouddirectory
-    mypy-boto3-cloudformation
-    mypy-boto3-cloudfront
-    mypy-boto3-cloudhsm
-    mypy-boto3-cloudhsmv2
-    mypy-boto3-cloudsearch
-    mypy-boto3-cloudsearchdomain
-    mypy-boto3-cloudtrail
-    mypy-boto3-cloudtrail-data
-    mypy-boto3-cloudwatch
-    mypy-boto3-codeartifact
-    mypy-boto3-codebuild
-    mypy-boto3-codecatalyst
-    mypy-boto3-codecommit
-    mypy-boto3-codedeploy
-    mypy-boto3-codeguru-reviewer
-    mypy-boto3-codeguru-security
-    mypy-boto3-codeguruprofiler
-    mypy-boto3-codepipeline
-    mypy-boto3-codestar
-    mypy-boto3-codestar-connections
-    mypy-boto3-codestar-notifications
-    mypy-boto3-cognito-identity
-    mypy-boto3-cognito-idp
-    mypy-boto3-cognito-sync
-    mypy-boto3-comprehend
-    mypy-boto3-comprehendmedical
-    mypy-boto3-compute-optimizer
-    mypy-boto3-config
-    mypy-boto3-connect
-    mypy-boto3-connect-contact-lens
-    mypy-boto3-connectcampaigns
-    mypy-boto3-connectcases
-    mypy-boto3-connectparticipant
-    mypy-boto3-controltower
-    mypy-boto3-cur
-    mypy-boto3-customer-profiles
-    mypy-boto3-databrew
-    mypy-boto3-dataexchange
-    mypy-boto3-datapipeline
-    mypy-boto3-datasync
-    mypy-boto3-dax
-    mypy-boto3-detective
-    mypy-boto3-devicefarm
-    mypy-boto3-devops-guru
-    mypy-boto3-directconnect
-    mypy-boto3-discovery
-    mypy-boto3-dlm
-    mypy-boto3-dms
-    mypy-boto3-docdb
-    mypy-boto3-docdb-elastic
-    mypy-boto3-drs
-    mypy-boto3-ds
-    mypy-boto3-dynamodb
-    mypy-boto3-dynamodbstreams
-    mypy-boto3-ebs
-    mypy-boto3-ec2
-    mypy-boto3-ec2-instance-connect
-    mypy-boto3-ecr
-    mypy-boto3-ecr-public
-    mypy-boto3-ecs
-    mypy-boto3-efs
-    mypy-boto3-eks
-    mypy-boto3-elastic-inference
-    mypy-boto3-elasticache
-    mypy-boto3-elasticbeanstalk
-    mypy-boto3-elastictranscoder
-    mypy-boto3-elb
-    mypy-boto3-elbv2
-    mypy-boto3-emr
-    mypy-boto3-emr-containers
-    mypy-boto3-emr-serverless
-    mypy-boto3-entityresolution
-    mypy-boto3-es
-    mypy-boto3-events
-    mypy-boto3-evidently
-    mypy-boto3-finspace
-    mypy-boto3-finspace-data
-    mypy-boto3-firehose
-    mypy-boto3-fis
-    mypy-boto3-fms
-    mypy-boto3-forecast
-    mypy-boto3-forecastquery
-    mypy-boto3-frauddetector
-    mypy-boto3-fsx
-    mypy-boto3-gamelift
-    mypy-boto3-glacier
-    mypy-boto3-globalaccelerator
-    mypy-boto3-glue
-    mypy-boto3-grafana
-    mypy-boto3-greengrass
-    mypy-boto3-greengrassv2
-    mypy-boto3-groundstation
-    mypy-boto3-guardduty
-    mypy-boto3-health
-    mypy-boto3-healthlake
-    mypy-boto3-iam
-    mypy-boto3-identitystore
-    mypy-boto3-imagebuilder
-    mypy-boto3-importexport
-    mypy-boto3-inspector
-    mypy-boto3-inspector2
-    mypy-boto3-internetmonitor
-    mypy-boto3-iot
-    mypy-boto3-iot-data
-    mypy-boto3-iot-jobs-data
-    mypy-boto3-iot1click-devices
-    mypy-boto3-iot1click-projects
-    mypy-boto3-iotanalytics
-    mypy-boto3-iotdeviceadvisor
-    mypy-boto3-iotevents
-    mypy-boto3-iotevents-data
-    mypy-boto3-iotfleethub
-    mypy-boto3-iotfleetwise
-    mypy-boto3-iotsecuretunneling
-    mypy-boto3-iotsitewise
-    mypy-boto3-iotthingsgraph
-    mypy-boto3-iottwinmaker
-    mypy-boto3-iotwireless
-    mypy-boto3-ivs
-    mypy-boto3-ivs-realtime
-    mypy-boto3-ivschat
-    mypy-boto3-kafka
-    mypy-boto3-kafkaconnect
-    mypy-boto3-kendra
-    mypy-boto3-kendra-ranking
-    mypy-boto3-keyspaces
-    mypy-boto3-kinesis
-    mypy-boto3-kinesis-video-archived-media
-    mypy-boto3-kinesis-video-media
-    mypy-boto3-kinesis-video-signaling
-    mypy-boto3-kinesis-video-webrtc-storage
-    mypy-boto3-kinesisanalytics
-    mypy-boto3-kinesisanalyticsv2
-    mypy-boto3-kinesisvideo
-    mypy-boto3-kms
-    mypy-boto3-lakeformation
-    mypy-boto3-lambda
-    mypy-boto3-lex-models
-    mypy-boto3-lex-runtime
-    mypy-boto3-lexv2-models
-    mypy-boto3-lexv2-runtime
-    mypy-boto3-license-manager
-    mypy-boto3-license-manager-linux-subscriptions
-    mypy-boto3-license-manager-user-subscriptions
-    mypy-boto3-lightsail
-    mypy-boto3-location
-    mypy-boto3-logs
-    mypy-boto3-lookoutequipment
-    mypy-boto3-lookoutmetrics
-    mypy-boto3-lookoutvision
-    mypy-boto3-m2
-    mypy-boto3-machinelearning
-    mypy-boto3-macie2
-    mypy-boto3-managedblockchain
-    mypy-boto3-managedblockchain-query
-    mypy-boto3-marketplace-catalog
-    mypy-boto3-marketplace-entitlement
-    mypy-boto3-marketplacecommerceanalytics
-    mypy-boto3-mediaconnect
-    mypy-boto3-mediaconvert
-    mypy-boto3-medialive
-    mypy-boto3-mediapackage
-    mypy-boto3-mediapackage-vod
-    mypy-boto3-mediapackagev2
-    mypy-boto3-mediastore
-    mypy-boto3-mediastore-data
-    mypy-boto3-mediatailor
-    mypy-boto3-medical-imaging
-    mypy-boto3-memorydb
-    mypy-boto3-meteringmarketplace
-    mypy-boto3-mgh
-    mypy-boto3-mgn
-    mypy-boto3-migration-hub-refactor-spaces
-    mypy-boto3-migrationhub-config
-    mypy-boto3-migrationhuborchestrator
-    mypy-boto3-migrationhubstrategy
-    mypy-boto3-mq
-    mypy-boto3-mturk
-    mypy-boto3-mwaa
-    mypy-boto3-neptune
-    mypy-boto3-neptunedata
-    mypy-boto3-network-firewall
-    mypy-boto3-networkmanager
-    mypy-boto3-nimble
-    mypy-boto3-oam
-    mypy-boto3-omics
-    mypy-boto3-opensearch
-    mypy-boto3-opensearchserverless
-    mypy-boto3-opsworks
-    mypy-boto3-opsworkscm
-    mypy-boto3-organizations
-    mypy-boto3-osis
-    mypy-boto3-outposts
-    mypy-boto3-panorama
-    mypy-boto3-payment-cryptography
-    mypy-boto3-payment-cryptography-data
-    mypy-boto3-pca-connector-ad
-    mypy-boto3-personalize
-    mypy-boto3-personalize-events
-    mypy-boto3-personalize-runtime
-    mypy-boto3-pi
-    mypy-boto3-pinpoint
-    mypy-boto3-pinpoint-email
-    mypy-boto3-pinpoint-sms-voice
-    mypy-boto3-pinpoint-sms-voice-v2
-    mypy-boto3-pipes
-    mypy-boto3-polly
-    mypy-boto3-pricing
-    mypy-boto3-privatenetworks
-    mypy-boto3-proton
-    mypy-boto3-qldb
-    mypy-boto3-qldb-session
-    mypy-boto3-quicksight
-    mypy-boto3-ram
-    mypy-boto3-rbin
-    mypy-boto3-rds
-    mypy-boto3-rds-data
-    mypy-boto3-redshift
-    mypy-boto3-redshift-data
-    mypy-boto3-redshift-serverless
-    mypy-boto3-rekognition
-    mypy-boto3-resiliencehub
-    mypy-boto3-resource-explorer-2
-    mypy-boto3-resource-groups
-    mypy-boto3-resourcegroupstaggingapi
-    mypy-boto3-robomaker
-    mypy-boto3-rolesanywhere
-    mypy-boto3-route53
-    mypy-boto3-route53-recovery-cluster
-    mypy-boto3-route53-recovery-control-config
-    mypy-boto3-route53-recovery-readiness
-    mypy-boto3-route53domains
-    mypy-boto3-route53resolver
-    mypy-boto3-rum
-    mypy-boto3-s3
-    mypy-boto3-s3control
-    mypy-boto3-s3outposts
-    mypy-boto3-sagemaker
-    mypy-boto3-sagemaker-a2i-runtime
-    mypy-boto3-sagemaker-edge
-    mypy-boto3-sagemaker-featurestore-runtime
-    mypy-boto3-sagemaker-geospatial
-    mypy-boto3-sagemaker-metrics
-    mypy-boto3-sagemaker-runtime
-    mypy-boto3-savingsplans
-    mypy-boto3-scheduler
-    mypy-boto3-schemas
-    mypy-boto3-sdb
-    mypy-boto3-secretsmanager
-    mypy-boto3-securityhub
-    mypy-boto3-securitylake
-    mypy-boto3-serverlessrepo
-    mypy-boto3-service-quotas
-    mypy-boto3-servicecatalog
-    mypy-boto3-servicecatalog-appregistry
-    mypy-boto3-servicediscovery
-    mypy-boto3-ses
-    mypy-boto3-sesv2
-    mypy-boto3-shield
-    mypy-boto3-signer
-    mypy-boto3-simspaceweaver
-    mypy-boto3-sms
-    mypy-boto3-sms-voice
-    mypy-boto3-snow-device-management
-    mypy-boto3-snowball
-    mypy-boto3-sns
-    mypy-boto3-sqs
-    mypy-boto3-ssm
-    mypy-boto3-ssm-contacts
-    mypy-boto3-ssm-incidents
-    mypy-boto3-ssm-sap
-    mypy-boto3-sso
-    mypy-boto3-sso-admin
-    mypy-boto3-sso-oidc
-    mypy-boto3-stepfunctions
-    mypy-boto3-storagegateway
-    mypy-boto3-sts
-    mypy-boto3-support
-    mypy-boto3-support-app
-    mypy-boto3-swf
-    mypy-boto3-synthetics
-    mypy-boto3-textract
-    mypy-boto3-timestream-query
-    mypy-boto3-timestream-write
-    mypy-boto3-tnb
-    mypy-boto3-transcribe
-    mypy-boto3-transfer
-    mypy-boto3-translate
-    mypy-boto3-verifiedpermissions
-    mypy-boto3-voice-id
-    mypy-boto3-vpc-lattice
-    mypy-boto3-waf
-    mypy-boto3-waf-regional
-    mypy-boto3-wafv2
-    mypy-boto3-wellarchitected
-    mypy-boto3-wisdom
-    mypy-boto3-workdocs
-    mypy-boto3-worklink
-    mypy-boto3-workmail
-    mypy-boto3-workmailmessageflow
-    mypy-boto3-workspaces
-    mypy-boto3-workspaces-web
-    mypy-boto3-xray
-    ;
-
-  inherit (callPackage ../development/python-modules/types-aiobotocore-packages { })
-
-    types-aiobotocore-accessanalyzer
-
-    types-aiobotocore-account
-
-    types-aiobotocore-acm
-
-    types-aiobotocore-acm-pca
-
-    types-aiobotocore-alexaforbusiness
-
-    types-aiobotocore-amp
-
-    types-aiobotocore-amplify
-
-    types-aiobotocore-amplifybackend
-
-    types-aiobotocore-amplifyuibuilder
-
-    types-aiobotocore-apigateway
-
-    types-aiobotocore-apigatewaymanagementapi
-
-    types-aiobotocore-apigatewayv2
-
-    types-aiobotocore-appconfig
-
-    types-aiobotocore-appconfigdata
-
-    types-aiobotocore-appfabric
-
-    types-aiobotocore-appflow
-
-    types-aiobotocore-appintegrations
-
-    types-aiobotocore-application-autoscaling
-
-    types-aiobotocore-application-insights
-
-    types-aiobotocore-applicationcostprofiler
-
-    types-aiobotocore-appmesh
-
-    types-aiobotocore-apprunner
-
-    types-aiobotocore-appstream
-
-    types-aiobotocore-appsync
-
-    types-aiobotocore-arc-zonal-shift
-
-    types-aiobotocore-athena
-
-    types-aiobotocore-auditmanager
-
-    types-aiobotocore-autoscaling
-
-    types-aiobotocore-autoscaling-plans
-
-    types-aiobotocore-backup
-
-    types-aiobotocore-backup-gateway
-
-    types-aiobotocore-backupstorage
-
-    types-aiobotocore-batch
-
-    types-aiobotocore-billingconductor
-
-    types-aiobotocore-braket
-
-    types-aiobotocore-budgets
-
-    types-aiobotocore-ce
-
-    types-aiobotocore-chime
-
-    types-aiobotocore-chime-sdk-identity
-
-    types-aiobotocore-chime-sdk-media-pipelines
-
-    types-aiobotocore-chime-sdk-meetings
-
-    types-aiobotocore-chime-sdk-messaging
-
-    types-aiobotocore-chime-sdk-voice
-
-    types-aiobotocore-cleanrooms
-
-    types-aiobotocore-cloud9
-
-    types-aiobotocore-cloudcontrol
-
-    types-aiobotocore-clouddirectory
-
-    types-aiobotocore-cloudformation
-
-    types-aiobotocore-cloudfront
-
-    types-aiobotocore-cloudhsm
-
-    types-aiobotocore-cloudhsmv2
-
-    types-aiobotocore-cloudsearch
-
-    types-aiobotocore-cloudsearchdomain
-
-    types-aiobotocore-cloudtrail
-
-    types-aiobotocore-cloudtrail-data
-
-    types-aiobotocore-cloudwatch
-
-    types-aiobotocore-codeartifact
-
-    types-aiobotocore-codebuild
-
-    types-aiobotocore-codecatalyst
-
-    types-aiobotocore-codecommit
-
-    types-aiobotocore-codedeploy
-
-    types-aiobotocore-codeguru-reviewer
-
-    types-aiobotocore-codeguru-security
-
-    types-aiobotocore-codeguruprofiler
-
-    types-aiobotocore-codepipeline
-
-    types-aiobotocore-codestar
-
-    types-aiobotocore-codestar-connections
-
-    types-aiobotocore-codestar-notifications
-
-    types-aiobotocore-cognito-identity
-
-    types-aiobotocore-cognito-idp
-
-    types-aiobotocore-cognito-sync
-
-    types-aiobotocore-comprehend
-
-    types-aiobotocore-comprehendmedical
-
-    types-aiobotocore-compute-optimizer
-
-    types-aiobotocore-config
-
-    types-aiobotocore-connect
-
-    types-aiobotocore-connect-contact-lens
-
-    types-aiobotocore-connectcampaigns
-
-    types-aiobotocore-connectcases
-
-    types-aiobotocore-connectparticipant
-
-    types-aiobotocore-controltower
-
-    types-aiobotocore-cur
-
-    types-aiobotocore-customer-profiles
-
-    types-aiobotocore-databrew
-
-    types-aiobotocore-dataexchange
-
-    types-aiobotocore-datapipeline
-
-    types-aiobotocore-datasync
-
-    types-aiobotocore-dax
-
-    types-aiobotocore-detective
-
-    types-aiobotocore-devicefarm
-
-    types-aiobotocore-devops-guru
-
-    types-aiobotocore-directconnect
-
-    types-aiobotocore-discovery
-
-    types-aiobotocore-dlm
-
-    types-aiobotocore-dms
-
-    types-aiobotocore-docdb
-
-    types-aiobotocore-docdb-elastic
-
-    types-aiobotocore-drs
-
-    types-aiobotocore-ds
-
-    types-aiobotocore-dynamodb
-
-    types-aiobotocore-dynamodbstreams
-
-    types-aiobotocore-ebs
-
-    types-aiobotocore-ec2
-
-    types-aiobotocore-ec2-instance-connect
-
-    types-aiobotocore-ecr
-
-    types-aiobotocore-ecr-public
-
-    types-aiobotocore-ecs
-
-    types-aiobotocore-efs
-
-    types-aiobotocore-eks
-
-    types-aiobotocore-elastic-inference
-
-    types-aiobotocore-elasticache
-
-    types-aiobotocore-elasticbeanstalk
-
-    types-aiobotocore-elastictranscoder
-
-    types-aiobotocore-elb
-
-    types-aiobotocore-elbv2
-
-    types-aiobotocore-emr
-
-    types-aiobotocore-emr-containers
-
-    types-aiobotocore-emr-serverless
-
-    types-aiobotocore-entityresolution
-
-    types-aiobotocore-es
-
-    types-aiobotocore-events
-
-    types-aiobotocore-evidently
-
-    types-aiobotocore-finspace
-
-    types-aiobotocore-finspace-data
-
-    types-aiobotocore-firehose
-
-    types-aiobotocore-fis
-
-    types-aiobotocore-fms
-
-    types-aiobotocore-forecast
-
-    types-aiobotocore-forecastquery
-
-    types-aiobotocore-frauddetector
-
-    types-aiobotocore-fsx
-
-    types-aiobotocore-gamelift
-
-    types-aiobotocore-gamesparks
-
-    types-aiobotocore-glacier
-
-    types-aiobotocore-globalaccelerator
-
-    types-aiobotocore-glue
-
-    types-aiobotocore-grafana
-
-    types-aiobotocore-greengrass
-
-    types-aiobotocore-greengrassv2
-
-    types-aiobotocore-groundstation
-
-    types-aiobotocore-guardduty
-
-    types-aiobotocore-health
-
-    types-aiobotocore-healthlake
-
-    types-aiobotocore-honeycode
-
-    types-aiobotocore-iam
-
-    types-aiobotocore-identitystore
-
-    types-aiobotocore-imagebuilder
-
-    types-aiobotocore-importexport
-
-    types-aiobotocore-inspector
-
-    types-aiobotocore-inspector2
-
-    types-aiobotocore-internetmonitor
-
-    types-aiobotocore-iot
-
-    types-aiobotocore-iot-data
-
-    types-aiobotocore-iot-jobs-data
-
-    types-aiobotocore-iot-roborunner
-
-    types-aiobotocore-iot1click-devices
-
-    types-aiobotocore-iot1click-projects
-
-    types-aiobotocore-iotanalytics
-
-    types-aiobotocore-iotdeviceadvisor
-
-    types-aiobotocore-iotevents
-
-    types-aiobotocore-iotevents-data
-
-    types-aiobotocore-iotfleethub
-
-    types-aiobotocore-iotfleetwise
-
-    types-aiobotocore-iotsecuretunneling
-
-    types-aiobotocore-iotsitewise
-
-    types-aiobotocore-iotthingsgraph
-
-    types-aiobotocore-iottwinmaker
-
-    types-aiobotocore-iotwireless
-
-    types-aiobotocore-ivs
-
-    types-aiobotocore-ivs-realtime
-
-    types-aiobotocore-ivschat
-
-    types-aiobotocore-kafka
-
-    types-aiobotocore-kafkaconnect
-
-    types-aiobotocore-kendra
-
-    types-aiobotocore-kendra-ranking
-
-    types-aiobotocore-keyspaces
-
-    types-aiobotocore-kinesis
-
-    types-aiobotocore-kinesis-video-archived-media
-
-    types-aiobotocore-kinesis-video-media
-
-    types-aiobotocore-kinesis-video-signaling
-
-    types-aiobotocore-kinesis-video-webrtc-storage
-
-    types-aiobotocore-kinesisanalytics
-
-    types-aiobotocore-kinesisanalyticsv2
-
-    types-aiobotocore-kinesisvideo
-
-    types-aiobotocore-kms
-
-    types-aiobotocore-lakeformation
-
-    types-aiobotocore-lambda
-
-    types-aiobotocore-lex-models
-
-    types-aiobotocore-lex-runtime
-
-    types-aiobotocore-lexv2-models
-
-    types-aiobotocore-lexv2-runtime
-
-    types-aiobotocore-license-manager
-
-    types-aiobotocore-license-manager-linux-subscriptions
-
-    types-aiobotocore-license-manager-user-subscriptions
-
-    types-aiobotocore-lightsail
-
-    types-aiobotocore-location
-
-    types-aiobotocore-logs
-
-    types-aiobotocore-lookoutequipment
-
-    types-aiobotocore-lookoutmetrics
-
-    types-aiobotocore-lookoutvision
-
-    types-aiobotocore-m2
-
-    types-aiobotocore-machinelearning
-
-    types-aiobotocore-macie
-
-    types-aiobotocore-macie2
-
-    types-aiobotocore-managedblockchain
-
-    types-aiobotocore-managedblockchain-query
-
-    types-aiobotocore-marketplace-catalog
-
-    types-aiobotocore-marketplace-entitlement
-
-    types-aiobotocore-marketplacecommerceanalytics
-
-    types-aiobotocore-mediaconnect
-
-    types-aiobotocore-mediaconvert
-
-    types-aiobotocore-medialive
-
-    types-aiobotocore-mediapackage
-
-    types-aiobotocore-mediapackage-vod
-
-    types-aiobotocore-mediapackagev2
-
-    types-aiobotocore-mediastore
-
-    types-aiobotocore-mediastore-data
-
-    types-aiobotocore-mediatailor
-
-    types-aiobotocore-medical-imaging
-
-    types-aiobotocore-memorydb
-
-    types-aiobotocore-meteringmarketplace
-
-    types-aiobotocore-mgh
-
-    types-aiobotocore-mgn
-
-    types-aiobotocore-migration-hub-refactor-spaces
-
-    types-aiobotocore-migrationhub-config
-
-    types-aiobotocore-migrationhuborchestrator
-
-    types-aiobotocore-migrationhubstrategy
-
-    types-aiobotocore-mobile
-
-    types-aiobotocore-mq
-
-    types-aiobotocore-mturk
-
-    types-aiobotocore-mwaa
-
-    types-aiobotocore-neptune
-
-    types-aiobotocore-network-firewall
-
-    types-aiobotocore-networkmanager
-
-    types-aiobotocore-nimble
-
-    types-aiobotocore-oam
-
-    types-aiobotocore-omics
-
-    types-aiobotocore-opensearch
-
-    types-aiobotocore-opensearchserverless
-
-    types-aiobotocore-opsworks
-
-    types-aiobotocore-opsworkscm
-
-    types-aiobotocore-organizations
-
-    types-aiobotocore-osis
-
-    types-aiobotocore-outposts
-
-    types-aiobotocore-panorama
-
-    types-aiobotocore-payment-cryptography
-
-    types-aiobotocore-payment-cryptography-data
-
-    types-aiobotocore-personalize
-
-    types-aiobotocore-personalize-events
-
-    types-aiobotocore-personalize-runtime
-
-    types-aiobotocore-pi
-
-    types-aiobotocore-pinpoint
-
-    types-aiobotocore-pinpoint-email
-
-    types-aiobotocore-pinpoint-sms-voice
-
-    types-aiobotocore-pinpoint-sms-voice-v2
-
-    types-aiobotocore-pipes
-
-    types-aiobotocore-polly
-
-    types-aiobotocore-pricing
-
-    types-aiobotocore-privatenetworks
-
-    types-aiobotocore-proton
-
-    types-aiobotocore-qldb
-
-    types-aiobotocore-qldb-session
-
-    types-aiobotocore-quicksight
-
-    types-aiobotocore-ram
-
-    types-aiobotocore-rbin
-
-    types-aiobotocore-rds
-
-    types-aiobotocore-rds-data
-
-    types-aiobotocore-redshift
-
-    types-aiobotocore-redshift-data
-
-    types-aiobotocore-redshift-serverless
-
-    types-aiobotocore-rekognition
-
-    types-aiobotocore-resiliencehub
-
-    types-aiobotocore-resource-explorer-2
-
-    types-aiobotocore-resource-groups
-
-    types-aiobotocore-resourcegroupstaggingapi
-
-    types-aiobotocore-robomaker
-
-    types-aiobotocore-rolesanywhere
-
-    types-aiobotocore-route53
-
-    types-aiobotocore-route53-recovery-cluster
-
-    types-aiobotocore-route53-recovery-control-config
-
-    types-aiobotocore-route53-recovery-readiness
-
-    types-aiobotocore-route53domains
-
-    types-aiobotocore-route53resolver
-
-    types-aiobotocore-rum
-
-    types-aiobotocore-s3
-
-    types-aiobotocore-s3control
-
-    types-aiobotocore-s3outposts
-
-    types-aiobotocore-sagemaker
-
-    types-aiobotocore-sagemaker-a2i-runtime
-
-    types-aiobotocore-sagemaker-edge
-
-    types-aiobotocore-sagemaker-featurestore-runtime
-
-    types-aiobotocore-sagemaker-geospatial
-
-    types-aiobotocore-sagemaker-metrics
-
-    types-aiobotocore-sagemaker-runtime
-
-    types-aiobotocore-savingsplans
-
-    types-aiobotocore-scheduler
-
-    types-aiobotocore-schemas
-
-    types-aiobotocore-sdb
-
-    types-aiobotocore-secretsmanager
-
-    types-aiobotocore-securityhub
-
-    types-aiobotocore-securitylake
-
-    types-aiobotocore-serverlessrepo
-
-    types-aiobotocore-service-quotas
-
-    types-aiobotocore-servicecatalog
-
-    types-aiobotocore-servicecatalog-appregistry
-
-    types-aiobotocore-servicediscovery
-
-    types-aiobotocore-ses
-
-    types-aiobotocore-sesv2
-
-    types-aiobotocore-shield
-
-    types-aiobotocore-signer
-
-    types-aiobotocore-simspaceweaver
-
-    types-aiobotocore-sms
-
-    types-aiobotocore-sms-voice
-
-    types-aiobotocore-snow-device-management
-
-    types-aiobotocore-snowball
-
-    types-aiobotocore-sns
-
-    types-aiobotocore-sqs
-
-    types-aiobotocore-ssm
-
-    types-aiobotocore-ssm-contacts
-
-    types-aiobotocore-ssm-incidents
-
-    types-aiobotocore-ssm-sap
-
-    types-aiobotocore-sso
-
-    types-aiobotocore-sso-admin
-
-    types-aiobotocore-sso-oidc
-
-    types-aiobotocore-stepfunctions
-
-    types-aiobotocore-storagegateway
-
-    types-aiobotocore-sts
-
-    types-aiobotocore-support
-
-    types-aiobotocore-support-app
-
-    types-aiobotocore-swf
-
-    types-aiobotocore-synthetics
-
-    types-aiobotocore-textract
-
-    types-aiobotocore-timestream-query
-
-    types-aiobotocore-timestream-write
-
-    types-aiobotocore-tnb
-
-    types-aiobotocore-transcribe
-
-    types-aiobotocore-transfer
-
-    types-aiobotocore-translate
-
-    types-aiobotocore-verifiedpermissions
-
-    types-aiobotocore-voice-id
-
-    types-aiobotocore-vpc-lattice
-
-    types-aiobotocore-waf
-
-    types-aiobotocore-waf-regional
-
-    types-aiobotocore-wafv2
-
-    types-aiobotocore-wellarchitected
-
-    types-aiobotocore-wisdom
-
-    types-aiobotocore-workdocs
-
-    types-aiobotocore-worklink
-
-    types-aiobotocore-workmail
-
-    types-aiobotocore-workmailmessageflow
-
-    types-aiobotocore-workspaces
-
-    types-aiobotocore-workspaces-web
-
-    types-aiobotocore-xray
-
-    ;
-
-  inherit (self.wasmerPackages)
-    wasmer
-    wasmer-compiler-cranelift
-    wasmer-compiler-llvm
-    wasmer-compiler-singlepass
-    ;
-
   iniconfig = callPackage ../development/python-modules/iniconfig { };
 
   inifile = callPackage ../development/python-modules/inifile { };
@@ -10211,6 +9143,357 @@ self: super: with self; {
   mypermobil = callPackage ../development/python-modules/mypermobil { };
 
   mypy = callPackage ../development/python-modules/mypy { };
+
+  inherit (callPackage ../development/python-modules/mypy-boto3 { })
+    mypy-boto3-accessanalyzer
+    mypy-boto3-account
+    mypy-boto3-acm
+    mypy-boto3-acm-pca
+    mypy-boto3-amp
+    mypy-boto3-amplify
+    mypy-boto3-amplifybackend
+    mypy-boto3-amplifyuibuilder
+    mypy-boto3-apigateway
+    mypy-boto3-apigatewaymanagementapi
+    mypy-boto3-apigatewayv2
+    mypy-boto3-appconfig
+    mypy-boto3-appconfigdata
+    mypy-boto3-appfabric
+    mypy-boto3-appflow
+    mypy-boto3-appintegrations
+    mypy-boto3-application-autoscaling
+    mypy-boto3-application-insights
+    mypy-boto3-applicationcostprofiler
+    mypy-boto3-appmesh
+    mypy-boto3-apprunner
+    mypy-boto3-appstream
+    mypy-boto3-appsync
+    mypy-boto3-arc-zonal-shift
+    mypy-boto3-athena
+    mypy-boto3-auditmanager
+    mypy-boto3-autoscaling
+    mypy-boto3-autoscaling-plans
+    mypy-boto3-backup
+    mypy-boto3-backup-gateway
+    mypy-boto3-batch
+    mypy-boto3-billingconductor
+    mypy-boto3-braket
+    mypy-boto3-budgets
+    mypy-boto3-ce
+    mypy-boto3-chime
+    mypy-boto3-chime-sdk-identity
+    mypy-boto3-chime-sdk-media-pipelines
+    mypy-boto3-chime-sdk-meetings
+    mypy-boto3-chime-sdk-messaging
+    mypy-boto3-chime-sdk-voice
+    mypy-boto3-cleanrooms
+    mypy-boto3-cloud9
+    mypy-boto3-cloudcontrol
+    mypy-boto3-clouddirectory
+    mypy-boto3-cloudformation
+    mypy-boto3-cloudfront
+    mypy-boto3-cloudhsm
+    mypy-boto3-cloudhsmv2
+    mypy-boto3-cloudsearch
+    mypy-boto3-cloudsearchdomain
+    mypy-boto3-cloudtrail
+    mypy-boto3-cloudtrail-data
+    mypy-boto3-cloudwatch
+    mypy-boto3-codeartifact
+    mypy-boto3-codebuild
+    mypy-boto3-codecatalyst
+    mypy-boto3-codecommit
+    mypy-boto3-codedeploy
+    mypy-boto3-codeguru-reviewer
+    mypy-boto3-codeguru-security
+    mypy-boto3-codeguruprofiler
+    mypy-boto3-codepipeline
+    mypy-boto3-codestar
+    mypy-boto3-codestar-connections
+    mypy-boto3-codestar-notifications
+    mypy-boto3-cognito-identity
+    mypy-boto3-cognito-idp
+    mypy-boto3-cognito-sync
+    mypy-boto3-comprehend
+    mypy-boto3-comprehendmedical
+    mypy-boto3-compute-optimizer
+    mypy-boto3-config
+    mypy-boto3-connect
+    mypy-boto3-connect-contact-lens
+    mypy-boto3-connectcampaigns
+    mypy-boto3-connectcases
+    mypy-boto3-connectparticipant
+    mypy-boto3-controltower
+    mypy-boto3-cur
+    mypy-boto3-customer-profiles
+    mypy-boto3-databrew
+    mypy-boto3-dataexchange
+    mypy-boto3-datapipeline
+    mypy-boto3-datasync
+    mypy-boto3-dax
+    mypy-boto3-detective
+    mypy-boto3-devicefarm
+    mypy-boto3-devops-guru
+    mypy-boto3-directconnect
+    mypy-boto3-discovery
+    mypy-boto3-dlm
+    mypy-boto3-dms
+    mypy-boto3-docdb
+    mypy-boto3-docdb-elastic
+    mypy-boto3-drs
+    mypy-boto3-ds
+    mypy-boto3-dynamodb
+    mypy-boto3-dynamodbstreams
+    mypy-boto3-ebs
+    mypy-boto3-ec2
+    mypy-boto3-ec2-instance-connect
+    mypy-boto3-ecr
+    mypy-boto3-ecr-public
+    mypy-boto3-ecs
+    mypy-boto3-efs
+    mypy-boto3-eks
+    mypy-boto3-elastic-inference
+    mypy-boto3-elasticache
+    mypy-boto3-elasticbeanstalk
+    mypy-boto3-elastictranscoder
+    mypy-boto3-elb
+    mypy-boto3-elbv2
+    mypy-boto3-emr
+    mypy-boto3-emr-containers
+    mypy-boto3-emr-serverless
+    mypy-boto3-entityresolution
+    mypy-boto3-es
+    mypy-boto3-events
+    mypy-boto3-evidently
+    mypy-boto3-finspace
+    mypy-boto3-finspace-data
+    mypy-boto3-firehose
+    mypy-boto3-fis
+    mypy-boto3-fms
+    mypy-boto3-forecast
+    mypy-boto3-forecastquery
+    mypy-boto3-frauddetector
+    mypy-boto3-fsx
+    mypy-boto3-gamelift
+    mypy-boto3-glacier
+    mypy-boto3-globalaccelerator
+    mypy-boto3-glue
+    mypy-boto3-grafana
+    mypy-boto3-greengrass
+    mypy-boto3-greengrassv2
+    mypy-boto3-groundstation
+    mypy-boto3-guardduty
+    mypy-boto3-health
+    mypy-boto3-healthlake
+    mypy-boto3-iam
+    mypy-boto3-identitystore
+    mypy-boto3-imagebuilder
+    mypy-boto3-importexport
+    mypy-boto3-inspector
+    mypy-boto3-inspector2
+    mypy-boto3-internetmonitor
+    mypy-boto3-iot
+    mypy-boto3-iot-data
+    mypy-boto3-iot-jobs-data
+    mypy-boto3-iot1click-devices
+    mypy-boto3-iot1click-projects
+    mypy-boto3-iotanalytics
+    mypy-boto3-iotdeviceadvisor
+    mypy-boto3-iotevents
+    mypy-boto3-iotevents-data
+    mypy-boto3-iotfleethub
+    mypy-boto3-iotfleetwise
+    mypy-boto3-iotsecuretunneling
+    mypy-boto3-iotsitewise
+    mypy-boto3-iotthingsgraph
+    mypy-boto3-iottwinmaker
+    mypy-boto3-iotwireless
+    mypy-boto3-ivs
+    mypy-boto3-ivs-realtime
+    mypy-boto3-ivschat
+    mypy-boto3-kafka
+    mypy-boto3-kafkaconnect
+    mypy-boto3-kendra
+    mypy-boto3-kendra-ranking
+    mypy-boto3-keyspaces
+    mypy-boto3-kinesis
+    mypy-boto3-kinesis-video-archived-media
+    mypy-boto3-kinesis-video-media
+    mypy-boto3-kinesis-video-signaling
+    mypy-boto3-kinesis-video-webrtc-storage
+    mypy-boto3-kinesisanalytics
+    mypy-boto3-kinesisanalyticsv2
+    mypy-boto3-kinesisvideo
+    mypy-boto3-kms
+    mypy-boto3-lakeformation
+    mypy-boto3-lambda
+    mypy-boto3-lex-models
+    mypy-boto3-lex-runtime
+    mypy-boto3-lexv2-models
+    mypy-boto3-lexv2-runtime
+    mypy-boto3-license-manager
+    mypy-boto3-license-manager-linux-subscriptions
+    mypy-boto3-license-manager-user-subscriptions
+    mypy-boto3-lightsail
+    mypy-boto3-location
+    mypy-boto3-logs
+    mypy-boto3-lookoutequipment
+    mypy-boto3-lookoutmetrics
+    mypy-boto3-lookoutvision
+    mypy-boto3-m2
+    mypy-boto3-machinelearning
+    mypy-boto3-macie2
+    mypy-boto3-managedblockchain
+    mypy-boto3-managedblockchain-query
+    mypy-boto3-marketplace-catalog
+    mypy-boto3-marketplace-entitlement
+    mypy-boto3-marketplacecommerceanalytics
+    mypy-boto3-mediaconnect
+    mypy-boto3-mediaconvert
+    mypy-boto3-medialive
+    mypy-boto3-mediapackage
+    mypy-boto3-mediapackage-vod
+    mypy-boto3-mediapackagev2
+    mypy-boto3-mediastore
+    mypy-boto3-mediastore-data
+    mypy-boto3-mediatailor
+    mypy-boto3-medical-imaging
+    mypy-boto3-memorydb
+    mypy-boto3-meteringmarketplace
+    mypy-boto3-mgh
+    mypy-boto3-mgn
+    mypy-boto3-migration-hub-refactor-spaces
+    mypy-boto3-migrationhub-config
+    mypy-boto3-migrationhuborchestrator
+    mypy-boto3-migrationhubstrategy
+    mypy-boto3-mq
+    mypy-boto3-mturk
+    mypy-boto3-mwaa
+    mypy-boto3-neptune
+    mypy-boto3-neptunedata
+    mypy-boto3-network-firewall
+    mypy-boto3-networkmanager
+    mypy-boto3-nimble
+    mypy-boto3-oam
+    mypy-boto3-omics
+    mypy-boto3-opensearch
+    mypy-boto3-opensearchserverless
+    mypy-boto3-opsworks
+    mypy-boto3-opsworkscm
+    mypy-boto3-organizations
+    mypy-boto3-osis
+    mypy-boto3-outposts
+    mypy-boto3-panorama
+    mypy-boto3-payment-cryptography
+    mypy-boto3-payment-cryptography-data
+    mypy-boto3-pca-connector-ad
+    mypy-boto3-personalize
+    mypy-boto3-personalize-events
+    mypy-boto3-personalize-runtime
+    mypy-boto3-pi
+    mypy-boto3-pinpoint
+    mypy-boto3-pinpoint-email
+    mypy-boto3-pinpoint-sms-voice
+    mypy-boto3-pinpoint-sms-voice-v2
+    mypy-boto3-pipes
+    mypy-boto3-polly
+    mypy-boto3-pricing
+    mypy-boto3-privatenetworks
+    mypy-boto3-proton
+    mypy-boto3-qldb
+    mypy-boto3-qldb-session
+    mypy-boto3-quicksight
+    mypy-boto3-ram
+    mypy-boto3-rbin
+    mypy-boto3-rds
+    mypy-boto3-rds-data
+    mypy-boto3-redshift
+    mypy-boto3-redshift-data
+    mypy-boto3-redshift-serverless
+    mypy-boto3-rekognition
+    mypy-boto3-resiliencehub
+    mypy-boto3-resource-explorer-2
+    mypy-boto3-resource-groups
+    mypy-boto3-resourcegroupstaggingapi
+    mypy-boto3-robomaker
+    mypy-boto3-rolesanywhere
+    mypy-boto3-route53
+    mypy-boto3-route53-recovery-cluster
+    mypy-boto3-route53-recovery-control-config
+    mypy-boto3-route53-recovery-readiness
+    mypy-boto3-route53domains
+    mypy-boto3-route53resolver
+    mypy-boto3-rum
+    mypy-boto3-s3
+    mypy-boto3-s3control
+    mypy-boto3-s3outposts
+    mypy-boto3-sagemaker
+    mypy-boto3-sagemaker-a2i-runtime
+    mypy-boto3-sagemaker-edge
+    mypy-boto3-sagemaker-featurestore-runtime
+    mypy-boto3-sagemaker-geospatial
+    mypy-boto3-sagemaker-metrics
+    mypy-boto3-sagemaker-runtime
+    mypy-boto3-savingsplans
+    mypy-boto3-scheduler
+    mypy-boto3-schemas
+    mypy-boto3-sdb
+    mypy-boto3-secretsmanager
+    mypy-boto3-securityhub
+    mypy-boto3-securitylake
+    mypy-boto3-serverlessrepo
+    mypy-boto3-service-quotas
+    mypy-boto3-servicecatalog
+    mypy-boto3-servicecatalog-appregistry
+    mypy-boto3-servicediscovery
+    mypy-boto3-ses
+    mypy-boto3-sesv2
+    mypy-boto3-shield
+    mypy-boto3-signer
+    mypy-boto3-simspaceweaver
+    mypy-boto3-sms
+    mypy-boto3-sms-voice
+    mypy-boto3-snow-device-management
+    mypy-boto3-snowball
+    mypy-boto3-sns
+    mypy-boto3-sqs
+    mypy-boto3-ssm
+    mypy-boto3-ssm-contacts
+    mypy-boto3-ssm-incidents
+    mypy-boto3-ssm-sap
+    mypy-boto3-sso
+    mypy-boto3-sso-admin
+    mypy-boto3-sso-oidc
+    mypy-boto3-stepfunctions
+    mypy-boto3-storagegateway
+    mypy-boto3-sts
+    mypy-boto3-support
+    mypy-boto3-support-app
+    mypy-boto3-swf
+    mypy-boto3-synthetics
+    mypy-boto3-textract
+    mypy-boto3-timestream-query
+    mypy-boto3-timestream-write
+    mypy-boto3-tnb
+    mypy-boto3-transcribe
+    mypy-boto3-transfer
+    mypy-boto3-translate
+    mypy-boto3-verifiedpermissions
+    mypy-boto3-voice-id
+    mypy-boto3-vpc-lattice
+    mypy-boto3-waf
+    mypy-boto3-waf-regional
+    mypy-boto3-wafv2
+    mypy-boto3-wellarchitected
+    mypy-boto3-wisdom
+    mypy-boto3-workdocs
+    mypy-boto3-worklink
+    mypy-boto3-workmail
+    mypy-boto3-workmailmessageflow
+    mypy-boto3-workspaces
+    mypy-boto3-workspaces-web
+    mypy-boto3-xray
+    ;
 
   mypy-boto3-builder = callPackage ../development/python-modules/mypy-boto3-builder { };
 
@@ -18273,6 +17556,362 @@ self: super: with self; {
 
   types-aiobotocore = callPackage ../development/python-modules/types-aiobotocore { };
 
+  inherit (callPackage ../development/python-modules/types-aiobotocore-packages { })
+    types-aiobotocore-accessanalyzer
+    types-aiobotocore-account
+    types-aiobotocore-acm
+    types-aiobotocore-acm-pca
+    types-aiobotocore-alexaforbusiness
+    types-aiobotocore-amp
+    types-aiobotocore-amplify
+    types-aiobotocore-amplifybackend
+    types-aiobotocore-amplifyuibuilder
+    types-aiobotocore-apigateway
+    types-aiobotocore-apigatewaymanagementapi
+    types-aiobotocore-apigatewayv2
+    types-aiobotocore-appconfig
+    types-aiobotocore-appconfigdata
+    types-aiobotocore-appfabric
+    types-aiobotocore-appflow
+    types-aiobotocore-appintegrations
+    types-aiobotocore-application-autoscaling
+    types-aiobotocore-application-insights
+    types-aiobotocore-applicationcostprofiler
+    types-aiobotocore-appmesh
+    types-aiobotocore-apprunner
+    types-aiobotocore-appstream
+    types-aiobotocore-appsync
+    types-aiobotocore-arc-zonal-shift
+    types-aiobotocore-athena
+    types-aiobotocore-auditmanager
+    types-aiobotocore-autoscaling
+    types-aiobotocore-autoscaling-plans
+    types-aiobotocore-backup
+    types-aiobotocore-backup-gateway
+    types-aiobotocore-backupstorage
+    types-aiobotocore-batch
+    types-aiobotocore-billingconductor
+    types-aiobotocore-braket
+    types-aiobotocore-budgets
+    types-aiobotocore-ce
+    types-aiobotocore-chime
+    types-aiobotocore-chime-sdk-identity
+    types-aiobotocore-chime-sdk-media-pipelines
+    types-aiobotocore-chime-sdk-meetings
+    types-aiobotocore-chime-sdk-messaging
+    types-aiobotocore-chime-sdk-voice
+    types-aiobotocore-cleanrooms
+    types-aiobotocore-cloud9
+    types-aiobotocore-cloudcontrol
+    types-aiobotocore-clouddirectory
+    types-aiobotocore-cloudformation
+    types-aiobotocore-cloudfront
+    types-aiobotocore-cloudhsm
+    types-aiobotocore-cloudhsmv2
+    types-aiobotocore-cloudsearch
+    types-aiobotocore-cloudsearchdomain
+    types-aiobotocore-cloudtrail
+    types-aiobotocore-cloudtrail-data
+    types-aiobotocore-cloudwatch
+    types-aiobotocore-codeartifact
+    types-aiobotocore-codebuild
+    types-aiobotocore-codecatalyst
+    types-aiobotocore-codecommit
+    types-aiobotocore-codedeploy
+    types-aiobotocore-codeguru-reviewer
+    types-aiobotocore-codeguru-security
+    types-aiobotocore-codeguruprofiler
+    types-aiobotocore-codepipeline
+    types-aiobotocore-codestar
+    types-aiobotocore-codestar-connections
+    types-aiobotocore-codestar-notifications
+    types-aiobotocore-cognito-identity
+    types-aiobotocore-cognito-idp
+    types-aiobotocore-cognito-sync
+    types-aiobotocore-comprehend
+    types-aiobotocore-comprehendmedical
+    types-aiobotocore-compute-optimizer
+    types-aiobotocore-config
+    types-aiobotocore-connect
+    types-aiobotocore-connect-contact-lens
+    types-aiobotocore-connectcampaigns
+    types-aiobotocore-connectcases
+    types-aiobotocore-connectparticipant
+    types-aiobotocore-controltower
+    types-aiobotocore-cur
+    types-aiobotocore-customer-profiles
+    types-aiobotocore-databrew
+    types-aiobotocore-dataexchange
+    types-aiobotocore-datapipeline
+    types-aiobotocore-datasync
+    types-aiobotocore-dax
+    types-aiobotocore-detective
+    types-aiobotocore-devicefarm
+    types-aiobotocore-devops-guru
+    types-aiobotocore-directconnect
+    types-aiobotocore-discovery
+    types-aiobotocore-dlm
+    types-aiobotocore-dms
+    types-aiobotocore-docdb
+    types-aiobotocore-docdb-elastic
+    types-aiobotocore-drs
+    types-aiobotocore-ds
+    types-aiobotocore-dynamodb
+    types-aiobotocore-dynamodbstreams
+    types-aiobotocore-ebs
+    types-aiobotocore-ec2
+    types-aiobotocore-ec2-instance-connect
+    types-aiobotocore-ecr
+    types-aiobotocore-ecr-public
+    types-aiobotocore-ecs
+    types-aiobotocore-efs
+    types-aiobotocore-eks
+    types-aiobotocore-elastic-inference
+    types-aiobotocore-elasticache
+    types-aiobotocore-elasticbeanstalk
+    types-aiobotocore-elastictranscoder
+    types-aiobotocore-elb
+    types-aiobotocore-elbv2
+    types-aiobotocore-emr
+    types-aiobotocore-emr-containers
+    types-aiobotocore-emr-serverless
+    types-aiobotocore-entityresolution
+    types-aiobotocore-es
+    types-aiobotocore-events
+    types-aiobotocore-evidently
+    types-aiobotocore-finspace
+    types-aiobotocore-finspace-data
+    types-aiobotocore-firehose
+    types-aiobotocore-fis
+    types-aiobotocore-fms
+    types-aiobotocore-forecast
+    types-aiobotocore-forecastquery
+    types-aiobotocore-frauddetector
+    types-aiobotocore-fsx
+    types-aiobotocore-gamelift
+    types-aiobotocore-gamesparks
+    types-aiobotocore-glacier
+    types-aiobotocore-globalaccelerator
+    types-aiobotocore-glue
+    types-aiobotocore-grafana
+    types-aiobotocore-greengrass
+    types-aiobotocore-greengrassv2
+    types-aiobotocore-groundstation
+    types-aiobotocore-guardduty
+    types-aiobotocore-health
+    types-aiobotocore-healthlake
+    types-aiobotocore-honeycode
+    types-aiobotocore-iam
+    types-aiobotocore-identitystore
+    types-aiobotocore-imagebuilder
+    types-aiobotocore-importexport
+    types-aiobotocore-inspector
+    types-aiobotocore-inspector2
+    types-aiobotocore-internetmonitor
+    types-aiobotocore-iot
+    types-aiobotocore-iot-data
+    types-aiobotocore-iot-jobs-data
+    types-aiobotocore-iot-roborunner
+    types-aiobotocore-iot1click-devices
+    types-aiobotocore-iot1click-projects
+    types-aiobotocore-iotanalytics
+    types-aiobotocore-iotdeviceadvisor
+    types-aiobotocore-iotevents
+    types-aiobotocore-iotevents-data
+    types-aiobotocore-iotfleethub
+    types-aiobotocore-iotfleetwise
+    types-aiobotocore-iotsecuretunneling
+    types-aiobotocore-iotsitewise
+    types-aiobotocore-iotthingsgraph
+    types-aiobotocore-iottwinmaker
+    types-aiobotocore-iotwireless
+    types-aiobotocore-ivs
+    types-aiobotocore-ivs-realtime
+    types-aiobotocore-ivschat
+    types-aiobotocore-kafka
+    types-aiobotocore-kafkaconnect
+    types-aiobotocore-kendra
+    types-aiobotocore-kendra-ranking
+    types-aiobotocore-keyspaces
+    types-aiobotocore-kinesis
+    types-aiobotocore-kinesis-video-archived-media
+    types-aiobotocore-kinesis-video-media
+    types-aiobotocore-kinesis-video-signaling
+    types-aiobotocore-kinesis-video-webrtc-storage
+    types-aiobotocore-kinesisanalytics
+    types-aiobotocore-kinesisanalyticsv2
+    types-aiobotocore-kinesisvideo
+    types-aiobotocore-kms
+    types-aiobotocore-lakeformation
+    types-aiobotocore-lambda
+    types-aiobotocore-lex-models
+    types-aiobotocore-lex-runtime
+    types-aiobotocore-lexv2-models
+    types-aiobotocore-lexv2-runtime
+    types-aiobotocore-license-manager
+    types-aiobotocore-license-manager-linux-subscriptions
+    types-aiobotocore-license-manager-user-subscriptions
+    types-aiobotocore-lightsail
+    types-aiobotocore-location
+    types-aiobotocore-logs
+    types-aiobotocore-lookoutequipment
+    types-aiobotocore-lookoutmetrics
+    types-aiobotocore-lookoutvision
+    types-aiobotocore-m2
+    types-aiobotocore-machinelearning
+    types-aiobotocore-macie
+    types-aiobotocore-macie2
+    types-aiobotocore-managedblockchain
+    types-aiobotocore-managedblockchain-query
+    types-aiobotocore-marketplace-catalog
+    types-aiobotocore-marketplace-entitlement
+    types-aiobotocore-marketplacecommerceanalytics
+    types-aiobotocore-mediaconnect
+    types-aiobotocore-mediaconvert
+    types-aiobotocore-medialive
+    types-aiobotocore-mediapackage
+    types-aiobotocore-mediapackage-vod
+    types-aiobotocore-mediapackagev2
+    types-aiobotocore-mediastore
+    types-aiobotocore-mediastore-data
+    types-aiobotocore-mediatailor
+    types-aiobotocore-medical-imaging
+    types-aiobotocore-memorydb
+    types-aiobotocore-meteringmarketplace
+    types-aiobotocore-mgh
+    types-aiobotocore-mgn
+    types-aiobotocore-migration-hub-refactor-spaces
+    types-aiobotocore-migrationhub-config
+    types-aiobotocore-migrationhuborchestrator
+    types-aiobotocore-migrationhubstrategy
+    types-aiobotocore-mobile
+    types-aiobotocore-mq
+    types-aiobotocore-mturk
+    types-aiobotocore-mwaa
+    types-aiobotocore-neptune
+    types-aiobotocore-network-firewall
+    types-aiobotocore-networkmanager
+    types-aiobotocore-nimble
+    types-aiobotocore-oam
+    types-aiobotocore-omics
+    types-aiobotocore-opensearch
+    types-aiobotocore-opensearchserverless
+    types-aiobotocore-opsworks
+    types-aiobotocore-opsworkscm
+    types-aiobotocore-organizations
+    types-aiobotocore-osis
+    types-aiobotocore-outposts
+    types-aiobotocore-panorama
+    types-aiobotocore-payment-cryptography
+    types-aiobotocore-payment-cryptography-data
+    types-aiobotocore-personalize
+    types-aiobotocore-personalize-events
+    types-aiobotocore-personalize-runtime
+    types-aiobotocore-pi
+    types-aiobotocore-pinpoint
+    types-aiobotocore-pinpoint-email
+    types-aiobotocore-pinpoint-sms-voice
+    types-aiobotocore-pinpoint-sms-voice-v2
+    types-aiobotocore-pipes
+    types-aiobotocore-polly
+    types-aiobotocore-pricing
+    types-aiobotocore-privatenetworks
+    types-aiobotocore-proton
+    types-aiobotocore-qldb
+    types-aiobotocore-qldb-session
+    types-aiobotocore-quicksight
+    types-aiobotocore-ram
+    types-aiobotocore-rbin
+    types-aiobotocore-rds
+    types-aiobotocore-rds-data
+    types-aiobotocore-redshift
+    types-aiobotocore-redshift-data
+    types-aiobotocore-redshift-serverless
+    types-aiobotocore-rekognition
+    types-aiobotocore-resiliencehub
+    types-aiobotocore-resource-explorer-2
+    types-aiobotocore-resource-groups
+    types-aiobotocore-resourcegroupstaggingapi
+    types-aiobotocore-robomaker
+    types-aiobotocore-rolesanywhere
+    types-aiobotocore-route53
+    types-aiobotocore-route53-recovery-cluster
+    types-aiobotocore-route53-recovery-control-config
+    types-aiobotocore-route53-recovery-readiness
+    types-aiobotocore-route53domains
+    types-aiobotocore-route53resolver
+    types-aiobotocore-rum
+    types-aiobotocore-s3
+    types-aiobotocore-s3control
+    types-aiobotocore-s3outposts
+    types-aiobotocore-sagemaker
+    types-aiobotocore-sagemaker-a2i-runtime
+    types-aiobotocore-sagemaker-edge
+    types-aiobotocore-sagemaker-featurestore-runtime
+    types-aiobotocore-sagemaker-geospatial
+    types-aiobotocore-sagemaker-metrics
+    types-aiobotocore-sagemaker-runtime
+    types-aiobotocore-savingsplans
+    types-aiobotocore-scheduler
+    types-aiobotocore-schemas
+    types-aiobotocore-sdb
+    types-aiobotocore-secretsmanager
+    types-aiobotocore-securityhub
+    types-aiobotocore-securitylake
+    types-aiobotocore-serverlessrepo
+    types-aiobotocore-service-quotas
+    types-aiobotocore-servicecatalog
+    types-aiobotocore-servicecatalog-appregistry
+    types-aiobotocore-servicediscovery
+    types-aiobotocore-ses
+    types-aiobotocore-sesv2
+    types-aiobotocore-shield
+    types-aiobotocore-signer
+    types-aiobotocore-simspaceweaver
+    types-aiobotocore-sms
+    types-aiobotocore-sms-voice
+    types-aiobotocore-snow-device-management
+    types-aiobotocore-snowball
+    types-aiobotocore-sns
+    types-aiobotocore-sqs
+    types-aiobotocore-ssm
+    types-aiobotocore-ssm-contacts
+    types-aiobotocore-ssm-incidents
+    types-aiobotocore-ssm-sap
+    types-aiobotocore-sso
+    types-aiobotocore-sso-admin
+    types-aiobotocore-sso-oidc
+    types-aiobotocore-stepfunctions
+    types-aiobotocore-storagegateway
+    types-aiobotocore-sts
+    types-aiobotocore-support
+    types-aiobotocore-support-app
+    types-aiobotocore-swf
+    types-aiobotocore-synthetics
+    types-aiobotocore-textract
+    types-aiobotocore-timestream-query
+    types-aiobotocore-timestream-write
+    types-aiobotocore-tnb
+    types-aiobotocore-transcribe
+    types-aiobotocore-transfer
+    types-aiobotocore-translate
+    types-aiobotocore-verifiedpermissions
+    types-aiobotocore-voice-id
+    types-aiobotocore-vpc-lattice
+    types-aiobotocore-waf
+    types-aiobotocore-waf-regional
+    types-aiobotocore-wafv2
+    types-aiobotocore-wellarchitected
+    types-aiobotocore-wisdom
+    types-aiobotocore-workdocs
+    types-aiobotocore-worklink
+    types-aiobotocore-workmail
+    types-aiobotocore-workmailmessageflow
+    types-aiobotocore-workspaces
+    types-aiobotocore-workspaces-web
+    types-aiobotocore-xray
+    ;
+
   types-appdirs = callPackage ../development/python-modules/types-appdirs { };
 
   types-awscrt = callPackage ../development/python-modules/types-awscrt { };
@@ -18879,6 +18518,13 @@ self: super: with self; {
   warrant-lite = callPackage ../development/python-modules/warrant-lite { };
 
   wasabi = callPackage ../development/python-modules/wasabi { };
+
+  inherit (self.wasmerPackages)
+    wasmer
+    wasmer-compiler-cranelift
+    wasmer-compiler-llvm
+    wasmer-compiler-singlepass
+    ;
 
   wasmerPackages = pkgs.recurseIntoAttrs (callPackage ../development/python-modules/wasmer { });
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -27,7 +27,8 @@ self: super: with self; {
 
   setuptools = callPackage ../development/python-modules/setuptools { };
 
-  # keep-sorted start block=yes newline_separated=yes
+  # by_regex ensures inherit statements are sorted after the (first) attribute name that is inherited.
+  # keep-sorted start block=yes newline_separated=yes by_regex=["(?:inherit\\s+\\([^)]+\\)\\n?\\s*)?(.+)"]
   a2wsgi = callPackage ../development/python-modules/a2wsgi { };
 
   aafigure = callPackage ../development/python-modules/aafigure { };


### PR DESCRIPTION
This is a follow up to https://github.com/NixOS/nixpkgs/pull/391087, fixing the sorting of inherit blocks. I know this is a bit ugly, but it is working. I'd say we shouldn't let the regex get to complicated to keep the sorting language-agnostic, but the inherit is just such a common use case in these top-level files (and there is no easy way to rewrite it to make sorting easier).

The regex ignores a leading `inherit (something.here)` with a non-capturing group, including an eventually present following newline, so the block will be sorted by (the first) attribute name.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
