### PR TITLE
pypy: 7.3.17 -> 7.3.19

### DIFF
--- a/pkgs/development/interpreters/python/default.nix
+++ b/pkgs/development/interpreters/python/default.nix
@@ -138,10 +138,10 @@
       sourceVersion = {
         major = "7";
         minor = "3";
-        patch = "17";
+        patch = "19";
       };
 
-      hash = "sha256-UOBoQPS73pFEgICkEYBoqJuPvK4l/42h4rsUAtyaA0Y=";
+      hash = "sha256-hwPNywH5+Clm3UO2pgGPFAOZ21HrtDwSXB+aIV57sAM=";
       pythonVersion = "2.7";
       db = db.override { dbmSupport = !stdenv.hostPlatform.isDarwin; };
       python = __splicedPackages.pythonInterpreters.pypy27_prebuilt;
@@ -153,11 +153,26 @@
       sourceVersion = {
         major = "7";
         minor = "3";
-        patch = "17";
+        patch = "19";
       };
 
-      hash = "sha256-atdLxXjpxtOoocUVAzEwWOPFjDXfhvdIVFPEvmqyS/c=";
+      hash = "sha256-p8IpMLkY9Ahwhl7Yp0FH9ENO+E09bKKzweupNV1JKcg=";
       pythonVersion = "3.10";
+      db = db.override { dbmSupport = !stdenv.hostPlatform.isDarwin; };
+      python = __splicedPackages.pypy27;
+      inherit passthruFun;
+    };
+
+    pypy311 = callPackage ./pypy {
+      self = __splicedPackages.pypy311;
+      sourceVersion = {
+        major = "7";
+        minor = "3";
+        patch = "19";
+      };
+
+      hash = "sha256-SBfARLtGmjJ05gqjZFdw+B60+RZup/3E5sNRNFVUyNg=";
+      pythonVersion = "3.11";
       db = db.override { dbmSupport = !stdenv.hostPlatform.isDarwin; };
       python = __splicedPackages.pypy27;
       inherit passthruFun;
@@ -169,15 +184,15 @@
       sourceVersion = {
         major = "7";
         minor = "3";
-        patch = "17";
+        patch = "19";
       };
 
       hash =
         {
-          aarch64-linux = "sha256-qN9c4WUPR1aTP4eAhwyRoKQOfJhw10YpvyQTkry1wuM=";
-          x86_64-linux = "sha256-nzSX+HszctF+RHNp4AFqS+yZprTSpZq6d0olv+Q1NHQ=";
-          aarch64-darwin = "sha256-gCJIc5sqzIwb5tlH8Zsy/A44wI4xKzXAXMf7IvEHCeQ=";
-          x86_64-darwin = "sha256-gtRgQhRmyBraSh2Z3y3xuLNTQbOXyF///lGkwwItCDM=";
+          aarch64-linux = "sha256-/onU/UrxP3bf5zFZdQA1GM8XZSDjzOwVRKiNF09QkQ4=";
+          x86_64-linux = "sha256-04RFUIwurxTrs4DZwd7TIcXr6uMcfmaAAXPYPLjd9CM=";
+          aarch64-darwin = "sha256-KHgOC5CK1ttLTglvQjcSS+eezJcxlG2EDZyHSetnp1k=";
+          x86_64-darwin = "sha256-a+KNRI2OZP/8WG2bCuTQkGSoPMrrW4BgxlHFzZrgaHg=";
         }
         .${stdenv.system};
       pythonVersion = "2.7";
@@ -190,17 +205,37 @@
       sourceVersion = {
         major = "7";
         minor = "3";
-        patch = "17";
+        patch = "19";
       };
       hash =
         {
-          aarch64-linux = "sha256-v79JVJirwv53G2C/ZOXDwHLgr7z8pprHKCxP9Dd/9BY=";
-          x86_64-linux = "sha256-NA2kGWYGsiRQmhuLMa/SAYE/CCYB3xicE46QXB1g4K8=";
-          aarch64-darwin = "sha256-KPKf/JxcyQbo6QgT/BRPA34js4TwUuGE4kIzL3tgqwY=";
-          x86_64-darwin = "sha256-I/8mS3PlvFt8OhufrHdosj35bH1mDLZBLxxSNSGjNL8=";
+          aarch64-linux = "sha256-ryeliRePERmOIkSrZcpRBjC6l8Ex18zEAh61vFjef1c=";
+          x86_64-linux = "sha256-xzrCzCOArJIn/Sl0gr8qPheoBhi6Rtt1RNU1UVMh7B4=";
+          aarch64-darwin = "sha256-PbigP8SWFkgBZGhE1/OxK6oK2zrZoLfLEkUhvC4WijY=";
+          x86_64-darwin = "sha256-LF5cKjOsiCVR1/KLmNGdSGuJlapQgkpztO3Mau7DXGM=";
         }
         .${stdenv.system};
       pythonVersion = "3.10";
+      inherit passthruFun;
+    };
+
+    pypy311_prebuilt = callPackage ./pypy/prebuilt.nix {
+      # Not included at top-level
+      self = __splicedPackages.pythonInterpreters.pypy311_prebuilt;
+      sourceVersion = {
+        major = "7";
+        minor = "3";
+        patch = "19";
+      };
+      hash =
+        {
+          aarch64-linux = "sha256-EyB9v4HOJOltp2CxuGNie3e7ILH7TJUZHgKgtyOD33Q=";
+          x86_64-linux = "sha256-kXfZ4LuRsF+SHGQssP9xoPNlO10ppC1A1qB4wVt1cg8=";
+          aarch64-darwin = "sha256-dwTg1TAuU5INMtz+mv7rEENtTJQjPogwz2A6qVWoYcE=";
+          x86_64-darwin = "sha256-okOfnTDf2ulqXpEBx9xUqKaLVsnXMU6jmbCiXT6H67I=";
+        }
+        .${stdenv.system};
+      pythonVersion = "3.11";
       inherit passthruFun;
     };
   }

