### PR TITLE
matrix-sdk-crypto-nodejs: mark broken for cross/static

### DIFF
--- a/pkgs/by-name/ma/matrix-sdk-crypto-nodejs/package.nix
+++ b/pkgs/by-name/ma/matrix-sdk-crypto-nodejs/package.nix
@@ -68,5 +68,7 @@ stdenv.mkDerivation rec {
       dandellion
     ];
     inherit (nodejs.meta) platforms;
+    # napi_build doesn't handle most cross-compilation configurations
+    broken = (!stdenv.buildPlatform.canExecute stdenv.hostPlatform) || stdenv.hostPlatform.isStatic;
   };
 }


### PR DESCRIPTION
e.g. building for aarch64-linux on x86 Linux fails with:

```
  TARGET = Some("x86_64-unknown-linux-gnu")
  HOST = Some("x86_64-unknown-linux-gnu")
```

Building for pkgsStatic "works", but $out has a dependency on glibc.

## Things done

- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).