### PR TITLE
llvmPackages_{12,13,14,15,16,17,18,19,20,git}.lldb: refactor

### DIFF
--- a/pkgs/development/compilers/llvm/common/default.nix
+++ b/pkgs/development/compilers/llvm/common/default.nix
@@ -228,7 +228,7 @@ let
         lib.recurseIntoAttrs { llef = callPackage ./lldb-plugins/llef.nix { }; }
       );
 
-      lldb = callPackage ./lldb.nix (
+      lldb = callPackage ./lldb (
         {
         }
         // lib.optionalAttrs (lib.versions.major metadata.release_version == "16") {

--- a/pkgs/development/compilers/llvm/common/lldb.nix
+++ b/pkgs/development/compilers/llvm/common/lldb.nix
@@ -58,7 +58,8 @@ let
 in
 
 stdenv.mkDerivation (
-  rec {
+  finalAttrs:
+  {
     passthru.monorepoSrc = monorepoSrc;
     pname = "lldb";
     inherit version;
@@ -73,7 +74,7 @@ stdenv.mkDerivation (
       "dev"
     ];
 
-    sourceRoot = lib.optional (lib.versionAtLeast release_version "13") "${src.name}/${pname}";
+    sourceRoot = lib.optional (lib.versionAtLeast release_version "13") "${finalAttrs.src.name}/${finalAttrs.pname}";
 
     patches =
       let

--- a/pkgs/development/compilers/llvm/common/lldb.nix
+++ b/pkgs/development/compilers/llvm/common/lldb.nix
@@ -32,25 +32,6 @@
 }:
 
 let
-  src' =
-    if monorepoSrc != null then
-      runCommand "lldb-src-${version}" { inherit (monorepoSrc) passthru; } (
-        ''
-          mkdir -p "$out"
-        ''
-        + lib.optionalString (lib.versionAtLeast release_version "14") ''
-          cp -r ${monorepoSrc}/cmake "$out"
-        ''
-        + ''
-          cp -r ${monorepoSrc}/lldb "$out"
-        ''
-        + lib.optionalString (lib.versionAtLeast release_version "19" && enableManpages) ''
-          mkdir -p "$out/llvm"
-          cp -r ${monorepoSrc}/llvm/docs "$out/llvm/docs"
-        ''
-      )
-    else
-      src;
   vscodeExt = {
     name = if lib.versionAtLeast release_version "18" then "lldb-dap" else "lldb-vscode";
     version = if lib.versionAtLeast release_version "18" then "0.2.0" else "0.1.0";
@@ -64,7 +45,25 @@ stdenv.mkDerivation (
     pname = "lldb";
     inherit version;
 
-    src = src';
+    src =
+      if monorepoSrc != null then
+        runCommand "lldb-src-${version}" { inherit (monorepoSrc) passthru; } (
+          ''
+            mkdir -p "$out"
+          ''
+          + lib.optionalString (lib.versionAtLeast release_version "14") ''
+            cp -r ${monorepoSrc}/cmake "$out"
+          ''
+          + ''
+            cp -r ${monorepoSrc}/lldb "$out"
+          ''
+          + lib.optionalString (lib.versionAtLeast release_version "19" && enableManpages) ''
+            mkdir -p "$out/llvm"
+            cp -r ${monorepoSrc}/llvm/docs "$out/llvm/docs"
+          ''
+        )
+      else
+        src;
 
     # There is no `lib` output because some of the files in `$out/lib` depend on files in `$out/bin`.
     # For example, `$out/lib/python3.12/site-packages/lldb/lldb-argdumper` is a symlink to `$out/bin/lldb-argdumper`.

--- a/pkgs/development/compilers/llvm/common/lldb/default.nix
+++ b/pkgs/development/compilers/llvm/common/lldb/default.nix
@@ -130,7 +130,7 @@ stdenv.mkDerivation (
       ++ lib.optional (lib.versionOlder release_version "14") (
         getVersionFile "lldb/gnu-install-dirs.patch"
       )
-      ++ lib.optional (lib.versionAtLeast release_version "14") ./lldb/gnu-install-dirs.patch;
+      ++ lib.optional (lib.versionAtLeast release_version "14") ./gnu-install-dirs.patch;
 
     nativeBuildInputs =
       [


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Similar to https://github.com/NixOS/nixpkgs/pull/389873, refactor the lldb subpackage.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
