### PR TITLE
nix-prefetch-github: add nix to dependencies

### DIFF
--- a/pkgs/development/python-modules/nix-prefetch-github/default.nix
+++ b/pkgs/development/python-modules/nix-prefetch-github/default.nix
@@ -10,6 +10,7 @@
   sphinx-argparse,
   parameterized,
   setuptools,
+  nix,
 }:
 
 buildPythonPackage rec {
@@ -29,6 +30,8 @@ buildPythonPackage rec {
     rev = "v${version}";
     hash = "sha256-eQd/MNlnuzXzgFzvwUMchvHoIvkIrbpGKV7iknO14Cc=";
   };
+
+  dependencies = [ nix ];
 
   nativeBuildInputs = [
     sphinxHook


### PR DESCRIPTION
`nix-prefetch-github` breaks when `nix-prefetch-git`/`nix-prefetch-url` aren't in the user's PATH.
To fix this, I added `nix` to `propagatedBuildInputs` to ensure these tools are available in the runtime environment.

Closes #393703
Maintainers: @seppeljordan