### PR TITLE
haskell.compiler.ghc967: init at 9.6.7

### DIFF
--- a/pkgs/development/compilers/ghc/9.6.7.nix
+++ b/pkgs/development/compilers/ghc/9.6.7.nix
@@ -1,0 +1,4 @@
+import ./common-hadrian.nix {
+  version = "9.6.7";
+  sha256 = "sha256-0FO/bOHViKdc/oyTFiaUhunY+4nc32/ZKDb6Lj32EwU=";
+}

--- a/pkgs/development/compilers/ghc/common-hadrian.nix
+++ b/pkgs/development/compilers/ghc/common-hadrian.nix
@@ -173,13 +173,14 @@
         in
 
         # Fix docs build with Sphinx >= 7 https://gitlab.haskell.org/ghc/ghc/-/issues/24129
-        lib.optionals (lib.versionOlder version "9.8") [
+        lib.optionals (lib.versionOlder version "9.6.7") [
            ./docs-sphinx-7.patch
         ]
 
         ++ lib.optional (
           # 2025-01-16: unix >= 2.8.6.0 is unaffected which is shipped by GHC 9.12.1 and 9.8.4
           lib.versionOlder version "9.11"
+          && !(lib.versionAtLeast version "9.6.7" && lib.versionOlder version "9.8")
           && !(lib.versionAtLeast version "9.8.4" && lib.versionOlder version "9.9")
         ) [
           # Determine size of time related types using hsc2hs instead of assuming CLong.

--- a/pkgs/development/tools/haskell/hadrian/hadrian.nix
+++ b/pkgs/development/tools/haskell/hadrian/hadrian.nix
@@ -52,7 +52,8 @@ mkDerivation {
     # that only seems to affect Windows. We never build GHC natively on Windows.
     # https://gitlab.haskell.org/ghc/ghc/-/issues/24382
     # https://gitlab.haskell.org/ghc/ghc/-/commit/a2c033cf82635c83f3107706634bebee43297b99
-    (lib.versionAtLeast ghcVersion "9.12" && lib.versionOlder ghcVersion "9.15");
+    (lib.versionAtLeast ghcVersion "9.6.7" && lib.versionOlder ghcVersion "9.7")
+    || (lib.versionAtLeast ghcVersion "9.12" && lib.versionOlder ghcVersion "9.15");
   isLibrary = false;
   isExecutable = true;
   executableHaskellDepends =

--- a/pkgs/top-level/haskell-packages.nix
+++ b/pkgs/top-level/haskell-packages.nix
@@ -267,7 +267,25 @@ in
         buildTargetLlvmPackages = pkgsBuildTarget.llvmPackages_15;
         llvmPackages = pkgs.llvmPackages_15;
       };
-      ghc96 = compiler.ghc966;
+      ghc967 = callPackage ../development/compilers/ghc/9.6.7.nix {
+        bootPkgs =
+          # For GHC 9.2 no armv7l bindists are available.
+          if stdenv.buildPlatform.isAarch32 then
+            bb.packages.ghc928
+          else if stdenv.buildPlatform.isPower64 && stdenv.buildPlatform.isLittleEndian then
+            bb.packages.ghc928
+          else
+            bb.packages.ghc924Binary;
+        inherit (buildPackages.python3Packages) sphinx;
+        # Need to use apple's patched xattr until
+        # https://github.com/xattr/xattr/issues/44 and
+        # https://github.com/xattr/xattr/issues/55 are solved.
+        inherit (buildPackages.darwin) xattr autoSignDarwinBinariesHook;
+        # Support range >= 11 && < 16
+        buildTargetLlvmPackages = pkgsBuildTarget.llvmPackages_15;
+        llvmPackages = pkgs.llvmPackages_15;
+      };
+      ghc96 = compiler.ghc967;
       ghc981 = callPackage ../development/compilers/ghc/9.8.1.nix {
         bootPkgs =
           # For GHC 9.6 no armv7l bindists are available.
@@ -527,7 +545,12 @@ in
         ghc = bh.compiler.ghc966;
         compilerConfig = callPackage ../development/haskell-modules/configuration-ghc-9.6.x.nix { };
       };
-      ghc96 = packages.ghc966;
+      ghc967 = callPackage ../development/haskell-modules {
+        buildHaskellPackages = bh.packages.ghc967;
+        ghc = bh.compiler.ghc967;
+        compilerConfig = callPackage ../development/haskell-modules/configuration-ghc-9.6.x.nix { };
+      };
+      ghc96 = packages.ghc967;
       ghc981 = callPackage ../development/haskell-modules {
         buildHaskellPackages = bh.packages.ghc981;
         ghc = bh.compiler.ghc981;

--- a/pkgs/top-level/release-haskell.nix
+++ b/pkgs/top-level/release-haskell.nix
@@ -72,6 +72,7 @@ let
     ghc964
     ghc965
     ghc966
+    ghc967
     ghc981
     ghc982
     ghc983


### PR DESCRIPTION
Release notes:
https://downloads.haskell.org/ghc/9.6.7/docs/users_guide/9.6.7-notes.html

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
