### PR TITLE
mpd: 0.23.17 -> 0.24.2

### DIFF
--- a/pkgs/servers/mpd/default.nix
+++ b/pkgs/servers/mpd/default.nix
@@ -2,13 +2,11 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  fetchpatch2,
   meson,
   ninja,
   pkg-config,
   glib,
   systemd,
-  boost,
   fmt,
   buildPackages,
   # Darwin inputs
@@ -202,30 +200,18 @@ let
     in
     stdenv.mkDerivation rec {
       pname = "mpd";
-      version = "0.23.17";
+      version = "0.24.2";
 
       src = fetchFromGitHub {
         owner = "MusicPlayerDaemon";
         repo = "MPD";
         rev = "v${version}";
-        sha256 = "sha256-1+eVLvwMp6mR38y39wV73rhPA998ip7clyyKcJ008z0=";
+        sha256 = "sha256-6wEFgiMsEoWvmfH609d+UZY7jzqDoNmXalpHBipqTN0=";
       };
-
-      patches = [
-        # Revert of https://github.com/MusicPlayerDaemon/MPD/commit/0aeda01ba6d22a8d9fc583faa67ffc6473869a43
-        # We use a yajl fork that fixed this issue in the pkg-config manifest
-        (fetchpatch2 {
-          name = "revert-yajl-include-fix.patch";
-          url = "https://github.com/MusicPlayerDaemon/MPD/commit/0aeda01ba6d22a8d9fc583faa67ffc6473869a43.diff";
-          hash = "sha256-p/sYvWpr0GTw8gjt+W9FQysadOK/QOUp81ykTI50UYg=";
-          revert = true;
-        })
-      ];
 
       buildInputs =
         [
           glib
-          boost
           fmt
           # According to the configurePhase of meson, gtest is considered a
           # runtime dependency. Quoting:
@@ -248,13 +234,25 @@ let
       depsBuildBuild = [ buildPackages.stdenv.cc ];
 
       postPatch =
-        lib.optionalString
-          (stdenv.hostPlatform.isDarwin && lib.versionOlder stdenv.hostPlatform.darwinSdkVersion "12.0")
-          ''
-            substituteInPlace src/output/plugins/OSXOutputPlugin.cxx \
-              --replace kAudioObjectPropertyElement{Main,Master} \
-              --replace kAudioHardwareServiceDeviceProperty_Virtual{Main,Master}Volume
-          '';
+        ''
+          # Basically a revert of https://github.com/MusicPlayerDaemon/MPD/commit/0aeda01ba6d22a8d9fc583faa67ffc6473869a43
+          # We use a yajl fork that fixed this issue in the pkg-config manifest
+          substituteInPlace \
+            src/lib/yajl/Callbacks.hxx \
+            src/lib/yajl/Handle.hxx \
+            --replace-fail "<yajl_parse.h>" "<yajl/yajl_parse.h>"
+          substituteInPlace \
+            src/lib/yajl/Gen.hxx \
+            --replace-fail "<yajl_gen.h>" "<yajl/yajl_gen.h>"
+        ''
+        +
+          lib.optionalString
+            (stdenv.hostPlatform.isDarwin && lib.versionOlder stdenv.hostPlatform.darwinSdkVersion "12.0")
+            ''
+              substituteInPlace src/output/plugins/OSXOutputPlugin.cxx \
+                --replace kAudioObjectPropertyElement{Main,Master} \
+                --replace kAudioHardwareServiceDeviceProperty_Virtual{Main,Master}Volume
+            '';
 
       # Otherwise, the meson log says:
       #


### PR DESCRIPTION
https://github.com/MusicPlayerDaemon/MPD/releases/tag/v0.24.2
Changelog: https://github.com/MusicPlayerDaemon/MPD/blob/v0.24.2/NEWS

Replaced the patch revert with substituteInPlace calls.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
