### PR TITLE
vectorcode: init at 0.5.3

### DIFF
--- a/pkgs/by-name/ve/vectorcode/package.nix
+++ b/pkgs/by-name/ve/vectorcode/package.nix
@@ -1,0 +1,86 @@
+{
+  lib,
+  python3Packages,
+  fetchFromGitHub,
+  versionCheckHook,
+}:
+
+python3Packages.buildPythonApplication rec {
+  pname = "vectorcode";
+  version = "0.5.3";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "Davidyz";
+    repo = "VectorCode";
+    tag = version;
+    hash = "sha256-Vfo+wY51b3triiDhURlMl1iKNlYDy7eqEtT9/RVNZCM=";
+  };
+
+  build-system = with python3Packages; [
+    pdm-backend
+  ];
+
+  dependencies = with python3Packages; [
+    chromadb
+    httpx
+    numpy
+    pathspec
+    psutil
+    pygments
+    sentence-transformers
+    shtab
+    tabulate
+    transformers
+    tree-sitter
+    tree-sitter-language-pack
+  ];
+
+  optional-dependencies = with python3Packages; {
+    intel = [
+      openvino
+      optimum
+    ];
+    legacy = [
+      numpy
+      torch
+      transformers
+    ];
+    lsp = [
+      lsprotocol
+      pygls
+    ];
+    mcp = [
+      mcp
+      pydantic
+    ];
+  };
+
+  pythonImportsCheck = [ "vectorcode" ];
+
+  nativeCheckInputs =
+    [
+      versionCheckHook
+    ]
+    ++ (with python3Packages; [
+      mcp
+      pygls
+      pytestCheckHook
+    ]);
+  versionCheckProgramArg = "version";
+
+  disabledTests = [
+    # Require internet access
+    "test_get_embedding_function"
+    "test_get_embedding_function_fallback"
+  ];
+
+  meta = {
+    description = "Code repository indexing tool to supercharge your LLM experience";
+    homepage = "https://github.com/Davidyz/VectorCode";
+    changelog = "https://github.com/Davidyz/VectorCode/releases/tag/${version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ GaetanLepage ];
+    mainProgram = "vectorcode";
+  };
+}

--- a/pkgs/development/python-modules/tree-sitter-c-sharp/default.nix
+++ b/pkgs/development/python-modules/tree-sitter-c-sharp/default.nix
@@ -2,30 +2,25 @@
   lib,
   fetchFromGitHub,
   buildPythonPackage,
-  pythonOlder,
-  cargo,
   rustPlatform,
+  cargo,
   rustc,
   setuptools,
-  wheel,
   tree-sitter,
+  pytestCheckHook,
 }:
 
-let
+buildPythonPackage rec {
+  pname = "tree-sitter-c-sharp";
   version = "0.23.1";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "tree-sitter";
     repo = "tree-sitter-c-sharp";
-    rev = "v${version}";
+    tag = "v${version}";
     hash = "sha256-weH0nyLpvVK/OpgvOjTuJdH2Hm4a1wVshHmhUdFq3XA=";
   };
