### PR TITLE
xtensor: Fix darwin build with clang

### DIFF
--- a/pkgs/by-name/xt/xtensor/0001-Fix-clang-build-errors-on-darwin.patch
+++ b/pkgs/by-name/xt/xtensor/0001-Fix-clang-build-errors-on-darwin.patch
@@ -1,0 +1,66 @@
+From 475bedb15252a3732683f3a62c45cc3f1abbab5c Mon Sep 17 00:00:00 2001
+From: Mykola Vankovych <mykola.vankovych@biodataanalysis.de>
+Date: Tue, 14 Jan 2025 16:48:47 +0100
+Subject: [PATCH] Added fixes for building with clang 19 (more strict template
+ matching rules)
+
+---
+ include/xtensor/xexpression_traits.hpp | 7 +++----
+ include/xtensor/xstorage.hpp           | 4 ++--
+ include/xtensor/xutils.hpp             | 3 ++-
+ 3 files changed, 7 insertions(+), 7 deletions(-)
+
+diff --git a/include/xtensor/xexpression_traits.hpp b/include/xtensor/xexpression_traits.hpp
+index 205de67a5..2f84ae234 100644
+--- a/include/xtensor/xexpression_traits.hpp
++++ b/include/xtensor/xexpression_traits.hpp
+@@ -103,16 +103,15 @@ namespace xt
+             using type = xarray<T, L>;
+         };
+ 
+-#if defined(__GNUC__) && (__GNUC__ > 6)
+-#if __cplusplus == 201703L
++// Workaround for rebind_container problems when C++17 feature is enabled
++#ifdef __cpp_template_template_args
+         template <template <class, std::size_t, class, bool> class S, class X, std::size_t N, class A, bool Init>
+         struct xtype_for_shape<S<X, N, A, Init>>
+         {
+             template <class T, layout_type L>
+             using type = xarray<T, L>;
+         };
+-#endif  // __cplusplus == 201703L
+-#endif  // __GNUC__ && (__GNUC__ > 6)
++#endif  // __cpp_template_template_args
+ 
+         template <template <class, std::size_t> class S, class X, std::size_t N>
+         struct xtype_for_shape<S<X, N>>
+diff --git a/include/xtensor/xstorage.hpp b/include/xtensor/xstorage.hpp
+index ac179a852..fec8e10f3 100644
+--- a/include/xtensor/xstorage.hpp
++++ b/include/xtensor/xstorage.hpp
+@@ -1637,8 +1637,8 @@ namespace xt
+         return !(lhs < rhs);
+     }
+ 
+-// Workaround for rebind_container problems on GCC 8 with C++17 enabled
+-#if defined(__GNUC__) && __GNUC__ > 6 && !defined(__clang__) && __cplusplus >= 201703L
++// Workaround for rebind_container problems when C++17 feature is enabled
++#ifdef __cpp_template_template_args
+     template <class X, class T, std::size_t N>
+     struct rebind_container<X, aligned_array<T, N>>
+     {
+diff --git a/include/xtensor/xutils.hpp b/include/xtensor/xutils.hpp
+index 9844b0ba7..b8c818efd 100644
+--- a/include/xtensor/xutils.hpp
++++ b/include/xtensor/xutils.hpp
+@@ -1023,7 +1023,8 @@ namespace xt
+         using type = C<X, allocator>;
+     };
+ 
+-#if defined(__GNUC__) && __GNUC__ > 6 && !defined(__clang__) && __cplusplus >= 201703L
++// Workaround for rebind_container problems when C++17 feature is enabled
++#ifdef __cpp_template_template_args
+     template <class X, class T, std::size_t N>
+     struct rebind_container<X, std::array<T, N>>
+     {
+

--- a/pkgs/by-name/xt/xtensor/package.nix
+++ b/pkgs/by-name/xt/xtensor/package.nix
@@ -22,6 +22,9 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-hVfdtYcJ6mzqj0AUu6QF9aVKQGYKd45RngY6UN3yOH4=";
   };
 
+  # See https://github.com/xtensor-stack/xtensor/pull/2821
+  patches = lib.optionals stdenv.cc.isClang [ ./0001-Fix-clang-build-errors-on-darwin.patch ];
+
   nativeBuildInputs = [
     cmake
   ];


### PR DESCRIPTION
`xtensor` does not build on `darwin` due to using newer verison of `clang`

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ x aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).