### PR TITLE
graphhopper: init at 10.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2607,6 +2607,12 @@
     githubId = 31864305;
     name = "William Hai";
   };
+  baileylu = {
+    name = "Luke Bailey";
+    email = "baileylu@tcd.ie";
+    github = "baileyluTCD";
+    githubId = 156000062;
+  };
   baitinq = {
     email = "manuelpalenzuelamerino@gmail.com";
     name = "Baitinq";

--- a/pkgs/by-name/gr/graphhopper/package.nix
+++ b/pkgs/by-name/gr/graphhopper/package.nix
@@ -1,0 +1,152 @@
+{
+  fetchFromGitHub,
+  fetchurl,
+  lib,
+  stdenv,
+  testers,
+
+  jre,
+  makeWrapper,
+  maven,
+  ...
+}:
+let
+  version = builtins.fromTOML (builtins.readFile ./version.toml);
+
+  src = fetchFromGitHub {
+    owner = "graphhopper";
+    repo = "graphhopper";
+    tag = version.patch;
+    hash = version.hash.src;
+  };
+
+  # Patch graphhopper to remove the npm download
+  patches = [ ./remove-npm-dependency.patch ];
+
+  # Graphhopper also relies on a maps bundle downloaded from npm
+  # By default it installs nodejs and npm during the build,
+  # But we patch that out so we much fetch it ourselves
+  mapsBundle = fetchurl {
+    name = "@graphhopper/graphhopper-maps-bundle-${version.mapsBundle}";
+    url = "https://registry.npmjs.org/@graphhopper/graphhopper-maps-bundle/-/graphhopper-maps-bundle-${version.mapsBundle}.tgz";
+    hash = version.hash.mapsBundle;
+  };
+
+  # We cannot use `buildMavenPackage` as we need to load in the
+  # mapsBundle before doing anything
+  mvnDeps = stdenv.mkDerivation {
+    name = "graphhopper-dependencies";
+
+    inherit src patches;
+
+    buildInputs = [ maven ];
+
+    buildPhase = ''
+      # Fetching deps with mvn dependency:go-offline does not quite catch everything, so we use this plugin instead
+      mvn de.qaware.maven:go-offline-maven-plugin:resolve-dependencies \
+        -Dmaven.repo.local=$out/.m2 \
+        -Dmaven.wagon.rto=5000
+    '';
+
+    installPhase = ''
+      # keep only *.{pom,jar,sha1,nbm} and delete all ephemeral files with lastModified timestamps inside
+      find $out -type f \( \
+        -name \*.lastUpdated \
+        -o -name resolver-status.properties \
+        -o -name _remote.repositories \) \
+        -delete
+    '';
+
+    outputHashMode = "recursive";
+    outputHash = version.hash.mvnDeps;
+  };
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "graphhopper";
+
+  inherit src patches;
+
+  version = version.patch;
+
+  buildInputs = [
+    makeWrapper
+    maven
+  ];
+
+  configurePhase = ''
+    runHook preConfigure
+
+    mkdir -p ./web-bundle/target/
+    ln -s ${mapsBundle} ./web-bundle/target/graphhopper-graphhopper-maps-bundle-${version.mapsBundle}.tgz
+
+    runHook postConfigure
+  '';
+
+  # Build and skip tests because downloading of
+  # test deps seems to not work with the go-offline plugin
+  buildPhase = ''
+    runHook preBuild
+
+    mvn package --offline \
+      -Dmaven.repo.local=${mvnDeps}/.m2 \
+      -DskipTests
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+
+    ln -s ${mvnDeps}/.m2 $out/lib
+
+    # Grapphopper versions are seemingly compiled under the major release name,
+    # not the patch name, which is the version we want for our package
+    cp ./web/target/graphhopper-web-${version.major}-SNAPSHOT.jar $out/bin/graphhopper-web-${version.major}-SNAPSHOT.jar
+
+    makeWrapper ${jre}/bin/java $out/bin/graphhopper \
+      --add-flags "-jar $out/bin/graphhopper-web-${version.major}-SNAPSHOT.jar" \
+      --chdir $out
+
+    runHook postInstall
+  '';
+
+  fixupPhase = ''
+    runHook preFixup
+
+    # keep only *.{pom,jar,sha1,nbm} and delete all ephemeral files with lastModified timestamps inside
+    find $out -type f \( \
+      -name \*.lastUpdated \
+      -o -name resolver-status.properties \
+      -o -name _remote.repositories \) \
+      -delete
+
+    runHook postFixup
+  '';
+
+  meta = {
+    description = "Fast and memory-efficient routing engine for OpenStreetMap";
+    homepage = "https://www.graphhopper.com/";
+    changelog = "https://github.com/graphhopper/graphhopper/releases/tag/${version.patch}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ baileylu ];
+    teams = [ lib.teams.geospatial ];
+    platforms = lib.platforms.all;
+    mainProgram = "graphhopper";
+    sourceProvenance = with lib.sourceTypes; [
+      fromSource
+      binaryBytecode
+    ];
+  };
+
+  passthru = {
+    updateScript = ./update.nu;
+    tests.version = testers.testVersion {
+      package = finalAttrs.finalPackage;
+      # `graphhopper --version` does not work as the source does not specify `Implementation-Version`
+      command = "graphhopper --help";
+      version = "graphhopper-web-${version.major}-SNAPSHOT.jar";
+    };
+  };
+})

