### PR TITLE
gprbuild, gnatprove: configure for aarch64

### DIFF
--- a/pkgs/development/ada-modules/gnatprove/0002-mute-aarch64-warnings.patch
+++ b/pkgs/development/ada-modules/gnatprove/0002-mute-aarch64-warnings.patch
@@ -1,0 +1,22 @@
+--- a/src/counterexamples/ce_parsing.adb	2025-03-14 21:48:15.657409808 +0100
++++ b/src/counterexamples/ce_parsing.adb	2025-03-14 22:04:32.114664704 +0100
+@@ -975,6 +975,9 @@
+                elsif Is_Extended_Precision_Floating_Point_Type (Ty) then
+                   pragma Assert (Size (Exp) = 15);
+                   pragma Assert (Size (Significand) = 63);
++                  pragma Warnings (Off, "assertion will fail at run time");
++                  pragma Warnings (Off,
++                      "types for unchecked conversion have different sizes");
+                   declare
+                      package P is new Parse_Conversion
+                        (Interfaces.Unsigned_128, Long_Long_Float);
+@@ -983,6 +986,9 @@
+                   begin
+                      return (Float_K, (Extended_K, F));
+                   end;
++                  pragma Warnings (On,
++                      "types for unchecked conversion have different sizes");
++                  pragma Warnings (On, "assertion will fail at run time");
+                else
+                   raise Program_Error;
+                end if;

--- a/pkgs/development/ada-modules/gnatprove/default.nix
+++ b/pkgs/development/ada-modules/gnatprove/default.nix
@@ -56,6 +56,9 @@ let
       patches = [
         # Disable Coq related targets which are missing in the fsf-14 branch
         ./0001-fix-install.patch
+
+        # Suppress warnings on aarch64: https://github.com/AdaCore/spark2014/issues/54
+        ./0002-mute-aarch64-warnings.patch
       ];
       commit_date = "2024-01-11";
     };

--- a/pkgs/development/ada-modules/gprbuild/nixpkgs-gnat.xml
+++ b/pkgs/development/ada-modules/gprbuild/nixpkgs-gnat.xml
@@ -53,4 +53,37 @@
       <grep regexp="[^\r\n]+"></grep>
     </target>
   </compiler_description>
+  <configuration>
+    <!-- aarch64-linux - native compiler. -->
+    <targets>
+      <target name="^aarch64-unknown-linux-gnu$" />
+    </targets>
+    <hosts>
+      <host name="^aarch64-unknown-linux-gnu$" />
+    </hosts>
+    <config>
+   for Archive_Builder  use ("ar", "cr");
+   for Archive_Builder_Append_Option use ("q");
+   for Archive_Indexer  use ("ranlib");
+   for Archive_Suffix   use ".a";
+    </config>
+  </configuration>
+  <configuration>
+    <!-- aarch64-linux - native compiler. -->
+    <targets>
+      <target name="^aarch64-unknown-linux-gnu$" />
+    </targets>
+    <hosts>
+      <host name="^aarch64-unknown-linux-gnu$" />
+    </hosts>
+    <config>
+   for Object_Lister use ("nm", "-g");
+   for Object_Lister_Matcher use " [TDRBSG] (.*)";
+
+   package Linker is
+      for Export_File_Format use "GNU";
+      for Export_File_Switch use "-Wl,--version-script=";
+   end Linker;
+    </config>
+  </configuration>
 </gprconfig>


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Amends #387468:  Configure `gprbuild` for aarch64-linux native builds. 

_Cross-compiling still needs to be tested_.

Suppressing the warnings of gnatprove is necessary because there is no official aarch64 support yet (see [linked issue](https://github.com/AdaCore/spark2014/issues/54)).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
