### PR TITLE
spliit: init at 1.19.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -21461,6 +21461,12 @@
     githubId = 2141853;
     name = "Bang Lee";
   };
+  qvalentin = {
+    email = "valentin.theodor@web.de";
+    github = "qvalentin";
+    githubId = 36446499;
+    name = "qvalentin";
+  };
   qweered = {
     email = "grubian2@gmail.com";
     github = "qweered";

--- a/nixos/doc/manual/redirects.json
+++ b/nixos/doc/manual/redirects.json
@@ -1098,6 +1098,18 @@
   "module-services-samba-configuring-file-share": [
     "index.html#module-services-samba-configuring-file-share"
   ],
+  "module-services-spliit": [
+    "index.html#module-services-spliit"
+  ],
+  "module-services-spliit-basic-usage": [
+    "index.html#module-services-spliit-basic-usage"
+  ],
+  "module-services-spliit-external-database": [
+    "index.html#module-services-spliit-external-database"
+  ],
+  "module-services-spliit-extra-config-and-secrets": [
+    "index.html#module-services-spliit-extra-config-and-secrets"
+  ],
   "module-services-litestream": [
     "index.html#module-services-litestream"
   ],

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1725,6 +1725,7 @@
   ./services/web-apps/snipe-it.nix
   ./services/web-apps/snips-sh.nix
   ./services/web-apps/sogo.nix
+  ./services/web-apps/spliit.nix
   ./services/web-apps/sshwifty.nix
   ./services/web-apps/stash.nix
   ./services/web-apps/stirling-pdf.nix

--- a/nixos/modules/services/web-apps/spliit.md
+++ b/nixos/modules/services/web-apps/spliit.md
@@ -1,0 +1,65 @@
+# Spliit {#module-services-spliit}
+
+A webapp to share expenses with your friends and family.
+Free and Open Source Alternative to Splitwise.
+
+## Basic usage {#module-services-spliit-basic-usage}
+
+By default the module will run spliit on port `3000` and configure the required postgres database.
+
+```nix
+{ ... }:
+
+{
+  services.spliit = {
+    enable = true;
+  };
+}
+```
+
+It runs in the systemd service named `spliit`.
+
+## External database {#module-services-spliit-external-database}
+
+If you want to connect to an external database, set the connection options:
+
+```nix
+{ ... }:
+
+{
+  services.spliit = {
+    enable = true;
+    database = {
+      createLocally = false;
+      hostname = "localhost";
+      name = "postgres";
+      user = "postgres";
+      passwordFile = /run/secrets/spliit-postgres-password;
+    };
+  };
+}
+```
+
+## Extra config and secrets {#module-services-spliit-extra-config-and-secrets}
+
+To configure additional features of split as described [here](https://github.com/spliit-app/spliit?tab=readme-ov-file#opt-in-features)
+you can add the config:
+
+```nix
+{ ... }:
+
+{
+  services.spliit = {
+    enable = true;
+
+    settings = {
+      NEXT_PUBLIC_ENABLE_EXPENSE_DOCUMENTS = true;
+      S3_UPLOAD_BUCKET = "name-of-s3-bucket";
+      S3_UPLOAD_REGION = "us-east-1";
+    };
+
+    # A .env file with your secrets (S3_UPLOAD_KEY, etc)
+    secretFile = /run/secrets/spliit-secret-settings;
+  };
+}
+```

--- a/nixos/modules/services/web-apps/spliit.nix
+++ b/nixos/modules/services/web-apps/spliit.nix
@@ -42,7 +42,7 @@ in
 
     configureNginx = mkOption {
       type = types.bool;
-      default = true;
+      default = false;
       description = "Configure nginx as a reverse proxy for Spliit.";
     };
 
@@ -155,6 +155,7 @@ in
         User = cfg.user;
         Group = cfg.group;
         LoadCredential = lib.mkIf (cfg.secretFile != null) "env-secrets:${cfg.secretFile}";
+        DynamicUser = true;
 
         # Hardening
         CapabilityBoundingSet = "";
@@ -226,18 +227,6 @@ in
             };
           };
         };
