### PR TITLE
python312Packages.mhcflurry: 2.1.4 -> 2.1.5

### DIFF
--- a/pkgs/development/python-modules/mhcflurry/default.nix
+++ b/pkgs/development/python-modules/mhcflurry/default.nix
@@ -2,12 +2,12 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  fetchpatch,
 
   # dependencies
   appdirs,
   keras,
   mhcgnomes,
+  numpy,
   pandas,
   pyyaml,
   scikit-learn,
@@ -21,30 +21,22 @@
 
 buildPythonPackage rec {
   pname = "mhcflurry";
-  version = "2.1.4";
+  version = "2.1.5";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "openvax";
     repo = "mhcflurry";
     tag = "v${version}";
-    hash = "sha256-dxCGCPnk1IFKg8ZVqMJsojQL0KlNirKlHJoaaOYIzMU=";
+    hash = "sha256-TNb3oKZvgBuXoSwsTuEJjFKEVZyHynazuPInj7wVKs8=";
   };
-
-  patches = [
-    # TODO: this has been merged in master and will thus be included in the next release.
-    (fetchpatch {
-      name = "migrate-from-nose-to-pytest";
-      url = "https://github.com/openvax/mhcflurry/commit/8e9f35381a476362ca41cb71eb0a90f6573fe4b3.patch";
-      hash = "sha256-PyyxGrjE3OZR8dKHEQBQGiRG9A8kcz/e14PRyrVvqrE=";
-    })
-  ];
 
   # keras and tensorflow are not in the official setup.py requirements but are required for the CLI utilities to run.
   dependencies = [
     appdirs
     keras
     mhcgnomes
+    numpy
     pandas
     pyyaml
     scikit-learn
@@ -53,8 +45,6 @@ buildPythonPackage rec {
     tqdm
   ];
 
-  # Tests currently depend on nose; see
-  # <https://github.com/openvax/mhcflurry/pull/244>.
   nativeCheckInputs = [
     pytestCheckHook
   ];


### PR DESCRIPTION
## Things done

Changelog: https://github.com/openvax/mhcflurry/releases/tag/v2.1.5

cc @samuela

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
