### PR TITLE
python3: Fixing excessive memory usage for overriden python in cross-compile

### DIFF
--- a/pkgs/development/interpreters/python/passthrufun.nix
+++ b/pkgs/development/interpreters/python/passthrufun.nix
@@ -106,10 +106,6 @@ let
           python = self;
         }
     );
-  pythonOnBuildForHost_overridden = pythonOnBuildForHost.override {
-    inherit packageOverrides;
-    self = pythonOnBuildForHost_overridden;
-  };
 in
 rec {
   isPy27 = pythonVersion == "2.7";
@@ -144,7 +140,7 @@ rec {
   pythonAtLeast = lib.versionAtLeast pythonVersion;
   pythonOlder = lib.versionOlder pythonVersion;
   inherit hasDistutilsCxxPatch;
-  pythonOnBuildForHost = pythonOnBuildForHost_overridden;
+  inherit pythonOnBuildForHost;
 
   tests = callPackage ./tests.nix {
     python = self;


### PR DESCRIPTION
An attempt to address #338231. The current release of nixpkgs takes over 20GB of memory to evaluate python when the interpreter is overriden. This adds memoization to the spliced python packages to avoid evaluating all the commbinations of overrides.

Tested with 
`command time -v nix-build ./. -A pkgsCross.aarch64-multiplatform.home-assistant`
**Before (22.176272GB)** 
```
/nix/store/lr44rdql62pgq6ji59f2pgmgcn7b5vg4-homeassistant-2025.3.4-aarch64-unknown-linux-gnu
        Command being timed: "nix-build ./. -A pkgsCross.aarch64-multiplatform.home-assistant"
        User time (seconds): 24.91
        System time (seconds): 6.91
        Percent of CPU this job got: 88%
        Elapsed (wall clock) time (h:mm:ss or m:ss): 0:35.82
        Average shared text size (kbytes): 0
        Average unshared data size (kbytes): 0
        Average stack size (kbytes): 0
        Average total size (kbytes): 0
        Maximum resident set size (kbytes): 22176272
        Average resident set size (kbytes): 0
        Major (requiring I/O) page faults: 0
        Minor (reclaiming a frame) page faults: 5545717
        Voluntary context switches: 39869
        Involuntary context switches: 830
        Swaps: 0
        File system inputs: 64
        File system outputs: 192
        Socket messages sent: 0
        Socket messages received: 0
        Signals delivered: 0
        Page size (bytes): 4096
        Exit status: 0
```
**After (0.921048GB)**
```
/nix/store/lr44rdql62pgq6ji59f2pgmgcn7b5vg4-homeassistant-2025.3.4-aarch64-unknown-linux-gnu
        Command being timed: "nix-build ./. -A pkgsCross.aarch64-multiplatform.home-assistant"
        User time (seconds): 2.40
        System time (seconds): 0.49
        Percent of CPU this job got: 63%
        Elapsed (wall clock) time (h:mm:ss or m:ss): 0:04.57
        Average shared text size (kbytes): 0
        Average unshared data size (kbytes): 0
        Average stack size (kbytes): 0
        Average total size (kbytes): 0
        Maximum resident set size (kbytes): 921048
        Average resident set size (kbytes): 0
        Major (requiring I/O) page faults: 0
        Minor (reclaiming a frame) page faults: 231995
        Voluntary context switches: 17321
        Involuntary context switches: 171
        Swaps: 0
        File system inputs: 13696
        File system outputs: 160
        Socket messages sent: 0
        Socket messages received: 0
        Signals delivered: 0
        Page size (bytes): 4096
        Exit status: 0
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
