### PR TITLE
Scala 3.3.4 -> 3.3.5, Scala (next) 3.6.3 -> 3.6.4

### DIFF
--- a/pkgs/by-name/sc/scala-next/package.nix
+++ b/pkgs/by-name/sc/scala-next/package.nix
@@ -1,10 +1,10 @@
 { scala, fetchurl }:
 
 scala.bare.overrideAttrs (oldAttrs: {
-  version = "3.6.3";
+  version = "3.6.4";
   pname = "scala-next";
   src = fetchurl {
     inherit (oldAttrs.src) url;
-    hash = "sha256-I+PYPSRLS8Q0SJ/BEAoFwB7EcFERZpN5pGcD5cGwlNU=";
+    hash = "sha256-I8Jpq/aelCJyAZzvNq5/QbfdD0Mk5mPuzTDxVdkIxKU=";
   };
 })

--- a/pkgs/development/compilers/scala/bare.nix
+++ b/pkgs/development/compilers/scala/bare.nix
@@ -8,12 +8,12 @@
 }:
 
 stdenv.mkDerivation (finalAttrs: {
-  version = "3.3.4";
+  version = "3.3.5";
   pname = "scala-bare";
 
   src = fetchurl {
     url = "https://github.com/scala/scala3/releases/download/${finalAttrs.version}/scala3-${finalAttrs.version}.tar.gz";
-    hash = "sha256-/Q7KKe8fbEGHS2cR57ZRTx3Hw4fAh3QvuHP25yCWN3A=";
+    hash = "sha256-JVQG16L0/3RbahJc+FDz6pazTyb5vnxqP4272l0TalI=";
   };
 
   propagatedBuildInputs = [


### PR DESCRIPTION
Updating Scala and Scala next packages to the latest versions.

![CleanShot 2025-03-28 at 09 11 06@2x](https://github.com/user-attachments/assets/16787116-0408-4e9f-8bb0-77d2e0e04e00)
![CleanShot 2025-03-28 at 09 11 53@2x](https://github.com/user-attachments/assets/f0d54c74-e3a4-49bf-996c-c2ca307df6af)

## Release Notes:

- `scala`: [3.3.5](https://github.com/scala/scala3/releases/tag/3.3.5)
- `scala-next`: [3.6.4](https://github.com/scala/scala3/releases/tag/3.6.4)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
