### PR TITLE
python3Packages.nanoneigenpy: init at 0.3.0

### DIFF
--- a/pkgs/development/python-modules/nanoeigenpy/default.nix
+++ b/pkgs/development/python-modules/nanoeigenpy/default.nix
@@ -1,0 +1,106 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  nix-update-script,
+  python,
+
+  # nativeBuildInputs
+  cmake,
+  doxygen,
+  nanobind,
+
+  # propagatedBuildInputs
+  suitesparse,
+  eigen,
+  jrl-cmakemodules,
+
+  # dependencies
+  numpy,
+
+  # checkInputs
+  pytest,
+  scipy,
+}:
+
+buildPythonPackage rec {
+  pname = "nanoeigenpy";
+  version = "0.3.0";
+  pyproject = false; # Built with cmake
+
+  src = fetchFromGitHub {
+    owner = "Simple-Robotics";
+    repo = "nanoeigenpy";
+    tag = "v${version}";
+    hash = "sha256-asDe1mrTsAxVl0gAo7zlWqQRfWYBiSLqQk1d8bEBsn4=";
+  };
+
+  # Fix:
+  # > PermissionError: [Errno 13] Permission denied:
+  # > '/nix/store/…-python3-3.12.9/lib/python3.12/site-packages/nanoeigenpy.pyi'
+  postPatch = ''
+    substituteInPlace CMakeLists.txt --replace-fail \
+      "$""{Python_SITELIB}" \
+      "${python.sitePackages}"
+  '';
+
+  outputs = [
+    "dev"
+    "doc"
+    "out"
+  ];
+
+  cmakeFlags = [
+    (lib.cmakeBool "INSTALL_DOCUMENTATION" true)
+    (lib.cmakeBool "BUILD_TESTING" true)
+    (lib.cmakeBool "BUILD_WITH_CHOLMOD_SUPPORT" true)
+    # Accelerate support in eigen requires
+    # https://gitlab.com/libeigen/eigen/-/merge_requests/856
+    # which is not in the current eigen v3.4.0-unstable-2022-05-19
+    # (lib.cmakeBool "BUILD_WITH_ACCELERATE_SUPPORT" stdenv.hostPlatform.isDarwin)
+  ];
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    cmake
+    doxygen
+    nanobind
+  ];
+
+  propagatedBuildInputs = [
+    suitesparse
+    eigen
+    jrl-cmakemodules
+  ];
+
+  dependencies = [
+    numpy
+  ];
+
+  checkInputs = [
+    pytest
+    scipy
+  ];
+
+  # Ensure the unit tests are built
+  preInstallCheck = "make test";
+
+  pythonImportsCheck = [ "nanoeigenpy" ];
+
+  passthru.updateScript = nix-update-script { };
+
+  postFixup = ''
+    substituteInPlace $dev/lib/cmake/nanoeigenpy/nanoeigenpyConfig.cmake \
+      --replace-fail $out $dev
+  '';
+
+  meta = {
+    description = "Support library for bindings between Eigen in C++ and Python, based on nanobind";
+    homepage = "https://github.com/Simple-Robotics/nanoeigenpy";
+    changelog = "https://github.com/Simple-Robotics/nanoeigenpy/releases/tag/${src.tag}";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ nim65s ];
+    platforms = lib.platforms.unix ++ lib.platforms.windows;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9696,6 +9696,8 @@ self: super: with self; {
 
   nanobind = callPackage ../development/python-modules/nanobind { };
 
+  nanoeigenpy = callPackage ../development/python-modules/nanoeigenpy { };
+
   nanoemoji = callPackage ../development/python-modules/nanoemoji { };
 
   nanoid = callPackage ../development/python-modules/nanoid { };


### PR DESCRIPTION
nanoneigenpy is the successor of eigenpy, rewritten from Boost::python to nanobind


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
