### PR TITLE
python313Packages.msmart-ng: 2025.3.1 -> 2025.3.3, home-assistant-custom-components.midea_ac: 2025.3.0 -> 2025.3.1

### DIFF
--- a/pkgs/development/python-modules/msmart-ng/default.nix
+++ b/pkgs/development/python-modules/msmart-ng/default.nix
@@ -2,6 +2,7 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+  fetchpatch2,
 
   # build-system
   setuptools,
@@ -17,15 +18,26 @@
 
 buildPythonPackage rec {
   pname = "msmart-ng";
-  version = "2025.3.1";
+  version = "2025.3.3";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "mill1000";
     repo = "midea-msmart";
     tag = version;
-    hash = "sha256-hTYqRJn/ixseHHezfTOG0UzdQmnpn4hACijYOMtwtT8=";
+    hash = "sha256-M8Gl6QXj0tRN7VFDhop47vINk8MeWSyCJ9bboo3j8Go=";
   };
+
+  patches = [
+    (fetchpatch2 {
+      # Revert <https://github.com/mill1000/midea-msmart/pull/209> until setuptools
+      # implements support for <https://peps.python.org/pep-0639/>.
+      name = "revert-pyproject-license-declaration-pep639-syntax.patch";
+      url = "https://github.com/mill1000/midea-msmart/commit/e5d6a982135e497c251095e421d3de4686f36056.patch?full_index=1";
+      hash = "sha256-+mxmFGZd04MZY2C5eo4k1lFoXsM8XyeJNazShnjAseE=";
+      revert = true;
+    })
+  ];
 
   build-system = [
     setuptools

--- a/pkgs/servers/home-assistant/custom-components/midea_ac/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/midea_ac/package.nix
@@ -8,13 +8,13 @@
 buildHomeAssistantComponent rec {
   owner = "mill1000";
   domain = "midea_ac";
-  version = "2025.3.0";
+  version = "2025.3.1";
 
   src = fetchFromGitHub {
     owner = "mill1000";
     repo = "midea-ac-py";
     tag = version;
-    hash = "sha256-UJS9z+t+Tb/w7yRHKXJ6HoQ4uS1guM8PYl0OcLz4EJM=";
+    hash = "sha256-oO+t0my72PwWWUAzr8blA3Q8uJyICZNcfoOHsLFL3MQ=";
   };
 
   dependencies = [ msmart-ng ];


### PR DESCRIPTION
https://github.com/mill1000/midea-msmart/releases/tag/2025.3.2

https://github.com/mill1000/midea-msmart/releases/tag/2025.3.3

https://github.com/mill1000/midea-ac-py/releases/tag/2025.3.1

This also reverts the pep639 license format change in pyproject.toml because setuptools has yet to implement pep639.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
