### PR TITLE
python3Packages.langchain*: bulk update

### DIFF
--- a/pkgs/development/python-modules/langchain-community/default.nix
+++ b/pkgs/development/python-modules/langchain-community/default.nix
@@ -37,14 +37,14 @@
 
 buildPythonPackage rec {
   pname = "langchain-community";
-  version = "0.3.19";
+  version = "0.3.20";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "langchain-ai";
     repo = "langchain";
     tag = "langchain-community==${version}";
-    hash = "sha256-U7L60GyxRQL9ze22Wy7g6ZdI/IFyAtUe1bRCconv6pg=";
+    hash = "sha256-6YLy7G1kZIqHAGMUIQoGCfDO2ZuVgNEtpkOI1o8eFvc=";
   };
 
   sourceRoot = "${src.name}/libs/community";
@@ -120,6 +120,11 @@ buildPythonPackage rec {
     "test_variable_key_naming"
     # Fails due to the lack of blockbuster
     "test_group_dependencies"
+  ];
+
+  disabledTestPaths = [
+    # ValueError: Received unsupported arguments {'strict': None}
+    "tests/unit_tests/chat_models/test_cloudflare_workersai.py"
   ];
 
   passthru.updateScript = nix-update-script {

--- a/pkgs/development/python-modules/langchain-core/default.nix
+++ b/pkgs/development/python-modules/langchain-core/default.nix
@@ -28,9 +28,6 @@
   pytest-xdist,
   pytestCheckHook,
   syrupy,
-
-  # passthru
-  nix-update-script,
 }:
 
 buildPythonPackage rec {
@@ -95,11 +92,9 @@ buildPythonPackage rec {
       doCheck = true;
     });
 
-    updateScript = nix-update-script {
-      extraArgs = [
-        "--version-regex"
-        "^langchain-core==([0-9.]+)$"
-      ];
+    updateScript = {
+       command = [./update.sh ];
+       supportedFeatures = [ "commit"];
     };
   };
 

--- a/pkgs/development/python-modules/langchain-core/default.nix
+++ b/pkgs/development/python-modules/langchain-core/default.nix
@@ -32,14 +32,14 @@
 
 buildPythonPackage rec {
   pname = "langchain-core";
-  version = "0.3.47";
+  version = "0.3.49";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "langchain-ai";
     repo = "langchain";
     tag = "langchain-core==${version}";
-    hash = "sha256-UUsT8RvBK4TJNrAwXjv/LPzHrgTEoSewUb+8pHG6Xa8=";
+    hash = "sha256-s1vZ7G6Wzywf3euwX/RdCPkgzxvZTYVG0udGpHTIiQc=";
   };
 
   sourceRoot = "${src.name}/libs/core";
@@ -93,8 +93,8 @@ buildPythonPackage rec {
     });
 
     updateScript = {
-       command = [./update.sh ];
-       supportedFeatures = [ "commit"];
+      command = [ ./update.sh ];
+      supportedFeatures = [ "commit" ];
     };
   };
 

--- a/pkgs/development/python-modules/langchain-core/update.sh
+++ b/pkgs/development/python-modules/langchain-core/update.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p common-updater-scripts jq
+
+set -euo pipefail
+
+declare -ar packages=(
+    langchain
+    langchain-azure-dynamic-sessions
+    langchain-chroma
+    langchain-community
+    langchain-core
+    langchain-groq
+    langchain-huggingface
+    langchain-mongodb
+    langchain-ollama
+    langchain-openai
+    langchain-tests
+    langchain-text-splitters
+)
+
+tags=$(git ls-remote --tags --refs "https://github.com/langchain-ai/langchain" | cut --delimiter=/ --field=3-)
+
+# Will be printed as JSON at the end to list what  needs updating
+updates=""
+
+for package in ${packages[@]}
+do
+    pyPackage="python3Packages.$package"
+    oldVersion="$(nix-instantiate --eval -E "with import ./. {}; lib.getVersion $pyPackage" | tr -d '"')"
+    newVersion=$(echo "$tags" | grep -Po "(?<=$package==)\d+\.\d+\.\d+$" | sort --version-sort --reverse | head -1 )
+    if [[ "$newVersion" != "$oldVersion" ]]; then
+        update-source-version $pyPackage "$newVersion"
+        updates+="{
+    \"attrPath\": \"$pyPackage\",
+    \"oldVersion\": \"$oldVersion\",
+    \"newVersion\": \"$newVersion\",
+    \"files\": [
+        \"$PWD/pkgs/development/python-modules/${package}/default.nix\"
+    ]
+},"
+    fi
+done
+# Remove trailing comma
+updates=${updates%,}
+# Print the updates in JSON format
+echo "[ $updates ]"

--- a/pkgs/development/python-modules/langchain-groq/default.nix
+++ b/pkgs/development/python-modules/langchain-groq/default.nix
@@ -18,14 +18,14 @@
 
 buildPythonPackage rec {
   pname = "langchain-groq";
-  version = "0.3.1";
+  version = "0.3.2";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "langchain-ai";
     repo = "langchain";
     tag = "langchain-groq==${version}";
-    hash = "sha256-kdqgX2fnagVL+W6dRJwnpngcJK2q4E4nk8r4+zIwPt4=";
+    hash = "sha256-KsKT7+jpTTiSVMZWcIwW7+1BCL7rpZHg/OX3PNLI6As=";
   };
 
   sourceRoot = "${src.name}/libs/partners/groq";

