### PR TITLE
sshguard: adding options for subnet bans

### DIFF
--- a/nixos/modules/services/security/sshguard.nix
+++ b/nixos/modules/services/security/sshguard.nix
@@ -19,10 +19,14 @@ let
         ++ (map (name: "-t ${lib.escapeShellArg name}") cfg.services)
       );
       backend = if config.networking.nftables.enable then "sshg-fw-nft-sets" else "sshg-fw-ipset";
+      ipv4_subnet = builtins.toString cfg.ipv4_subnet;
+      ipv6_subnet = builtins.toString cfg.ipv6_subnet;
     in
     pkgs.writeText "sshguard.conf" ''
       BACKEND="${pkgs.sshguard}/libexec/${backend}"
       LOGREADER="LANG=C ${config.systemd.package}/bin/journalctl ${args}"
+      IPV4_SUBNET=${ipv4_subnet}
+      IPV6_SUBNET=${ipv6_subnet}
     '';
 
 in
@@ -79,6 +83,22 @@ in
         type = lib.types.int;
         description = ''
           Remember potential attackers for up to detection_time seconds before resetting their score.
+        '';
+      };
+
+      ipv4_subnet = lib.mkOption {
+        default = 32;
+        type = lib.types.ints.unsigned;
+        description = ''
+          IPv4 subnet size to block. Defaults to a single address, CIDR notation.
+        '';
+      };
+
+      ipv6_subnet = lib.mkOption {
+        default = 128;
+        type = lib.types.ints.unsigned;
+        description = ''
+          IPv6 subnet size to block. Defaults to a single address, CIDR notation.
         '';
       };
 


### PR DESCRIPTION
SSHguard offers option to not only ban a single ip address but a whole subnet. This commit adds subnet banning options in NixOS.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
