### PR TITLE
maintainers/team-list: remove ralith from matrix

### DIFF
--- a/maintainers/team-list.nix
+++ b/maintainers/team-list.nix
@@ -786,7 +786,6 @@ with lib.maintainers;
       ma27
       fadenb
       mguentner
-      ralith
       dandellion
       nickcao
       teutat3s


### PR DESCRIPTION
I haven't had time/context to review this increasingly broad space for some time.