### PR TITLE
nixos/lib/testing: avoid generating darwin VM tests

### DIFF
--- a/nixos/lib/testing/default.nix
+++ b/nixos/lib/testing/default.nix
@@ -9,13 +9,15 @@ let
     };
   runTest =
     module:
-    (evalTest (
-      { config, ... }:
-      {
-        imports = [ module ];
-        result = config.test;
-      }
-    )).config.result;
+    # Infra issue: virtualization on darwin doesn't seem to work yet.
+    lib.addMetaAttrs { hydraPlatforms = lib.platforms.linux; }
+      (evalTest (
+        { config, ... }:
+        {
+          imports = [ module ];
+          result = config.test;
+        }
+      )).config.result;
 
   testModules = [
     ./call-test.nix

--- a/nixos/lib/testing/meta.nix
+++ b/nixos/lib/testing/meta.nix
@@ -36,7 +36,9 @@ in
           };
           platforms = lib.mkOption {
             type = types.listOf types.raw;
-            default = lib.platforms.linux ++ lib.platforms.darwin;
+            # darwin could be added, but it would add VM tests that don't work on Hydra.nixos.org (so far)
+            # see https://github.com/NixOS/nixpkgs/pull/303597#issuecomment-2128782362
+            default = lib.platforms.linux;
             description = ''
               Sets the [`meta.platforms`](https://nixos.org/manual/nixpkgs/stable/#var-meta-platforms) attribute on the [{option}`test`](#test-opt-test) derivation.
             '';


### PR DESCRIPTION
We're getting 2x5 darwin VM jobs that aren't schedulable on our current Hydra.nixos.org, which makes them hang around and delay advancing of all `nixpkgs-*` channels.
To me that's quite an annoying effect, as it can be like an extra day of additional delay without any benefit that I can really perceive. (unless someone like me keeps manually cancelling the jobs all the time)


## Things done

The normal checklist doesn't apply here really.  I checked that the 2x5 problematic jobs do all disappear.

<!--
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
