### PR TITLE
kdePackages.kio: allow loading admin worker from /nix/store

### DIFF
--- a/pkgs/kde/frameworks/kio/allow-admin-from-store.patch
+++ b/pkgs/kde/frameworks/kio/allow-admin-from-store.patch
@@ -1,0 +1,20 @@
+diff --git a/src/core/worker.cpp b/src/core/worker.cpp
+index da423731c..443c8db19 100644
+--- a/src/core/worker.cpp
++++ b/src/core/worker.cpp
+@@ -343,13 +343,13 @@ Worker *Worker::createWorker(const QString &protocol, const QUrl &url, int &erro
+         return nullptr;
+     }
+ 
+-    if (protocol == QLatin1String("admin") && !lib_path.startsWith(QLatin1String{KDE_INSTALL_FULL_KIO_PLUGINDIR})) {
++    if (protocol == QLatin1String("admin") && !lib_path.startsWith(QLatin1String("/nix/store"))) {
+         error_text = i18nc("@info %2 and %3 are paths",
+                            "The KIO worker for protocol “%1” in %2 was not loaded because all KIO workers which are located outside of %3 and ask for elevated "
+                            "privileges are considered insecure.",
+                            protocol,
+                            lib_path,
+-                           QLatin1String{KDE_INSTALL_FULL_KIO_PLUGINDIR});
++                           QLatin1String("/nix/store"));
+         error = KIO::ERR_CANNOT_CREATE_WORKER;
+         return nullptr;
+     }

--- a/pkgs/kde/frameworks/kio/default.nix
+++ b/pkgs/kde/frameworks/kio/default.nix
@@ -11,6 +11,8 @@ mkKdeDerivation {
   patches = [
     # Remove hardcoded smbd search path
     ./0001-Remove-impure-smbd-search-path.patch
+    # Allow loading kio-admin from the store
+    ./allow-admin-from-store.patch
   ];
 
   extraBuildInputs = [


### PR DESCRIPTION
This does technically somewhat extend the trust boundary, but users with permissions to put things in the store can basically do anything they want anyway, so this should be fine(tm).

Fixes #394540.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
