### PR TITLE
python312Packages.torch: build torch.distributed on darwin

### DIFF
--- a/pkgs/development/python-modules/accelerate/default.nix
+++ b/pkgs/development/python-modules/accelerate/default.nix
@@ -3,6 +3,7 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+  fetchpatch,
   pythonAtLeast,
 
   # buildInputs
@@ -42,6 +43,14 @@ buildPythonPackage rec {
     tag = "v${version}";
     hash = "sha256-J4eDm/PcyKK3256l6CAWUj4AWTB6neTKgxbBmul0BPE=";
   };
+
+  patches = [
+    # Fix tests on darwin: https://github.com/huggingface/accelerate/pull/3464
+    (fetchpatch {
+      url = "https://github.com/huggingface/accelerate/commit/8b31a2fe2c6d0246fff9885fb1f8456fb560abc7.patch";
+      hash = "sha256-Ek9Ou4Y/H1jt3qanf2g3HowBoTsN/bn4yV9O3ogcXMo=";
+    })
+  ];
 
   buildInputs = [ llvmPackages.openmp ];
 

--- a/pkgs/development/python-modules/colbert-ai/default.nix
+++ b/pkgs/development/python-modules/colbert-ai/default.nix
@@ -74,10 +74,5 @@ buildPythonPackage rec {
     maintainers = with lib.maintainers; [
       bachp
     ];
-    badPlatforms = [
-      # `import torch.distributed.tensor` fails on darwin:
-      # ModuleNotFoundError: No module named 'torch._C._distributed_c10d'; 'torch._C' is not a packag
-      lib.systems.inspect.patterns.isDarwin
-    ];
   };
 }

--- a/pkgs/development/python-modules/compressed-tensors/default.nix
+++ b/pkgs/development/python-modules/compressed-tensors/default.nix
@@ -43,21 +43,15 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
-  disabledTests =
-    [
-      # these try to download models from HF Hub
-      "test_get_observer_token_count"
-      "test_kv_cache_quantization"
-      "test_target_prioritization"
-      "test_load_compressed_sharded"
-      "test_save_compressed_model"
-      "test_apply_tinyllama_dynamic_activations"
-    ]
-    ++ lib.optionals stdenv.hostPlatform.isDarwin [
-      # No module named 'torch._C._distributed_c10d'; 'torch._C' is not a package
-      "test_composability"
-      "test_missing_and_unexpected_keys_on_compression"
-    ];
+  disabledTests = [
+    # these try to download models from HF Hub
+    "test_get_observer_token_count"
+    "test_kv_cache_quantization"
+    "test_target_prioritization"
+    "test_load_compressed_sharded"
+    "test_save_compressed_model"
+    "test_apply_tinyllama_dynamic_activations"
+  ];
 
   disabledTestPaths = [
     # these try to download models from HF Hub

--- a/pkgs/development/python-modules/docling-ibm-models/default.nix
+++ b/pkgs/development/python-modules/docling-ibm-models/default.nix
@@ -83,12 +83,6 @@ buildPythonPackage rec {
     "test_tf_predictor"
   ];
 
-  disabledTestPaths = lib.optionals stdenv.hostPlatform.isDarwin [
-    # No module named 'torch._C._distributed_c10d'; 'torch._C' is not a package
-    "tests/test_code_formula_predictor.py"
-    "tests/test_layout_predictor.py"
-  ];
-
   meta = {
     changelog = "https://github.com/DS4SD/docling-ibm-models/blob/${src.tag}/CHANGELOG.md";
     description = "Docling IBM models";

--- a/pkgs/development/python-modules/docling/default.nix
+++ b/pkgs/development/python-modules/docling/default.nix
@@ -164,26 +164,6 @@ buildPythonPackage rec {
     "test_e2e_valid_csv_conversions"
   ];
 
-  disabledTestPaths = lib.optionals stdenv.hostPlatform.isDarwin [
-    # No module named 'torch._C._distributed_c10d'; 'torch._C' is not a package
-    "tests/test_backend_csv.py"
-    "tests/test_backend_html.py"
-    "tests/test_backend_jats.py"
-    "tests/test_backend_msexcel.py"
-    "tests/test_backend_msword.py"
-    "tests/test_backend_pptx.py"
-    "tests/test_cli.py"
-    "tests/test_code_formula.py"
-    "tests/test_document_picture_classifier.py"
-    "tests/test_e2e_conversion.py"
-    "tests/test_e2e_ocr_conversion.py"
-    "tests/test_input_doc.py"
-    "tests/test_interfaces.py"
-    "tests/test_invalid_input.py"
-    "tests/test_legacy_format_transform.py"
-    "tests/test_options.py"
-  ];
-
   meta = {
     description = "Get your documents ready for gen AI";
     homepage = "https://github.com/DS4SD/docling";

--- a/pkgs/development/python-modules/finetuning-scheduler/default.nix
+++ b/pkgs/development/python-modules/finetuning-scheduler/default.nix
@@ -71,9 +71,5 @@ buildPythonPackage rec {
     changelog = "https://github.com/speediedan/finetuning-scheduler/blob/v${version}/CHANGELOG.md";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ bcdarwin ];
-    badPlatforms = [
-      # "No module named 'torch._C._distributed_c10d'; 'torch._C' is not a package" at import time:
-      lib.systems.inspect.patterns.isDarwin
-    ];
   };
 }

--- a/pkgs/development/python-modules/finetuning-scheduler/default.nix
+++ b/pkgs/development/python-modules/finetuning-scheduler/default.nix
@@ -3,6 +3,7 @@
   stdenv,
   buildPythonPackage,
   fetchFromGitHub,
+  fetchpatch,
 
   # build-system
   setuptools,
@@ -28,6 +29,13 @@ buildPythonPackage rec {
     tag = "v${version}";
     hash = "sha256-+jt+if9aAbEd2XDMC7RpZmJpm4VUEZMt5xoLOP/esMg=";
   };
+
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/speediedan/finetuning-scheduler/commit/78e6e225f353d1ba95db05d7fc6ff541859ed6a2.patch";
+      hash = "sha256-7mbtsaHrnHph8lvuwhBGqxPQimbZcbGeyBYXzApFPn4=";
+    })
+  ];
 
   build-system = [ setuptools ];
 

