### PR TITLE
ci/keep-sorted: friendlier error message

### DIFF
--- a/.github/workflows/keep-sorted.yml
+++ b/.github/workflows/keep-sorted.yml
@@ -33,8 +33,8 @@ jobs:
           nix_path: nixpkgs=${{ env.url }}
 
       - name: Install keep-sorted
-        run: "nix-env -f '<nixpkgs>' -iAP keep-sorted"
+        run: "nix-env -f '<nixpkgs>' -iAP keep-sorted jq"
 
       - name: Check that Nix files are sorted
         run: |
-          git ls-files | xargs keep-sorted --mode lint
+          git ls-files | xargs keep-sorted --mode lint | jq --raw-output '.[] | "Please make sure any new entries in \(.path) are sorted alphabetically."'


### PR DESCRIPTION
Address https://github.com/NixOS/nixpkgs/pull/391087#issuecomment-2762731147

CI fail log will now be much shorter and easier to read. See patch for precise wording.

## Things done

- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).