### PR TITLE
lib/modules: Reject extra attributes on properties

### DIFF
--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -999,15 +999,15 @@ let
 
     : 1\. Function argument
   */
-  pushDownProperties = cfg:
-    if cfg._type or "" == "merge" then
-      concatMap pushDownProperties cfg.contents
-    else if cfg._type or "" == "if" then
-      map (mapAttrs (n: v: mkIf cfg.condition v)) (pushDownProperties cfg.content)
-    else if cfg._type or "" == "override" then
-      map (mapAttrs (n: v: mkOverride cfg.priority v)) (pushDownProperties cfg.content)
-    else # FIXME: handle mkOrder?
-      [ cfg ];
+  pushDownProperties =
+    let
+      matchProperties = {
+        "merge" = { _type, contents }: concatMap pushDownProperties contents;
+        "if" = { _type, condition, content }: map (mapAttrs (n: v: mkIf condition v)) (pushDownProperties content);
+        "override" = { _type, priority, content }: map (mapAttrs (n: v: mkOverride priority v)) (pushDownProperties content);
+      };
+    in
+      cfg: (matchProperties.${cfg._type or ""} or (cfg: [ cfg ])) cfg;
 
   /**
     Given a config value, expand mkMerge properties, and discharge
@@ -1027,19 +1027,25 @@ let
 
     : 1\. Function argument
   */
-  dischargeProperties = def:
-    if def._type or "" == "merge" then
-      concatMap dischargeProperties def.contents
-    else if def._type or "" == "if" then
-      if isBool def.condition then
-        if def.condition then
-          dischargeProperties def.content
-        else
-          [ ]
-      else
-        throw "‘mkIf’ called with a non-Boolean condition"
-    else
-      [ def ];
+  dischargeProperties =
+    let
+      matchProperties = {
+        "merge" =
+          # Handle mkMerge attributes (error if unknown attributes are present)
+          { _type, contents }: concatMap dischargeProperties contents;
+        "if" =
+          # Handle mkIf attributes (error if unknown attributes are present)
+          { _type, condition, content }:
+          if isBool condition then
+            if condition then
+              dischargeProperties content
+            else
+              [ ]
+          else
+            throw "‘mkIf’ called with a non-Boolean condition";
+      };
+    in
+      def: (matchProperties.${def._type or ""} or (def: [ def ])) def;
 
   /**
     Given a list of config values, process the mkOverride properties,

--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -649,7 +649,9 @@ let
             (module:
               mapAttrs
                 (n: value:
-                  map (config: { inherit (module) file; inherit config; }) (pushDownProperties value)
+                  map (config: { inherit (module) file; inherit config; }) (
+                    builtins.addErrorContext "while processing definitions from `${module.file}`" (pushDownProperties value)
+                  )
                 )
               module.config
             )

--- a/nixos/modules/services/web-apps/movim.nix
+++ b/nixos/modules/services/web-apps/movim.nix
@@ -579,7 +579,7 @@ in
       };
 
       nginx =
-        mkIf (cfg.nginx != null) {
+        mkIf (cfg.nginx != null) ({
           enable = true;
           recommendedOptimisation = mkDefault true;
           recommendedProxySettings = true;
@@ -677,7 +677,7 @@ in
         }
         // lib.optionalAttrs (cfg.precompressStaticFiles.brotli.enable) {
           recommendedBrotliSettings = mkDefault true;
-        };
+        });
 
       mysql = mkIf (cfg.database.createLocally && cfg.database.type == "mysql") {
         enable = mkDefault true;


### PR DESCRIPTION
... because they would be ignored, and their presence is probably a (easy) user mistake.

This reduces our forward compatibility, but I doubt that we need any here, and I doubt that the forward compatibility behavior should be anything other than an error anyway.

TODO
- [ ] benchmark
- [ ] tests
- [ ] something similar for `mkOverride`

Context:
I'm using a lambda call to perform this check with minimal function calls. This should reduce allocations and time spent (unconfirmed) at a small penalty in terms of error message quality. I believe this would be the right trade-off.


- Alternative to #72949
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
