### PR TITLE
nixos/hddfancontrol: use attrset for config

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2505.section.md
+++ b/nixos/doc/manual/release-notes/rl-2505.section.md
@@ -618,7 +618,7 @@
 
 - All services that require a root certificate bundle now use the value of a new read-only option, `security.pki.caBundle`.
 
-- hddfancontrol has been updated to major release 2. See the [migration guide](https://github.com/desbma/hddfancontrol/tree/master?tab=readme-ov-file#migrating-from-v1x), as there are breaking changes.
+- hddfancontrol has been updated to major release 2. See the [migration guide](https://github.com/desbma/hddfancontrol/tree/master?tab=readme-ov-file#migrating-from-v1x), as there are breaking changes. The settings options have been modified to use an attrset, enabling configurations with multiple instances of the daemon running at once, eg, for two separate drive bays.
 
 - `services.cloudflared` now uses a dynamic user, and its `user` and `group` options have been removed. If the user or group is still necessary, they can be created manually.
 

--- a/nixos/modules/services/hardware/hddfancontrol.nix
+++ b/nixos/modules/services/hardware/hddfancontrol.nix
@@ -18,64 +18,162 @@ in
       "hddfancontrol"
       "smartctl"
     ] "Smartctl is now automatically used when necessary, which makes this option redundant")
