### PR TITLE
m4rie: 20250103 -> 20250128

### DIFF
--- a/pkgs/by-name/m4/m4ri/package.nix
+++ b/pkgs/by-name/m4/m4ri/package.nix
@@ -6,47 +6,15 @@
 }:
 
 stdenv.mkDerivation rec {
-  version = "20240729";
+  version = "20250128";
   pname = "m4ri";
 
   src = fetchFromGitHub {
     owner = "malb";
     repo = "m4ri";
-    # 20240729 has a broken m4ri.pc file, fixed in the next commit.
-    # TODO: remove if on update
-    rev =
-      if version == "20240729" then "775189bfea96ffaeab460513413fcf4fbcd64392" else "release-${version}";
-    hash = "sha256-untwo0go8O8zNO0EyZ4n/n7mngSXLr3Z/FSkXA8ptnU=";
+    rev = version;
+    hash = "sha256-YoCTI4dLy95xuRJyNugIzGxE40B9pCWxRQtsyS/1Pds=";
   };
-
-  # based on the list in m4/m4_ax_ext.m4
-  configureFlags = builtins.map (s: "ax_cv_have_${s}_cpu_ext=no") (
-    [
-      "sha"
-      "xop"
-    ]
-    ++ lib.optional (!stdenv.hostPlatform.sse3Support) "sse3"
-    ++ lib.optional (!stdenv.hostPlatform.ssse3Support) "ssse3"
-    ++ lib.optional (!stdenv.hostPlatform.sse4_1Support) "sse41"
-    ++ lib.optional (!stdenv.hostPlatform.sse4_2Support) "sse42"
-    ++ lib.optional (!stdenv.hostPlatform.sse4_aSupport) "sse4a"
-    ++ lib.optional (!stdenv.hostPlatform.aesSupport) "aes"
-    ++ lib.optional (!stdenv.hostPlatform.avxSupport) "avx"
-    ++ lib.optional (!stdenv.hostPlatform.fmaSupport) "fma3"
-    ++ lib.optional (!stdenv.hostPlatform.fma4Support) "fma4"
-    ++ lib.optional (!stdenv.hostPlatform.avx2Support) "avx2"
-    ++ lib.optionals (!stdenv.hostPlatform.avx512Support) [
-      "avx512f"
-      "avx512cd"
-      "avx512pf"
-      "avx512er"
-      "avx512vl"
-      "avx512bw"
-      "avx512dq"
-      "avx512ifma"
-      "avx512vbmi"
-    ]
-  );
 
   doCheck = true;
 

--- a/pkgs/by-name/m4/m4rie/package.nix
+++ b/pkgs/by-name/m4/m4rie/package.nix
@@ -1,20 +1,21 @@
 {
   lib,
   stdenv,
-  fetchFromBitbucket,
+  fetchFromGitHub,
   autoreconfHook,
+  pkg-config,
   m4ri,
 }:
 
 stdenv.mkDerivation rec {
-  version = "20250103";
+  version = "20250128";
   pname = "m4rie";
 
-  src = fetchFromBitbucket {
+  src = fetchFromGitHub {
     owner = "malb";
     repo = "m4rie";
-    rev = "release-${version}";
-    hash = "sha256-CbzDLSqdtQ+CLKoKycznKzD3VCa+gfuh8TLvRC1fVz0=";
+    rev = version;
+    hash = "sha256-tw6ZX8hKfr9wQLF2nuO1dSkkTYZX6pzNWMlWfzLqQNE=";
   };
 
   doCheck = true;
@@ -28,6 +29,7 @@ stdenv.mkDerivation rec {
   makeFlags = [ ] ++ lib.optionals stdenv.hostPlatform.isDarwin [ "CFLAGS=-O0" ];
   nativeBuildInputs = [
     autoreconfHook
+    pkg-config
   ];
 
   meta = with lib; {


### PR DESCRIPTION
m4rie moved to GitHub, and the m4ri configure hack is no longer necessary as of https://github.com/malb/m4ri/pull/24.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
