### PR TITLE
gprbuild-boot: disable PIE hardening

### DIFF
--- a/pkgs/development/ada-modules/gprbuild/boot.nix
+++ b/pkgs/development/ada-modules/gprbuild/boot.nix
@@ -62,6 +62,10 @@ stdenv.mkDerivation {
     ./gpr-project-darwin-rpath-hook.sh
   ];
 
+  # ld: ./unicode.o: relocation R_X86_64_32S against symbol `unicode__valid_basechar' can not be used when making a PIE object; recompile with -fPIE
+  # ld: failed to set dynamic section sizes: bad value
+  hardeningDisable = [ "pie" ];
+
   installPhase = ''
     runHook preInstall
 


### PR DESCRIPTION
Note: this is mostly a no-op at the moment. #205031

This particular error message is usually fixable, but the build system used here is inscrutable to me. So just disable PIE for now.

Full log https://paste.fliegendewurst.eu/T7Ie-d.log

## Things done

- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).