--- a/pkgs/by-name/gr/graphhopper/remove-npm-dependency.patch
+++ b/pkgs/by-name/gr/graphhopper/remove-npm-dependency.patch
@@ -1,0 +1,55 @@
+From ad687709cfca51603264ff565f296cfb5dceb15a Mon Sep 17 00:00:00 2001
+From: Luke Bailey <baileylu@tcd.ie>
+Date: Wed, 19 Mar 2025 22:25:44 +0000
+Subject: [PATCH] Swap out frontend maven plugin which downloads npm
+ for fetching it through nix instead
+
+---
+ web-bundle/pom.xml | 31 -------------------------------
+ 1 file changed, 31 deletions(-)
+
+diff --git a/web-bundle/pom.xml b/web-bundle/pom.xml
+index 9a4d83b62..1d995cbaf 100644
+--- a/web-bundle/pom.xml
++++ b/web-bundle/pom.xml
+@@ -129,37 +129,6 @@
+ 
+     <build>
+         <plugins>
+-            <plugin>
+-                <groupId>com.github.eirslett</groupId>
+-                <artifactId>frontend-maven-plugin</artifactId>
+-                <version>1.12.1</version>
+-                <executions>
+-                    <execution>
+-                        <id>install node and npm</id>
+-                        <goals>
+-                            <goal>install-node-and-npm</goal>
+-                        </goals>
+-                        <configuration>
+-                            <nodeVersion>v20.14.0</nodeVersion>
+-                            <npmVersion>10.7.0</npmVersion>
+-                        </configuration>
+-                    </execution>
+-                    <execution>
+-                        <id>download graphhopper maps</id>
+-                        <phase>generate-resources</phase>
+-                        <goals>
+-                            <goal>npm</goal>
+-                        </goals>
+-                        <configuration>
+-                            <!--suppress UnresolvedMavenProperty (IntelliJ shows an error otherwise...)-->
+-                            <arguments>
+-                                pack --pack-destination=${basedir}/target
+-                                @graphhopper/graphhopper-maps-bundle@${graphhopper-maps.version}
+-                            </arguments>
+-                        </configuration>
+-                    </execution>
+-                </executions>
+-            </plugin>
+             <plugin>
+                 <artifactId>maven-antrun-plugin</artifactId>
+                 <executions>
+-- 
+2.48.1
+

