### PR TITLE
xee: init at 0.1.5

### DIFF
--- a/pkgs/by-name/xe/xee/package.nix
+++ b/pkgs/by-name/xe/xee/package.nix
@@ -1,0 +1,63 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  writers,
+  versionCheckHook,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "xee";
+  version = "0.1.5";
+
+  src = fetchFromGitHub {
+    owner = "Paligo";
+    repo = "xee";
+    tag = "xee-v${finalAttrs.version}";
+    hash = "sha256-l5g2YZ4lNu+CLyya0FavDEqbJayaTXGrB8fYCr3fj0s=";
+  };
+
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-Ora6VwYLDyFI4iA4FkygGsup8I4OvK0kkLvHs4F/YhY=";
+
+  cargoBuildFlags = [
+    "--package"
+    "xee"
+  ];
+
+  nativeBuildInputs = [
+    # "${cargoDeps}/build-data-0.2.1/src/lib.rs" is pretty terrible
+    (writers.writePython3Bin "git" { } ''
+      import sys
+      import os
+      sys.argv[0] = os.path.basename(sys.argv[0])
+      if sys.argv == ["git", "rev-parse", "HEAD"]:
+          print("${finalAttrs.src.rev}")
+      elif sys.argv == ["git", "rev-parse", "--abbrev-ref=loose", "HEAD"]:
+          print("${finalAttrs.src.rev}")
+      elif sys.argv == ["git", "status", "-s"]:
+          pass
+      elif sys.argv == ["git", "log", "-1", "--pretty=%ct"]:
+          print(os.environ.get("SOURCE_DATE_EPOCH", "0"))
+      else:
+          raise RuntimeError(sys.argv[1:])
+    '')
+  ];
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgramArg = "--version";
+
+  meta = {
+    description = "XML Execution Engine written in Rust.";
+    longDescription = ''
+      Load XML documents, issue XPath expressions against them, including in
+      a REPL, and pretty-print XML documents. A Swiss Army knife CLI for XML.
+    '';
+    homepage = "https://github.com/Paligo/xee";
+    changelog = "https://github.com/Paligo/xee/releases/tag/xee-v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ pbsds ];
+    mainProgram = "xee";
+  };
+})


### PR DESCRIPTION
https://github.com/Paligo/xee
https://blog.startifact.com/posts/xee/

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
