### PR TITLE
setup-hooks: add auto-patch-pc-hook

### DIFF
--- a/doc/hooks/autoPatchPkgConfigHook.section.md
+++ b/doc/hooks/autoPatchPkgConfigHook.section.md
@@ -1,0 +1,12 @@
+# autoPatchPkgConfigHook {#auto-patch-pkg-config-hook}
+
+The `autoPatchPkgConfigHook` hook replaces all packages listed in `Requires` and
+`Requires.private` fields with absolute paths to their pkg-config files. This
+effectively means that dependency resolution by `pkg-config` is moved from the
+build phase of the dependent package to the build phase of the dependency which
+is important since the dependent package may not be aware of its transitive
+dependencies.
+
+You should use this hook if your package produces pkg-config files with
+non-empty `Requires` or `Requires.private` fields. To use it simply add it to
+the `nativeBuildInputs`.

--- a/doc/hooks/index.md
+++ b/doc/hooks/index.md
@@ -36,6 +36,7 @@ tauri.section.md
 tetex-tex-live.section.md
 unzip.section.md
 validatePkgConfig.section.md
+autoPatchPkgConfigHook.section.md
 versionCheckHook.section.md
 waf.section.md
 zig.section.md

--- a/doc/redirects.json
+++ b/doc/redirects.json
@@ -1,4 +1,7 @@
 {
+  "auto-patch-pkg-config-hook": [
+    "index.html#auto-patch-pkg-config-hook"
+  ],
   "chap-build-helpers-finalAttrs": [
     "index.html#chap-build-helpers-finalAttrs"
   ],

--- a/pkgs/build-support/setup-hooks/patch-pc.py
+++ b/pkgs/build-support/setup-hooks/patch-pc.py
@@ -1,0 +1,52 @@
+# Replaces dependencies in pc files with their absolute paths
+#
+# Usage: python patch-pc.py /path/to/pkgconf libfoo.pc
+# The tool writes patched .pc file to the stdout
+
+from subprocess import run
+import sys
+import re
+
+LINE_SEP = re.compile(r"(?<!\\)\n")
+
+pkgconf_bin = sys.argv[1]
+pc_file = sys.argv[2]
+
+
+def run_pkgconf(*args: str) -> str:
+    result = run([pkgconf_bin, *args], capture_output=True, check=True)
+    return result.stdout.decode().rstrip()
+
+
+def get_path(name: str) -> str:
+    return run_pkgconf("--path", name)
+
+
+def list_requires(file: str, private: bool) -> list[str]:
+    return run_pkgconf(
+        f"--print-requires{"-private" if private else ""}", file
+    ).splitlines()
+
+
+def transform_dep_spec(dep_spec: str) -> str:
+    def escape(s: str) -> str:
+        return s.replace("#", "\\#")
+
+    [name, *version_spec] = dep_spec.split(" ")
+    return " ".join(escape(s) for s in [get_path(name), *version_spec])
+
+
+def print_requires(file: str, private: bool):
+    requires = (transform_dep_spec(dep) for dep in list_requires(file, private))
+    print(f"Requires{".private" if private else ""}: ", end="")
+    print(*requires, sep=", ")
+
+
+with open(pc_file, "r") as f:
+    for line in LINE_SEP.split(f.read()):
+        if line.lstrip().startswith("Requires:"):
+            print_requires(pc_file, private=False)
+        elif line.lstrip().startswith("Requires.private:"):
+            print_requires(pc_file, private=True)
+        else:
+            print(line)

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1004,6 +1004,36 @@ with pkgs;
     ];
   } ../build-support/setup-hooks/validate-pkg-config.sh;
 
+  autoPatchPkgConfigHook =
+    makeSetupHook
+      {
+        name = "auto-patch-pkg-config-hook";
+        propagatedBuildInputs = [ pkg-config ];
+      }
+      (
+        writeScript "patch-pc.sh" ''
+          fixupOutputHooks+=(autoPatchPcHook)
+
+          autoPatchPcHook() (
+              # Some packages list their own libraries as deps, they should be searched first in case of cyclic deps
+              export PKG_CONFIG_PATH_${pkgconf.suffixSalt}="$prefix/lib/pkgconfig:$prefix/share/pkgconfig:$PKG_CONFIG_PATH_${pkgconf.suffixSalt}"
+
+              shopt -s nullglob
+              for pc in $prefix/{lib,lib64,share}/pkgconfig/*.pc; do
+                  echo Fixing require paths in $pc file
+
+                  if ! ${lib.getExe python3Minimal} \
+                    ${../build-support/setup-hooks/patch-pc.py} \
+                    ${lib.getExe pkgconf} "$pc" > "$pc.patched"; then
+                      exit 1
+                  fi
+                  mv "$pc.patched" "$pc"
+              done
+          )
+
+        ''
+      );
+
   #package writers
   writers = callPackage ../build-support/writers { };
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
`patch-pc` replaces dependencies in pc files with their absolute paths, `auto-patch-pc-hook` automatically runs it during fixup phase for all `.pc` files produced by the package. See #334195 for motivation. Feel free to also comment on the `patch-pc` code in this PR, I'll tag it as `0.1.0` once I'm sure no more changes are necessary.

I am currently in the process of rebuilding my personal NixOS system on top of the #394607 branch. So far it's going well, the only problematic package is `xorgproto` which produces `.pc` files that reference packages depending on `xorgproto`, creating circular dependency. I've patched them out for now, not sure what's the proper way to address it.

cc @emilazy 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
