### PR TITLE
untie: fix build with gcc14, modernize

### DIFF
--- a/pkgs/by-name/un/untie/add-define-gnu-source.patch
+++ b/pkgs/by-name/un/untie/add-define-gnu-source.patch
@@ -1,0 +1,12 @@
+diff --git a/untie.c b/untie.c
+index f08a10d..d3d20b4 100644
+--- a/untie.c
++++ b/untie.c
+@@ -18,6 +18,7 @@
+  * Copyright (c) 2006, 2007 Guillaume Chazarain <guichaz@yahoo.fr>
+  */
+ 
++#define _GNU_SOURCE
+ #include <sys/time.h>
+ #include <sys/resource.h>
+ #include <sys/wait.h>

--- a/pkgs/by-name/un/untie/package.nix
+++ b/pkgs/by-name/un/untie/package.nix
@@ -12,6 +12,11 @@ stdenv.mkDerivation rec {
     sha256 = "1334ngvbi4arcch462mzi5vxvxck4sy1nf0m58116d9xmx83ak0m";
   };
 
+  patches = [
+    # fix build with gcc14
+    ./add-define-gnu-source.patch
+  ];
+
   makeFlags = [ "PREFIX=$(out)" ];
 
   meta = with lib; {

--- a/pkgs/by-name/un/untie/package.nix
+++ b/pkgs/by-name/un/untie/package.nix
@@ -4,11 +4,11 @@
   fetchurl,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "untie";
   version = "0.3";
   src = fetchurl {
-    url = "http://guichaz.free.fr/untie/files/${pname}-${version}.tar.bz2";
+    url = "http://guichaz.free.fr/untie/files/${finalAttrs.pname}-${finalAttrs.version}.tar.bz2";
     sha256 = "1334ngvbi4arcch462mzi5vxvxck4sy1nf0m58116d9xmx83ak0m";
   };
 
@@ -19,12 +19,12 @@ stdenv.mkDerivation rec {
 
   makeFlags = [ "PREFIX=$(out)" ];
 
-  meta = with lib; {
+  meta = {
     description = "Tool to run processes untied from some of the namespaces";
     mainProgram = "untie";
-    maintainers = with maintainers; [ raskin ];
-    platforms = platforms.linux;
-    license = licenses.gpl2Plus;
+    maintainers = with lib.maintainers; [ raskin ];
+    platforms = lib.platforms.linux;
+    license = lib.licenses.gpl2Plus;
   };
 
   passthru = {
@@ -32,4 +32,4 @@ stdenv.mkDerivation rec {
       downloadPage = "http://guichaz.free.fr/untie";
     };
   };
-}
+})


### PR DESCRIPTION
- add patch that adds `#define _GNU_SOURCE` to `untie.c`, as glibc wrapper over clone syscall is not declared otherwise.
Fixes `-Wimplicit-function-declaration` error:
```
untie.c:411:15: error: implicit declaration of function 'clone';
did you mean 'close'? []
  411 |         ret = clone(child_process, &stack[STACK_SIZE - 1], flags, &args_info);
      |               ^~~~~
      |               close
make: *** [<builtin>: untie.o] Error 1
```

---

untie: modernize

- replace `rec` with `finalAttrs`
- remove `with lib;` in `meta`

---

Fixes build failure of `untie` since `2025-01-14` (update to GCC14 - #356812):
https://hydra.nixos.org/job/nixos/trunk-combined/nixpkgs.untie.x86_64-linux
https://hydra.nixos.org/build/293107917

Log:
```text
untie.c: In function 'main':
untie.c:411:15: error: implicit declaration of function 'clone'; did you mean 'close'? []
  411 |         ret = clone(child_process, &stack[STACK_SIZE - 1], flags, &args_info);
      |               ^~~~~
      |               close
make: *** [<builtin>: untie.o] Error 1
```

Tracking issue: #388196

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
