### PR TITLE
llvmPackages_{12,13,14,15,16,17,18,19,20,git}.mlir: refactor

### DIFF
--- a/pkgs/development/compilers/llvm/common/mlir/default.nix
+++ b/pkgs/development/compilers/llvm/common/mlir/default.nix
@@ -58,27 +58,27 @@ stdenv.mkDerivation (finalAttrs: {
 
   cmakeFlags =
     [
-      "-DLLVM_BUILD_TOOLS=ON"
+      (lib.cmakeBool "LLVM_BUILD_TOOLS" true)
       # Install headers as well
-      "-DLLVM_INSTALL_TOOLCHAIN_ONLY=OFF"
-      "-DMLIR_TOOLS_INSTALL_DIR=${placeholder "out"}/bin/"
-      "-DLLVM_ENABLE_IDE=OFF"
-      "-DMLIR_INSTALL_PACKAGE_DIR=${placeholder "dev"}/lib/cmake/mlir"
-      "-DMLIR_INSTALL_CMAKE_DIR=${placeholder "dev"}/lib/cmake/mlir"
-      "-DLLVM_BUILD_TESTS=${if finalAttrs.finalPackage.doCheck then "ON" else "OFF"}"
-      "-DLLVM_ENABLE_FFI=ON"
-      "-DLLVM_HOST_TRIPLE=${stdenv.hostPlatform.config}"
-      "-DLLVM_DEFAULT_TARGET_TRIPLE=${stdenv.hostPlatform.config}"
-      "-DLLVM_ENABLE_DUMP=ON"
-      "-DLLVM_TABLEGEN_EXE=${buildLlvmTools.tblgen}/bin/llvm-tblgen"
-      "-DMLIR_TABLEGEN_EXE=${buildLlvmTools.tblgen}/bin/mlir-tblgen"
+      (lib.cmakeBool "LLVM_INSTALL_TOOLCHAIN_ONLY" false)
+      (lib.cmakeFeature "MLIR_TOOLS_INSTALL_DIR" "${placeholder "out"}/bin/")
+      (lib.cmakeBool "LLVM_ENABLE_IDE" false)
+      (lib.cmakeFeature "MLIR_INSTALL_PACKAGE_DIR" "${placeholder "dev"}/lib/cmake/mlir")
+      (lib.cmakeFeature "MLIR_INSTALL_CMAKE_DIR" "${placeholder "dev"}/lib/cmake/mlir")
+      (lib.cmakeBool "LLVM_BUILD_TESTS" finalAttrs.finalPackage.doCheck)
+      (lib.cmakeBool "LLVM_ENABLE_FFI" true)
+      (lib.cmakeFeature "LLVM_HOST_TRIPLE" stdenv.hostPlatform.config)
+      (lib.cmakeFeature "LLVM_DEFAULT_TARGET_TRIPLE" stdenv.hostPlatform.config)
+      (lib.cmakeBool "LLVM_ENABLE_DUMP" true)
+      (lib.cmakeFeature "LLVM_TABLEGEN_EXE" "${buildLlvmTools.tblgen}/bin/llvm-tblgen")
+      (lib.cmakeFeature "MLIR_TABLEGEN_EXE" "${buildLlvmTools.tblgen}/bin/mlir-tblgen")
       (lib.cmakeBool "LLVM_BUILD_LLVM_DYLIB" (!stdenv.hostPlatform.isStatic))
     ]
     ++ lib.optionals stdenv.hostPlatform.isStatic [
       # Disables building of shared libs, -fPIC is still injected by cc-wrapper
-      "-DLLVM_ENABLE_PIC=OFF"
-      "-DLLVM_BUILD_STATIC=ON"
-      "-DLLVM_LINK_LLVM_DYLIB=OFF"
+      (lib.cmakeBool "LLVM_ENABLE_PIC" false)
+      (lib.cmakeBool "LLVM_BUILD_STATIC" true)
+      (lib.cmakeBool "LLVM_LINK_LLVM_DYLIB" false)
     ]
     ++ devExtraCmakeFlags;
 

--- a/pkgs/development/compilers/llvm/common/mlir/default.nix
+++ b/pkgs/development/compilers/llvm/common/mlir/default.nix
@@ -19,12 +19,12 @@
   devExtraCmakeFlags ? [ ],
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "mlir";
   inherit version doCheck;
 
   # Blank llvm dir just so relative path works
-  src = runCommand "${pname}-src-${version}" { inherit (monorepoSrc) passthru; } (
+  src = runCommand "${finalAttrs.pname}-src-${version}" { inherit (monorepoSrc) passthru; } (
     ''
       mkdir -p "$out"
     ''
@@ -39,7 +39,7 @@ stdenv.mkDerivation rec {
     ''
   );
 
-  sourceRoot = "${src.name}/mlir";
+  sourceRoot = "${finalAttrs.src.name}/mlir";
 
   patches = [
     ./gnu-install-dirs.patch
@@ -64,7 +64,7 @@ stdenv.mkDerivation rec {
       "-DLLVM_ENABLE_IDE=OFF"
       "-DMLIR_INSTALL_PACKAGE_DIR=${placeholder "dev"}/lib/cmake/mlir"
       "-DMLIR_INSTALL_CMAKE_DIR=${placeholder "dev"}/lib/cmake/mlir"
-      "-DLLVM_BUILD_TESTS=${if doCheck then "ON" else "OFF"}"
+      "-DLLVM_BUILD_TESTS=${if finalAttrs.finalPackage.doCheck then "ON" else "OFF"}"
       "-DLLVM_ENABLE_FFI=ON"
       "-DLLVM_HOST_TRIPLE=${stdenv.hostPlatform.config}"
       "-DLLVM_DEFAULT_TARGET_TRIPLE=${stdenv.hostPlatform.config}"
@@ -99,4 +99,4 @@ stdenv.mkDerivation rec {
       existing compilers together.
     '';
   };
-}
+})

--- a/pkgs/development/compilers/llvm/common/mlir/default.nix
+++ b/pkgs/development/compilers/llvm/common/mlir/default.nix
@@ -11,17 +11,18 @@
   libxml2,
   libllvm,
   version,
-  doCheck ?
-    (
-      !stdenv.hostPlatform.isx86_32 # TODO: why
-    )
-    && (!stdenv.hostPlatform.isMusl),
   devExtraCmakeFlags ? [ ],
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "mlir";
-  inherit version doCheck;
+  inherit version;
+
+  doCheck =
+    (
+      !stdenv.hostPlatform.isx86_32 # TODO: why
+    )
+    && (!stdenv.hostPlatform.isMusl);
 
   # Blank llvm dir just so relative path works
   src = runCommand "${finalAttrs.pname}-src-${version}" { inherit (monorepoSrc) passthru; } (


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Similar to https://github.com/NixOS/nixpkgs/pull/389873, refactor the mlir subpackage.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
