### PR TITLE
varnish77: init at 7.7.0, varnish: move to varnish77, varnish75: drop

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2505.section.md
+++ b/nixos/doc/manual/release-notes/rl-2505.section.md
@@ -259,6 +259,9 @@
 - The `gotenberg` package has been updated to 8.16.0, which brings breaking changes to the configuration from version 8.13.0. See the [upstream release notes](https://github.com/gotenberg/gotenberg/releases/tag/v8.13.0)
   for that release to get all the details. The `services.gotenberg` module has been updated appropriately to ensure your configuration is valid with this new release.
 
+- `varnish` was updated from 7.5.0 to 7.7.0, see [Varnish 7.6.0 upgrade guide](https://varnish-cache.org/docs/7.6/whats-new/upgrading-7.6.html) and
+[Varnish 7.7.0 upgrade guide](https://varnish-cache.org/docs/7.7/whats-new/upgrading-7.7.html#whatsnew-upgrading-7-7).
+
 - `asusd` has been upgraded to version 6 which supports multiple aura devices. To account for this, the single `auraConfig` configuration option has been replaced with `auraConfigs` which is an attribute set of config options per each device. The config files may also be now specified as either source files or text strings; to account for this you will need to specify that `text` is used for your existing configs, e.g.:
   ```diff
   -services.asusd.asusdConfig = '''file contents'''

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1410,6 +1410,7 @@ in
   user-activation-scripts = handleTest ./user-activation-scripts.nix { };
   user-enable-option = runTest ./user-enable-option.nix;
   user-expiry = runTest ./user-expiry.nix;
+<<<<<<< HEAD
   user-home-mode = handleTest ./user-home-mode.nix { };
   ustreamer = handleTest ./ustreamer.nix { };
   uwsgi = handleTest ./uwsgi.nix { };
@@ -1430,6 +1431,20 @@ in
   vault-agent = handleTest ./vault-agent.nix { };
   vault-dev = handleTest ./vault-dev.nix { };
   vault-postgresql = handleTest ./vault-postgresql.nix { };
+=======
+  user-home-mode = handleTest ./user-home-mode.nix {};
+  ustreamer = handleTest ./ustreamer.nix {};
+  uwsgi = handleTest ./uwsgi.nix {};
+  v2ray = handleTest ./v2ray.nix {};
+  varnish60 = handleTest ./varnish.nix { package = pkgs.varnish60; };
+  varnish75 = handleTest ./varnish.nix { package = pkgs.varnish75; };
+  varnish76 = handleTest ./varnish.nix { package = pkgs.varnish76; };
+  varnish77 = handleTest ./varnish.nix { package = pkgs.varnish77; };
+  vault = handleTest ./vault.nix {};
+  vault-agent = handleTest ./vault-agent.nix {};
+  vault-dev = handleTest ./vault-dev.nix {};
+  vault-postgresql = handleTest ./vault-postgresql.nix {};
+>>>>>>> 0a00164b4295 (varnish77: init at 7.7.0)
   vaultwarden = discoverTests (import ./vaultwarden.nix);
   vdirsyncer = handleTest ./vdirsyncer.nix { };
   vector = handleTest ./vector { };

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1410,7 +1410,6 @@ in
   user-activation-scripts = handleTest ./user-activation-scripts.nix { };
   user-enable-option = runTest ./user-enable-option.nix;
   user-expiry = runTest ./user-expiry.nix;
-<<<<<<< HEAD
   user-home-mode = handleTest ./user-home-mode.nix { };
   ustreamer = handleTest ./ustreamer.nix { };
   uwsgi = handleTest ./uwsgi.nix { };
@@ -1419,32 +1418,18 @@ in
     imports = [ ./varnish.nix ];
     _module.args.package = pkgs.varnish60;
   };
-  varnish75 = runTest {
-    imports = [ ./varnish.nix ];
-    _module.args.package = pkgs.varnish75;
-  };
   varnish76 = runTest {
     imports = [ ./varnish.nix ];
     _module.args.package = pkgs.varnish76;
+  };
+  varnish77 = runTest {
+    imports = [ ./varnish.nix ];
+    _module.args.package = pkgs.varnish77;
   };
   vault = handleTest ./vault.nix { };
   vault-agent = handleTest ./vault-agent.nix { };
   vault-dev = handleTest ./vault-dev.nix { };
   vault-postgresql = handleTest ./vault-postgresql.nix { };
-=======
-  user-home-mode = handleTest ./user-home-mode.nix {};
-  ustreamer = handleTest ./ustreamer.nix {};
-  uwsgi = handleTest ./uwsgi.nix {};
-  v2ray = handleTest ./v2ray.nix {};
-  varnish60 = handleTest ./varnish.nix { package = pkgs.varnish60; };
-  varnish75 = handleTest ./varnish.nix { package = pkgs.varnish75; };
-  varnish76 = handleTest ./varnish.nix { package = pkgs.varnish76; };
-  varnish77 = handleTest ./varnish.nix { package = pkgs.varnish77; };
-  vault = handleTest ./vault.nix {};
-  vault-agent = handleTest ./vault-agent.nix {};
-  vault-dev = handleTest ./vault-dev.nix {};
-  vault-postgresql = handleTest ./vault-postgresql.nix {};
->>>>>>> 0a00164b4295 (varnish77: init at 7.7.0)
   vaultwarden = discoverTests (import ./vaultwarden.nix);
   vdirsyncer = handleTest ./vdirsyncer.nix { };
   vector = handleTest ./vector { };

--- a/pkgs/servers/varnish/default.nix
+++ b/pkgs/servers/varnish/default.nix
@@ -104,4 +104,9 @@ in
     version = "7.6.2";
     hash = "sha256-OFxhDsxj3P61PXb0fMRl6J6+J9osCSJvmGHE+o6dLJo=";
   };
+  # EOL 2026-03-15
+  varnish77 = common {
+    version = "7.7.0";
+    hash = "sha256-aZSPIVEfgc548JqXFdmodQ6BEWGb1gVaPIYTFaIQtOQ=";
+  };
 }

--- a/pkgs/servers/varnish/default.nix
+++ b/pkgs/servers/varnish/default.nix
@@ -94,11 +94,6 @@ in
     version = "6.0.13";
     hash = "sha256-DcpilfnGnUenIIWYxBU4XFkMZoY+vUK/6wijZ7eIqbo=";
   };
-  # EOL 2025-03-15
-  varnish75 = common {
-    version = "7.5.0";
-    hash = "sha256-/KYbmDE54arGHEVG0SoaOrmAfbsdgxRXHjFIyT/3K10=";
-  };
   # EOL 2025-09-15
   varnish76 = common {
     version = "7.6.2";

--- a/pkgs/servers/varnish/modules.nix
+++ b/pkgs/servers/varnish/modules.nix
@@ -63,4 +63,8 @@ in
     version = "0.25.0";
     hash = "sha256-m/7moizVyvoP8xnpircAFVUqCmCfTGkgVyRc6zkdVsk=";
   };
+  modules26 = common {
+    version = "0.26.0";
+    hash = "sha256-xKMOkqm6/GoBve0AhPqyVMQv/oh5Rtj6uCeg/yId7BU=";
+  };
 }

--- a/pkgs/servers/varnish/modules.nix
+++ b/pkgs/servers/varnish/modules.nix
@@ -55,10 +55,6 @@ in
     version = "0.15.1";
     hash = "sha256-Et/iWOk2FWJBDOpKjNXm4Nh5i1SU4zVPaID7kh+Uj9M=";
   };
-  modules24 = common {
-    version = "0.24.0";
-    hash = "sha256-2MfcrhhkBz9GyQxEWzjipdn1CBEqnCvC3t1G2YSauak=";
-  };
   modules25 = common {
     version = "0.25.0";
     hash = "sha256-m/7moizVyvoP8xnpircAFVUqCmCfTGkgVyRc6zkdVsk=";

--- a/pkgs/servers/varnish/packages.nix
+++ b/pkgs/servers/varnish/packages.nix
@@ -4,6 +4,7 @@
   varnish60,
   varnish75,
   varnish76,
+  varnish77,
 }:
 {
   varnish60Packages = rec {
@@ -27,5 +28,9 @@
   varnish76Packages = rec {
     varnish = varnish76;
     modules = (callPackages ./modules.nix { inherit varnish; }).modules25;
+  };
+  varnish77Packages = rec {
+    varnish = varnish77;
+    modules = (callPackages ./modules.nix { inherit varnish; }).modules26;
   };
 }

--- a/pkgs/servers/varnish/packages.nix
+++ b/pkgs/servers/varnish/packages.nix
@@ -2,7 +2,6 @@
   callPackages,
   callPackage,
   varnish60,
-  varnish75,
   varnish76,
   varnish77,
 }:
@@ -20,10 +19,6 @@
       version = "0.4";
       sha256 = "1n94slrm6vn3hpymfkla03gw9603jajclg84bjhwb8kxsk3rxpmk";
     };
-  };
-  varnish75Packages = rec {
-    varnish = varnish75;
-    modules = (callPackages ./modules.nix { inherit varnish; }).modules24;
   };
   varnish76Packages = rec {
     varnish = varnish76;

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -1809,6 +1809,8 @@ mapAliases {
   vaultwarden-vault = vaultwarden.webvault; # Added 2022-12-13
   varnish74 = throw "varnish 7.4 is EOL. Either use the LTS or upgrade."; # Added 2024-10-31
   varnish74Packages = throw "varnish 7.4 is EOL. Either use the LTS or upgrade."; # Added 2024-10-31
+  varnish75 = throw "varnish 7.5 is EOL. Either use the LTS or upgrade."; # Added 22025-03-29
+  varnish75Packages = throw "varnish 7.5 is EOL. Either use the LTS or upgrade."; # Added 2025-03-29
   vdirsyncerStable = vdirsyncer; # Added 2020-11-08, see https://github.com/NixOS/nixpkgs/issues/103026#issuecomment-723428168
   ventoy-bin = ventoy; # Added 2023-04-12
   ventoy-bin-full = ventoy-full; # Added 2023-04-12

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5615,7 +5615,7 @@ with pkgs;
     varnish76Packages
     varnish77Packages
     ;
-  varnishPackages = varnish75Packages;
+  varnishPackages = varnish77Packages;
   varnish = varnishPackages.varnish;
 
   viceroy = callPackage ../development/tools/viceroy {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5607,13 +5607,14 @@ with pkgs;
     varnish60
     varnish75
     varnish76
+    varnish77
     ;
   inherit (callPackages ../servers/varnish/packages.nix { })
     varnish60Packages
     varnish75Packages
     varnish76Packages
+    varnish77Packages
     ;
-
   varnishPackages = varnish75Packages;
   varnish = varnishPackages.varnish;
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5605,13 +5605,11 @@ with pkgs;
 
   inherit (callPackages ../servers/varnish { })
     varnish60
-    varnish75
     varnish76
     varnish77
     ;
   inherit (callPackages ../servers/varnish/packages.nix { })
     varnish60Packages
-    varnish75Packages
     varnish76Packages
     varnish77Packages
     ;


### PR DESCRIPTION
https://varnish-cache.org/docs/7.7/whats-new/changes-7.7.html

varnish75 is EOL and vulnerable to CVE-2025-30346

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
