### PR TITLE
python312Packages.textual: 2.1.2 -> 3.0.0; python312Packages.tree-sitter-markdown: init at 0.4.1 

### DIFF
--- a/pkgs/by-name/ha/harlequin/package.nix
+++ b/pkgs/by-name/ha/harlequin/package.nix
@@ -97,5 +97,8 @@ python3Packages.buildPythonApplication rec {
     mainProgram = "harlequin";
     maintainers = with lib.maintainers; [ pcboy ];
     platforms = lib.platforms.unix;
+    # builds but needs tree-sitter-sql at runtime
+    # "LanguageDoesNotExist: tree-sitter is available, but no built-in or user-registered language called 'sql'"
+    broken = lib.versionAtLeast python3Packages.textual.version "3.0.0";
   };
 }

--- a/pkgs/development/python-modules/textual-textarea/default.nix
+++ b/pkgs/development/python-modules/textual-textarea/default.nix
@@ -13,6 +13,7 @@
   # tests
   pytestCheckHook,
   pytest-asyncio,
+  tree-sitter-python,
 }:
 
 buildPythonPackage rec {
@@ -46,6 +47,7 @@ buildPythonPackage rec {
   nativeCheckInputs = [
     pytestCheckHook
     pytest-asyncio
+    tree-sitter-python
   ];
 
   pythonImportsCheck = [ "textual_textarea" ];
@@ -53,6 +55,11 @@ buildPythonPackage rec {
   disabledTestPaths = [
     # https://github.com/tconbeer/textual-textarea/issues/296
     "tests/functional_tests/test_textarea.py"
+  ];
+
+  disabledTests = [
+    # requires tree-sitter-sql dependency
+    "test_comments[sql--- ]"
   ];
 
   meta = {

--- a/pkgs/development/python-modules/textual/default.nix
+++ b/pkgs/development/python-modules/textual/default.nix
@@ -23,6 +23,8 @@
   pytestCheckHook,
   syrupy,
   time-machine,
+  tree-sitter-python,
+  tree-sitter-markdown,
 }:
 
 buildPythonPackage rec {
@@ -63,6 +65,8 @@ buildPythonPackage rec {
     syrupy
     time-machine
     tree-sitter
+    tree-sitter-python
+    tree-sitter-markdown
   ];
 
   disabledTestPaths = [
@@ -75,16 +79,8 @@ buildPythonPackage rec {
   ];
 
   disabledTests = [
-    # Assertion issues
+    # Depends on textual-dev which we can't add as it depends on this package
     "test_textual_env_var"
-
-    # Requirements for tests are not quite ready
-    "test_register_language"
-
-    # Requires python bindings for tree-sitter languages
-    # https://github.com/Textualize/textual/issues/5449
-    "test_setting_unknown_language"
-    "test_update_highlight_query"
   ];
 
   # Some tests in groups require state from previous tests

--- a/pkgs/development/python-modules/textual/default.nix
+++ b/pkgs/development/python-modules/textual/default.nix
@@ -29,14 +29,14 @@
 
 buildPythonPackage rec {
   pname = "textual";
-  version = "2.1.2";
+  version = "3.0.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "Textualize";
     repo = "textual";
     tag = "v${version}";
-    hash = "sha256-VKo1idLu5sYGtuK8yZzVE6QrrMOciYIesbGVlqzNjfk=";
+    hash = "sha256-bubOKqLF8DWlMNaqnmDNtUCuAb7K14ZG781htrEnDc0=";
   };
 
   build-system = [ poetry-core ];

--- a/pkgs/development/python-modules/tree-sitter-markdown/default.nix
+++ b/pkgs/development/python-modules/tree-sitter-markdown/default.nix
@@ -1,0 +1,43 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  tree-sitter,
+}:
+
+buildPythonPackage rec {
+  pname = "tree-sitter-markdown";
+  version = "0.4.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "tree-sitter-grammars";
+    repo = "tree-sitter-markdown";
+    tag = "v${version}";
+    hash = "sha256-Oe2iL5b1Cyv+dK0nQYFNLCCOCe+93nojxt6ukH2lEmU=";
+  };
+
+  build-system = [
+    setuptools
+  ];
+
+  optional-dependencies = {
+    core = [
+      tree-sitter
+    ];
+  };
+
+  # There are no tests
+  doCheck = false;
+  pythonImportsCheck = [ "tree_sitter_markdown" ];
+
+  meta = {
+    description = "Markdown grammar for tree-sitter";
+    homepage = "https://github.com/tree-sitter-grammars/tree-sitter-markdown";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
+      gepbird
+    ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -17388,6 +17388,8 @@ self: super: with self; {
 
   tree-sitter-make = callPackage ../development/python-modules/tree-sitter-make { };
 
+  tree-sitter-markdown = callPackage ../development/python-modules/tree-sitter-markdown { };
+
   tree-sitter-python = callPackage ../development/python-modules/tree-sitter-python { };
 
   tree-sitter-rust = callPackage ../development/python-modules/tree-sitter-rust { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Release: https://github.com/Textualize/textual/releases/tag/v3.0.0

cc @GaetanLepage 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
