### PR TITLE
Xfce updates 2025-03-28

### DIFF
--- a/pkgs/desktops/xfce/applications/mousepad/default.nix
+++ b/pkgs/desktops/xfce/applications/mousepad/default.nix
@@ -29,6 +29,8 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-6ddPma6B4hNgtILavJFz/wtSzLViABkluZ5BTXpbcEE=";
   };
 
+  strictDeps = true;
+
   nativeBuildInputs = [
     glib # glib-compile-schemas
     meson

--- a/pkgs/desktops/xfce/applications/orage/default.nix
+++ b/pkgs/desktops/xfce/applications/orage/default.nix
@@ -13,9 +13,9 @@
 mkXfceDerivation {
   category = "apps";
   pname = "orage";
-  version = "4.20.0";
+  version = "4.20.1";
 
-  sha256 = "sha256-VaabhMRgH/q9HiFXBPQ90HbMLW21BXTvZtxd8bhYYnw=";
+  sha256 = "sha256-WdvqsgHfhJ2sk4vQ75m1zmWjefJBJdDKH8E0GA4fCNg=";
 
   buildInputs = [
     glib

--- a/pkgs/desktops/xfce/applications/ristretto/default.nix
+++ b/pkgs/desktops/xfce/applications/ristretto/default.nix
@@ -1,28 +1,52 @@
 {
+  stdenv,
   lib,
-  mkXfceDerivation,
-  gtk3,
+  fetchFromGitLab,
   glib,
-  gnome,
+  meson,
+  ninja,
+  pkg-config,
+  wrapGAppsHook3,
+  cairo,
+  exo,
+  gtk3,
   libexif,
+  libxfce4ui,
+  libxfce4util,
+  xfconf,
+  gnome,
   libheif,
   libjxl,
   librsvg,
-  libxfce4ui,
-  libxfce4util,
   webp-pixbuf-loader,
-  xfconf,
+  gitUpdater,
 }:
 
-mkXfceDerivation {
-  category = "apps";
+stdenv.mkDerivation (finalAttrs: {
   pname = "ristretto";
-  version = "0.13.3";
-  odd-unstable = false;
+  version = "0.13.4";
 
-  sha256 = "sha256-cJMHRN4Wl6Fm0yoVqe0h30ZUlE1+Hw1uEDBHfHXBbC0=";
+  src = fetchFromGitLab {
+    domain = "gitlab.xfce.org";
+    owner = "apps";
+    repo = "ristretto";
+    tag = "ristretto-${finalAttrs.version}";
+    hash = "sha256-X0liZddeEOxlo0tyn3Irvo0+MTnMFuvKY2m4h+/EI2E=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    glib # glib-compile-schemas
+    meson
+    ninja
+    pkg-config
+    wrapGAppsHook3
+  ];
 
   buildInputs = [
+    cairo
+    exo
     glib
     gtk3
     libexif
@@ -46,9 +70,14 @@ mkXfceDerivation {
     }"
   '';
 
-  meta = with lib; {
+  passthru.updateScript = gitUpdater { rev-prefix = "ristretto-"; };
+
+  meta = {
     description = "Fast and lightweight picture-viewer for the Xfce desktop environment";
+    homepage = "https://gitlab.xfce.org/apps/ristretto";
+    license = lib.licenses.gpl2Plus;
     mainProgram = "ristretto";
-    maintainers = with maintainers; [ ] ++ teams.xfce.members;
+    maintainers = lib.teams.xfce.members;
+    platforms = lib.platforms.linux;
   };
-}
+})

--- a/pkgs/desktops/xfce/applications/xfce4-terminal/default.nix
+++ b/pkgs/desktops/xfce/applications/xfce4-terminal/default.nix
@@ -1,50 +1,75 @@
 {
+  stdenv,
   lib,
-  mkXfceDerivation,
-  glib,
-  gtk3,
-  gtk-layer-shell,
-  libX11,
-  libxfce4ui,
-  vte,
-  xfconf,
-  pcre2,
-  libxslt,
+  fetchFromGitLab,
   docbook_xml_dtd_45,
   docbook_xsl,
+  glib,
+  libxslt, # xsltproc
+  meson,
+  ninja,
+  pkg-config,
+  wrapGAppsHook3,
+  gtk3,
+  gtk-layer-shell,
+  libutempter,
+  libX11,
+  libxfce4ui,
+  pcre2,
+  vte,
+  xfconf,
   nixosTests,
+  gitUpdater,
 }:
 
-mkXfceDerivation {
-  category = "apps";
+stdenv.mkDerivation (finalAttrs: {
   pname = "xfce4-terminal";
-  version = "1.1.4";
-  odd-unstable = false;
+  version = "1.1.5";
 
-  sha256 = "sha256-WrmffY8kC9tBorvtEb8q6DmHKX5d7HnvbxtBbpy4LJs=";
+  src = fetchFromGitLab {
+    domain = "gitlab.xfce.org";
+    owner = "apps";
+    repo = "xfce4-terminal";
+    tag = "xfce4-terminal-${finalAttrs.version}";
+    hash = "sha256-qNXrxUjmuY6+k95/zcOu1/CUfhb1u0Ca91aFD3c4uoc=";
+  };
+
+  strictDeps = true;
 
   nativeBuildInputs = [
-    libxslt
     docbook_xml_dtd_45
     docbook_xsl
+    glib # glib-mkenums
+    libxslt # xsltproc
+    meson
+    ninja
+    pkg-config
+    wrapGAppsHook3
   ];
 
   buildInputs = [
     glib
     gtk3
     gtk-layer-shell
+    libutempter
     libX11
     libxfce4ui
+    pcre2
     vte
     xfconf
-    pcre2
   ];
 
-  passthru.tests.test = nixosTests.terminal-emulators.xfce4-terminal;
-
-  meta = with lib; {
-    description = "Modern terminal emulator";
-    maintainers = with maintainers; [ ] ++ teams.xfce.members;
-    mainProgram = "xfce4-terminal";
+  passthru = {
+    tests.test = nixosTests.terminal-emulators.xfce4-terminal;
+    updateScript = gitUpdater { rev-prefix = "xfce4-terminal-"; };
   };
-}
+
+  meta = {
+    description = "Modern terminal emulator";
+    homepage = "https://gitlab.xfce.org/apps/xfce4-terminal";
+    license = lib.licenses.gpl2Plus;
+    mainProgram = "xfce4-terminal";
+    maintainers = lib.teams.xfce.members;
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
More autotools -> meson.

P.s. upstream's meson port follows a [fixed template](https://gitlab.xfce.org/xfce/xfce4-dev-tools/-/tree/master/meson-project-template) so for the root meson.build file mostly you only need to look at the dependencies and the `feature_cflags`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