--- a/pkgs/development/python-modules/langchain-ollama/default.nix
+++ b/pkgs/development/python-modules/langchain-ollama/default.nix
@@ -4,6 +4,7 @@
   fetchFromGitHub,
 
   # build-system
+  pdm-backend,
   poetry-core,
 
   # dependencies
@@ -21,19 +22,22 @@
 
 buildPythonPackage rec {
   pname = "langchain-ollama";
-  version = "0.2.3";
+  version = "0.3.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "langchain-ai";
     repo = "langchain";
     tag = "langchain-ollama==${version}";
-    hash = "sha256-G7faykRlpfmafSnSe/CdPW87uCtofBp7mLzbxZgBBhM=";
+    hash = "sha256-KsQV2jM2rXbFg+ZlDnpw8sD3Nm8C37BWo+DkDTaMDtQ=";
   };
 
   sourceRoot = "${src.name}/libs/partners/ollama";
 
-  build-system = [ poetry-core ];
+  build-system = [
+    pdm-backend
+    poetry-core
+  ];
 
   pythonRelaxDeps = [
     # Each component release requests the exact latest core.

--- a/pkgs/development/python-modules/langchain-openai/default.nix
+++ b/pkgs/development/python-modules/langchain-openai/default.nix
@@ -29,14 +29,14 @@
 
 buildPythonPackage rec {
   pname = "langchain-openai";
-  version = "0.3.8";
+  version = "0.3.11";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "langchain-ai";
     repo = "langchain";
     tag = "langchain-openai==${version}";
-    hash = "sha256-ooqIUHel/tAI0jNI/j7OXD9ytAH3pXQ3QN5YMhFt2ac=";
+    hash = "sha256-yIYVRn9IHjxBSxnBOTayYrIxw8ZbAeuawu3gKk9gA0M=";
   };
 
   sourceRoot = "${src.name}/libs/partners/openai";

--- a/pkgs/development/python-modules/langchain-tests/default.nix
+++ b/pkgs/development/python-modules/langchain-tests/default.nix
@@ -23,14 +23,14 @@
 
 buildPythonPackage rec {
   pname = "langchain-tests";
-  version = "0.3.13";
+  version = "0.3.17";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "langchain-ai";
     repo = "langchain";
     tag = "langchain-tests==${version}";
-    hash = "sha256-N209wUGdlHkOZynhSSE+ZHylL7cK+8H3PfZIG/wvMd0=";
+    hash = "sha256-jhdCpZsRvCxDIfaZpdqAdx+rxJTU6QHDgNKc4w7XmR8=";
   };
 
   sourceRoot = "${src.name}/libs/standard-tests";

--- a/pkgs/development/python-modules/langchain-tests/default.nix
+++ b/pkgs/development/python-modules/langchain-tests/default.nix
@@ -2,7 +2,6 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  nix-update-script,
 
   # build-system
   pdm-backend,
@@ -62,11 +61,8 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
-  passthru.updateScript = nix-update-script {
-    extraArgs = [
-      "--version-regex"
-      "^langchain-tests==([0-9.]+)$"
-    ];
+  passthru = {
+    inherit (langchain-core) updateScript;
   };
 
   meta = {

--- a/pkgs/development/python-modules/langchain-text-splitters/default.nix
+++ b/pkgs/development/python-modules/langchain-text-splitters/default.nix
@@ -18,14 +18,14 @@
 
 buildPythonPackage rec {
   pname = "langchain-text-splitters";
-  version = "0.3.6";
+  version = "0.3.7";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "langchain-ai";
     repo = "langchain";
     tag = "langchain-text-splitters==${version}";
-    hash = "sha256-mYaIVE/v+t7TJw/l87IJcFh893OTIew6jl6OVj0gXCo=";
+    hash = "sha256-tIX1nxmXU3xhJuM2Q3Tm4fbCoJwI0A8+G1aSyLcoNo0=";
   };
 
   sourceRoot = "${src.name}/libs/text-splitters";

--- a/pkgs/development/python-modules/langchain/default.nix
+++ b/pkgs/development/python-modules/langchain/default.nix
@@ -41,14 +41,14 @@
 
 buildPythonPackage rec {
   pname = "langchain";
-  version = "0.3.20";
+  version = "0.3.21";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "langchain-ai";
     repo = "langchain";
     tag = "langchain==${version}";
-    hash = "sha256-N209wUGdlHkOZynhSSE+ZHylL7cK+8H3PfZIG/wvMd0=";
+    hash = "sha256-Up/pH2TxLPiPO49oIa2ZlNeH3TyN9sZSlNsqOIRmlxc=";
   };
 
   sourceRoot = "${src.name}/libs/langchain";


### PR DESCRIPTION
Langchain is built in a monorepo and releases multiple components from the same repo. This confused `nix-update` when called from an update script: it would replace the current component's URL and tag with whatever component was released last. I reported the bug and it appears I'm the only person affected by it.

1. Rewrote the local update script to filter the release tags itself and update each component using `update-source`version`. This prevents the confusion that happened when calling nix-update from the update script.
2. Enabled [the `commit` feature](https://ryantm.github.io/nixpkgs/stdenv/stdenv/#var-passthru-updateScript-commit) of `passthru.updateScript` and emitted a JSON list from the update script. 
3. Attached this bulk update script to `langchain-core` and `langchain-tests` as changes to these are harbingers of downstream changes.
4. Left the rest of the components able to update singly (such as via r-ryantm).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
