### PR TITLE
nixosTests.wordpress: migrate to runTest

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1314,7 +1314,7 @@ in {
   wmderland = handleTest ./wmderland.nix {};
   workout-tracker = handleTest ./workout-tracker.nix {};
   wpa_supplicant = import ./wpa_supplicant.nix { inherit pkgs runTest; };
-  wordpress = handleTest ./wordpress.nix {};
+  wordpress = runTest ./wordpress.nix;
   wrappers = handleTest ./wrappers.nix {};
   writefreely = handleTest ./web-apps/writefreely.nix {};
   wstunnel = runTest ./wstunnel.nix;

--- a/nixos/tests/wordpress.nix
+++ b/nixos/tests/wordpress.nix
@@ -1,123 +1,121 @@
-import ./make-test-python.nix (
-  { lib, pkgs, ... }:
+{ lib, config, ... }:
 
-  rec {
-    name = "wordpress";
-    meta = with pkgs.lib.maintainers; {
-      maintainers = [
-        flokli
-        grahamc # under duress!
-        mmilata
+rec {
+  name = "wordpress";
+  meta = with lib.maintainers; {
+    maintainers = [
+      flokli
+      grahamc # under duress!
+      mmilata
+    ];
+  };
+
+  nodes =
+    lib.foldl
+      (
+        a: version:
+        let
+          package = config.node.pkgs."wordpress_${version}";
+        in
+        a
+        // {
+          "wp${version}_httpd" = _: {
+            services.httpd.adminAddr = "webmaster@site.local";
+            services.httpd.logPerVirtualHost = true;
+
+            services.wordpress.webserver = "httpd";
+            services.wordpress.sites = {
+              "site1.local" = {
+                database.tablePrefix = "site1_";
+                inherit package;
+              };
+              "site2.local" = {
+                database.tablePrefix = "site2_";
+                inherit package;
+              };
+            };
+
+            networking.firewall.allowedTCPPorts = [ 80 ];
+            networking.hosts."127.0.0.1" = [
+              "site1.local"
+              "site2.local"
+            ];
+          };
+
+          "wp${version}_nginx" = _: {
+            services.wordpress.webserver = "nginx";
+            services.wordpress.sites = {
+              "site1.local" = {
+                database.tablePrefix = "site1_";
+                inherit package;
+              };
+              "site2.local" = {
+                database.tablePrefix = "site2_";
+                inherit package;
+              };
+            };
+
+            networking.firewall.allowedTCPPorts = [ 80 ];
+            networking.hosts."127.0.0.1" = [
+              "site1.local"
+              "site2.local"
+            ];
+          };
+
+          "wp${version}_caddy" = _: {
+            services.wordpress.webserver = "caddy";
+            services.wordpress.sites = {
+              "site1.local" = {
+                database.tablePrefix = "site1_";
+                inherit package;
+              };
+              "site2.local" = {
+                database.tablePrefix = "site2_";
+                inherit package;
+              };
+            };
+
+            networking.firewall.allowedTCPPorts = [ 80 ];
+            networking.hosts."127.0.0.1" = [
+              "site1.local"
+              "site2.local"
+            ];
+          };
+        }
+      )
+      { }
+      [
+        "6_7"
       ];
-    };
 
-    nodes =
-      lib.foldl
-        (
-          a: version:
-          let
-            package = pkgs."wordpress_${version}";
-          in
-          a
-          // {
-            "wp${version}_httpd" = _: {
-              services.httpd.adminAddr = "webmaster@site.local";
-              services.httpd.logPerVirtualHost = true;
+  testScript = ''
+    import re
 
-              services.wordpress.webserver = "httpd";
-              services.wordpress.sites = {
-                "site1.local" = {
-                  database.tablePrefix = "site1_";
-                  inherit package;
-                };
-                "site2.local" = {
-                  database.tablePrefix = "site2_";
-                  inherit package;
-                };
-              };
+    start_all()
 
-              networking.firewall.allowedTCPPorts = [ 80 ];
-              networking.hosts."127.0.0.1" = [
-                "site1.local"
-                "site2.local"
-              ];
-            };
+    ${lib.concatStrings (
+      lib.mapAttrsToList (name: value: ''
+        ${name}.wait_for_unit("${(value null).services.wordpress.webserver}")
+      '') nodes
+    )}
 
-            "wp${version}_nginx" = _: {
-              services.wordpress.webserver = "nginx";
-              services.wordpress.sites = {
-                "site1.local" = {
-                  database.tablePrefix = "site1_";
-                  inherit package;
-                };
-                "site2.local" = {
-                  database.tablePrefix = "site2_";
-                  inherit package;
-                };
-              };
+    site_names = ["site1.local", "site2.local"]
 
-              networking.firewall.allowedTCPPorts = [ 80 ];
-              networking.hosts."127.0.0.1" = [
-                "site1.local"
-                "site2.local"
-              ];
-            };
+    for machine in (${lib.concatStringsSep ", " (builtins.attrNames nodes)}):
+        for site_name in site_names:
+            machine.wait_for_unit(f"phpfpm-wordpress-{site_name}")
 
-            "wp${version}_caddy" = _: {
-              services.wordpress.webserver = "caddy";
-              services.wordpress.sites = {
-                "site1.local" = {
-                  database.tablePrefix = "site1_";
-                  inherit package;
-                };
-                "site2.local" = {
-                  database.tablePrefix = "site2_";
-                  inherit package;
-                };
-              };
+            with subtest("website returns welcome screen"):
+                assert "Welcome to the famous" in machine.succeed(f"curl -L {site_name}")
 
-              networking.firewall.allowedTCPPorts = [ 80 ];
-              networking.hosts."127.0.0.1" = [
-                "site1.local"
-                "site2.local"
-              ];
-            };
-          }
-        )
-        { }
-        [
-          "6_7"
-        ];
+            with subtest("wordpress-init went through"):
+                info = machine.get_unit_info(f"wordpress-init-{site_name}")
+                assert info["Result"] == "success"
 
-    testScript = ''
-      import re
-
-      start_all()
-
-      ${lib.concatStrings (
-        lib.mapAttrsToList (name: value: ''
-          ${name}.wait_for_unit("${(value null).services.wordpress.webserver}")
-        '') nodes
-      )}
-
-      site_names = ["site1.local", "site2.local"]
-
-      for machine in (${lib.concatStringsSep ", " (builtins.attrNames nodes)}):
-          for site_name in site_names:
-              machine.wait_for_unit(f"phpfpm-wordpress-{site_name}")
-
-              with subtest("website returns welcome screen"):
-                  assert "Welcome to the famous" in machine.succeed(f"curl -L {site_name}")
-
-              with subtest("wordpress-init went through"):
-                  info = machine.get_unit_info(f"wordpress-init-{site_name}")
-                  assert info["Result"] == "success"
-
-              with subtest("secret keys are set"):
-                  pattern = re.compile(r"^define.*NONCE_SALT.{64,};$", re.MULTILINE)
-                  assert pattern.search(
-                      machine.succeed(f"cat /var/lib/wordpress/{site_name}/secret-keys.php")
-                  )
-    '';
-  }
-)
+            with subtest("secret keys are set"):
+                pattern = re.compile(r"^define.*NONCE_SALT.{64,};$", re.MULTILINE)
+                assert pattern.search(
+                    machine.succeed(f"cat /var/lib/wordpress/{site_name}/secret-keys.php")
+                )
+  '';
+}


### PR DESCRIPTION
Part of #386873

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
