### PR TITLE
coturn: add systemd support

### DIFF
--- a/nixos/modules/services/networking/coturn.nix
+++ b/nixos/modules/services/networking/coturn.nix
@@ -413,6 +413,7 @@ in
                 [
                   "AF_INET"
                   "AF_INET6"
+                  "AF_UNIX"
                 ]
                 ++ lib.optionals (cfg.listening-ips == [ ]) [
                   # only used for interface discovery when no listening ips are configured

--- a/nixos/modules/services/networking/coturn.nix
+++ b/nixos/modules/services/networking/coturn.nix
@@ -363,7 +363,7 @@ in
               chmod 640 ${runConfig}
             '';
             serviceConfig = rec {
-              Type = "simple";
+              Type = "notify";
               ExecStart = utils.escapeSystemdExecArgs [
                 (lib.getExe' pkgs.coturn "turnserver")
                 "-c"

--- a/pkgs/by-name/co/coturn/package.nix
+++ b/pkgs/by-name/co/coturn/package.nix
@@ -9,6 +9,7 @@
   libmicrohttpd,
   sqlite,
   nixosTests,
+  systemdMinimal,
 }:
 
 stdenv.mkDerivation rec {
@@ -26,13 +27,17 @@ stdenv.mkDerivation rec {
     pkg-config
   ];
 
-  buildInputs = [
-    openssl
-    (libevent.override { inherit openssl; })
-    libprom
-    libmicrohttpd
-    sqlite.dev
-  ];
+  buildInputs =
+    [
+      openssl
+      (libevent.override { inherit openssl; })
+      libprom
+      libmicrohttpd
+      sqlite.dev
+    ]
+    ++ lib.optionals (lib.meta.availableOn stdenv.hostPlatform systemdMinimal) [
+      systemdMinimal
+    ];
 
   patches = [
     ./pure-configure.patch


### PR DESCRIPTION
[coturn supports systemd notify type](https://github.com/coturn/coturn/blob/831b7245aa03a230178a6b617b28264def4047d7/src/apps/relay/netengine.c#L1597-L1619) through `sd_notify`, so this PR adds systemd support by setting the type to notify and allowing the unix socket to be used for this purpose.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
