### PR TITLE
dbus-cpp: 5.0.3 -> 5.0.4

### DIFF
--- a/pkgs/by-name/db/dbus-cpp/package.nix
+++ b/pkgs/by-name/db/dbus-cpp/package.nix
@@ -2,7 +2,6 @@
   stdenv,
   lib,
   fetchFromGitLab,
-  fetchpatch,
   gitUpdater,
   testers,
   boost186,
@@ -20,13 +19,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "dbus-cpp";
-  version = "5.0.3";
+  version = "5.0.4";
 
   src = fetchFromGitLab {
     owner = "ubports";
     repo = "development/core/lib-cpp/dbus-cpp";
-    rev = finalAttrs.version;
-    hash = "sha256-t8SzPRUuKeEchT8vAsITf8MwbgHA+mR5C9CnkdVyX7s=";
+    tag = finalAttrs.version;
+    hash = "sha256-ki4bnwRpvmB9yzt/Mn3MQs1Dr6Vrcs2D0tvCjvvfmq4=";
   };
 
   outputs = [
@@ -36,39 +35,22 @@ stdenv.mkDerivation (finalAttrs: {
     "examples"
   ];
 
-  patches = [
-    # Handle already-stolen dbus call better
-    # Remove when version > 5.0.3
-    (fetchpatch {
-      name = "0001-dbus-cpp-src-Dont-steal-a-pending-dbus-call-more-then-once.patch";
-      url = "https://gitlab.com/ubports/development/core/lib-cpp/dbus-cpp/-/commit/9f3d1ff2b1c6c732285949c3dbb35e40cf55ea92.patch";
-      hash = "sha256-xzOCIJVsK2J+X9RsV930R9uw6h4UxqwSaNOgv8v4qQU=";
-    })
-
-    # Fix GCC13 compilation
-    # Remove when version > 5.0.3
-    (fetchpatch {
-      name = "0002-dbus-cpp-Add-missing-headers-for-GCC13.patch";
-      url = "https://gitlab.com/ubports/development/core/lib-cpp/dbus-cpp/-/commit/c761b1eec084962dbe64d35d7f7b86dcbe57a3f7.patch";
-      hash = "sha256-/tKe3iHWxP9jWtpdgwwRynj8565u9LxCt4WXJDXzgX4=";
-    })
-  ];
-
   postPatch =
     ''
       substituteInPlace doc/CMakeLists.txt \
-        --replace 'DESTINATION share/''${CMAKE_PROJECT_NAME}/doc' 'DESTINATION ''${CMAKE_INSTALL_DOCDIR}'
+        --replace-fail 'DESTINATION share/''${CMAKE_PROJECT_NAME}/doc' 'DESTINATION ''${CMAKE_INSTALL_DOCDIR}'
 
       # Warning on aarch64-linux breaks build due to -Werror
       substituteInPlace CMakeLists.txt \
-        --replace '-Werror' ""
+        --replace-fail '-Werror' ""
 
       # pkg-config output patching hook expects prefix variable here
       substituteInPlace data/dbus-cpp.pc.in \
-        --replace 'includedir=''${exec_prefix}' 'includedir=''${prefix}'
+        --replace-fail 'includedir=''${exec_prefix}' 'includedir=''${prefix}'
     ''
     + lib.optionalString (!finalAttrs.finalPackage.doCheck) ''
-      sed -i -e '/add_subdirectory(tests)/d' CMakeLists.txt
+      substituteInPlace CMakeLists.txt \
+        --replace-fail 'add_subdirectory(tests)' '# add_subdirectory(tests)'
     '';
 
   strictDeps = true;
@@ -98,11 +80,10 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   cmakeFlags = [
-    "-DDBUS_CPP_ENABLE_DOC_GENERATION=ON"
+    (lib.cmakeBool "DBUS_CPP_ENABLE_DOC_GENERATION" true)
   ];
 
-  # Too flaky on ARM CI & for some amd64 users
-  doCheck = false;
+  doCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
 
   # DBus, parallelism messes with communication
   enableParallelChecking = false;
@@ -112,17 +93,21 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   passthru = {
-    tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+    tests.pkg-config = testers.hasPkgConfigModules {
+      package = finalAttrs.finalPackage;
+      versionCheck = true;
+    };
     updateScript = gitUpdater { };
   };
 
-  meta = with lib; {
+  meta = {
     description = "Dbus-binding leveraging C++-11";
     homepage = "https://gitlab.com/ubports/development/core/lib-cpp/dbus-cpp";
-    license = licenses.lgpl3Only;
-    maintainers = with maintainers; [ OPNA2608 ];
+    changelog = "https://gitlab.com/ubports/development/core/lib-cpp/dbus-cpp/-/blob/${finalAttrs.version}/ChangeLog";
+    license = lib.licenses.lgpl3Only;
+    maintainers = with lib.maintainers; [ OPNA2608 ];
     mainProgram = "dbus-cppc";
-    platforms = platforms.linux;
+    platforms = lib.platforms.linux;
     pkgConfigModules = [
       "dbus-cpp"
     ];


### PR DESCRIPTION
https://gitlab.com/ubports/development/core/lib-cpp/dbus-cpp/-/blob/5.0.4/ChangeLog

Trying to re-enable tests - IDR what the exact failure was and upstream pushed a commit to help weaker hardware in the tests, let's be optimistic and assume that this resolved the issue.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
