### PR TITLE
cryptographic-id-rs: init at 0.4.1

### DIFF
--- a/pkgs/by-name/cr/cryptographic-id-rs/package.nix
+++ b/pkgs/by-name/cr/cryptographic-id-rs/package.nix
@@ -1,0 +1,55 @@
+{
+  lib,
+  fetchFromGitLab,
+  rustPlatform,
+  libclang,
+  linuxHeaders,
+  pkg-config,
+  tpm2-tss,
+  protobuf,
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "cryptographic-id-rs";
+  version = "0.4.1";
+
+  src = fetchFromGitLab {
+    owner = "cryptographic_id";
+    repo = "cryptographic-id-rs";
+    tag = "v${finalAttrs.version}";
+    fetchSubmodules = true;
+    hash = "sha256-cKy3psFXV5LkUHC9UaF6QOee1kr/OXm1k2LxDCBypOA=";
+  };
+
+  cargoHash = "sha256-xlP6u+c8R6c1aevod1CwBN+8Y2M/f2jvKzWUHrgqmVM=";
+
+  nativeBuildInputs = [
+    rustPlatform.bindgenHook
+    pkg-config
+    linuxHeaders
+    protobuf
+  ];
+
+  buildInputs = [
+    tpm2-tss
+  ];
+
+  # tests are broken without access to TPM / swTPM
+  doCheck = false;
+
+  env = {
+    LIBCLANG_PATH = "${lib.getLib libclang}/lib";
+  };
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Attest the trustworthiness of a computer using asymmetric cryptography";
+    homepage = "https://gitlab.com/cryptographic_id/cryptographic-id-rs";
+    changelog = "https://gitlab.com/cryptographic_id/cryptographic-id-rs/-/releases/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ arbel-arad ];
+    mainProgram = "cryptographic-id-rs";
+  };
+})


### PR DESCRIPTION
Added package for cryptographic-id-rs
https://gitlab.com/cryptographic_id/cryptographic-id-rs

notes:
the upstream arch package includes scripts and a module for displaying attestation at boot.
this version currently only has the binary.

tests seem to require TPM access with `tpm2-abrmd` and didn't run on my device so i disabled them.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
