### PR TITLE
eigenpy: run unit tests

### DIFF
--- a/pkgs/development/python-modules/eigenpy/default.nix
+++ b/pkgs/development/python-modules/eigenpy/default.nix
@@ -31,6 +31,7 @@ buildPythonPackage rec {
 
   cmakeFlags = [
     "-DINSTALL_DOCUMENTATION=ON"
+    "-DBUILD_TESTING=ON"
     "-DBUILD_TESTING_SCIPY=ON"
   ];
 
@@ -49,6 +50,8 @@ buildPythonPackage rec {
     jrl-cmakemodules
     numpy
   ];
+
+  preInstallCheck = "make test";
 
   pythonImportsCheck = [ "eigenpy" ];
 

--- a/pkgs/development/python-modules/eigenpy/default.nix
+++ b/pkgs/development/python-modules/eigenpy/default.nix
@@ -2,13 +2,21 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+
+  # nativeBuildInputs
   cmake,
   doxygen,
+  graphviz,
+  scipy,
+
+  # buildInputs
   boost,
+
+  # propagatedBuildInputs
   eigen,
   jrl-cmakemodules,
   numpy,
-  scipy,
+
 }:
 
 buildPythonPackage rec {
@@ -40,6 +48,7 @@ buildPythonPackage rec {
   nativeBuildInputs = [
     cmake
     doxygen
+    graphviz
     scipy
   ];
 

--- a/pkgs/development/python-modules/eigenpy/default.nix
+++ b/pkgs/development/python-modules/eigenpy/default.nix
@@ -3,6 +3,8 @@
   buildPythonPackage,
   fetchFromGitHub,
 
+  fontconfig,
+
   # nativeBuildInputs
   cmake,
   doxygen,
@@ -44,6 +46,12 @@ buildPythonPackage rec {
   ];
 
   strictDeps = true;
+
+  # Fontconfig error: No writable cache directories
+  preBuild = "export XDG_CACHE_HOME=$(mktemp -d)";
+
+  # Fontconfig error: Cannot load default config file: No such file: (null)
+  env.FONTCONFIG_FILE = "${fontconfig.out}/etc/fonts/fonts.conf";
 
   nativeBuildInputs = [
     cmake

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4375,7 +4375,9 @@ self: super: with self; {
 
   eheimdigital = callPackage ../development/python-modules/eheimdigital { };
 
-  eigenpy = callPackage ../development/python-modules/eigenpy { };
+  eigenpy = callPackage ../development/python-modules/eigenpy {
+    inherit (pkgs) graphviz; # need the `dot` program, not the python module
+  };
 
   einops = callPackage ../development/python-modules/einops { };
 


### PR DESCRIPTION
Working on #395016 to add the successor of eigenpy, I noticed that contrary to what I thought, tests were not ran in eigenpy.

The [manual](https://nixos.org/manual/nixpkgs/unstable/#buildpythonpackage-function) says 
> By default tests are run because doCheck = true

But that is false, `doCheck` is removed: https://github.com/NixOS/nixpkgs/blob/da88ca0530b70c3e72e814726c4c740d5c3dbef0/pkgs/development/interpreters/python/mk-python-derivation.nix#L105

Because:
> Python packages don't have a checkPhase, only an installCheckPhase

So I guess for `buildPythonPackage` built with CMake need a `preInstallCheck = "make test";`

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
