### PR TITLE
palera1n: init at 2.0.2

### DIFF
--- a/pkgs/by-name/pa/palera1n/disable-downloads.patch
+++ b/pkgs/by-name/pa/palera1n/disable-downloads.patch
@@ -1,0 +1,50 @@
+diff --git a/Makefile b/Makefile
+index ea691e3..b9938fe 100644
+--- a/Makefile
++++ b/Makefile
+@@ -80,7 +80,7 @@ clean:
+ 	$(MAKE) -C docs clean
+ 
+ download-deps:
+-	$(MAKE) -C src $(patsubst %, resources/%, checkra1n-macos checkra1n-linux-arm64 checkra1n-linux-armel checkra1n-linux-x86 checkra1n-linux-x86_64 checkra1n-kpf-pongo ramdisk.dmg binpack.dmg Pongo.bin)
++	@echo "All dependencies already provided in resources directory"
+ 
+ docs:
+ 	$(MAKE) -C docs
+diff --git a/src/Makefile b/src/Makefile
+index 11ba5f8..fe72611 100644
+--- a/src/Makefile
++++ b/src/Makefile
+@@ -108,7 +108,8 @@ endif
+ endif
+ 
+ $(RESOURCES_DIR)/checkra1n-%:
+-	curl -Lfo $@ https://assets.checkra.in/downloads/preview/$(CHECKRA1N_VERSION)/$$(echo $@ | cut -d/ -f2)
++	@echo "checkra1n binary for $(patsubst $(RESOURCES_DIR)/checkra1n-%,%,$@) already provided"
++	@test -f $@ || (echo "Error: $@ not found" && exit 1)
+ 	chmod 755 $@
+ 
+ $(RESOURCES_DIR)/checkra1n: $(RESOURCES_DIR)/checkra1n-macos usb.xml
+@@ -140,7 +141,7 @@ $(RESOURCES_DIR)/libcheckra1nhelper.dylib: chkstk.S
+ 	$(CC) $(CFLAGS) $(LDFLAGS) -shared chkstk.S -o $@
+ 
+ $(RESOURCES_DIR)/checkra1n-kpf-pongo:
+-	curl -Lfo $@ https://cdn.nickchan.lol/palera1n/artifacts/kpf/iOS15/checkra1n-kpf-pongo
++	@echo "checkra1n-kpf-pongo already provided"
+ 
+ $(RESOURCES_DIR)/ramdisk.dmg.lzma: $(RESOURCES_DIR)/ramdisk.dmg
+ 	xz --format=lzma -vfc6ekT 0 $< > $@
+@@ -149,11 +150,11 @@ $(RESOURCES_DIR)/checkra1n-kpf-pongo.lzma: $(RESOURCES_DIR)/checkra1n-kpf-pongo
+ 	xz --format=lzma -vfc6ekT 0 $< > $@
+ 
+ $(RESOURCES_DIR)/ramdisk.dmg:
+-	curl -Lfo $@ https://cdn.nickchan.lol/palera1n/c-rewrite/deps/ramdisk.dmg
++	@echo "ramdisk.dmg already provided"
+ 
+ $(RESOURCES_DIR)/binpack.dmg:
+-	curl -Lfo $@ https://cdn.nickchan.lol/palera1n/c-rewrite/deps/binpack.dmg
++	@echo "binpack.dmg already provided"
+ 
+ $(RESOURCES_DIR)/Pongo.bin:
+-	curl -Lfo $@ https://cdn.nickchan.lol/palera1n/artifacts/kpf/iOS15/Pongo.bin
++	@echo "Pongo.bin already provided"