-      };
-    };
-
-    users.groups = {
-      ${cfg.group} = { };
-    };
-
-    users.users = {
-      ${cfg.user} = {
-        group = cfg.group;
-        isSystemUser = true;
-        description = "Spliit daemon user";
       };
     };
 

--- a/nixos/modules/services/web-apps/spliit.nix
+++ b/nixos/modules/services/web-apps/spliit.nix
@@ -8,6 +8,10 @@ let
   cfg = config.services.spliit;
 in
 {
+  meta = {
+    maintainers = with lib.maintainers; [ qvalentin ];
+  };
+
   options.services.spliit = with lib; {
     enable = mkEnableOption (mdDoc "Spliit bill-splitting web application");
     package = mkPackageOption pkgs "spliit" { };

--- a/nixos/modules/services/web-apps/spliit.nix
+++ b/nixos/modules/services/web-apps/spliit.nix
@@ -1,0 +1,243 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.services.spliit;
+in
+{
+  options.services.spliit = with lib; {
+    enable = mkEnableOption (mdDoc "Spliit bill-splitting web application");
+    package = mkPackageOption pkgs "spliit" { };
+
+    port = mkOption {
+      type = types.port;
+      default = 3000;
+      description = mdDoc "Port to listen on.";
+    };
+
+    user = mkOption {
+      type = types.str;
+      default = "spliit";
+      description = mdDoc "User account under which Spliit runs.";
+    };
+
+    group = mkOption {
+      type = types.str;
+      default = "spliit";
+      description = mdDoc "Group under which Spliit runs.";
+    };
+
+    openFirewall = mkOption {
+      type = types.bool;
+      default = false;
+      description = mdDoc "Whether to open the firewall for the specified port.";
+    };
+
+    configureNginx = mkOption {
+      type = types.bool;
+      default = true;
+      description = "Configure nginx as a reverse proxy for Spliit.";
+    };
+
+    host = mkOption {
+      type = lib.types.str;
+      description = "Domain on which nginx will serve Spliit";
+    };
+
+    secretFile = mkOption {
+      type = types.nullOr types.path;
+      default = null;
+      description = ''
+        A secret file to be sourced for the environment variables settings.
+        Place `S3_UPLOAD_KEY`, `OPENAI_API_KEY` and other settings that should not end up in the Nix store here.
+      '';
+    };
+
+    settings = mkOption {
+      type =
+        with types;
+        (attrsOf (oneOf [
+          bool
+          int
+          str
+        ]));
+      default = { };
+      description = ''
+        Environment variables settings for spliit.
+        Secrets should use `secretFile` option instead.
+      '';
+      example = {
+        NEXT_PUBLIC_ENABLE_RECEIPT_EXTRACT = true;
+      };
+    };
+
+    database = {
+      createLocally = mkOption {
+        type = types.bool;
+        default = true;
+        description = ''
+          Create the PostgreSQL database and database user locally.
+        '';
+      };
+      hostname = mkOption {
+        type = types.str;
+        default = "/run/postgresql";
+        description = "Database hostname.";
+      };
+      port = mkOption {
+        type = types.port;
+        default = 5432;
+        description = "Database port.";
+      };
+      name = mkOption {
+        type = types.str;
+        default = "spliit";
+        description = "Database name.";
+      };
+      user = mkOption {
+        type = types.str;
+        default = "spliit";
+        description = "Database user.";
+      };
+      passwordFile = mkOption {
+        type = types.nullOr types.path;
+        default = null;
+        example = "/run/keys/spliit-dbpassword";
+        description = ''
+          A file containing the password corresponding to
+          [](#opt-services.spliit.database.user).
+        '';
+      };
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    systemd.services.spliit = {
+      description = "Spliit bill-splitting web application";
+      wantedBy = [ "multi-user.target" ];
+      after = [ "network.target" ] ++ lib.optional cfg.database.createLocally "postgresql.service";
+      requires = lib.mkIf cfg.database.createLocally [ "postgresql.service" ];
+
+      environment = lib.mkMerge [
+        (lib.mkIf cfg.database.createLocally {
+          POSTGRES_PRISMA_URL = "postgresql://${cfg.database.user}@${cfg.database.name}/${cfg.database.name}?host=/var/run/postgresql/";
+          POSTGRES_URL_NON_POOLING = "postgresql://${cfg.database.user}@${cfg.database.name}/${cfg.database.name}?host=/var/run/postgresql/";
+        })
+        {
+          PORT = toString cfg.port;
+        }
+        cfg.settings
+      ];
+
+      preStart = lib.mkIf (cfg.database.passwordFile != null) ''
+        DATABASE_PASSWORD="$(cat ${cfg.database.passwordFile})"
+
+        POSTGRES_PRISMA_URL="postgresql://${cfg.database.user}:$DATABASE_PASSWORD@${cfg.database.name}?host=${cfg.database.hostname}:${toString cfg.database.port}";
+
+        echo -n "POSTGRES_PRISMA_URL=\"$POSTGRES_PRISMA_URL\"" > /run/spliit/.env
+        echo -n "POSTGRES_URL_NON_POOLING=\"$POSTGRES_PRISMA_URL\"" > /run/spliit/.env
+      '';
+
+      serviceConfig = {
+        EnvironmentFile = lib.mkIf (cfg.database.passwordFile != null) "/run/spliit/.env";
+        Type = "simple";
+
+        StateDirectory = "spliit";
+        ExecStart = lib.getExe cfg.package;
+        Restart = "always";
+        User = cfg.user;
+        Group = cfg.group;
+        LoadCredential = lib.mkIf (cfg.secretFile != null) "env-secrets:${cfg.secretFile}";
+
+        # Hardening
+        CapabilityBoundingSet = "";
+        LockPersonality = true;
+        MemoryDenyWriteExecute = false; # required for Node.js JIT
+        PrivateUsers = true;
+        ProtectClock = true;
+        ProtectControlGroups = true;
+        ProtectHome = true;
+        ProtectHostname = true;
+        ProtectKernelLogs = true;
+        ProtectKernelModules = true;
+        ProtectKernelTunables = true;
+        ProtectProc = "invisible";
+        ProcSubset = "pid";
+        ProtectSystem = "strict";
+        RestrictAddressFamilies = [
+          "AF_INET"
+          "AF_INET6"
+          "AF_NETLINK"
+          # Required for connecting to database sockets,
+          # and listening to unix socket at `cfg.settings.path`
+          "AF_UNIX"
+        ];
+        RestrictNamespaces = true;
+        RestrictRealtime = true;
+        SystemCallArchitectures = "native";
+        SystemCallFilter = [
+          "@system-service"
+          "@pkey"
+        ];
+        RestrictSUIDSGID = true;
+        PrivateMounts = true;
+        UMask = "0077";
+      };
+    };
+
+    assertions = [
+      {
+        assertion =
+          cfg.database.createLocally -> cfg.database.user == cfg.user && cfg.database.name == cfg.user;
+        message = "<option>services.spliit.database.user</option> and <option>services.spliit.database.name</option> must be
+        the same as <option>services.spliit.user</option> if <option>services.spliit.database.createLocally</option> is set to true";
+      }
+      {
+        assertion = cfg.database.createLocally -> cfg.database.passwordFile == null;
+        message = "a password cannot be specified if <option>services.spliit.database.createLocally</option> is set to true";
+      }
+    ];
+
+    services.postgresql = lib.mkIf cfg.database.createLocally {
+      enable = true;
+      ensureDatabases = [ cfg.database.name ];
+      ensureUsers = [
+        {
+          name = cfg.database.user;
+          ensureDBOwnership = true;
+        }
+      ];
+    };
+
+    services.nginx = lib.mkIf cfg.configureNginx {
+      enable = true;
+      virtualHosts = {
+        ${cfg.host} = {
+          locations = {
+            "/" = {
+              proxyPass = "http://localhost:${toString cfg.port}";
+            };
+          };
+        };
+      };
+    };
+
+    users.groups = {
+      ${cfg.group} = { };
+    };
+
+    users.users = {
+      ${cfg.user} = {
+        group = cfg.group;
+        isSystemUser = true;
+        description = "Spliit daemon user";
+      };
+    };
+
+    networking.firewall.allowedTCPPorts = lib.mkIf cfg.openFirewall [ cfg.port ];
+  };
+
+}

--- a/nixos/modules/services/web-apps/spliit.nix
+++ b/nixos/modules/services/web-apps/spliit.nix
@@ -20,25 +20,25 @@ in
     port = mkOption {
       type = types.port;
       default = 3000;
-      description = mdDoc "Port to listen on.";
+      description = "Port to listen on.";
     };
 
     user = mkOption {
       type = types.str;
       default = "spliit";
-      description = mdDoc "User account under which Spliit runs.";
+      description = "User account under which Spliit runs.";
     };
 
     group = mkOption {
       type = types.str;
       default = "spliit";
-      description = mdDoc "Group under which Spliit runs.";
+      description = "Group under which Spliit runs.";
     };
 
     openFirewall = mkOption {
       type = types.bool;
       default = false;
-      description = mdDoc "Whether to open the firewall for the specified port.";
+      description = "Whether to open the firewall for the specified port.";
     };
 
     configureNginx = mkOption {

--- a/nixos/modules/services/web-apps/spliit.nix
+++ b/nixos/modules/services/web-apps/spliit.nix
@@ -10,10 +10,11 @@ in
 {
   meta = {
     maintainers = with lib.maintainers; [ qvalentin ];
+    doc = ./spliit.md;
   };
 
   options.services.spliit = with lib; {
-    enable = mkEnableOption (mdDoc "Spliit bill-splitting web application");
+    enable = mkEnableOption "Spliit bill-splitting web application";
     package = mkPackageOption pkgs "spliit" { };
 
     port = mkOption {

--- a/nixos/modules/services/web-apps/spliit.nix
+++ b/nixos/modules/services/web-apps/spliit.nix
@@ -52,7 +52,7 @@ in
       description = "Domain on which nginx will serve Spliit";
     };
 
-    secretFile = mkOption {
+    environmentFile = mkOption {
       type = types.nullOr types.path;
       default = null;
       description = ''
@@ -71,7 +71,7 @@ in
         ]));
       default = { };
       description = ''
-        Environment variables settings for spliit.
+        Environment variables settings for spliit. See <https://github.com/spliit-app/spliit?tab=readme-ov-file#opt-in-features> for the possible options.
         Secrets should use `secretFile` option instead.
       '';
       example = {

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1416,6 +1416,7 @@ in
   spacecookie = runTest ./spacecookie.nix;
   spark = handleTestOn [ "x86_64-linux" "aarch64-linux" ] ./spark { };
   spiped = runTest ./spiped.nix;
+  spliit = runTest ./spliit.nix;
   sqlite3-to-mysql = runTest ./sqlite3-to-mysql.nix;
   squid = runTest ./squid.nix;
   ssh-agent-auth = runTest ./ssh-agent-auth.nix;

--- a/nixos/tests/spliit.nix
+++ b/nixos/tests/spliit.nix
@@ -1,0 +1,21 @@
+import ./make-test-python.nix (
+  { lib, ... }:
+  {
+    name = "spliit";
+    meta.maintainers = with lib.maintainers; [ qvalentin ];
+
+    nodes.machine =
+      { ... }:
+      {
+        services.spliit = {
+          enable = true;
+        };
+      };
+
+    testScript = ''
+      machine.wait_for_unit("spliit.service")
+      machine.wait_for_open_port(3000)
+      machine.succeed("curl --fail http://127.0.0.1:3000")
+    '';
+  }
+)

--- a/pkgs/by-name/sp/spliit/package.nix
+++ b/pkgs/by-name/sp/spliit/package.nix
@@ -39,30 +39,29 @@ buildNpmPackage rec {
     NEXT_TELEMETRY_DISABLED = 1;
   };
 
-  installPhase = ''
-    runHook preInstall
+  postBuild = ''
+    rm -r .next/cache
+  '';
 
-    mkdir -p $out/bin
-    cp -r .next $out/.next
-    cp -r public $out/public
-    cp package*.json $out/
-    cp next.config.mjs $out/
-    cp -r prisma $out/prisma
-    cp -r node_modules $out/
-
-    makeWrapper $out/node_modules/.bin/next $out/bin/spliit \
-      --chdir $out \
+  postInstall = ''
+    cp -r .next $out/lib/node_modules/spliit2/
+    rm -r $out/lib/node_modules/spliit2/{scripts,src}
+    makeWrapper $out/lib/node_modules/spliit2/node_modules/.bin/next $out/bin/spliit \
+      --chdir $out/lib/node_modules/spliit2 \
       --set PRISMA_SCHEMA_ENGINE_BINARY ${lib.getExe' prisma-engines "schema-engine"} \
       --set PRISMA_QUERY_ENGINE_BINARY ${lib.getExe' prisma-engines "query-engine"} \
       --set PRISMA_QUERY_ENGINE_LIBRARY ${lib.getLib prisma-engines}/lib/libquery_engine.node \
-      --run "node_modules/.bin/prisma migrate deploy" \
+      --run "$out/lib/node_modules/spliit2/node_modules/.bin/prisma migrate deploy" \
       --add-flags start \
-
-    runHook postInstall
   '';
 
   # Skip postinstall which runs prisma commands
   npmFlags = [ "--ignore-scripts" ];
+  npmPruneFlags = [
+    "--ignore-scripts"
+    "--omit=optional"
+    "--omit=dev"
+  ];
 
   passthru.tests = {
     spliit = nixosTests.spliit;

--- a/pkgs/by-name/sp/spliit/package.nix
+++ b/pkgs/by-name/sp/spliit/package.nix
@@ -1,0 +1,73 @@
+{
+  lib,
+  buildNpmPackage,
+  fetchFromGitHub,
+  openssl,
+  prisma,
+  prisma-engines,
+}:
+
+buildNpmPackage rec {
+  pname = "spliit";
+  version = "1.15.0";
+
+  src = fetchFromGitHub {
+    owner = "spliit-app";
+    repo = "spliit";
+    tag = version;
+    hash = "sha256-rFnaYmS0IA2Bh6+aOUVsJRYlBHzMPDTJzdCyPhBD8LA=";
+  };
+
+  preBuild = ''
+    prisma generate
+    # The build.env file is required for the building, during runtime it will not be used.
+    cp ./scripts/build.env .env
+  '';
+
+  npmDepsHash = "sha256-0wMd6bxWsIv90eHVt95Y8//AUERx2P9LpzeO05DIm1U=";
+
+  buildInputs = [
+    openssl
+  ];
+
+  nativeBuildInputs = [
+    prisma
+  ];
+
+  env = {
+    NEXT_TELEMETRY_DISABLED = 1;
+  };
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+    cp -r .next $out/.next
+    cp -r public $out/public
+    cp package*.json $out/
+    cp next.config.mjs $out/
+    cp -r prisma $out/prisma
+    cp -r node_modules $out/
+
+    makeWrapper $out/node_modules/.bin/next $out/bin/spliit \
+      --chdir $out \
+      --set PRISMA_SCHEMA_ENGINE_BINARY ${lib.getExe' prisma-engines "schema-engine"} \
+      --set PRISMA_QUERY_ENGINE_BINARY ${lib.getExe' prisma-engines "query-engine"} \
+      --set PRISMA_QUERY_ENGINE_LIBRARY ${lib.getLib prisma-engines}/lib/libquery_engine.node \
+      --run "node_modules/.bin/prisma migrate deploy" \
+      --add-flags start \
+
+    runHook postInstall
+  '';
+
+  # Skip postinstall which runs prisma commands
+  npmFlags = [ "--ignore-scripts" ];
+
+  meta = {
+    description = "Web UI for sharing expenses with your friends and family, a free and Open Source Alternative to Splitwise";
+    homepage = "https://spliit.app/";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ qvalentin ];
+    mainProgram = "spliit";
+  };
+}

--- a/pkgs/by-name/sp/spliit/package.nix
+++ b/pkgs/by-name/sp/spliit/package.nix
@@ -21,8 +21,6 @@ buildNpmPackage rec {
 
   preBuild = ''
     prisma generate
-    # The build.env file is required for the building, during runtime it will not be used.
-    cp ./scripts/build.env .env
   '';
 
   npmDepsHash = "sha256-0wMd6bxWsIv90eHVt95Y8//AUERx2P9LpzeO05DIm1U=";
@@ -37,6 +35,10 @@ buildNpmPackage rec {
 
   env = {
     NEXT_TELEMETRY_DISABLED = 1;
+
+    # Mock values for build
+    POSTGRES_PRISMA_URL = "postgresql://postgres:1234@db";
+    POSTGRES_URL_NON_POOLING = "postgresql://postgres:1234@db";
   };
 
   postBuild = ''

--- a/pkgs/by-name/sp/spliit/package.nix
+++ b/pkgs/by-name/sp/spliit/package.nix
@@ -5,6 +5,7 @@
   openssl,
   prisma,
   prisma-engines,
+  nixosTests,
 }:
 
 buildNpmPackage rec {
@@ -62,6 +63,10 @@ buildNpmPackage rec {
 
   # Skip postinstall which runs prisma commands
   npmFlags = [ "--ignore-scripts" ];
+
+  passthru.tests = {
+    spliit = nixosTests.spliit;
+  };
 
   meta = {
     description = "Web UI for sharing expenses with your friends and family, a free and Open Source Alternative to Splitwise";

--- a/pkgs/by-name/sp/spliit/package.nix
+++ b/pkgs/by-name/sp/spliit/package.nix
@@ -10,20 +10,20 @@
 
 buildNpmPackage rec {
   pname = "spliit";
-  version = "1.15.0";
+  version = "1.16.0";
 
   src = fetchFromGitHub {
     owner = "spliit-app";
     repo = "spliit";
     tag = version;
-    hash = "sha256-rFnaYmS0IA2Bh6+aOUVsJRYlBHzMPDTJzdCyPhBD8LA=";
+    hash = "sha256-vYNs8dYXZTWHySB3aaUcvXpoVIm7usNq7wb7WNrf+D4=";
   };
 
   preBuild = ''
     prisma generate
   '';
 
-  npmDepsHash = "sha256-0wMd6bxWsIv90eHVt95Y8//AUERx2P9LpzeO05DIm1U=";
+  npmDepsHash = "sha256-sd0/7ruNUFxUKTeTwx/v8Vc/G3llkXP6RSDE78h3qVU=";
 
   buildInputs = [
     openssl

--- a/pkgs/by-name/sp/spliit/package.nix
+++ b/pkgs/by-name/sp/spliit/package.nix
@@ -10,20 +10,20 @@
 
 buildNpmPackage rec {
   pname = "spliit";
-  version = "1.19.0";
+  version = "1.19.1";
 
   src = fetchFromGitHub {
     owner = "spliit-app";
     repo = "spliit";
     tag = version;
-    hash = "sha256-lIfP3Ybos0j6bTS4rDLSK/QeTUR3IRJxCeMaCjzu9l8=";
+    hash = "sha256-a2xz91g2tCkW+Si5mN2VQ29BE1PXHg4BBNdYt/gnIUs=";
   };
 
   preBuild = ''
     prisma generate
   '';
 
-  npmDepsHash = "sha256-RbUC92Ik0T9Tfe103srPkmZ5Ji5gNAmfxmkAB1WnL90=";
+  npmDepsHash = "sha256-XBaFjoJpB6jE97G4hADdHRyywUn8gcgY0fb3DpV3NsE=";
 
   buildInputs = [
     openssl

--- a/pkgs/by-name/sp/spliit/package.nix
+++ b/pkgs/by-name/sp/spliit/package.nix
@@ -66,10 +66,11 @@ buildNpmPackage rec {
   ];
 
   passthru.tests = {
-    spliit = nixosTests.spliit;
+    inherit (nixosTests) spliit;
   };
 
   meta = {
+    changelog = "https://github.com/spliit-app/spliit/releases/tag/${src.tag}";
     description = "Web UI for sharing expenses with your friends and family, a free and Open Source Alternative to Splitwise";
     homepage = "https://spliit.app/";
     license = lib.licenses.mit;

--- a/pkgs/by-name/sp/spliit/package.nix
+++ b/pkgs/by-name/sp/spliit/package.nix
@@ -8,22 +8,22 @@
   nixosTests,
 }:
 
-buildNpmPackage rec {
+buildNpmPackage {
   pname = "spliit";
-  version = "1.16.0";
+  version = "1.19.0-pre";
 
   src = fetchFromGitHub {
     owner = "spliit-app";
     repo = "spliit";
-    tag = version;
-    hash = "sha256-vYNs8dYXZTWHySB3aaUcvXpoVIm7usNq7wb7WNrf+D4=";
+    rev = "fca040a44db2990adc67c039ef5d103328c9bd64";
+    hash = "sha256-aTl2j4p1p7IQZyaWFxxkAmVjHIDU07FDzKJ7A/t/ZtU=";
   };
 
   preBuild = ''
     prisma generate
   '';
 
-  npmDepsHash = "sha256-sd0/7ruNUFxUKTeTwx/v8Vc/G3llkXP6RSDE78h3qVU=";
+  npmDepsHash = "sha256-YxR3wQ5LDsmiVJgrX4KzeFXJuJBh9/w69UVYEeswTe0=";
 
   buildInputs = [
     openssl

--- a/pkgs/by-name/sp/spliit/package.nix
+++ b/pkgs/by-name/sp/spliit/package.nix
@@ -8,22 +8,22 @@
   nixosTests,
 }:
 
-buildNpmPackage {
+buildNpmPackage rec {
   pname = "spliit";
-  version = "1.19.0-pre";
+  version = "1.19.0";
 
   src = fetchFromGitHub {
     owner = "spliit-app";
     repo = "spliit";
-    rev = "fca040a44db2990adc67c039ef5d103328c9bd64";
-    hash = "sha256-aTl2j4p1p7IQZyaWFxxkAmVjHIDU07FDzKJ7A/t/ZtU=";
+    tag = version;
+    hash = "sha256-lIfP3Ybos0j6bTS4rDLSK/QeTUR3IRJxCeMaCjzu9l8=";
   };
 
   preBuild = ''
     prisma generate
   '';
 
-  npmDepsHash = "sha256-YxR3wQ5LDsmiVJgrX4KzeFXJuJBh9/w69UVYEeswTe0=";
+  npmDepsHash = "sha256-RbUC92Ik0T9Tfe103srPkmZ5Ji5gNAmfxmkAB1WnL90=";
 
   buildInputs = [
     openssl


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Add spliit, a free and Open Source Alternative to Splitwise. A webapp to share expenses with your friends and family.
Upstream homepage: https://spliit.app/

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

Fixes https://github.com/NixOS/nixpkgs/issues/392139. 

Additional Info:
- I would also like to contribute a NixOS module, for which NixOS tests could be added, that's why I added no package tests for now.
- To run the app some env vars are required and the app, I would handle this in the module
- The app can be started using `npm run start` in the result dir (should a script be added to `bin` to do this?)

Example for the required env vars:

```sh
export POSTGRES_PRISMA_URL=postgresql://postgres:your_password@localhost:5432
export POSTGRES_URL_NON_POOLING=postgresql://postgres:your_password@localhost:5432
export NEXT_PUBLIC_DEFAULT_CURRENCY_SYMBOL=""

export PRISMA_SCHEMA_ENGINE_BINARY=/nix/store/j0xs986nyyg3q8650irb86pvicxmy24i-prisma-engines-5.22.0/bin/schema-engine
export PRISMA_QUERY_ENGINE_BINARY=/nix/store/j0xs986nyyg3q8650irb86pvicxmy24i-prisma-engines-5.22.0/bin/query-engine
export PRISMA_QUERY_ENGINE_LIBRARY=/nix/store/j0xs986nyyg3q8650irb86pvicxmy24i-prisma-engines-5.22.0/lib/libquery_engine.node
```

Let me know if the module should go in the same PR as the package.
