### PR TITLE
amnezia-vpn: fix openvpn; refactor install and fixup

### DIFF
--- a/nixos/modules/programs/amnezia-vpn.nix
+++ b/nixos/modules/programs/amnezia-vpn.nix
@@ -10,16 +10,24 @@ in
 {
   options.programs.amnezia-vpn = {
     enable = lib.mkEnableOption "The AmneziaVPN client";
+    package = lib.mkPackageOption pkgs "amnezia-vpn" { };
   };
 
   config = lib.mkIf cfg.enable {
-    environment.systemPackages = [ pkgs.amnezia-vpn ];
-    services.dbus.packages = [ pkgs.amnezia-vpn ];
+    environment.systemPackages = [ cfg.package ];
+    services.dbus.packages = [ cfg.package ];
     services.resolved.enable = true;
 
     systemd = {
-      packages = [ pkgs.amnezia-vpn ];
-      services."AmneziaVPN".wantedBy = [ "multi-user.target" ];
+      packages = [ cfg.package ];
+      services."AmneziaVPN" = {
+        wantedBy = [ "multi-user.target" ];
+        path = with pkgs; [
+          procps
+          iproute2
+          sudo
+        ];
+      };
     };
   };
 

--- a/pkgs/by-name/am/amnezia-vpn/package.nix
+++ b/pkgs/by-name/am/amnezia-vpn/package.nix
@@ -12,14 +12,12 @@
   shadowsocks-rust,
   cloak-pt,
   wireguard-tools,
-  procps,
-  iproute2,
-  sudo,
   libssh,
   zlib,
   tun2socks,
   xray,
   nix-update-script,
+  bash,
 }:
 let
   amnezia-tun2socks = tun2socks.overrideAttrs (
@@ -83,7 +81,7 @@ stdenv.mkDerivation (finalAttrs: {
       substituteInPlace client/configurators/openvpn_configurator.cpp \
         --replace-fail ".arg(qApp->applicationDirPath());" ".arg(\"$out/libexec\");"
       substituteInPlace client/ui/qautostart.cpp \
-        --replace-fail "/usr/share/pixmaps/AmneziaVPN.png" "$out/share/pixmaps/AmneziaVPN.png"
+        --replace-fail "/usr/share/pixmaps/AmneziaVPN.png" "AmneziaVPN"
       substituteInPlace deploy/installer/config/AmneziaVPN.desktop.in \
         --replace-fail "/usr/share/pixmaps/AmneziaVPN.png" "$out/share/pixmaps/AmneziaVPN.png"
       substituteInPlace deploy/data/linux/AmneziaVPN.service \
@@ -107,31 +105,31 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   buildInputs = [
+    bash
+    kdePackages.qt5compat
+    kdePackages.qtremoteobjects
+    kdePackages.qtsvg
     libsecret
     qt6.qtbase
     qt6.qttools
-    kdePackages.qtremoteobjects
-    kdePackages.qtsvg
-    kdePackages.qt5compat
   ];
 
-  qtWrapperArgs = [
-    ''--prefix PATH : ${
-      lib.makeBinPath [
-        procps
-        iproute2
-        sudo
-      ]
-    }''
-  ];
+  installPhase = ''
+    runHook preInstall
 
-  postInstall = ''
     mkdir -p $out/bin $out/libexec $out/share/applications $out/share/pixmaps $out/lib/systemd/system
-    cp client/AmneziaVPN service/server/AmneziaVPN-service $out/bin/
-    cp ../deploy/data/linux/client/bin/update-resolv-conf.sh $out/libexec/
-    cp ../AppDir/AmneziaVPN.desktop $out/share/applications/
-    cp ../deploy/data/linux/AmneziaVPN.png $out/share/pixmaps/
-    cp ../deploy/data/linux/AmneziaVPN.service $out/lib/systemd/system/
+    install -m555 client/AmneziaVPN service/server/AmneziaVPN-service $out/bin/
+    install -m555 ../deploy/data/linux/client/bin/update-resolv-conf.sh $out/libexec/
+    install -m444 ../AppDir/AmneziaVPN.desktop $out/share/applications/
+    install -m444 ../deploy/data/linux/AmneziaVPN.png $out/share/pixmaps/
+    install -m444 ../deploy/data/linux/AmneziaVPN.service $out/lib/systemd/system/
+
+    runHook postInstall
+  '';
+
+  postFixup = ''
+    # Temporary unwrap non-binary executable until qt6.wrapQtAppsHook is fixed
+    mv $out/libexec/.update-resolv-conf.sh-wrapped $out/libexec/update-resolv-conf.sh
   '';
 
   passthru = {
@@ -149,7 +147,7 @@ stdenv.mkDerivation (finalAttrs: {
   meta = with lib; {
     description = "Amnezia VPN Client";
     downloadPage = "https://amnezia.org/en/downloads";
-    homepage = "https://amnezia.org/en";
+    homepage = "https://github.com/amnezia-vpn/amnezia-client";
     license = licenses.gpl3;
     mainProgram = "AmneziaVPN";
     maintainers = with maintainers; [ sund3RRR ];


### PR DESCRIPTION
1) Use the `install` command instead of `cp` (to fix the executable bits warning in the systemd service).
2) Change the wrapping strategy (add binaries to path in the NixOS module instead of wrapping the binary, as it is needed only for the systemd service).
3) Patch `wrapQtAppsHook` to prevent it from wrapping scripts as ELF programs (which causes issues with OpenVPN, as `libexec/update-resolv-conf.sh` does not work due to ELF wrapping).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
