### PR TITLE
givaro: fix cross build, add meta.homepage

### DIFF
--- a/pkgs/development/libraries/givaro/default.nix
+++ b/pkgs/development/libraries/givaro/default.nix
@@ -44,6 +44,8 @@ stdenv.mkDerivation rec {
       url = "https://github.com/linbox-team/givaro/commit/a18baf5227d4f3e81a50850fe98e0d954eaa3ddb.patch";
       hash = "sha256-IR0IHhCqbxgtsST30vxM9ak1nGtt0apxcLUQ1kS1DHw=";
     })
+    # skip gmp version check for cross-compiling, our version is new enough
+    ./skip-gmp-check.patch
   ];
 
   enableParallelBuilding = true;
@@ -59,6 +61,7 @@ stdenv.mkDerivation rec {
   configureFlags =
     [
       "--without-archnative"
+      "CCNAM=${stdenv.cc.cc.pname}"
     ]
     ++ lib.optionals stdenv.hostPlatform.isx86_64 [
       # disable SIMD instructions (which are enabled *when available* by default)

--- a/pkgs/development/libraries/givaro/default.nix
+++ b/pkgs/development/libraries/givaro/default.nix
@@ -12,12 +12,14 @@
 stdenv.mkDerivation rec {
   pname = "givaro";
   version = "4.2.0";
+
   src = fetchFromGitHub {
     owner = "linbox-team";
-    repo = pname;
-    rev = "v${version}";
+    repo = "givaro";
+    tag = "v${version}";
     sha256 = "sha256-KR0WJc0CSvaBnPRott4hQJhWNBb/Wi6MIhcTExtVobQ=";
   };
+
   patches = [
     # Pull upstream fix for gcc-13:
     #   https://github.com/linbox-team/givaro/pull/218
@@ -83,6 +85,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "C++ library for arithmetic and algebraic computations";
+    homepage = "https://casys.gricad-pages.univ-grenoble-alpes.fr/givaro/";
     mainProgram = "givaro-config";
     license = lib.licenses.cecill-b;
     maintainers = [ lib.maintainers.raskin ];

--- a/pkgs/development/libraries/givaro/skip-gmp-check.patch
+++ b/pkgs/development/libraries/givaro/skip-gmp-check.patch
@@ -1,0 +1,26 @@
+diff --git a/macros/gmp-check.m4 b/macros/gmp-check.m4
+index 72eba8c..25af64e 100644
+--- a/macros/gmp-check.m4
++++ b/macros/gmp-check.m4
+@@ -105,21 +105,6 @@ AC_DEFUN([GIV_CHECK_GMP], [
+ 		exit 1
+ 	])
+ 
+-	AC_MSG_CHECKING([whether gmp version is at least $min_gmp_release])
+-	AC_TRY_RUN(
+-		[ 
+-			#include <cstddef>
+-			#include <gmp.h>
+-			int main () {
+-				return (__GNU_MP_RELEASE < $min_gmp_release);
+-			}
+-		],
+-		[ AC_MSG_RESULT(yes)
+-		],
+-		[ AC_MSG_RESULT(no)
+-		  AC_MSG_ERROR(your GMP is too old. GMP release >= $min_gmp_release needed)
+-		  exit 1]
+-	)
+ 	AC_LANG_POP([C++])
+ 	
+ 	AC_SUBST(GMP_CFLAGS)


### PR DESCRIPTION


## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux (cross)
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).