### PR TITLE
separateDebugInfo: add symlinks to executable and source for debuginfod support

### DIFF
--- a/doc/release-notes/rl-2511.section.md
+++ b/doc/release-notes/rl-2511.section.md
@@ -31,6 +31,14 @@
 
 - `vmalert` now supports multiple instances with the option `services.vmalert.instances."".enable`
 
+- The debug outputs produced by `separateDebugInfo = true;` now contain symlinks mapping build-ids to the original source and ELF file.
+  Specifically, if `$out/bin/ninja` has build-id `483bd7f7229bdb06462222e1e353e4f37e15c293`, then
+  * `$debug/lib/debug/.build-id/48/3bd7f7229bdb06462222e1e353e4f37e15c293.executable` is a symlink to `$out/bin/ninja`
+  * `$debug/lib/debug/.build-id/48/3bd7f7229bdb06462222e1e353e4f37e15c293.source` is a symlink to the value of `$src` during build
+  * `$debug/lib/debug/.build-id/48/3bd7f7229bdb06462222e1e353e4f37e15c293.sourceoverlay` is a symlink to a directory with the same structure as the expanded `$sourceRoot` but containing only a copy of files which were patched during the build
+  * `$debug/lib/debug/.build-id/48/3bd7f7229bdb06462222e1e353e4f37e15c293.debug` is the file containing debug symbols (like before).
+
+
 ## Nixpkgs Library {#sec-nixpkgs-release-25.11-lib}
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->

