### PR TITLE
opnborg: 0.1.66 -> 0.1.68,  add versionCheckHook, use finalAttrs pattern

### DIFF
--- a/pkgs/by-name/op/opnborg/package.nix
+++ b/pkgs/by-name/op/opnborg/package.nix
@@ -3,19 +3,21 @@
   buildGoModule,
   fetchFromGitHub,
   nix-update-script,
+  versionCheckHook,
 }:
-buildGoModule rec {
+
+buildGoModule (finalAttrs: {
   pname = "opnborg";
-  version = "0.1.66";
+  version = "0.1.68";
 
   src = fetchFromGitHub {
     owner = "paepckehh";
     repo = "opnborg";
-    rev = "v${version}";
-    hash = "sha256-7WYDkAHhCrVghNd+77XfwF1WwYJ8azt0Twn4d/rDjU8=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-fES3YlJu8Zy1CLNEkzWW0KAhy3dZj1JXAT8y9tRjyEA=";
   };
 
-  vendorHash = "sha256-i9MDtaR5uTrIhpliCyK/WMZqT69TyPVLQI9AGHCWavU=";
+  vendorHash = "sha256-u1LZvLAKYd1TQlZkYxgztOm1g94N4orMe6Y1Ab1to5Y=";
 
   ldflags = [
     "-s"
@@ -24,12 +26,18 @@ buildGoModule rec {
 
   passthru.updateScript = nix-update-script { };
 
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  doInstallCheck = true;
+  versionCheckProgram = "${placeholder "out"}/bin/opnborg";
+  versionCheckProgramArg = "--version";
+
   meta = {
-    changelog = "https://github.com/paepckehh/opnborg/releases/tag/v${version}";
+    changelog = "https://github.com/paepckehh/opnborg/releases/tag/v${finalAttrs.version}";
     homepage = "https://paepcke.de/opnborg";
     description = "Sefhosted OPNSense Appliance Backup & Configuration Management Portal";
     license = lib.licenses.bsd3;
     mainProgram = "opnborg";
     maintainers = with lib.maintainers; [ paepcke ];
   };
-}
+})


### PR DESCRIPTION
https://github.com/paepckehh/opnborg
(tldr; backup. monitor, manage selfhosted opnsense and unifi appliances)


- update package to v0.1.68
- add via versionHook build binary & version test (including needed upstream cli parser changes)
- use finalAttrs pattern 

update: split the service module into separate pr as requested

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [X] `sandbox = true`
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
