### PR TITLE
obs-studio-plugins.advanced-scene-switcher: 1.28.1 -> 1.30.1

### DIFF
--- a/pkgs/applications/video/obs-studio/plugins/advanced-scene-switcher/default.nix
+++ b/pkgs/applications/video/obs-studio/plugins/advanced-scene-switcher/default.nix
@@ -20,10 +20,9 @@
   libXScrnSaver,
   libusb1,
   pkg-config,
-  fetchpatch,
 # #FIXME: Could not get cmake to pick up on these dependencies
-# Prevents cmake from building the OCR video capabilities
-# Everything else should work just missing this on plugin
+# Ommiting them prevents cmake from building the OCR video capabilities
+# Everything else should work it's just missing this one plugin
 # tesseract,
 # leptonica,
 }:
@@ -37,27 +36,19 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "advanced-scene-switcher";
-  version = "1.28.1";
+  version = "1.30.1";
 
   src = fetchFromGitHub {
     owner = "WarmUpTill";
     repo = "SceneSwitcher";
     rev = version;
-    hash = "sha256-1U5quhfdhEBcCbEzW0uEpimYgvdbsIwaL2EdQ4cLF/M=";
+    hash = "sha256-UTgOZK4SFjTcbAGQGY4kQbaskWhKA5fAkHBPNlPYzxo=";
   };
 
   nativeBuildInputs = [
     cmake
     ninja
     pkg-config
-  ];
-
-  patches = [
-    # https://github.com/WarmUpTill/SceneSwitcher/pull/1244
-    (fetchpatch {
-      url = "https://github.com/WarmUpTill/SceneSwitcher/commit/e0c650574f9f7f6cae5626afa9abf8a838dc0858.diff";
-      hash = "sha256-eXO8LdGYf60sd/kyxWVDSEpwyzp4Uu9TpPADg5ED4yU=";
-    })
   ];
 
   buildInputs = [


### PR DESCRIPTION
https://github.com/WarmUpTill/SceneSwitcher/releases/tag/1.29.0
https://github.com/WarmUpTill/SceneSwitcher/releases/tag/1.29.1
https://github.com/WarmUpTill/SceneSwitcher/releases/tag/1.30.0
https://github.com/WarmUpTill/SceneSwitcher/releases/tag/1.30.1
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