--- a/doc/release-notes/rl-2511.section.md
+++ b/doc/release-notes/rl-2511.section.md
@@ -19,6 +19,8 @@
 - `gentium` package now provides `Gentium-*.ttf` files, and not `GentiumPlus-*.ttf` files like before. The font identifiers `Gentium Plus*` are available in the `gentium-plus` package, and if you want to use the more recently updated package `gentium` [by sil](https://software.sil.org/gentium/), you should update your configuration files to use the `Gentium` font identifier.
 - `space-orbit` package has been removed due to lack of upstream maintenance. Debian upstream stopped tracking it in 2011.
 
+- Derivations setting both `separateDebugInfo` and one of `allowedReferences`, `allowedRequistes`, `disallowedReferences` or `disallowedRequisites` must now set `__structuredAttrs` to `true`. The effect of reference whitelisting or blacklisting will be disabled on the `debug` output created by `separateDebugInfo`.
+
 - `gnome-keyring` no longer ships with an SSH agent anymore because it has been deprecated upstream. You should use `gcr_4` instead, which provides the same features. More information on why this was done can be found on [the relevant GCR upstream PR](https://gitlab.gnome.org/GNOME/gcr/-/merge_requests/67).
 
 ## Other Notable Changes {#sec-nixpkgs-release-25.11-notable-changes}

--- a/pkgs/applications/version-management/git/default.nix
+++ b/pkgs/applications/version-management/git/default.nix
@@ -94,6 +94,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   outputs = [ "out" ] ++ lib.optional withManual "doc";
   separateDebugInfo = true;
+  __structuredAttrs = true;
 
   hardeningDisable = [ "format" ];
 
@@ -165,7 +166,7 @@ stdenv.mkDerivation (finalAttrs: {
     ];
 
   # required to support pthread_cancel()
-  NIX_LDFLAGS =
+  env.NIX_LDFLAGS =
     lib.optionalString (stdenv.cc.isGNU && stdenv.hostPlatform.libc == "glibc") "-lgcc_s"
     + lib.optionalString (stdenv.hostPlatform.isFreeBSD) "-lthr";
 

--- a/pkgs/build-support/setup-hooks/auto-patchelf.sh
+++ b/pkgs/build-support/setup-hooks/auto-patchelf.sh
@@ -95,6 +95,7 @@ autoPatchelfPostFixup() {
     if [[ -z "${dontAutoPatchelf-}" ]]; then
         autoPatchelf -- $(for output in $(getAllOutputNames); do
             [ -e "${!output}" ] || continue
+            [ "${output}" = debug ] && continue
             echo "${!output}"
         done)
     fi

--- a/pkgs/build-support/setup-hooks/separate-debug-info.sh
+++ b/pkgs/build-support/setup-hooks/separate-debug-info.sh
@@ -3,18 +3,47 @@ export NIX_LDFLAGS+=" --compress-debug-sections=zlib"
 export NIX_CFLAGS_COMPILE+=" -ggdb -Wa,--compress-debug-sections"
 export NIX_RUSTFLAGS+=" -g -C strip=none"
 
+cksumAlgo=sha256
+
 fixupOutputHooks+=(_separateDebugInfo)
+postUnpackHooks+=(_recordPristineSourceHashes)
+
+_recordPristineSourceHashes() {
+    # shellcheck disable=2154
+    [ -e "$sourceRoot" ] || return 0
+
+    local checksumFileName=__nix_source_checksums
+    echo "separate-debug-info: recording checksum of source files for debug support..."
+    find "$sourceRoot" -type f -exec cksum -a "$cksumAlgo" '{}' \+ > "$checksumFileName"
+    recordedSourceChecksumsFileName="$(readlink -f "$checksumFileName")"
+}
 
 _separateDebugInfo() {
+    # shellcheck disable=2154
     [ -e "$prefix" ] || return 0
 
-    local dst="${debug:-$out}"
-    if [ "$prefix" = "$dst" ]; then return 0; fi
+    local debugOutput="${debug:-$out}"
+    if [ "$prefix" = "$debugOutput" ]; then return 0; fi
 
     # in case there is nothing to strip, don't fail the build
-    mkdir -p "$dst"
+    mkdir -p "$debugOutput"
 
-    dst="$dst/lib/debug/.build-id"
+    local dst="$debugOutput/lib/debug/.build-id"
+
+    local source
+    local sourceOverlay
+    # shellcheck disable=2154
+    if [ -e "$src" ]; then
+        source="$src"
+        if [ -n "${recordedSourceChecksumsFileName:-}" ]; then
+            sourceOverlay="$debugOutput/src/overlay"
+        else
+            sourceOverlay=""
+        fi
+    else
+        source=""
+        sourceOverlay=""
+    fi
 
     # Find executables and dynamic libraries.
     local i
@@ -25,30 +54,64 @@ _separateDebugInfo() {
         [ -z "${OBJCOPY:-}" ] && echo "_separateDebugInfo: '\$OBJCOPY' variable is empty, skipping." 1>&2 && break
 
         # Extract the Build ID. FIXME: there's probably a cleaner way.
-        local id="$($READELF -n "$i" | sed 's/.*Build ID: \([0-9a-f]*\).*/\1/; t; d')"
+        local id
+        id="$($READELF -n "$i" | sed 's/.*Build ID: \([0-9a-f]*\).*/\1/; t; d')"
         if [ "${#id}" != 40 ]; then
             echo "could not find build ID of $i, skipping" >&2
             continue
         fi
 
+
         # Extract the debug info.
         echo "separating debug info from $i (build ID $id)"
 
-        destDir=$dst/${id:0:2}
-        destFile=$dst/${id:0:2}/${id:2}.debug
+        local debuginfoDir="$dst/${id:0:2}"
+        local buildIdPrefix="$debuginfoDir/${id:2}"
+        local debuginfoFile="$buildIdPrefix.debug"
+        local executableSymlink="$buildIdPrefix.executable"
+        local sourceSymlink="$buildIdPrefix.source"
+        local sourceOverlaySymlink="$buildIdPrefix.sourceoverlay"
 
-        mkdir -p "$destDir"
+        mkdir -p "$debuginfoDir"
 
-        if [ -f "$destFile" ]; then
+        if [ -f "$debuginfoFile" ]; then
             echo "separate-debug-info: warning: multiple files with build id $id found, overwriting"
         fi
 
         # This may fail, e.g. if the binary is for a different
         # architecture than we're building for.  (This happens with
         # firmware blobs in QEMU.)
-        if $OBJCOPY --only-keep-debug "$i" "$destFile"; then
+        if $OBJCOPY --only-keep-debug "$i" "$debuginfoFile"; then
             # If we succeeded, also a create a symlink <original-name>.debug.
-            ln -sfn ".build-id/${id:0:2}/${id:2}.debug" "$dst/../$(basename "$i")"
+            ln -sfn "$debuginfoFile" "$dst/../$(basename "$i")"
+            # also create a symlink mapping the build-id to the original elf file and the source
+            # debuginfod protocol relies on it
+            ln -sfn "$i" "$executableSymlink"
+            if [ -n "$source" ]; then
+                ln -sfn "$source" "$sourceSymlink"
+            fi
+            if [ -n "$sourceOverlay" ]; then
+                # create it lazily
+                if [ ! -d "$sourceOverlay" ]; then
+                    echo "separate-debug-info: copying patched source files to $sourceOverlay..."
+                    mkdir -p "$sourceOverlay"
+                    pushd "$(dirname "$recordedSourceChecksumsFileName")" || { echo "separate-debug-info: failed to cd parent directory of $recordedSourceChecksumsFileName"; return 1; }
+                    while IFS= read -r -d $'\0'  modifiedSourceFile; do
+                        if [ -z "$modifiedSourceFile" ]; then
+                            continue
+                        fi
+                        # this can happen with files with '\n' in their name
+                        if [ ! -f "$modifiedSourceFile" ]; then
+                            echo "separate-debug-info: cannot save modified source file $modifiedSourceFile: does not exist. ignoring"
+                            continue
+                        fi
+                        mkdir -p "$sourceOverlay/$(dirname "$modifiedSourceFile")"
+                        cp -v "$modifiedSourceFile" "$sourceOverlay/$modifiedSourceFile"
+                    done < <(LANG=C cksum -a "$cksumAlgo" --check --ignore-missing --quiet "$recordedSourceChecksumsFileName" 2>&1 | sed -n -e 's/: FAILED$/\x00/p' | sed -z -e 's/^\n//')
+                    popd || { echo "separate-debug-info: failed to popd" ; return 1; }
+                fi
+                ln -sfn "$sourceOverlay" "$sourceOverlaySymlink"
+            fi
         else
             # If we failed, try to clean up unnecessary directories
             rmdir -p "$dst/${id:0:2}" --ignore-fail-on-non-empty

--- a/pkgs/development/compilers/openjdk/generic.nix
+++ b/pkgs/development/compilers/openjdk/generic.nix
@@ -428,6 +428,7 @@ stdenv.mkDerivation (finalAttrs: {
   buildFlags = if atLeast17 then [ "images" ] else [ "all" ];
 
   separateDebugInfo = true;
+  __structuredAttrs = true;
 
   # -j flag is explicitly rejected by the build system:
   #     Error: 'make -jN' is not supported, use 'make JOBS=N'

--- a/pkgs/development/interpreters/python/cpython/default.nix
+++ b/pkgs/development/interpreters/python/cpython/default.nix
@@ -788,6 +788,7 @@ stdenv.mkDerivation (finalAttrs: {
     ];
 
   separateDebugInfo = true;
+  __structuredAttrs = true;
 
   passthru = passthru // {
     doc = stdenv.mkDerivation {

--- a/pkgs/development/libraries/mesa/default.nix
+++ b/pkgs/development/libraries/mesa/default.nix
@@ -205,6 +205,7 @@ stdenv.mkDerivation {
   # Keep build-ids so drivers can use them for caching, etc.
   # Also some drivers segfault without this.
   separateDebugInfo = true;
+  __structuredAttrs = true;
 
   # Needed to discover llvm-config for cross
   preConfigure = ''

--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -331,6 +331,7 @@ stdenv.mkDerivation (finalAttrs: {
     "dev"
   ] ++ (lib.optional (!buildLibsOnly) "man");
   separateDebugInfo = true;
+  __structuredAttrs = true;
 
   hardeningDisable =
     [

--- a/pkgs/tools/package-management/lix/common-lix.nix
+++ b/pkgs/tools/package-management/lix/common-lix.nix
@@ -128,6 +128,7 @@ stdenv.mkDerivation (finalAttrs: {
     # We don't want the underlying GCC neither!
     stdenv.cc.cc.stdenv.cc.cc
   ];
+  __structuredAttrs = true;
 
   # We only include CMake so that Meson can locate toml11, which only ships CMake dependency metadata.
   dontUseCmakeConfigure = true;


### PR DESCRIPTION
For debuginfod support we must be able to map a build-id to
- debug symbols
- the original elf file for which the debug symbols where separated
- the corresponding source files

Currently, hydra provides an index from build-id to the nar of the debug output containing the debug symbols.

Add symlinks in these outputs so that we can recover the store path of the source and original elf file. We can then fetch them by the normal binary cache protocol.

Pros:
- we could host an official instance of such a debuginfod server

Cons
- debug outputs now depend on the source and executable, and the nixos option [environment.enableDebugInfo](https://search.nixos.org/options?channel=24.11&show=environment.enableDebugInfo&from=0&size=50&sort=relevance&type=packages&query=debug+enable+symbol) consumes more disk space.

A proof of concept of such debuginfo server is available at https://github.com/symphorien/nixseparatedebuginfod2


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
