### PR TITLE
update-python-libraries: make hermetic

### DIFF
--- a/pkgs/by-name/up/update-python-libraries/package.nix
+++ b/pkgs/by-name/up/update-python-libraries/package.nix
@@ -1,4 +1,5 @@
 {
+  lib,
   python3,
   runCommand,
   git,
@@ -9,8 +10,6 @@
 runCommand "update-python-libraries"
   {
     buildInputs = [
-      nix
-      nix-prefetch-git
       (python3.withPackages (
         ps: with ps; [
           packaging
@@ -18,11 +17,14 @@ runCommand "update-python-libraries"
           toolz
         ]
       ))
-      git
     ];
   }
   ''
     cp ${./update-python-libraries.py} $out
     patchShebangs $out
-    substituteInPlace $out --replace 'GIT = "git"' 'GIT = "${git}/bin/git"'
+    substituteInPlace $out \
+      --replace-fail 'NIX = "nix"' 'NIX = "${lib.getExe nix}"' \
+      --replace-fail 'NIX_PREFETCH_URL = "nix-prefetch-url"' 'NIX_PREFETCH_URL = "${lib.getExe' nix "nix-prefetch-url"}"' \
+      --replace-fail 'NIX_PREFETCH_GIT = "nix-prefetch-git"' 'NIX_PREFETCH_GIT = "${lib.getExe nix-prefetch-git}"' \
+      --replace-fail 'GIT = "git"' 'GIT = "${lib.getExe git}"'
   ''

--- a/pkgs/by-name/up/update-python-libraries/update-python-libraries.py
+++ b/pkgs/by-name/up/update-python-libraries/update-python-libraries.py
@@ -36,10 +36,13 @@ PRERELEASES = False
 
 BULK_UPDATE = False
 
+NIX = "nix"
+NIX_PREFETCH_URL = "nix-prefetch-url"
+NIX_PREFETCH_GIT = "nix-prefetch-git"
 GIT = "git"
 
 NIXPKGS_ROOT = (
-    subprocess.check_output(["git", "rev-parse", "--show-toplevel"])
+    subprocess.check_output([GIT, "rev-parse", "--show-toplevel"])
     .decode("utf-8")
     .strip()
 )
@@ -79,7 +82,7 @@ def _get_attr_value(attr_path: str) -> Optional[Any]:
     try:
         response = subprocess.check_output(
             [
-                "nix",
+                NIX,
                 "--extra-experimental-features",
                 "nix-command",
                 "eval",
@@ -164,7 +167,7 @@ def _hash_to_sri(algorithm, value):
     return (
         subprocess.check_output(
             [
-                "nix",
+                NIX,
                 "--extra-experimental-features",
                 "nix-command",
                 "hash",
@@ -260,7 +263,7 @@ def _get_latest_version_github(attr_path, package, extension, current_version, t
     try:
         homepage = subprocess.check_output(
             [
-                "nix",
+                NIX,
                 "--extra-experimental-features",
                 "nix-command",
                 "eval",
@@ -301,7 +304,7 @@ def _get_latest_version_github(attr_path, package, extension, current_version, t
 
         algorithm = "sha256"
         cmd = [
-            "nix-prefetch-git",
+            NIX_PREFETCH_GIT,
             f"https://github.com/{owner}/{repo}.git",
             "--hash",
             algorithm,
@@ -317,7 +320,7 @@ def _get_latest_version_github(attr_path, package, extension, current_version, t
             hash = (
                 subprocess.check_output(
                     [
-                        "nix-prefetch-url",
+                        NIX_PREFETCH_URL,
                         "--type",
                         "sha256",
                         "--unpack",
@@ -336,7 +339,7 @@ def _get_latest_version_github(attr_path, package, extension, current_version, t
             try:
                 hash = (
                     subprocess.check_output(
-                        ["nix-prefetch-url", "--type", "sha256", "--unpack", tag_url],
+                        [NIX_PREFETCH_URL, "--type", "sha256", "--unpack", tag_url],
                         stderr=subprocess.DEVNULL,
                     )
                     .decode("utf-8")

--- a/pkgs/tools/package-management/nix-prefetch-scripts/default.nix
+++ b/pkgs/tools/package-management/nix-prefetch-scripts/default.nix
@@ -49,6 +49,7 @@ let
         description = "Script used to obtain source hashes for fetch${tool}";
         maintainers = with maintainers; [ bennofs ];
         platforms = platforms.unix;
+        mainProgram = "nix-prefetch-${tool}";
       };
     };
 in


### PR DESCRIPTION
Should fix issues like https://nixpkgs-update-logs.nix-community.org/python312Packages.jschon/2025-03-22.log

This has been going on for a while, we may now get a surge of bumps from r-ryantm

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
