### PR TITLE
redfang: unbreak on GCC 14, modernize

### DIFF
--- a/pkgs/by-name/re/redfang/include-pthread.patch
+++ b/pkgs/by-name/re/redfang/include-pthread.patch
@@ -1,0 +1,12 @@
+diff --git a/fang.c b/fang.c
+index cda61bf..52f9659 100755
+--- a/fang.c
++++ b/fang.c
+@@ -45,6 +45,7 @@
+ #include <sys/socket.h>
+ #include <asm/types.h>
+ #include <netinet/in.h>
++#include <pthread.h>
+
+ #include <bluetooth/bluetooth.h>
+ #include <bluetooth/hci.h>

--- a/pkgs/by-name/re/redfang/package.nix
+++ b/pkgs/by-name/re/redfang/package.nix
@@ -6,7 +6,7 @@
   bluez,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "redfang";
   version = "2.5";
 
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
     group = "kalilinux";
     owner = "packages";
     repo = "redfang";
-    rev = "upstream/${version}";
+    rev = "upstream/${finalAttrs.version}";
     hash = "sha256-dF9QmBckyHAZ+JbLr0jTmp0eMu947unJqjrTMsJAfIE=";
   };
 
@@ -24,6 +24,8 @@ stdenv.mkDerivation rec {
       url = "https://gitlab.com/kalilinux/packages/redfang/-/merge_requests/1.diff";
       sha256 = "sha256-oxIrUAucxsBL4+u9zNNe2XXoAd088AEAHcRB/AN7B1M=";
     })
+    # error: implicit declaration of function 'pthread_create' []
+    ./include-pthread.patch
   ];
 
   installFlags = [ "DESTDIR=$(out)" ];
@@ -32,11 +34,11 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ bluez ];
 
-  meta = with lib; {
+  meta = {
     description = "Small proof-of-concept application to find non discoverable bluetooth devices";
     homepage = "https://gitlab.com/kalilinux/packages/redfang";
-    license = licenses.gpl2Only;
-    maintainers = with maintainers; [ moni ];
+    license = lib.licenses.gpl2Only;
+    maintainers = with lib.maintainers; [ moni ];
     mainProgram = "fang";
   };
-}
+})


### PR DESCRIPTION
#388196
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
