### PR TITLE
cnsprcy : 0.2.0 -> 0.3.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -17817,6 +17817,12 @@
     githubId = 35628088;
     name = "oluceps";
   };
+  oluchitheanalyst = {
+    name = "ndukauba maryjane oluchi";
+    email = "ndukauba.oluchi2000@gmail.com";
+    github = "oluchitheanalyst";
+    githubId = 152318870;
+  };
   olynch = {
     email = "owen@olynch.me";
     github = "olynch";

--- a/pkgs/by-name/cn/cnsprcy/package.nix
+++ b/pkgs/by-name/cn/cnsprcy/package.nix
@@ -5,30 +5,42 @@
   sqlite,
 }:
 
-rustPlatform.buildRustPackage {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "cnsprcy";
-  version = "0.2.0";
+  version = "0.3.2";
 
   src = fetchFromSourcehut {
     owner = "~xaos";
     repo = "cnsprcy";
-    rev = "v0.2.0";
-    hash = "sha256-f+DauSU4bT3EljY8/ig7jLnUgyDPEo2NSBQcPN0iKx0=";
+    rev = "cnspr/v${finalAttrs.version}";
+    hash = "sha256-wwsemwN87YsNRLkr0UNbzSLF2WDaKY6IFXew64g4QoU=";
   };
 
+  sourceRoot = "${finalAttrs.src.name}/v${finalAttrs.version}";
+
   useFetchCargoVendor = true;
-  cargoHash = "sha256-lPTufjKOXMvPy+cP1UyVCTfRXkOmzZqDR6yraIgk+Dg=";
+
+  cargoHash = "sha256-8hNuF5tD1PwdIJB0q3wxDOGDcppo0ac+zol3AHWGv0s=";
+
+  passthru.updateScript = lib.mkUpdateScript {
+    extraFetchers = [ fetchFromSourcehut ];
+  };
 
   RUSTC_BOOTSTRAP = true;
-
   buildInputs = [ sqlite ];
 
   meta = {
     description = "End to end encrypted connections between trusted devices";
     homepage = "https://git.sr.ht/~xaos/cnsprcy";
     license = lib.licenses.gpl3;
-    maintainers = with lib.maintainers; [ supinie ];
+    maintainers =
+      with lib.maintainers;
+      [
+        supinie
+        oluchitheanalyst
+      ]
+      ++ lib.teams.ngi.members;
     mainProgram = "cnspr";
     platforms = lib.platforms.linux;
   };
-}
+})


### PR DESCRIPTION
 - Updated ` cnsprcy ` from ` v0.2.0 ` -> ` v0.3.2 `
 - Added a Nix update script and added ngi team to maintainers
 **Package description**
- ` cnsprcy ` is an end-to-end encrypted connection tool for trusted devices.  
**Homepage**: [https://git.sr.ht/~xaos/cnsprcy](https://git.sr.ht/~xaos/cnsprcy)  
**License**: GPL-3.0  


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
