### PR TITLE
nixosTests.fail2ban: migrate to runTest and extend test coverage

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -386,7 +386,7 @@ in {
   etebase-server = handleTest ./etebase-server.nix {};
   etesync-dav = handleTest ./etesync-dav.nix {};
   evcc = runTest ./evcc.nix;
-  fail2ban = handleTest ./fail2ban.nix { };
+  fail2ban = runTest ./fail2ban.nix;
   fakeroute = handleTest ./fakeroute.nix {};
   fancontrol = handleTest ./fancontrol.nix {};
   fanout = handleTest ./fanout.nix {};

--- a/nixos/tests/fail2ban.nix
+++ b/nixos/tests/fail2ban.nix
@@ -7,13 +7,40 @@
       enable = true;
       bantime-increment.enable = true;
     };
-
     services.openssh.enable = true;
+    networking.nftables.enable = true;
+  };
+
+  nodes.client = _: {
+    environment.systemPackages = [
+      pkgs.sshpass
+      pkgs.libressl.nc
+    ];
+
   };
 
   testScript = ''
-    machine.wait_for_unit("multi-user.target")
+    start_all()
 
+    # Wait for everything to be ready.
+    machine.wait_for_unit("multi-user.target")
     machine.wait_for_unit("fail2ban")
+    machine.wait_for_unit("sshd")
+    client.wait_for_unit("multi-user.target")
+
+    client_addr = "2001:db8:1::1"
+    machine_addr = "2001:db8:1::2"
+
+    # Verify there is not ban and the port is reachable from the client.
+    machine.succeed(f"test 0 -eq $(fail2ban-client get sshd banned {client_addr})")
+    client.succeed(f"nc -w3 -z {machine_addr} 22")
+
+    # Cause authentication failure log entries.
+    for _ in range(2):
+      client.fail(f"sshpass -p 'wrongpassword' ssh -o StrictHostKeyChecking=no {machine_addr}")
+
+    # Verify there is a ban and the port is unreachable from the client.
+    machine.wait_until_succeeds(f"test 1 -eq $(fail2ban-client get sshd banned {client_addr})")
+    client.fail(f"nc -w3 -z {machine_addr} 22")
   '';
 }

--- a/nixos/tests/fail2ban.nix
+++ b/nixos/tests/fail2ban.nix
@@ -1,21 +1,19 @@
-import ./make-test-python.nix (
-  { pkgs, ... }:
-  {
-    name = "fail2ban";
+{ pkgs, ... }:
+{
+  name = "fail2ban";
 
-    nodes.machine = _: {
-      services.fail2ban = {
-        enable = true;
-        bantime-increment.enable = true;
-      };
-
-      services.openssh.enable = true;
+  nodes.machine = _: {
+    services.fail2ban = {
+      enable = true;
+      bantime-increment.enable = true;
     };
 
-    testScript = ''
-      machine.wait_for_unit("multi-user.target")
+    services.openssh.enable = true;
+  };
 
-      machine.wait_for_unit("fail2ban")
-    '';
-  }
-)
+  testScript = ''
+    machine.wait_for_unit("multi-user.target")
+
+    machine.wait_for_unit("fail2ban")
+  '';
+}


### PR DESCRIPTION
Now the fail2ban test exercise fail2ban's basic functionality.

Also moved from `handleTest` to `runTest`. Related to https://github.com/NixOS/nixpkgs/issues/386873.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

CC fail2ban maintainer: @lovek323 

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
