### PR TITLE
maelstrom: fix build with gcc14, modernize

### DIFF
--- a/pkgs/by-name/ma/maelstrom/add-maelstrom-netd-include-time.diff
+++ b/pkgs/by-name/ma/maelstrom/add-maelstrom-netd-include-time.diff
@@ -1,0 +1,12 @@
+diff --git a/Maelstrom-netd.c b/Maelstrom-netd.c
+index 3e6e942..41ed9a5 100644
+--- a/Maelstrom-netd.c
++++ b/Maelstrom-netd.c
+@@ -13,6 +13,7 @@
+ #include <arpa/inet.h>
+ #include <netdb.h>
+ #include <unistd.h>
++#include <time.h>
+
+ /* We wait in a loop for players to connect and tell us how many people
+    are playing.  Then, once all players have connected, then we broadcast

--- a/pkgs/by-name/ma/maelstrom/package.nix
+++ b/pkgs/by-name/ma/maelstrom/package.nix
@@ -21,6 +21,8 @@ stdenv.mkDerivation rec {
     ./fix-compilation.patch
     # removes register keyword
     ./c++17-fixes.diff
+    # fix build with gcc14
+    ./add-maelstrom-netd-include-time.diff
   ];
 
   buildInputs = [

--- a/pkgs/by-name/ma/maelstrom/package.nix
+++ b/pkgs/by-name/ma/maelstrom/package.nix
@@ -7,12 +7,12 @@
   SDL2_net,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "maelstrom";
   version = "3.0.7";
 
   src = fetchurl {
-    url = "http://www.libsdl.org/projects/Maelstrom/src/Maelstrom-${version}.tar.gz";
+    url = "http://www.libsdl.org/projects/Maelstrom/src/Maelstrom-${finalAttrs.version}.tar.gz";
     sha256 = "0dm0m5wd7amrsa8wnrblkv34sq4v4lglc2wfx8klfkdhyhi06s4k";
   };
 
@@ -46,11 +46,11 @@ stdenv.mkDerivation rec {
     })
   ];
 
-  meta = with lib; {
+  meta = {
     description = "Arcade-style game resembling Asteroids";
     mainProgram = "maelstrom";
-    license = licenses.gpl2Plus;
-    platforms = platforms.all;
-    maintainers = with maintainers; [ tmountain ];
+    license = lib.licenses.gpl2Plus;
+    platforms = lib.platforms.all;
+    maintainers = with lib.maintainers; [ tmountain ];
   };
-}
+})


### PR DESCRIPTION
maelstrom: fix build with gcc14
- add patch with `#include <time.h>` fixing:
`error: implicit declaration of function 'time'`

---

maelstrom: modernize
- convert `rec` to `finalAttrs`
- remove `with lib;` from `meta`

---

Fixes build of `maelstrom`, fails since `2025-01-14` (update to GCC14 - #356812):
https://hydra.nixos.org/job/nixos/trunk-combined/nixpkgs.maelstrom.x86_64-linux
https://hydra.nixos.org/build/293037454

Log:
```text
Maelstrom-netd.c: In function 'CheckPlayers':
Maelstrom-netd.c:93:15: error: implicit declaration of function 'time' []
   93 |         now = time(NULL);
      |               ^~~~
Maelstrom-netd.c:26:1: note: 'time' is defined in header '<time.h>'; this is probably fixable by adding '#include <time.h>'
   25 | #include "protocol.h"
  +++ |+#include <time.h>
   26 | 
```

Tracking issue: #388196

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
