### PR TITLE
vscodium: mark non-glibc as broken

### DIFF
--- a/pkgs/applications/editors/vscode/vscodium.nix
+++ b/pkgs/applications/editors/vscode/vscodium.nix
@@ -91,5 +91,7 @@ callPackage ./generic.nix rec {
       "aarch64-darwin"
       "armv7l-linux"
     ];
+    # requires libc.so.6 and other glibc specifics
+    broken = stdenv.hostPlatform.isLinux && !stdenv.hostPlatform.isGnu;
   };
 }


### PR DESCRIPTION
Trying pkgsMusl.vscodium:
```
error: auto-patchelf could not satisfy dependency libm.so.6 wanted by /nix/store/cd8rva763hqhn5nma0ppnjdcbm8vb4k0-vscodium-1.98.2.25072/lib/vscode/resources/app/node_modules/@parcel/watcher/build/Release/watcher.node
error: auto-patchelf could not satisfy dependency libpthread.so.0 wanted by /nix/store/cd8rva763hqhn5nma0ppnjdcbm8vb4k0-vscodium-1.98.2.25072/lib/vscode/resources/app/node_modules/@parcel/watcher/build/Release/watcher.node
error: auto-patchelf could not satisfy dependency libc.so.6 wanted by /nix/store/cd8rva763hqhn5nma0ppnjdcbm8vb4k0-vscodium-1.98.2.25072/lib/vscode/resources/app/node_modules/@parcel/watcher/build/Release/watcher.node
error: auto-patchelf could not satisfy dependency ld-linux-x86-64.so.2 wanted by /nix/store/cd8rva763hqhn5nma0ppnjdcbm8vb4k0-vscodium-1.98.2.25072/lib/vscode/resources/app/node_modules/@parcel/watcher/build/Release/watcher.node
```
Probably the same applies to vscode

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).