### PR TITLE
nixos/openrazer: allow to configure packages

### DIFF
--- a/nixos/modules/hardware/openrazer.nix
+++ b/nixos/modules/hardware/openrazer.nix
@@ -137,9 +137,7 @@ in
       packages = {
         kernel = lib.mkPackageOption pkgs "openrazer kernel" { } // {
           default = config.boot.kernelPackages.openrazer;
-          defaultText = lib.literalExpression ''
-            config.boot.kernelPackages.openrazer
-          '';
+          defaultText = lib.literalExpression "config.boot.kernelPackages.openrazer";
         };
         daemon = lib.mkPackageOption pkgs [ "python3Packages" "openrazer-daemon" ] { };
       };

--- a/nixos/modules/hardware/openrazer.nix
+++ b/nixos/modules/hardware/openrazer.nix
@@ -6,11 +6,10 @@
 }:
 let
   cfg = config.hardware.openrazer;
-  kernelPackages = config.boot.kernelPackages;
 
   toPyBoolStr = b: if b then "True" else "False";
 
-  daemonExe = "${pkgs.openrazer-daemon}/bin/openrazer-daemon --config ${daemonConfFile}";
+  daemonExe = "${cfg.packages.daemon}/bin/openrazer-daemon --config ${daemonConfFile}";
 
   daemonConfFile = pkgs.writeTextFile {
     name = "razer.conf";
@@ -134,6 +133,16 @@ in
           can start and interact with the OpenRazer userspace daemon.
         '';
       };
+
+      packages = {
+        kernel = lib.mkPackageOption pkgs "openrazer kernel" { } // {
+          default = config.boot.kernelPackages.openrazer;
+          defaultText = lib.literalExpression ''
+            config.boot.kernelPackages.openrazer
+          '';
+        };
+        daemon = lib.mkPackageOption pkgs [ "python3Packages" "openrazer-daemon" ] { };
+      };
     };
   };
 
@@ -145,14 +154,16 @@ in
   ];
 
   config = lib.mkIf cfg.enable {
-    boot.extraModulePackages = [ kernelPackages.openrazer ];
+    boot.extraModulePackages = [ cfg.packages.kernel ];
     boot.kernelModules = drivers;
 
     # Makes the man pages available so you can successfully run
     # > systemctl --user help openrazer-daemon
-    environment.systemPackages = [ pkgs.python3Packages.openrazer-daemon.man ];
+    environment.systemPackages = lib.mkIf (cfg.packages.daemon ? man) [
+      cfg.packages.daemon.man
+    ];
 
-    services.udev.packages = [ kernelPackages.openrazer ];
+    services.udev.packages = [ cfg.packages.kernel ];
     services.dbus.packages = [ dbusServiceFile ];
 
     # A user must be a member of the openrazer group in order to start


### PR DESCRIPTION
Adds options to configure packages used by the openrazer module.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
