### PR TITLE
nixVersions.nix_2_24: 2.24.12 -> 2.24.13

### DIFF
--- a/pkgs/tools/package-management/nix/default.nix
+++ b/pkgs/tools/package-management/nix/default.nix
@@ -238,8 +238,8 @@ lib.makeExtensible (
           };
 
       nix_2_24 = common {
-        version = "2.24.12";
-        hash = "sha256-lPiheE0D146tstoUInOUf1451stezrd8j6H6w7+RCv8=";
+        version = "2.24.13";
+        hash = "sha256-lUsK8lAwaaTEM+KFML/6sYwaVAiSf70g1EfSDJNNrU0=";
         self_attribute_name = "nix_2_24";
       };
 


### PR DESCRIPTION
This version was tagged without much ceremony a few days ago. It appears to have a regular set of bug fixes.

It has 46 commits: https://github.com/NixOS/nix/compare/2.24.12...2.24.13

Changes:

- https://github.com/NixOS/nix/pull/12332
- https://github.com/NixOS/nix/pull/12344
- https://github.com/NixOS/nix/pull/12352
- https://github.com/NixOS/nix/pull/12365
- https://github.com/NixOS/nix/pull/12357
- https://github.com/NixOS/nix/pull/12434
- https://github.com/NixOS/nix/pull/12451
- https://github.com/NixOS/nix/pull/12487
- https://github.com/NixOS/nix/pull/12508
- https://github.com/NixOS/nix/pull/12528
- https://github.com/NixOS/nix/pull/12535
- https://github.com/NixOS/nix/pull/12653
- https://github.com/NixOS/nix/pull/12683
- https://github.com/NixOS/nix/pull/12731
- https://github.com/NixOS/nix/pull/12737

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).