### PR TITLE
imgui: add docking and multi-viewports support, 1.91.4 -> 1.91.9b

### DIFF
--- a/pkgs/development/libraries/imgui/default.nix
+++ b/pkgs/development/libraries/imgui/default.nix
@@ -41,7 +41,7 @@
   IMGUI_FREETYPE ? false,
   IMGUI_FREETYPE_LUNASVG ? false,
   IMGUI_USE_WCHAR32 ? false,
-}@args:
+}:
 
 let
   vcpkgSource = applyPatches {
@@ -56,9 +56,9 @@ let
   };
 in
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "imgui";
-  version = "1.91.4";
+  version = "1.91.9b";
   outputs = [
     # Note: no "dev" because vcpkg installs include/ and imgui-config.cmake
     # into different prefixes but expects the merged layout at import time
@@ -69,8 +69,8 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "ocornut";
     repo = "imgui";
-    tag = "v${version}";
-    hash = "sha256-6j4keBOAzbBDsV0+R4zTNlsltxz2dJDGI43UIrHXDNM=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-dkukDP0HD8CHC2ds0kmqy7KiGIh4148hMCyA1QF3IMo=";
   };
 
   cmakeRules = "${vcpkgSource}/ports/imgui";
@@ -142,7 +142,8 @@ stdenv.mkDerivation rec {
     license = lib.licenses.mit; # vcpkg licensed as MIT too
     maintainers = with lib.maintainers; [
       SomeoneSerge
+      ivyfanchiang
     ];
     platforms = lib.platforms.all;
   };
-}
+})

--- a/pkgs/development/libraries/imgui/default.nix
+++ b/pkgs/development/libraries/imgui/default.nix
@@ -41,9 +41,27 @@
   IMGUI_FREETYPE ? false,
   IMGUI_FREETYPE_LUNASVG ? false,
   IMGUI_USE_WCHAR32 ? false,
+  # Enable docking and multi-viewports features[^2]
+  # [^2]: https://github.com/ocornut/imgui/wiki/Docking
+  dockingSupport ? false,
 }:
 
 let
+  version = "1.91.9b";
+  srcs = {
+    master = fetchFromGitHub {
+      owner = "ocornut";
+      repo = "imgui";
+      tag = "v${version}";
+      hash = "sha256-dkukDP0HD8CHC2ds0kmqy7KiGIh4148hMCyA1QF3IMo=";
+    };
+    docking = fetchFromGitHub {
+      owner = "ocornut";
+      repo = "imgui";
+      tag = "v${version}-docking";
+      hash = "sha256-mQOJ6jCN+7VopgZ61yzaCnt4R1QLrW7+47xxMhFRHLQ=";
+    };
+  };
   vcpkgSource = applyPatches {
     inherit (vcpkg) src;
     patches = [
@@ -58,7 +76,7 @@ in
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "imgui";
-  version = "1.91.9b";
+  inherit version;
   outputs = [
     # Note: no "dev" because vcpkg installs include/ and imgui-config.cmake
     # into different prefixes but expects the merged layout at import time
@@ -66,12 +84,7 @@ stdenv.mkDerivation (finalAttrs: {
     "lib"
   ];
 
-  src = fetchFromGitHub {
-    owner = "ocornut";
-    repo = "imgui";
-    tag = "v${finalAttrs.version}";
-    hash = "sha256-dkukDP0HD8CHC2ds0kmqy7KiGIh4148hMCyA1QF3IMo=";
-  };
+  src = if dockingSupport then srcs.docking else srcs.master;
 
   cmakeRules = "${vcpkgSource}/ports/imgui";
   postPatch = ''

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9218,6 +9218,7 @@ with pkgs;
   imgui = callPackage ../development/libraries/imgui {
     stdenv = if stdenv.hostPlatform.isDarwin then overrideSDK stdenv "11.0" else stdenv;
   };
+  imgui-docking = imgui.override { dockingSupport = true; };
 
   imlib2Full = imlib2.override {
     # Compilation error on Darwin with librsvg. For more information see:


### PR DESCRIPTION
Adds [docking](https://github.com/ocornut/imgui/wiki/Docking) and multi-viewports support to ImGui which can be enabled with the `dockingSupport` argument or with the `imgui-docking` alias. The docking features can be found upstream in the `docking` branch which is mostly API stable[^1], well maintained[^2], recieves regular releases, and used by many other programs and libraries like [ImHex](https://search.nixos.org/packages?query=imhex) and [Dear PyGui](https://dearpygui.readthedocs.io/en/latest/)[^3].

Also version bumps from 1.91.4 to [1.91.9b](https://github.com/ocornut/imgui/releases/tag/v1.91.9b) and changes `rec` to `finalAttrs` pattern. 

[^1]: https://github.com/ocornut/imgui/wiki/Docking#why-is-not-merged-to-master
[^2]: https://github.com/ocornut/imgui/wiki/Docking#where-to-find-it
[^3]: https://github.com/hoffstadt/DearPyGui/issues/1689#issuecomment-1093067793

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
