### PR TITLE
colord: 1.4.6 -> 1.4.7, refactor

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -275,6 +275,7 @@ in {
   cockroachdb = handleTestOn ["x86_64-linux"] ./cockroachdb.nix {};
   code-server = handleTest ./code-server.nix {};
   coder = handleTest ./coder.nix {};
+  colord = runTest ./colord.nix;
   collectd = handleTest ./collectd.nix {};
   commafeed = handleTest ./commafeed.nix {};
   conduwuit = runTest ./matrix/conduwuit.nix;

--- a/nixos/tests/colord.nix
+++ b/nixos/tests/colord.nix
@@ -1,0 +1,12 @@
+{ ...}: {
+  name = "colord";
+  nodes.machine = {
+    services.colord.enable = true;
+  };
+  testScript = ''
+    machine.wait_for_unit("multi-user.target")
+    
+    with subtest("colord daemon started"):
+          machine.succeed("systemctl status colord.service")
+  '';
+}

--- a/pkgs/by-name/co/colord/package.nix
+++ b/pkgs/by-name/co/colord/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   stdenv,
-  fetchurl,
+  fetchFromGitHub,
   nixosTests,
   bash-completion,
   glib,
@@ -31,11 +31,12 @@
   gtk-doc,
   libxslt,
   enableDaemon ? true,
+  nix-update-script,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "colord";
-  version = "1.4.6";
+  version = "1.4.7";
 
   outputs = [
     "out"
@@ -45,9 +46,11 @@ stdenv.mkDerivation rec {
     "installedTests"
   ];
 
-  src = fetchurl {
-    url = "https://www.freedesktop.org/software/colord/releases/colord-${version}.tar.xz";
-    sha256 = "dAdjGie/5dG2cueuQndwAcEF2GC3tzkig8jGMA3ojm8=";
+  src = fetchFromGitHub {
+    owner = "hughsie";
+    repo = "colord";
+    tag = finalAttrs.version;
+    hash = "sha256-/lAj8T2V23V6F8IhNNeJAq5BDWCeaMaxVd2igZP6oMo=";
   };
 
   patches = [
@@ -130,6 +133,7 @@ stdenv.mkDerivation rec {
     tests = {
       installedTests = nixosTests.installed-tests.colord;
     };
+    updateScript = nix-update-script { };
   };
 
   meta = with lib; {
@@ -139,4 +143,4 @@ stdenv.mkDerivation rec {
     maintainers = [ maintainers.marcweber ] ++ teams.freedesktop.members;
     platforms = platforms.linux;
   };
-}
+})

--- a/pkgs/by-name/co/colord/package.nix
+++ b/pkgs/by-name/co/colord/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  fetchpatch,
   nixosTests,
   bash-completion,
   glib,
@@ -56,6 +57,16 @@ stdenv.mkDerivation (finalAttrs: {
   patches = [
     # Put installed tests into its own output
     ./installed-tests-path.patch
+    (fetchpatch {
+      # Fix writing to the database with ProtectSystem=strict, can be dropped on 1.4.8
+      url = "https://github.com/hughsie/colord/commit/08a32b2379fb5582f4312e59bf51a2823df56276.patch?full_index=1";
+      hash = "sha256-E8EXgvyd9jMXhQOO97ZOgv3oCTWcrbtS8IR0yQNyhyo=";
+    })
+    # Fix USB scanners not working with RestrictAddressFamilies, can be dropped on 1.4.8
+    (fetchpatch {
+      url = "https://github.com/hughsie/colord/commit/9283abd9c00468edb94d2a06d6fa3681cae2700d.patch?full_index=1";
+      hash = "sha256-hDA4bTuTJJxmSnmPUkVnYl2FYLoGFEBAeSDhVyr+Nhw=";
+    })
   ];
 
   postPatch = ''


### PR DESCRIPTION
changelog: https://github.com/hughsie/colord/compare/1.4.6...1.4.7

The freedesktop download page [1] is mostly unmaintained, listing only releases up to 1.4.4. Fetching from GitHub allows nix-update-script and makes tampering with the release sources harder. The GitHub used is the correct one, it is explicitly linked on the fdo download page.

Refactors:
- update script
- fetchFromGitHub
- finalAttrs

[1] https://www.freedesktop.org/software/colord/download.html

Maintainer ping: @jtojnar 

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
