### PR TITLE
luaPackages.luv: 1.48.0-2 -> 1.50.0-1

### DIFF
--- a/maintainers/scripts/luarocks-packages.csv
+++ b/maintainers/scripts/luarocks-packages.csv
@@ -105,7 +105,6 @@ luazip,,,,,,
 lusc_luv,,,,,,
 lush.nvim,,,https://luarocks.org/dev,,,teto
 luuid,,,,20120509-2,,
-luv,,,,1.50.0-1,,
 lyaml,,,,,,lblasc
 lz.n,,,,,,mrcjkb
 lze,,,,,,birdee

--- a/maintainers/scripts/luarocks-packages.csv
+++ b/maintainers/scripts/luarocks-packages.csv
@@ -105,7 +105,7 @@ luazip,,,,,,
 lusc_luv,,,,,,
 lush.nvim,,,https://luarocks.org/dev,,,teto
 luuid,,,,20120509-2,,
-luv,,,,1.48.0-2,,
+luv,,,,1.50.0-1,,
 lyaml,,,,,,lblasc
 lz.n,,,,,,mrcjkb
 lze,,,,,,birdee

--- a/pkgs/development/lua-modules/generated-packages.nix
+++ b/pkgs/development/lua-modules/generated-packages.nix
@@ -3470,15 +3470,15 @@ final: prev: {
     }:
     buildLuarocksPackage {
       pname = "luv";
-      version = "1.48.0-2";
+      version = "1.50.0-1";
       knownRockspec =
         (fetchurl {
-          url = "mirror://luarocks/luv-1.48.0-2.rockspec";
-          sha256 = "0353bjn9z90a1hd7rksdfrd9fbdd31hbvdaxr1fb0fh0bc1cpy94";
+          url = "mirror://luarocks/luv-1.50.0-1.rockspec";
+          sha256 = "01i6hs3nllbdwlwcfgjdbxmzgww2yk6a8bn0s5q4lkv67dx89g90";
         }).outPath;
       src = fetchurl {
-        url = "https://github.com/luvit/luv/releases/download/1.48.0-2/luv-1.48.0-2.tar.gz";
-        sha256 = "0yivq14dw0vjyl8ibrgdgrj9fbhjyy4yf3m4jc15bxmlxggisfic";
+        url = "https://github.com/luvit/luv/releases/download/1.50.0-1/luv-1.50.0-1.tar.gz";
+        sha256 = "0d5wnn35asqg3ixmyqq80s7ibhbdzl9kxn7dy9a1v64w9l1c6ryq";
       };
 
       disabled = luaOlder "5.1";

--- a/pkgs/development/lua-modules/generated-packages.nix
+++ b/pkgs/development/lua-modules/generated-packages.nix
@@ -3461,37 +3461,6 @@ final: prev: {
     }
   ) { };
 
