### PR TITLE
anubis: 1.14.2 -> 1.15.0

### DIFF
--- a/pkgs/by-name/an/anubis/package.nix
+++ b/pkgs/by-name/an/anubis/package.nix
@@ -43,7 +43,10 @@ buildGoModule (finalAttrs: {
     homepage = "https://github.com/TecharoHQ/anubis/";
     changelog = "https://github.com/TecharoHQ/anubis/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ knightpp ];
+    maintainers = with lib.maintainers; [
+      knightpp
+      soopyc
+    ];
     mainProgram = "anubis";
   };
 })

--- a/pkgs/by-name/an/anubis/package.nix
+++ b/pkgs/by-name/an/anubis/package.nix
@@ -7,16 +7,16 @@
 }:
 buildGoModule (finalAttrs: {
   pname = "anubis";
-  version = "1.14.2";
+  version = "1.15.0";
 
   src = fetchFromGitHub {
     owner = "TecharoHQ";
     repo = "anubis";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-K4VXTO8F3GTOA9jOrI0OF6CYTRaDUlUT9/HujYmnHpM=";
+    hash = "sha256-n70H2FBvp7hxvRqU1+bvef9UrOzkSpg9QtFoqGyXiaM=";
   };
 
-  vendorHash = "sha256-t+E3sILEwXGkTaBtKLO2kFEntivY9fVK8o86arvMaOU=";
+  vendorHash = "sha256-Rcra5cu7zxGm2LhL2x9Kd3j/uQaEb8OOh/j5Rhh8S1k=";
 
   subPackages = [
     "cmd/anubis"


### PR DESCRIPTION
Diff: https://github.com/TecharoHQ/anubis/compare/v1.14.2...v1.15.0
Changelog: https://github.com/TecharoHQ/anubis/blob/v1.15.0/docs/docs/CHANGELOG.md#v1150

There is a NixOS test written in #392018, so if that PR is merged before this one, the test can be linked.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
