### PR TITLE
wine-discord-ipc-bridge: add support for darwin hosts

### DIFF
--- a/pkgs/by-name/wi/wine-discord-ipc-bridge/darwinSupport.patch
+++ b/pkgs/by-name/wi/wine-discord-ipc-bridge/darwinSupport.patch
@@ -1,0 +1,251 @@
+From 5f4cb07bab783dce3acc1dda76d36e3dee8eb848 Mon Sep 17 00:00:00 2001
+From: George Huebner <george@feyor.sh>
+Date: Thu, 27 Mar 2025 22:40:32 -0500
+Subject: [PATCH] macOS: use x86_64 system calls and executable format
+
+Co-Authored-By: Technocoder <8334328+Techno-coder@users.noreply.github.com>
+---
+ Makefile |   2 +-
+ main.c   | 173 +++++++++++++++++--------------------------------------
+ 2 files changed, 54 insertions(+), 121 deletions(-)
+
+diff --git a/Makefile b/Makefile
+index 43f53fb..cc305a7 100644
+--- a/Makefile
++++ b/Makefile
+@@ -2,4 +2,4 @@
+ EXTRAFLAGS = -D__USE_MINGW_ANSI_STDIO=0 -Wl,--disable-reloc-section -fno-asynchronous-unwind-tables -O2
+ 
+ winediscordipcbridge.exe: main.c
+-	i686-w64-mingw32-gcc $(EXTRAFLAGS) -masm=intel main.c -o winediscordipcbridge
++	x86_64-w64-mingw32-gcc $(EXTRAFLAGS) -masm=intel main.c -o winediscordipcbridge
+diff --git a/main.c b/main.c
+index 7c18b9f..9e5f4d0 100644
+--- a/main.c
++++ b/main.c
+@@ -25,151 +25,84 @@ struct sockaddr_un {
+ 
+ #pragma endregion wine-specific header thingy
+ #pragma region
+-__declspec(naked) int l_close(int fd) {
+-    __asm__ (
+-            "push ebx\n\t"
++__declspec(naked) void __syscall() {
++	__asm__ (
++            "__syscall:\n\t"
++            "add rax, 0x2000000\n\t"
+ 
++            "syscall\n\t"
++            "jnc noerror\n\t"
++            "neg rax\n\t"
++
++            "noerror:\n\t"
++            "ret"
++            );
++}
++
++__declspec(naked) __attribute__((sysv_abi)) unsigned int l_getpid() {
++    __asm__ (
++            "mov eax, 0x14\n\t"
++            "jmp __syscall\n\t"
++            "ret"
++            );
++}
++__declspec(naked) __attribute__((sysv_abi)) int l_close(int fd) {
++    __asm__ (
+             "mov eax, 0x06\n\t"
+-            "mov ebx, [esp + 4 + 4]\n\t"
+-            "int 0x80\n\t"
+-
+-            "pop ebx\n\t"
++            "jmp __syscall\n\t"
+             "ret"
+             );
+ }
+-__declspec(naked) int l_socketcall(int call, void* args) {
++__declspec(naked) __attribute__((sysv_abi)) int l_fcntl(unsigned int fd, unsigned int cmd, unsigned long arg) {
+     __asm__ (
+-            "push ebx\n\t"
+-
+-            "mov eax, 0x66\n\t"
+-            "mov ebx, [esp + 4 + 4]\n\t"
+-            "mov ecx, [esp + 4 + 8]\n\t"
+-            "int 0x80\n\t"
+-
+-            "pop ebx\n\t"
++            "mov eax, 0x5c\n\t"
++            "jmp __syscall\n\t"
+             "ret"
+             );
+ }
+-__declspec(naked) int l_open(const char* filename, int flags, int mode) {
++__declspec(naked) __attribute__((sysv_abi)) int l_open(const char* filename, int flags, int mode) {
+     __asm__ (
+-            "push ebx\n\t"
+-
+             "mov eax, 0x05\n\t"
+-            "mov ebx, [esp + 4 + 4]\n\t"
+-            "mov ecx, [esp + 4 + 8]\n\t"
+-            "mov edx, [esp + 4 + 12]\n\t"
+-            "int 0x80\n\t"
+-
+-            "pop ebx\n\t"
++            "jmp __syscall\n\t"
+             "ret"
+             );
+ }
+-__declspec(naked) int l_write(unsigned int fd, const char* buf, unsigned int count) {
++__declspec(naked) __attribute__((sysv_abi)) int l_write(unsigned int fd, const char* buf, unsigned int count) {
+     __asm__ (
+-            "push ebx\n\t"
+-
+             "mov eax, 0x04\n\t"
+-            "mov ebx, [esp + 4 + 4]\n\t"
+-            "mov ecx, [esp + 4 + 8]\n\t"
+-            "mov edx, [esp + 4 + 12]\n\t"
+-            "int 0x80\n\t"
+-
+-            "pop ebx\n\t"
++            "jmp __syscall\n\t"
+             "ret"
+             );
+ }
+-__declspec(naked) int l_read(unsigned int fd, char* buf, unsigned int count) {
++__declspec(naked) __attribute__((sysv_abi)) int l_read(unsigned int fd, char* buf, unsigned int count) {
+     __asm__ (
+-            "push ebx\n\t"
+-
+             "mov eax, 0x03\n\t"
+-            "mov ebx, [esp + 4 + 4]\n\t"
+-            "mov ecx, [esp + 4 + 8]\n\t"
+-            "mov edx, [esp + 4 + 12]\n\t"
+-            "int 0x80\n\t"
+-
+-            "pop ebx\n\t"
++            "jmp __syscall\n\t"
++            "ret"
++            );
++}
++__declspec(naked) __attribute__((sysv_abi)) int l_socket(int domain, int type, int protocol) {
++	__asm__ (
++            "mov eax, 0x61\n\t"
++            "jmp __syscall\n\t"
++            "ret"
++            );
++}
++__declspec(naked) __attribute__((sysv_abi)) int l_connect(int sockfd, const struct sockaddr *addr, unsigned int addrlen) {
++	__asm__ (
++            "mov eax, 0x62\n\t"
++            "jmp __syscall\n\t"
+             "ret"
+             );
+ }
+ #pragma endregion syscall wrappers
+-#pragma region
+-int l_socket(int domain, int type, int protocol) {
+-    void* args[3];
+-    args[0] = (void*)(int*)domain;
+-    args[1] = (void*)(int*)type;
+-    args[2] = (void*)(int*)protocol;
+-    return l_socketcall(1, args);
+-}
+-int l_connect(int sockfd, const struct sockaddr *addr, unsigned int addrlen) {
+-    void* args[3];
+-    args[0] = (void*)(int*)sockfd;
+-    args[1] = (void*)addr;
+-    args[2] = (void*)(int*)addrlen;
+-    return l_socketcall(3, args);
+-}
+-/* int send(int sockfd, const void* buf, unsigned int len, int flags) { */
+-/*     void* args[4]; */
+-/*     args[0] = (void*)(int*)sockfd; */
+-/*     args[1] = (void*)buf; */
+-/*     args[2] = (void*)(unsigned int*)len; */
+-/*     args[3] = (void*)(int*)flags; */
+-/*     return l_socketcall(9, args); */
+-/* } */
+-/* int recv(int fd, void* buf, unsigned int len, int flags) { */
+-/*     void* args[4]; */
+-/*     args[0] = (void*)(int*)fd; */
+-/*     args[1] = (void*)buf; */
+-/*     args[2] = (void*)(unsigned int*)len; */
+-/*     args[3] = (void*)(int*)flags; */
+-/*     return l_socketcall(10, args); */
+-/* } */
+-#pragma endregion socketcall wrappers
+-
+-char* getenv_(char* name) // written by https://github.com/Francesco149
+-{
+-    static char buf[1024 * 1024];
+-    static char* end = 0;
+-    unsigned int namelen;
+-    char* p;
+-
+-    if (!end) {
+-        int fd, n;
+-
+-        fd = l_open("/proc/self/environ", 0, 0);
+-        if (fd < 0) {
+-            return 0;
+-        }
+-
+-        n = l_read((unsigned int)fd, buf, (unsigned int)sizeof(buf));
+-        if (n < 0) {
+-            return 0;
+-        }
+-
+-        l_close(fd);
+-        end = buf + n;
+-    }
+-
+-    namelen = strlen(name);
+-
+-    for (p = buf; p < end;) {
+-        if (!strncmp(p, name, namelen)) {
+-            return p + namelen + 1; /* skip name and the = */
+-        }
+-
+-        for (; *p && p < end; ++p); /* skip to next entry */
+-        ++p;
+-    }
+-
+-    return 0;
+-}
+ 
+ static const char* get_temp_path()
+ {
+-    const char* temp = getenv_("XDG_RUNTIME_DIR");
+-    temp = temp ? temp : getenv_("TMPDIR");
+-    temp = temp ? temp : getenv_("TMP");
+-    temp = temp ? temp : getenv_("TEMP");
++    const char* temp = getenv("XDG_RUNTIME_DIR");
++    temp = temp ? temp : getenv("TMPDIR");
++    temp = temp ? temp : getenv("TMP");
++    temp = temp ? temp : getenv("TEMP");
+     temp = temp ? temp : "/tmp";
+     return temp;
+ }
+@@ -299,9 +232,9 @@ breakout:;
+                 }
+             }
+ 
+-            printf("%d bytes w->l\n", bytes_read);
++            printf("%ld bytes w->l\n", bytes_read);
+             /* If WDB_DEBUG is set, then dump the contents of the message to stdout */
+-            const char* wdb_debug_env = getenv_("WDB_DEBUG");
++            const char* wdb_debug_env = getenv("WDB_DEBUG");
+             if (wdb_debug_env && strcmp(wdb_debug_env, "1") == 0) {
+                 for (int i = 0; i < bytes_read; i++)
+                     putchar(buf[i]);
+@@ -344,7 +277,7 @@ DWORD WINAPI winwrite_thread(LPVOID lpvParam) {
+ 
+         printf("%d bytes l->w\n", bytes_read);
+         /* If WDB_DEBUG is set, then dump the contents of the message to stdout */
+-        const char* wdb_debug_env = getenv_("WDB_DEBUG");
++        const char* wdb_debug_env = getenv("WDB_DEBUG");
+         if (wdb_debug_env && strcmp(wdb_debug_env, "1") == 0) {
+             for (int i = 0; i < bytes_read; i++)
+                 putchar(buf[i]);
+-- 
+2.47.0
+

--- a/pkgs/by-name/wi/wine-discord-ipc-bridge/package.nix
+++ b/pkgs/by-name/wi/wine-discord-ipc-bridge/package.nix
@@ -1,38 +1,36 @@
 {
-  lib,
-  stdenv,
-  fetchFromGitHub,
+  stdenvNoCC,
+  pkgsCross,
+  symlinkJoin,
 }:
+let
+  innerDrv =
+    if stdenvNoCC.hostPlatform.isDarwin then
+      pkgsCross.mingwW64.callPackage ./unwrapped.nix {
+        darwinSupport = true;
+      }
+    else
+      pkgsCross.mingw32.callPackage ./unwrapped.nix { };
+in
+symlinkJoin {
+  name = "wine-discord-ipc-bridge-${innerDrv.version}";
 
-stdenv.mkDerivation (finalAttrs: {
-  pname = "wine-discord-ipc-bridge";
-  version = "0.0.3";
+  paths = [ innerDrv ];
 
-  src = fetchFromGitHub {
-    owner = "0e4ef622";
-    repo = "wine-discord-ipc-bridge";
-    tag = "v${finalAttrs.version}";
-    hash = "sha256-jzsbOKMakNQ6RNMlioX088fGzFBDxOP45Atlsfm2RKg=";
-  };
-
-  postPatch = ''
-    patchShebangs winediscordipcbridge-steam.sh
-  '';
-
-  installPhase = ''
-    runHook preInstall
-    mkdir -p $out/bin
-    cp winediscordipcbridge.exe $out/bin
-    cp winediscordipcbridge-steam.sh $out/bin
-    runHook postInstall
-  '';
+  passthru.wine-discord-ipc-bridge = innerDrv;
 
   meta = {
-    description = "Enable games running under wine to use Discord Rich Presence";
-    homepage = "https://github.com/0e4ef622/wine-discord-ipc-bridge";
-    license = lib.licenses.mit;
-    maintainers = [ lib.maintainers.uku3lig ];
-    mainProgram = "winediscordipcbridge";
-    platforms = [ "i686-windows" ];
+    inherit (innerDrv.meta)
+      description
+      homepage
+      license
+      maintainers
+      mainProgram
+      ;
+    platforms = [
+      "i386-linux"
+      "x86_64-linux"
+      "x86_64-darwin"
+    ];
   };
-})
+}

--- a/pkgs/by-name/wi/wine-discord-ipc-bridge/unwrapped.nix
+++ b/pkgs/by-name/wi/wine-discord-ipc-bridge/unwrapped.nix
@@ -1,0 +1,47 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  darwinSupport ? false,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "wine-discord-ipc-bridge";
+  version = "0.0.3";
+
+  src = fetchFromGitHub {
+    owner = "0e4ef622";
+    repo = "wine-discord-ipc-bridge";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-jzsbOKMakNQ6RNMlioX088fGzFBDxOP45Atlsfm2RKg=";
+  };
+
+  patches = lib.optional darwinSupport ./darwinSupport.patch;
+
+  postPatch = ''
+    patchShebangs winediscordipcbridge-steam.sh
+  ''
+    # darwin patch replaces l_getenv with a windows getenv; make sure
+    # we're looking up tmp on the unix host, not windows
+  + lib.optionalString darwinSupport ''
+    substituteInPlace main.c --replace-fail '"TMPDIR"' '"WINE_HOST_TMPDIR"' \
+                             --replace-fail '"TMP"' '"WINE_HOST_TMP"' \
+                             --replace-fail '"TEMP"' '"WINE_HOST_TEMP"'
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/bin
+    cp winediscordipcbridge.exe $out/bin
+    cp winediscordipcbridge-steam.sh $out/bin
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Enable games running under wine to use Discord Rich Presence";
+    homepage = "https://github.com/0e4ef622/wine-discord-ipc-bridge";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.uku3lig ];
+    mainProgram = "winediscordipcbridge";
+    platforms = if darwinSupport then [ "x86_64-windows" ] else [ "i686-windows" ];
+  };
+})


### PR DESCRIPTION
This patch integrates the work from https://github.com/Techno-coder/macOS-wine-bridge to add support for x86_64-darwin hosts (including hosts emulating x86_64 with Rosetta 2).

_Why vendor a patch?_
- Some small Nix-specific changes had to be made to the original commit by Techno-Coder
- Pretty much every subsequent commit made in the macOS-wine-bridge upstream is not relevant, so I don't believe changing src to that repo is necessary
- The logic in this patch is stable and is unlikely to ever change in the future

-------

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin (under Rosetta 2)
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc