### PR TITLE
lomiri.lomiri: 0.3.0 -> 0.4.1

### DIFF
--- a/pkgs/desktops/lomiri/applications/lomiri/default.nix
+++ b/pkgs/desktops/lomiri/applications/lomiri/default.nix
@@ -61,30 +61,16 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "lomiri";
-  version = "0.3.0";
+  version = "0.4.1";
 
   src = fetchFromGitLab {
     owner = "ubports";
     repo = "development/core/lomiri";
-    rev = finalAttrs.version;
-    hash = "sha256-Godl/SQ0+NkI6kwH85SXHPQ5GRlih3xvCyeYxwiqH/s=";
+    tag = finalAttrs.version;
+    hash = "sha256-5fwSLUTntVyV5FIVnPishrU/55tyTyx0Fzh6oitaWwo=";
   };
 
   patches = [
-    # Remove when version > 0.3.0
-    (fetchpatch {
-      name = "0001-lomiri-Fix-accountsservice-test.patch";
-      url = "https://gitlab.com/ubports/development/core/lomiri/-/commit/353153c4ebc40ffcc7702af42205d2075fc81503.patch";
-      hash = "sha256-J9ySZgWd7KR7aU1cCRu5iirq7bi3NdLR9SZs9Pd1I8w=";
-    })
-
-    # Remove when https://gitlab.com/ubports/development/core/lomiri/-/merge_requests/181 merged & in release
-    (fetchpatch {
-      name = "0101-lomiri-Fix-accountsservice-property-defaults.patch";
-      url = "https://gitlab.com/ubports/development/core/lomiri/-/commit/369c7aac242f1798ce46b1415ab6112ac5e9d095.patch";
-      hash = "sha256-ieJCA1F/ljmgwEfGXWCTQNG1A/bmiJhNH9uzzULpUEc=";
-    })
-
     # Fix greeter & related settings
     # These patches are seemingly not submitted upstream yet
     (fetchpatch {
@@ -99,14 +85,8 @@ stdenv.mkDerivation (finalAttrs: {
     })
     (fetchpatch {
       name = "1002-lomiri-Fix-Lomiri-greeter.patch";
-      url = "https://salsa.debian.org/ubports-team/lomiri/-/raw/ebbe0f3f568bd145bb58a2e47f7112442328a0a5/debian/patches/1008_lomiri-greeter-wayland.patch";
-      excludes = [ "data/lomiri-greeter.desktop.in.in" ]; # conflict with GNUInstallDirs patch
-      hash = "sha256-XSSxf06Su8PMoqYwqevN034b/li8G/cNXjrqOXyhTRg=";
-    })
-    (fetchpatch {
-      name = "1003-lomiri-Hide-launcher-in-greeter-mode.patch";
-      url = "https://salsa.debian.org/ubports-team/lomiri/-/raw/ebbe0f3f568bd145bb58a2e47f7112442328a0a5/debian/patches/0002_qml-shell-hide-and-disallow-launcher-in-greeter-only-mode.patch";
-      hash = "sha256-R0aMlb7N7XACCthML4SQSd0LvbadADfdQJqrYFhmujk=";
+      url = "https://salsa.debian.org/ubports-team/lomiri/-/raw/5f9d28fe6f0ba9ab7eed149b4da7f6b3f4eae55a/debian/patches/1008_lomiri-greeter-wayland.patch";
+      hash = "sha256-vuNTKWA50krtx/+XB2pMI271q57N+kqWlfq54gtf/HI=";
     })
     (fetchpatch {
       name = "1004-lomiri-Dont-reset-OSK-setting.patch";
@@ -122,11 +102,6 @@ stdenv.mkDerivation (finalAttrs: {
 
   postPatch =
     ''
-      # Part of greeter fix, applies separately due to merge conflicts
-      substituteInPlace data/lomiri-greeter.desktop.in.in \
-        --replace-fail '@CMAKE_INSTALL_FULL_BINDIR@/lomiri-greeter-wrapper @CMAKE_INSTALL_FULL_BINDIR@/lomiri --mode=greeter' '@CMAKE_INSTALL_FULL_BINDIR@/lomiri --mode=greeter' \
-        --replace-fail 'X-LightDM-Session-Type=mir' 'X-LightDM-Session-Type=wayland'
-
       # Written with a different qtmir branch in mind, but different branch breaks compat with some patches
       substituteInPlace CMakeLists.txt \
         --replace-fail 'qt5mir2server' 'qtmirserver'
@@ -281,7 +256,7 @@ stdenv.mkDerivation (finalAttrs: {
     ];
   };
 
-  meta = with lib; {
+  meta = {
     description = "Shell of the Lomiri Operating environment";
     longDescription = ''
       Shell of the Lomiri Operating environment optimized for touch based human-machine interaction, but also supporting
@@ -291,9 +266,9 @@ stdenv.mkDerivation (finalAttrs: {
     '';
     homepage = "https://lomiri.com/";
     changelog = "https://gitlab.com/ubports/development/core/lomiri/-/blob/${finalAttrs.version}/ChangeLog";
-    license = licenses.gpl3Only;
+    license = lib.licenses.gpl3Only;
     mainProgram = "lomiri";
-    teams = [ teams.lomiri ];
-    platforms = platforms.linux;
+    teams = [ lib.teams.lomiri ];
+    platforms = lib.platforms.linux;
   };
 })


### PR DESCRIPTION
https://gitlab.com/ubports/development/core/lomiri/-/blob/0.4.0/ChangeLog
https://gitlab.com/ubports/development/core/lomiri/-/blob/0.4.1/ChangeLog

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
