### PR TITLE
solana-agave: init at 2.1.21

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -26972,6 +26972,12 @@
     githubId = 67477750;
     name = "Tomkoid";
   };
+  TomMD = {
+    name = "Thomas M. DuBuisson";
+    email = "thomas.dubuisson@gmail.com";
+    github = "TomMD";
+    githubId = 137806;
+  };
   Tommimon = {
     name = "Tommaso Montanari";
     email = "sefymw7q8@mozmail.com";

--- a/pkgs/by-name/so/solana-agave/crossbeam-epoch.patch
+++ b/pkgs/by-name/so/solana-agave/crossbeam-epoch.patch
@@ -1,0 +1,49 @@
+diff --git a/Cargo.lock b/Cargo.lock
+index 0194c34ed2..0d58655f70 100644
+--- a/Cargo.lock
++++ b/Cargo.lock
+@@ -1419,14 +1419,14 @@ dependencies = [
+ 
+ [[package]]
+ name = "crossbeam-epoch"
+-version = "0.9.5"
+-source = "git+https://github.com/anza-xyz/crossbeam?rev=fd279d707025f0e60951e429bf778b4813d1b6bf#fd279d707025f0e60951e429bf778b4813d1b6bf"
++version = "0.9.16"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "2d2fe95351b870527a5d09bf563ed3c97c0cffb87cf1c78a591bf48bb218d9aa"
+ dependencies = [
++ "autocfg",
+  "cfg-if 1.0.0",
+  "crossbeam-utils",
+- "lazy_static",
+- "memoffset 0.6.4",
+- "scopeguard",
++ "memoffset 0.9.0",
+ ]
+ 
+ [[package]]
+@@ -3118,15 +3118,6 @@ dependencies = [
+  "libc",
+ ]
+ 
+-[[package]]
+-name = "memoffset"
+-version = "0.6.4"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "59accc507f1338036a0477ef61afdae33cde60840f4dfe481319ce3ad116ddf9"
+-dependencies = [
+- "autocfg",
+-]
+-
+ [[package]]
+ name = "memoffset"
+ version = "0.7.1"
+diff --git a/Cargo.toml b/Cargo.toml
+index 2ff2094d67..a3ace4459a 100644
+--- a/Cargo.toml
++++ b/Cargo.toml
+@@ -665,4 +665,4 @@
+ [patch.crates-io]
+ # for details, see https://github.com/anza-xyz/crossbeam/commit/fd279d707025f0e60951e429bf778b4813d1b6bf
+-crossbeam-epoch = { git = "https://github.com/anza-xyz/crossbeam", rev = "fd279d707025f0e60951e429bf778b4813d1b6bf" }
++# crossbeam-epoch = { git = "https://github.com/anza-xyz/crossbeam", rev = "fd279d707025f0e60951e429bf778b4813d1b6bf" }

--- a/pkgs/by-name/so/solana-agave/package.nix
+++ b/pkgs/by-name/so/solana-agave/package.nix
@@ -1,0 +1,103 @@
+{
+  lib,
+  stdenv,
+  buildPackages,
+  fetchFromGitHub,
+  rustPlatform,
+  rustfmt,
+  installShellFiles,
+  pkg-config,
+  apple-sdk_15,
+  udev,
+  openssl,
+  libz,
+  protobuf,
+  cmake,
+  gnumake,
+  clang,
+  llvm,
+  llvmPackages,
+  rocksdb,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "solana-agave";
+  version = "2.3.12";
+
+  src = fetchFromGitHub {
+    owner = "anza-xyz";
+    repo = "agave";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-25UgiC5jAnlNE8Z7WrQRIviCuFp4zg57ddYA4h0qJ6U=";
+  };
+
+  cargoHash = "sha256-SVngabz9mrYNn7DlL7Rh7llvO4GmJdt5vpXVcjwqtNg=";
+
+  # For the same reason as discussed in solana-cli derivation (crossbeam softlink), the no_atomic file is missing
+  # and either must somehow be rendered unneeded (using an upstream package) or replaced. A cleaner, non-behavior-changing,
+  # solution would be to commit the file to the repo fork (replacing the softlink).
+  cargoPatches = [
+    ./crossbeam-epoch.patch
+  ];
+
+  nativeBuildInputs = [
+    installShellFiles
+    protobuf
+    cmake
+    gnumake
+    clang
+    llvm
+    llvmPackages.bintools
+    openssl.dev
+    pkg-config
+    rustfmt
+  ];
+  buildInputs = [
+    openssl
+    libz
+    rustPlatform.bindgenHook
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [ apple-sdk_15 ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [ udev ];
+
+  doInstallCheck = false;
+
+  env = {
+    # If set, always finds OpenSSL in the system, even if the vendored feature is enabled.
+    OPENSSL_NO_VENDOR = 1;
+    # Agave uses deny(warnings) which breaks when nixpkgs updates rustc.
+    # Cap lints to warnings so the build doesn't fail on new compiler lints.
+    RUSTFLAGS = "--cap-lints warn";
+    # Use the pre-built rocksdb from nixpkgs instead of compiling from source.
+    # This avoids GCC 13+ compatibility issues with missing <cstdint> includes.
+    ROCKSDB_LIB_DIR = "${rocksdb}/lib";
+  };
+
+  # Disabling tests because:
+  #
+  # ```
+  # running 3 tests
+  # test args::tests::test_max_genesis_archive_unpacked_size_constant ... ok
+  # test bigtable::tests::test_missing_blocks ... ok
+  # error: test failed, to rerun pass `-p agave-ledger-tool --bin agave-ledger-tool`
+  #
+  # Caused by:
+  #   process didn't exit successfully: `/build/source/target/x86_64-unknown-linux-gnu/release/deps/agave_ledger_tool-b8aca978c218ed51` (signal: 4, SIGILL: illegal instruction)
+  # ```
+  #
+  # Almost certainly caused by the ledger-tool test calling `Command::cargo_bin` which assumes a good bit about the current environment.
+  doCheck = false;
+
+  meta = {
+    description = "Solana Network Validator";
+    homepage = "https://github.com/anza-xyz/agave";
+    changelog = "https://github.com/anza-xyz/agave/releases/tag/${finalAttrs.version}";
+    license = with lib.licenses; [
+      asl20
+    ];
+    maintainers = with lib.maintainers; [
+      TomMD
+    ];
+    mainProgram = "agave";
+  };
+})


### PR DESCRIPTION
Add a derivation of the tooling at https://github.com/anza-xyz/agave. This is a solana network validator and cli tooling.

1. Add TomMD as a maintainer
2. Add solana-agave package

## Things done

- Built on platform(s)
  - [X] x86_64-linux
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)