### PR TITLE
python3Packages.ezdxf: 1.3.2 -> 1.4.3, add updateScript, add withGui argument

### DIFF
--- a/pkgs/development/python-modules/ezdxf/default.nix
+++ b/pkgs/development/python-modules/ezdxf/default.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildPythonPackage,
   fetchFromGitHub,
   pyparsing,
@@ -14,6 +15,7 @@
   matplotlib,
   pymupdf,
   pyqt5,
+  librecad,
 }:
 
 buildPythonPackage rec {
@@ -64,6 +66,15 @@ buildPythonPackage rec {
     "ezdxf"
     "ezdxf.addons"
   ];
+
+  preCheck = ''
+    ln -s "${librecad}/${
+      if stdenv.hostPlatform.isDarwin then
+        "Applications/LibreCAD.app/Contents/Resources"
+      else
+        "share/librecad"
+    }/fonts" fonts/librecad
+  '';
 
   meta = {
     description = "Python package to read and write DXF drawings (interface to the DXF file format)";

--- a/pkgs/development/python-modules/ezdxf/default.nix
+++ b/pkgs/development/python-modules/ezdxf/default.nix
@@ -22,7 +22,7 @@
 }:
 
 buildPythonPackage rec {
-  version = "1.4.0";
+  version = "1.4.3";
   pname = "ezdxf";
 
   pyproject = true;
@@ -31,7 +31,7 @@ buildPythonPackage rec {
     owner = "mozman";
     repo = "ezdxf";
     tag = "v${version}";
-    hash = "sha256-p8wvnBIOOcZ8XKPN1b9wsWF9eutSNeeoGSkgLfA/kjQ=";
+    hash = "sha256-v/xW/Tg3OgzwvSNy3cfkxzf6R33ZvW4VE8k7MB+rM+w=";
   };
 
   nativeBuildInputs = lib.optionals withGui [ qt6.wrapQtAppsHook ];

--- a/pkgs/development/python-modules/ezdxf/default.nix
+++ b/pkgs/development/python-modules/ezdxf/default.nix
@@ -1,7 +1,6 @@
 {
   lib,
   buildPythonPackage,
-  pythonOlder,
   fetchFromGitHub,
   pyparsing,
   typing-extensions,
@@ -22,8 +21,6 @@ buildPythonPackage rec {
   pname = "ezdxf";
 
   pyproject = true;
-
-  disabled = pythonOlder "3.5";
 
   src = fetchFromGitHub {
     owner = "mozman";
@@ -71,7 +68,8 @@ buildPythonPackage rec {
   meta = {
     description = "Python package to read and write DXF drawings (interface to the DXF file format)";
     mainProgram = "ezdxf";
-    homepage = "https://github.com/mozman/ezdxf/";
+    homepage = "https://ezdxf.mozman.at/";
+    changelog = "https://github.com/mozman/ezdxf/blob/${src.rev}/notes/pages/CHANGELOG.md";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ hodapp ];
     platforms = lib.platforms.unix;

--- a/pkgs/development/python-modules/ezdxf/default.nix
+++ b/pkgs/development/python-modules/ezdxf/default.nix
@@ -18,7 +18,7 @@
 }:
 
 buildPythonPackage rec {
-  version = "1.3.2";
+  version = "1.4.0";
   pname = "ezdxf";
 
   pyproject = true;
@@ -29,7 +29,7 @@ buildPythonPackage rec {
     owner = "mozman";
     repo = "ezdxf";
     tag = "v${version}";
-    hash = "sha256-BzdLl2GjLh2ABJzJ6bhdbic9jlSABIVR3XGrYiLJHa0=";
+    hash = "sha256-p8wvnBIOOcZ8XKPN1b9wsWF9eutSNeeoGSkgLfA/kjQ=";
   };
 
   dependencies = [

--- a/pkgs/development/python-modules/ezdxf/default.nix
+++ b/pkgs/development/python-modules/ezdxf/default.nix
@@ -15,6 +15,8 @@
   matplotlib,
   pymupdf,
   pyqt5,
+  withGui ? false,
+  qt6,
   librecad,
 }:
 
@@ -31,12 +33,15 @@ buildPythonPackage rec {
     hash = "sha256-p8wvnBIOOcZ8XKPN1b9wsWF9eutSNeeoGSkgLfA/kjQ=";
   };
 
+  nativeBuildInputs = lib.optionals withGui [ qt6.wrapQtAppsHook ];
+
   dependencies = [
     pyparsing
     typing-extensions
     numpy
     fonttools
-  ];
+  ]
+  ++ lib.optionals withGui ([ qt6.qtbase ] ++ optional-dependencies.draw);
 
   optional-dependencies = {
     draw = [
@@ -57,6 +62,12 @@ buildPythonPackage rec {
     setuptools
     cython
   ];
+
+  dontWrapQtApps = true;
+
+  preFixup = lib.optionalString withGui ''
+    makeWrapperArgs+=("''${qtWrapperArgs[@]}")
+  '';
 
   checkInputs = [ pillow ];
 

--- a/pkgs/development/python-modules/ezdxf/default.nix
+++ b/pkgs/development/python-modules/ezdxf/default.nix
@@ -18,6 +18,7 @@
   withGui ? false,
   qt6,
   librecad,
+  gitUpdater,
 }:
 
 buildPythonPackage rec {
@@ -86,6 +87,12 @@ buildPythonPackage rec {
         "share/librecad"
     }/fonts" fonts/librecad
   '';
+
+  # The default updateScript of Python packages does not filter prerelease versions.
+  passthru.updateScript = gitUpdater {
+    rev-prefix = "v";
+    allowedVersions = "^[0-9]+\\.[0-9]+\\.[0-9]+$";
+  };
 
   meta = {
     description = "Python package to read and write DXF drawings (interface to the DXF file format)";


### PR DESCRIPTION
https://github.com/mozman/ezdxf/blob/refs/tags/v1.4.3/notes/pages/CHANGELOG.md
https://github.com/mozman/ezdxf/compare/refs/tags/v1.3.2...refs/tags/v1.4.3

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review`
Commit: `493f6d1f1c47bb17af70cc78205fb950f00c07e6`

---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 6 packages built:</summary>
  <ul>
    <li>meerk40t</li>
    <li>meerk40t.dist</li>
    <li>python312Packages.ezdxf</li>
    <li>python312Packages.ezdxf.dist</li>
    <li>python313Packages.ezdxf</li>
    <li>python313Packages.ezdxf.dist</li>
  </ul>
</details>

---
### `aarch64-linux`
<details>
  <summary>:white_check_mark: 6 packages built:</summary>
  <ul>
    <li>meerk40t</li>
    <li>meerk40t.dist</li>
    <li>python312Packages.ezdxf</li>
    <li>python312Packages.ezdxf.dist</li>
    <li>python313Packages.ezdxf</li>
    <li>python313Packages.ezdxf.dist</li>
  </ul>
</details>

---
### `x86_64-darwin`
<details>
  <summary>:white_check_mark: 6 packages built:</summary>
  <ul>
    <li>meerk40t</li>
    <li>meerk40t.dist</li>
    <li>python312Packages.ezdxf</li>
    <li>python312Packages.ezdxf.dist</li>
    <li>python313Packages.ezdxf</li>
    <li>python313Packages.ezdxf.dist</li>
  </ul>
</details>

---
### `aarch64-darwin`
<details>
  <summary>:white_check_mark: 6 packages built:</summary>
  <ul>
    <li>meerk40t</li>
    <li>meerk40t.dist</li>
    <li>python312Packages.ezdxf</li>
    <li>python312Packages.ezdxf.dist</li>
    <li>python313Packages.ezdxf</li>
    <li>python313Packages.ezdxf.dist</li>
  </ul>
</details>

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc