### PR TITLE
python312Packages.equinox: 0.11.12 -> 0.12.1

### DIFF
--- a/pkgs/development/python-modules/equinox/default.nix
+++ b/pkgs/development/python-modules/equinox/default.nix
@@ -22,14 +22,14 @@
 
 buildPythonPackage rec {
   pname = "equinox";
-  version = "0.11.12";
+  version = "0.12.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "patrick-kidger";
     repo = "equinox";
     tag = "v${version}";
-    hash = "sha256-hor2qw+aTL7yhV53E/y5DUwyDEYJA8RPRS39xxa8xcw=";
+    hash = "sha256-mw2fk+527b6Rx6FGe6QJf3ZbxZ3rjYFXKleX2g6AryU=";
   };
 
   # Relax speed constraints on tests that can fail on busy builders
@@ -54,14 +54,6 @@ buildPythonPackage rec {
     optax
     pytest-xdist
     pytestCheckHook
-  ];
-
-  pytestFlagsArray = [
-    # Since jax 0.5.3:
-    # DeprecationWarning: shape requires ndarray or scalar arguments, got <class 'jax._src.api.ShapeDtypeStruct'> at position 0. In a future JAX release this will be an error.
-    # https://github.com/patrick-kidger/equinox/issues/979
-    "-W"
-    "ignore::DeprecationWarning"
   ];
 
   disabledTests = lib.optionals stdenv.hostPlatform.isDarwin [

--- a/pkgs/development/python-modules/lineax/default.nix
+++ b/pkgs/development/python-modules/lineax/default.nix
@@ -16,31 +16,19 @@
   beartype,
   pytest,
   python,
-
-  fetchpatch,
 }:
 
 buildPythonPackage rec {
   pname = "lineax";
-  version = "0.0.7";
+  version = "0.0.8";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "patrick-kidger";
     repo = "lineax";
     tag = "v${version}";
-    hash = "sha256-HcFI55Ww/y7ZaUkawj7xWSb7VDTBec3u0ulWL8kTm2c=";
+    hash = "sha256-VMTDCExgxfCcd/3UZAglfAxAFaSjzFJJuvSWJAx2tJs=";
   };
-
-  patches = [
-    (fetchpatch {
-      # Reported upstream: https://github.com/patrick-kidger/lineax/issues/118
-      # Fixed by https://github.com/patrick-kidger/lineax/pull/119
-      name = "fix-vmap-tests";
-      url = "https://github.com/patrick-kidger/lineax/pull/119/commits/d21552ac4c504d7b139ad8e4f15d5f102b54d705.patch";
-      hash = "sha256-pBejiqIVNjXi7dXuDBQdAy892wro1WxzwbI7v07N86c=";
-    })
-  ];
 
   build-system = [ hatchling ];
 

--- a/pkgs/development/python-modules/stable-baselines3/default.nix
+++ b/pkgs/development/python-modules/stable-baselines3/default.nix
@@ -65,6 +65,9 @@ buildPythonPackage rec {
   ];
 
   disabledTests = [
+    # Flaky: Can fail if it takes too long, which happens when the system is under heavy load
+    "test_fps_logger"
+
     # Tests that attempt to access the filesystem
     "test_make_atari_env"
     "test_vec_env_monitor_kwargs"


### PR DESCRIPTION
## Things done

- **python312Packages.equinox: 0.11.12 -> 0.12.1**
  Changelog: https://github.com/patrick-kidger/equinox/releases/tag/v0.12.1
- **python312Packages.lineax: 0.0.7 -> 0.0.8**
  Changelog: https://github.com/patrick-kidger/lineax/releases/tag/v0.0.8
- **python312Packages.stable-baselines3: disable flaky tests**

---
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
