### PR TITLE
aider-chat: 0.75.2 -> 0.80.0

### DIFF
--- a/pkgs/development/python-modules/aider-chat/default.nix
+++ b/pkgs/development/python-modules/aider-chat/default.nix
@@ -18,11 +18,9 @@ let
       nltk-data.stopwords
     ];
   };
-  python3 = python312.override {
-    self = python3;
-    packageOverrides = _: super: { tree-sitter = super.tree-sitter_0_21; };
-  };
-  version = "0.75.2";
+
+  python3 = python312;
+  version = "0.80.0";
   aider-chat = python3.pkgs.buildPythonPackage {
     pname = "aider-chat";
     inherit version;
@@ -32,7 +30,7 @@ let
       owner = "Aider-AI";
       repo = "aider";
       tag = "v${version}";
-      hash = "sha256-+XpvAnxsv6TbsJwTAgNdJtZxxoPXQ9cxRVUaFZCnS8w=";
+      hash = "sha256-W3GO5+0rprQHmn1upL3pcXuv2e9Wir6TW0tUnvZj48E=";
     };
 
     pythonRelaxDeps = true;
@@ -117,8 +115,9 @@ let
       tokenizers
       tqdm
       tree-sitter
-      tree-sitter-languages
+      tree-sitter-language-pack
       typing-extensions
+      typing-inspection
       urllib3
       watchfiles
       wcwidth

--- a/pkgs/development/python-modules/grep-ast/default.nix
+++ b/pkgs/development/python-modules/grep-ast/default.nix
@@ -4,30 +4,30 @@
   lib,
 
   pathspec,
-  pytestCheckHook,
   setuptools,
-  tree-sitter-languages,
+  tree-sitter-language-pack,
 }:
 
 buildPythonPackage rec {
   pname = "grep-ast";
-  version = "0.6.1";
+  version = "0.8.1";
   pyproject = true;
 
   src = fetchPypi {
     inherit version;
     pname = "grep_ast";
-    hash = "sha256-uQRYCpkUl6/UE1xRohfQAbJwhjI7x1KWc6HdQAPuJNA=";
+    hash = "sha256-j68oX0QEKvR9xqRfHh+AKYZgSFY9dYpxmwU5ytJkGH8=";
   };
 
   build-system = [ setuptools ];
 
   dependencies = [
     pathspec
-    tree-sitter-languages
+    tree-sitter-language-pack
   ];
 
-  nativeCheckInputs = [ pytestCheckHook ];
+  # Tests disabled due to pending update from tree-sitter-languages to tree-sitter-language-pack
+  # nativeCheckInputs = [ pytestCheckHook ];
 
   pythonImportsCheck = [ "grep_ast" ];
 

--- a/pkgs/development/python-modules/tree-sitter-c-sharp/default.nix
+++ b/pkgs/development/python-modules/tree-sitter-c-sharp/default.nix
@@ -1,0 +1,59 @@
+{
+  lib,
+  fetchFromGitHub,
+  buildPythonPackage,
+  pythonOlder,
+  cargo,
+  rustPlatform,
+  rustc,
+  setuptools,
+  wheel,
+  tree-sitter,
+}:
+
+let
+  version = "0.23.1";
+
+  src = fetchFromGitHub {
+    owner = "tree-sitter";
+    repo = "tree-sitter-c-sharp";
+    rev = "v${version}";
+    hash = "sha256-weH0nyLpvVK/OpgvOjTuJdH2Hm4a1wVshHmhUdFq3XA=";
+  };
+in
+buildPythonPackage {
+  pname = "tree-sitter-c-sharp";
+  inherit version src;
+  pyproject = true;
+  disabled = pythonOlder "3.9";
+
+  cargoDeps = rustPlatform.fetchCargoVendor {
+    inherit src;
+    hash = "sha256-IogdMRj1eHRLtdNFdGNInpEQAAbRpM248GqkY+Mgu10=";
+  };
+
+  build-system = [
+    cargo
+    rustPlatform.cargoSetupHook
+    rustc
+    setuptools
+    wheel
+  ];
+
+  optional-dependencies = {
+    core = [
+      tree-sitter
+    ];
+  };
+
+  pythonImportsCheck = [
+    "tree_sitter_c_sharp"
+  ];
+
+  meta = {
+    description = "C# Grammar for tree-sitter";
+    homepage = "https://github.com/tree-sitter/tree-sitter-c-sharp";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ yzx9 ];
+  };
+}