-  luv = callPackage (
-    {
-      buildLuarocksPackage,
-      cmake,
-      fetchurl,
-      luaOlder,
-    }:
-    buildLuarocksPackage {
-      pname = "luv";
-      version = "1.50.0-1";
-      knownRockspec =
-        (fetchurl {
-          url = "mirror://luarocks/luv-1.50.0-1.rockspec";
-          sha256 = "01i6hs3nllbdwlwcfgjdbxmzgww2yk6a8bn0s5q4lkv67dx89g90";
-        }).outPath;
-      src = fetchurl {
-        url = "https://github.com/luvit/luv/releases/download/1.50.0-1/luv-1.50.0-1.tar.gz";
-        sha256 = "0d5wnn35asqg3ixmyqq80s7ibhbdzl9kxn7dy9a1v64w9l1c6ryq";
-      };
-
-      disabled = luaOlder "5.1";
-      nativeBuildInputs = [ cmake ];
-
-      meta = {
-        homepage = "https://github.com/luvit/luv";
-        description = "Bare libuv bindings for lua";
-        license.fullName = "Apache 2.0";
-      };
-    }
-  ) { };
-
   lyaml = callPackage (
     {
       buildLuarocksPackage,

--- a/pkgs/development/lua-modules/luv/lib.nix
+++ b/pkgs/development/lua-modules/luv/lib.nix
@@ -1,0 +1,36 @@
+{
+  lib,
+  cmake,
+  fixDarwinDylibNames,
+  isLuaJIT,
+  libuv,
+  lua,
+  stdenv,
+}:
+
+stdenv.mkDerivation {
+  pname = "libluv";
+  inherit (lua.pkgs.luv) version src meta;
+
+  cmakeFlags = [
+    "-DBUILD_SHARED_LIBS=ON"
+    "-DBUILD_MODULE=OFF"
+    "-DWITH_SHARED_LIBUV=ON"
+    "-DLUA_BUILD_TYPE=System"
+    "-DWITH_LUA_ENGINE=${if isLuaJIT then "LuaJit" else "Lua"}"
+  ];
+
+  # to make sure we dont use bundled deps
+  prePatch = ''
+    rm -rf deps/lua deps/luajit deps/libuv
+  '';
+
+  buildInputs = [
+    libuv
+    lua
+  ];
+
+  nativeBuildInputs = [
+    cmake
+  ] ++ lib.optionals stdenv.hostPlatform.isDarwin [ fixDarwinDylibNames ];
+}

--- a/pkgs/development/lua-modules/overrides.nix
+++ b/pkgs/development/lua-modules/overrides.nix
@@ -15,7 +15,6 @@
   fetchFromGitHub,
   fetchpatch,
   fetchurl,
-  fixDarwinDylibNames,
   fzf,
   glib,
   glibc,
@@ -33,7 +32,6 @@
   libpsl,
   libpq,
   libuuid,
-  libuv,
   libxcrypt,
   libyaml,
   lua-language-server,
@@ -819,57 +817,6 @@ in
       rm tests/plenary/job_spec.lua tests/plenary/scandir_spec.lua tests/plenary/curl_spec.lua
       make test
       runHook postCheck
-    '';
-  });
-
-  # as advised in https://github.com/luarocks/luarocks/issues/1402#issuecomment-1080616570
-  # we shouldn't use luarocks machinery to build complex cmake components
-  libluv = stdenv.mkDerivation {
-
-    pname = "libluv";
-    inherit (prev.luv) version meta src;
-
-    cmakeFlags = [
-      "-DBUILD_SHARED_LIBS=ON"
-      "-DBUILD_MODULE=OFF"
-      "-DWITH_SHARED_LIBUV=ON"
-      "-DLUA_BUILD_TYPE=System"
-      "-DWITH_LUA_ENGINE=${if isLuaJIT then "LuaJit" else "Lua"}"
-    ];
-
-    # to make sure we dont use bundled deps
-    postUnpack = ''
-      rm -rf deps/lua deps/libuv
-    '';
-
-    buildInputs = [
-      libuv
-      final.lua
-    ];
-
-    nativeBuildInputs = [
-      pkg-config
-      cmake
-    ] ++ lib.optionals stdenv.hostPlatform.isDarwin [ fixDarwinDylibNames ];
-  };
-
-  luv = prev.luv.overrideAttrs (oa: {
-
-    nativeBuildInputs = oa.nativeBuildInputs ++ [ pkg-config ];
-    buildInputs = [ libuv ];
-
-    # Use system libuv instead of building local and statically linking
-    luarocksConfig = lib.recursiveUpdate oa.luarocksConfig {
-      variables = {
-        WITH_SHARED_LIBUV = "ON";
-      };
-    };
-
-    # we unset the LUA_PATH since the hook erases the interpreter defaults (To fix)
-    # tests is not run since they are not part of the tarball anymore
-    preCheck = ''
-      unset LUA_PATH
-      rm tests/test-{dns,thread}.lua
     '';
   });
 

--- a/pkgs/top-level/lua-packages.nix
+++ b/pkgs/top-level/lua-packages.nix
@@ -205,6 +205,9 @@ rec {
     }
   ) { };
 
+  luv = callPackage ../development/lua-modules/luv { };
+  libluv = callPackage ../development/lua-modules/luv/lib.nix { };
+
   luxio = callPackage (
     {
       fetchurl,


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
* Instead of pinned generated package, luv was migrated to manually crafted package.
* Tests were enabled.
* Added passthru.tests.
* Added passthru.updateScript.
* luv dynamically linked to libuv.
* Updated luv to 1.50.0-1.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
