### PR TITLE
cc-wrapper: pass correct -B prefix

### DIFF
--- a/pkgs/build-support/cc-wrapper/add-flags.sh
+++ b/pkgs/build-support/cc-wrapper/add-flags.sh
@@ -30,7 +30,7 @@ done
 # Arocc does not support "-B"
 if [[ -z "@isArocc@" ]]; then
     # `-B@bintools@/bin' forces cc to use ld-wrapper.sh when calling ld.
-    NIX_CFLAGS_COMPILE_@suffixSalt@="-B@bintools@/bin/ $NIX_CFLAGS_COMPILE_@suffixSalt@"
+    NIX_CFLAGS_COMPILE_@suffixSalt@="-B@bintools@/bin/@bintools_targetPrefix@ $NIX_CFLAGS_COMPILE_@suffixSalt@"
 fi
 
 # Export and assign separately in order that a failing $(..) will fail

--- a/pkgs/build-support/cc-wrapper/default.nix
+++ b/pkgs/build-support/cc-wrapper/default.nix
@@ -872,6 +872,7 @@ stdenvNoCC.mkDerivation {
       cc = optionalString (!nativeTools) cc;
       wrapperName = "CC_WRAPPER";
       inherit suffixSalt coreutils_bin bintools;
+      bintools_targetPrefix = bintools.targetPrefix;
       inherit libc_bin libc_dev libc_lib;
       inherit darwinPlatformForCC;
       default_hardening_flags_str = builtins.toString defaultHardeningFlags;


### PR DESCRIPTION
We have this line in cc-wrapper:

https://github.com/NixOS/nixpkgs/blob/86e22e1e806d86c5c8af94996bb0dba466dbc50e/pkgs/build-support/cc-wrapper/add-flags.sh#L32-L33

For clang this fails to work entirely. You can verify by running the wrapped clang outside of its stdenv:

~~~nix
let
pkgs = import <nixpkgs> {
  crossSystem = {
    config = "x86_64-unknown-linux-gnu";
    useLLVM = true;
  };
};
source = pkgs.writeText "test.c" "int main() { return 0; }";
cc = pkgs.stdenv.cc;
in pkgs.runCommand "test" {} ''
  ${cc}/bin/${cc.targetPrefix}clang ${source} -o $out
''
~~~

~~~
clang: error: unable to execute command: Executable "ld" doesn't exist!
clang: error: linker command failed with exit code 1 (use -v to see invocation)
~~~

This PR fixes the issue by correcting `-B@bintools@/bin/` to `-B@bintools@/bin/@targetPrefix@`. Because the original option could still be useful in other situations I'm not keeping into account (such as gcc) I suggest keeping both.

Reasons the mistake wasn't found until now seem to include:
- When running inside its corresponding stdenv, the associated bintools will be in `$PATH` and thus be found by the fallback behavior.
- It only manifests when `targetPrefix != ""`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
