### PR TITLE
nixos/bash: reset title bar when logging out from remote NixOS system

### DIFF
--- a/nixos/modules/programs/bash/bash.nix
+++ b/nixos/modules/programs/bash/bash.nix
@@ -112,7 +112,14 @@ in
       };
 
       logout = lib.mkOption {
-        default = "";
+        # Reset the title bar when logging out.  This protects against a remote
+        # NixOS system clobbering your local terminal's title bar when you SSH
+        # into the remote NixOS system and then log out.
+        #
+        # For more details, see: https://superuser.com/a/339946
+        default = ''
+          printf '\e]0;\a'
+        '';
         description = ''
           Shell script code called during login bash shell logout.
         '';

--- a/nixos/modules/programs/bash/bash.nix
+++ b/nixos/modules/programs/bash/bash.nix
@@ -111,6 +111,13 @@ in
         internal = true;
       };
 
+      logout = lib.mkOption {
+        default = "";
+        description = ''
+          Shell script code called during login bash shell logout.
+        '';
+        type = lib.types.lines;
+      };
     };
 
   };
@@ -194,6 +201,21 @@ in
         # Read system-wide modifications.
         if test -f /etc/bashrc.local; then
             . /etc/bashrc.local
+        fi
+      '';
+
+      environment.etc.bash_logout.text = ''
+        # /etc/bash_logout: DO NOT EDIT -- this file has been generated automatically.
+
+        # Only execute this file once per shell.
+        if [ -n "$__ETC_BASHLOGOUT_SOURCED" ] || [ -n "$NOSYSBASHLOGOUT" ]; then return; fi
+        __ETC_BASHLOGOUT_SOURCED=1
+
+        ${cfg.logout}
+
+        # Read system-wide modifications.
+        if test -f /etc/bash_logout.local; then
+            . /etc/bash_logout.local
         fi
       '';
 


### PR DESCRIPTION
The motivation for this change is to fix the issue where if you `ssh` into a NixOS system and then log out the title bar is permanently hosed.  Specifically, when you `ssh` into a NixOS system it will add `${USER}@${HOST}` to the title bar, but when you log out of that system the title bar will still have `${USER}@${HOST}` afterwards.

The solution I went with is the one described in [this StackOverflow answer](https://superuser.com/a/339946) to reset the title bar using the `/etc/bash_logout` script, which will then prompt the local shell to restore its own default title bar.  That in turn entailed adding a new NixOS option to configure `/etc/bash_logout`.

Note that `/etc/bash_logout` is a NixOS-specific thing.  Stock Bash doesn't support a global `/etc/bash_logout` script and only supports user-local `~/.bash_logout` scripts but Nixpkgs patches Bash to support `/etc/bash_logout`, which is why this change works.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
