### PR TITLE
nixos/oci-containers: stricter dependencies for rootless containers with sdnotify=healthy

### DIFF
--- a/nixos/modules/virtualisation/oci-containers.nix
+++ b/nixos/modules/virtualisation/oci-containers.nix
@@ -434,6 +434,7 @@ let
       };
 
       effectiveUser = container.podman.user or "root";
+      inherit (config.users.users.${effectiveUser}) uid;
       dependOnLingerService =
         cfg.backend == "podman" && effectiveUser != "root" && config.users.users.${effectiveUser}.linger;
     in
@@ -441,7 +442,7 @@ let
       wantedBy = [ ] ++ optional (container.autoStart) "multi-user.target";
       wants =
         lib.optional (container.imageFile == null && container.imageStream == null) "network-online.target"
-        ++ lib.optional dependOnLingerService "linger-users.service";
+        ++ lib.optionals dependOnLingerService [ "linger-users.service" ];
       after =
         lib.optionals (cfg.backend == "docker") [
           "docker.service"
@@ -452,8 +453,15 @@ let
           "network-online.target"
         ]
         ++ dependsOn
-        ++ lib.optional dependOnLingerService "linger-users.service";
-      requires = dependsOn;
+        ++ lib.optionals dependOnLingerService [ "linger-users.service" ]
+        ++ lib.optionals (effectiveUser != "root" && container.podman.sdnotify == "healthy") [
+          "user@${toString uid}.service"
+        ];
+      requires =
+        dependsOn
+        ++ lib.optionals (effectiveUser != "root" && container.podman.sdnotify == "healthy") [
+          "user@${toString uid}.service"
+        ];
       environment = lib.mkMerge [
         proxy_env
         (mkIf (cfg.backend == "podman" && container.podman.user != "root") {
@@ -522,6 +530,10 @@ let
           "podman rm -f --ignore --cidfile=/run/${escapedName}/ctr-id"
         else
           "${cfg.backend} rm -f ${name} || true";
+
+      unitConfig = mkIf (effectiveUser != "root") {
+        RequiresMountsFor = "/run/user/${toString uid}/containers";
+      };
 
       serviceConfig =
         {
@@ -615,6 +627,15 @@ in
                 {
                   assertion = cfg.backend == "docker" -> podman == null;
                   message = "virtualisation.oci-containers.containers.${name}: Cannot set `podman` option if backend is `docker`.";
+                }
+                {
+                  assertion =
+                    cfg.backend == "podman" && podman.sdnotify == "healthy" && podman.user != "root"
+                    -> config.users.users.${podman.user}.uid != null;
+                  message = ''
+                    Rootless container ${name} (with podman and sdnotify=healthy)
+                    requires that its running user ${podman.user} has a statically specified uid.
+                  '';
                 }
               ];
           in

--- a/nixos/tests/oci-containers.nix
+++ b/nixos/tests/oci-containers.nix
@@ -80,6 +80,7 @@ let
               home = "/var/lib/redis";
               linger = type == "healthy";
               createHome = true;
+              uid = 2342;
               subUidRanges = [
                 {
                   count = 65536;


### PR DESCRIPTION
After running this configuration for a while, we
noticed that the containers didn't get back up once and the services failed with the following error:

    Error: current system boot ID differs from cached boot ID; an unhandled reboot has occurred.

This is hard to reproduce and seems to be a timing issue. However, the logs indicated another issue that this patch now solves:

* The ExecStartPost= indicated that the user session got stopped before which is required or sdnotify=healthy. Add explicit ordering for user@. This unfortunately requires a statically declared uid.

cc @frlan @megheaiulian @fpletz

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
