### PR TITLE
check-meta: add a teams attribute

### DIFF
--- a/ci/eval/compare/default.nix
+++ b/ci/eval/compare/default.nix
@@ -9,6 +9,7 @@
   beforeResultDir,
   afterResultDir,
   touchedFilesJson,
+  byName ? false,
 }:
 let
   /*
@@ -119,6 +120,7 @@ let
   maintainers = import ./maintainers.nix {
     changedattrs = lib.attrNames (lib.groupBy (a: a.name) rebuildsPackagePlatformAttrs);
     changedpathsjson = touchedFilesJson;
+    inherit byName;
   };
 in
 runCommand "compare"

--- a/ci/eval/compare/maintainers.nix
+++ b/ci/eval/compare/maintainers.nix
@@ -41,7 +41,18 @@ let
   ) validPackageAttributes;
 
   attrsWithMaintainers = builtins.map (
-    pkg: pkg // { maintainers = (pkg.package.meta or { }).maintainers or [ ]; }
+    pkg:
+    let
+      meta = pkg.package.meta or { };
+    in
+    pkg
+    // {
+      # TODO: Refactor this so we can ping entire teams instead of the individual members.
+      # Note that this will require keeping track of GH team IDs in "maintainers/teams.nix".
+      maintainers =
+        meta.maintainers or [ ]
+        ++ lib.flatten (map (team: team.members or [ ]) (meta.teams or [ ]));
+    }
   ) attrsWithPackages;
 
   relevantFilenames =

--- a/ci/eval/compare/maintainers.nix
+++ b/ci/eval/compare/maintainers.nix
@@ -1,5 +1,9 @@
 # Almost directly vendored from https://github.com/NixOS/ofborg/blob/5a4e743f192fb151915fcbe8789922fa401ecf48/ofborg/src/maintainers.nix
-{ changedattrs, changedpathsjson }:
+{
+  changedattrs,
+  changedpathsjson,
+  byName ? false,
+}:
 let
   pkgs = import ../../.. {
     system = "x86_64-linux";
@@ -94,12 +98,13 @@ let
     pkg:
     builtins.map (maintainer: {
       id = maintainer.githubId;
+      inherit (maintainer) github;
       packageName = pkg.name;
       dueToFiles = pkg.filenames;
     }) pkg.maintainers
   ) attrsWithModifiedFiles;
 
-  byMaintainer = lib.groupBy (ping: toString ping.id) listToPing;
+  byMaintainer = lib.groupBy (ping: toString ping.${if byName then "github" else "id"}) listToPing;
 
   packagesPerMaintainer = lib.attrsets.mapAttrs (
     maintainer: packages: builtins.map (pkg: pkg.packageName) packages

--- a/doc/redirects.json
+++ b/doc/redirects.json
@@ -431,6 +431,9 @@
   "typst-package-scope-and-usage": [
     "index.html#typst-package-scope-and-usage"
   ],
+  "var-meta-teams": [
+    "index.html#var-meta-teams"
+  ],
   "variables-specifying-dependencies": [
     "index.html#variables-specifying-dependencies"
   ],

--- a/doc/stdenv/meta.chapter.md
+++ b/doc/stdenv/meta.chapter.md
@@ -91,6 +91,10 @@ For details, see [Source provenance](#sec-meta-sourceProvenance).
 
 A list of the maintainers of this Nix expression. Maintainers are defined in [`nixpkgs/maintainers/maintainer-list.nix`](https://github.com/NixOS/nixpkgs/blob/master/maintainers/maintainer-list.nix). There is no restriction to becoming a maintainer, just add yourself to that list in a separate commit titled “maintainers: add alice” in the same pull request, and reference maintainers with `maintainers = with lib.maintainers; [ alice bob ]`.
 
+### `teams` {#var-meta-teams}
+
+A list of the teams of this Nix expression. Teams are defined in [`nixpkgs/maintainers/team-list.nix`](https://github.com/NixOS/nixpkgs/blob/master/maintainers/team-list.nix), and can be defined in a package with `meta.teams = with lib.teams; [ team1 team2 ]`.
+
 ### `mainProgram` {#var-meta-mainProgram}
 
 The name of the main binary for the package. This affects the binary `nix run` executes. Example: `"rg"`

--- a/maintainers/scripts/README.md
+++ b/maintainers/scripts/README.md
@@ -57,6 +57,17 @@ The maintainer is designated by a `selector` which must be one of:
 
 [`maintainer-list.nix`]: ../maintainer-list.nix
 
+### `get-maintainer-pings-between.sh`
+
+Gets which maintainers would be pinged between two Nixpkgs revisions.
+Outputs a JSON object on stdout mapping GitHub usernames to the attributes
+that they would be getting pinged for.
+
+Example:
+
+```sh
+maintainers/scripts/get-maintainer-pings-between.sh HEAD^ HEAD
+```
 
 ## Conventions
 

--- a/maintainers/scripts/get-maintainer-pings-between.sh
+++ b/maintainers/scripts/get-maintainer-pings-between.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p git jq
+
+# Outputs a list of maintainers that would be pinged across two nixpkgs revisions.
+# Authors:
+#  Morgan Jones (@numinit)
+#  Tristan Ross (@RossComputerGuy)
+
+set -euo pipefail
+
+if [ $# -lt 2 ]; then
+    echo "Usage: $0 <rev-from> <rev-to>" >&2
+    exit 1
+fi
+
+repo="$(git rev-parse --show-toplevel)"
+system="$(nix-instantiate --eval --expr builtins.currentSystem)"
+rev1="$(git -C "$repo" rev-parse "$1")"
+rev2="$(git -C "$repo" rev-parse "$2")"
+
+echo "Touched files:" >&2
+git -C "$repo" diff --name-only "$rev1" "$rev2" \
+    | jq --raw-input --slurp 'split("\n")[:-1]' | tee "$TMPDIR/touched-files.json" >&2
+
+# Runs an eval in the given worktree, outputting the path to $TMPDIR/$1.path.
+# $1: The revision SHA.
+eval_in_worktree() (
+    mkdir -p .worktree
+    local rev="$1"
+    local tree=".worktree/$rev"
+    if [ ! -d "$tree" ]; then
+        git -C "$repo" worktree add -f -d "$tree" "$rev" >&2
+    fi
+    cd "$tree"
+
+    local workdir="$TMPDIR/$rev"
+    rm -rf "$workdir"
+    mkdir -p "$workdir"
+
+    nix-build ci -A eval.attrpathsSuperset -o "$workdir/paths" >&2
+    mkdir -p "$workdir/intermediates"
+    nix-build ci -A eval.singleSystem \
+        --arg evalSystem "$system" \
+        --arg attrpathFile "$workdir/paths/paths.json" \
+        --arg chunkSize ${CHUNK_SIZE:-10000} \
+        -o "$workdir/intermediates/.intermediate-1" >&2
+
+    # eval.combine nix-build needs a directory, not a symlink
+    cp -RL "$workdir/intermediates/.intermediate-1" "$workdir/intermediates/intermediate-1"
+    chmod -R +w "$workdir/intermediates/intermediate-1"
+    rm -rf "$workdir/intermediates/.intermediate-1"
+
+    nix-build ci -A eval.combine \
+        --arg resultsDir "$workdir/intermediates" \
+        -o "$workdir/result" >&2
+)
+
+eval_in_worktree "$rev1" &
+pid1=$!
+eval_in_worktree "$rev2" &
+pid2=$!
+
+wait $pid1
+wait $pid2
+
+path1="$TMPDIR/$rev1"
+path2="$TMPDIR/$rev2"
+
+# Use the repo this script was executed in to get accurate maintainer info
+nix-build "$repo/ci" -A eval.compare \
+    --arg beforeResultDir "$path1/result" \
+    --arg afterResultDir "$path2/result" \
+    --arg touchedFilesJson "$TMPDIR/touched-files.json" \
+    --arg byName true \
+    -o comparison
+
+echo "Pinged maintainers (check $repo/comparison for more details)" >&2
+jq < comparison/maintainers.json

--- a/pkgs/stdenv/generic/check-meta.nix
+++ b/pkgs/stdenv/generic/check-meta.nix
@@ -108,7 +108,10 @@ let
 
   hasUnfreeLicense = attrs: hasLicense attrs && isUnfree attrs.meta.license;
 
-  hasNoMaintainers = attrs: attrs ? meta.maintainers && (length attrs.meta.maintainers) == 0;
+  hasNoMaintainers =
+    attrs:
+    (attrs ? meta.maintainers && (length attrs.meta.maintainers) == 0)
+    && (attrs ? meta.teams && (length attrs.meta.teams) == 0);
 
   isMarkedBroken = attrs: attrs.meta.broken or false;
 
@@ -368,6 +371,7 @@ let
         ];
       sourceProvenance = listOf attrs;
       maintainers = listOf (attrsOf any); # TODO use the maintainer type from lib/tests/maintainer-module.nix
+      teams = listOf (attrsOf any); # TODO similar to maintainers, use a teams type
       priority = int;
       pkgConfigModules = listOf str;
       inherit platforms;
@@ -534,7 +538,7 @@ let
       {
         valid = "warn";
         reason = "maintainerless";
-        errormsg = "has no maintainers";
+        errormsg = "has no maintainers or teams";
       }
     # -----
     else


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

This is something I've had in mind for some time. It'd be great for `meta` to be aware of teams so if a package is only owned by a team or set of teams, the maintainers could be pulled from the members list of each team. This could go onto the package search and make it possible to see which team owns a package.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
