### PR TITLE
orca-slicer: fixing build on GCC < 14

### DIFF
--- a/pkgs/by-name/or/orca-slicer/package.nix
+++ b/pkgs/by-name/or/orca-slicer/package.nix
@@ -145,27 +145,32 @@ stdenv.mkDerivation (finalAttrs: {
 
   NLOPT = nlopt;
 
-  NIX_CFLAGS_COMPILE = toString [
-    "-Wno-ignored-attributes"
-    "-I${opencv.out}/include/opencv4"
-    "-Wno-error=template-id-cdtor"
-    "-Wno-error=incompatible-pointer-types"
-    "-Wno-template-id-cdtor"
-    "-Wno-uninitialized"
-    "-Wno-unused-result"
-    "-Wno-deprecated-declarations"
-    "-Wno-use-after-free"
-    "-Wno-format-overflow"
-    "-Wno-stringop-overflow"
-    "-DBOOST_ALLOW_DEPRECATED_HEADERS"
-    "-DBOOST_MATH_DISABLE_STD_FPCLASSIFY"
-    "-DBOOST_MATH_NO_LONG_DOUBLE_MATH_FUNCTIONS"
-    "-DBOOST_MATH_DISABLE_FLOAT128"
-    "-DBOOST_MATH_NO_QUAD_SUPPORT"
-    "-DBOOST_MATH_MAX_FLOAT128_DIGITS=0"
-    "-DBOOST_CSTDFLOAT_NO_LIBQUADMATH_SUPPORT"
-    "-DBOOST_MATH_DISABLE_FLOAT128_BUILTIN_FPCLASSIFY"
-  ];
+  NIX_CFLAGS_COMPILE = toString (
+    [
+      "-Wno-ignored-attributes"
+      "-I${opencv.out}/include/opencv4"
+      "-Wno-error=incompatible-pointer-types"
+      "-Wno-template-id-cdtor"
+      "-Wno-uninitialized"
+      "-Wno-unused-result"
+      "-Wno-deprecated-declarations"
+      "-Wno-use-after-free"
+      "-Wno-format-overflow"
+      "-Wno-stringop-overflow"
+      "-DBOOST_ALLOW_DEPRECATED_HEADERS"
+      "-DBOOST_MATH_DISABLE_STD_FPCLASSIFY"
+      "-DBOOST_MATH_NO_LONG_DOUBLE_MATH_FUNCTIONS"
+      "-DBOOST_MATH_DISABLE_FLOAT128"
+      "-DBOOST_MATH_NO_QUAD_SUPPORT"
+      "-DBOOST_MATH_MAX_FLOAT128_DIGITS=0"
+      "-DBOOST_CSTDFLOAT_NO_LIBQUADMATH_SUPPORT"
+      "-DBOOST_MATH_DISABLE_FLOAT128_BUILTIN_FPCLASSIFY"
+    ]
+    # Making it compatible with GCC 14+, see https://github.com/SoftFever/OrcaSlicer/pull/7710
+    ++ lib.optionals (stdenv.cc.isGNU && lib.versionAtLeast stdenv.cc.version "14") [
+      "-Wno-error=template-id-cdtor"
+    ]
+  );
 
   NIX_LDFLAGS = toString [
     (lib.optionalString withSystemd "-ludev")


### PR DESCRIPTION
Making `orca-slicer` compatible with the `release-24.11` branch, so it can be backported on #392957

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
