### PR TITLE
rs: fix build with gcc14, modernize

### DIFF
--- a/pkgs/by-name/rs/rs/package.nix
+++ b/pkgs/by-name/rs/rs/package.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
   buildPhase = ''
     runHook preBuild
 
-    ${stdenv.cc}/bin/cc utf8.c rs.c -o rs -lbsd
+    ${stdenv.cc}/bin/cc -DNEED_STRTONUM utf8.c rs.c -o rs -lbsd
 
     runHook postBuild
   '';

--- a/pkgs/by-name/rs/rs/package.nix
+++ b/pkgs/by-name/rs/rs/package.nix
@@ -6,12 +6,12 @@
   libbsd,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "rs";
   version = "20200313";
 
   src = fetchurl {
-    url = "https://www.mirbsd.org/MirOS/dist/mir/rs/rs-${version}.tar.gz";
+    url = "https://www.mirbsd.org/MirOS/dist/mir/rs/rs-${finalAttrs.version}.tar.gz";
     hash = "sha256-kZIV3J/oWiejC/Y9VkBs+1A/n8mCAyPEvTv+daajvD8=";
   };
 
@@ -41,7 +41,7 @@ stdenv.mkDerivation rec {
     runHook postInstall
   '';
 
-  meta = with lib; {
+  meta = {
     homepage = "http://www.mirbsd.org/htman/i386/man1/rs.htm";
     description = "Reshape a data array from standard input";
     mainProgram = "rs";
@@ -66,8 +66,8 @@ stdenv.mkDerivation rec {
       to control presentation of the output columns, including transposition of
       the rows and columns.
     '';
-    license = licenses.bsd3;
-    maintainers = with maintainers; [ ];
-    platforms = platforms.unix;
+    license = lib.licenses.bsd3;
+    maintainers = [ ];
+    platforms = lib.platforms.unix;
   };
-}
+})


### PR DESCRIPTION
rs: fix build with gcc14

- add `-DNEED_STRTONUM` flag to include declaration of `strtonum` from `rs.h`:
```
#ifdef NEED_STRTONUM
/* .linked/strtonum.c */
extern long long strtonum(const char *, long long, long long, const char **);
#endif
```
Fixes `implicit-function-declaration` error with gcc 14:
```
rs.c: In function 'getargs':
rs.c:410:34: error: implicit declaration of function 'strtonum'; did you mean 'strtouq'? []
  410 |                         owidth = strtonum(optarg, 1, INT_MAX, &errstr);
      |                                  ^~~~~~~~
      |                                  strtouq
```
---
rs: modernize

- replace `rec` with `finalAttrs`
- remove `with lib;` from `meta`
---

Fixes build failure of `rs` since `2025-01-14` (update to GCC14 in #356812):
https://hydra.nixos.org/job/nixos/trunk-combined/nixpkgs.rs.x86_64-linux
https://hydra.nixos.org/build/293094997

Log:
```text
rs.c: In function 'getargs':
rs.c:410:34: error: implicit declaration of function 'strtonum'; did you mean 'strtouq'? []
  410 |                         owidth = strtonum(optarg, 1, INT_MAX, &errstr);
      |                                  ^~~~~~~~
      |                                  strtouq
```

Tracking issue: #388196

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
