### PR TITLE
nixosTests.varnish{75,76,60}: migrate to runTest

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1277,9 +1277,18 @@ in {
   ustreamer = handleTest ./ustreamer.nix {};
   uwsgi = handleTest ./uwsgi.nix {};
   v2ray = handleTest ./v2ray.nix {};
-  varnish60 = handleTest ./varnish.nix { package = pkgs.varnish60; };
-  varnish75 = handleTest ./varnish.nix { package = pkgs.varnish75; };
-  varnish76 = handleTest ./varnish.nix { package = pkgs.varnish76; };
+  varnish60 = runTest {
+    imports = [ ./varnish.nix ];
+    _module.args.package = pkgs.varnish60;
+  };
+  varnish75 = runTest {
+    imports = [ ./varnish.nix ];
+    _module.args.package = pkgs.varnish75;
+  };
+  varnish76 = runTest {
+    imports = [ ./varnish.nix ];
+    _module.args.package = pkgs.varnish76;
+  };
   vault = handleTest ./vault.nix {};
   vault-agent = handleTest ./vault-agent.nix {};
   vault-dev = handleTest ./vault-dev.nix {};

--- a/nixos/tests/varnish.nix
+++ b/nixos/tests/varnish.nix
@@ -1,67 +1,60 @@
+{ pkgs, package, ... }:
+let
+  testPath = pkgs.hello;
+in
 {
-  system ? builtins.currentSystem,
-  pkgs ? import ../.. { inherit system; },
-  package,
-}:
-import ./make-test-python.nix (
-  { pkgs, lib, ... }:
-  let
-    testPath = pkgs.hello;
-  in
-  {
-    name = "varnish";
-    meta = {
-      maintainers = [ ];
-    };
+  name = "varnish";
+  meta = {
+    maintainers = [ ];
+  };
 
-    nodes = {
-      varnish =
-        { config, pkgs, ... }:
-        {
-          services.nix-serve = {
-            enable = true;
-          };
-
-          services.varnish = {
-            inherit package;
-            enable = true;
-            http_address = "0.0.0.0:80";
-            config = ''
-              vcl 4.0;
-
-              backend nix-serve {
-                .host = "127.0.0.1";
-                .port = "${toString config.services.nix-serve.port}";
-              }
-            '';
-          };
-
-          networking.firewall.allowedTCPPorts = [ 80 ];
-          system.extraDependencies = [ testPath ];
+  nodes = {
+    varnish =
+      { config, pkgs, ... }:
+      {
+        services.nix-serve = {
+          enable = true;
         };
 
-      client =
-        { lib, ... }:
-        {
-          nix.settings = {
-            require-sigs = false;
-            substituters = lib.mkForce [ "http://varnish" ];
-          };
+        services.varnish = {
+          inherit package;
+          enable = true;
+          http_address = "0.0.0.0:80";
+          config = ''
+            vcl 4.0;
+
+            backend nix-serve {
+              .host = "127.0.0.1";
+              .port = "${toString config.services.nix-serve.port}";
+            }
+          '';
         };
-    };
 
-    testScript = ''
-      start_all()
-      varnish.wait_for_open_port(80)
+        networking.firewall.allowedTCPPorts = [ 80 ];
+        system.extraDependencies = [ testPath ];
+      };
 
-      client.wait_until_succeeds("curl -f http://varnish/nix-cache-info");
+    client =
+      { lib, ... }:
+      {
+        nix.settings = {
+          require-sigs = false;
+          substituters = lib.mkForce [ "http://varnish" ];
+        };
+      };
+  };
 
-      client.wait_until_succeeds("nix-store -r ${testPath}")
-      client.succeed("${testPath}/bin/hello")
+  testScript = ''
+    start_all()
+    varnish.wait_for_open_port(80)
 
-      output = varnish.succeed("varnishadm status")
-      print(output)
-      assert "Child in state running" in output, "Unexpected varnishadm response"
-    '';
-  }
-)
+    client.wait_until_succeeds("curl -f http://varnish/nix-cache-info");
+
+    client.wait_until_succeeds("nix-store -r ${testPath}")
+    client.succeed("${testPath}/bin/hello")
+
+    output = varnish.succeed("varnishadm status")
+    print(output)
+    assert "Child in state running" in output, "Unexpected varnishadm response"
+  '';
+}


### PR DESCRIPTION
Part of #386873

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