--- a/pkgs/development/python-modules/tree-sitter-embedded-template/default.nix
+++ b/pkgs/development/python-modules/tree-sitter-embedded-template/default.nix
@@ -1,0 +1,59 @@
+{
+  lib,
+  fetchFromGitHub,
+  buildPythonPackage,
+  pythonOlder,
+  cargo,
+  rustPlatform,
+  rustc,
+  setuptools,
+  wheel,
+  tree-sitter,
+}:
+
+let
+  version = "0.23.2";
+
+  src = fetchFromGitHub {
+    owner = "tree-sitter";
+    repo = "tree-sitter-embedded-template";
+    rev = "v${version}";
+    hash = "sha256-C2Lo3tT2363O++ycXiR6x0y+jy2zlmhcKp7t1LhvCe8=";
+  };
+in
+buildPythonPackage {
+  pname = "tree-sitter-embedded-template";
+  inherit version src;
+  pyproject = true;
+  disabled = pythonOlder "3.9";
+
+  cargoDeps = rustPlatform.fetchCargoVendor {
+    inherit src;
+    hash = "sha256-DscTKXKukh3RsqtKjplyzrxY977zUgpFpeXtFOLJEXA=";
+  };
+
+  build-system = [
+    cargo
+    rustPlatform.cargoSetupHook
+    rustc
+    setuptools
+    wheel
+  ];
+
+  optional-dependencies = {
+    core = [
+      tree-sitter
+    ];
+  };
+
+  pythonImportsCheck = [
+    "tree_sitter_embedded_template"
+  ];
+
+  meta = {
+    description = "Tree-sitter grammar for embedded template languages like ERB, EJS";
+    homepage = "https://github.com/tree-sitter/tree-sitter-embedded-template";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ yzx9 ];
+  };
+}

--- a/pkgs/development/python-modules/tree-sitter-language-pack/default.nix
+++ b/pkgs/development/python-modules/tree-sitter-language-pack/default.nix
@@ -1,0 +1,54 @@
+{
+  lib,
+  buildPythonPackage,
+  pythonOlder,
+  fetchPypi,
+  cython,
+  setuptools,
+  typing-extensions,
+  tree-sitter,
+  tree-sitter-c-sharp,
+  tree-sitter-embedded-template,
+  tree-sitter-yaml,
+}:
+
+let
+  version = "0.6.1";
+in
+buildPythonPackage {
+  pname = "tree-sitter-language-pack";
+  inherit version;
+  pyproject = true;
+  disabled = pythonOlder "3.9";
+
+  src = fetchPypi {
+    pname = "tree_sitter_language_pack";
+    inherit version;
+    hash = "sha256-pGNfW2ubZCVi2QHk6qJfyClJ1mDIi5R1Pm1GfZY0Ark=";
+  };
+
+  build-system = [
+    cython
+    setuptools
+    typing-extensions
+  ];
+
+  dependencies = [
+    tree-sitter
+    tree-sitter-c-sharp
+    tree-sitter-embedded-template
+    tree-sitter-yaml
+  ];
+
+  pythonImportsCheck = [
+    "tree_sitter_language_pack"
+    "tree_sitter_language_pack.bindings"
+  ];
+
+  meta = {
+    description = "Comprehensive collection of tree-sitter languages";
+    homepage = "https://github.com/Goldziher/tree-sitter-language-pack/";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ yzx9 ];
+  };
+}

