### PR TITLE
alda: build from source

### DIFF
--- a/pkgs/by-name/al/alda/deps.json
+++ b/pkgs/by-name/al/alda/deps.json
@@ -1,0 +1,269 @@
+{
+ "!comment": "This is a nixpkgs Gradle dependency lockfile. For more details, refer to the Gradle section in the nixpkgs manual.",
+ "!version": 1,
+ "https://plugins.gradle.org/m2": {
+  "net/java/dev/jna#jna/5.6.0": {
+   "jar": "sha256-VVfiNaiqL5dm1dxgnWeUjyqIMsLXls6p7x1svgs7fq8=",
+   "pom": "sha256-X+gbAlWXjyRhbTexBgi3lJil8wc+HZsgONhzaoMfJgg="
+  },
+  "org/jetbrains/intellij/deps#trove4j/1.0.20200330": {
+   "jar": "sha256-xf1yW/+rUYRr88d9sTg8YKquv+G3/i8A0j/ht98KQ50=",
+   "pom": "sha256-h3IcuqZaPJfYsbqdIHhA8WTJ/jh1n8nqEP/iZWX40+k="
+  },
+  "org/jetbrains/kotlin#kotlin-android-extensions/1.7.21": {
+   "jar": "sha256-JVeliP7QxmbRVq1uDfXjFOqz1p5m6aJyJ5uaRiQ0xq8=",
+   "pom": "sha256-8pic3UN0A8hyZc/K8GHSFOaGlVyX40ntFWa6FqouDI0="
+  },
+  "org/jetbrains/kotlin#kotlin-annotation-processing-gradle/1.7.21": {
+   "jar": "sha256-RhyKdFvNVeRyXykBIVnUdOEor/G4KlPR80UkYFK5cwk=",
+   "pom": "sha256-r2JZxfjfTezw8FXmZcTLaP8TtK9c1HfuHTO/7gAaFr4="
+  },
+  "org/jetbrains/kotlin#kotlin-build-common/1.7.21": {
+   "jar": "sha256-Y3O9HhUPfcsnL1KvvBWZBkCSqddbKM7WvroA/qy6u/8=",
+   "pom": "sha256-msmBVHbIUfFKH3QeG46CJRxyepVGgMdXT4owUn2z718="
+  },
+  "org/jetbrains/kotlin#kotlin-compiler-embeddable/1.7.21": {
+   "jar": "sha256-Ty5JK8x5XgaA4/h67qGtrp8wbK9SBAuUpvoPiP2skvk=",
+   "pom": "sha256-CwIzMip2MO/eEzUmjkYSPw1tNjg5gg/TfE7Lbv+njjs="
+  },
+  "org/jetbrains/kotlin#kotlin-compiler-runner/1.7.21": {
+   "jar": "sha256-LdVae/7udr97ASbFtx0FuJmBK6a0Cjc1n50T+uIC8yc=",
+   "pom": "sha256-+JDieVykDuyu+jpdjkOND3C7YCo5SUe7rOp2Quqy+Tw="
+  },
+  "org/jetbrains/kotlin#kotlin-daemon-client/1.7.21": {
+   "jar": "sha256-tyPlHq8syE/a+sqHJnk/7I1SFyUNiAv0eDA/JE3UGoU=",
+   "pom": "sha256-Be4Gj7v3IvWRSlqiWO6KKLZChF9B1/+bVGhtXKJbvxk="
+  },
+  "org/jetbrains/kotlin#kotlin-daemon-embeddable/1.7.21": {
+   "jar": "sha256-A+bwJUNSJIlOSe5e2EfLCwtKh540z6uQ1wzakmKnV00=",
+   "pom": "sha256-vB3pwgh7ouTlQQF6i66PQF7IAKGK5MJH6R8rVedh5kk="
+  },
+  "org/jetbrains/kotlin#kotlin-gradle-plugin-api/1.7.21": {
+   "jar": "sha256-rflytT2LY7s2jZA88y6bB+pTZW6PnaXxDfuv03gxviE=",
+   "module": "sha256-zGXnGhweng0JaG9cpJGORShIY1q7VCl15HwYlnw6A10=",
+   "pom": "sha256-89unBFqYcdah5QnkF+tjQa3bmHFaL409ZnJlAdq0s0Y="
+  },
+  "org/jetbrains/kotlin#kotlin-gradle-plugin-api/1.7.21/gradle71": {
+   "jar": "sha256-rflytT2LY7s2jZA88y6bB+pTZW6PnaXxDfuv03gxviE="
+  },
+  "org/jetbrains/kotlin#kotlin-gradle-plugin-idea-proto/1.7.21": {
+   "jar": "sha256-NZhwZybLzo0oE05oiZw9WAv3LH6/kJcUHY28rtgnmHg=",
+   "pom": "sha256-PRwDYK9odF8qAyoMAYR//Pnriq1wa/ZZydhAoYTsXyM="
+  },
+  "org/jetbrains/kotlin#kotlin-gradle-plugin-idea/1.7.21": {
+   "jar": "sha256-C1dqyzeBqctWEKphxbev3zKQ/C2digzUv+FTe4dcReY=",
+   "module": "sha256-ygHy2JJMcpaXMax+oVbwi7GP60LDEAClIj2dwW1ZuTg=",
+   "pom": "sha256-Flz/idoRsXIpiJPHg0sNQadm1/PdIPoIvfiJxlXD5zc="
+  },
+  "org/jetbrains/kotlin#kotlin-gradle-plugin-model/1.7.21": {
+   "jar": "sha256-FNP/F7o8tMi+uK3297QFB4gTS4kbsTyr5yPIwQ0dDhg=",
+   "module": "sha256-kCJoZCp1guVF4xgQnjdIw3WxOLCKFVuBX2yAi7vuR7U=",
+   "pom": "sha256-y2vKOdHhBWBXcMCj3ubUXw58XtPFNGiZ9ycQsf//HaY="
+  },
+  "org/jetbrains/kotlin#kotlin-gradle-plugin/1.7.21": {
+   "module": "sha256-j6I2KYtJBynes0XjG8ZPKSj3wbXxwjH8ZtvINlnBZ+E=",
+   "pom": "sha256-0gTXpKcf6Scv44M9x0IAkan/EJaky6JfcnihlUI1BGk="
+  },
+  "org/jetbrains/kotlin#kotlin-gradle-plugin/1.7.21/gradle71": {
+   "jar": "sha256-P12cqfSxiGOZjcVpNIk9m1ICRRzucJ+uuXbI+rI2cyI="
+  },
+  "org/jetbrains/kotlin#kotlin-klib-commonizer-api/1.7.21": {
+   "jar": "sha256-MOGWrbAAH9F7ZgNe2QcNPw5Hui0ycTt1wwPGt7e3FeI=",
+   "pom": "sha256-so6g3vy5lNH7U6e7olh9J0DG0mAXk2UglP1ox0Ul0CA="
+  },
+  "org/jetbrains/kotlin#kotlin-native-utils/1.7.21": {
+   "jar": "sha256-k1KYF/2Nj9hlItZqqtyr0UKhcueMz+uUnNKJ40xw+Qs=",
+   "pom": "sha256-CEYFdUhagoAZC0g8H3fyCk063IegIXTzDuxVdNm65FY="
+  },
+  "org/jetbrains/kotlin#kotlin-project-model/1.7.21": {
+   "jar": "sha256-4htTvrj3SxM6Y4mClPSlfcSiKJvoVfZrD5rosVYjFT8=",
+   "pom": "sha256-JQfT7SKoHyssNSxMUOY1MivHEQClFQJN0NtQRifJ8Bs="
+  },
+  "org/jetbrains/kotlin#kotlin-scripting-common/1.7.21": {
+   "jar": "sha256-0ZLMLNlDFecijrkTZqNpdmpoIrPOvKwUwR1MSXM2y6Q=",
+   "pom": "sha256-2xzYRWGPDLQXOK3H72jZ+NIjZ1sFg+NbsMCEA30AWe4="
+  },
+  "org/jetbrains/kotlin#kotlin-scripting-compiler-embeddable/1.7.21": {
+   "jar": "sha256-qu9jHwICEl2ZHZgjRxn4ZK1anW40m/DtRGsTd9gXGKE=",
+   "pom": "sha256-xHXL2+0BepcMD9y46qu1UNc9E6T+a4e3efxM9S148JM="
+  },
+  "org/jetbrains/kotlin#kotlin-scripting-compiler-impl-embeddable/1.7.21": {
+   "jar": "sha256-ZOK9uuvzgJSzwh5nCX5Qe4NoTaQTi6h6CwmhMgOXVCg=",
+   "pom": "sha256-5c0+HEj+qhC1YVqidOFh5/dcFijcJhZ1ALZ0b4gfweM="
+  },
+  "org/jetbrains/kotlin#kotlin-scripting-jvm/1.7.21": {
+   "jar": "sha256-Uz441a1oFCoFE0HyK8cO113IUGSxk3rPBRN1XMPwSF4=",
+   "pom": "sha256-cnwtOnluoiOWPu7P7kHvKygsVbZ+V8O0mgFwpMSbfGE="
+  },
+  "org/jetbrains/kotlin#kotlin-tooling-core/1.7.21": {
+   "jar": "sha256-N5fxg1NC+8EuycHU+YMyugKCkaMyUakHySJ9j9lK7kg=",
+   "pom": "sha256-tw2g1Eorhw7Lz85ZcMMOOOLs3htfQqHdRC0TA5gSKUY="
+  },
+  "org/jetbrains/kotlin#kotlin-util-io/1.7.21": {
+   "jar": "sha256-7MKI4AQqAUdgOeILbOXgaRj+8fic+J9V39KO8Xwm800=",
+   "pom": "sha256-ziTM1kPWW+8Cey9uINCnkhdq29ug2eVVmS5CR6Y3Ne8="
+  },
+  "org/jetbrains/kotlin#kotlin-util-klib/1.7.21": {
+   "jar": "sha256-UgkkU0RkIN+7h4BN6s6yGfVI53fm3xK35wRKOmaHEgs=",
+   "pom": "sha256-D8d7J3Rc+kzuX+AA5tEpmtSUT3rMB4A7u8ws0rAT3oU="
+  },
+  "org/jetbrains/kotlin/jvm#org.jetbrains.kotlin.jvm.gradle.plugin/1.7.21": {
+   "pom": "sha256-18S+c5nTziimR77ivh3nCwUdpLqoz9X4KYNDJ2UKD30="
+  },
+  "org/jetbrains/kotlinx#kotlinx-coroutines-core-jvm/1.5.0": {
+   "jar": "sha256-eNbMcTX4TWkv83Uvz9H6G74JQNffcGUuTx6u7Ax4r7s=",
+   "module": "sha256-yIXdAoEHbFhDgm3jF+PLzcPYhZ2+71OuHPrNG5xg+W4=",
+   "pom": "sha256-U2IuA3eN+EQPwBIgGjW7S9/kAWTv7GErvvze7LL/wqs="
+  }
+ },
+ "https://repo.maven.apache.org/maven2": {
+  "com/beust#klaxon/5.5": {
+   "jar": "sha256-f3Dsuhzc49DOpclOquGebQxaghgbbCTT3YCKNBnoNmM=",
+   "module": "sha256-cTrnhsjIf450jQbQoAExvIoDm8D8CiW/hPlV7VfMVsk=",
+   "pom": "sha256-teJXipFEa32OdDdaMvcHE4Txk2PIgVVKeC+oi9rc4G0="
+  },
+  "com/github/ajalt#clikt/2.4.0": {
+   "jar": "sha256-y21C07flGUor7O60y2LyYbteF0ZO/UEoWCOx0CaX5NM=",
+   "pom": "sha256-NzDHKP9dkuJfCDJCAtZtUrjqo6pxK15lz2pk+7LQWu0="
+  },
+  "com/illposed/osc#javaosc-core/0.8": {
+   "jar": "sha256-7PP/me8hI4cOUWtC4ey+JDiTHqgPOpAFWB3j4JxPEa0=",
+   "pom": "sha256-mNnI2Dr2I8tkc2WpiY8o6+l8xE7IvEuSu2RnxbN3iig="
+  },
+  "com/illposed/osc#javaosc-parent/0.8": {
+   "pom": "sha256-nEUgmNlVT1AifJfkGt0/t6mvSSUGgHK/3YywUtl8x3U="
+  },
+  "io/github/microutils#kotlin-logging/1.7.7": {
+   "jar": "sha256-1wWAiO9qS6YuCdp5Z3L4Au0bTKiEngcfUaE8BnJ7yNU=",
+   "pom": "sha256-S5CFtHXe6jjnDkQOqtKXvd64cOe72bSs83Lh6XpufwQ="
+  },
+  "io/github/soc#directories/11": {
+   "jar": "sha256-77POMLMv/9qN5mZtpIYCIHOS9+OWbgwuXK92LV8xtNA=",
+   "pom": "sha256-9TrWtmVBXtGq6uEj/Et/1aAjlJ6YYA3ebUBPJoY41L0="
+  },
+  "junit#junit/4.13.2": {
+   "jar": "sha256-jklbY0Rp1k+4rPo0laBly6zIoP/1XOHjEAe+TBbcV9M=",
+   "pom": "sha256-Vptpd+5GA8llwcRsMFj6bpaSkbAWDraWTdCSzYnq3ZQ="
+  },
+  "net/java/dev/jna#jna/5.6.0": {
+   "jar": "sha256-VVfiNaiqL5dm1dxgnWeUjyqIMsLXls6p7x1svgs7fq8=",
+   "pom": "sha256-X+gbAlWXjyRhbTexBgi3lJil8wc+HZsgONhzaoMfJgg="
+  },
+  "org/apache#apache/23": {
+   "pom": "sha256-vBBiTgYj82V3+sVjnKKTbTJA7RUvttjVM6tNJwVDSRw="
+  },
+  "org/apache/logging#logging-parent/3": {
+   "pom": "sha256-djouwrgJTUFh3rbCZLEmIIW5vjC/OjHCzhNyQuV3Iqc="
+  },
+  "org/apache/logging/log4j#log4j-api/2.17.0": {
+   "jar": "sha256-q5ytyA4jRYDj88jBhkQxT8zUs80/cIXU6TSGbLVhuV0=",
+   "pom": "sha256-ZCLZr1mssAd+ipHHw0pAYv9WqXMcNINqckJwhOJ6pHk="
+  },
+  "org/apache/logging/log4j#log4j-core/2.17.0": {
+   "jar": "sha256-ZcM9ybJKXl9srK5iaAZBWCiUdJx78WyVEDLvkvPhKmA=",
+   "pom": "sha256-WUQnTrlVkKznwmIB2XJbSrHHZU0pU658wm1z/95AaL4="
+  },
+  "org/apache/logging/log4j#log4j-slf4j-impl/2.17.0": {
+   "jar": "sha256-+t6tPpnGeG2PtMLM94EEx+xinUfNsKDxT0gmOWHxfiw=",
+   "pom": "sha256-2425FiIV2tNpmqWxkBLh4lcivt+S3nhYvY7R/+kGRak="
+  },
+  "org/apache/logging/log4j#log4j/2.17.0": {
+   "pom": "sha256-hwRgb663edbSkE8CymFuC5gf44nZ/puJ7ISh5CrugdI="
+  },
+  "org/hamcrest#hamcrest-core/1.3": {
+   "jar": "sha256-Zv3vkelzk0jfeglqo4SlaF9Oh1WEzOiThqekclHE2Ok=",
+   "pom": "sha256-/eOGp5BRc6GxA95quCBydYS1DQ4yKC4nl3h8IKZP+pM="
+  },
+  "org/hamcrest#hamcrest-parent/1.3": {
+   "pom": "sha256-bVNflO+2Y722gsnyelAzU5RogAlkK6epZ3UEvBvkEps="
+  },
+  "org/jetbrains#annotations/13.0": {
+   "jar": "sha256-rOKhDcji1f00kl7KwD5JiLLA+FFlDJS4zvSbob0RFHg=",
+   "pom": "sha256-llrrK+3/NpgZvd4b96CzuJuCR91pyIuGN112Fju4w5c="
+  },
+  "org/jetbrains/intellij/deps#trove4j/1.0.20200330": {
+   "jar": "sha256-xf1yW/+rUYRr88d9sTg8YKquv+G3/i8A0j/ht98KQ50=",
+   "pom": "sha256-h3IcuqZaPJfYsbqdIHhA8WTJ/jh1n8nqEP/iZWX40+k="
+  },
+  "org/jetbrains/kotlin#kotlin-compiler-embeddable/1.7.21": {
+   "jar": "sha256-Ty5JK8x5XgaA4/h67qGtrp8wbK9SBAuUpvoPiP2skvk=",
+   "pom": "sha256-CwIzMip2MO/eEzUmjkYSPw1tNjg5gg/TfE7Lbv+njjs="
+  },
+  "org/jetbrains/kotlin#kotlin-daemon-embeddable/1.7.21": {
+   "jar": "sha256-A+bwJUNSJIlOSe5e2EfLCwtKh540z6uQ1wzakmKnV00=",
+   "pom": "sha256-vB3pwgh7ouTlQQF6i66PQF7IAKGK5MJH6R8rVedh5kk="
+  },
+  "org/jetbrains/kotlin#kotlin-klib-commonizer-embeddable/1.7.21": {
+   "jar": "sha256-nTpktCC+2+20HV5tsJ28h2FKffCBR5PACQqDYJBp+1Y=",
+   "pom": "sha256-bOmRoyzYOdq3wbf88+1xbr6XgbRgg3ViDC9fH8RwjrA="
+  },
+  "org/jetbrains/kotlin#kotlin-reflect/1.7.21": {
+   "jar": "sha256-wbF65MSTF+7Sb3ecM8lpBEbFZp6zx+Jsibbg1s8sogQ=",
+   "pom": "sha256-Xn69/iAG9vHksPORwbqBhTmKj2NF2xpStYTx40Cz8EM="
+  },
+  "org/jetbrains/kotlin#kotlin-script-runtime/1.7.21": {
+   "jar": "sha256-LEmLbZiWTK3dS1hLe0mPmxCPaf8akVOrxlt02uQJJ/Y=",
+   "pom": "sha256-LuSdd/3Dw6l0akiYCbfGQ3fh2NnEXCDZI+MXI5sicwQ="
+  },
+  "org/jetbrains/kotlin#kotlin-scripting-common/1.7.21": {
+   "jar": "sha256-0ZLMLNlDFecijrkTZqNpdmpoIrPOvKwUwR1MSXM2y6Q=",
+   "pom": "sha256-2xzYRWGPDLQXOK3H72jZ+NIjZ1sFg+NbsMCEA30AWe4="
+  },
+  "org/jetbrains/kotlin#kotlin-scripting-compiler-embeddable/1.7.21": {
+   "jar": "sha256-qu9jHwICEl2ZHZgjRxn4ZK1anW40m/DtRGsTd9gXGKE=",
+   "pom": "sha256-xHXL2+0BepcMD9y46qu1UNc9E6T+a4e3efxM9S148JM="
+  },
+  "org/jetbrains/kotlin#kotlin-scripting-compiler-impl-embeddable/1.7.21": {
+   "jar": "sha256-ZOK9uuvzgJSzwh5nCX5Qe4NoTaQTi6h6CwmhMgOXVCg=",
+   "pom": "sha256-5c0+HEj+qhC1YVqidOFh5/dcFijcJhZ1ALZ0b4gfweM="
+  },
+  "org/jetbrains/kotlin#kotlin-scripting-jvm/1.7.21": {
+   "jar": "sha256-Uz441a1oFCoFE0HyK8cO113IUGSxk3rPBRN1XMPwSF4=",
+   "pom": "sha256-cnwtOnluoiOWPu7P7kHvKygsVbZ+V8O0mgFwpMSbfGE="
+  },
+  "org/jetbrains/kotlin#kotlin-stdlib-common/1.3.50": {
+   "pom": "sha256-tjlv6ALXvHajgUheJmy5dfOy8tPdm/chOqtsonpWH8E="
+  },
+  "org/jetbrains/kotlin#kotlin-stdlib-common/1.7.21": {
+   "jar": "sha256-5iv+yiNhA6EBciS4oiqEHbXcTbSdgKOb1E27IkaEpmo=",
+   "pom": "sha256-LuberkeOGLGvushzHFvxoUe1dWiT1Z7b+nEWBcNDX4Q="
+  },
+  "org/jetbrains/kotlin#kotlin-stdlib-jdk7/1.7.21": {
+   "jar": "sha256-uMqg+XFaIYf0+pmQba5Xy6EM7vmn+Ajb7o6vNjWVWKU=",
+   "pom": "sha256-vy6yU9onofKT0RRpMpRBeF26xRceWB8v7Z1aKm2YaZw="
+  },
+  "org/jetbrains/kotlin#kotlin-stdlib-jdk8/1.7.21": {
+   "jar": "sha256-sy5K5+uwVycz/kOThb8DT1+u6LbFhdQW/s+TPpSR044=",
+   "pom": "sha256-bzuTQ8QS1q5ApMePuKcJhklkUKlSjNusdimojhqlg4k="
+  },
+  "org/jetbrains/kotlin#kotlin-stdlib/1.7.21": {
+   "jar": "sha256-1Gqddz/7ne5P8adIrIRdyOUABcWJMClRdgorUYe93Rk=",
+   "pom": "sha256-mzkq1D4vQhJp9jxiBz+ulCN9LjHe7o9msZzBkbTaBqw="
+  },
+  "org/jetbrains/kotlin#kotlin-test-annotations-common/1.7.21": {
+   "jar": "sha256-rL18jX1a/ozZJj0T56fr9lAj6tdop723/lXpF6v/PCA=",
+   "pom": "sha256-g9wLShdNHayV7j+hTG6sY+/BMtneVJjaaY+/IcAaD00="
+  },
+  "org/jetbrains/kotlin#kotlin-test-common/1.7.21": {
+   "jar": "sha256-viIcyIaWha97LEDdTl2wIWbODGMiIjdQJ6AH1RefST4=",
+   "pom": "sha256-82l3EYhGqaGsUURO61wrH8ADdOQEgmmdO5BHccR9Ea8="
+  },
+  "org/jetbrains/kotlin#kotlin-test-junit/1.7.21": {
+   "jar": "sha256-uEDz41MSnnZO8oEKLD60oUy9N4OyKMRuFq76xrdjnXA=",
+   "module": "sha256-Y2wOGDQFBAASi++BC4QLyOaTacNK8Wzcdcc08pY3ba4=",
+   "pom": "sha256-JuG33A35HRRJeLEF5jrY09f4XD9Nig0Ayzv6A40QbsQ="
+  },
+  "org/jetbrains/kotlin#kotlin-test/1.7.21": {
+   "jar": "sha256-gduLV6zilmvvZtsh9AG1BA8IDtNgSgLANsKpEftfUSQ=",
+   "module": "sha256-oFFqqWK+trPpadPnwMXIIDv3enEWHxL/RXxDr+Q+VIo=",
+   "pom": "sha256-7cxHqPMffTxln+ebYm673YZp1tqHc8rVf+o+cvfKj/4="
+  },
+  "org/slf4j#slf4j-api/1.7.30": {
+   "jar": "sha256-zboHlk0btAoHYUhcax6ML4/Z6x0ZxTkorA1/lRAQXFc=",
+   "pom": "sha256-fgdHdR6bZ+Gdy1IG8E6iLMA9JQxCJCZALq3QNRPywxQ="
+  },
+  "org/slf4j#slf4j-parent/1.7.30": {
+   "pom": "sha256-EWR5VuSKDFv7OsM/bafoPzQQAraFfv0zWlBbaHvjS3U="
+  }
+ }
+}

