### PR TITLE
teleport_16: 16.4.18 -> 16.5.0; teleport_17: 17.4.0 -> 17.4.1

### DIFF
--- a/pkgs/servers/teleport/16/default.nix
+++ b/pkgs/servers/teleport/16/default.nix
@@ -2,10 +2,10 @@ args:
 import ../generic.nix (
   args
   // {
-    version = "16.4.18";
-    hash = "sha256-DpbRfWVsfGpIANs6LMtIPtgsCEt5UMoNBpqelMQF+7s=";
-    vendorHash = "sha256-H7EIt9HImdjSQMCv0Jr4mx3woMA6ZSR7KMpQbKvggZU=";
-    pnpmHash = "sha256-LHdX7Vo4neaN+SNrh/De3n/0mR6ZgGvJzNKcxOOHpZA=";
+    version = "16.5.0";
+    hash = "sha256-d634UB/YGDdAeBEJcRsRE5gqd31oQX3P4HJ+PoMQUmk=";
+    vendorHash = "sha256-0/ZYG8mYv3B0YJ89NJVG7M29/hU2zBtSXmoD32VEqpk=";
+    pnpmHash = "sha256-dqCfwMzSnEPQXz1bsroqSihkvw2Kcvyz+A4fpa52LVk=";
     cargoHash = "sha256-NASNBk4QVoqe2cz4l94aXo6pUtF8Qxwb61XRI/ErjTs=";
   }
 )

--- a/pkgs/servers/teleport/17/default.nix
+++ b/pkgs/servers/teleport/17/default.nix
@@ -2,8 +2,8 @@
 import ../generic.nix (
   args
   // {
-    version = "17.4.0";
-    hash = "sha256-O/JMv757DcO7x8Lh5cMeoa1GPvtQETxUlW2meMSSoM0=";
+    version = "17.4.1";
+    hash = "sha256-wXQ2ZFbx/Nx8BzJK/yOGrtGs9ELhRRYlPQIbgBegOHQ=";
     vendorHash = "sha256-C2YpZr9baUUE3pPHXNCIppujYQkioC9DWzSqeigmzmE=";
     pnpmHash = "sha256-Hh4R+mkJJp9CR4NHw+VFzLPxb7e9T1BQkey0in2t934=";
     cargoHash = "sha256-0PT9y56V/WHo3M5TcpVWBuHcQMZ0w2L4rEuXuTvVNFU=";

--- a/pkgs/servers/teleport/generic.nix
+++ b/pkgs/servers/teleport/generic.nix
@@ -14,7 +14,6 @@
   nodejs,
   openssl,
   pkg-config,
-  pnpm_9,
   pnpm_10,
   rustc,
   Security,
@@ -92,16 +91,10 @@ let
 
     pnpmDeps =
       if pnpmHash != null then
-        if lib.versionAtLeast version "17" then
-          pnpm_10.fetchDeps {
-            inherit src pname version;
-            hash = pnpmHash;
-          }
-        else
-          pnpm_9.fetchDeps {
-            inherit src pname version;
-            hash = pnpmHash;
-          }
+        pnpm_10.fetchDeps {
+          inherit src pname version;
+          hash = pnpmHash;
+        }
       else
         null;
 
@@ -118,10 +111,8 @@ let
         wasm-pack
       ]
       ++ (
-        if lib.versionAtLeast version "17" then
+        if lib.versionAtLeast version "16" then
           [ pnpm_10.configHook ]
-        else if lib.versionAtLeast version "16" then
-          [ pnpm_9.configHook ]
         else
           [
             yarn


### PR DESCRIPTION
This also removes the need for distinguishing between `pnpm_9` and `pnpm_10`, as 16.5.0 also migrated to the latter.

Changelog: https://github.com/gravitational/teleport/releases/tag/v17.4.1
Diff: https://github.com/gravitational/teleport/compare/v17.4.0...v17.4.1

Changelog: https://github.com/gravitational/teleport/releases/tag/v16.5.0
Diff: https://github.com/gravitational/teleport/compare/v16.4.18...v16.5.0

cc @techknowlogick 

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