+    (lib.mkRemovedOptionModule [
+      "services"
+      "hddfancontrol"
+      "disks"
+    ] "Disks should now be specified per hddfancontrol instance in its attrset")
+    (lib.mkRemovedOptionModule [
+      "services"
+      "hddfancontrol"
+      "pwmPaths"
+    ] "Pwm Paths should now be specified per hddfancontrol instance in its attrset")
+    (lib.mkRemovedOptionModule [
+      "services"
+      "hddfancontrol"
+      "logVerbosity"
+    ] "Log Verbosity should now be specified per hddfancontrol instance in its attrset")
+    (lib.mkRemovedOptionModule [
+      "services"
+      "hddfancontrol"
+      "extraArgs"
+    ] "Extra Args should now be specified per hddfancontrol instance in its attrset")
   ];
 
   options = {
     services.hddfancontrol.enable = lib.mkEnableOption "hddfancontrol daemon";
 
-    services.hddfancontrol.disks = lib.mkOption {
-      type = lib.types.listOf lib.types.path;
-      default = [ ];
-      description = ''
-        Drive(s) to get temperature from
-      '';
-      example = [ "/dev/sda" ];
-    };
+    services.hddfancontrol.settings = lib.mkOption {
+      type = lib.types.attrsWith {
+        placeholder = "drive-bay-name";
+        elemType = (
+          lib.types.submodule (
+            { ... }:
+            {
+              options = {
+                disks = lib.mkOption {
+                  type = lib.types.listOf lib.types.path;
+                  default = [ ];
+                  description = ''
+                    Drive(s) to get temperature from
+                  '';
+                  example = [ "/dev/sda" ];
+                };
 
-    services.hddfancontrol.pwmPaths = lib.mkOption {
-      type = lib.types.listOf lib.types.path;
-      default = [ ];
-      description = ''
-        PWM filepath(s) to control fan speed (under /sys), followed by initial and fan-stop PWM values
-      '';
-      example = [ "/sys/class/hwmon/hwmon2/pwm1:30:10" ];
-    };
+                pwmPaths = lib.mkOption {
+                  type = lib.types.listOf lib.types.path;
+                  default = [ ];
+                  description = ''
+                    PWM filepath(s) to control fan speed (under /sys), followed by initial and fan-stop PWM values
+                  '';
+                  example = [ "/sys/class/hwmon/hwmon2/pwm1:30:10" ];
+                };
 
-    services.hddfancontrol.logVerbosity = lib.mkOption {
-      type = lib.types.enum [
-        "TRACE"
-        "DEBUG"
-        "INFO"
-        "WARN"
-        "ERROR"
-      ];
-      default = "INFO";
-      description = ''
-        Verbosity of the log level
-      '';
-    };
+                logVerbosity = lib.mkOption {
+                  type = lib.types.enum [
+                    "TRACE"
+                    "DEBUG"
+                    "INFO"
+                    "WARN"
+                    "ERROR"
+                  ];
+                  default = "INFO";
+                  description = ''
+                    Verbosity of the log level
+                  '';
+                };
 
-    services.hddfancontrol.extraArgs = lib.mkOption {
-      type = lib.types.listOf lib.types.str;
-      default = [ ];
+                extraArgs = lib.mkOption {
+                  type = lib.types.listOf lib.types.str;
+                  default = [ ];
+                  description = ''
+                    Extra commandline arguments for hddfancontrol
+                  '';
+                  example = [
+                    "--min-fan-speed-prct=10"
+                    "--interval=1min"
+                  ];
+                };
+              };
+            }
+          )
+        );
+      };
+      default = { };
       description = ''
-        Extra commandline arguments for hddfancontrol
+        Parameter-sets for each instance of hddfancontrol.
       '';
-      example = [
-        "--min-fan-speed-prct=10"
-        "--interval=1min"
-      ];
+      example = lib.literalExpression ''
+        {
+          harddrives = {
+            disks = [
+              "/dev/sda"
+              "/dev/sdb"
+              "/dev/sdc"
+            ];
+            pwmPaths = [
+              "/sys/class/hwmon/hwmon1/pwm1:25:10"
+            ];
+            logVerbosity = "DEBUG";
+          };
+          ssddrives = {
+            disks = [
+              "/dev/sdd"
+              "/dev/sde"
+              "/dev/sdf"
+            ];
+            pwmPaths = [
+              "/sys/class/hwmon/hwmon1/pwm2:25:10"
+            ];
+            extraArgs = [
+              "--interval=30s"
+            ];
+          };
+        }
+      '';
     };
   };
 
   config = lib.mkIf cfg.enable (
     let
-      args = lib.concatLists [
-        [ "-d" ]
-        cfg.disks
-        [ "-p" ]
-        cfg.pwmPaths
-        cfg.extraArgs
+      args =
+        cnf:
+        lib.concatLists [
+          [ "-d" ]
+          cnf.disks
+          [ "-p" ]
+          cnf.pwmPaths
+          cnf.extraArgs
+        ];
+
+      createService = cnf: {
+        description = "HDD fan control";
+        documentation = [ "man:hddfancontrol(1)" ];
+        after = [ "hddtemp.service" ];
+        wants = [ "hddtemp.service" ];
+        serviceConfig = {
+          ExecStart = "${lib.getExe pkgs.hddfancontrol} -v ${cnf.logVerbosity} daemon ${lib.escapeShellArgs (args cnf)}";
+
+          CPUSchedulingPolicy = "rr";
+          CPUSchedulingPriority = 49;
+
+          ProtectSystem = "strict";
+          PrivateTmp = true;
+          ProtectHome = true;
+          SystemCallArchitectures = "native";
+          MemoryDenyWriteExecute = true;
+          NoNewPrivileges = true;
+        };
+        wantedBy = [ "multi-user.target" ];
+      };
+
+      services = lib.attrsets.mergeAttrsList [
+        (lib.attrsets.mapAttrs' (
+          name: cnf: lib.nameValuePair "hddfancontrol-${name}" (createService cnf)
+        ) cfg.settings)
+        {
+          "hddfancontrol".enable = false;
+        }
       ];
     in
     {
@@ -83,16 +181,10 @@ in
 
       hardware.sensor.hddtemp = {
         enable = true;
-        drives = cfg.disks;
+        drives = lib.lists.flatten (lib.attrsets.catAttrs "disks" (lib.attrsets.attrValues cfg.settings));
       };
 
-      systemd.services.hddfancontrol = {
-        wantedBy = [ "multi-user.target" ];
-        environment = {
-          HDDFANCONTROL_LOG_LEVEL = cfg.logVerbosity;
-          HDDFANCONTROL_DAEMON_ARGS = lib.escapeShellArgs args;
-        };
-      };
+      systemd.services = services;
     }
   );
 }


### PR DESCRIPTION
Enables use of multiple instances, eg; multiple drive bays.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

@benley