### PR TITLE
libowfat: mark cross as broken

### DIFF
--- a/pkgs/by-name/li/libowfat/package.nix
+++ b/pkgs/by-name/li/libowfat/package.nix
@@ -22,7 +22,10 @@ stdenv.mkDerivation rec {
     make headers
   '';
 
-  makeFlags = [ "prefix=$(out)" ];
+  makeFlags = [
+    "prefix=$(out)"
+    "CC=${stdenv.cc.targetPrefix}cc"
+  ];
   enableParallelBuilding = true;
 
   meta = with lib; {
@@ -30,5 +33,7 @@ stdenv.mkDerivation rec {
     homepage = "https://www.fefe.de/libowfat/";
     license = licenses.gpl2;
     platforms = platforms.linux;
+    # build tool "json" is built for the host platform
+    broken = !stdenv.buildPlatform.canExecute stdenv.hostPlatform;
   };
 }


### PR DESCRIPTION
The change to makeFlags might still help e.g. musl / static / 32-bit builds.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).