--- a/pkgs/development/python-modules/gradio/default.nix
+++ b/pkgs/development/python-modules/gradio/default.nix
@@ -301,21 +301,16 @@ buildPythonPackage rec {
       "test_updates_stored_up_to_capacity"
       "test_varying_output_forms_with_generators"
     ];
-  disabledTestPaths =
-    [
-      # 100% touches network
-      "test/test_networking.py"
-      "client/python/test/test_client.py"
-      # makes pytest freeze 50% of the time
-      "test/test_interfaces.py"
+  disabledTestPaths = [
+    # 100% touches network
+    "test/test_networking.py"
+    "client/python/test/test_client.py"
+    # makes pytest freeze 50% of the time
+    "test/test_interfaces.py"
 
-      # Local network tests dependant on port availability (port 7860-7959)
-      "test/test_routes.py"
-    ]
-    ++ lib.optionals (stdenv.hostPlatform.isDarwin) [
-      # No module named 'torch._C._distributed_c10d'; 'torch._C' is not a package
-      "test/test_pipelines.py"
-    ];
+    # Local network tests dependant on port availability (port 7860-7959)
+    "test/test_routes.py"
+  ];
   pytestFlagsArray = [
     "-x" # abort on first failure
     "-m 'not flaky'"

--- a/pkgs/development/python-modules/ignite/default.nix
+++ b/pkgs/development/python-modules/ignite/default.nix
@@ -96,7 +96,5 @@ buildPythonPackage rec {
     changelog = "https://github.com/pytorch/ignite/releases/tag/v${version}";
     license = lib.licenses.bsd3;
     maintainers = [ lib.maintainers.bcdarwin ];
-    # ModuleNotFoundError: No module named 'torch._C._distributed_c10d'; 'torch._C' is not a package
-    broken = stdenv.hostPlatform.isDarwin;
   };
 }

--- a/pkgs/development/python-modules/peft/default.nix
+++ b/pkgs/development/python-modules/peft/default.nix
@@ -2,6 +2,7 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+  stdenv,
 
   # build-system
   setuptools,
@@ -68,6 +69,11 @@ buildPythonPackage rec {
   ];
 
   pytestFlagsArray = [ "tests" ];
+
+  # These tests fail when MPS devices are detected
+  disabledTests = lib.optional stdenv.isDarwin [
+    "gpu"
+  ];
 
   disabledTestPaths = [
     # ValueError: Can't find 'adapter_config.json'

--- a/pkgs/development/python-modules/peft/default.nix
+++ b/pkgs/development/python-modules/peft/default.nix
@@ -104,9 +104,5 @@ buildPythonPackage rec {
     changelog = "https://github.com/huggingface/peft/releases/tag/v${version}";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ bcdarwin ];
-    badPlatforms = [
-      # No module named 'torch._C._distributed_c10d'; 'torch._C' is not a package
-      lib.systems.inspect.patterns.isDarwin
-    ];
   };
 }

--- a/pkgs/development/python-modules/pytorch-pfn-extras/default.nix
+++ b/pkgs/development/python-modules/pytorch-pfn-extras/default.nix
@@ -66,7 +66,7 @@ buildPythonPackage rec {
       "test_register"
     ]
     ++ lib.optionals stdenv.hostPlatform.isDarwin [
-      # torch.distributed is not available on darwin
+      # torch.distributed was not available on darwin at one point; revisit
       "test_create_distributed_evaluator"
       "test_distributed_evaluation"
       "test_distributed_evaluator_progress_bar"
@@ -96,7 +96,7 @@ buildPythonPackage rec {
       "tests/pytorch_pfn_extras_tests/dynamo_tests/test_compile.py"
     ]
     ++ lib.optionals (stdenv.hostPlatform.isDarwin) [
-      # torch.distributed is not available on darwin
+      # torch.distributed was not available on darwin at one point; revisit
       "tests/pytorch_pfn_extras_tests/distributed_tests/test_distributed_validation_sampler.py"
       "tests/pytorch_pfn_extras_tests/nn_tests/parallel_tests/test_distributed.py"
       "tests/pytorch_pfn_extras_tests/profiler_tests/test_record.py"
@@ -116,5 +116,9 @@ buildPythonPackage rec {
     changelog = "https://github.com/pfnet/pytorch-pfn-extras/releases/tag/${src.tag}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ samuela ];
+    badPlatforms = [
+      # test_profile_report is broken on darwin
+      lib.systems.inspect.patterns.isDarwin
+    ];
   };
 }

--- a/pkgs/development/python-modules/sentence-transformers/default.nix
+++ b/pkgs/development/python-modules/sentence-transformers/default.nix
@@ -113,9 +113,5 @@ buildPythonPackage rec {
     changelog = "https://github.com/UKPLab/sentence-transformers/releases/tag/v${version}";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ dit7ya ];
-    badPlatforms = [
-      # No module named 'torch._C._distributed_c10d'; 'torch._C' is not a package
-      lib.systems.inspect.patterns.isDarwin
-    ];
   };
 }

--- a/pkgs/development/python-modules/smolagents/default.nix
+++ b/pkgs/development/python-modules/smolagents/default.nix
@@ -136,12 +136,6 @@ buildPythonPackage rec {
       "test_new_instance"
     ];
 
-  disabledTestPaths = lib.optionals stdenv.hostPlatform.isDarwin [
-    # No module named 'torch._C._distributed_c10d'; 'torch._C' is not a package
-    "tests/test_final_answer.py"
-    "tests/test_types.py"
-  ];
-
   __darwinAllowLocalNetworking = true;
 
   meta = {

--- a/pkgs/development/python-modules/tensordict/default.nix
+++ b/pkgs/development/python-modules/tensordict/default.nix
@@ -66,15 +66,10 @@ buildPythonPackage rec {
     "test_map_iter_interrupt_early"
   ];
 
-  disabledTestPaths =
-    [
-      # torch._dynamo.exc.Unsupported: Graph break due to unsupported builtin None.ReferenceType.__new__.
-      "test/test_compile.py"
-    ]
-    ++ lib.optionals stdenv.hostPlatform.isDarwin [
-      # ModuleNotFoundError: No module named 'torch._C._distributed_c10d'; 'torch._C' is not a package
-      "test/test_distributed.py"
-    ];
+  disabledTestPaths = [
+    # torch._dynamo.exc.Unsupported: Graph break due to unsupported builtin None.ReferenceType.__new__.
+    "test/test_compile.py"
+  ];
 
   meta = {
     description = "Pytorch dedicated tensor container";

--- a/pkgs/development/python-modules/torch/clang19-template-warning.patch
+++ b/pkgs/development/python-modules/torch/clang19-template-warning.patch
@@ -1,0 +1,31 @@
+Submodule third_party/libnop contains modified content
+diff --git a/third_party/tensorpipe/third_party/libnop/include/nop/types/variant.h b/third_party/tensorpipe/third_party/libnop/include/nop/types/variant.h
+index cffbde1..b6ebfab 100644
+--- a/third_party/tensorpipe/third_party/libnop/include/nop/types/variant.h
++++ b/third_party/tensorpipe/third_party/libnop/include/nop/types/variant.h
+@@ -238,7 +238,7 @@ class Variant {
+   // resulting type.
+   template <typename... Args>
+   void Construct(Args&&... args) {
+-    index_ = value_.template Construct(std::forward<Args>(args)...);
++    index_ = value_.template Construct<>(std::forward<Args>(args)...);
+   }
+   void Construct(EmptyVariant) {}
+ 
+@@ -255,14 +255,14 @@ class Variant {
+   // multiple element types.
+   template <typename T, typename U>
+   void Assign(TypeTag<T>, U&& value) {
+-    if (!value_.template Assign(TypeTag<T>{}, index_, std::forward<U>(value))) {
++    if (!value_.template Assign<>(TypeTag<T>{}, index_, std::forward<U>(value))) {
+       Destruct();
+       Construct(TypeTag<T>{}, std::forward<U>(value));
+     }
+   }
+   template <typename T>
+   void Assign(T&& value) {
+-    if (!value_.template Assign(index_, std::forward<T>(value))) {
++    if (!value_.template Assign<>(index_, std::forward<T>(value))) {
+       Destruct();
+       Construct(std::forward<T>(value));
+     }

--- a/pkgs/development/python-modules/torch/default.nix
+++ b/pkgs/development/python-modules/torch/default.nix
@@ -266,7 +266,8 @@ buildPythonPackage rec {
   };
 
   patches =
-    lib.optionals cudaSupport [ ./fix-cmake-cuda-toolkit.patch ]
+    [ ./clang19-template-warning.patch ]
+    ++ lib.optionals cudaSupport [ ./fix-cmake-cuda-toolkit.patch ]
     ++ lib.optionals stdenv.hostPlatform.isLinux [
       # Propagate CUPTI to Kineto by overriding the search path with environment variables.
       # https://github.com/pytorch/pytorch/pull/108847
@@ -380,6 +381,10 @@ buildPythonPackage rec {
 
   # Explicitly enable MPS for Darwin
   USE_MPS = setBool stdenv.hostPlatform.isDarwin;
+
+  # building torch.distributed on Darwin is disabled by default
+  # https://pytorch.org/docs/stable/distributed.html#torch.distributed.is_available
+  USE_DISTRIBUTED = setBool true;
 
   cmakeFlags =
     [

--- a/pkgs/development/python-modules/torch/default.nix
+++ b/pkgs/development/python-modules/torch/default.nix
@@ -587,8 +587,15 @@ buildPythonPackage rec {
       find "$out/${python.sitePackages}/torch/include" "$out/${python.sitePackages}/torch/lib" -type f -exec remove-references-to -t ${stdenv.cc} '{}' +
 
       mkdir $dev
+
+      # CppExtension requires that include files are packaged with the main
+      # python library output; which is why they are copied here.
       cp -r $out/${python.sitePackages}/torch/include $dev/include
-      cp -r $out/${python.sitePackages}/torch/share $dev/share
+
+      # Cmake files under /share are different and can be safely moved. This
+      # avoids unnecessary closure blow-up due to apple sdk references when
+      # USE_DISTRIBUTED is enabled.
+      mv $out/${python.sitePackages}/torch/share $dev/share
 
       # Fix up library paths for split outputs
       substituteInPlace \

--- a/pkgs/development/python-modules/torchsnapshot/default.nix
+++ b/pkgs/development/python-modules/torchsnapshot/default.nix
@@ -67,9 +67,5 @@ buildPythonPackage rec {
     changelog = "https://github.com/pytorch/torchsnapshot/releases/tag/${version}";
     license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [ GaetanLepage ];
-    badPlatforms = [
-      # ModuleNotFoundError: No module named 'torch._C._distributed_c10d'; 'torch._C' is not a package
-      lib.systems.inspect.patterns.isDarwin
-    ];
   };
 }

--- a/pkgs/development/python-modules/torchsnapshot/default.nix
+++ b/pkgs/development/python-modules/torchsnapshot/default.nix
@@ -67,5 +67,9 @@ buildPythonPackage rec {
     changelog = "https://github.com/pytorch/torchsnapshot/releases/tag/${version}";
     license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [ GaetanLepage ];
+    badPlatforms = [
+      # test suite gets stuck and eventually times out with: "torch.distributed.DistNetworkError: The client socket has timed out after"
+      lib.systems.inspect.patterns.isDarwin
+    ];
   };
 }


### PR DESCRIPTION
This PR removes all `brokenPlatform` and disabled tests due to the previously missing module. It also includes several fixes for the newly enabled packages that are specific to Darwin platform, so that we can keep them enabled now.

- **python312Packages.torch: build torch.distributed on darwin**
- **python312Packages.peft: disable gpu tests on darwin**
- **python312Packages.accelerate: fix tests on darwin**
- **python312Packages.finetuning-scheduler: fix tests on darwin**

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
