### PR TITLE
nixos/plymouth: plymouth-switch-root-initramfs run on stage2 systemd

### DIFF
--- a/nixos/modules/system/boot/plymouth.nix
+++ b/nixos/modules/system/boot/plymouth.nix
@@ -167,6 +167,16 @@ in
     systemd.services.plymouth-poweroff.wantedBy = [ "poweroff.target" ];
     systemd.services.plymouth-reboot.wantedBy = [ "reboot.target" ];
     systemd.services.plymouth-read-write.wantedBy = [ "sysinit.target" ];
+    systemd.services.plymouth-switch-root-initramfs.wantedBy = [
+      "halt.target"
+      "kexec.target"
+      "poweroff.target"
+      "reboot.target"
+      "plymouth-switch-root-initramfs.service"
+    ];
+    systemd.services.plymouth-switch-root-initramfs.after = [
+      "generate-shutdown-ramfs.service"
+    ];
     systemd.services.systemd-ask-password-plymouth.wantedBy = [ "multi-user.target" ];
     systemd.paths.systemd-ask-password-plymouth.wantedBy = [ "multi-user.target" ];
 
@@ -255,13 +265,6 @@ in
         plymouth-start.wantedBy = [
           "initrd-switch-root.target"
           "sysinit.target"
-        ];
-        plymouth-switch-root-initramfs.wantedBy = [
-          "halt.target"
-          "kexec.target"
-          "plymouth-switch-root-initramfs.service"
-          "poweroff.target"
-          "reboot.target"
         ];
         plymouth-switch-root.wantedBy = [ "initrd-switch-root.target" ];
       };

--- a/nixos/modules/system/boot/plymouth.nix
+++ b/nixos/modules/system/boot/plymouth.nix
@@ -183,6 +183,9 @@ in
     # Prevent Plymouth taking over the screen during system updates.
     systemd.services.plymouth-start.restartIfChanged = false;
 
+    # helper binary which is used to hold onto the pixel-displays fds until the end
+    systemd.shutdownRamfs.storePaths = [ "${plymouth}/libexec/plymouth/plymouthd-fd-escrow" ];
+
     boot.initrd.systemd = {
       extraBin.plymouth = "${plymouth}/bin/plymouth"; # for the recovery shell
       storePaths = [


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Before shutting down plymouth needs to switch to initramfs mode in order to be able to unmount the rootfs. The service to switch to initramfs was being bound in stage 1 systemd whereas it should be done in stage 2.

Otherwise we get errors like this on shutdown:

```
[    87.778393] sd-umoun[2335]: Failed to unmount /oldroot/nix/store: Device or resource busy
[    87.778853] sd-umoun[2336]: Failed to unmount /oldroot/dev: Device or resource busy
[    87.779264] sd-umoun[2337]: Failed to unmount /oldroot: Device or resource busy
[    87.779715] shutdown[1]: Could not detach DM /dev/dm-0: Device or resource busy
[    87.780182] shutdown[1]: Failed to finalize file systems, DM devices, ignoring.
```

Also on shutdown plymouth wasn't being shown (or only very briefly). Plymouth relies on `plymouthd-fd-escrow` helper binary to hold on to the pixel-displays fds until the end, but this binary needs to be added to the shutdown initramfs.

Fixes #191620.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