--- a/pkgs/by-name/al/alda/package.nix
+++ b/pkgs/by-name/al/alda/package.nix
@@ -1,46 +1,84 @@
 {
   lib,
   stdenv,
-  fetchurl,
+  fetchFromGitHub,
+  buildGoModule,
+  gradle,
   makeWrapper,
   jre,
+  symlinkJoin,
 }:
-
-stdenv.mkDerivation (finalAttrs: {
+let
   pname = "alda";
   version = "2.3.1";
-
-  src_alda = fetchurl {
-    url = "https://alda-releases.nyc3.digitaloceanspaces.com/${finalAttrs.version}/client/linux-amd64/alda";
-    hash = "sha256-m4d3cLgqWmGMw0SM4J+7nvV/ytSoB7obMDiJCh3yboQ=";
+  src = fetchFromGitHub {
+    owner = "alda-lang";
+    repo = "alda";
+    rev = "release-${version}";
+    hash = "sha256-//VfegK8wkGKSpvtsNTEQqbVJkcucNiamoNIXaEBLb8=";
   };
 
-  src_player = fetchurl {
-    url = "https://alda-releases.nyc3.digitaloceanspaces.com/${finalAttrs.version}/player/non-windows/alda-player";
-    hash = "sha256-XwgOidQjnMClXPIS1JPzsVJ6c7vXwBHBAfUPX3WL8uU=";
-  };
+  alda_client = buildGoModule {
+    pname = "${pname}-client";
+    inherit version src;
 
-  dontUnpack = true;
+    sourceRoot = "${src.name}/client";
+    vendorHash = "sha256-h09w6ZLirLNxYv/ibeN5pCnXSvT+1FGiXiYNReZBMXI=";
 
-  nativeBuildInputs = [ makeWrapper ];
-
-  installPhase =
-    let
-      binPath = lib.makeBinPath [ jre ];
-    in
-    ''
-      install -D ${finalAttrs.src_alda} $out/bin/alda
-      install -D ${finalAttrs.src_player} $out/bin/alda-player
-
-      wrapProgram $out/bin/alda --prefix PATH : $out/bin:${binPath}
-      wrapProgram $out/bin/alda-player --prefix PATH : $out/bin:${binPath}
+    preBuild = ''
+      go generate main.go
     '';
+
+    env.CGO_ENABLED = 0;
+    ldflags = [
+      "-w"
+      "-extldflags '-static'"
+    ];
+    tags = [ "netgo" ];
+    subPackages = [ "." ];
+
+
+    postInstall = ''
+      mv $out/bin/client $out/bin/alda
+    '';
+  };
+  alda_player = stdenv.mkDerivation {
+    pname = "${pname}-player";
+    inherit version src;
+
+    sourceRoot = "${src.name}/player";
+    nativeBuildInputs = [ gradle makeWrapper ];
+
+    mitmCache = gradle.fetchDeps {
+      inherit pname;
+      data = ./deps.json;
+    };
+    __darwinAllowLocalNetworking = true;
+
+    gradleBuildTask = "fatJar";
+
+    installPhase = ''
+    mkdir -p $out/{bin,share}
+    cp build/libs/alda-player-fat.jar $out/share
+
+    makeWrapper ${lib.getExe jre} $out/bin/alda-player \
+      --add-flags "-jar $out/share/alda-player-fat.jar"
+  '';
+  };
+in
+symlinkJoin {
+  inherit pname version;
+  paths = [ alda_client alda_player ];
 
   meta = {
     description = "Music programming language for musicians";
     homepage = "https://alda.io";
     license = lib.licenses.epl10;
+    sourceProvenance = with lib.sourceTypes; [
+      fromSource
+      binaryBytecode
+    ];
     maintainers = [ lib.maintainers.ericdallo ];
     platforms = jre.meta.platforms;
   };
-})
+}

--- a/pkgs/by-name/pl/playerctl/package.nix
+++ b/pkgs/by-name/pl/playerctl/package.nix
@@ -25,6 +25,11 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-OiGKUnsKX0ihDRceZoNkcZcEAnz17h2j2QUOSVcxQEY=";
   };
 