--- a/pkgs/development/interpreters/python/pypy/prebuilt_2_7.nix
+++ b/pkgs/development/interpreters/python/pypy/prebuilt_2_7.nix
@@ -100,7 +100,6 @@ stdenv.mkDerivation {
     mv -t $out bin include lib-python lib_pypy site-packages
     mv $out/bin/libpypy*-c${stdenv.hostPlatform.extensions.sharedLibrary} $out/lib/
     ${lib.optionalString stdenv.hostPlatform.isLinux ''
-      mv lib/libffi.so.6* $out/lib/
       rm $out/bin/*.debug
     ''}
 

--- a/pkgs/development/interpreters/python/tests.nix
+++ b/pkgs/development/interpreters/python/tests.nix
@@ -237,7 +237,8 @@ let
       }
     );
 
-  condaTests =
+  # depends on mypy, which depends on CPython internals
+  condaTests = lib.optionalAttrs (!python.isPyPy) (
     let
       requests = callPackage (
         {
@@ -276,7 +277,8 @@ let
       condaExamplePackage = runCommand "import-requests" { } ''
         ${pythonWithRequests.interpreter} -c "import requests" > $out
       '';
-    };
+    }
+  );
 
 in
 lib.optionalAttrs (stdenv.hostPlatform == stdenv.buildPlatform) (

--- a/pkgs/development/python-modules/cython/default.nix
+++ b/pkgs/development/python-modules/cython/default.nix
@@ -3,6 +3,7 @@
   buildPythonPackage,
   fetchFromGitHub,
   gdb,
+  isPyPy,
   ncurses,
   numpy,
   pkg-config,
@@ -36,7 +37,9 @@ buildPythonPackage rec {
     ncurses
   ];
 
-  env.LC_ALL = "en_US.UTF-8";
+  env = lib.optionalAttrs (!isPyPy) {
+    LC_ALL = "en_US.UTF-8";
+  };
 
   # https://github.com/cython/cython/issues/2785
   # Temporary solution

--- a/pkgs/development/python-modules/mypy/default.nix
+++ b/pkgs/development/python-modules/mypy/default.nix
@@ -6,6 +6,7 @@
   gitUpdater,
   pythonAtLeast,
   pythonOlder,
+  isPyPy,
 
   # build-system
   setuptools,
@@ -35,7 +36,8 @@ buildPythonPackage rec {
   version = "1.15.0";
   pyproject = true;
 
-  disabled = pythonOlder "3.8";
+  # relies on several CPython internals
+  disabled = pythonOlder "3.8" || isPyPy;
 
   src = fetchFromGitHub {
     owner = "python";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6580,7 +6580,7 @@ with pkgs;
 
   pypy = pypy2;
   pypy2 = pypy27;
-  pypy3 = pypy310;
+  pypy3 = pypy311;
 
   # Python interpreter that is build with all modules, including tkinter.
   # These are for compatibility and should not be used inside Nixpkgs.
@@ -6652,6 +6652,7 @@ with pkgs;
     python3Minimal
     pypy27
     pypy310
+    pypy311
     ;
 
   # List of extensions with overrides to apply to all Python package sets.
@@ -6669,6 +6670,7 @@ with pkgs;
   pypy27Packages = pypy27.pkgs;
   pypy3Packages = pypy3.pkgs;
   pypy310Packages = pypy310.pkgs;
+  pypy311Packages = pypy311.pkgs;
 
   pythonManylinuxPackages = callPackage ./../development/interpreters/python/manylinux { };
 


### PR DESCRIPTION
Regular update, and

- fix for not working `test.support` module
- re-enabled most tests. Still lots of undiagnosed failures however.

Closes #240300 (seems this was taken care of upstream)

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`): some pypy3Packages build. Nothing libxml2-based but that's not new.
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).