### PR TITLE
overskride: 0.6.1 -> 0.6.2

### DIFF
--- a/pkgs/by-name/ov/overskride/package.nix
+++ b/pkgs/by-name/ov/overskride/package.nix
@@ -69,8 +69,6 @@ rustPlatform.buildRustPackage {
   '';
 
   # The "Validate appstream file" test fails.
-  # TODO: This appears to have been fixed upstream
-  # so checks should be enabled with the next version.
   doCheck = false;
 
   preFixup = ''

--- a/pkgs/by-name/ov/overskride/package.nix
+++ b/pkgs/by-name/ov/overskride/package.nix
@@ -21,7 +21,7 @@ let
 
   owner = "kaii-lb";
   name = "overskride";
-  version = "0.6.1";
+  version = "0.6.2";
 
 in
 rustPlatform.buildRustPackage {
@@ -33,7 +33,7 @@ rustPlatform.buildRustPackage {
     inherit owner;
     repo = name;
     rev = "v${version}";
-    hash = "sha256-SqaPhub/HwZz7uBg/kevH8LvPDVLgRd/Rvi03ivNrRc=";
+    hash = "sha256-eMT0wNTpW75V08rmwFtU6NkmZ4auiujzYgbcktewNcI=";
   };
 
   useFetchCargoVendor = true;

--- a/pkgs/by-name/ov/overskride/package.nix
+++ b/pkgs/by-name/ov/overskride/package.nix
@@ -17,20 +17,14 @@
   bluez,
   libpulseaudio,
 }:
-let
-
-  version = "0.6.2";
-
-in
-rustPlatform.buildRustPackage {
-
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "overskride";
-  inherit version;
+  version = "0.6.2";
 
   src = fetchFromGitHub {
     owner = "kaii-lb";
     repo = "overskride";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-eMT0wNTpW75V08rmwFtU6NkmZ4auiujzYgbcktewNcI=";
   };
 
@@ -70,17 +64,16 @@ rustPlatform.buildRustPackage {
   doCheck = false;
 
   preFixup = ''
-    glib-compile-schemas $out/share/gsettings-schemas/overskride-${version}/glib-2.0/schemas
+    glib-compile-schemas $out/share/gsettings-schemas/overskride-${finalAttrs.version}/glib-2.0/schemas
   '';
 
   meta = {
     description = "Bluetooth and Obex client that is straight to the point, DE/WM agnostic, and beautiful";
     homepage = "https://github.com/kaii-lb/overskride";
-    changelog = "https://github.com/kaii-lb/overskride/blob/v${version}/CHANGELOG.md";
+    changelog = "https://github.com/kaii-lb/overskride/blob/v${finalAttrs.version}/CHANGELOG.md";
     license = lib.licenses.gpl3Only;
     mainProgram = "overskride";
     maintainers = with lib.maintainers; [ mrcjkb ];
     platforms = lib.platforms.linux;
   };
-
-}
+})

--- a/pkgs/by-name/ov/overskride/package.nix
+++ b/pkgs/by-name/ov/overskride/package.nix
@@ -19,20 +19,18 @@
 }:
 let
 
-  owner = "kaii-lb";
-  name = "overskride";
   version = "0.6.2";
 
 in
 rustPlatform.buildRustPackage {
 
-  pname = name;
+  pname = "overskride";
   inherit version;
 
   src = fetchFromGitHub {
-    inherit owner;
-    repo = name;
-    rev = "v${version}";
+    owner = "kaii-lb";
+    repo = "overskride";
+    tag = "v${version}";
     hash = "sha256-eMT0wNTpW75V08rmwFtU6NkmZ4auiujzYgbcktewNcI=";
   };
 
@@ -72,15 +70,15 @@ rustPlatform.buildRustPackage {
   doCheck = false;
 
   preFixup = ''
-    glib-compile-schemas $out/share/gsettings-schemas/${name}-${version}/glib-2.0/schemas
+    glib-compile-schemas $out/share/gsettings-schemas/overskride-${version}/glib-2.0/schemas
   '';
 
   meta = {
     description = "Bluetooth and Obex client that is straight to the point, DE/WM agnostic, and beautiful";
-    homepage = "https://github.com/${owner}/${name}";
-    changelog = "https://github.com/${owner}/${name}/blob/v${version}/CHANGELOG.md";
+    homepage = "https://github.com/kaii-lb/overskride";
+    changelog = "https://github.com/kaii-lb/overskride/blob/v${version}/CHANGELOG.md";
     license = lib.licenses.gpl3Only;
-    mainProgram = name;
+    mainProgram = "overskride";
     maintainers = with lib.maintainers; [ mrcjkb ];
     platforms = lib.platforms.linux;
   };


### PR DESCRIPTION
Closes #393667.

## [Changelog](https://github.com/kaii-lb/overskride/releases/tag/v0.6.2)

-  order trusted devices below connected devices (from eclairevoyant's pull request)


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Updated package.
- Refactored `package.nix` (Removed the `name` and `owner` variables).
- Removed a `TODO` comment (the test still fails with v0.6.2).

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
