### PR TITLE
envoy-bin: init at 1.33.2

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -407,7 +407,10 @@ in
   enlightenment = handleTest ./enlightenment.nix { };
   env = handleTest ./env.nix { };
   envfs = handleTest ./envfs.nix { };
-  envoy = handleTest ./envoy.nix { };
+  envoy = runTest {
+    imports = [ ./envoy.nix ];
+    _module.args.envoyPackage = pkgs.envoy;
+  };
   ergo = handleTest ./ergo.nix { };
   ergochat = handleTest ./ergochat.nix { };
   eris-server = handleTest ./eris-server.nix { };

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -411,6 +411,10 @@ in
     imports = [ ./envoy.nix ];
     _module.args.envoyPackage = pkgs.envoy;
   };
+  envoy-bin = runTest {
+    imports = [ ./envoy.nix ];
+    _module.args.envoyPackage = pkgs.envoy-bin;
+  };
   ergo = handleTest ./ergo.nix { };
   ergochat = handleTest ./ergochat.nix { };
   eris-server = handleTest ./eris-server.nix { };

--- a/nixos/tests/envoy.nix
+++ b/nixos/tests/envoy.nix
@@ -1,62 +1,60 @@
-import ./make-test-python.nix (
-  { pkgs, lib, ... }:
-  {
-    name = "envoy";
-    meta = with pkgs.lib.maintainers; {
-      maintainers = [ cameronnemo ];
-    };
+{ envoyPackage, lib, ... }:
+{
+  name = envoyPackage.pname;
 
-    nodes.machine =
-      { pkgs, ... }:
-      {
-        services.envoy.enable = true;
-        services.envoy.settings = {
-          admin = {
-            access_log_path = "/dev/null";
-            address = {
-              socket_address = {
-                protocol = "TCP";
-                address = "127.0.0.1";
-                port_value = 80;
-              };
-            };
+  meta = with lib.maintainers; {
+    maintainers = [ cameronnemo ];
+  };
+
+  nodes.machine = {
+    services.envoy.enable = true;
+    services.envoy.package = envoyPackage;
+    services.envoy.settings = {
+      admin = {
+        access_log_path = "/dev/null";
+        address = {
+          socket_address = {
+            protocol = "TCP";
+            address = "127.0.0.1";
+            port_value = 80;
           };
-          static_resources = {
-            listeners = [ ];
-            clusters = [ ];
-          };
-        };
-        specialisation = {
-          withoutConfigValidation.configuration =
-            { ... }:
-            {
-              services.envoy = {
-                requireValidConfig = false;
-                settings.admin.access_log_path = lib.mkForce "/var/log/envoy/access.log";
-              };
-            };
         };
       };
+      static_resources = {
+        listeners = [ ];
+        clusters = [ ];
+      };
+    };
+    specialisation = {
+      withoutConfigValidation.configuration =
+        { ... }:
+        {
+          services.envoy = {
+            requireValidConfig = false;
+            settings.admin.access_log_path = lib.mkForce "/var/log/envoy/access.log";
+          };
+        };
+    };
+  };
 
-    testScript =
-      { nodes, ... }:
-      let
-        specialisations = "${nodes.machine.system.build.toplevel}/specialisation";
-      in
-      ''
-        machine.start()
+  testScript =
+    { nodes, ... }:
+    let
+      specialisations = "${nodes.machine.system.build.toplevel}/specialisation";
+    in
+    ''
+      machine.start()
 
-        with subtest("envoy.service starts and responds with ready"):
-          machine.wait_for_unit("envoy.service")
-          machine.wait_for_open_port(80)
-          machine.wait_until_succeeds("curl -fsS localhost:80/ready")
+      with subtest("envoy.service starts and responds with ready"):
+        machine.wait_for_unit("envoy.service")
+        machine.wait_for_open_port(80)
+        machine.wait_until_succeeds("curl -fsS localhost:80/ready")
 
-        with subtest("envoy.service works with config path not available at eval time"):
-          machine.succeed('${specialisations}/withoutConfigValidation/bin/switch-to-configuration test')
-          machine.wait_for_unit("envoy.service")
-          machine.wait_for_open_port(80)
-          machine.wait_until_succeeds("curl -fsS localhost:80/ready")
-          machine.succeed('test -f /var/log/envoy/access.log')
-      '';
-  }
-)
+      with subtest("envoy.service works with config path not available at eval time"):
+        machine.succeed('${specialisations}/withoutConfigValidation/bin/switch-to-configuration test')
+        machine.wait_for_unit("envoy.service")
+        machine.wait_for_open_port(80)
+        machine.wait_until_succeeds("curl -fsS localhost:80/ready")
+        machine.succeed('test -f /var/log/envoy/access.log')
+    '';
+}

--- a/pkgs/by-name/en/envoy-bin/package.nix
+++ b/pkgs/by-name/en/envoy-bin/package.nix
@@ -1,0 +1,77 @@
+{
+  lib,
+  stdenv,
+  autoPatchelfHook,
+  fetchurl,
+  makeWrapper,
+  nixosTests,
+  versionCheckHook,
+}:
+let
+  version = "1.33.2";
+  inherit (stdenv.hostPlatform) system;
+  throwSystem = throw "envoy-bin is not available for ${system}.";
+
+  plat =
+    {
+      aarch64-linux = "aarch_64";
+      x86_64-linux = "x86_64";
+    }
+    .${system} or throwSystem;
+
+  hash =
+    {
+      aarch64-linux = "sha256-gew2iaghIu/wymgMSBdvTTUbb5iBp5zJ2QeKb7Swtqg=";
+      x86_64-linux = "sha256-vS/4fF78lf14gNcQkV9XPBqrTZxV2NqIbc2R30P610E=";
+    }
+    .${system} or throwSystem;
+in
+stdenv.mkDerivation {
+  pname = "envoy-bin";
+  inherit version;
+
+  src = fetchurl {
+    url = "https://github.com/envoyproxy/envoy/releases/download/v${version}/envoy-${version}-linux-${plat}";
+    inherit hash;
+  };
+
+  nativeBuildInputs = [ autoPatchelfHook ];
+  buildInputs = [ makeWrapper ];
+
+  dontUnpack = true;
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/bin
+    install -m755 $src $out/bin/envoy
+    runHook postInstall
+  '';
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+  versionCheckProgram = "${placeholder "out"}/bin/envoy";
+  versionCheckProgramArg = "--version";
+
+  passthru = {
+    tests.envoy-bin = nixosTests.envoy-bin;
+
+    updateScript = ./update.sh;
+  };
+
+  meta = {
+    homepage = "https://envoyproxy.io";
+    changelog = "https://github.com/envoyproxy/envoy/releases/tag/v${version}";
+    description = "Cloud-native edge and service proxy";
+    license = lib.licenses.asl20;
+    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+    maintainers = with lib.maintainers; [
+      adamcstephens
+    ];
+    mainProgram = "envoy";
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+    ];
+  };
+}

--- a/pkgs/by-name/en/envoy-bin/update.sh
+++ b/pkgs/by-name/en/envoy-bin/update.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p curl gnused gawk nix-prefetch common-updater-scripts jq
+
+set -euo pipefail
+
+ROOT="$(dirname "$(readlink -f "$0")")"
+NIX_DRV="$ROOT/package.nix"
+if [ ! -f "$NIX_DRV" ]; then
+    echo "ERROR: cannot find package.nix in $ROOT"
+    exit 1
+fi
+
+fetch_arch() {
+    VER="$1"
+    ARCH="$2"
+    URL="https://github.com/envoyproxy/envoy/releases/download/v${VER}/envoy-${VER}-linux-${ARCH}"
+    nix hash convert --to sri --hash-algo sha256 "$(nix-prefetch-url --type sha256 "$URL")"
+}
+
+replace_hash() {
+    sed -i "s#$1 = \"sha256-.\{44\}\"#$1 = \"$2\"#" "$NIX_DRV"
+}
+
+VER=$(list-git-tags --url=https://github.com/envoyproxy/envoy | rg 'v[0-9\.]*$' | sed -e 's/^v//' | sort -V | tail -n 1)
+
+LINUX_X64_HASH=$(fetch_arch "$VER" "x86_64")
+LINUX_AARCH64_HASH=$(fetch_arch "$VER" "aarch_64")
+
+sed -i "s/version = \".*\"/version = \"$VER\"/" "$NIX_DRV"
+
+replace_hash "x86_64-linux" "$LINUX_X64_HASH"
+replace_hash "aarch64-linux" "$LINUX_AARCH64_HASH"


### PR DESCRIPTION
We package envoy, but it's a maintenance burden to keep up to date given the ever changing bazel build environment. Even a relatively minor bump, from 1.33.0 -> 1.33.2 is not straightforward. I've thus opened this to add the upstream built binary as an alternative for those who prefer the more up to date package.

Moved the envoy test to [runTest](https://github.com/NixOS/nixpkgs/issues/386873) and exposed it for both source and binary packages.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
