### PR TITLE
nixosTests.xscreensaver: migrate to runTest

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1337,7 +1337,7 @@ in {
   xpadneo = runTest ./xpadneo.nix;
   xrdp = runTest ./xrdp.nix;
   xrdp-with-audio-pulseaudio = runTest ./xrdp-with-audio-pulseaudio.nix;
-  xscreensaver = handleTest ./xscreensaver.nix {};
+  xscreensaver = runTest ./xscreensaver.nix;
   xss-lock = runTest ./xss-lock.nix;
   xterm = runTest ./xterm.nix;
   xxh = runTest ./xxh.nix;

--- a/nixos/tests/xscreensaver.nix
+++ b/nixos/tests/xscreensaver.nix
@@ -1,81 +1,81 @@
-import ./make-test-python.nix (
-  { pkgs, lib, ... }:
-  {
-    name = "pass-secret-service";
-    meta.maintainers = with lib.maintainers; [
-      vancluever
-    ];
+{ lib, ... }:
+{
+  name = "pass-secret-service";
+  meta.maintainers = with lib.maintainers; [
+    vancluever
+  ];
 
-    nodes = {
-      ok =
-        { nodes, pkgs, ... }:
-        {
-          imports = [
-            ./common/x11.nix
-            ./common/user-account.nix
-          ];
-          test-support.displayManager.auto.user = "alice";
-          services.xscreensaver.enable = true;
-        };
+  node.pkgsReadOnly = false;
 
-      empty_wrapperPrefix =
-        { nodes, pkgs, ... }:
-        {
-          imports = [
-            ./common/x11.nix
-            ./common/user-account.nix
-          ];
-          test-support.displayManager.auto.user = "alice";
-          services.xscreensaver.enable = true;
-          nixpkgs.overlays = [
-            (self: super: {
-              xscreensaver = super.xscreensaver.override {
-                wrapperPrefix = "";
-              };
-            })
-          ];
-        };
+  nodes = {
+    ok =
+      { nodes, pkgs, ... }:
+      {
+        imports = [
+          ./common/x11.nix
+          ./common/user-account.nix
+        ];
+        test-support.displayManager.auto.user = "alice";
+        services.xscreensaver.enable = true;
+      };
 
-      bad_wrapperPrefix =
-        { nodes, pkgs, ... }:
-        {
-          imports = [
-            ./common/x11.nix
-            ./common/user-account.nix
-          ];
-          test-support.displayManager.auto.user = "alice";
-          services.xscreensaver.enable = true;
-          nixpkgs.overlays = [
-            (self: super: {
-              xscreensaver = super.xscreensaver.override {
-                wrapperPrefix = "/a/bad/path";
-              };
-            })
-          ];
-        };
-    };
+    empty_wrapperPrefix =
+      { nodes, pkgs, ... }:
+      {
+        imports = [
+          ./common/x11.nix
+          ./common/user-account.nix
+        ];
+        test-support.displayManager.auto.user = "alice";
+        services.xscreensaver.enable = true;
+        nixpkgs.overlays = [
+          (self: super: {
+            xscreensaver = super.xscreensaver.override {
+              wrapperPrefix = "";
+            };
+          })
+        ];
+      };
 
-    testScript = ''
-      ok.wait_for_x()
-      ok.wait_for_unit("xscreensaver", "alice")
-      _, output_ok = ok.systemctl("status xscreensaver", "alice")
-      assert 'To prevent the kernel from randomly unlocking' not in output_ok
-      assert 'your screen via the out-of-memory killer' not in output_ok
-      assert '"xscreensaver-auth" must be setuid root' not in output_ok
+    bad_wrapperPrefix =
+      { nodes, pkgs, ... }:
+      {
+        imports = [
+          ./common/x11.nix
+          ./common/user-account.nix
+        ];
+        test-support.displayManager.auto.user = "alice";
+        services.xscreensaver.enable = true;
+        nixpkgs.overlays = [
+          (self: super: {
+            xscreensaver = super.xscreensaver.override {
+              wrapperPrefix = "/a/bad/path";
+            };
+          })
+        ];
+      };
+  };
 
-      empty_wrapperPrefix.wait_for_x()
-      empty_wrapperPrefix.wait_for_unit("xscreensaver", "alice")
-      _, output_empty_wrapperPrefix = empty_wrapperPrefix.systemctl("status xscreensaver", "alice")
-      assert 'To prevent the kernel from randomly unlocking' in output_empty_wrapperPrefix
-      assert 'your screen via the out-of-memory killer' in output_empty_wrapperPrefix
-      assert '"xscreensaver-auth" must be setuid root' in output_empty_wrapperPrefix
+  testScript = ''
+    ok.wait_for_x()
+    ok.wait_for_unit("xscreensaver", "alice")
+    _, output_ok = ok.systemctl("status xscreensaver", "alice")
+    assert 'To prevent the kernel from randomly unlocking' not in output_ok
+    assert 'your screen via the out-of-memory killer' not in output_ok
+    assert '"xscreensaver-auth" must be setuid root' not in output_ok
 
-      bad_wrapperPrefix.wait_for_x()
-      bad_wrapperPrefix.wait_for_unit("xscreensaver", "alice")
-      _, output_bad_wrapperPrefix = bad_wrapperPrefix.systemctl("status xscreensaver", "alice")
-      assert 'To prevent the kernel from randomly unlocking' in output_bad_wrapperPrefix
-      assert 'your screen via the out-of-memory killer' in output_bad_wrapperPrefix
-      assert '"xscreensaver-auth" must be setuid root' in output_bad_wrapperPrefix
-    '';
-  }
-)
+    empty_wrapperPrefix.wait_for_x()
+    empty_wrapperPrefix.wait_for_unit("xscreensaver", "alice")
+    _, output_empty_wrapperPrefix = empty_wrapperPrefix.systemctl("status xscreensaver", "alice")
+    assert 'To prevent the kernel from randomly unlocking' in output_empty_wrapperPrefix
+    assert 'your screen via the out-of-memory killer' in output_empty_wrapperPrefix
+    assert '"xscreensaver-auth" must be setuid root' in output_empty_wrapperPrefix
+
+    bad_wrapperPrefix.wait_for_x()
+    bad_wrapperPrefix.wait_for_unit("xscreensaver", "alice")
+    _, output_bad_wrapperPrefix = bad_wrapperPrefix.systemctl("status xscreensaver", "alice")
+    assert 'To prevent the kernel from randomly unlocking' in output_bad_wrapperPrefix
+    assert 'your screen via the out-of-memory killer' in output_bad_wrapperPrefix
+    assert '"xscreensaver-auth" must be setuid root' in output_bad_wrapperPrefix
+  '';
+}


### PR DESCRIPTION
Part of #386873

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