+  postPatch = lib.optionalString (stdenv.hostPlatform.isDarwin) ''
+    substituteInPlace playerctl/meson.build \
+      --replace-fail 'link_args' '# link_args'
+  '';
+
   nativeBuildInputs =
     [
       docbook_xsl
@@ -51,7 +56,6 @@ stdenv.mkDerivation rec {
     license = licenses.lgpl3;
     platforms = platforms.unix;
     maintainers = with maintainers; [ puffnfresh ];
-    broken = stdenv.hostPlatform.isDarwin;
     mainProgram = "playerctl";
   };
 }

--- a/pkgs/by-name/sp/spotifyd/package.nix
+++ b/pkgs/by-name/sp/spotifyd/package.nix
@@ -45,8 +45,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   buildInputs =
     lib.optionals stdenv.hostPlatform.isDarwin [ apple-sdk_11 ]
     ++ lib.optionals stdenv.hostPlatform.isLinux [ openssl ]
-    # The `dbus_mpris` feature works on other platforms, but only requires `dbus` on Linux
-    ++ lib.optional (withMpris && stdenv.hostPlatform.isLinux) dbus
+    ++ lib.optional withMpris dbus
     ++ lib.optional (withALSA || withJack) alsa-lib
     ++ lib.optional withJack libjack2
     ++ lib.optional withPulseAudio libpulseaudio

