### PR TITLE
gst-plugins-bad: remove libvdpau, libkate, xvidcore dependencies

### DIFF
--- a/pkgs/development/libraries/gstreamer/bad/default.nix
+++ b/pkgs/development/libraries/gstreamer/bad/default.nix
@@ -23,7 +23,6 @@
 , ldacbt
 , liblc3
 , libass
-, libkate
 , lrdf
 , ladspaH
 , lcms2
@@ -165,7 +164,6 @@ stdenv.mkDerivation (finalAttrs: {
     ldacbt
     liblc3
     libass
-    libkate
     webrtc-audio-processing_1
     libbs2b
     libmodplug

--- a/pkgs/development/libraries/gstreamer/bad/default.nix
+++ b/pkgs/development/libraries/gstreamer/bad/default.nix
@@ -78,7 +78,6 @@
 , svt-av1
 , fluidsynth
 , libva
-, libvdpau
 , wayland
 , libwebp
 , xvidcore
@@ -196,7 +195,6 @@ stdenv.mkDerivation (finalAttrs: {
     soundtouch
     srtp
     fluidsynth
-    libvdpau
     libwebp
     xvidcore
     gnutls

--- a/pkgs/development/libraries/gstreamer/bad/default.nix
+++ b/pkgs/development/libraries/gstreamer/bad/default.nix
@@ -80,7 +80,6 @@
 , libva
 , wayland
 , libwebp
-, xvidcore
 , gnutls
 , mjpegtools
 , libGL
@@ -196,7 +195,6 @@ stdenv.mkDerivation (finalAttrs: {
     srtp
     fluidsynth
     libwebp
-    xvidcore
     gnutls
     game-music-emu
     openssl


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Follow-up to https://github.com/NixOS/nixpkgs/pull/394242, now having my tools optimized to get less false-positive flags about unused dependencies.

Removes `libvdpau`, `libkate` and `xvidcore` which were deleted upstream.

other flagged dependencies i checked:
- [x] sratom
- [x] sord
- [x] libkate
- [ ] libmpeg2

By the looks of it:
mpeg2 is still in use. Whether libmpeg2 is unknown. `libmpeg2` was added in the very first commit to gst-plugins-bad: https://github.com/NixOS/nixpkgs/commit/7a74215face789c9e8b287373f9155840122a236. 

sord and sratom provide LV2 things, and LV2 is in use. See also https://github.com/NixOS/nixpkgs/commit/be382109ad01d0aa8660f2b19a20e345c86d246b

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
