### PR TITLE
dirt: unstable-2018-01-01 -> 0-unstable-2025-03-30

### DIFF
--- a/pkgs/by-name/di/dirt/package.nix
+++ b/pkgs/by-name/di/dirt/package.nix
@@ -2,7 +2,6 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  fetchpatch,
   libsndfile,
   libsamplerate,
   liblo,
@@ -11,44 +10,43 @@
 
 stdenv.mkDerivation {
   pname = "dirt";
-  version = "unstable-2018-01-01";
+  version = "0-unstable-2025-03-30";
+
   src = fetchFromGitHub {
     repo = "Dirt";
     owner = "tidalcycles";
-    rev = "b09604c7d8e581bc7799d7e2ad293e7cdd254bda";
-    sha256 = "13adglk2d31d7mswfvi02b0rjdhzmsv11cc8smhidmrns3f9s96n";
+    rev = "4edc6192da3508fecb9f2e26bb0370cdeb6c4166";
+    hash = "sha256-Zo1RzlfENnI2OmwPfO+O8u6Y1BToy911PYzdPQzK2sk=";
     fetchSubmodules = true;
   };
-  patches = [
-    # Pull patch pending upstream inclusion for upstream gcc-10 support:
-    #  https://github.com/tidalcycles/Dirt/pull/65
-    (fetchpatch {
-      name = "fno-common.patch";
-      url = "https://github.com/tidalcycles/Dirt/commit/43fd267745d486228c4185b4fcbd7d9fbc362cc2.patch";
-      sha256 = "08r34ylzs31wwf0la995pb149ccq0vr7qg4792pkhca57zi0bff8";
-    })
-  ];
+
   buildInputs = [
     libsndfile
     libsamplerate
     liblo
     libjack2
   ];
+
   postPatch = ''
     sed -i "s|./samples|$out/share/dirt/samples|" dirt.c
   '';
+
   makeFlags = [ "PREFIX=$(out)" ];
+
+  # error: passing argument 4 of 'lo_server_thread_add_method' from incompatible pointer type
+  env.NIX_CFLAGS_COMPILE = "-Wno-error=incompatible-pointer-types";
+
   postInstall = ''
     mkdir -p $out/share/dirt/
     cp -r samples $out/share/dirt/
   '';
 
-  meta = with lib; {
+  meta = {
     description = "Unimpressive thingie for playing bits of samples with some level of accuracy";
     homepage = "https://github.com/tidalcycles/Dirt";
-    license = licenses.gpl3;
-    maintainers = with maintainers; [ anderspapitto ];
-    platforms = with platforms; linux;
+    license = lib.licenses.gpl3;
+    maintainers = with lib.maintainers; [ anderspapitto ];
+    platforms = lib.platforms.linux;
     mainProgram = "dirt";
   };
 }


### PR DESCRIPTION
also unbreaks on GCC 14 #388196
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
