### PR TITLE
verilator: 5.028 -> 5.034

### DIFF
--- a/pkgs/by-name/ve/verilator/package.nix
+++ b/pkgs/by-name/ve/verilator/package.nix
@@ -14,11 +14,12 @@
   git,
   numactl,
   coreutils,
+  gdb,
 }:
 
 stdenv.mkDerivation rec {
   pname = "verilator";
-  version = "5.028";
+  version = "5.034";
 
   # Verilator gets the version from this environment variable
   # if it can't do git describe while building.
@@ -28,7 +29,7 @@ stdenv.mkDerivation rec {
     owner = "verilator";
     repo = "verilator";
     rev = "v${version}";
-    hash = "sha256-YgK60fAYG5575uiWmbCODqNZMbRfFdOVcJXz5h5TLuE=";
+    hash = "sha256-1o9Qf6avdiRgIYUgBS/S0W2GLSi/HdO9Xgs78oW6VJE=";
   };
 
   enableParallelBuilding = true;
@@ -38,35 +39,51 @@ stdenv.mkDerivation rec {
     systemc
     # ccache
   ];
-  nativeBuildInputs = [
-    makeWrapper
-    flex
-    bison
-    autoconf
-    help2man
-    git
-  ];
-  nativeCheckInputs = [
-    which
-    numactl
-    coreutils
-    # cmake
-  ];
+  nativeBuildInputs =
+    [
+      makeWrapper
+      flex
+      bison
+      autoconf
+      help2man
+      git
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isLinux [
+      gdb
+    ];
 
-  doCheck = stdenv.hostPlatform.isLinux; # darwin tests are broken for now...
+  nativeCheckInputs =
+    [
+      which
+      coreutils
+      # cmake
+      python3
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isLinux [
+      numactl
+    ];
+
+  doCheck = true;
   checkTarget = "test";
 
   preConfigure = "autoconf";
 
   postPatch = ''
     patchShebangs bin/* src/* nodist/* docs/bin/* examples/xml_py/* \
-    test_regress/{driver.pl,t/*.{pl,pf}} \
+    test_regress/{driver.py,t/*.{pl,pf}} \
+    test_regress/t/t_a1_first_cc.py \
+    test_regress/t/t_a2_first_sc.py \
     ci/* ci/docker/run/* ci/docker/run/hooks/* ci/docker/buildenv/build.sh
     # verilator --gdbbt uses /bin/echo to test if gdb works.
-    sed -i 's|/bin/echo|${coreutils}\/bin\/echo|' bin/verilator
+    substituteInPlace bin/verilator --replace-fail "/bin/echo" "${coreutils}/bin/echo"
   '';
   # grep '^#!/' -R . | grep -v /nix/store | less
   # (in nix-shell after patchPhase)
+
+  # This is needed to ensure that the check phase can find the verilator_bin_dbg.
+  preCheck = ''
+    export PATH=$PWD/bin:$PATH
+  '';
 
   env = {
     SYSTEMC_INCLUDE = "${lib.getDev systemc}/include";


### PR DESCRIPTION
* Bump the Verilator version from 5.028 to 5.034
* Adjusted the `nativeBuildInputs` and `nativeCheckInputs` lists to use `lib.optionals` for platform-specific dependencies
* Replace `sed` command with `substituteInPlace`
* Added a `preCheck` phase to ensure the check phase can find the `verilator_bin_dbg` binary by adding the current working directory bin folder to the PATH
* Enabled the check phase on all platforms

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
