### PR TITLE
netatalk: 4.1.2 -> 4.2.0

### DIFF
--- a/pkgs/by-name/ne/netatalk/0000-no-install-under-usr-cupsd.patch
+++ b/pkgs/by-name/ne/netatalk/0000-no-install-under-usr-cupsd.patch
@@ -1,0 +1,29 @@
+diff --git a/config/meson.build b/config/meson.build
+index 4d750dba..f6bd6e6e 100644
+--- a/config/meson.build
++++ b/config/meson.build
+@@ -55,15 +55,15 @@ elif host_os in ['linux']
+     cups_libdir = '/usr/lib'
+ endif
+ 
+-if have_appletalk and have_cups and cups_libdir != ''
+-    configure_file(
+-        input: 'pap.in',
+-        output: 'pap',
+-        configuration: cdata,
+-        install: true,
+-        install_dir: cups_libdir / 'cups/backend',
+-    )
+-endif
++#if have_appletalk and have_cups and cups_libdir != ''
++#    configure_file(
++#        input: 'pap.in',
++#        output: 'pap',
++#        configuration: cdata,
++#        install: true,
++#        install_dir: cups_libdir / 'cups/backend',
++#    )
++#endif
+ 
+ foreach file : static_conf_files
+     if (

--- a/pkgs/by-name/ne/netatalk/0001-no-install-under-var-CNID.patch
+++ b/pkgs/by-name/ne/netatalk/0001-no-install-under-var-CNID.patch
@@ -1,0 +1,13 @@
+diff --git a/config/meson.build b/config/meson.build
+index 4d750dba..111389e7 100644
+--- a/config/meson.build
++++ b/config/meson.build
+@@ -89,7 +89,7 @@ if (
+     )
+ endif
+ 
+-install_data('README', install_dir: localstatedir / 'netatalk/CNID')
++# install_data('README', install_dir: localstatedir / 'netatalk/CNID')
+ 
+ if have_pam
+     subdir('pam')

--- a/pkgs/by-name/ne/netatalk/package.nix
+++ b/pkgs/by-name/ne/netatalk/package.nix
@@ -23,17 +23,23 @@
   glib,
   dbus,
   docbook-xsl-nons,
-  libxslt,
+  cmark-gfm,
+  iniparser,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "netatalk";
-  version = "4.1.2";
+  version = "4.2.0";
 
   src = fetchurl {
     url = "mirror://sourceforge/netatalk/netatalk/netatalk-${finalAttrs.version}.tar.xz";
-    hash = "sha256-qCX2/37+2wm7nKdXJ6tDEmeXAA+Jd123LI2VIL9IHpw=";
+    hash = "sha256-doqRAU4pjcHRTvKOvjMN2tSZKOPDTzBzU7i90xf1ClI=";
   };
+
+  patches = [
+    ./0000-no-install-under-usr-cupsd.patch
+    ./0001-no-install-under-var-CNID.patch
+  ];
 
   nativeBuildInputs = [
     pkg-config
@@ -59,11 +65,13 @@ stdenv.mkDerivation (finalAttrs: {
     perl
     dbus
     docbook-xsl-nons
-    libxslt
+    cmark-gfm
+    iniparser
   ];
 
   mesonFlags = [
     "-Dwith-appletalk=true"
+    "-Dwith-statedir-path=/var/lib"
     "-Dwith-bdb-path=${db.out}"
     "-Dwith-bdb-include-path=${db.dev}/include"
     "-Dwith-install-hooks=false"


### PR DESCRIPTION
https://github.com/Netatalk/netatalk/releases/tag/netatalk-4-2-0

Fixes #389617

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
