### PR TITLE
fig2dev: apply patches for CVE-2025-31162 and CVE-2025-31163

### DIFF
--- a/pkgs/by-name/fi/fig2dev/CVE-2025-31162.patch
+++ b/pkgs/by-name/fi/fig2dev/CVE-2025-31162.patch
@@ -1,0 +1,27 @@
+commit da8992f44b84a337b4edaa67fc8b36b55eaef696
+Date:   Wed Jan 22 23:18:54 2025 +0100
+
+    Reject huge pattern lengths, ticket #185
+    
+    Reject patterned lines, e.g., dashed lines, where the
+    pattern length exceeds 80 inches.
+
+diff --git a/fig2dev/object.h b/fig2dev/object.h
+index 29f5a62..7f83939 100644
+--- a/fig2dev/object.h
++++ b/fig2dev/object.h
+@@ -57,12 +57,13 @@ typedef struct f_comment {
+ 	struct f_comment	*next;
+ } F_comment;
+ 
++#define	STYLE_VAL_MAX	6400.0	/* dash length 80 inches, that is enough */
+ #define COMMON_PROPERTIES(o)						\
+ 	o->style < SOLID_LINE || o->style > DASH_3_DOTS_LINE ||		\
+ 	o->thickness < 0 || o->depth < 0 || o->depth > 999 ||		\
+ 	o->fill_style < UNFILLED ||					\
+ 	o->fill_style >= NUMSHADES + NUMTINTS + NUMPATTERNS ||		\
+-	o->style_val < 0.0
++	o->style_val < 0.0 || o->style_val > STYLE_VAL_MAX
+ 
+ typedef struct f_ellipse {
+ 	int			type;

--- a/pkgs/by-name/fi/fig2dev/CVE-2025-31163.patch
+++ b/pkgs/by-name/fi/fig2dev/CVE-2025-31163.patch
@@ -1,0 +1,91 @@
+commit c8a87d22036e62bac0c6f7836078d8103caa6457
+Author: Thomas Loimer <thomas.loimer@tuwien.ac.at>
+Date:   Wed Jan 22 23:27:43 2025 +0100
+
+    Reject arcs with co-incident points, ticket #186
+
+diff --git a/fig2dev/object.h b/fig2dev/object.h
+index 7f83939..50afbf0 100644
+--- a/fig2dev/object.h
++++ b/fig2dev/object.h
+@@ -3,7 +3,7 @@
+  * Copyright (c) 1991 by Micah Beck
+  * Parts Copyright (c) 1985-1988 by Supoj Sutanthavibul
+  * Parts Copyright (c) 1989-2015 by Brian V. Smith
+- * Parts Copyright (c) 2015-2023 by Thomas Loimer
++ * Parts Copyright (c) 2015-2025 by Thomas Loimer
+  *
+  * Any party obtaining a copy of these files is granted, free of charge, a
+  * full and unrestricted irrevocable, world-wide, paid up, royalty-free,
+@@ -92,10 +92,10 @@ typedef struct f_ellipse {
+ 	struct f_ellipse	*next;
+ } F_ellipse;
+ 
+-#define INVALID_ELLIPSE(e)	\
++#define INVALID_ELLIPSE(e)						\
+ 	e->type < T_ELLIPSE_BY_RAD || e->type > T_CIRCLE_BY_DIA ||	\
+-	COMMON_PROPERTIES(e) || (e->direction != 1 && e->direction != 0) || \
+-	e->radiuses.x == 0 || e->radiuses.y == 0 || \
++	COMMON_PROPERTIES(e) || (e->direction != 1 && e->direction != 0) ||  \
++	e->radiuses.x == 0 || e->radiuses.y == 0 ||			\
+ 	e->angle < -7. || e->angle > 7.
+ 
+ typedef struct f_arc {
+@@ -126,12 +126,16 @@ typedef struct f_arc {
+ #define CIRCARC       9
+ #define CIRCULARARC   > 8
+ 
+-#define INVALID_ARC(a)	\
++#define COINCIDENT(a, b)	(a.x == b.x && a.y == b.y)
++#define INVALID_ARC(a)							\
+ 	a->type < T_OPEN_ARC || a->type > T_PIE_WEDGE_ARC ||		\
+ 	COMMON_PROPERTIES(a) || a->cap_style < 0 || a->cap_style > 2 ||	\
+ 	a->center.x < COORD_MIN || a->center.x > COORD_MAX ||		\
+ 	a->center.y < COORD_MIN || a->center.y > COORD_MAX ||		\
+-	(a->direction != 0 && a->direction != 1)
++	(a->direction != 0 && a->direction != 1) ||			\
++	COINCIDENT(a->point[0], a->point[1]) ||				\
++	COINCIDENT(a->point[0], a->point[2]) ||				\
++	COINCIDENT(a->point[1], a->point[2])
+ 
+ typedef struct f_line {
+ 	int			type;
+diff --git a/fig2dev/tests/read.at b/fig2dev/tests/read.at
+index 1b4baea..da9ea3e 100644
+--- a/fig2dev/tests/read.at
++++ b/fig2dev/tests/read.at
+@@ -2,7 +2,7 @@ dnl Fig2dev: Translate Fig code to various Devices
+ dnl Copyright (c) 1991 by Micah Beck
+ dnl Parts Copyright (c) 1985-1988 by Supoj Sutanthavibul
+ dnl Parts Copyright (c) 1989-2015 by Brian V. Smith
+-dnl Parts Copyright (c) 2015-2024 by Thomas Loimer
++dnl Parts Copyright (c) 2015-2025 by Thomas Loimer
+ dnl
+ dnl Any party obtaining a copy of these files is granted, free of charge, a
+ dnl full and unrestricted irrevocable, world-wide, paid up, royalty-free,
+@@ -14,7 +14,7 @@ dnl party to do so, with the only requirement being that the above copyright
+ dnl and this permission notice remain intact.
+ 
+ dnl read.at
+-dnl Author: Thomas Loimer, 2017-2024
++dnl Author: Thomas Loimer, 2017-2025
+ 
+ 
+ AT_BANNER([Sanitize and harden input.])
+@@ -248,6 +248,16 @@ EOF
+ ])
+ AT_CLEANUP
+ 
++AT_SETUP([reject arcs with coincident points, ticket #186])
++AT_KEYWORDS(read.c arc)
++AT_CHECK([fig2dev -L pict2e <<EOF
++FIG_FILE_TOP
++5 1 0 15 0 7 50 0 -1 0.0 1 0 0 0 0.0 0.0 1 1 1 1 2 0
++EOF
++], 1, ignore, [Invalid arc object at line 10.
++])
++AT_CLEANUP
++
+ AT_SETUP([survive debian bugs #881143, #881144])
+ AT_KEYWORDS([font pic tikz])
+ AT_CHECK([fig2dev -L pic <<EOF

--- a/pkgs/by-name/fi/fig2dev/package.nix
+++ b/pkgs/by-name/fi/fig2dev/package.nix
@@ -21,6 +21,11 @@ stdenv.mkDerivation rec {
     hash = "sha256-YeGFOTF2hS8DuQGzsFsZ+8Wtglj/FC89pucLG4NRMyY=";
   };
 
+  patches = [
+    ./CVE-2025-31162.patch
+    ./CVE-2025-31163.patch
+  ];
+
   nativeBuildInputs = [ makeWrapper ];
   buildInputs = [ libpng ];
 


### PR DESCRIPTION
https://sourceforge.net/p/mcj/tickets/185/
https://sourceforge.net/p/mcj/tickets/186/


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review pr 394682`

---
### `x86_64-linux`
<details>
  <summary>:fast_forward: 2 packages marked as broken and skipped:</summary>
  <ul>
    <li>spring</li>
    <li>springLobby</li>
  </ul>
</details>
<details>
  <summary>:x: 1 package failed to build:</summary>
  <ul>
    <li>skribilo</li>
  </ul>
</details>
<details>
  <summary>:white_check_mark: 17 packages built:</summary>
  <ul>
    <li>asciidoc-full</li>
    <li>asciidoc-full-with-plugins</li>
    <li>asciidoc-full-with-plugins.dist</li>
    <li>asciidoc-full.dist</li>
    <li>chemtool</li>
    <li>clevis</li>
    <li>clevis.man</li>
    <li>cyrus-imapd</li>
    <li>dblatexFull</li>
    <li>disorderfs</li>
    <li>fig2dev</li>
    <li>fped</li>
    <li>rep (kakounePlugins.rep)</li>
    <li>luksmeta</li>
    <li>tang</li>
    <li>tang.man</li>
    <li>xfig</li>
  </ul>
</details>
---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
