### PR TITLE
pangolin: Use libtiff.out as buildInput, finalAttrs and cmakeBool

### DIFF
--- a/pkgs/development/libraries/pangolin/default.nix
+++ b/pkgs/development/libraries/pangolin/default.nix
@@ -17,14 +17,14 @@
   Cocoa,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "pangolin";
   version = "0.9.1";
 
   src = fetchFromGitHub {
     owner = "stevenlovegrove";
     repo = "Pangolin";
-    rev = "v${version}";
+    rev = "v${finalAttrs.version}";
     sha256 = "sha256-B5YuNcJZHjR3dlVs66rySi68j29O3iMtlQvCjTUZBeY=";
   };
 
@@ -42,7 +42,7 @@ stdenv.mkDerivation rec {
       ffmpeg
       libjpeg
       libpng
-      libtiff
+      libtiff.out
       eigen
     ]
     ++ lib.optionals stdenv.hostPlatform.isDarwin [
@@ -53,7 +53,7 @@ stdenv.mkDerivation rec {
   # The tests use cmake's findPackage to find the installed version of
   # pangolin, which isn't what we want (or available).
   doCheck = false;
-  cmakeFlags = [ "-DBUILD_TESTS=OFF" ];
+  cmakeFlags = [ (lib.cmakeBool "BUILD_TESTS" false) ];
 
   meta = {
     description = "Lightweight portable rapid development library for managing OpenGL display / interaction and abstracting video input";
@@ -72,4 +72,4 @@ stdenv.mkDerivation rec {
     maintainers = [ ];
     platforms = lib.platforms.all;
   };
-}
+})


### PR DESCRIPTION
Found out that the linking `pangolin` throws linking errors
```
       > [ 84%] Linking CXX shared library libpango_tools.so
       > [ 84%] Linking CXX shared library libpango_plot.so
       > [ 85%] Linking CXX executable SimpleDisplay
       > [ 85%] Built target pango_tools
       > [ 85%] Built target pango_plot
       > /nix/store/s40y31bdn82sj6daaxid1bn3p7la03lv-binutils-2.43.1/bin/ld: ../../libpango_image.so: undefined reference to `TIFFSetWarningHandler'
       > /nix/store/s40y31bdn82sj6daaxid1bn3p7la03lv-binutils-2.43.1/bin/ld: ../../libpango_image.so: undefined reference to `TIFFClose'
       > /nix/store/s40y31bdn82sj6daaxid1bn3p7la03lv-binutils-2.43.1/bin/ld: ../../libpango_image.so: undefined reference to `TIFFGetField'
       > /nix/store/s40y31bdn82sj6daaxid1bn3p7la03lv-binutils-2.43.1/bin/ld: ../../libpango_image.so: undefined reference to `TIFFReadScanline'
       > /nix/store/s40y31bdn82sj6daaxid1bn3p7la03lv-binutils-2.43.1/bin/ld: ../../libpango_image.so: undefined reference to `TIFFOpen'
       > /nix/store/s40y31bdn82sj6daaxid1bn3p7la03lv-binutils-2.43.1/bin/ld: ../../libpango_image.so: undefined reference to `TIFFScanlineSize'
       > collect2: error: ld returned 1 exit status
       > make[2]: *** [examples/SimpleDisplay/CMakeFiles/SimpleDisplay.dir/build.make:112: examples/SimpleDisplay/SimpleDisplay] Error 1
       > make[1]: *** [CMakeFiles/Makefile2:1442: examples/SimpleDisplay/CMakeFiles/SimpleDisplay.dir/all] Error 2
       > make: *** [Makefile:136: all] Error 2

```
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).