### PR TITLE
mtail: 3.0.9 -> 3.0.23

### DIFF
--- a/pkgs/by-name/mt/mtail/package.nix
+++ b/pkgs/by-name/mt/mtail/package.nix
@@ -7,16 +7,16 @@
 
 buildGoModule rec {
   pname = "mtail";
-  version = "3.0.9";
+  version = "3.0.23";
 
   src = fetchFromGitHub {
-    owner = "google";
+    owner = "jaqx0r";
     repo = "mtail";
     rev = "v${version}";
-    hash = "sha256-ZyQpTxWBCU+pmulEXi/Y2PimbNMsUlbEFj8r+gTOTA0=";
+    hash = "sha256-B/to05/qORplhNyz0s7t/WgpmOJ6UZoKnmJfqaf6Htc=";
   };
 
-  vendorHash = "sha256-96r2UWM5HUF69BOGW6buV6juJEDYoiBPmR5iGNmI5WA=";
+  vendorHash = "sha256-jE1tcZJ7TaMC3yegBHE3Zad9sF0EfbHxDA8ffehNL4U=";
 
   ldflags = [
     "-X=main.Branch=main"
@@ -29,7 +29,7 @@ buildGoModule rec {
 
   meta = with lib; {
     description = "Tool for extracting metrics from application logs";
-    homepage = "https://github.com/google/mtail";
+    homepage = "https://github.com/jaqx0r/mtail";
     license = licenses.asl20;
     maintainers = with maintainers; [ nickcao ];
     mainProgram = "mtail";


### PR DESCRIPTION
This bump mtail from 3.0.9 (latest tag on Google's repo) to 3.0.23 (latest release on original author repo).

In this issue (https://github.com/google/mtail/issues/929), the original `mtail`'s author' mentioned that the development will continue on its personal repo since no mtail maintainers have write access to the Google repo anymore.

On jaqx0r's repo (https://github.com/jaqx0r/mtail), there has been multiple releases.

I don't really know what to do about that since there has not been any official response nor archiving of the Google repo, and I'm not sure it's gonna happen to be honest. I made this PR to upgrade to the latest release, but I really don't know what to think about that and if it should be merged?
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
