### PR TITLE
thrift: fix cross build

### DIFF
--- a/pkgs/by-name/th/thrift/package.nix
+++ b/pkgs/by-name/th/thrift/package.nix
@@ -111,6 +111,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Library for scalable cross-language services";
     mainProgram = "thrift";
     homepage = "https://thrift.apache.org/";
+    downloadPage = "https://github.com/apache/thrift";
     license = lib.licenses.asl20;
     platforms = lib.platforms.linux ++ lib.platforms.darwin;
     maintainers = with lib.maintainers; [ bjornfor ];

--- a/pkgs/by-name/th/thrift/package.nix
+++ b/pkgs/by-name/th/thrift/package.nix
@@ -12,6 +12,7 @@
   bison,
   flex,
   ctestCheckHook,
+  buildPackages,
   static ? stdenv.hostPlatform.isStatic,
 }:
 
@@ -26,6 +27,12 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-gGAO+D0A/hEoHMm6OvRBc1Mks9y52kfd0q/Sg96pdW4=";
   };
 
+  postPatch = lib.optionalString (!finalAttrs.finalPackage.doCheck) ''
+    # Compiling the tests doesn't work for cross builds.
+    substituteInPlace lib/py/CMakeLists.txt \
+      --replace-fail 'COMMAND ''${THRIFT_COMPILER} --gen py test/test_thrift_file/TestServer.thrift' ""
+  '';
+
   # Workaround to make the Python wrapper not drop this package:
   # pythonFull.buildEnv.override { extraLibs = [ thrift ]; }
   pythonPath = [ ];
@@ -35,7 +42,7 @@ stdenv.mkDerivation (finalAttrs: {
     cmake
     flex
     pkg-config
-    (python3.withPackages (
+    (buildPackages.python3.withPackages (
       ps:
       with ps;
       [
@@ -74,7 +81,9 @@ stdenv.mkDerivation (finalAttrs: {
 
     # FIXME: Fails to link in static mode with undefined reference to
     # `boost::unit_test::unit_test_main(bool (*)(), int, char**)'
-    (lib.cmakeBool "BUILD_TESTING" (!static))
+    (lib.cmakeBool "BUILD_TESTING" finalAttrs.finalPackage.doCheck)
+    # Building tutorials requires running thrift.
+    (lib.cmakeBool "BUILD_TUTORIALS" (stdenv.buildPlatform.canExecute stdenv.hostPlatform))
   ];
 
   disabledTests = [


### PR DESCRIPTION
## Things done

- [x] built for x86_64-linux
- [x] built for aarch64-linux (cross)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).