### PR TITLE
omnom: 0-unstable-2024-11-20 -> 0.3.0

### DIFF
--- a/pkgs/by-name/om/omnom/package.nix
+++ b/pkgs/by-name/om/omnom/package.nix
@@ -11,13 +11,13 @@
 
 buildGoModule rec {
   pname = "omnom";
-  version = "0-unstable-2024-11-20";
+  version = "0.3.0";
 
   src = fetchFromGitHub {
     owner = "asciimoo";
     repo = "omnom";
-    rev = "dbf40c9c50b74335286faea7c5070bba11dced83";
-    hash = "sha256-dl0jfFwn+Fd8/aQNhXFNEoDIMgMia2MHZntp0EKhimg=";
+    tag = "v${version}";
+    hash = "sha256-2D+hEOlyjCJQKnLBBO1cXeqTS/QUWraPWPtI8pCf9KM=";
     fetchSubmodules = true;
   };
 

--- a/pkgs/by-name/re/redocly/package.nix
+++ b/pkgs/by-name/re/redocly/package.nix
@@ -1,4 +1,11 @@
-{ lib, nodejs, buildNpmPackage, fetchFromGitHub, redocly, testers, }:
+{
+  lib,
+  nodejs,
+  buildNpmPackage,
+  fetchFromGitHub,
+  redocly,
+  testers,
+}:
 
 buildNpmPackage rec {
   pname = "redocly";
@@ -43,12 +50,13 @@ buildNpmPackage rec {
     chmod +x $out/bin/redocly
   '';
 
-  passthru = { tests.version = testers.testVersion { package = redocly; }; };
+  passthru = {
+    tests.version = testers.testVersion { package = redocly; };
+  };
 
   meta = {
     changelog = "https://redocly.com/docs/cli/changelog/";
-    description =
-      "Makes OpenAPI easy. Lint/validate to any standard, generate beautiful docs, and more";
+    description = "Makes OpenAPI easy. Lint/validate to any standard, generate beautiful docs, and more";
     homepage = "https://github.com/Redocly/redocly-cli";
     license = lib.licenses.mit;
     mainProgram = "redocly";

--- a/pkgs/by-name/re/redocly/package.nix
+++ b/pkgs/by-name/re/redocly/package.nix
@@ -1,11 +1,4 @@
-{
-  lib,
-  nodejs,
-  buildNpmPackage,
-  fetchFromGitHub,
-  redocly,
-  testers,
-}:
+{ lib, nodejs, buildNpmPackage, fetchFromGitHub, redocly, testers, }:
 
 buildNpmPackage rec {
   pname = "redocly";
@@ -22,7 +15,7 @@ buildNpmPackage rec {
 
   npmBuildScript = "prepare";
 
-  nativeBuildInputs = [];
+  nativeBuildInputs = [ ];
 
   postBuild = ''
     npm --prefix packages/cli run copy-assets
@@ -50,15 +43,12 @@ buildNpmPackage rec {
     chmod +x $out/bin/redocly
   '';
 
-  passthru = {
-    tests.version = testers.testVersion {
-      package = redocly;
-    };
-  };
+  passthru = { tests.version = testers.testVersion { package = redocly; }; };
 
   meta = {
     changelog = "https://redocly.com/docs/cli/changelog/";
-    description = "Makes OpenAPI easy. Lint/validate to any standard, generate beautiful docs, and more";
+    description =
+      "Makes OpenAPI easy. Lint/validate to any standard, generate beautiful docs, and more";
     homepage = "https://github.com/Redocly/redocly-cli";
     license = lib.licenses.mit;
     mainProgram = "redocly";

--- a/pkgs/by-name/re/redocly/package.nix
+++ b/pkgs/by-name/re/redocly/package.nix
@@ -40,8 +40,8 @@ buildNpmPackage rec {
     process.argv[1] = 'redocly';
 
     // Set environment variables directly
-    process.env.REDOCLY_TELEMETRY = "off";
-    process.env.REDOCLY_SUPPRESS_UPDATE_NOTICE = "true"
+    process.env.REDOCLY_TELEMETRY = process.env.REDOCLY_TELEMETRY || "off";
+    process.env.REDOCLY_SUPPRESS_UPDATE_NOTICE = process.env.REDOCLY_SUPPRESS_UPDATE_NOTICE || "true";
 
     require('$out/lib/node_modules/@redocly/cli/node_modules/@redocly/cli/bin/cli.js');
     EOF

--- a/pkgs/by-name/re/redocly/package.nix
+++ b/pkgs/by-name/re/redocly/package.nix
@@ -1,9 +1,8 @@
 {
   lib,
-  pkgs,
+  nodejs,
   buildNpmPackage,
   fetchFromGitHub,
-  makeWrapper,
   redocly,
   testers,
 }:
@@ -23,7 +22,7 @@ buildNpmPackage rec {
 
   npmBuildScript = "prepare";
 
-  nativeBuildInputs = [ makeWrapper ];
+  nativeBuildInputs = [];
 
   postBuild = ''
     npm --prefix packages/cli run copy-assets
@@ -38,17 +37,17 @@ buildNpmPackage rec {
     # Create a wrapper script to force the correct command name (Nodejs uses argv[1] for command name)
     mkdir -p $out/bin
     cat <<EOF > $out/bin/redocly
-    #!${lib.getBin pkgs.nodejs}/bin/node
+    #!${lib.getBin nodejs}/bin/node
     // Override argv[1] to show "redocly" instead of "cli.js"
     process.argv[1] = 'redocly';
+
+    // Set environment variables directly
+    process.env.REDOCLY_TELEMETRY = "off";
+    process.env.REDOCLY_SUPPRESS_UPDATE_NOTICE = "true"
+
     require('$out/lib/node_modules/@redocly/cli/node_modules/@redocly/cli/bin/cli.js');
     EOF
     chmod +x $out/bin/redocly
-
-    # Add telemetry and update notice flags
-    wrapProgram $out/bin/redocly \
-      --set-default REDOCLY_TELEMETRY off \
-      --set-default REDOCLY_SUPPRESS_UPDATE_NOTICE true
   '';
 
   passthru = {

--- a/pkgs/by-name/re/redocly/package.nix
+++ b/pkgs/by-name/re/redocly/package.nix
@@ -9,16 +9,16 @@
 
 buildNpmPackage rec {
   pname = "redocly";
-  version = "1.29.0";
+  version = "1.34.0";
 
   src = fetchFromGitHub {
     owner = "Redocly";
     repo = "redocly-cli";
     rev = "@redocly/cli@${version}";
-    hash = "sha256-Oa4R4R7Obg26DKWZkccqjIcrD35pBw1AYIPe2/KN8f4=";
+    hash = "sha256-1iyE0LYbVEleCdSw6fWvIHqCkWMEZrjK6tum+qytcCY=";
   };
 
-  npmDepsHash = "sha256-V0NklVsPRqRJ479nIMWqs/sXciXOm6LAlIh3YcPPDEc=";
+  npmDepsHash = "sha256-TIsVjdohsmvAAn9xQeeD5pu4CjXtYlD7bmKeDp113Lc=";
 
   npmBuildScript = "prepare";
 
@@ -29,9 +29,10 @@ buildNpmPackage rec {
   '';
 
   postInstall = ''
-    rm $out/lib/node_modules/@redocly/cli/node_modules/@redocly/{cli,openapi-core}
+    rm $out/lib/node_modules/@redocly/cli/node_modules/@redocly/{cli,openapi-core,respect-core}
     cp -R packages/cli $out/lib/node_modules/@redocly/cli/node_modules/@redocly/cli
     cp -R packages/core $out/lib/node_modules/@redocly/cli/node_modules/@redocly/openapi-core
+    cp -R packages/respect-core $out/lib/node_modules/@redocly/cli/node_modules/@redocly/respect-core
 
     mkdir $out/bin
     makeWrapper $out/lib/node_modules/@redocly/cli/node_modules/@redocly/cli/bin/cli.js \

--- a/pkgs/by-name/re/redocly/package.nix
+++ b/pkgs/by-name/re/redocly/package.nix
@@ -48,7 +48,7 @@ buildNpmPackage rec {
     chmod +x $out/bin/redocly
   '';
 
-  passthru = {  
+  passthru = {
     tests.version = testers.testVersion { package = redocly; };
   };
 

--- a/pkgs/by-name/re/redocly/package.nix
+++ b/pkgs/by-name/re/redocly/package.nix
@@ -22,8 +22,6 @@ buildNpmPackage rec {
 
   npmBuildScript = "prepare";
 
-  nativeBuildInputs = [ ];
-
   postBuild = ''
     npm --prefix packages/cli run copy-assets
   '';
@@ -50,7 +48,7 @@ buildNpmPackage rec {
     chmod +x $out/bin/redocly
   '';
 
-  passthru = {
+  passthru = {  
     tests.version = testers.testVersion { package = redocly; };
   };
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

While the package has been updated to the latest omnom release, `0.3.0` , `omnom -v` prints `v0.2.0`, and I've confirmed that it's indeed hardcoded in their `0.3.0` source that the version is `0.2.0`. I'll raise an issue with them and probably fix that myself. LGTY? @eljamm 

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
