### PR TITLE
drip: unbreak, modernize

### DIFF
--- a/pkgs/by-name/dr/drip/package.nix
+++ b/pkgs/by-name/dr/drip/package.nix
@@ -2,25 +2,30 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  jdk8,
-  which,
   makeWrapper,
+  jdk8,
+  coreutils,
+  which,
+  gnumake,
+  versionCheckHook,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "drip";
   version = "0.2.4";
 
   src = fetchFromGitHub {
     repo = "drip";
     owner = "ninjudd";
-    rev = version;
-    sha256 = "1zl62wdwfak6z725asq5lcqb506la1aavj7ag78lvp155wyh8aq1";
+    tag = finalAttrs.version;
+    hash = "sha256-ASsEPS8l3E3ReerIrVRQ1ICyMKMFa1XE+WYqxxsXhv4=";
   };
 
   nativeBuildInputs = [ makeWrapper ];
 
   buildInputs = [ jdk8 ];
+
+  patches = [ ./wait.patch ];
 
   postPatch = ''
     patchShebangs .
@@ -31,16 +36,26 @@ stdenv.mkDerivation rec {
     mkdir $out
     cp ./* $out -r
     wrapProgram $out/bin/drip \
-      --prefix PATH : "${which}/bin"
-    $out/bin/drip version
+      --prefix PATH : ${
+        lib.makeBinPath [
+          coreutils
+          which
+          gnumake
+          jdk8
+        ]
+      }
     runHook postInstall
   '';
 
-  meta = with lib; {
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgramArg = "version";
+
+  meta = {
     description = "Launcher for the Java Virtual Machine intended to be a drop-in replacement for the java command, only faster";
-    license = licenses.epl10;
+    license = lib.licenses.epl10;
     homepage = "https://github.com/ninjudd/drip";
-    platforms = platforms.linux;
-    maintainers = [ maintainers.rybern ];
+    platforms = lib.platforms.linux;
+    maintainers = [ lib.maintainers.rybern ];
   };
-}
+})

--- a/pkgs/by-name/dr/drip/package.nix
+++ b/pkgs/by-name/dr/drip/package.nix
@@ -56,6 +56,9 @@ stdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.epl10;
     homepage = "https://github.com/ninjudd/drip";
     platforms = lib.platforms.linux;
-    maintainers = [ lib.maintainers.rybern ];
+    maintainers = with lib.maintainers; [
+      rybern
+      awwpotato
+    ];
   };
 })

--- a/pkgs/by-name/dr/drip/wait.patch
+++ b/pkgs/by-name/dr/drip/wait.patch
@@ -1,0 +1,11 @@
+diff --git a/src/drip_daemon.c b/src/drip_daemon.c
+index cbfd4d9..79fdaf4 100644
+--- a/src/drip_daemon.c
++++ b/src/drip_daemon.c
+@@ -5,6 +5,7 @@
+ #include <stdio.h>
+ #include <unistd.h>
+ #include <sys/stat.h>
++#include <sys/wait.h>
+
+ static char* jvm_dir;


### PR DESCRIPTION
Hasn't had any commits in 8 years on the repo so I've patched in the missing include. Also drip-wrapped had some missing deps that I added. Part of #388196
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
