### PR TITLE
python3Packages.textnets: 0.9.5 -> 0.10.3

### DIFF
--- a/pkgs/development/python-modules/textnets/default.nix
+++ b/pkgs/development/python-modules/textnets/default.nix
@@ -5,14 +5,14 @@
   fetchFromGitHub,
 
   # build-system
-  cython,
-  poetry-core,
+  cython_0,
+  pdm-backend,
   setuptools,
 
   # dependencies
-  cairocffi,
   igraph,
   leidenalg,
+  matplotlib,
   pandas,
   pyarrow,
   scipy,
@@ -29,33 +29,31 @@
 
 buildPythonPackage rec {
   pname = "textnets";
-  version = "0.9.5";
+  version = "0.10.3";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "jboynyc";
     repo = "textnets";
     tag = "v${version}";
-    hash = "sha256-MdKPxIshSx6U2EFGDTUS4EhoByyuVf0HKqvm9cS2KNY=";
+    hash = "sha256-BK0bBoe6GrZpVL4HvTwzRlXRWXfKdYJDhLD2UQctTjc=";
   };
 
   build-system = [
-    cython
-    poetry-core
+    cython_0
+    pdm-backend
     setuptools
   ];
 
   pythonRelaxDeps = [
-    "igraph"
-    "leidenalg"
     "pyarrow"
     "toolz"
   ];
 
   dependencies = [
-    cairocffi
     igraph
     leidenalg
+    matplotlib
     pandas
     pyarrow
     scipy
@@ -73,24 +71,12 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "textnets" ];
 
-  # Enables the package to find the cythonized .so files during testing. See #255262
+  # Enable the package to find the cythonized .so files during testing. See #255262
+  # Set MPLBACKEND=agg for headless matplotlib on darwin. See #350784
   preCheck = ''
     rm -r textnets
+    export MPLBACKEND=agg
   '';
-
-  disabledTests =
-    [
-      # Test fails: Throws a UserWarning asking the user to install `textnets[fca]`.
-      "test_context"
-    ]
-    ++ lib.optionals stdenv.hostPlatform.isDarwin [
-      # MemoryError: ("cairo returned CAIRO_STATUS_NO_MEMORY: b'out of memory'", 1)
-      "test_plot_backbone"
-      "test_plot_filtered"
-      "test_plot_layout"
-      "test_plot_projected"
-      "test_plot_scaled"
-    ];
 
   meta = {
     description = "Text analysis with networks";


### PR DESCRIPTION
Release: https://github.com/jboynyc/textnets/releases/tag/v0.10.1

- Switch build backend to  `pdm-backend` 
- Replace dependency on cairo with dependency on matplotlib.
- Tests no longer have to be skipped for darwin since cairo was the cause of errors
- Several version constraints were relaxed upstream


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
