### PR TITLE
gnucash: 5.10 -> 5.11

### DIFF
--- a/pkgs/by-name/gn/gnucash/package.nix
+++ b/pkgs/by-name/gn/gnucash/package.nix
@@ -3,7 +3,6 @@
   stdenv,
   fetchFromGitHub,
   fetchurl,
-  fetchpatch,
   aqbanking,
   boost,
   cmake,
@@ -30,12 +29,12 @@
 
 stdenv.mkDerivation rec {
   pname = "gnucash";
-  version = "5.10";
+  version = "5.11";
 
   # raw source code doesn't work out of box; fetchFromGitHub not usable
   src = fetchurl {
     url = "https://github.com/Gnucash/gnucash/releases/download/${version}/gnucash-${version}.tar.bz2";
-    hash = "sha256-eJ2fNpjuW4ZyAnmjo+EOd0QhDhLFJa5/A9MvpwQHrZM=";
+    hash = "sha256-a6QjE6qqmbXwf/bk28WLM/v19L5ukRN2cB1lwm/U3r4=";
   };
 
   nativeBuildInputs = [
@@ -80,18 +79,6 @@ stdenv.mkDerivation rec {
     ./0003-remove-valgrind.patch
     # this patch makes gnucash exec the Finance::Quote wrapper directly
     ./0004-exec-fq-wrapper.patch
-    # this patch fixes the build against icu 76
-    (fetchpatch {
-      name = "icu-76.patch";
-      url = "https://github.com/Gnucash/gnucash/commit/579eed1facc0f7834ea70b1a342ebca0f125d788.patch";
-      hash = "sha256-XzRPHDPxt2TfeqO48vaNEcfF58neVDMxVqkPKrG5xoM=";
-    })
-    # fixes QIF imports: https://bugs.gnucash.org/show_bug.cgi?id=799492
-    (fetchpatch {
-      name = "qif-import.patch";
-      url = "https://github.com/Gnucash/gnucash/commit/6531d3e46b7bee1add61aa6c6aaf8fb1f889a586.patch";
-      hash = "sha256-Lque2w9X9yencNVzI/DfuE3H2dN46yVNnbBdiEQE6/4=";
-    })
   ];
 
   # this needs to be an environment variable and not a cmake flag to suppress


### PR DESCRIPTION
https://github.com/Gnucash/gnucash/releases/tag/5.11
Diff: https://github.com/Gnucash/gnucash/compare/5.10...5.11
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
