### PR TITLE
gst-plugins-bad: remove libGLU dependency

### DIFF
--- a/pkgs/development/libraries/gstreamer/bad/default.nix
+++ b/pkgs/development/libraries/gstreamer/bad/default.nix
@@ -83,7 +83,6 @@
 , xvidcore
 , gnutls
 , mjpegtools
-, libGLU
 , libGL
 , addDriverRunpath
 , gtk3
@@ -250,7 +249,6 @@ stdenv.mkDerivation rec {
     sratom
 
     libGL
-    libGLU
   ] ++ lib.optionals guiSupport [
     gtk3
   ] ++ lib.optionals stdenv.hostPlatform.isDarwin [


### PR DESCRIPTION
libGLU is an unmaintained GL library.
glu was removed upstream in 6bd1150ca889c17342520b3bbd8e729fb843a1a5 [1], which took effect in version 1.5.1 released June 2015 [2].

Later, in 769a21d0bb310906b880c07da0e1e2376e11c187 [3], upstream removed the entirety of direct OpenGL integration. This change took effect in 1.13.1, released February 2018 [4].

libGLU nix package supplies a couple shared objects, a package config file, and a single C header.
None of these are used anymore: code search on the package config comes back empty, and `nix why-depends` confirms the shared objects are not being linked against.

libGLU is a dependency in many packages, but really should be phased out.

[1] https://github.com/GStreamer/gst-plugins-bad/commit/6bd1150ca889c17342520b3bbd8e729fb843a1a5
[2] https://github.com/GStreamer/gst-plugins-bad/releases/tag/1.5.1
[3] https://github.com/GStreamer/gst-plugins-bad/commit/769a21d0bb310906b880c07da0e1e2376e11c187
[4] https://github.com/GStreamer/gst-plugins-bad/releases/tag/1.13.1


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
