### PR TITLE
kaminpar: init at 3.5.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6472,6 +6472,13 @@
     githubId = 11205987;
     name = "Daniel Salazar";
   };
+  dsalwasser = {
+    name = "Daniel Salwasser";
+    email = "daniel.salwasser@outlook.com";
+    github = "dsalwasser";
+    githubId = 148379503;
+    keys = [ { fingerprint = "DBA9 AE6B 84A9 C08E C4AD  1E46 6CD2 0B2D 0655 BDF6"; } ];
+  };
   dschrempf = {
     name = "Dominik Schrempf";
     email = "dominik.schrempf@gmail.com";

--- a/pkgs/by-name/ka/kaminpar/package.nix
+++ b/pkgs/by-name/ka/kaminpar/package.nix
@@ -1,0 +1,88 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  fetchpatch2,
+  cmake,
+  numactl,
+  mpi,
+  sparsehash,
+  tbb_2022_0,
+  gtest,
+  mpiCheckPhaseHook,
+}:
+let
+  kassert-src = fetchFromGitHub {
+    owner = "kamping-site";
+    repo = "kassert";
+    rev = "988b7d54b79ae6634f2fcc53a0314fb1cf2c6a23";
+
+    fetchSubmodules = true;
+    hash = "sha256-CBglUfVl9lgEa1t95G0mG4CCj0OWnIBwk7ep62rwIAA=";
+  };
+
+  kagen-src = fetchFromGitHub {
+    owner = "KarlsruheGraphGeneration";
+    repo = "KaGen";
+    rev = "70386f48e513051656f020360c482ce6bff9a24f";
+
+    fetchSubmodules = true;
+    hash = "sha256-5EvRPpjUZpmAIEgybXjNU/mO0+gsAyhlwbT+syDUr48=";
+  };
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "kaminpar";
+  version = "3.5.1";
+
+  src = fetchFromGitHub {
+    owner = "KaHIP";
+    repo = "KaMinPar";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-1azBj1DSEb7b8u+S51Sncn6EVMgu+SuFJcK4QVVhRk4=";
+  };
+
+  patches = [
+    # require gtest to be preinstalled by default if building tests
+    (fetchpatch2 {
+      url = "https://github.com/KaHip/KaMinPar/commit/9cb9883eea076d11cffcf4b0d14bf1f4f95a00e4.patch?full_index=1";
+      hash = "sha256-aUO5E0HTZqjfu5BUzyRdSZgyQYcE4PGqZaJvLD40sn8=";
+    })
+  ];
+
+  nativeBuildInputs = [ cmake ];
+
+  buildInputs = lib.optional stdenv.hostPlatform.isLinux numactl;
+
+  propagatedBuildInputs = [
+    mpi
+    sparsehash
+    tbb_2022_0
+  ];
+
+  cmakeFlags = [
+    (lib.cmakeBool "BUILD_SHARED_LIBS" (!stdenv.hostPlatform.isStatic))
+    (lib.cmakeBool "KAMINPAR_BUILD_DISTRIBUTED" true)
+    (lib.cmakeBool "KAMINPAR_BUILD_WITH_MTUNE_NATIVE" false)
+    (lib.cmakeFeature "FETCHCONTENT_SOURCE_DIR_KASSERT" "${kassert-src}")
+    (lib.cmakeFeature "FETCHCONTENT_SOURCE_DIR_KAGEN" "${kagen-src}")
+  ];
+
+  doCheck = true;
+
+  __darwinAllowLocalNetworking = true;
+
+  nativeCheckInputs = [
+    gtest
+    mpiCheckPhaseHook
+  ];
+
+  meta = {
+    description = "Parallel heuristic solver for the balanced k-way graph partitioning problem";
+    homepage = "https://github.com/KaHIP/KaMinPar";
+    changelog = "https://github.com/KaHIP/KaMinPar/releases/tag/v${finalAttrs.version}";
+    mainProgram = "KaMinPar";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.unix;
+    maintainers = with lib.maintainers; [ dsalwasser ];
+  };
+})


### PR DESCRIPTION
Parallel heuristic solver for the balanced k-way graph partitioning problem

https://github.com/KaHIP/KaMinPar

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
