### PR TITLE
passmenu-otp: init at 0-unstable-2019-04-21

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -17913,6 +17913,12 @@
     github = "oosquare";
     githubId = 42143810;
   };
+  opdavies = {
+    email = "oliver@oliverdavies.uk";
+    github = "opdavies";
+    githubId = 339813;
+    name = "Oliver Davies";
+  };
   opeik = {
     email = "sandro@stikic.com";
     github = "opeik";

--- a/pkgs/by-name/pa/passmenu-otp/package.nix
+++ b/pkgs/by-name/pa/passmenu-otp/package.nix
@@ -1,0 +1,41 @@
+{
+  stdenv,
+  lib,
+  pkgs,
+  fetchFromGitHub,
+}:
+
+stdenv.mkDerivation {
+  pname = "passmenu-otp";
+  version = "0-unstable-2019-04-21";
+
+  src = fetchFromGitHub {
+    owner = "petrmanek";
+    repo = "passmenu-otp";
+    rev = "2623a0845cc2bb68b636a743862693fce9ec8b02";
+    hash = "sha256-2EGomeK/p3uVfgho5xGR11ovJQ2q3cPZoFG+z88DyxA=";
+  };
+
+  buildInputs = with pkgs; [
+    dmenu
+    pass
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+    cp passmenu-otp $out/bin
+    chmod +x $out/bin/passmenu-otp
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Extension of passmenu, friendly to one-time passwords (OTP)";
+    homepage = "https://github.com/petrmanek/passmenu-otp";
+    mainProgram = "passmenu-otp";
+    maintainers = with lib.maintainers; [ opdavies ];
+    platforms = lib.platforms.unix;
+  };
+}


### PR DESCRIPTION
Add passmenu-otp, an extension for passmenu that will run `passmenu otp` automatically if the password is an OTP code.

I've added this to my own NixOS configuration and thought it may be useful to others, so wanted to contribute it back to nixpkgs.

There isn't a tag to use for the version number but I've seen others use the branch name and date of the commit, so I've followed that convention.

This is my first time submitting a PR to nixpkgs, so I'm happy to receive any feedback and make any required changes.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
