### PR TITLE
pythonPackages: prevent incorrect package definitions

### DIFF
--- a/pkgs/by-name/ta/tandoor-recipes/package.nix
+++ b/pkgs/by-name/ta/tandoor-recipes/package.nix
@@ -9,7 +9,7 @@ let
 
   frontend = callPackage ./frontend.nix { };
 in
-python.pkgs.pythonPackages.buildPythonPackage {
+python.pkgs.buildPythonPackage {
   pname = "tandoor-recipes";
 
   inherit (common) version src;

--- a/pkgs/development/python-modules/datamodel-code-generator/default.nix
+++ b/pkgs/development/python-modules/datamodel-code-generator/default.nix
@@ -19,7 +19,6 @@
   pytest-mock,
   pytestCheckHook,
   pydantic,
-  python3,
   pyyaml,
   toml,
 }:

--- a/pkgs/development/python-modules/django-fsm/default.nix
+++ b/pkgs/development/python-modules/django-fsm/default.nix
@@ -4,7 +4,7 @@
   fetchFromGitHub,
   setuptools,
   django,
-  python3,
+  python,
   django-guardian,
 }:
 
@@ -27,7 +27,7 @@ buildPythonPackage rec {
   checkInputs = [ django-guardian ];
 
   checkPhase = ''
-    ${python3.interpreter} tests/manage.py test
+    ${python.interpreter} tests/manage.py test
   '';
 
   pythonImportsCheck = [ "django_fsm" ];

--- a/pkgs/development/python-modules/language-tool-python/default.nix
+++ b/pkgs/development/python-modules/language-tool-python/default.nix
@@ -1,8 +1,13 @@
 {
-  python3,
   fetchFromGitHub,
   buildPythonPackage,
   lib,
+  setuptools,
+  requests,
+  tqdm,
+  psutil,
+  toml,
+  pip,
 }:
 buildPythonPackage rec {
   pname = "language-tool-python";
@@ -17,8 +22,8 @@ buildPythonPackage rec {
     hash = "sha256-v82RCg2lE0/ETJTiMogrI09fZ28tq1jhzFhbC89kbTU=";
   };
 
-  build-system = [ python3.pkgs.setuptools ];
-  dependencies = with python3.pkgs; [
+  build-system = [ setuptools ];
+  dependencies = [
     requests
     tqdm
     psutil

--- a/pkgs/top-level/python-aliases.nix
+++ b/pkgs/top-level/python-aliases.nix
@@ -33,6 +33,31 @@ in
   ### Deprecated aliases - for backward compatibility
 
 mapAliases ({
+  # Prevent incorrect Python packaging attempts.
+  # Note: `{ python3, python3Packages, ... }: with python3Packages; [ ... python3 ]` still works, since `with` has lower priority.
+  pythonPackages = throw "do not use pythonPackages when building Python packages, specify each used package as a separate argument"; # do not remove
+  python2Packages = throw "do not use python2Packages when building Python packages, specify each used package as a separate argument"; # do not remove
+  python27Packages = throw "do not use python27Packages when building Python packages, specify each used package as a separate argument"; # do not remove
+  python3Packages = throw "do not use python3Packages when building Python packages, specify each used package as a separate argument"; # do not remove
+  python39Packages = throw "do not use python39Packages when building Python packages, specify each used package as a separate argument"; # do not remove
+  python310Packages = throw "do not use python310Packages when building Python packages, specify each used package as a separate argument"; # do not remove
+  python311Packages = throw "do not use python311Packages when building Python packages, specify each used package as a separate argument"; # do not remove
+  python312Packages = throw "do not use python312Packages when building Python packages, specify each used package as a separate argument"; # do not remove
+  python313Packages = throw "do not use python313Packages when building Python packages, specify each used package as a separate argument"; # do not remove
+  python2 = throw "do not use python2 when building Python packages, use the generic python parameter instead"; # do not remove
+  python3 = throw "do not use python3 when building Python packages, use the generic python parameter instead"; # do not remove
+  python39 = throw "do not use python39 when building Python packages, use the generic python parameter instead"; # do not remove
+  python310 = throw "do not use python310 when building Python packages, use the generic python parameter instead"; # do not remove
+  python311 = throw "do not use python311 when building Python packages, use the generic python parameter instead"; # do not remove
+  python312 = throw "do not use python312 when building Python packages, use the generic python parameter instead"; # do not remove
+  python313 = throw "do not use python313 when building Python packages, use the generic python parameter instead"; # do not remove
+  pypy = throw "do not use pypy when building Python packages, use the generic python parameter instead"; # do not remove
+  pypy2 = throw "do not use pypy2 when building Python packages, use the generic python parameter instead"; # do not remove
+  pypy27 = throw "do not use pypy27 when building Python packages, use the generic python parameter instead"; # do not remove
+  pypy3 = throw "do not use pypy3 when building Python packages, use the generic python parameter instead"; # do not remove
+  pypy310 = throw "do not use pypy310 when building Python packages, use the generic python parameter instead"; # do not remove
+  pypy311 = throw "do not use pypy311 when building Python packages, use the generic python parameter instead"; # do not remove
+
   aadict = throw "aadict was removed, it was introduced as a dependency for a package that never manifested and has been an unused leaf package ever since"; # added 2024-07-08
   abodepy = jaraco-abode; # added 2023-02-01
   acebinf = throw "acebinf has been removed because it is abandoned and broken."; # Added 2023-05-19


### PR DESCRIPTION
As I suggested in https://github.com/NixOS/nixpkgs/pull/379092#discussion_r1939711445

## Things done

I tried finding and fixing all problematic instances in nixpkgs. For some reason CI does not catch use of these aliases, even when I added them to python-packages.

UPDATE: CI does catch this in Eval / Process.

- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).