### PR TITLE
feroxbuster: 2.10.3 -> 2.11.0

### DIFF
--- a/pkgs/by-name/fe/feroxbuster/package.nix
+++ b/pkgs/by-name/fe/feroxbuster/package.nix
@@ -6,6 +6,7 @@
   pkg-config,
   rustPlatform,
   nix-update-script,
+  versionCheckHook,
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -25,12 +26,19 @@ rustPlatform.buildRustPackage rec {
 
   OPENSSL_NO_VENDOR = true;
 
-  nativeBuildInputs = [ pkg-config ];
+  nativeBuildInputs = [
+    pkg-config
+    versionCheckHook
+  ];
 
   buildInputs = [ openssl ];
 
   # Tests require network access
   doCheck = false;
+
+  doInstallCheck = true;
+
+  versionCheckProgramArg = [ "--version" ];
 
   passthru.updateScript = nix-update-script { };
 

--- a/pkgs/by-name/fe/feroxbuster/package.nix
+++ b/pkgs/by-name/fe/feroxbuster/package.nix
@@ -5,38 +5,29 @@
   openssl,
   pkg-config,
   rustPlatform,
-  Security,
-  SystemConfiguration,
   nix-update-script,
 }:
+
 rustPlatform.buildRustPackage rec {
   pname = "feroxbuster";
   version = "2.11.0";
 
   src = fetchFromGitHub {
     owner = "epi052";
-    repo = pname;
+    repo = "feroxbuster";
     tag = "v${version}";
     hash = "sha256-/NgGlXYMxGxpX93SJ6gWgZW21cSSZsgo/WMvRuLw+Bw=";
   };
 
   useFetchCargoVendor = true;
+
   cargoHash = "sha256-L5s+P9eerv+O2vBUczGmn0rUMbHQtnF8hVa22wOrTGo=";
 
   OPENSSL_NO_VENDOR = true;
 
-  nativeBuildInputs = [
-    pkg-config
-  ];
+  nativeBuildInputs = [ pkg-config ];
 
-  buildInputs =
-    [
-      openssl
-    ]
-    ++ lib.optionals stdenv.hostPlatform.isDarwin [
-      Security
-      SystemConfiguration
-    ];
+  buildInputs = [ openssl ];
 
   # Tests require network access
   doCheck = false;
@@ -44,10 +35,10 @@ rustPlatform.buildRustPackage rec {
   passthru.updateScript = nix-update-script { };
 
   meta = with lib; {
-    description = "Fast, simple, recursive content discovery tool";
+    description = "Recursive content discovery tool";
     homepage = "https://github.com/epi052/feroxbuster";
-    changelog = "https://github.com/epi052/feroxbuster/releases/tag/v${version}";
-    license = with licenses; [ mit ];
+    changelog = "https://github.com/epi052/feroxbuster/releases/tag/v${src.tag}";
+    license = licenses.mit;
     maintainers = with maintainers; [ fab ];
     platforms = platforms.unix;
     mainProgram = "feroxbuster";

--- a/pkgs/tools/security/feroxbuster/default.nix
+++ b/pkgs/tools/security/feroxbuster/default.nix
@@ -7,6 +7,7 @@
   rustPlatform,
   Security,
   SystemConfiguration,
+  nix-update-script,
 }:
 rustPlatform.buildRustPackage rec {
   pname = "feroxbuster";
@@ -44,6 +45,8 @@ rustPlatform.buildRustPackage rec {
 
   # Tests require network access
   doCheck = false;
+
+  passthru.updateScript = nix-update-script { };
 
   meta = with lib; {
     description = "Fast, simple, recursive content discovery tool";

--- a/pkgs/tools/security/feroxbuster/default.nix
+++ b/pkgs/tools/security/feroxbuster/default.nix
@@ -20,11 +20,6 @@ rustPlatform.buildRustPackage rec {
     hash = "sha256-/NgGlXYMxGxpX93SJ6gWgZW21cSSZsgo/WMvRuLw+Bw=";
   };
 
-  # disable linker overrides on aarch64-linux
-  postPatch = ''
-    rm .cargo/config
-  '';
-
   useFetchCargoVendor = true;
   cargoHash = "sha256-L5s+P9eerv+O2vBUczGmn0rUMbHQtnF8hVa22wOrTGo=";
 

--- a/pkgs/tools/security/feroxbuster/default.nix
+++ b/pkgs/tools/security/feroxbuster/default.nix
@@ -8,16 +8,15 @@
   Security,
   SystemConfiguration,
 }:
-
 rustPlatform.buildRustPackage rec {
   pname = "feroxbuster";
-  version = "2.10.3";
+  version = "2.11.0";
 
   src = fetchFromGitHub {
     owner = "epi052";
     repo = pname;
     tag = "v${version}";
-    hash = "sha256-3cznGVpZISLD2TbsHYyYYUTD55NmgBdNJ44V4XfZ40k=";
+    hash = "sha256-/NgGlXYMxGxpX93SJ6gWgZW21cSSZsgo/WMvRuLw+Bw=";
   };
 
   # disable linker overrides on aarch64-linux
@@ -26,7 +25,7 @@ rustPlatform.buildRustPackage rec {
   '';
 
   useFetchCargoVendor = true;
-  cargoHash = "sha256-DjmMoATagWGK2DHMc6YB0u2X5x5hnqgCwIGe3+Wmdic=";
+  cargoHash = "sha256-L5s+P9eerv+O2vBUczGmn0rUMbHQtnF8hVa22wOrTGo=";
 
   OPENSSL_NO_VENDOR = true;
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3124,10 +3124,6 @@ with pkgs;
 
   featherpad = qt5.callPackage ../applications/editors/featherpad { };
 
-  feroxbuster = callPackage ../tools/security/feroxbuster {
-    inherit (darwin.apple_sdk.frameworks) Security SystemConfiguration;
-  };
-
   ffsend = callPackage ../tools/misc/ffsend {
     inherit (darwin.apple_sdk.frameworks) Security AppKit;
   };


### PR DESCRIPTION
Key changes:

* Updated `feroxbuster` version from `2.10.3` to `2.11.0`
* Added `nix-update-script` to the list of dependencies and included a `passthru.updateScript` for easier updates.
* Removed `postPatch`

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
