### PR TITLE
prometheus-chrony-exporter: init chrony nixos module

### DIFF
--- a/nixos/modules/services/monitoring/prometheus/exporters.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters.nix
@@ -29,6 +29,7 @@ let
     "blackbox"
     "borgmatic"
     "buildkite-agent"
+    "chrony"
     "collectd"
     "deluge"
     "dmarc"

--- a/nixos/modules/services/monitoring/prometheus/exporters/chrony.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/chrony.nix
@@ -1,0 +1,97 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.services.prometheus.exporters.chrony;
+  inherit (lib)
+    mkOption
+    types
+    concatStringsSep
+    concatMapStringsSep
+    ;
+in
+{
+  port = 9123;
+  extraOpts = {
+    chronyServerAddress = mkOption {
+      type = types.str;
+      default = "unix:///run/chrony/chronyd.sock";
+      example = [ "192.82.0.1:323" ];
+      description = ''
+        ChronyServerAddress of the chrony server side command port. (Not enabled by default.)
+        Defaults to the local unix socket.
+      '';
+    };
+    user = mkOption {
+      type = types.str;
+      default = "chrony";
+      description = ''
+        User name under which the chrony exporter shall be run.
+        This allows the exporter to talk to chrony using a unix socket, which is owned by chrony.
+        The exporter startup with the default user chrony will fail without local chrony instance.
+      '';
+    };
+    group = mkOption {
+      type = types.str;
+      default = "chrony";
+      description = ''
+        Group under which the chrony exporter shall be run.
+        This allows the exporter to talk to chrony using a unix socket, which is owned by chrony group.
+        The service startup with the default group chrony will fail without local chrony instance.
+      '';
+    };
+    enabledCollectors = mkOption {
+      type = types.listOf types.str;
+      default = [
+        "tracking"
+        "sources"
+        "sources.with-ntpdata"
+        "serverstats"
+        "dns-lookups"
+      ];
+      example = [ "dns-lookups" ];
+      description = ''
+        Collectors to enable.
+        Currently all collectors are enabled by default.
+      '';
+    };
+    disabledCollectors = mkOption {
+      type = types.listOf types.str;
+      default = [ ];
+      example = [ "sources.with-ntpdata" ];
+      description = ''
+        Collectors to disable which are enabled by default.
+        Disable sources.with-ntpdata for network scraper. Option requires unix socket.
+      '';
+    };
+  };
+  serviceOpts = {
+    serviceConfig = {
+      AmbientCapabilities = [ "CAP_NET_BIND_SERVICE" ];
+      CapabilityBoundingSet = [ "CAP_NET_BIND_SERVICE" ];
+      MemoryDenyWriteExecute = true;
+      NoNewPrivileges = true;
+      ProtectClock = true;
+      ProtectSystem = "strict";
+      Restart = "on-failure";
+      RestrictAddressFamilies = [
+        "AF_INET"
+        "AF_INET6"
+        "AF_UNIX"
+      ];
+      RestrictNamespaces = true;
+      RestrictRealtime = true;
+      ExecStart = ''
+        ${lib.getExe pkgs.prometheus-chrony-exporter} \
+          ${concatMapStringsSep " " (x: "--collector." + x) cfg.enabledCollectors} \
+          ${concatMapStringsSep " " (x: "--no-collector." + x) cfg.disabledCollectors} \
+          --chrony.address ${cfg.chronyServerAddress} \
+          --web.listen-address ${cfg.listenAddress}:${toString cfg.port} \
+          ${concatStringsSep " " cfg.extraFlags}
+      '';
+    };
+  };
+}


### PR DESCRIPTION
nixos services.prometheus.exporters.chrony integration module, pkg is already available, integration is missing

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [X] `sandbox = true`
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
