### PR TITLE
git-point: init at 0.2.2

### DIFF
--- a/pkgs/by-name/gi/git-point/package.nix
+++ b/pkgs/by-name/gi/git-point/package.nix
@@ -1,0 +1,38 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "git-point";
+  version = "0.2.2";
+
+  src = fetchFromGitHub {
+    owner = "Qyriad";
+    repo = "git-point";
+    rev = "v0.2.2";
+    hash = "sha256-mH++Ddfv+OqjRTTGhagAtnNZpD13OtKhAiGxh7Mu0lY=";
+  };
+
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-YwinEAJ8djCE2tHp8VcfcyHSa8rUn8RBnsdW0YqIM3o=";
+
+  postInstall = ''
+    mkdir -p "$out/share/man/man1"
+    "$out/bin/git-point" --mangen > "$out/share/man/man1/git-point.1"
+  '';
+
+  meta = {
+    homepage = "https://github.com/Qyriad/git-point";
+    description = "Set arbitrary refs without shooting yourself in the foot, a procelain `git update-ref`";
+    maintainers = [
+      lib.maintainers.qyriad
+      lib.maintainers.philiptaron
+    ];
+    license = [ lib.licenses.mit ];
+    sourceProvenance = [ lib.sourceTypes.fromSource ];
+    platforms = lib.platforms.all;
+    mainProgram = "git-point";
+  };
+}


### PR DESCRIPTION
Not to be confused with https://gitpoint.co/, an (abandoned?) GitHub mobile app.

`git-point` is a tool to set arbitrary refs without shooting yourself in the foot.

It's a porcelain around the plumbing off `git update-ref`. I found it useful! Thanks @Qyriad.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).