### PR TITLE
material-maker: fix crash by using export templates from nixpkgs

### DIFF
--- a/pkgs/by-name/ma/material-maker/package.nix
+++ b/pkgs/by-name/ma/material-maker/package.nix
@@ -3,6 +3,7 @@
   stdenv,
   fetchFromGitHub,
   godot3-headless,
+  godot3-export-templates,
   libglvnd,
   libX11,
   libXcursor,
@@ -45,6 +46,16 @@ stdenv.mkDerivation (finalAttrs: {
     runHook preBuild
 
     export HOME=$TMPDIR
+
+    # Link the export-templates to the expected location. The --export commands
+    # expects the template-file at .../templates/{godot-version}.stable/linux_x11_64_release
+    mkdir -p $HOME/.local/share/godot
+    ln -s ${godot3-export-templates}/share/godot/templates $HOME/.local/share/godot
+
+    # Don't use the included export template, which might use a mismatched version of godot.
+    rm ./material_maker/misc/linux/godot.x11.opt.64
+    substituteInPlace ./export_presets.cfg \
+      --replace-fail '"material_maker/misc/linux/godot.x11.opt.64"' '""'
 
     mkdir -vp build
     godot3-headless -v --export 'Linux/X11' build/material-maker


### PR DESCRIPTION
This was previously using a vendored export template built from godot 3.5.2. This probably happened to work when godot3-headless used the same version, but now that godot3 is on 3.6, you would get this fatal error when launching material-maker:

    ERROR: Pack created with a newer version of the engine: 3.6.
       at: try_open_pack (core/io/file_access_pack.cpp:217)

Instead, use the export templates in nixpkgs (godot3-export-templates). I copied an idiom I saw used for the other godot3 packages.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