--- a/pkgs/by-name/pa/palera1n/package.nix
+++ b/pkgs/by-name/pa/palera1n/package.nix
@@ -1,0 +1,179 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  fetchurl,
+  pkg-config,
+  libusb1,
+  openssl,
+  darwin,
+  zlib,
+  libirecovery,
+  libimobiledevice,
+  usbmuxd,
+  libplist,
+  libpng,
+  libusbmuxd,
+  automake,
+  autoconf,
+  readline,
+  mbedtls,
+  xxd,
+}:
+
+let
+
+  checkra1n-platforms = {
+    x86_64-linux = "linux-x86_64";
+    i686-linux = "linux-i86";
+    aarch64-linux = "linux-arm64";
+    armv7l-linux = "linux-armel";
+  };
+
+  checkra1n-platform =
+    checkra1n-platforms.${stdenv.hostPlatform.system}
+      or (throw "Unsupported platform: ${stdenv.hostPlatform.system}");
+
+  checkra1n-macos = fetchurl {
+    url = "https://assets.checkra.in/downloads/preview/0.1337.3/checkra1n-macos";
+    hash = "sha256-O8GgJH3ZeCsY3olF47s7LcdAIIuMePeGNLgKeASp+b4=";
+  };
+  checkra1n-linux-arm64 = fetchurl {
+    url = "https://assets.checkra.in/downloads/preview/0.1337.3/checkra1n-linux-arm64";
+    hash = "sha256-B4BTwR6aMB8Ocbh7a4VObIppyHlyMl3QyQ3u66HDy3A=";
+  };
+  checkra1n-linux-armel = fetchurl {
+    url = "https://assets.checkra.in/downloads/preview/0.1337.3/checkra1n-linux-armel";
+    hash = "sha256-FdwkP8Dn7nepxcWBRmd3DQK+NK4Swtdyk9UG0YsTCrI=";
+  };
+  checkra1n-linux-x86 = fetchurl {
+    url = "https://assets.checkra.in/downloads/preview/0.1337.3/checkra1n-linux-x86";
+    hash = "sha256-VV4aIc5QvtMYJtSc7660vZCZhGzSrAx+4M/mSctYiIc=";
+  };
+  checkra1n-linux-x86_64 = fetchurl {
+    url = "https://assets.checkra.in/downloads/preview/0.1337.3/checkra1n-linux-x86_64";
+    hash = "sha256-UxVNh1lM9nxWZZ8kVH8bW7Uzb4TqWMLULyWnst+BqWQ=";
+  };
+
+  checkra1n-kpf-pongo = fetchurl {
+    url = "https://cdn.nickchan.lol/palera1n/artifacts/kpf/iOS15/checkra1n-kpf-pongo";
+    hash = "sha256-2B3t0epbnNyYIqVJj/mduvPqe0C8gekCkIAtclMWTHY=";
+  };
+
+  ramdisk-dmg = fetchurl {
+    url = "https://cdn.nickchan.lol/palera1n/c-rewrite/deps/ramdisk.dmg";
+    hash = "sha256-1k/cLxtWOY6hpX0M9xMOUm0ufKzsGglnR21dgzGQZ4M=";
+  };
+
+  binpack-dmg = fetchurl {
+    url = "https://cdn.nickchan.lol/palera1n/c-rewrite/deps/binpack.dmg";
+    hash = "sha256-rUIjFVtqYm+mamSk+y0p+RzFb4giyrfN9FrHfqJE79M=";
+  };
+
+  Pongo-bin = fetchurl {
+    url = "https://cdn.nickchan.lol/palera1n/artifacts/kpf/iOS15/Pongo.bin";
+    hash = "sha256-go0J/oAd1EuK+UMySTC/TU2rX2zB4vMA8sQPKU8Nzko=";
+  };
+
+  checkra1n-binaries = {
+    "linux-x86_64" = checkra1n-linux-x86_64;
+    "linux-i86" = checkra1n-linux-x86;
+    "linux-arm64" = checkra1n-linux-arm64;
+    "linux-armel" = checkra1n-linux-armel;
+  };
+
+  checkra1n-binary = checkra1n-binaries.${checkra1n-platform};
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "palera1n";
+  version = "2.0.2";
+
+  src = fetchFromGitHub {
+    owner = "palera1n";
+    repo = "palera1n";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-7c5upg9DxkDzNln8bmGYf+ko68wUwWoXp637WtqfJZo=";
+  };
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  buildInputs =
+    [
+      libusb1
+      openssl
+      zlib
+      libirecovery
+      libimobiledevice
+      usbmuxd
+      libplist.out
+      libpng
+      libusbmuxd
+      automake
+      autoconf
+      readline
+      mbedtls
+      xxd
+    ]
+    ++ lib.optionals stdenv.isDarwin [
+      darwin.apple_sdk.frameworks.IOKit
+      darwin.apple_sdk.frameworks.Security
+    ];
+
+  patches = [ ./disable-downloads.patch ];
+
+  prePatch = ''
+    mkdir -p src/resources
+
+    cp ${checkra1n-binary} src/resources/checkra1n-${checkra1n-platform}
+    cp ${checkra1n-kpf-pongo} src/resources/checkra1n-kpf-pongo
+    cp ${binpack-dmg} src/resources/binpack.dmg
+    cp ${ramdisk-dmg} src/resources/ramdisk.dmg
+    cp ${Pongo-bin} src/resources/Pongo.bin
+
+    # Built with shared libraries
+    substituteInPlace Makefile \
+      --replace-fail "-static" "" \
+      --replace-fail "\$(DEP)/lib/libimobiledevice-1.0.a" "" \
+      --replace-fail "\$(DEP)/lib/libirecovery-1.0.a" "" \
+      --replace-fail "\$(DEP)/lib/libusbmuxd-2.0.a" "" \
+      --replace-fail "\$(DEP)/lib/libimobiledevice-glue-1.0.a" "" \
+      --replace-fail "\$(DEP)/lib/libplist-2.0.a" "" \
+      --replace-fail "\$(DEP)/lib/libmbedtls.a" "" \
+      --replace-fail "\$(DEP)/lib/libmbedcrypto.a" "" \
+      --replace-fail "\$(DEP)/lib/libmbedx509.a" "" \
+      --replace-fail "\$(DEP)/lib/libreadline.a" ""
+
+    substituteInPlace src/Makefile \
+      --replace-fail "\$(DEP)/lib/libusb-1.0.a" ""
+  '';
+
+  makeFlags = [
+    "PREFIX=$out"
+    "CHECKRA1N_NAME=${checkra1n-platform}"
+  ];
+
+  NIX_LDFLAGS = "-limobiledevice-1.0 -lirecovery-1.0 -lmbedtls -lreadline -lusbmuxd-2.0 -lplist-2.0 -lusb-1.0 -lm -lpthread -lc";
+
+  installPhase = ''
+    mkdir -p $out/bin
+
+    install -m755 src/palera1n $out/bin/palera1n
+  '';
+
+  meta = {
+    description = "iOS 15.0-16.5.1 semi-tethered checkm8 jailbreak";
+    homepage = "https://github.com/palera1n/palera1n";
+    license = lib.licenses.gpl3;
+    platforms = lib.platforms.darwin ++ [
+      "x86_64-linux"
+      "i686-linux"
+      "aarch64-linux"
+      "armv7l-linux"
+    ];
+    maintainers = with lib.maintainers; [ phodina ];
+    mainProgram = "palera1n";
+    sourceProvenance = with lib.sourceTypes; [ fromSource binaryNativeCode ];
+  };
+})


### PR DESCRIPTION
Tool to jailbreak certain Apple IPhones.

https://github.com/palera1n/palera1n/tree/main

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
