### PR TITLE
libndctl: fix musl build

### DIFF
--- a/pkgs/by-name/li/libndctl/musl-compat.patch
+++ b/pkgs/by-name/li/libndctl/musl-compat.patch
@@ -1,0 +1,22 @@
+diff --git a/daxctl/device.c b/daxctl/device.c
+index e3993b1..0b2f20d 100644
+--- a/daxctl/device.c
++++ b/daxctl/device.c
+@@ -23,6 +23,8 @@
+ #include "filter.h"
+ #include "json.h"
+ 
++#include <libgen.h>
++
+ static struct {
+ 	const char *dev;
+ 	const char *mode;
+@@ -366,7 +368,7 @@ static const char *parse_device_options(int argc, const char **argv,
+ 
+ 	argc = parse_options(argc, argv, options, u, 0);
+ 	if (argc > 0)
+-		device = basename(argv[0]);
++		device = basename(strdup(argv[0]));
+ 
+ 	/* Handle action-agnostic non-option arguments */
+ 	if (argc == 0 &&

--- a/pkgs/by-name/li/libndctl/package.nix
+++ b/pkgs/by-name/li/libndctl/package.nix
@@ -25,6 +25,13 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-gG1Rz5AtDLzikGFr8A3l25ypd+VoLw2oWjszy9ogDLk=";
   };
 
+  patches = lib.optionals (!stdenv.hostPlatform.isGnu) [
+    # Use POSIX basename on non-glib.
+    # Remove when https://github.com/pmem/ndctl/pull/263
+    # or equivalent fix is merged and released.
+    ./musl-compat.patch
+  ];
+
   outputs = [
     "out"
     "man"


### PR DESCRIPTION
Technically this patch will leak the first argument passed to daxctl, so I made it optional. But it is a short-running CLI tool it doesn't matter much.

Upstream PR https://github.com/pmem/ndctl/pull/263

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).