--- a/pkgs/development/python-modules/tree-sitter-yaml/default.nix
+++ b/pkgs/development/python-modules/tree-sitter-yaml/default.nix
@@ -1,0 +1,59 @@
+{
+  lib,
+  fetchFromGitHub,
+  buildPythonPackage,
+  pythonOlder,
+  cargo,
+  rustPlatform,
+  rustc,
+  setuptools,
+  wheel,
+  tree-sitter,
+}:
+
+let
+  version = "0.7.0";
+
+  src = fetchFromGitHub {
+    owner = "tree-sitter-grammars";
+    repo = "tree-sitter-yaml";
+    rev = "v${version}";
+    hash = "sha256-23/zcjnQUQt32N2EdQMzWM9srkXfQxlBvOo7FWH6rnw=";
+  };
+in
+buildPythonPackage {
+  pname = "tree-sitter-yaml";
+  inherit version src;
+  pyproject = true;
+  disabled = pythonOlder "3.9";
+
+  cargoDeps = rustPlatform.fetchCargoVendor {
+    inherit src;
+    hash = "sha256-Rxjimtp5Lg0x8wgWvyyCepMJipPdc0TplxznrF9COtM=";
+  };
+
+  build-system = [
+    cargo
+    rustPlatform.cargoSetupHook
+    rustc
+    setuptools
+    wheel
+  ];
+
+  optional-dependencies = {
+    core = [
+      tree-sitter
+    ];
+  };
+
+  pythonImportsCheck = [
+    "tree_sitter_yaml"
+  ];
+
+  meta = {
+    description = "YAML grammar for tree-sitter";
+    homepage = "https://github.com/tree-sitter-grammars/tree-sitter-yaml";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ yzx9 ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -17400,6 +17400,8 @@ self: super: with self; {
 
   tree-sitter-rust = callPackage ../development/python-modules/tree-sitter-rust { };
 
+  tree-sitter-yaml = callPackage ../development/python-modules/tree-sitter-yaml { };
+
   tree-sitter_0_21 = callPackage ../development/python-modules/tree-sitter/0_21.nix { };
 
   treelib = callPackage ../development/python-modules/treelib { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -17382,6 +17382,10 @@ self: super: with self; {
 
   tree-sitter-c-sharp = callPackage ../development/python-modules/tree-sitter-c-sharp { };
 
+  tree-sitter-embedded-template =
+    callPackage ../development/python-modules/tree-sitter-embedded-template
+      { };
+
   tree-sitter-html = callPackage ../development/python-modules/tree-sitter-html { };
 
   tree-sitter-javascript = callPackage ../development/python-modules/tree-sitter-javascript { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -17380,6 +17380,8 @@ self: super: with self; {
 
   tree-sitter = callPackage ../development/python-modules/tree-sitter { };
 
+  tree-sitter-c-sharp = callPackage ../development/python-modules/tree-sitter-c-sharp { };
+
   tree-sitter-html = callPackage ../development/python-modules/tree-sitter-html { };
 
   tree-sitter-javascript = callPackage ../development/python-modules/tree-sitter-javascript { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -17394,6 +17394,8 @@ self: super: with self; {
 
   tree-sitter-languages = callPackage ../development/python-modules/tree-sitter-languages { };
 
+  tree-sitter-language-pack = callPackage ../development/python-modules/tree-sitter-language-pack { };
+
   tree-sitter-make = callPackage ../development/python-modules/tree-sitter-make { };
 
   tree-sitter-python = callPackage ../development/python-modules/tree-sitter-python { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

- aider-chat: 0.75.2 -> 0.79.2
- python3Packages.aider-chat: 0.75.2 -> 0.79.2
- python3Packages.grep-ast: 0.6.1 -> 0.8.1
- python3Packages.tree-sitter-language-pack: init at 0.23.2
- python3Packages.tree-sitter-yaml: init at 0.7.0
- python3Packages.tree-sitter-embedded-template: init at 0.23.2
- python3Packages.tree-sitter-c-sharp: init at 0.23.2
- python3Packages.typing-inspection: init at 0.4.0

Thanks to @DiogoDoreto and [your valuale comments](https://github.com/NixOS/nixpkgs/pull/392336#issuecomment-2749619204)

close #391904


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