--- a/pkgs/by-name/gr/graphhopper/update.nu
+++ b/pkgs/by-name/gr/graphhopper/update.nu
@@ -1,0 +1,102 @@
+#!/usr/bin/env nix-shell
+#! nix-shell -i nu -p nushell nix-prefetch-github common-updater-scripts
+
+use std/log
+
+let version_info = "./pkgs/by-name/gr/graphhopper/version.toml"
+
+let current_version = open $version_info
+
+let latest_tag = list-git-tags --url=https://github.com/graphhopper/graphhopper
+    | lines
+    | sort --natural
+    | where ($it =~ '^[\d.]+$')
+    | last
+
+if $current_version.patch == $latest_tag {
+    log debug "Current graphhopper version matched latest version of graphhopper, no update is needed, exiting..."
+    exit 0
+}
+
+let major = $latest_tag
+    | str replace -ar '(\d+)\.\d+' '$1.0'
+
+log debug $"Fetching source for graphhopper patch ($latest_tag) on version ($major)"
+let source = nix-prefetch-github graphhopper graphhopper --rev $latest_tag
+    | from json
+
+log debug $"Reading maps bundle version for ($latest_tag)"
+let web_bundle_pom = http get $"https://api.github.com/repos/graphhopper/graphhopper/contents/web-bundle/pom.xml?ref=($latest_tag)"
+    | $in.content
+    | base64 --decode
+    | into string
+    | from xml
+
+let maps_bundle_properties = $web_bundle_pom.content
+    | where ($it.tag =~ "properties")
+    | first
+
+let maps_bundle_version = $maps_bundle_properties.content
+    | where ($it.tag =~ "graphhopper-maps.version")
+    | first
+    | $in.content
+    | first
+    | $in.content
+
+log debug $"Fetching maps bundle ($maps_bundle_version)"
+let maps_bundle_hash = nix-prefetch-url $"https://registry.npmjs.org/@graphhopper/graphhopper-maps-bundle/-/graphhopper-maps-bundle-($maps_bundle_version).tgz"
+    | nix-hash --type sha256 --to-base64 $in
+    | ["sha256-", $in]
+    | str join
+
+log debug $"Writing to ($version_info) without mvnDeps hash..."
+
+{
+    major: $major,
+    patch: $latest_tag,
+    mapsBundle: $maps_bundle_version,
+
+    hash: {
+        src: $source.hash
+        mapsBundle: $maps_bundle_hash
+        mvnDeps: "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+    }
+}
+    | to toml
+    | save $version_info -f
+
+log debug "Calculating mvnDeps hash..."
+let graphhopper_build_logs = nix-build -A graphhopper o+e>| cat
+
+let mvn_hash_lines = $graphhopper_build_logs
+    | lines
+    | find "got:"
+
+if ($mvn_hash_lines | length) == 0 {
+    log error $"Could not find any maven hash in the graphhopper build logs - maybe a different error occurred: \n$($graphhopper_build_logs)"
+    exit 1
+}
+
+log debug $"Found relevant hash lines: ($mvn_hash_lines)"
+let mvn_hash = $mvn_hash_lines
+    | first
+    | ansi strip
+    | str replace 'got:' ''
+    | str trim
+
+log debug $"Writing to ($version_info) with mvnDeps hash ($mvn_hash).."
+{
+    major: $major,
+    patch: $latest_tag,
+    mapsBundle: $maps_bundle_version,
+
+    hash: {
+        src: $source.hash
+        mapsBundle: $maps_bundle_hash
+        mvnDeps: $mvn_hash
+    }
+}
+    | to toml
+    | save $version_info -f
+
+log debug $"Successfully updated graphhopper package!"

--- a/pkgs/by-name/gr/graphhopper/version.toml
+++ b/pkgs/by-name/gr/graphhopper/version.toml
@@ -1,0 +1,8 @@
+major = "10.0"
+patch = "10.2"
+mapsBundle = "0.0.0-4718098d1db1798841a4d12f1727e8e8f7eab202"
+
+[hash]
+src = "sha256-E6G9JR1lrXhNJ4YgMM0n0RsQcMZQM2QldGc74f5FALo="
+mapsBundle = "sha256-jZTNJfmMWJQHpJ8um3yTBx/KtIfdr0EwKJ9kSFalWJQ="
+mvnDeps = "sha256-KidbIBnW//IiKPFy3plFWOED8gP/ZCg4buwMgzttaY8="


### PR DESCRIPTION
[GraphHopper](https://github.com/graphhopper/graphhopper) is an open source Open Street Map based routing engine written in java and packaged in maven.

To quote their own description:

> GraphHopper is a fast and memory-efficient routing engine released under Apache License 2.0. It can be used as a Java library or standalone web server to calculate the distance, time, turn-by-turn instructions and many road attributes for a route between two or more points. Beyond this "A-to-B" routing it supports ["snap to road"](https://github.com/graphhopper/graphhopper/blob/master/README.md#Map-Matching), [Isochrone calculation](https://github.com/graphhopper/graphhopper/blob/master/README.md#Analysis), [mobile navigation](https://github.com/graphhopper/graphhopper/blob/master/README.md#mobile-apps) and [more](https://github.com/graphhopper/graphhopper/blob/master/README.md#Features). GraphHopper uses OpenStreetMap and GTFS data by default and it can import [other data sources too](https://github.com/graphhopper/graphhopper/blob/master/README.md#OpenStreetMap-Support).

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin (with a slightly older iteration of the package code)
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

The way I approached building this package was:
- Original attempt with `buildMavenPackage`: This did not work as graphhopper depends on [maven-frontend-plugin](https://github.com/eirslett/frontend-maven-plugin), which installs it's own version of node/npm and uses it to fetch a [single npm package with no dependencies](https://www.npmjs.com/package/@graphhopper/graphhopper-maps-bundle).
- As a result, I decided to write a patch which removes the dependency from `pom.xml` and instead fetch the npm package manually during the derivation.
- In light of this, I decided to implement the [double-invocation](https://github.com/NixOS/nixpkgs/blob/master/doc/languages-frameworks/maven.section.md#double-invocation-double-invocation) pattern where dependencies are fetched first and separately so I could load the tarball of the npm package into the correct place.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
