### PR TITLE
portaudio: 19.7.0 → 19.7.0-unstable-2026-02-19; portaudiocpp: init

### DIFF
--- a/pkgs/by-name/li/libopenmpt/package.nix
+++ b/pkgs/by-name/li/libopenmpt/package.nix
@@ -8,7 +8,7 @@
   mpg123,
   libogg,
   libvorbis,
-  portaudio,
+  portaudiocpp,
   libsndfile,
   flac,
   usePulseAudio ? config.pulseaudio or stdenv.hostPlatform.isLinux,
@@ -41,7 +41,7 @@ stdenv.mkDerivation (finalAttrs: {
     mpg123
     libogg
     libvorbis
-    portaudio
+    portaudiocpp
     libsndfile
     flac
   ]

--- a/pkgs/by-name/po/portaudio/package.nix
+++ b/pkgs/by-name/po/portaudio/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   stdenv,
-  fetchurl,
+  fetchFromGitHub,
   alsa-lib,
   libjack2,
   pkg-config,
@@ -10,11 +10,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "portaudio";
-  version = "190700_20210406";
+  version = "19.7.0";
 
-  src = fetchurl {
-    url = "https://files.portaudio.com/archives/pa_stable_v${finalAttrs.version}.tgz";
-    sha256 = "1vrdrd42jsnffh6rq8ap2c6fr4g9fcld89z649fs06bwqx1bzvs7";
+  src = fetchFromGitHub {
+    owner = "PortAudio";
+    repo = "portaudio";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-P2gIMSID2rclezJ/L7Uyu7uCmCpFGeoWyz7PRVDPIdc=";
   };
 
   strictDeps = true;

--- a/pkgs/by-name/po/portaudio/package.nix
+++ b/pkgs/by-name/po/portaudio/package.nix
@@ -4,7 +4,9 @@
   stdenv,
   cmake,
   fetchFromGitHub,
+  alsaSupport ? stdenv.hostPlatform.isLinux,
   alsa-lib,
+  jackSupport ? true,
   libjack2,
   pulseSupport ? config.pulseaudio or stdenv.hostPlatform.isLinux,
   libpulseaudio,
@@ -39,15 +41,15 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   propagatedBuildInputs =
-    [
-      libjack2
-    ]
-    ++ lib.optionals pulseSupport [ libpulseaudio ]
-    # Enabling alsa causes linux-only sources to be built
-    ++ lib.optionals stdenv.hostPlatform.isLinux [ alsa-lib ];
+    lib.optionals alsaSupport [ alsa-lib ]
+    ++ lib.optionals jackSupport [ libjack2 ]
+    ++ lib.optionals pulseSupport [ libpulseaudio ];
 
   cmakeFlags = lib.mapAttrsToList (flag: value: lib.cmakeBool flag value) {
     BUILD_SHARED_LIBS = !stdenv.hostPlatform.isStatic;
+
+    PA_USE_ALSA = alsaSupport;
+    PA_USE_JACK = jackSupport;
     PA_USE_PULSEAUDIO = pulseSupport;
   };
 

--- a/pkgs/by-name/po/portaudio/package.nix
+++ b/pkgs/by-name/po/portaudio/package.nix
@@ -8,6 +8,7 @@
   alsa-lib,
   jackSupport ? true,
   libjack2,
+  ossSupport ? stdenv.hostPlatform.isBSD,
   pulseSupport ? config.pulseaudio or stdenv.hostPlatform.isLinux,
   libpulseaudio,
   pkg-config,
@@ -50,6 +51,7 @@ stdenv.mkDerivation (finalAttrs: {
 
     PA_USE_ALSA = alsaSupport;
     PA_USE_JACK = jackSupport;
+    PA_USE_OSS = ossSupport;
     PA_USE_PULSEAUDIO = pulseSupport;
   };
 

--- a/pkgs/by-name/po/portaudio/package.nix
+++ b/pkgs/by-name/po/portaudio/package.nix
@@ -6,6 +6,7 @@
   libjack2,
   pkg-config,
   which,
+  nix-update-script,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -72,5 +73,6 @@ stdenv.mkDerivation (finalAttrs: {
 
   passthru = {
     api_version = 19;
+    updateScript = nix-update-script { };
   };
 })

--- a/pkgs/by-name/po/portaudio/package.nix
+++ b/pkgs/by-name/po/portaudio/package.nix
@@ -7,6 +7,7 @@
   libjack2,
   pkg-config,
   which,
+  testers,
   nix-update-script,
 }:
 
@@ -64,10 +65,13 @@ stdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.mit;
     maintainers = [ ];
     platforms = lib.platforms.unix;
+
+    pkgConfigModules = [ "portaudio-2.0" ];
   };
 
   passthru = {
     api_version = 19;
+    tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
     updateScript = nix-update-script {
       extraArgs = [ "--version=branch" ];
     };

--- a/pkgs/by-name/po/portaudio/package.nix
+++ b/pkgs/by-name/po/portaudio/package.nix
@@ -67,6 +67,7 @@ stdenv.mkDerivation (finalAttrs: {
   meta = {
     description = "Portable cross-platform Audio API";
     homepage = "https://www.portaudio.com/";
+    changelog = "https://github.com/PortAudio/portaudio/releases";
     # Not exactly a bsd license, but alike
     license = lib.licenses.mit;
     maintainers = [ ];

--- a/pkgs/by-name/po/portaudio/package.nix
+++ b/pkgs/by-name/po/portaudio/package.nix
@@ -14,6 +14,12 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "portaudio";
   version = "19.7.0-unstable-2026-02-19";
 
+  outputs = [
+    "out"
+    "dev"
+    "doc"
+  ];
+
   src = fetchFromGitHub {
     owner = "PortAudio";
     repo = "portaudio";
@@ -35,9 +41,16 @@ stdenv.mkDerivation (finalAttrs: {
 
   cmakeFlags = [
     (lib.cmakeBool "BUILD_SHARED_LIBS" (!stdenv.hostPlatform.isStatic))
-    "-DCMAKE_INSTALL_INCLUDEDIR=include"
-    "-DCMAKE_INSTALL_LIBDIR=lib"
   ];
+
+  postPatch = ''
+    # remove prefix from library and include paths
+    substituteInPlace cmake/portaudio-2.0.pc.in \
+      --replace-fail 'libdir=''${prefix}/@CMAKE_INSTALL_LIBDIR@' \
+                     'libdir=@CMAKE_INSTALL_FULL_LIBDIR@' \
+      --replace-fail 'includedir=''${prefix}/@CMAKE_INSTALL_INCLUDEDIR@' \
+                     'includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@'
+  '';
 
   postInstall = lib.optionalString stdenv.hostPlatform.isLinux ''
     # fixup .pc file to find alsa library

--- a/pkgs/by-name/po/portaudio/package.nix
+++ b/pkgs/by-name/po/portaudio/package.nix
@@ -11,13 +11,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "portaudio";
-  version = "19.7.0";
+  version = "19.7.0-unstable-2026-02-19";
 
   src = fetchFromGitHub {
     owner = "PortAudio";
     repo = "portaudio";
-    tag = "v${finalAttrs.version}";
-    hash = "sha256-P2gIMSID2rclezJ/L7Uyu7uCmCpFGeoWyz7PRVDPIdc=";
+    rev = "5dcff94e28a63aed67b404af9eef9ef8423ab9e9";
+    hash = "sha256-jHYFLNnDUWtls3pj92dTXieZCG7cBVy6dgdPzXT49wI=";
   };
 
   strictDeps = true;
@@ -73,6 +73,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   passthru = {
     api_version = 19;
-    updateScript = nix-update-script { };
+    updateScript = nix-update-script {
+      extraArgs = [ "--version=branch" ];
+    };
   };
 })

--- a/pkgs/by-name/po/portaudio/package.nix
+++ b/pkgs/by-name/po/portaudio/package.nix
@@ -34,11 +34,13 @@ stdenv.mkDerivation (finalAttrs: {
     pkg-config
     which
   ];
-  buildInputs = [
-    libjack2
-  ]
-  # Enabling alsa causes linux-only sources to be built
-  ++ lib.optionals stdenv.hostPlatform.isLinux [ alsa-lib ];
+
+  propagatedBuildInputs =
+    [
+      libjack2
+    ]
+    # Enabling alsa causes linux-only sources to be built
+    ++ lib.optionals stdenv.hostPlatform.isLinux [ alsa-lib ];
 
   cmakeFlags = [
     (lib.cmakeBool "BUILD_SHARED_LIBS" (!stdenv.hostPlatform.isStatic))
@@ -51,11 +53,6 @@ stdenv.mkDerivation (finalAttrs: {
                      'libdir=@CMAKE_INSTALL_FULL_LIBDIR@' \
       --replace-fail 'includedir=''${prefix}/@CMAKE_INSTALL_INCLUDEDIR@' \
                      'includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@'
-  '';
-
-  postInstall = lib.optionalString stdenv.hostPlatform.isLinux ''
-    # fixup .pc file to find alsa library
-    sed -i "s|-lasound|-L${lib.getLib alsa-lib}/lib -lasound|" "$out/lib/pkgconfig/"*.pc
   '';
 
   meta = {

--- a/pkgs/by-name/po/portaudiocpp/package.nix
+++ b/pkgs/by-name/po/portaudiocpp/package.nix
@@ -57,6 +57,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "PortAudio C++ bindings";
     inherit (portaudio.meta)
       homepage
+      changelog
       license
       maintainers
       platforms

--- a/pkgs/by-name/po/portaudiocpp/package.nix
+++ b/pkgs/by-name/po/portaudiocpp/package.nix
@@ -1,0 +1,67 @@
+{
+  lib,
+  stdenv,
+  portaudio,
+  cmake,
+  pkg-config,
+  tre,
+  testers,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "portaudiocpp";
+  inherit (portaudio) version src;
+
+  outputs = [
+    "out"
+    "dev"
+  ];
+
+  sourceRoot = "${finalAttrs.src.name}/bindings/cpp";
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
+
+  buildInputs = [ tre ];
+  propagatedBuildInputs = [ portaudio ];
+
+  cmakeFlags = [
+    (lib.cmakeBool "BUILD_SHARED_LIBS" (!stdenv.hostPlatform.isStatic))
+  ];
+
+  postPatch = ''
+    # allow compilation of C sources
+    substituteInPlace CMakeLists.txt \
+      --replace-fail 'project(PortAudioCpp VERSION 19.8 LANGUAGES CXX)' \
+                     'project(PortAudioCpp VERSION 19.8 LANGUAGES C CXX)'
+
+    # correct installation paths
+    substituteInPlace cmake/portaudiocpp.pc.in \
+      --replace-fail 'prefix=@PC_PREFIX@' \
+                     'prefix=@CMAKE_INSTALL_PREFIX@' \
+      --replace-fail 'libdir=''${prefix}/lib' \
+                     'libdir=@CMAKE_INSTALL_FULL_LIBDIR@' \
+      --replace-fail 'includedir=''${prefix}/include' \
+                     'includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@'
+  '';
+
+  passthru = {
+    tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+  };
+
+  meta = {
+    description = "PortAudio C++ bindings";
+    inherit (portaudio.meta)
+      homepage
+      license
+      maintainers
+      platforms
+      ;
+
+    pkgConfigModules = [ "portaudiocpp" ];
+  };
+})

--- a/pkgs/by-name/xo/xournalpp/package.nix
+++ b/pkgs/by-name/xo/xournalpp/package.nix
@@ -22,7 +22,7 @@
   libzip,
   pcre,
   poppler,
-  portaudio,
+  portaudiocpp,
   qpdf,
   zlib,
   # plugins
@@ -61,7 +61,7 @@ stdenv.mkDerivation (finalAttrs: {
     libzip
     pcre
     poppler
-    portaudio
+    portaudiocpp
     qpdf
     zlib
   ]


### PR DESCRIPTION
Overhaul of PortAudio package:

- Build PortAudio from current GitHub master,
- switch to CMake for building,
- split outputs,
- split off C++ bindings into separate package (`portaudiocpp`)
- enable optional support for PulseAudio and OSS,
- add tests for pkg-config modules,
- provide update script,
- ~use `finalAttrs` pattern~,
- ~remove use of `with lib;`~ and
- provide changelog.

PortAudio has not seen a release for four years despite active development. One of the most important changes is the introduction of PulseAudio support, which I believe warrants switching to the current GitHub master until the next release.

The new CMake‐based build appears to be somewhat less buggy than the autoconf‐based one, but requires building the C++ bindings separately. As they rely on PortAudio as a separate library, I decided to split them off from the main package.

I have not tested these changes on Darwin, but I have checked that the `pa_mac_core.h` header is listed as installable in `CMakeLists.txt`.

This change may require secondary changes to packages relying on the C++ bindings, which I shall add to this PR later, if it is otherwise acceptable.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
