### PR TITLE
rxp: 1.5.0 -> 1.5.2, fix build with gcc14

### DIFF
--- a/pkgs/by-name/rx/rxp/package.nix
+++ b/pkgs/by-name/rx/rxp/package.nix
@@ -4,12 +4,12 @@
   fetchurl,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "rxp";
   version = "1.5.2";
 
   src = fetchurl {
-    url = "https://www.inf.ed.ac.uk/research/isddarch/admin/rxp-${version}.tar.gz";
+    url = "https://www.inf.ed.ac.uk/research/isddarch/admin/rxp-${finalAttrs.version}.tar.gz";
     hash = "sha256-+mQbSlGF0KHZYQyCRbnVr/WXLBoooNqU8+ONafbBRRM=";
   };
 
@@ -20,4 +20,4 @@ stdenv.mkDerivation rec {
     platforms = lib.platforms.unix;
     mainProgram = "rxp";
   };
-}
+})

--- a/pkgs/by-name/rx/rxp/package.nix
+++ b/pkgs/by-name/rx/rxp/package.nix
@@ -6,14 +6,12 @@
 
 stdenv.mkDerivation rec {
   pname = "rxp";
-  version = "1.5.0";
+  version = "1.5.2";
 
   src = fetchurl {
-    url = "mirror://debian/pool/main/r/rxp/rxp_${version}.orig.tar.gz";
-    sha256 = "0y365r36wzj4xn1dzhb03spxljnrx8vwqbiwnnwz4630129gzpm6";
+    url = "https://www.inf.ed.ac.uk/research/isddarch/admin/rxp-${version}.tar.gz";
+    hash = "sha256-+mQbSlGF0KHZYQyCRbnVr/WXLBoooNqU8+ONafbBRRM=";
   };
-
-  env.NIX_CFLAGS_COMPILE = lib.optionalString stdenv.cc.isClang "-Wno-error=implicit-function-declaration -Wno-error=int-conversion";
 
   meta = {
     license = lib.licenses.gpl2Plus;


### PR DESCRIPTION
rxp: 1.5.0 -> 1.5.2

- switch `src` from debian mirror to upstream url because debian does not have 1.5.2 version
- update to 1.5.2, fixing build with gcc14
- remove clang specific flags as errors were fixed in new version

---

rxp: modernize

- replace `rec` with `finalAttrs`

---

Fixes build failure of `rxp` since `2025-01-14` (update to GCC14 in #356812):
https://hydra.nixos.org/job/nixos/trunk-combined/nixpkgs.rxp.x86_64-linux
https://hydra.nixos.org/build/293099345

Log:
```text
catalog/resolve.c: In function 'res_ext':
catalog/resolve.c:135:20: error: implicit declaration of function 'strdup8'; did you mean 'strdup'? []
  135 |             return strdup8(entry->value);
      |                    ^~~~~~~
      |                    strdup
catalog/resolve.c:135:20: error: returning 'int' from a function with return type 'char *' makes pointer from integer without a cast []
  135 |             return strdup8(entry->value);
      |                    ^~~~~~~~~~~~~~~~~~~~~
catalog/resolve.c:232:20: error: returning 'int' from a function with return type 'char *' makes pointer from integer without a cast []
  232 |             return strdup8(entry->value);
      |                    ^~~~~~~~~~~~~~~~~~~~~
make[1]: *** [Makefile:578: resolve.lo] Error 1
make[1]: Leaving directory '/build/rxp-1.5.0'
make: *** [Makefile:248: all] Error 2
```

Tracking issue: #388196

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
