### PR TITLE
Add `nixVersions.nix_2_26.overrideScope`

### DIFF
--- a/lib/tests/nix-for-tests.nix
+++ b/lib/tests/nix-for-tests.nix
@@ -1,4 +1,5 @@
 {
+  lib ? pkgs.lib,
   pkgs,
 }:
 
@@ -13,20 +14,8 @@
 
 builtins.mapAttrs (
   attr: pkg:
-  if
-    # TODO descend in `nixComponents_*` and override `nix-store`. Also
-    # need to introduce the flag needed to do that with.
-    #
-    # This must be done before Nix 2.26 and beyond becomes the default.
-    !(builtins.elem attr [
-      "nixComponents_2_26"
-      "nix_2_26"
-      "latest"
-    ])
-    # There may-be non-package things, like functions, in there too
-    && builtins.isAttrs pkg
-  then
-    pkg.override { withAWS = false; }
+  if lib.versionAtLeast pkg.version "2.26" then
+    pkg.overrideScope (finalScope: prevScope: { aws-sdk-cpp = null; })
   else
-    pkg
+    pkg.override { withAWS = false; }
 ) pkgs.nixVersions

--- a/pkgs/tools/package-management/nix/vendor/2_26/packaging/components.nix
+++ b/pkgs/tools/package-management/nix/vendor/2_26/packaging/components.nix
@@ -414,5 +414,17 @@ in
     */
     overrideSource = src: (scope.overrideSource src).nix-everything;
 
+    /**
+      Override any internals of the Nix package set.
+
+      Single argument: the extension function to apply to the package set (finalScope: prevScope: { ... })
+
+      Example:
+      ```
+      overrideScope (finalScope: prevScope: { aws-sdk-cpp = null; })
+      ```
+    */
+    overrideScope = f: (scope.overrideScope f).nix-everything;
+
   };
 }

--- a/pkgs/tools/package-management/nix/vendor/2_26/packaging/components.nix
+++ b/pkgs/tools/package-management/nix/vendor/2_26/packaging/components.nix
@@ -240,6 +240,8 @@ in
 
   /**
     Apply an extension function (i.e. overlay-shaped) to all component derivations.
+
+    Single argument: the extension function to apply (finalAttrs: prevAttrs: { ... })
   */
   overrideAllMesonComponents =
     f:
@@ -253,7 +255,11 @@ in
     Provide an alternate source. This allows the expressions to be vendored without copying the sources,
     but it does make the build non-granular; all components will use a complete source.
 
-    Packaging expressions will be ignored.
+    Filesets in the packaging expressions will be ignored.
+
+    Single argument: the source to use.
+
+    See also `appendPatches`
   */
   overrideSource =
     src:
@@ -294,6 +300,10 @@ in
     This affects all components.
 
     Changes to the packaging expressions will be ignored.
+
+    Single argument: list of patches to apply
+
+    See also `overrideSource`
   */
   appendPatches =
     patches:
@@ -367,7 +377,7 @@ in
   nix-perl-bindings = callPackage ../src/perl/package.nix { };
 
   nix-everything = callPackage ../packaging/everything.nix { } // {
-    # Note: no `passthru.overrideAllMesonComponents`
+    # Note: no `passthru.overrideAllMesonComponents` etc
     #       This would propagate into `nix.overrideAttrs f`, but then discard
     #       `f` when `.overrideAllMesonComponents` is used.
     #       Both "methods" should be views on the same fixpoint overriding mechanism
@@ -375,6 +385,8 @@ in
     #       two-fixpoint solution.
     /**
       Apply an extension function (i.e. overlay-shaped) to all component derivations, and return the nix package.
+
+      Single argument: the extension function to apply (finalAttrs: prevAttrs: { ... })
     */
     overrideAllMesonComponents = f: (scope.overrideAllMesonComponents f).nix-everything;
 
@@ -383,6 +395,10 @@ in
       This affects all components.
 
       Changes to the packaging expressions will be ignored.
+
+      Single argument: list of patches to apply
+
+      See also `overrideSource`
     */
     appendPatches = ps: (scope.appendPatches ps).nix-everything;
 
@@ -390,7 +406,11 @@ in
       Provide an alternate source. This allows the expressions to be vendored without copying the sources,
       but it does make the build non-granular; all components will use a complete source.
 
-      Packaging expressions will be ignored.
+      Filesets in the packaging expressions will be ignored.
+
+      Single argument: the source to use.
+
+      See also `appendPatches`
     */
     overrideSource = src: (scope.overrideSource src).nix-everything;
 


### PR DESCRIPTION
Required for overriding inputs of all of Nix, including its libraries.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
