### PR TITLE
haskellPackages: pull from hackage

### DIFF
--- a/pkgs/data/misc/hackage/pin.json
+++ b/pkgs/data/misc/hackage/pin.json
@@ -1,6 +1,6 @@
 {
-  "commit": "264a7959091df9d0be29b5ef12a0a4155e8d55a7",
-  "url": "https://github.com/commercialhaskell/all-cabal-hashes/archive/264a7959091df9d0be29b5ef12a0a4155e8d55a7.tar.gz",
-  "sha256": "0m0imbi3pd7j2484qc45wr2iknm922rdn0pd8fyz4n2dz7bjr5hb",
-  "msg": "Update from Hackage at 2025-02-15T14:17:54Z"
+  "commit": "6fc5e0d20fed4a6e8ec26f6956786d0077f028b4",
+  "url": "https://github.com/commercialhaskell/all-cabal-hashes/archive/6fc5e0d20fed4a6e8ec26f6956786d0077f028b4.tar.gz",
+  "sha256": "08vkrfn4s1jb680rq1flxas8hv04f5l715z0kh8sv909k3psbfak",
+  "msg": "Update from Hackage at 2025-03-30T11:13:14Z"
 }

--- a/pkgs/development/haskell-modules/configuration-hackage2nix/transitive-broken.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/transitive-broken.yaml
@@ -379,6 +379,7 @@ dont-distribute-packages:
  - TreeCounter
  - Treiber
  - TrieMap
+ - TypeClass
  - TypeIlluminator
  - UMM
  - URLT
@@ -678,6 +679,7 @@ dont-distribute-packages:
  - botan-low
  - both
  - bound-gen
+ - breakout
  - bricks
  - bricks-internal-test
  - bricks-parsec
@@ -783,6 +785,8 @@ dont-distribute-packages:
  - chp-plus
  - chp-spec
  - chp-transformers
+ - chr-core
+ - chr-data
  - chr-lang
  - chromatin
  - chu2
@@ -1197,6 +1201,7 @@ dont-distribute-packages:
  - extract-dependencies
  - factual-api
  - fair
+ - fallingblocks
  - family-tree
  - fast-arithmetic
  - fast-bech32
@@ -1424,6 +1429,9 @@ dont-distribute-packages:
  - gps
  - gps2htmlReport
  - gpu-vulkan
+ - gpu-vulkan-khr-surface
+ - gpu-vulkan-khr-surface-glfw
+ - gpu-vulkan-khr-swapchain
  - grab-form
  - graflog
  - grammar-combinators
@@ -1555,6 +1563,7 @@ dont-distribute-packages:
  - hashable-accelerate
  - hashflare
  - hask-home
+ - haskanoid
  - haskdeep
  - haskeem
  - haskell-admin
@@ -1609,6 +1618,7 @@ dont-distribute-packages:
  - haskelm
  - haskey
  - haskey-mtl
+ - haskgame
  - hasklepias
  - haskoin-bitcoind
  - haskoin-crypto
@@ -1635,6 +1645,7 @@ dont-distribute-packages:
  - hasql-postgres
  - hasql-postgres-options
  - hasql-queue
+ - hasql-streams-example
  - hastache-aeson
  - haste-app
  - haste-gapi
@@ -1818,7 +1829,6 @@ dont-distribute-packages:
  - hsfacter
  - hsinspect-lsp
  - hslogstash
- - hsparql
  - hspec-dirstream
  - hspec-expectations-pretty
  - hspec-pg-transact
@@ -2246,6 +2256,7 @@ dont-distribute-packages:
  - luachunk
  - lucid-colonnade
  - lucienne
+ - lui
  - luminance-samples
  - lvish
  - lz4-conduit
@@ -2867,6 +2878,7 @@ dont-distribute-packages:
  - rds-data
  - react-flux-servant
  - reactive
+ - reactive-banana-sdl
  - reactive-banana-wx
  - reactive-fieldtrip
  - reactive-glut
@@ -2914,6 +2926,7 @@ dont-distribute-packages:
  - regular-web
  - regular-xmlpickler
  - reheat
+ - rel8
  - relative-date
  - remote-json
  - remote-json-client
@@ -3134,6 +3147,7 @@ dont-distribute-packages:
  - shady-gen
  - shady-graphics
  - shake-ats
+ - shake-language-c
  - shake-minify-css
  - shakebook
  - shaker
