### PR TITLE
coolercontrol.*: 1.4.5 -> 2.1.0

### DIFF
--- a/pkgs/applications/system/coolercontrol/coolercontrol-gui.nix
+++ b/pkgs/applications/system/coolercontrol/coolercontrol-gui.nix
@@ -1,16 +1,7 @@
 {
-  lib,
-  rustPlatform,
-  dbus,
-  freetype,
-  gtk3,
-  libsoup_3,
-  openssl,
-  pkg-config,
-  webkitgtk_4_1,
-  libappindicator,
-  makeWrapper,
-  coolercontrol,
+  cmake,
+  stdenv,
+  qt6,
 }:
 
 {
@@ -19,48 +10,26 @@
   meta,
 }:
 
-rustPlatform.buildRustPackage {
+stdenv.mkDerivation {
   pname = "coolercontrol";
   inherit version src;
-  sourceRoot = "${src.name}/coolercontrol-ui/src-tauri";
-
-  useFetchCargoVendor = true;
-  cargoHash = "sha256-C0oVtU6esXOkssKyJ4XzLV2vGCPbvVKgvf3wXo9L158=";
-
-  buildFeatures = [ "custom-protocol" ];
+  sourceRoot = "${src.name}/coolercontrol";
 
   nativeBuildInputs = [
-    makeWrapper
-    pkg-config
+    cmake
+    qt6.wrapQtAppsHook
   ];
 
   buildInputs = [
-    dbus
-    openssl
-    freetype
-    libsoup_3
-    gtk3
-    webkitgtk_4_1
-    libappindicator
+    qt6.qtbase
+    qt6.qtwebengine
   ];
-
-  checkFeatures = [ "custom-protocol" ];
-
-  # copy the frontend static resources to final build directory
-  # Also modify tauri.conf.json so that it expects the resources at the new location
-  postPatch = ''
-    mkdir -p ui-build
-    cp -R ${coolercontrol.coolercontrol-ui-data}/* ui-build/
-    substituteInPlace tauri.conf.json --replace-fail '"frontendDist": "../dist"' '"frontendDist": "ui-build"'
-  '';
 
   postInstall = ''
     install -Dm644 "${src}/packaging/metadata/org.coolercontrol.CoolerControl.desktop" -t "$out/share/applications/"
     install -Dm644 "${src}/packaging/metadata/org.coolercontrol.CoolerControl.metainfo.xml" -t "$out/share/metainfo/"
     install -Dm644 "${src}/packaging/metadata/org.coolercontrol.CoolerControl.png" -t "$out/share/icons/hicolor/256x256/apps/"
     install -Dm644 "${src}/packaging/metadata/org.coolercontrol.CoolerControl.svg" -t "$out/share/icons/hicolor/scalable/apps/"
-    wrapProgram $out/bin/coolercontrol \
-      --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ libappindicator ]}
   '';
 
   meta = meta // {

--- a/pkgs/applications/system/coolercontrol/coolercontrol-ui-data.nix
+++ b/pkgs/applications/system/coolercontrol/coolercontrol-ui-data.nix
@@ -1,4 +1,4 @@
-{ buildNpmPackage, autoPatchelfHook }:
+{ buildNpmPackage }:
 
 {
   version,
@@ -11,15 +11,7 @@ buildNpmPackage {
   inherit version src;
   sourceRoot = "${src.name}/coolercontrol-ui";
 
-  npmDepsHash = "sha256-t+QShKaXpQuEzeeu/ljBBEzeYsxqvMpx5waDZ2gyPAI=";
-
-  preBuild = ''
-    autoPatchelf node_modules/sass-embedded-linux-x64/dart-sass/src/dart
-  '';
-
-  nativeBuildInputs = [ autoPatchelfHook ];
-
-  dontAutoPatchelf = true;
+  npmDepsHash = "sha256-FFVCE3/E+eiTvTeU53cc1Mdbrl5J3+YgYUYltpnGXz0=";
 
   postBuild = ''
     cp -r dist $out

--- a/pkgs/applications/system/coolercontrol/coolercontrold.nix
+++ b/pkgs/applications/system/coolercontrol/coolercontrold.nix
@@ -18,15 +18,14 @@ rustPlatform.buildRustPackage {
   sourceRoot = "${src.name}/coolercontrold";
 
   useFetchCargoVendor = true;
-  cargoHash = "sha256-5gqtSZs/unFobEl1MHec2uhGDrWnO6ITlYbB78VasZg=";
+  cargoHash = "sha256-ZyYyQcaYd3VZ7FL0Hki33JO3LscPfBT5gl+nw2cXvUs=";
 
   buildInputs = [ libdrm ];
 
   postPatch = ''
     # copy the frontend static resources to a directory for embedding
     mkdir -p ui-build
-    cp -R ${coolercontrol.coolercontrol-ui-data}/* ui-build/
-    substituteInPlace build.rs --replace-fail '"./resources/app"' '"./ui-build"'
+    cp -R ${coolercontrol.coolercontrol-ui-data}/* resources/app/
 
     # Hardcode a shell
     substituteInPlace src/repositories/utils.rs \

--- a/pkgs/applications/system/coolercontrol/default.nix
+++ b/pkgs/applications/system/coolercontrol/default.nix
@@ -5,13 +5,13 @@
 }:
 
 let
-  version = "1.4.5";
+  version = "2.1.0";
 
   src = fetchFromGitLab {
     owner = "coolercontrol";
     repo = "coolercontrol";
     rev = version;
-    hash = "sha256-lRw5IcSrLM6aUajt2Ny1IUuGYcAjY1oUDZENyz0wVJI=";
+    hash = "sha256-xIc0ZecQGyjMQWVaucKomu7SbaHy+ymg5dkOjHjtJ9c=";
   };
 
   meta = {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Updates CoolerControl to the new major 2.0 version. Changelog: [2.0.0](https://gitlab.com/coolercontrol/coolercontrol/-/releases/2.0.0), [2.0.1](https://gitlab.com/coolercontrol/coolercontrol/-/releases/2.0.1), [2.1.0](https://gitlab.com/coolercontrol/coolercontrol/-/releases/2.1.0).

A notable change in terms of packaging is that the previous desktop application that required Rust/GTK+ has been replaced by a new one using Qt6's QtWebEngine.

I have tested basic functionality (sans the nvidiaSupport option, as I don't have one) and all seems to work as it should.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
