### PR TITLE
judy: make build reproducible by removing timestamps from manpages and LC_UUID on macos

### DIFF
--- a/pkgs/by-name/ju/judy/fix-source-date.patch
+++ b/pkgs/by-name/ju/judy/fix-source-date.patch
@@ -1,0 +1,25 @@
+diff -Naur judy-1.0.5.orig/jhton.c judy-1.0.5/jhton.c
+--- judy-1.0.5.orig/tool/jhton.c	2025-03-29 18:37:09
++++ judy-1.0.5/tool/jhton.c	2025-03-29 18:40:47
+@@ -674,7 +674,6 @@
+ 	char *	pagesection;		// such as "3X".
+ 	char	lcletter;		// manual tab section, such as "j".
+ 	char *	revision;		// from centered table datum.
+-	time_t	currtime;		// for ctime().
+ 
+ // Extract "weird" header values:
+ //
+@@ -690,11 +689,8 @@
+ 		  "contain revision information");
+ 	}
+ 
+-// Emit file header; note, ctime() output already contains a newline:
+-
+-	(void) time(&currtime);
+-	(void) printf(".\\\" Auto-translated to nroff -man from %s by %s at %s",
+-		      Filename, gc_myname, ctime(&currtime));
++	(void) printf(".\\\" Auto-translated to nroff -man from %s by %s\n",
++		      Filename, gc_myname);
+ 
+ 	(void) printf(".\\\" %s\n",  filerev);
+ 	(void) printf(".TA %c\n",    lcletter);

--- a/pkgs/by-name/ju/judy/package.nix
+++ b/pkgs/by-name/ju/judy/package.nix
@@ -17,7 +17,16 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ autoreconfHook ];
   depsBuildBuild = [ pkgsBuildBuild.stdenv.cc ];
-  patches = [ ./cross.patch ];
+  patches = [
+    ./cross.patch
+    # Fix reproducible timestamps.
+    ./fix-source-date.patch
+  ];
+
+  # fixes non-determinism between builds on macos
+  preConfigure = lib.optional stdenv.hostPlatform.isDarwin ''
+    export LDFLAGS="$LDFLAGS -Wl,-no_uuid -Wl,-install_name,@rpath/libJudy.1.dylib"
+  '';
 
   # Disable parallel builds as manpages lack some dependencies:
   #    ../tool/jhton ext/JudyHS_funcs_3.htm | grep -v '^[   ]*$' | sed -e 's/\.C//' > man/man3/JudyHS_funcs


### PR DESCRIPTION
Fixes non-deterministic timestamps in generated manpages to ensure reproducible builds.
Should resolve #393660 


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