@@ -3575,7 +3589,6 @@ dont-distribute-packages:
  - vault-tool-server
  - vault-trans
  - vaultaire-common
- - vaultenv
  - vcache-trie
  - vcard
  - vcsgui

--- a/pkgs/development/haskell-modules/configuration-hackage2nix/transitive-broken.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/transitive-broken.yaml
@@ -370,6 +370,7 @@ dont-distribute-packages:
  - StockholmAlignment
  - Strafunski-Sdf2Haskell
  - SybWidget
+ - Synapse
  - SyntaxMacros
  - TV
  - TastyTLT
@@ -570,7 +571,7 @@ dont-distribute-packages:
  - axel
  - axiom
  - azimuth-hs
- - aztecs-sdl
+ - aztecs-sdl-image
  - azure-functions-worker
  - azure-service-api
  - azure-servicebus
@@ -685,8 +686,6 @@ dont-distribute-packages:
  - bricks-parsec
  - bricks-rendering
  - bricks-syntax
- - broadcast-chan-conduit
- - broadcast-chan-pipes
  - bronyradiogermany-streaming
  - btc-lsp
  - btree
@@ -733,6 +732,7 @@ dont-distribute-packages:
  - captcha-core
  - car-pool
  - carboncopy
+ - cardano-addresses
  - cartel
  - cas-hashable-s3
  - cas-store
@@ -908,6 +908,7 @@ dont-distribute-packages:
  - constraint-reflection
  - constructible
  - consumers
+ - consumers-metrics-prometheus
  - container
  - containers-accelerate
  - content-store
@@ -1079,6 +1080,7 @@ dont-distribute-packages:
  - distribution-plot
  - dixi
  - dl-fedora
+ - dl-fedora_2_0_1
  - dmenu-pkill
  - dmenu-pmount
  - dmenu-search
@@ -1441,6 +1443,7 @@ dont-distribute-packages:
  - grapefruit-ui
  - grapefruit-ui-gtk
  - grapesy
+ - grapesy-etcd
  - graph-rewriting-cl
  - graph-rewriting-gl
  - graph-rewriting-lambdascope
@@ -1454,6 +1457,7 @@ dont-distribute-packages:
  - graphicstools
  - graphtype
  - graphula
+ - graphula_2_1_0_1
  - greencard-lib
  - grid-proto
  - gridbounds
@@ -1574,6 +1578,7 @@ dont-distribute-packages:
  - haskell-docs
  - haskell-eigen-util
  - haskell-ftp
+ - haskell-language-server
  - haskell-lsp
  - haskell-lsp-client
  - haskell-pdf-presenter
@@ -1790,6 +1795,7 @@ dont-distribute-packages:
  - hplayground
  - hpqtypes-effectful
  - hpqtypes-extras
+ - hpqtypes-extras_1_17_0_1
  - hprotoc
  - hprotoc-fork
  - hps
@@ -2147,7 +2153,6 @@ dont-distribute-packages:
  - layouting
  - lazy-hash-cache
  - lda
- - ldap-client-og
  - ldap-scim-bridge
  - ldapply
  - leaky
@@ -2747,8 +2752,11 @@ dont-distribute-packages:
  - potoki-zlib
  - powerqueue-sqs
  - ppad-base58
+ - ppad-bip32
+ - ppad-bip39
  - ppad-hkdf
  - ppad-hmac-drbg
+ - ppad-pbkdf
  - ppad-secp256k1
  - pqueue-mtl
  - practice-room
@@ -3361,6 +3369,7 @@ dont-distribute-packages:
  - symantic-lib
  - symbiote
  - symmetry-operations-symbols
+ - synapse
  - syncthing-hs
  - syntaxnet-haskell
  - sys-process
@@ -3639,10 +3648,12 @@ dont-distribute-packages:
  - wavesurfer
  - wavy
  - weatherhs
+ - weave
  - web-mongrel2
  - web-routes-hsp
  - web-routes-regular
  - web-routing
+ - web-view-colonnade
  - web3
  - web3-bignum
  - web3-crypto


### PR DESCRIPTION
Here's what I did:
- regenerated the package set on latest haskell-updates, got some changes.
- then updated hackage and regenerated again.

What's the usual process on top of this? Some manual checks?

I see that `haskell-language-server` is marked as transitively broken after the pull, which is probably not good. Would this be something to deal with now or later?