--- a/pkgs/development/libraries/dbus/default.nix
+++ b/pkgs/development/libraries/dbus/default.nix
@@ -44,6 +44,11 @@ stdenv.mkDerivation rec {
         --replace 'DBUS_BINDIR "/dbus-launch"' "\"$lib/bin/dbus-launch\""
       substituteInPlace ./tools/dbus-launch.c \
         --replace 'DBUS_DAEMONDIR"/dbus-daemon"' '"/run/current-system/sw/bin/dbus-daemon"'
+
+      substituteInPlace ./configure.ac \
+        --replace-fail 'AC_PATH_PROG([LAUNCHCTL], [launchctl])' 'LAUNCHCTL=/bin/launchctl'
+      substituteInPlace ./bus/org.freedesktop.dbus-session.plist.in \
+        --replace-fail '--session' '--config-file=${placeholder "out"}/share/dbus-1/session.conf'
     '';
 
   outputs = [
@@ -106,6 +111,10 @@ stdenv.mkDerivation rec {
     ++ lib.optionals stdenv.hostPlatform.isLinux [
       "--enable-apparmor"
       "--enable-libaudit"
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [
+      "--enable-launchd"
+      "--with-launchd-agent-dir=${placeholder "out"}/etc/launchd"
     ]
     ++ lib.optionals enableSystemd [ "SYSTEMCTL=${systemdMinimal}/bin/systemctl" ];
 

--- a/pkgs/development/python-modules/jeepney/default.nix
+++ b/pkgs/development/python-modules/jeepney/default.nix
@@ -41,7 +41,7 @@ buildPythonPackage rec {
       async-timeout
     ];
 
-  checkPhase = ''
+  checkPhase = lib.optionalString (!stdenv.hostPlatform.isDarwin) ''
     runHook preCheck
 
     dbus-run-session --config-file=${dbus}/share/dbus-1/session.conf -- pytest ${lib.optionalString stdenv.hostPlatform.isDarwin "--ignore=jeepney/io/tests"}


### PR DESCRIPTION
Unfortunately building `alda_player` fails in the Darwin sandbox (even with `__darwinAllowLocalNetworking = true;`) with the following error:
```
FAILURE: Build failed with an exception.

* What went wrong:
Could not connect to the Gradle daemon.
Daemon uid: 95e0f8d9-ff8a-4a84-b63e-bfed01f98bbf with diagnostics:
Daemon pid: 8311
  log file: /private/tmp/nix-build-alda-player-2.3.1.drv-0/tmp.4hRyP09Pgk/daemon/8.12.1/daemon-8311.out.log
----- Last 20 lines from daemon log file - daemon-8311.out.log -----
2025-03-27T23:48:10.086+0000 [DEBUG] [org.gradle.internal.remote.internal.inet.InetAddresses] Ignoring remote address on loopback interface /fe80:0:0:0:0:0:0:1%lo0
2025-03-27T23:48:10.086+0000 [DEBUG] [org.gradle.internal.remote.internal.inet.InetAddresses] Adding loopback address /0:0:0:0:0:0:0:1%lo0
2025-03-27T23:48:10.086+0000 [DEBUG] [org.gradle.internal.remote.internal.inet.InetAddresses] Adding loopback address /127.0.0.1
2025-03-27T23:48:10.109+0000 [INFO] [org.gradle.launcher.daemon.server.Daemon] start() called on daemon - DefaultDaemonContext[uid=95e0f8d9-ff8a-4a84-b63e-bfed01f98bbf,javaHome=/nix/store/nz43fcs7v4iqw62p729yv2dcv6v2xv98-zulu-ca-jdk-21.0.4/zulu-21.jdk/Contents/Home,javaVersion=21,javaVendor=Azul Systems, Inc.,daemonRegistryDir=/private/tmp/nix-build-alda-player-2.3.1.drv-0/tmp.4hRyP09Pgk/daemon,pid=8311,idleTimeout=120000,priority=NORMAL,applyInstrumentationAgent=true,nativeServicesMode=ENABLED,daemonOpts=-XX:MaxMetaspaceSize=384m,-XX:+HeapDumpOnOutOfMemoryError,-Xms256m,-Xmx512m,-Dfile.encoding=UTF-8,-Djavax.net.ssl.trustStore=/private/tmp/nix-build-alda-player-2.3.1.drv-0/tmp.r523vfcAR3/keystore,-Djavax.net.ssl.trustStorePassword=5TKQDK42RAA5USLH,-Duser.country=001,-Duser.language=en,-Duser.variant]
2025-03-27T23:48:10.131+0000 [DEBUG] [org.gradle.internal.remote.internal.inet.TcpIncomingConnector] Listening on [9d209726-4309-42c9-a82e-1fe1439c4519 port:60079, addresses:[localhost/127.0.0.1]].
2025-03-27T23:48:10.139+0000 [DEBUG] [org.gradle.launcher.daemon.server.Daemon] Daemon starting at: Thu Mar 27 23:48:10 UTC 2025, with address: [9d209726-4309-42c9-a82e-1fe1439c4519 port:60079, addresses:[localhost/127.0.0.1]]
2025-03-27T23:48:10.139+0000 [INFO] [org.gradle.launcher.daemon.server.DaemonRegistryUpdater] Advertising the daemon address to the clients: [9d209726-4309-42c9-a82e-1fe1439c4519 port:60079, addresses:[localhost/127.0.0.1]]
2025-03-27T23:48:10.139+0000 [DEBUG] [org.gradle.launcher.daemon.server.DaemonRegistryUpdater] Advertised daemon context: DefaultDaemonContext[uid=95e0f8d9-ff8a-4a84-b63e-bfed01f98bbf,javaHome=/nix/store/nz43fcs7v4iqw62p729yv2dcv6v2xv98-zulu-ca-jdk-21.0.4/zulu-21.jdk/Contents/Home,javaVersion=21,javaVendor=Azul Systems, Inc.,daemonRegistryDir=/private/tmp/nix-build-alda-player-2.3.1.drv-0/tmp.4hRyP09Pgk/daemon,pid=8311,idleTimeout=120000,priority=NORMAL,applyInstrumentationAgent=true,nativeServicesMode=ENABLED,daemonOpts=-XX:MaxMetaspaceSize=384m,-XX:+HeapDumpOnOutOfMemoryError,-Xms256m,-Xmx512m,-Dfile.encoding=UTF-8,-Djavax.net.ssl.trustStore=/private/tmp/nix-build-alda-player-2.3.1.drv-0/tmp.r523vfcAR3/keystore,-Djavax.net.ssl.trustStorePassword=5TKQDK42RAA5USLH,-Duser.country=001,-Duser.language=en,-Duser.variant]
2025-03-27T23:48:10.140+0000 [DEBUG] [org.gradle.launcher.daemon.registry.PersistentDaemonRegistry] Storing daemon address: [9d209726-4309-42c9-a82e-1fe1439c4519 port:60079, addresses:[localhost/127.0.0.1]], context: DefaultDaemonContext[uid=95e0f8d9-ff8a-4a84-b63e-bfed01f98bbf,javaHome=/nix/store/nz43fcs7v4iqw62p729yv2dcv6v2xv98-zulu-ca-jdk-21.0.4/zulu-21.jdk/Contents/Home,javaVersion=21,javaVendor=Azul Systems, Inc.,daemonRegistryDir=/private/tmp/nix-build-alda-player-2.3.1.drv-0/tmp.4hRyP09Pgk/daemon,pid=8311,idleTimeout=120000,priority=NORMAL,applyInstrumentationAgent=true,nativeServicesMode=ENABLED,daemonOpts=-XX:MaxMetaspaceSize=384m,-XX:+HeapDumpOnOutOfMemoryError,-Xms256m,-Xmx512m,-Dfile.encoding=UTF-8,-Djavax.net.ssl.trustStore=/private/tmp/nix-build-alda-player-2.3.1.drv-0/tmp.r523vfcAR3/keystore,-Djavax.net.ssl.trustStorePassword=5TKQDK42RAA5USLH,-Duser.country=001,-Duser.language=en,-Duser.variant]
2025-03-27T23:48:10.145+0000 [DEBUG] [org.gradle.cache.internal.DefaultFileLockManager] Waiting to acquire exclusive lock on daemon addresses registry.
2025-03-27T23:48:10.147+0000 [DEBUG] [org.gradle.cache.internal.DefaultFileLockManager] Lock acquired on daemon addresses registry.
2025-03-27T23:48:10.147+0000 [DEBUG] [org.gradle.cache.internal.DefaultFileLockManager] Releasing lock on daemon addresses registry.
2025-03-27T23:48:10.149+0000 [DEBUG] [org.gradle.cache.internal.DefaultFileLockManager] Waiting to acquire exclusive lock on daemon addresses registry.
2025-03-27T23:48:10.149+0000 [DEBUG] [org.gradle.cache.internal.DefaultFileLockManager] Lock acquired on daemon addresses registry.
2025-03-27T23:48:10.150+0000 [DEBUG] [org.gradle.cache.internal.DefaultFileLockManager] Releasing lock on daemon addresses registry.
2025-03-27T23:48:10.150+0000 [LIFECYCLE] [org.gradle.launcher.daemon.server.Daemon] Daemon server started.
2025-03-27T23:48:10.151+0000 [DEBUG] [org.gradle.launcher.daemon.bootstrap.DaemonStartupCommunication] Completed writing the daemon greeting. Closing streams...
2025-03-27T23:48:10.157+0000 [DEBUG] [org.gradle.launcher.daemon.server.Daemon] stopOnExpiration() called on daemon
2025-03-27T23:48:10.158+0000 [DEBUG] [org.gradle.launcher.daemon.server.Daemon] awaitExpiration() called on daemon
2025-03-27T23:48:10.158+0000 [DEBUG] [org.gradle.launcher.daemon.server.DaemonStateCoordinator] daemon is running. Sleeping until state changes.----- End of the daemon log -----


* Try:
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Run with --scan to get full insights.
> Get more help at https://help.gradle.org.
```
If someone more familiar with the Java ecosystem knows why that might be the case or have tips for debugging that, that would be fantastic.

I'm also not sure how idiomatic my usage of `symlinkJoin` to package the player and client together is, feedback welcome.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc