### PR TITLE
open-policy-agent: skip tests that require network, enable __darwinAllowLocalNetworking

### DIFF
--- a/pkgs/by-name/op/open-policy-agent/package.nix
+++ b/pkgs/by-name/op/open-policy-agent/package.nix
@@ -43,9 +43,24 @@ buildGoModule rec {
     ) "opa_wasm"
   );
 
-  checkFlags = lib.optionals (!enableWasmEval) [
-    "-skip=TestRegoTargetWasmAndTargetPluginDisablesIndexingTopdownStages"
-  ];
+  checkFlags =
+    let
+      skippedTests =
+        [
+          # Skip tests that require network, not available in the nix sandbox
+          "TestInterQueryCache_ClientError"
+          "TestIntraQueryCache_ClientError"
+        ]
+        ++ lib.optionals stdenv.hostPlatform.isDarwin [
+          # Skip tests that require network, not available in the darwin sandbox
+          "TestHTTPSClient"
+          "TestHTTPSNoClientCerts"
+        ]
+        ++ lib.optionals (!enableWasmEval) [
+          "TestRegoTargetWasmAndTargetPluginDisablesIndexingTopdownStages"
+        ];
+    in
+    [ "-skip=^${builtins.concatStringsSep "$|^" skippedTests}$" ];
 
   preCheck =
     ''

--- a/pkgs/by-name/op/open-policy-agent/package.nix
+++ b/pkgs/by-name/op/open-policy-agent/package.nix
@@ -99,6 +99,9 @@ buildGoModule rec {
     runHook postInstallCheck
   '';
 
+  # Required for tests that need networking
+  __darwinAllowLocalNetworking = true;
+
   meta = with lib; {
     mainProgram = "opa";
     homepage = "https://www.openpolicyagent.org";

--- a/pkgs/by-name/op/open-policy-agent/package.nix
+++ b/pkgs/by-name/op/open-policy-agent/package.nix
@@ -12,14 +12,14 @@ assert
   enableWasmEval && stdenv.hostPlatform.isDarwin
   -> builtins.throw "building with wasm on darwin is failing in nixpkgs";
 
-buildGoModule rec {
+buildGoModule (finalAttrs: {
   pname = "open-policy-agent";
   version = "1.3.0";
 
   src = fetchFromGitHub {
     owner = "open-policy-agent";
     repo = "opa";
-    rev = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-wWxWpJSDOaZLJ7ULdAzPFJ9YNXX3FyQRod2roaLsuis=";
   };
 
@@ -32,7 +32,7 @@ buildGoModule rec {
   ldflags = [
     "-s"
     "-w"
-    "-X github.com/open-policy-agent/opa/version.Version=${version}"
+    "-X github.com/open-policy-agent/opa/version.Version=${finalAttrs.version}"
   ];
 
   tags = lib.optional enableWasmEval (
@@ -63,17 +63,17 @@ buildGoModule rec {
     [ "-skip=^${builtins.concatStringsSep "$|^" skippedTests}$" ];
 
   preCheck =
+    # Feed in all but the e2e tests for testing
+    # This is because subPackages above limits what is built to just what we
+    # want but also limits the tests
+    # Also avoid wasm tests on darwin due to wasmtime-go build issues
     ''
-      # Feed in all but the e2e tests for testing
-      # This is because subPackages above limits what is built to just what we
-      # want but also limits the tests
-      # Also avoid wasm tests on darwin due to wasmtime-go build issues
       getGoDirs() {
         go list ./... | grep -v -e e2e ${lib.optionalString stdenv.hostPlatform.isDarwin "-e wasm"}
       }
     ''
+    # remove tests that have "too many open files"/"no space left on device" issues on darwin in hydra
     + lib.optionalString stdenv.hostPlatform.isDarwin ''
-      # remove tests that have "too many open files"/"no space left on device" issues on darwin in hydra
       rm v1/server/server_test.go
     '';
 
@@ -89,7 +89,7 @@ buildGoModule rec {
     runHook preInstallCheck
 
     $out/bin/opa --help
-    $out/bin/opa version | grep "Version: ${version}"
+    $out/bin/opa version | grep "Version: ${finalAttrs.version}"
 
     ${lib.optionalString enableWasmEval ''
       # If wasm is enabled verify it works
@@ -102,10 +102,10 @@ buildGoModule rec {
   # Required for tests that need networking
   __darwinAllowLocalNetworking = true;
 
-  meta = with lib; {
+  meta = {
     mainProgram = "opa";
     homepage = "https://www.openpolicyagent.org";
-    changelog = "https://github.com/open-policy-agent/opa/blob/v${version}/CHANGELOG.md";
+    changelog = "https://github.com/open-policy-agent/opa/blob/v${finalAttrs.version}/CHANGELOG.md";
     description = "General-purpose policy engine";
     longDescription = ''
       The Open Policy Agent (OPA, pronounced "oh-pa") is an open source, general-purpose policy engine that unifies
@@ -113,10 +113,10 @@ buildGoModule rec {
       as code and simple APIs to offload policy decision-making from your software. You can use OPA to enforce policies
       in microservices, Kubernetes, CI/CD pipelines, API gateways, and more.
     '';
-    license = licenses.asl20;
-    maintainers = with maintainers; [
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [
       lewo
       jk
     ];
   };
-}
+})


### PR DESCRIPTION
This test does not work in the `nix` sandbox.

Related to https://github.com/NixOS/nixpkgs/pull/393129#issuecomment-2766030314.
Fixes https://github.com/NixOS/nixpkgs/issues/390371.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
