### PR TITLE
binutils-unwrapped-all-targets: per-target gas

### DIFF
--- a/pkgs/development/tools/misc/binutils/default.nix
+++ b/pkgs/development/tools/misc/binutils/default.nix
@@ -148,21 +148,7 @@ stdenv.mkDerivation (finalAttrs: {
       for i in binutils/Makefile.in gas/Makefile.in ld/Makefile.in gold/Makefile.in; do
           sed -i "$i" -e 's|ln |ln -s |'
       done
-
-      # autoreconfHook is not included for all targets.
-      # Call it here explicitly as well.
-      ${finalAttrs.postAutoreconf}
     '';
-
-  postAutoreconf = ''
-    # As we regenerated configure build system tries hard to use
-    # texinfo to regenerate manuals. Let's avoid the dependency
-    # on texinfo in bootstrap path and keep manuals unmodified.
-    touch gas/doc/.dirstamp
-    touch gas/doc/asconfig.texi
-    touch gas/doc/as.1
-    touch gas/doc/as.info
-  '';
 
   # As binutils takes part in the stdenv building, we don't want references
   # to the bootstrap-tools libgcc (as uses to happen on arm/mips)
@@ -247,6 +233,13 @@ stdenv.mkDerivation (finalAttrs: {
         "LDFLAGS=-Wl,--undefined-version"
       ]
     );
+
+  makeFlags = [
+    # As we regenerated configure build system tries hard to use
+    # texinfo to regenerate manuals. Let's avoid the dependency
+    # on texinfo in bootstrap path and keep manuals unmodified.
+    "MAKEINFO=true"
+  ];
 
   # Fails
   doCheck = false;

--- a/pkgs/development/tools/misc/binutils/default.nix
+++ b/pkgs/development/tools/misc/binutils/default.nix
@@ -148,6 +148,10 @@ stdenv.mkDerivation (finalAttrs: {
       for i in binutils/Makefile.in gas/Makefile.in ld/Makefile.in gold/Makefile.in; do
           sed -i "$i" -e 's|ln |ln -s |'
       done
+
+      configureScript="$PWD/configure"
+      mkdir $NIX_BUILD_TOP/build
+      cd $NIX_BUILD_TOP/build
     '';
 
   # As binutils takes part in the stdenv building, we don't want references


### PR DESCRIPTION
pwntools wants to be able to disassemble arbitrary programs, so it wants to be able to find gas for an arbitrary architecture in the same prefix.  We had a long discussion on Matrix many months ago about the best way to accommodate this, and @emilazy's idea of just building one gas per target in binutils-unwrapped-all-targets sounded like the way that fit best.

See commit messages for more info.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
