### PR TITLE
chawan: 0-unstable-2025-01-06 -> 0-unstable-2025-03-27

### DIFF
--- a/pkgs/by-name/ch/chawan/package.nix
+++ b/pkgs/by-name/ch/chawan/package.nix
@@ -16,14 +16,13 @@
 
 stdenv.mkDerivation {
   pname = "chawan";
-  version = "0-unstable-2025-01-06";
+  version = "0-unstable-2025-03-27";
 
   src = fetchFromSourcehut {
     owner = "~bptato";
     repo = "chawan";
-    rev = "30a933adb2bade2ceee08a9b36371cecf554d648";
-    hash = "sha256-EepSEN66GTdWfCSiR/p69pN5bvTEiUFOMErCxedrq+g=";
-    fetchSubmodules = true;
+    rev = "b2d954b96f227597b62cfae1ac64785bd8f0fb37";
+    hash = "sha256-1kxqzzEMGDFNk25mQX8p7TuADuTMIz+hHZ7p+i7m494=";
   };
 
   patches = [ ./mancha-augment-path.diff ];


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This PR aims to fix [failing automatic updates](https://nixpkgs-update-logs.nix-community.org/chawan/2025-03-24.log)

```
Resolving deltas: 100% (52/52), done.
From https://git.sr.ht/~bptato/chawan
 * branch            HEAD       -> FETCH_HEAD
Switched to a new branch 'fetchgit'
fatal: No url found for submodule path 'lib/chame0/test/chagashi' in .gitmodules
fatal: No url found for submodule path 'lib/chame0/test/chagashi' in .gitmodules
error: builder for '/nix/store/q7hbmcd63p08vxs2w4wvvb3al37jv039-source.drv' failed with exit code 128;
       last 13 log lines:
       > exporting https://git.sr.ht/~bptato/chawan (rev 88c3e41ba98a52f525fc4a64ee4c0f8d63d82b73) into /nix/store/v9w7kypyfqxxdm55nm6i407rca74dpss-source
       > Initialized empty Git repository in /nix/store/v9w7kypyfqxxdm55nm6i407rca74dpss-source/.git/
       > remote: Enumerating objects: 770, done.
       > remote: Counting objects: 100% (770/770), done.
       > remote: Compressing objects: 100% (643/643), done.
       > remote: Total 770 (delta 52), reused 517 (delta 43), pack-reused 0 (from 0)
       > Receiving objects: 100% (770/770), 3.52 MiB | 14.02 MiB/s, done.
       > Resolving deltas: 100% (52/52), done.
       > From https://git.sr.ht/~bptato/chawan
       >  * branch            HEAD       -> FETCH_HEAD
       > Switched to a new branch 'fetchgit'
       > fatal: No url found for submodule path 'lib/chame0/test/chagashi' in .gitmodules
       > fatal: No url found for submodule path 'lib/chame0/test/chagashi' in .gitmodules
       For full logs, run 'nix log /nix/store/q7hbmcd63p08vxs2w4wvvb3al37jv039-source.drv'.
update-source-version: error: Couldn't figure out new hash of 'chawan.src'!
```


It requires to remove unused submodules.

https://git.sr.ht/~bptato/chawan/commit/cb1ec272443328c80d9e4bfb17f4853ff2745b16 https://git.sr.ht/~bptato/chawan/commit/4a1ca9038d05e2487d5d960c9a2642c2621b954d

I didn't know sourcehut providing compare view or not. So not including the diff link in this PR. Also not found the changelog of this project.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
