### PR TITLE
treewide: use 'buildGoModule' as input name

### DIFF
--- a/pkgs/by-name/al/ali/package.nix
+++ b/pkgs/by-name/al/ali/package.nix
@@ -1,10 +1,10 @@
 {
   lib,
-  buildGo122Module,
+  buildGoModule,
   fetchFromGitHub,
 }:
 
-buildGo122Module rec {
+buildGoModule rec {
   pname = "ali";
   version = "0.7.5";
 

--- a/pkgs/by-name/be/bettercap/package.nix
+++ b/pkgs/by-name/be/bettercap/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   stdenv,
-  buildGo122Module,
+  buildGoModule,
   fetchFromGitHub,
   pkg-config,
   libpcap,
@@ -10,7 +10,7 @@
   libusb1,
 }:
 
-buildGo122Module rec {
+buildGoModule rec {
   pname = "bettercap";
   version = "2.32.0";
 

--- a/pkgs/by-name/bi/bitmagnet/package.nix
+++ b/pkgs/by-name/bi/bitmagnet/package.nix
@@ -1,11 +1,11 @@
 {
   lib,
-  buildGo122Module, # builds, but does not start on 1.23
+  buildGoModule,
   fetchFromGitHub,
   nix-update-script,
 }:
 
-buildGo122Module rec {
+buildGoModule rec {
   pname = "bitmagnet";
   version = "0.9.5";
 

--- a/pkgs/by-name/ce/certinfo/package.nix
+++ b/pkgs/by-name/ce/certinfo/package.nix
@@ -1,13 +1,13 @@
 {
   stdenv,
   lib,
-  buildGo123Module,
+  buildGoModule,
   fetchFromGitHub,
   libX11,
   darwin,
 }:
 
-buildGo123Module rec {
+buildGoModule rec {
   pname = "certinfo";
   version = "1.0.24";
 

--- a/pkgs/by-name/cl/cloudpan189-go/package.nix
+++ b/pkgs/by-name/cl/cloudpan189-go/package.nix
@@ -1,10 +1,10 @@
 {
-  buildGo122Module,
+  buildGoModule,
   lib,
   fetchFromGitHub,
   versionCheckHook,
 }:
-buildGo122Module rec {
+buildGoModule rec {
   pname = "cloudpan189-go";
   version = "0.1.3";
   src = fetchFromGitHub {

--- a/pkgs/by-name/d2/d2/package.nix
+++ b/pkgs/by-name/d2/d2/package.nix
@@ -1,6 +1,6 @@
 {
   lib,
-  buildGo123Module,
+  buildGoModule,
   fetchFromGitHub,
   installShellFiles,
   git,
@@ -8,7 +8,7 @@
   d2,
 }:
 
-buildGo123Module rec {
+buildGoModule rec {
   pname = "d2";
   version = "0.6.9";
 

--- a/pkgs/by-name/de/devdash/package.nix
+++ b/pkgs/by-name/de/devdash/package.nix
@@ -1,12 +1,12 @@
 {
   lib,
-  buildGo122Module,
+  buildGoModule,
   fetchFromGitHub,
   nix-update-script,
   coreutils,
 }:
 
-buildGo122Module rec {
+buildGoModule rec {
   pname = "devdash";
   version = "0.5.0";
 

--- a/pkgs/by-name/de/dex-oidc/package.nix
+++ b/pkgs/by-name/de/dex-oidc/package.nix
@@ -1,13 +1,13 @@
 {
   lib,
-  buildGo124Module,
+  buildGoModule,
   fetchFromGitHub,
   nixosTests,
   testers,
   dex-oidc,
 }:
 
-buildGo124Module rec {
+buildGoModule rec {
   pname = "dex";
   version = "2.42.0";
 

--- a/pkgs/by-name/ev/evcc/package.nix
+++ b/pkgs/by-name/ev/evcc/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   stdenv,
-  buildGo124Module,
+  buildGoModule,
   fetchFromGitHub,
   fetchNpmDeps,
   cacert,
@@ -33,7 +33,7 @@ let
     maintainers = with maintainers; [ hexa ];
   };
 
-  decorate = buildGo124Module {
+  decorate = buildGoModule {
     pname = "evcc-decorate";
     inherit version src vendorHash;
 
@@ -46,7 +46,7 @@ let
   };
 in
 
-buildGo124Module rec {
+buildGoModule rec {
   pname = "evcc";
   inherit version src vendorHash;
 

--- a/pkgs/by-name/fa/fan2go/package.nix
+++ b/pkgs/by-name/fa/fan2go/package.nix
@@ -1,11 +1,11 @@
 {
-  buildGo123Module,
+  buildGoModule,
   fetchFromGitHub,
   lib,
   lm_sensors,
 }:
 
-buildGo123Module rec {
+buildGoModule rec {
   pname = "fan2go";
   version = "0.9.0";
 

--- a/pkgs/by-name/fi/filebrowser/package.nix
+++ b/pkgs/by-name/fi/filebrowser/package.nix
@@ -1,5 +1,5 @@
 {
-  buildGo123Module,
+  buildGoModule,
   buildNpmPackage,
   fetchFromGitHub,
   lib,
@@ -35,7 +35,7 @@ let
     '';
   };
 in
-buildGo123Module {
+buildGoModule {
   pname = "filebrowser";
   inherit version src;
 

--- a/pkgs/by-name/gi/git-spice/package.nix
+++ b/pkgs/by-name/gi/git-spice/package.nix
@@ -1,14 +1,14 @@
 {
   lib,
   stdenv,
-  buildGo124Module,
+  buildGoModule,
   fetchFromGitHub,
   git,
   nix-update-script,
   installShellFiles,
 }:
 
-buildGo124Module rec {
+buildGoModule rec {
   pname = "git-spice";
   version = "0.12.0";
 

--- a/pkgs/by-name/gi/gitea-actions-runner/package.nix
+++ b/pkgs/by-name/gi/gitea-actions-runner/package.nix
@@ -1,12 +1,12 @@
 {
   lib,
   fetchFromGitea,
-  buildGo123Module,
+  buildGoModule,
   testers,
   gitea-actions-runner,
 }:
 
-buildGo123Module rec {
+buildGoModule rec {
   pname = "gitea-actions-runner";
   version = "0.2.11";
 

--- a/pkgs/by-name/gl/glasskube/package.nix
+++ b/pkgs/by-name/gl/glasskube/package.nix
@@ -1,5 +1,5 @@
 { lib
-, buildGo123Module
+, buildGoModule
 , buildNpmPackage
 , fetchFromGitHub
 , nix-update-script
@@ -35,7 +35,7 @@ let
     '';
   };
 
-in buildGo123Module rec {
+in buildGoModule rec {
   inherit version;
   pname = "glasskube";
 

--- a/pkgs/by-name/go/go-camo/package.nix
+++ b/pkgs/by-name/go/go-camo/package.nix
@@ -1,12 +1,12 @@
 {
   lib,
-  buildGo124Module,
+  buildGoModule,
   fetchFromGitHub,
   installShellFiles,
   scdoc,
 }:
 
-buildGo124Module rec {
+buildGoModule rec {
   pname = "go-camo";
   version = "2.6.2";
 

--- a/pkgs/by-name/go/golangci-lint/package.nix
+++ b/pkgs/by-name/go/golangci-lint/package.nix
@@ -1,11 +1,11 @@
 {
-  buildGo124Module,
+  buildGoModule,
   fetchFromGitHub,
   lib,
   installShellFiles,
 }:
 
-buildGo124Module rec {
+buildGoModule rec {
   pname = "golangci-lint";
   version = "2.0.0";
 

--- a/pkgs/by-name/go/govulncheck/package.nix
+++ b/pkgs/by-name/go/govulncheck/package.nix
@@ -1,11 +1,11 @@
 {
   lib,
-  buildGo124Module,
+  buildGoModule,
   fetchFromGitHub,
   replaceVars,
 }:
 
-buildGo124Module rec {
+buildGoModule rec {
   pname = "govulncheck";
   version = "1.1.4";
 

--- a/pkgs/by-name/gr/grafana-agent/package.nix
+++ b/pkgs/by-name/gr/grafana-agent/package.nix
@@ -1,5 +1,5 @@
 { lib
-, buildGo122Module
+, buildGoModule
 , fetchFromGitHub
 , fetchYarnDeps
 , fixup-yarn-lock
@@ -15,7 +15,7 @@
 
 # Breaks with Go 1.23: https://github.com/grafana/agent/issues/6972
 # FIXME: unpin when fixed upstream
-buildGo122Module rec {
+buildGoModule rec {
   pname = "grafana-agent";
   version = "0.44.2";
 

--- a/pkgs/by-name/ho/hof/package.nix
+++ b/pkgs/by-name/ho/hof/package.nix
@@ -1,11 +1,11 @@
 {
   lib,
-  buildGo122Module,
+  buildGoModule,
   fetchFromGitHub,
   installShellFiles,
 }:
 
-buildGo122Module rec {
+buildGoModule rec {
   pname = "hof";
   version = "0.6.9";
 

--- a/pkgs/by-name/ho/homebox/package.nix
+++ b/pkgs/by-name/ho/homebox/package.nix
@@ -1,6 +1,6 @@
 {
   lib,
-  buildGo123Module,
+  buildGoModule,
   fetchFromGitHub,
   pnpm_9,
   nodejs,
@@ -19,7 +19,7 @@ let
     hash = "sha256-XzO/aJcLGu+ZHt9fDUhUzBbUS9VpChFVOH0cgvYK6kc=";
   };
 in
-buildGo123Module {
+buildGoModule {
   inherit pname version src;
 
   vendorHash = "sha256-Zo/yI1mNeN0O9gZsHux6aOzBlv72h17s7QNO+MaG2/g=";

--- a/pkgs/by-name/ho/honeytrap/package.nix
+++ b/pkgs/by-name/ho/honeytrap/package.nix
@@ -1,9 +1,9 @@
 {
   lib,
-  buildGo122Module,
+  buildGoModule,
   fetchFromGitHub,
 }:
-buildGo122Module {
+buildGoModule {
   pname = "honeytrap";
   version = "unstable-2021-12-20";
 

--- a/pkgs/by-name/hu/hubble/package.nix
+++ b/pkgs/by-name/hu/hubble/package.nix
@@ -1,11 +1,11 @@
 {
   lib,
-  buildGo124Module,
+  buildGoModule,
   fetchFromGitHub,
   installShellFiles,
 }:
 
-buildGo124Module rec {
+buildGoModule rec {
   pname = "hubble";
   version = "1.17.1";
 

--- a/pkgs/by-name/ki/kitty/package.nix
+++ b/pkgs/by-name/ki/kitty/package.nix
@@ -45,7 +45,7 @@
   fish,
   nixosTests,
   go_1_23,
-  buildGo123Module,
+  buildGoModule,
   nix-update-script,
   makeBinaryWrapper,
   autoSignDarwinBinariesHook,
@@ -67,7 +67,7 @@ buildPythonApplication rec {
   };
 
   goModules =
-    (buildGo123Module {
+    (buildGoModule {
       pname = "kitty-go-modules";
       inherit src version;
       vendorHash = "sha256-wr5R2X+lV8vVVWsDYLLSaz7HRNOB7Zzk/a7knsdDlXs=";

--- a/pkgs/by-name/ko/ko/package.nix
+++ b/pkgs/by-name/ko/ko/package.nix
@@ -1,13 +1,13 @@
 {
   lib,
   # broken with go 1.24 for some reason
-  buildGo123Module,
+  buildGoModule,
   fetchFromGitHub,
   gitMinimal,
   installShellFiles,
 }:
 
-buildGo123Module rec {
+buildGoModule rec {
   pname = "ko";
   version = "0.15.4";
 

--- a/pkgs/by-name/lo/local-ai/package.nix
+++ b/pkgs/by-name/lo/local-ai/package.nix
@@ -15,7 +15,7 @@
   ffmpeg,
   cmake,
   pkg-config,
-  buildGo123Module,
+  buildGoModule,
   makeWrapper,
   ncurses,
   which,
@@ -352,7 +352,7 @@ let
       ${cp} ${stable-diffusion} sources/stablediffusion-ggml.cpp
     '';
 
-  self = buildGo123Module.override { stdenv = effectiveStdenv; } {
+  self = buildGoModule.override { stdenv = effectiveStdenv; } {
     inherit pname version src;
 
     vendorHash = "sha256-6loR8bvt5BlijufUBVDpxNS/cVCMmbaCwEhYpJKwGys=";

--- a/pkgs/by-name/ma/matrix-alertmanager-receiver/package.nix
+++ b/pkgs/by-name/ma/matrix-alertmanager-receiver/package.nix
@@ -1,11 +1,11 @@
 {
   lib,
-  buildGo124Module,
+  buildGoModule,
   fetchFromGitHub,
   nix-update-script,
 }:
 
-buildGo124Module rec {
+buildGoModule rec {
   pname = "matrix-alertmanager-receiver";
   version = "2025.3.19";
 

--- a/pkgs/by-name/na/nak/package.nix
+++ b/pkgs/by-name/na/nak/package.nix
@@ -1,11 +1,11 @@
 {
   lib,
-  buildGo123Module,
+  buildGoModule,
   fetchFromGitHub,
   versionCheckHook,
   nix-update-script,
 }:
-buildGo123Module rec {
+buildGoModule rec {
   pname = "nak";
   version = "0.11.4";
 

--- a/pkgs/by-name/na/navidrome/package.nix
+++ b/pkgs/by-name/na/navidrome/package.nix
@@ -1,5 +1,5 @@
 {
-  buildGo123Module,
+  buildGoModule,
   buildPackages,
   fetchFromGitHub,
   fetchNpmDeps,
@@ -16,7 +16,7 @@
   ffmpegSupport ? true,
 }:
 
-buildGo123Module rec {
+buildGoModule rec {
   pname = "navidrome";
   version = "0.55.1";
 

--- a/pkgs/by-name/ne/nexttrace/package.nix
+++ b/pkgs/by-name/ne/nexttrace/package.nix
@@ -1,10 +1,10 @@
 {
   lib,
-  buildGo122Module,
+  buildGoModule,
   fetchFromGitHub,
 }:
 
-buildGo122Module rec {
+buildGoModule rec {
   pname = "nexttrace";
   version = "1.3.5";
 

--- a/pkgs/by-name/ne/nezha/package.nix
+++ b/pkgs/by-name/ne/nezha/package.nix
@@ -1,6 +1,6 @@
 {
   lib,
-  buildGo124Module,
+  buildGoModule,
   fetchFromGitHub,
   go-swag,
   versionCheckHook,
@@ -51,7 +51,7 @@ let
       ++ map mkTemplate withThemes
     );
 in
-buildGo124Module {
+buildGoModule {
   inherit pname version;
 
   src = fetchFromGitHub {

--- a/pkgs/by-name/ot/otpauth/package.nix
+++ b/pkgs/by-name/ot/otpauth/package.nix
@@ -1,10 +1,10 @@
 {
   lib,
   fetchFromGitHub,
-  buildGo124Module,
+  buildGoModule,
 }:
 
-buildGo124Module rec {
+buildGoModule rec {
   pname = "otpauth";
   version = "0.5.4";
 

--- a/pkgs/by-name/pe/peroxide/package.nix
+++ b/pkgs/by-name/pe/peroxide/package.nix
@@ -1,11 +1,11 @@
 {
   lib,
-  buildGo122Module,
+  buildGoModule,
   fetchFromGitHub,
   nixosTests,
 }:
 
-buildGo122Module rec {
+buildGoModule rec {
   pname = "peroxide";
   version = "0.5.0";
 

--- a/pkgs/by-name/ph/phlare/package.nix
+++ b/pkgs/by-name/ph/phlare/package.nix
@@ -1,11 +1,11 @@
 {
   lib,
-  buildGo122Module,
+  buildGoModule,
   fetchFromGitHub,
 }:
 # breaks in go 1.23 with `invalid reference to runtime.aeskeysched`
 # won't be fixed upstream since the repository is archived.
-buildGo122Module rec {
+buildGoModule rec {
   pname = "phlare";
   version = "0.6.1";
 

--- a/pkgs/by-name/ph/photofield/package.nix
+++ b/pkgs/by-name/ph/photofield/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   fetchFromGitHub,
-  buildGo122Module,
+  buildGoModule,
   buildNpmPackage,
   makeWrapper,
   exiftool,
@@ -36,7 +36,7 @@ let
   };
 in
 
-buildGo122Module {
+buildGoModule {
   pname = "photofield";
   inherit version src;
 

--- a/pkgs/by-name/pi/picocrypt/package.nix
+++ b/pkgs/by-name/pi/picocrypt/package.nix
@@ -1,6 +1,6 @@
 {
   lib,
-  buildGo124Module,
+  buildGoModule,
   fetchFromGitHub,
   stdenv,
   copyDesktopItems,
@@ -13,7 +13,7 @@
   wrapGAppsHook3,
 }:
 
-buildGo124Module rec {
+buildGoModule rec {
   pname = "picocrypt";
   version = "1.47";
 

--- a/pkgs/by-name/po/pomerium/package.nix
+++ b/pkgs/by-name/po/pomerium/package.nix
@@ -1,5 +1,5 @@
 {
-  buildGo123Module,
+  buildGoModule,
   fetchFromGitHub,
   lib,
   envoy,
@@ -17,7 +17,7 @@ let
     mapAttrsToList
     ;
 in
-buildGo123Module rec {
+buildGoModule rec {
   pname = "pomerium";
   version = "0.28.0";
   src = fetchFromGitHub {

--- a/pkgs/by-name/pr/prometheus-node-cert-exporter/package.nix
+++ b/pkgs/by-name/pr/prometheus-node-cert-exporter/package.nix
@@ -1,11 +1,11 @@
 {
   lib,
-  buildGo122Module,
+  buildGoModule,
   fetchFromGitHub,
   nixosTests,
 }:
 
-buildGo122Module {
+buildGoModule {
   pname = "node-cert-exporter";
   version = "1.1.7-unstable-2024-12-26";
 

--- a/pkgs/by-name/re/redli/package.nix
+++ b/pkgs/by-name/re/redli/package.nix
@@ -1,10 +1,10 @@
 {
   lib,
   fetchFromGitHub,
-  buildGo124Module,
+  buildGoModule,
 }:
 
-buildGo124Module rec {
+buildGoModule rec {
   pname = "redli";
   version = "0.15.0";
 

--- a/pkgs/by-name/re/resticprofile/package.nix
+++ b/pkgs/by-name/re/resticprofile/package.nix
@@ -1,6 +1,6 @@
 {
   lib,
-  buildGo123Module,
+  buildGoModule,
   fetchFromGitHub,
   installShellFiles,
   restic,
@@ -9,7 +9,7 @@
   resticprofile,
 }:
 
-buildGo123Module rec {
+buildGoModule rec {
   pname = "resticprofile";
   version = "0.29.1";
 

--- a/pkgs/by-name/sc/screego/package.nix
+++ b/pkgs/by-name/sc/screego/package.nix
@@ -1,6 +1,6 @@
 {
   lib,
-  buildGo123Module,
+  buildGoModule,
   fetchFromGitHub,
   fetchYarnDeps,
   yarnConfigHook,
@@ -48,7 +48,7 @@ let
 
 in
 
-buildGo123Module rec {
+buildGoModule rec {
   inherit src version;
 
   pname = "screego-server";

--- a/pkgs/by-name/si/siyuan/package.nix
+++ b/pkgs/by-name/si/siyuan/package.nix
@@ -2,7 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  buildGo123Module,
+  buildGoModule,
   replaceVars,
   pandoc,
   nodejs,
@@ -44,7 +44,7 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-ZLhLuRj5gdqca9Sbty7BEUBB/+8SgPYhnhoSOR5j4YE=";
   };
 
-  kernel = buildGo123Module {
+  kernel = buildGoModule {
     name = "${finalAttrs.pname}-${finalAttrs.version}-kernel";
     inherit (finalAttrs) src;
     sourceRoot = "${finalAttrs.src.name}/kernel";

--- a/pkgs/by-name/so/sops/package.nix
+++ b/pkgs/by-name/so/sops/package.nix
@@ -1,13 +1,13 @@
 {
   lib,
-  buildGo122Module,
+  buildGoModule,
   fetchFromGitHub,
   installShellFiles,
   versionCheckHook,
   nix-update-script,
 }:
 
-buildGo122Module rec {
+buildGoModule rec {
   pname = "sops";
   version = "3.9.4";
 

--- a/pkgs/by-name/ta/tailscale-gitops-pusher/package.nix
+++ b/pkgs/by-name/ta/tailscale-gitops-pusher/package.nix
@@ -1,10 +1,10 @@
 {
   lib,
   tailscale,
-  buildGo123Module,
+  buildGoModule,
 }:
 
-buildGo123Module {
+buildGoModule {
   inherit (tailscale)
     version
     src

--- a/pkgs/by-name/tr/traefik/package.nix
+++ b/pkgs/by-name/tr/traefik/package.nix
@@ -1,11 +1,11 @@
 {
   lib,
   fetchzip,
-  buildGo123Module,
+  buildGoModule,
   nixosTests,
 }:
 
-buildGo123Module rec {
+buildGoModule rec {
   pname = "traefik";
   version = "3.3.3";
 

--- a/pkgs/by-name/tr/trivy/package.nix
+++ b/pkgs/by-name/tr/trivy/package.nix
@@ -2,14 +2,14 @@
   lib,
   stdenv,
   buildPackages,
-  buildGo124Module,
+  buildGoModule,
   fetchFromGitHub,
   installShellFiles,
   testers,
   trivy,
 }:
 
-buildGo124Module rec {
+buildGoModule rec {
   pname = "trivy";
   version = "0.60.0";
 

--- a/pkgs/by-name/vu/vuls/package.nix
+++ b/pkgs/by-name/vu/vuls/package.nix
@@ -1,10 +1,10 @@
 {
   lib,
-  buildGo124Module,
+  buildGoModule,
   fetchFromGitHub,
 }:
 
-buildGo124Module rec {
+buildGoModule rec {
   pname = "vuls";
   version = "0.30.0";
 

--- a/pkgs/by-name/wo/workout-tracker/package.nix
+++ b/pkgs/by-name/wo/workout-tracker/package.nix
@@ -1,6 +1,6 @@
 {
   lib,
-  buildGo124Module,
+  buildGoModule,
   buildNpmPackage,
   fetchFromGitHub,
   nix-update-script,
@@ -34,7 +34,7 @@ let
     '';
   };
 in
-buildGo124Module {
+buildGoModule {
   inherit pname version src;
 
   vendorHash = null;

--- a/pkgs/by-name/zi/zincsearch/package.nix
+++ b/pkgs/by-name/zi/zincsearch/package.nix
@@ -1,6 +1,6 @@
 {
   lib,
-  buildGo122Module,
+  buildGoModule,
   fetchFromGitHub,
   buildNpmPackage,
 }:
@@ -33,7 +33,7 @@ let
   };
 in
 
-buildGo122Module rec {
+buildGoModule rec {
   pname = "zincsearch";
   inherit src version;
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1447,6 +1447,7 @@ with pkgs;
   cool-retro-term = libsForQt5.callPackage ../applications/terminal-emulators/cool-retro-term { };
 
   kitty = darwin.apple_sdk_11_0.callPackage ../by-name/ki/kitty/package.nix {
+    buildGoModule = buildGo123Module;
     harfbuzz = harfbuzz.override { withCoreText = stdenv.hostPlatform.isDarwin; };
     inherit (darwin) autoSignDarwinBinariesHook;
     inherit (darwin.apple_sdk_11_0) Libsystem;
@@ -12481,6 +12482,10 @@ with pkgs;
 
   adobe-reader = pkgsi686Linux.callPackage ../applications/misc/adobe-reader { };
 
+  ali = callPackage ../by-name/al/ali/package.nix {
+    buildGoModule = buildGo122Module;
+  };
+
   anilibria-winmaclinux = libsForQt5.callPackage ../applications/video/anilibria-winmaclinux { };
 
   masterpdfeditor4 = libsForQt5.callPackage ../applications/misc/masterpdfeditor4 { };
@@ -12580,12 +12585,20 @@ with pkgs;
     enableVST2 = true;
   };
 
+  bettercap = callPackage ../by-name/be/bettercap/package.nix {
+    buildGoModule = buildGo122Module;
+  };
+
   bfcal = libsForQt5.callPackage ../applications/misc/bfcal { };
 
   bino3d = qt6Packages.callPackage ../applications/video/bino3d { };
 
   bitlbee = callPackage ../applications/networking/instant-messengers/bitlbee { };
   bitlbee-plugins = callPackage ../applications/networking/instant-messengers/bitlbee/plugins.nix { };
+
+  bitmagnet = callPackage ../by-name/bi/bitmagnet/package.nix {
+    buildGoModule = buildGo122Module; # builds, but does not start on 1.23
+  };
 
   bitscope = recurseIntoAttrs
     (callPackage ../applications/science/electronics/bitscope/packages.nix { });
@@ -12663,6 +12676,10 @@ with pkgs;
 
   cdparanoia = cdparanoiaIII;
 
+  certinfo = callPackage ../by-name/ce/certinfo/package.nix {
+    buildGoModule = buildGo123Module;
+  };
+
   brotab = callPackage ../tools/misc/brotab {
     python = python3;
   };
@@ -12687,6 +12704,10 @@ with pkgs;
   clightd = callPackage ../applications/misc/clight/clightd.nix { };
 
   clipgrab = libsForQt5.callPackage ../applications/video/clipgrab { };
+
+  cloudpan189-go = callPackage ../by-name/cl/cloudpan189-go/package.nix {
+    buildGoModule = buildGo122Module;
+  };
 
   cmus = callPackage ../applications/audio/cmus {
     inherit (darwin.apple_sdk.frameworks) AudioUnit CoreAudio VideoToolbox;
@@ -12726,6 +12747,10 @@ with pkgs;
 
   cutecom = libsForQt5.callPackage ../tools/misc/cutecom { };
 
+  d2 = callPackage ../by-name/d2/d2/package.nix {
+    buildGoModule = buildGo123Module;
+  };
+
   darcs = haskell.lib.compose.disableCabalFlag "library"
     (haskell.lib.compose.justStaticExecutables haskellPackages.darcs);
 
@@ -12758,7 +12783,15 @@ with pkgs;
     plugins = [];
   };
 
+  devdash = callPackage ../by-name/de/devdash/package.nix {
+    buildGoModule = buildGo122Module;
+  };
+
   inherit (callPackage ../development/tools/devpod { }) devpod devpod-desktop;
+
+  dex-oidc = callPackage ../by-name/de/dex-oidc/package.nix {
+    buildGoModule = buildGo124Module;
+  };
 
   dfasma = libsForQt5.callPackage ../applications/audio/dfasma { };
 
@@ -12885,6 +12918,10 @@ with pkgs;
 
   espflash = callPackage ../by-name/es/espflash/package.nix {
     inherit (darwin.apple_sdk.frameworks) CoreServices Security SystemConfiguration;
+  };
+
+  evcc = callPackage ../by-name/ev/evcc/package.nix {
+    buildGoModule = buildGo124Module;
   };
 
   evilpixie = libsForQt5.callPackage ../applications/graphics/evilpixie { };
@@ -13034,12 +13071,20 @@ with pkgs;
     libpcap = libpcap.override { withBluez = stdenv.hostPlatform.isLinux; };
   };
 
+  fan2go = callPackage ../by-name/fa/fan2go/package.nix {
+    buildGoModule = buildGo123Module;
+  };
+
   fclones = callPackage ../tools/misc/fclones { };
 
   fclones-gui = darwin.apple_sdk_11_0.callPackage ../tools/misc/fclones/gui.nix { };
 
   feh = callPackage ../applications/graphics/feh {
     imlib2 = imlib2Full;
+  };
+
+  filebrowser = callPackage ../by-name/fi/filebrowser/package.nix {
+    buildGoModule = buildGo123Module;
   };
 
   filezilla = darwin.apple_sdk_11_0.callPackage ../applications/networking/ftp/filezilla {
@@ -13236,8 +13281,32 @@ with pkgs;
     jdk = jdk.override { enableJavaFX = true; };
   };
 
+  git-spice = callPackage ../by-name/gi/git-spice/package.nix {
+    buildGoModule = buildGo124Module;
+  };
+
+  gitea-actions-runner = callPackage ../by-name/gi/gitea-actions-runner/package.nix {
+    buildGoModule = buildGo123Module;
+  };
+
   gkrellm = callPackage ../applications/misc/gkrellm {
     inherit (darwin.apple_sdk.frameworks) IOKit;
+  };
+
+  glasskube = callPackage ../by-name/gl/glasskube/package.nix {
+    buildGoModule = buildGo123Module;
+  };
+
+  go-came = callPackage ../by-name/go/go-camo/package.nix {
+    buildGoModule = buildGo124Module;
+  };
+
+  golangci-lint = callPackage ../by-name/go/golangci-lint/package.nix {
+    buildGoModule = buildGo124Module;
+  };
+
+  govulncheck = callPackage ../by-name/go/govulncheck/package.nix {
+    buildGoModule = buildGo124Module;
   };
 
   gnunet = callPackage ../applications/networking/p2p/gnunet { };
@@ -13247,6 +13316,10 @@ with pkgs;
   gphoto2 = callPackage ../applications/misc/gphoto2 { };
 
   gphoto2fs = callPackage ../applications/misc/gphoto2/gphotofs.nix { };
+
+  grafana-agent = callPackage ../by-name/gr/grafana-agent/package.nix {
+    buildGoModule = buildGo122Module;
+  };
 
   graphicsmagick_q16 = graphicsmagick.override { quantumdepth = 16; };
   graphicsmagick-imagemagick-compat = graphicsmagick.imagemagick-compat;
@@ -13300,8 +13373,20 @@ with pkgs;
     haskellPackages.hledger-web;
   hledger-utils = with python3.pkgs; toPythonApplication hledger-utils;
 
+  hof = callPackage ../by-name/ho/hof/package.nix {
+    buildGoModule = buildGo122Module;
+  };
+
   hollywood = callPackage ../applications/misc/hollywood {
     inherit (python3Packages) pygments;
+  };
+
+  homebox = callPackage ../by-name/ho/homebox/package.nix {
+    buildGoModule = buildGo123Module;
+  };
+
+  honeytrap = callPackage ../by-name/ho/honeytrap/package.nix {
+    buildGoModule = buildGo122Module;
   };
 
   hors = callPackage ../development/tools/hors {
@@ -13313,6 +13398,10 @@ with pkgs;
   hpack = haskell.lib.compose.justStaticExecutables haskellPackages.hpack;
 
   hpmyroom = libsForQt5.callPackage ../applications/networking/hpmyroom { };
+
+  hubble = callPackage ../by-name/hu/hubble/package.nix {
+    buildGoModule = buildGo124Module;
+  };
 
   hue-cli = callPackage ../tools/networking/hue-cli { };
 
@@ -13628,6 +13717,10 @@ with pkgs;
 
   kmymoney = libsForQt5.callPackage ../applications/office/kmymoney { };
 
+  ko = callPackage ../by-name/ko/ko/package.nix {
+    buildGoModule = buildGo123Module;
+  };
+
   kotatogram-desktop = callPackage ../applications/networking/instant-messengers/telegram/kotatogram-desktop { };
 
   krane = callPackage ../applications/networking/cluster/krane { };
@@ -13797,6 +13890,10 @@ with pkgs;
     portaudio = null;
   };
 
+  local-ai = callPackage ../by-name/lo/local-ai/package.nix {
+    buildGoModule = buildGo123Module;
+  };
+
   luminanceHDR = libsForQt5.callPackage ../applications/graphics/luminance-hdr { };
 
   luddite = with python3Packages; toPythonApplication luddite;
@@ -13840,6 +13937,10 @@ with pkgs;
   mapmap = libsForQt5.callPackage ../applications/video/mapmap { };
 
   mastodon-bot = nodePackages.mastodon-bot;
+
+  matrix-alertmanager-receiver = callPackage ../by-name/ma/matrix-alertmanager-receiver/package.nix {
+    buildGoModule = buildGo124Module;
+  };
 
   matrix-commander = python3Packages.callPackage ../applications/networking/instant-messengers/matrix-commander { };
 
@@ -14172,9 +14273,25 @@ with pkgs;
 
   mythtv = libsForQt5.callPackage ../applications/video/mythtv { };
 
+  nak = callPackage ../by-name/na/nak/package.nix {
+    buildGoModule = buildGo123Module;
+  };
+
+  navidrome = callPackage ../by-name/na/navidrome/package.nix {
+    buildGoModule = buildGo123Module;
+  };
+
   ncdu = callPackage ../tools/misc/ncdu { };
 
   ncdu_1 = callPackage ../tools/misc/ncdu/1.nix { };
+
+  nexttrace = callPackage ../by-name/ne/nexttrace/package.nix {
+    buildGoModule = buildGo122Module;
+  };
+
+  nezha = callPackage ../by-name/ne/nezha/package.nix {
+    buildGoModule = buildGo124Module;
+  };
 
   notepadqq = libsForQt5.callPackage ../applications/editors/notepadqq { };
 
@@ -14272,6 +14389,10 @@ with pkgs;
     };
   };
 
+  otpauth = callPackage ../by-name/ot/otpauth/package.nix {
+    buildGoModule = buildGo124Module;
+  };
+
   palemoon-bin = callPackage ../applications/networking/browsers/palemoon/bin.nix { };
 
   pantalaimon = callPackage ../applications/networking/instant-messengers/pantalaimon { };
@@ -14309,6 +14430,18 @@ with pkgs;
     nodejs = nodejs_18;
   };
 
+  peroxide = callPackage ../by-name/pe/peroxide/package.nix {
+    buildGoModule = buildGo122Module;
+  };
+
+  phlare = callPackage ../by-name/ph/phlare/package.nix {
+    buildGoModule = buildGo122Module;
+  };
+
+  photofield = callPackage ../by-name/ph/photofield/package.nix {
+    buildGoModule = buildGo122Module;
+  };
+
   photoflare = libsForQt5.callPackage ../applications/graphics/photoflare { };
 
   phototonic = libsForQt5.callPackage ../applications/graphics/phototonic { };
@@ -14316,6 +14449,10 @@ with pkgs;
   pianobooster = qt5.callPackage ../applications/audio/pianobooster { };
 
   pianoteq = callPackage ../applications/audio/pianoteq { };
+
+  picocrypt = callPackage ../by-name/pi/picocrypt/package.nix {
+    buildGoModule = buildGo124Module;
+  };
 
   pidginPackages = recurseIntoAttrs (callPackage ../applications/networking/instant-messengers/pidgin/pidgin-plugins { });
 
@@ -14339,6 +14476,10 @@ with pkgs;
 
   pokefinder = qt6Packages.callPackage ../tools/games/pokefinder { };
 
+  pomerium = callPackage ../by-name/po/pomerium/package.nix {
+    buildGoModule = buildGo123Module;
+  };
+
   pomodoro = callPackage ../applications/misc/pomodoro {
     inherit (darwin.apple_sdk.frameworks) Foundation;
   };
@@ -14357,6 +14498,10 @@ with pkgs;
   # And I don't want to rewrite all rules
   profanity = callPackage ../applications/networking/instant-messengers/profanity ({
   } // (config.profanity or {}));
+
+  prometheus-node-cert-exporter = callPackage ../by-name/pr/prometheus-node-cert-exporter/package.nix {
+    buildGoModule = buildGo122Module;
+  };
 
   protonvpn-cli = python3Packages.callPackage ../applications/networking/protonvpn-cli { };
   protonvpn-cli_2 = python3Packages.callPackage ../applications/networking/protonvpn-cli/2.nix { };
@@ -14544,7 +14689,15 @@ with pkgs;
     inherit (darwin.apple_sdk.frameworks) Security;
   };
 
+  redli = callPackage ../by-name/re/redli/package.nix {
+    buildGoModule = buildGo124Module;
+  };
+
   rednotebook = python3Packages.callPackage ../applications/editors/rednotebook { };
+
+  resticprofile = callPackage ../by-name/re/resticprofile/package.nix {
+    buildGoModule = buildGo123Module;
+  };
 
   restique = libsForQt5.callPackage ../applications/backup/restique { };
 
@@ -14613,6 +14766,10 @@ with pkgs;
 
   scantailor-universal = libsForQt5.callPackage ../applications/graphics/scantailor/universal.nix { };
 
+  screego = callPackage ../by-name/sc/screego/package.nix {
+    buildGoModule = buildGo123Module;
+  };
+
   scribus_1_5 = libsForQt5.callPackage ../applications/office/scribus/default.nix { };
   scribus = scribus_1_5;
 
@@ -14622,12 +14779,20 @@ with pkgs;
 
   sfxr-qt = libsForQt5.callPackage ../applications/audio/sfxr-qt { };
 
+  siyuan = callPackage ../by-name/si/siyuan/package.nix {
+    buildGoModule = buildGo123Module;
+  };
+
   sommelier = callPackage ../applications/window-managers/sommelier { };
 
   spotify-qt = qt6Packages.callPackage ../applications/audio/spotify-qt { };
 
   squishyball = callPackage ../applications/audio/squishyball {
     ncurses = ncurses5;
+  };
+
+  sops = callPackage ../by-name/so/sops/package.nix {
+    buildGoModule = buildGo122Module;
   };
 
   sonic-pi = libsForQt5.callPackage ../applications/audio/sonic-pi { };
@@ -14822,6 +14987,10 @@ with pkgs;
 
   tagainijisho = libsForQt5.callPackage ../applications/office/tagainijisho { };
 
+  tailscale-gitops-pusher = callPackage ../by-name/ta/tailscale-gitops-pusher/package.nix {
+    buildGoModule = buildGo123Module;
+  };
+
   tamgamp.lv2 = callPackage ../applications/audio/tamgamp.lv2 { };
 
   telegram-desktop = kdePackages.callPackage ../applications/networking/instant-messengers/telegram/telegram-desktop {
@@ -14904,6 +15073,14 @@ with pkgs;
   };
 
   tony = libsForQt5.callPackage ../applications/audio/tony { };
+
+  traefik = callPackage ../by-name/tr/traefik/package.nix {
+    buildGoModule = buildGo123Module;
+  };
+
+  trivy = callPackage ../by-name/tr/trivy/package.nix {
+    buildGoModule = buildGo124Module;
+  };
 
   trustedqsl = tqsl; # Alias added 2019-02-10
 
@@ -15150,6 +15327,10 @@ with pkgs;
   vscodium-fhs = vscodium.fhs;
   vscodium-fhsWithPackages = vscodium.fhsWithPackages;
 
+  vuls = callPackage ../by-name/vu/vuls/package.nix {
+    buildGoModule = buildGo124Module;
+  };
+
   windsurf = callPackage ../by-name/wi/windsurf/package.nix {
     vscode-generic = ../applications/editors/vscode/generic.nix;
   };
@@ -15255,6 +15436,10 @@ with pkgs;
 
   wordnet = callPackage ../applications/misc/wordnet {
     inherit (darwin.apple_sdk.frameworks) Cocoa;
+  };
+
+  workout-tracker = callPackage ../by-name/wo/workout-tracker/package.nix {
+    buildGoModule = buildGo124Module;
   };
 
   worldengine-cli = python3Packages.worldengine;
@@ -15413,6 +15598,10 @@ with pkgs;
     # that it requires sixel graphics compatible terminals like mlterm
     # or xterm -ti 340
     SDL = SDL_sixel;
+  };
+
+  zincsearch = callPackage ../by-name/zi/zincsearch/package.nix {
+    buildGoModule = buildGo122Module;
   };
 
   zotero_7 = pkgs.zotero-beta;


### PR DESCRIPTION
This is not *quite* a tree-wide change, instead only focused on `pkgs/by-name`.

Commands ran:

$ rg -l -0 'buildGo[0-9]+Module' pkgs/by-name/ |
    xargs -0 sed -i -Ee 's/buildGo[0-9]+Module/buildGoModule/'

Then manual addition to `all-packages.nix`.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
