### PR TITLE
steamcmd: support x86_64-darwin

### DIFF
--- a/pkgs/by-name/st/steamcmd/package.nix
+++ b/pkgs/by-name/st/steamcmd/package.nix
@@ -3,19 +3,33 @@
   stdenv,
   fetchurl,
   steam-run,
-  bash,
   coreutils,
-  steamRoot ? "~/.local/share/Steam",
+  steamRoot ? "$HOME/.local/share/Steam",
 }:
-
+let
+  srcs =
+    let
+      url =
+        platform:
+        "https://web.archive.org/web/20240521141411/https://steamcdn-a.akamaihd.net/client/installer/steamcmd_${platform}.tar.gz";
+    in
+    {
+      x86_64-darwin = fetchurl {
+        url = url "osx";
+        hash = "sha256-jswXyJiOWsrcx45jHEhJD3YVDy36ps+Ne0tnsJe9dTs=";
+      };
+      x86_64-linux = fetchurl {
+        url = url "linux";
+        hash = "sha256-zr8ARr/QjPRdprwJSuR6o56/QVXl7eQTc7V5uPEHHnw=";
+      };
+    };
+in
 stdenv.mkDerivation {
   pname = "steamcmd";
   version = "20180104"; # According to steamcmd_linux.tar.gz mtime
 
-  src = fetchurl {
-    url = "https://web.archive.org/web/20240521141411/https://steamcdn-a.akamaihd.net/client/installer/steamcmd_linux.tar.gz";
-    hash = "sha256-zr8ARr/QjPRdprwJSuR6o56/QVXl7eQTc7V5uPEHHnw=";
-  };
+  src =
+    srcs.${stdenv.hostPlatform.system} or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
 
   # The source tarball does not have a single top-level directory.
   preUnpack = ''
@@ -24,24 +38,18 @@ stdenv.mkDerivation {
     sourceRoot=.
   '';
 
-  buildInputs = [
-    bash
-    steam-run
-  ];
-
   dontBuild = true;
 
   installPhase = ''
-    mkdir -p $out/share/steamcmd/linux32
-    install -Dm755 steamcmd.sh $out/share/steamcmd/steamcmd.sh
-    install -Dm755 linux32/* $out/share/steamcmd/linux32
+    mkdir -p $out/share/steamcmd
+    find . -type f -exec install -Dm 755 "{}" "$out/share/steamcmd/{}" \;
 
     mkdir -p $out/bin
     substitute ${./steamcmd.sh} $out/bin/steamcmd \
       --subst-var out \
       --subst-var-by coreutils ${coreutils} \
-      --subst-var-by steamRoot "${steamRoot}" \
-      --subst-var-by steamRun ${steam-run}
+      --subst-var-by steamRoot '${steamRoot}' \
+      --subst-var-by steamRun ${if stdenv.hostPlatform.isLinux then (lib.getExe steam-run) else "exec"}
     chmod 0755 $out/bin/steamcmd
   '';
 
@@ -49,7 +57,10 @@ stdenv.mkDerivation {
     homepage = "https://developer.valvesoftware.com/wiki/SteamCMD";
     description = "Steam command-line tools";
     mainProgram = "steamcmd";
-    platforms = lib.platforms.linux;
+    platforms = [
+      "x86_64-linux"
+      "x86_64-darwin"
+    ];
     license = lib.licenses.unfreeRedistributable;
     maintainers = with lib.maintainers; [ tadfisher ];
   };

--- a/pkgs/by-name/st/steamcmd/steamcmd.sh
+++ b/pkgs/by-name/st/steamcmd/steamcmd.sh
@@ -20,8 +20,8 @@ fi
 if [ ! -e "$STEAMROOT/steamcmd.sh" ]; then
   mkdir -p "$STEAMROOT/linux32"
   # steamcmd.sh will replace these on first use
-  cp @out@/share/steamcmd/steamcmd.sh "$STEAMROOT/."
-  cp @out@/share/steamcmd/linux32/* "$STEAMROOT/linux32/."
+  cd @out@/share/steamcmd
+  find . -type f -exec install -Dm 755 "{}" "$STEAMROOT/{}" \;
 fi
 
-@steamRun@/bin/steam-run "$STEAMROOT/steamcmd.sh" "$@"
+@steamRun@ "$STEAMROOT/steamcmd.sh" "$@"


### PR DESCRIPTION
In addition to adding an additional source and changing the steam-run invocation, I used `find` instead of manually `install`ing specific libraries/scripts into `~/.local/share/Steam` (this is the part of the patch that's the most likely to introduce a breaking change, so please ensure this looks ok!).

Also, I experienced some shell quoting issues with `~` instead of `$HOME` in a previous revision of this patch, but I don't think it's still an issue—I'm keeping it around just in case, but I can remove it if you would prefer.


-------

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin (with Rosetta 2)
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc