### PR TITLE
ipmitool: 1.8.19 -> 1.8.19-unstable-2023-01-12

### DIFF
--- a/pkgs/by-name/ip/ipmitool/package.nix
+++ b/pkgs/by-name/ip/ipmitool/package.nix
@@ -46,12 +46,12 @@ stdenv.mkDerivation {
 
   configureFlags = [ "--disable-registry-download" ];
 
-  meta = with lib; {
+  meta = {
     description = "Command-line interface to IPMI-enabled devices";
     mainProgram = "ipmitool";
-    license = licenses.bsd3;
+    license = lib.licenses.bsd3;
     homepage = "https://github.com/ipmitool/ipmitool";
-    platforms = platforms.unix;
-    maintainers = with maintainers; [ fpletz ];
+    platforms = lib.platforms.unix;
+    maintainers = with lib.maintainers; [ fpletz ];
   };
 }

--- a/pkgs/by-name/ip/ipmitool/package.nix
+++ b/pkgs/by-name/ip/ipmitool/package.nix
@@ -11,8 +11,8 @@
 
 let
   iana-enterprise-numbers = fetchurl {
-    url = "https://web.archive.org/web/20230312103209id_/https://www.iana.org/assignments/enterprise-numbers.txt";
-    sha256 = "sha256-3Z5uoOYfbF1o6MSgvnr00w4Z5w4IHc56L1voKDzeH/w=";
+    url = "https://web.archive.org/web/20250113140800id_/https://www.iana.org/assignments/enterprise-numbers.txt";
+    hash = "sha256-aRgBEfZYwoL6YnU3aD0WYeMnJD5ZCj34S/9aQyzBIO4=";
   };
 in
 stdenv.mkDerivation {

--- a/pkgs/by-name/ip/ipmitool/package.nix
+++ b/pkgs/by-name/ip/ipmitool/package.nix
@@ -3,41 +3,48 @@
   lib,
   fetchFromGitHub,
   autoreconfHook,
+  pkg-config,
   openssl,
   readline,
   fetchurl,
 }:
 
 let
-
   iana-enterprise-numbers = fetchurl {
     url = "https://web.archive.org/web/20230312103209id_/https://www.iana.org/assignments/enterprise-numbers.txt";
     sha256 = "sha256-3Z5uoOYfbF1o6MSgvnr00w4Z5w4IHc56L1voKDzeH/w=";
   };
-
 in
-stdenv.mkDerivation rec {
+stdenv.mkDerivation {
   pname = "ipmitool";
-  version = "1.8.19";
+  version = "1.8.19-unstable-2023-01-12";
 
   src = fetchFromGitHub {
-    owner = pname;
-    repo = pname;
-    rev = "IPMITOOL_${lib.replaceStrings [ "." ] [ "_" ] version}";
-    hash = "sha256-VVYvuldRIHhaIUibed9cLX8Avfy760fdBLNO8MoUKCk=";
+    owner = "ipmitool";
+    repo = "ipmitool";
+    rev = "be11d948f89b10be094e28d8a0a5e8fb532c7b60";
+    hash = "sha256-5s0F2cTZdmRb/I0rPqX/8KgK/7b5VCl3Hj/ALKpGbMQ=";
   };
 
-  nativeBuildInputs = [ autoreconfHook ];
+  nativeBuildInputs = [
+    autoreconfHook
+    pkg-config
+  ];
+
   buildInputs = [
     openssl
     readline
   ];
 
   postPatch = ''
-    substituteInPlace configure.ac \
-      --replace 'AC_MSG_WARN([** Neither wget nor curl could be found.])' 'AM_CONDITIONAL([DOWNLOAD], [true])'
+    # Fixes `ipmi_fru.c:1556:41: error: initialization of 'struct fru_multirec_mgmt *' from incompatible pointer type 'struct fru_multirect_mgmt *' []`
+    # Probably fine before GCC14, but this is an error now.
+    substituteInPlace lib/ipmi_fru.c \
+      --replace-fail fru_multirect_mgmt fru_multirec_mgmt
     cp ${iana-enterprise-numbers} enterprise-numbers
   '';
+
+  configureFlags = [ "--disable-registry-download" ];
 
   meta = with lib; {
     description = "Command-line interface to IPMI-enabled devices";


### PR DESCRIPTION
Upstream is archived, but some useful commits have been added after the last release:

* https://github.com/ipmitool/ipmitool/commit/9dfdf1427002b3f44845941faf1e780553ece566 fixes `pkgsStatic.ipmitool`
* https://github.com/ipmitool/ipmitool/commit/be11d948f89b10be094e28d8a0a5e8fb532c7b60 adds a flag to disable registry download

Unfortunately https://github.com/ipmitool/ipmitool/commit/f033b5549e90d7ae05cb5e331d887354f50bf7d6 seems to introduce a build error so we need another substitution.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux (also static)
  - [x] aarch64-linux (also static)
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
