### PR TITLE
lxpanel: fix build with gcc14, modernize

### DIFF
--- a/pkgs/desktops/lxde/core/lxpanel/default.nix
+++ b/pkgs/desktops/lxde/core/lxpanel/default.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchurl,
+  fetchpatch2,
   pkg-config,
   gettext,
   m4,
@@ -37,6 +38,15 @@ stdenv.mkDerivation rec {
     url = "mirror://sourceforge/lxde/${pname}-${version}.tar.xz";
     sha256 = "sha256-HjGPV9fja2HCOlBNA9JDDHja0ULBgERRBh8bPqVEHug=";
   };
+
+  patches = [
+    # fix build with gcc14
+    # https://github.com/lxde/lxpanel/commit/0853b0fc981285ebd2ac52f8dfc2a09b1090748c
+    (fetchpatch2 {
+      url = "https://github.com/lxde/lxpanel/commit/0853b0fc981285ebd2ac52f8dfc2a09b1090748c.patch?full_index=1";
+      hash = "sha256-lj4CWdiUQhEc9J8UNKcP7/tmsGnPjA5pwXAok5YFW4M=";
+    })
+  ];
 
   nativeBuildInputs = [
     pkg-config

--- a/pkgs/desktops/lxde/core/lxpanel/default.nix
+++ b/pkgs/desktops/lxde/core/lxpanel/default.nix
@@ -30,12 +30,12 @@
   withGtk3 ? true,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "lxpanel";
   version = "0.10.1";
 
   src = fetchurl {
-    url = "mirror://sourceforge/lxde/${pname}-${version}.tar.xz";
+    url = "mirror://sourceforge/lxde/${finalAttrs.pname}-${finalAttrs.version}.tar.xz";
     sha256 = "sha256-HjGPV9fja2HCOlBNA9JDDHja0ULBgERRBh8bPqVEHug=";
   };
 
@@ -82,11 +82,11 @@ stdenv.mkDerivation rec {
 
   configureFlags = lib.optional withGtk3 "--enable-gtk3";
 
-  meta = with lib; {
+  meta = {
     description = "Lightweight X11 desktop panel for LXDE";
     homepage = "https://lxde.org/";
-    license = licenses.gpl2Plus;
-    maintainers = [ maintainers.ryneeverett ];
-    platforms = platforms.linux;
+    license = lib.licenses.gpl2Plus;
+    maintainers = [ lib.maintainers.ryneeverett ];
+    platforms = lib.platforms.linux;
   };
-}
+})


### PR DESCRIPTION
lxpanel: fix build with gcc14

- add patch from upstream commit:
https://github.com/lxde/lxpanel/commit/0853b0fc981285ebd2ac52f8dfc2a09b1090748c
fixing `incompatible-pointer-types` error with gcc14

---

lxpanel: modernize

- replace `rec` with `finalAttrs`
- remove `with lib;` from `meta`

---

Fixes build failure of `lxpanel` since update to GCC 14 in #356812:
https://hydra.nixos.org/job/nixos/trunk-combined/nixpkgs.lxde.lxpanel.x86_64-linux
https://hydra.nixos.org/build/293037254

Log:
```
tray.c:634:19: error: assignment to 'GtkWidget *' {aka 'struct _GtkWidget *'} from incompatible pointer type 'GObject *' {aka 'struct _GObject *'} [-Wincompatible-pointer-types]
  634 |     tr->invisible = g_object_ref_sink(G_OBJECT(invisible));
      |                   ^
make[3]: *** [Makefile:1302: libbuiltin_plugins_a-tray.o] Error 1
make[3]: Leaving directory '/build/lxpanel-0.10.1/plugins'
make[2]: *** [Makefile:1107: builtin-plugins-hook] Error 2
make[2]: Leaving directory '/build/lxpanel-0.10.1/src'
make[1]: *** [Makefile:521: all-recursive] Error 1
make[1]: Leaving directory '/build/lxpanel-0.10.1'
make: *** [Makefile:424: all] Error 2
```

Tracking issue: #388196 

---

If somebody wants to test whether it runs after building, fyi - it immediately segfaults on wayland (same way it does on 24.11), backtrace goes: `main() -> resolve_atoms() -> XInternAtoms`
I assume it is not expected to run on wayland or through XWayland.
Seems to run fine in X11 VM (panel opens, shows currently open windows), tested inside `nixosTests.i3wm.driverInteractive` by adding `environment.systemPackages = [ pkgs.lxpanel ];` in test config.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
