### PR TITLE
ns-3: 39 -> 44, fix build with gcc14

### DIFF
--- a/pkgs/development/libraries/science/networking/ns-3/default.nix
+++ b/pkgs/development/libraries/science/networking/ns-3/default.nix
@@ -63,13 +63,13 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "ns-3";
-  version = "39";
+  version = "44";
 
   src = fetchFromGitLab {
     owner = "nsnam";
     repo = "ns-3-dev";
     rev = "ns-3.${version}";
-    hash = "sha256-2d8xCCfxRpcCZgt7ne17F7cUo/wIxLyvjQs3izNUnmY=";
+    hash = "sha256-rw/WAMk4ZitULqkdyEh9vAFp1UrD1tw2JqgxOT5JQ5I=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
- update to latest release tag (ns-3.44), that contains commit:
https://gitlab.com/nsnam/ns-3-dev/-/commit/5b130ba365831cf54674828e46cfa6b7b69c9f77
it fixes build with gcc14.
Without it build fails with this and similar errors:
```
/build/source/src/core/model/val-array.h:83:16: error: template-id not
allowed for constructor in C++20 []
   83 |     ValArray<T>() = default;
      |                ^
```

Diff: https://gitlab.com/nsnam/ns-3-dev/-/compare/ns-3.39...ns-3.44

Changelog: https://gitlab.com/nsnam/ns-3-dev/-/blob/ns-3.44/CHANGES.md

---

Fixes build failure of `ns-3`, fails since `2024-12-24` (update to GCC14 in #356812):
https://hydra.nixos.org/job/nixos/trunk-combined/nixpkgs.ns-3.x86_64-linux/all
https://hydra.nixos.org/build/293041573

<details>
<summary>Log</summary>

```text
/build/source/src/core/model/val-array.h:83:16: error: template-id not allowed for constructor in C++20 []
   83 |     ValArray<T>() = default;
      |                ^
/build/source/src/core/model/val-array.h:83:16: note: remove the '< >'
/build/source/src/core/model/val-array.h:92:17: error: template-id not allowed for constructor in C++20 []
   92 |     ValArray<T>(size_t numRows, size_t numCols = 1, size_t numPages = 1);
      |                 ^~~~~~
/build/source/src/core/model/val-array.h:92:17: note: remove the '< >'
/build/source/src/core/model/val-array.h:98:25: error: template-id not allowed for constructor in C++20 []
   98 |     explicit ValArray<T>(const std::valarray<T>& values);
      |                         ^
/build/source/src/core/model/val-array.h:98:25: note: remove the '< >'
/build/source/src/core/model/val-array.h:104:22: error: template-id not allowed for constructor in C++20 []
  104 |     ValArray<T>(std::valarray<T>&& values);
      |                      ^~~~~~~~~~~
/build/source/src/core/model/val-array.h:104:22: note: remove the '< >'
/build/source/src/core/model/val-array.h:110:25: error: template-id not allowed for constructor in C++20 []
  110 |     explicit ValArray<T>(const std::vector<T>& values);
      |                         ^
/build/source/src/core/model/val-array.h:110:25: note: remove the '< >'
/build/source/src/core/model/val-array.h:118:17: error: template-id not allowed for constructor in C++20 []
  118 |     ValArray<T>(size_t numRows, size_t numCols, const std::valarray<T>& values);
      |                 ^~~~~~
/build/source/src/core/model/val-array.h:118:17: note: remove the '< >'
/build/source/src/core/model/val-array.h:126:17: error: template-id not allowed for constructor in C++20 []
  126 |     ValArray<T>(size_t numRows, size_t numCols, std::valarray<T>&& values);
      |                 ^~~~~~
/build/source/src/core/model/val-array.h:126:17: note: remove the '< >'
/build/source/src/core/model/val-array.h:136:17: error: template-id not allowed for constructor in C++20 []
  136 |     ValArray<T>(size_t numRows, size_t numCols, size_t numPages, const std::valarray<T>& values);
      |                 ^~~~~~
/build/source/src/core/model/val-array.h:136:17: note: remove the '< >'
/build/source/src/core/model/val-array.h:146:17: error: template-id not allowed for constructor in C++20 []
  146 |     ValArray<T>(size_t numRows, size_t numCols, size_t numPages, std::valarray<T>&& values);
      |                 ^~~~~~
/build/source/src/core/model/val-array.h:146:17: note: remove the '< >'
/build/source/src/core/model/val-array.h:148:13: error: template-id not allowed for destructor in C++20 []
  148 |     virtual ~ValArray<T>() = default;
      |             ^
/build/source/src/core/model/val-array.h:148:13: note: remove the '< >'
/build/source/src/core/model/val-array.h:150:16: error: template-id not allowed for constructor in C++20 []
  150 |     ValArray<T>(const ValArray<T>&) = default;
      |                ^
/build/source/src/core/model/val-array.h:150:16: note: remove the '< >'
/build/source/src/core/model/val-array.h:158:17: error: template-id not allowed for constructor in C++20 []
  158 |     ValArray<T>(ValArray<T>&&) = default;
      |                 ^~~~~~~~~~~
/build/source/src/core/model/val-array.h:158:17: note: remove the '< >'
/build/source/src/core/model/matrix-array.h:86:19: error: template-id not allowed for constructor in C++20 []
   86 |     MatrixArray<T>() = default;
      |                   ^
/build/source/src/core/model/matrix-array.h:86:19: note: remove the '< >'
/build/source/src/core/model/matrix-array.h:95:20: error: template-id not allowed for constructor in C++20 []
   95 |     MatrixArray<T>(size_t numRows, size_t numCols = 1, size_t numPages = 1);
      |                    ^~~~~~
/build/source/src/core/model/matrix-array.h:95:20: note: remove the '< >'
/build/source/src/core/model/matrix-array.h:101:28: error: template-id not allowed for constructor in C++20 []
  101 |     explicit MatrixArray<T>(const std::valarray<T>& values);
      |                            ^
/build/source/src/core/model/matrix-array.h:101:28: note: remove the '< >'
/build/source/src/core/model/matrix-array.h:107:25: error: template-id not allowed for constructor in C++20 []
  107 |     MatrixArray<T>(std::valarray<T>&& values);
      |                         ^~~~~~~~~~~
/build/source/src/core/model/matrix-array.h:107:25: note: remove the '< >'
/build/source/src/core/model/matrix-array.h:113:28: error: template-id not allowed for constructor in C++20 []
  113 |     explicit MatrixArray<T>(const std::vector<T>& values);
      |                            ^
/build/source/src/core/model/matrix-array.h:113:28: note: remove the '< >'
/build/source/src/core/model/matrix-array.h:121:20: error: template-id not allowed for constructor in C++20 []
  121 |     MatrixArray<T>(size_t numRows, size_t numCols, const std::valarray<T>& values);
      |                    ^~~~~~
/build/source/src/core/model/matrix-array.h:121:20: note: remove the '< >'
/build/source/src/core/model/matrix-array.h:129:20: error: template-id not allowed for constructor in C++20 []
  129 |     MatrixArray<T>(size_t numRows, size_t numCols, std::valarray<T>&& values);
      |                    ^~~~~~
/build/source/src/core/model/matrix-array.h:129:20: note: remove the '< >'
/build/source/src/core/model/matrix-array.h:138:20: error: template-id not allowed for constructor in C++20 []
  138 |     MatrixArray<T>(size_t numRows, size_t numCols, size_t numPages, const std::valarray<T>& values);
      |                    ^~~~~~
/build/source/src/core/model/matrix-array.h:138:20: note: remove the '< >'
/build/source/src/core/model/matrix-array.h:147:20: error: template-id not allowed for constructor in C++20 []
  147 |     MatrixArray<T>(size_t numRows, size_t numCols, size_t numPages, std::valarray<T>&& values);
      |                    ^~~~~~
/build/source/src/core/model/matrix-array.h:147:20: note: remove the '< >'
/build/source/src/core/model/matrix-array.h:149:5: error: template-id not allowed for destructor in C++20 []
  149 |     ~MatrixArray<T>() override = default;
      |     ^
/build/source/src/core/model/matrix-array.h:149:5: note: remove the '< >'
/build/source/src/core/model/matrix-array.h:151:19: error: template-id not allowed for constructor in C++20 []
  151 |     MatrixArray<T>(const MatrixArray<T>&) = default;
      |                   ^
/build/source/src/core/model/matrix-array.h:151:19: note: remove the '< >'
/build/source/src/core/model/matrix-array.h:159:20: error: template-id not allowed for constructor in C++20 []
  159 |     MatrixArray<T>(MatrixArray<T>&&) = default;
      |                    ^~~~~~~~~~~~~~
/build/source/src/core/model/matrix-array.h:159:20: note: remove the '< >'
cc1plus: all warnings being treated as errors
make[2]: *** [src/lte/CMakeFiles/liblte-obj.dir/build.make:129: src/lte/CMakeFiles/liblte-obj.dir/helper/lte-global-pathloss-database.cc.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:4446: src/lte/CMakeFiles/liblte-obj.dir/all] Error 2
make[1]: *** Waiting for unfinished jobs....
make: *** [Makefile:136: all] Error 2
```
</details>

Tracking issue: #388196

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
