### PR TITLE
ttf2pt1: fix build with gcc14, modernize

### DIFF
--- a/pkgs/by-name/tt/ttf2pt1/package.nix
+++ b/pkgs/by-name/tt/ttf2pt1/package.nix
@@ -7,12 +7,12 @@
   fetchpatch,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "ttf2pt1";
   version = "3.4.4";
 
   src = fetchurl {
-    url = "mirror://sourceforge/ttf2pt1/ttf2pt1-${version}.tgz";
+    url = "mirror://sourceforge/ttf2pt1/ttf2pt1-${finalAttrs.version}.tgz";
     sha256 = "1l718n4k4widx49xz7qrj4mybzb8q67kp2jw7f47604ips4654mf";
   };
 
@@ -50,4 +50,4 @@ stdenv.mkDerivation rec {
     license = "ttf2pt1";
     platforms = lib.platforms.linux;
   };
-}
+})

--- a/pkgs/by-name/tt/ttf2pt1/package.nix
+++ b/pkgs/by-name/tt/ttf2pt1/package.nix
@@ -4,6 +4,7 @@
   fetchurl,
   perl,
   freetype,
+  fetchpatch,
 }:
 
 stdenv.mkDerivation rec {
@@ -28,7 +29,20 @@ stdenv.mkDerivation rec {
   buildInputs = [ freetype ];
   nativeBuildInputs = [ perl ];
 
-  patches = ./gentoo-makefile.patch; # also contains the freetype patch
+  patches = [
+    ./gentoo-makefile.patch # also contains the freetype patch
+
+    # fix build with c99
+    # https://src.fedoraproject.org/rpms/ttf2pt1/c/070de5269475785d27ae7996513bee12cb9a0f53
+    (fetchpatch {
+      url = "https://src.fedoraproject.org/rpms/ttf2pt1/raw/070de5269475785d27ae7996513bee12cb9a0f53/f/ttf2pt1-c99.patch";
+      hash = "sha256-7+RnExqxED+fUJSj3opfYi0eQ5zqswOZnKjQMvlF020=";
+    })
+
+    # fix build with gcc14
+    # https://src.fedoraproject.org/rpms/ttf2pt1/c/1ebb612acb7088095c6bd7242209f0ce848895fb
+    ./ttf2pt1-gcc14.patch
+  ];
 
   meta = {
     description = "True Type to Postscript Type 3 converter, fpdf";

--- a/pkgs/by-name/tt/ttf2pt1/ttf2pt1-gcc14.patch
+++ b/pkgs/by-name/tt/ttf2pt1/ttf2pt1-gcc14.patch
@@ -1,0 +1,47 @@
+diff --git a/ft.c b/ft.c
+index 4ca1ca6..3ae9ac9 100644
+--- a/ft.c
++++ b/ft.c
+@@ -457,7 +457,7 @@ static double lastx, lasty;
+ 
+ static int
+ outl_moveto(
+-	FT_Vector *to,
++	const FT_Vector *to,
+ 	void *unused
+ )
+ {
+@@ -477,7 +477,7 @@ outl_moveto(
+ 
+ static int
+ outl_lineto(
+-	FT_Vector *to,
++	const FT_Vector *to,
+ 	void *unused
+ )
+ {
+@@ -493,8 +493,8 @@ outl_lineto(
+ 
+ static int
+ outl_conicto(
+-	FT_Vector *control1,
+-	FT_Vector *to,
++	const FT_Vector *control1,
++	const FT_Vector *to,
+ 	void *unused
+ )
+ {
+@@ -514,9 +514,9 @@ outl_conicto(
+ 
+ static int
+ outl_cubicto(
+-	FT_Vector *control1,
+-	FT_Vector *control2,
+-	FT_Vector *to,
++	const FT_Vector *control1,
++	const FT_Vector *control2,
++	const FT_Vector *to,
+ 	void *unused
+ )
+ {
+


### PR DESCRIPTION
ttf2pt1: fix build with gcc14

- add patch fixing build with c99 from fedora:
https://src.fedoraproject.org/rpms/ttf2pt1/c/070de5269475785d27ae7996513bee12cb9a0f53
Fixes build error:
```
t1asm.c: In function 'main':
t1asm.c:501:15: error: implicit declaration of function 'getopt';
did you mean 'getsubopt'? []
  501 |   while ((c = getopt(argc, argv, "bl:")) != -1)
      |               ^~~~~~
      |               getsubopt
```

- add patch fixing build with gcc14 from fedora
https://src.fedoraproject.org/rpms/ttf2pt1/c/1ebb612acb7088095c6bd7242209f0ce848895fb
Patch does not apply as is with `fetchpatch` because of incorrect listed files: `diff -u ft.c{.orig,}`.
Fixes `-Wincompatible-pointer-types` errors:
`error: intialization of ... from incompatible pointer type ...`
for `outl_moveto`, `outl_lineto`, `outl_conicto` and `outl_cubicto` in `ft.c`

---

ttf2pt1: modernize

- replace `rec` with `finalAttrs`

---

Fixes build failure of `ttf2pt1` since `2025-01-14` (update to GCC14 - #356812):
https://hydra.nixos.org/job/nixos/trunk-combined/nixpkgs.ttf2pt1.x86_64-linux
https://hydra.nixos.org/build/282623787

Log:
```text
t1asm.c: In function 'main':
t1asm.c:501:15: error: implicit declaration of function 'getopt'; did you mean 'getsubopt'? [8;;https://gcc.gnu.org/onlinedocs/gcc-14.2.0/gcc/Warning-Options.html#index-Wimplicit-function-declaration-Wimplicit-function-declaration8;;]
  501 |   while ((c = getopt(argc, argv, "bl:")) != -1)
      |               ^~~~~~
      |               getsubopt
make: *** [Makefile:182: t1asm] Error 1
```

Log after applying C99 patch:
```text
ft.c: At top level:
ft.c:537:9: error: initialization of 'int (*)(const FT_Vector *, void *)' {aka 'int (*)(const struct FT_Vector_ *, void *)'} from incompatible pointer type 'int (*)(FT_Vector *, void *)' {aka 'int (*)(struct FT_Vector_ *, void *)'} [-Wincompatible-pointer-types]
  537 |         outl_moveto,
      |         ^~~~~~~~~~~
ft.c:537:9: note: (near initialization for 'ft_outl_funcs.move_to')
ft.c:538:9: error: initialization of 'int (*)(const FT_Vector *, void *)' {aka 'int (*)(const struct FT_Vector_ *, void *)'} from incompatible pointer type 'int (*)(FT_Vector *, void *)' {aka 'int (*)(struct FT_Vector_ *, void *)'} [-Wincompatible-pointer-types]
  538 |         outl_lineto,
      |         ^~~~~~~~~~~
ft.c:538:9: note: (near initialization for 'ft_outl_funcs.line_to')
ft.c:539:9: error: initialization of 'int (*)(const FT_Vector *, const FT_Vector *, void *)' {aka 'int (*)(const struct FT_Vector_ *, const struct FT_Vector_ *, void *)'} from incompatible pointer type 'int (*)(FT_Vector *, FT_Vector *, void *)' {aka 'int (*)(struct FT_Vector_ *, struct FT_Vector_ *, void *)'} [-Wincompatible-pointer-types]
  539 |         outl_conicto,
      |         ^~~~~~~~~~~~
ft.c:539:9: note: (near initialization for 'ft_outl_funcs.conic_to')
ft.c:540:9: error: initialization of 'int (*)(const FT_Vector *, const FT_Vector *, const FT_Vector *, void *)' {aka 'int (*)(const struct FT_Vector_ *, const struct FT_Vector_ *, const struct FT_Vector_ *, void *)'} from incompatible pointer type 'int (*)(FT_Vector *, FT_Vector *, FT_Vector *, void *)' {aka 'int (*)(struct FT_Vector_ *, struct FT_Vector_ *, struct FT_Vector_ *, void *)'} [-Wincompatible-pointer-types]
  540 |         outl_cubicto,
      |         ^~~~~~~~~~~~
ft.c:540:9: note: (near initialization for 'ft_outl_funcs.cubic_to')
make: *** [Makefile:194: ft.o] Error 1
```

With gcc14 patch on top, build succeeded.

Reason for including gcc14 patch (instead of doing `fetchpatch`):
```
...
applying patch /nix/store/v2zy7xbg7fc3m93lpqks69kgxxxv931l-ttf2pt1-gcc14.patch
can't find file to patch at input line 3
Perhaps you used the wrong -p or --strip option?
The text leading up to this was:
--------------------------
|--- ft.c.orig  2024-01-30 08:59:49.000000000 +0100
|+++ ft.c       2024-01-30 09:25:05.000000000 +0100
--------------------------
File to patch:
Skip this patch? [y]
Skipping patch.
4 out of 4 hunks ignored
```

Tracking issue: #388196

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
