### PR TITLE
kopia-ui: init at 0.19.0

### DIFF
--- a/pkgs/by-name/ko/kopia-ui/fix-paths.patch
+++ b/pkgs/by-name/ko/kopia-ui/fix-paths.patch
@@ -1,0 +1,42 @@
+diff --git a/public/utils.js b/public/utils.js
+index 3cd38b63..54152694 100644
+--- a/public/utils.js
++++ b/public/utils.js
+@@ -17,7 +17,7 @@ const osShortName = function () {
+ 
+ export function iconsPath() {
+     if (!app.isPackaged) {
+-        return path.join(__dirname, "..", "resources", osShortName, "icons");
++        return path.join(__dirname, "..", "..", "icons");
+     }
+ 
+     return path.join(process.resourcesPath, "icons");
+@@ -25,26 +25,14 @@ export function iconsPath() {
+ 
+ export function publicPath() {
+     if (!app.isPackaged) {
+-        return path.join(__dirname, "..", "public");
++        return path.join(__dirname, "..", "..", "public");
+     }
+ 
+     return process.resourcesPath;
+ }
+ 
+ export function defaultServerBinary() {
+-    if (!app.isPackaged) {
+-        return {
+-            "mac": path.join(__dirname, "..", "..", "dist", "kopia_darwin_amd64", "kopia"),
+-            "win": path.join(__dirname, "..", "..", "dist", "kopia_windows_amd64", "kopia.exe"),
+-            "linux": path.join(__dirname, "..", "..", "dist", "kopia_linux_amd64", "kopia"),
+-        }[osShortName]
+-    }
+-
+-    return {
+-        "mac": path.join(process.resourcesPath, "server", "kopia"),
+-        "win": path.join(process.resourcesPath, "server", "kopia.exe"),
+-        "linux": path.join(process.resourcesPath, "server", "kopia"),
+-    }[osShortName]
++    return "KOPIA"
+ }
+ export function selectByOS(x) {
+     return x[osShortName]

--- a/pkgs/by-name/ko/kopia-ui/package.nix
+++ b/pkgs/by-name/ko/kopia-ui/package.nix
@@ -1,0 +1,94 @@
+{
+  lib,
+  buildNpmPackage,
+  fetchFromGitHub,
+  electron,
+  copyDesktopItems,
+  makeDesktopItem,
+  nix-update-script,
+  makeWrapper,
+  kopia,
+}:
+let
+  version = "0.19.0";
+  src = fetchFromGitHub {
+    owner = "kopia";
+    repo = "kopia";
+    tag = "v${version}";
+    hash = "sha256-PfxMs9MwoI+4z8vZ1sVlIEal3TOmA06997jWwShNfrE=";
+  };
+in
+buildNpmPackage {
+  pname = "kopia-ui";
+  inherit version src;
+
+  sourceRoot = "${src.name}/app";
+
+  npmDepsHash = "sha256-3K5dwAQeAo98rz2gxGw3k/D+VkDJNe5pmAyEo4boetU=";
+  makeCacheWritable = true;
+
+  nativeBuildInputs = [
+    copyDesktopItems
+    makeWrapper
+  ];
+
+  env = {
+    ELECTRON_SKIP_BINARY_DOWNLOAD = 1;
+  };
+
+  patches = [ ./fix-paths.patch ];
+
+  postPatch = ''
+    substituteInPlace public/utils.js --replace-fail KOPIA ${lib.getExe kopia}
+  '';
+
+  buildPhase = ''
+    runHook preBuild
+    cp -r ${electron.dist} electron-dist
+    chmod -R u+w ..
+    npm exec electron-builder -- \
+      --dir \
+      -c.electronDist=electron-dist \
+      -c.electronVersion=${electron.version} \
+      -c.extraMetadata.version=v${version}
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/share/kopia
+    cp -r ../dist/kopia-ui/*-unpacked/{locales,resources{,.pak}} $out/share/kopia
+    install -Dm644 $src/icons/kopia.svg $out/share/icons/hicolor/scalable/apps/kopia.svg
+    makeWrapper ${lib.getExe electron} $out/bin/kopia-ui \
+      --prefix PATH : ${lib.makeBinPath [ kopia ]} \
+      --add-flags $out/share/kopia/resources/app.asar \
+      --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true}}" \
+      --inherit-argv0
+    runHook postInstall
+  '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "kopia-ui";
+      type = "Application";
+      desktopName = "KopiaUI";
+      comment = "Fast and secure open source backup.";
+      icon = "kopia-ui";
+      exec = "kopia-ui";
+      categories = [ "Utility" ];
+    })
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Cross-platform backup tool with fast, incremental backups, client-side end-to-end encryption, compression and data deduplication";
+    mainProgram = "kopia-ui";
+    homepage = "https://kopia.io";
+    downloadPage = "https://github.com/kopia/kopia";
+    changelog = "https://github.com/kopia/kopia/releases/tag/v${version}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ blenderfreaky ];
+    platforms = lib.platforms.linux;
+  };
+}


### PR DESCRIPTION
Packages the UI for the already existing Kopia backup utility.

Closes #300702 

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