-in
-buildPythonPackage {
-  pname = "tree-sitter-c-sharp";
-  inherit version src;
-  pyproject = true;
-  disabled = pythonOlder "3.9";
 
   cargoDeps = rustPlatform.fetchCargoVendor {
     inherit src;
@@ -37,7 +32,6 @@ buildPythonPackage {
     rustPlatform.cargoSetupHook
     rustc
     setuptools
-    wheel
   ];
 
   optional-dependencies = {
@@ -46,8 +40,11 @@ buildPythonPackage {
     ];
   };
 
-  pythonImportsCheck = [
-    "tree_sitter_c_sharp"
+  pythonImportsCheck = [ "tree_sitter_c_sharp" ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    tree-sitter
   ];
 
   meta = {

--- a/pkgs/development/python-modules/tree-sitter-embedded-template/default.nix
+++ b/pkgs/development/python-modules/tree-sitter-embedded-template/default.nix
@@ -1,31 +1,26 @@
 {
   lib,
-  fetchFromGitHub,
   buildPythonPackage,
-  pythonOlder,
-  cargo,
+  fetchFromGitHub,
   rustPlatform,
+  cargo,
   rustc,
   setuptools,
-  wheel,
   tree-sitter,
+  pytestCheckHook,
 }:
 
-let
+buildPythonPackage rec {
+  pname = "tree-sitter-embedded-template";
   version = "0.23.2";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "tree-sitter";
     repo = "tree-sitter-embedded-template";
-    rev = "v${version}";
+    tag = "v${version}";
     hash = "sha256-C2Lo3tT2363O++ycXiR6x0y+jy2zlmhcKp7t1LhvCe8=";
   };
-in
-buildPythonPackage {
-  pname = "tree-sitter-embedded-template";
-  inherit version src;
-  pyproject = true;
-  disabled = pythonOlder "3.9";
 
   cargoDeps = rustPlatform.fetchCargoVendor {
     inherit src;
@@ -37,7 +32,6 @@ buildPythonPackage {
     rustPlatform.cargoSetupHook
     rustc
     setuptools
-    wheel
   ];
 
   optional-dependencies = {
@@ -46,8 +40,11 @@ buildPythonPackage {
     ];
   };
 
-  pythonImportsCheck = [
-    "tree_sitter_embedded_template"
+  pythonImportsCheck = [ "tree_sitter_embedded_template" ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    tree-sitter
   ];
 
   meta = {

--- a/pkgs/development/python-modules/tree-sitter-language-pack/default.nix
+++ b/pkgs/development/python-modules/tree-sitter-language-pack/default.nix
@@ -1,26 +1,28 @@
 {
   lib,
   buildPythonPackage,
-  pythonOlder,
   fetchPypi,
+
+  # build-system
   cython,
   setuptools,
   typing-extensions,
+
+  # dependencies
   tree-sitter,
   tree-sitter-c-sharp,
   tree-sitter-embedded-template,
   tree-sitter-yaml,
 }:
 
-let
-  version = "0.6.1";
-in
-buildPythonPackage {
+buildPythonPackage rec {
   pname = "tree-sitter-language-pack";
-  inherit version;
+  version = "0.6.1";
   pyproject = true;
-  disabled = pythonOlder "3.9";
 
+  # Using the GitHub sources necessitates fetching the treesitter grammar parsers by using a vendored script:
+  # https://github.com/Goldziher/tree-sitter-language-pack/blob/main/scripts/clone_vendors.py
+  # The pypi archive has the benefit of already vendoring those dependencies which makes packaging easier on our side
   src = fetchPypi {
     pname = "tree_sitter_language_pack";
     inherit version;
@@ -45,9 +47,13 @@ buildPythonPackage {
     "tree_sitter_language_pack.bindings"
   ];
 
+  # No tests in the pypi archive
+  doCheck = false;
+
   meta = {
     description = "Comprehensive collection of tree-sitter languages";
-    homepage = "https://github.com/Goldziher/tree-sitter-language-pack/";
+    homepage = "https://github.com/Goldziher/tree-sitter-language-pack";
+    changelog = "https://github.com/Goldziher/tree-sitter-language-pack/releases/tag/v${version}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ yzx9 ];
   };

--- a/pkgs/development/python-modules/tree-sitter-yaml/default.nix
+++ b/pkgs/development/python-modules/tree-sitter-yaml/default.nix
@@ -1,31 +1,26 @@
 {
   lib,
-  fetchFromGitHub,
   buildPythonPackage,
-  pythonOlder,
-  cargo,
+  fetchFromGitHub,
   rustPlatform,
+  cargo,
   rustc,
   setuptools,
-  wheel,
   tree-sitter,
+  pytestCheckHook,
 }:
 
-let
+buildPythonPackage rec {
+  pname = "tree-sitter-yaml";
   version = "0.7.0";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "tree-sitter-grammars";
     repo = "tree-sitter-yaml";
-    rev = "v${version}";
+    tag = "v${version}";
     hash = "sha256-23/zcjnQUQt32N2EdQMzWM9srkXfQxlBvOo7FWH6rnw=";
   };
-in
-buildPythonPackage {
-  pname = "tree-sitter-yaml";
-  inherit version src;
-  pyproject = true;
-  disabled = pythonOlder "3.9";
 
   cargoDeps = rustPlatform.fetchCargoVendor {
     inherit src;
@@ -37,7 +32,6 @@ buildPythonPackage {
     rustPlatform.cargoSetupHook
     rustc
     setuptools
-    wheel
   ];
 
   optional-dependencies = {
@@ -46,8 +40,11 @@ buildPythonPackage {
     ];
   };
 
-  pythonImportsCheck = [
-    "tree_sitter_yaml"
+  pythonImportsCheck = [ "tree_sitter_yaml" ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    tree-sitter
   ];
 
   meta = {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -17402,9 +17402,9 @@ self: super: with self; {
 
   tree-sitter-json = callPackage ../development/python-modules/tree-sitter-json { };
 
-  tree-sitter-languages = callPackage ../development/python-modules/tree-sitter-languages { };
-
   tree-sitter-language-pack = callPackage ../development/python-modules/tree-sitter-language-pack { };
+
+  tree-sitter-languages = callPackage ../development/python-modules/tree-sitter-languages { };
 
   tree-sitter-make = callPackage ../development/python-modules/tree-sitter-make { };
 


### PR DESCRIPTION
## Things done

Add [VectorCode](https://github.com/Davidyz/VectorCode), a code repository indexing tool.

- **python312Packages.tree-sitter-yaml: init at 0.7.0**
- **python312Packages.tree-sitter-c-sharp: init at 0.23.1**
- **python312Packages.tree-sitter-embedded-template: init at 0.23.2**
- **python312Packages.tree-sitter-language-pack: init at 0.6.1**
- **vectorcode: init at 0.5.3**

---

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
