### PR TITLE
mkosi: 25.3 -> 25.3-unstable-2025-04-01

### DIFF
--- a/pkgs/tools/virtualization/mkosi/0001-Use-wrapped-binaries-instead-of-Python-interpreter.patch
+++ b/pkgs/tools/virtualization/mkosi/0001-Use-wrapped-binaries-instead-of-Python-interpreter.patch
@@ -7,16 +7,16 @@ Rather than calling ukify and mkosi with sys.executable, which doesn't use the P
 
 Signed-off-by: Moritz Sanft <58110325+msanft@users.noreply.github.com>
 ---
- mkosi/__init__.py   | 10 +++++-----
+ mkosi/__init__.py   | 11 +++++------
  mkosi/bootloader.py |  5 +----
  mkosi/run.py        |  8 ++++----
- 3 files changed, 10 insertions(+), 13 deletions(-)
+ 3 files changed, 10 insertions(+), 14 deletions(-)
 
 diff --git a/mkosi/__init__.py b/mkosi/__init__.py
-index c5f785d4f18564378021352fde76be62078324ed..580a5c6464397be5a1977b794d7c044724d43490 100644
+index 65cac772bf1fc9feabec5740ed89a958ba406125..12b29061c819d50559132aa6c3b6f24a12945bb9 100644
 --- a/mkosi/__init__.py
 +++ b/mkosi/__init__.py
-@@ -658,7 +658,7 @@ def script_maybe_chroot_sandbox(
+@@ -702,7 +702,7 @@ def script_maybe_chroot_sandbox(
  
      helpers = {
          "mkosi-chroot": [
@@ -25,25 +25,33 @@ index c5f785d4f18564378021352fde76be62078324ed..580a5c6464397be5a1977b794d7c0447
              "--bind", "/buildroot", "/",
              "--bind", "/var/tmp", "/var/tmp",
              *apivfs_options(root=Path("/")),
-@@ -1534,7 +1534,7 @@ def run_ukify(
-     options: Sequence[PathString] = (),
+@@ -1593,7 +1593,7 @@ def run_ukify(
      sign: bool = True,
- ) -> None:
+     json_out: bool = False,
+ ) -> dict[str, Any]:
 -    ukify = context.config.find_binary("ukify", "/usr/lib/systemd/ukify")
 +    ukify = context.config.find_binary("ukify", "@UKIFY@")
      if not ukify:
          die("Could not find ukify")
  
-@@ -1629,7 +1629,7 @@ def build_uki(
+@@ -1605,7 +1605,6 @@ def run_ukify(
+     (context.workspace / "cmdline").write_text(f"{' '.join(cmdline)}\x00")
+ 
+     cmd = [
+-        python_binary(context.config),
+         ukify,
+         "build",
+         *arguments,
+@@ -1700,7 +1699,7 @@ def build_uki(
      profiles: Sequence[Path],
      output: Path,
- ) -> None:
+ ) -> dict[str, Any]:
 -    if not (ukify := context.config.find_binary("ukify", "/usr/lib/systemd/ukify")):
 +    if not (ukify := context.config.find_binary("ukify", "@UKIFY@")):
          die("Could not find ukify")
  
-     arguments: list[PathString] = [
-@@ -1764,7 +1764,7 @@ def want_uki(context: Context) -> bool:
+     json_out = False
+@@ -1887,7 +1886,7 @@ def want_uki(context: Context) -> bool:
          or (
              context.config.unified_kernel_images == ConfigFeature.auto
              and systemd_stub_binary(context).exists()
@@ -52,7 +60,7 @@ index c5f785d4f18564378021352fde76be62078324ed..580a5c6464397be5a1977b794d7c0447
          )
      )
  
-@@ -2641,7 +2641,7 @@ def check_ukify(
+@@ -2769,7 +2768,7 @@ def check_ukify(
      reason: str,
      hint: Optional[str] = None,
  ) -> None:
@@ -62,10 +70,10 @@ index c5f785d4f18564378021352fde76be62078324ed..580a5c6464397be5a1977b794d7c0447
      v = systemd_tool_version(python_binary(config), ukify, sandbox=config.sandbox)
      if v < version:
 diff --git a/mkosi/bootloader.py b/mkosi/bootloader.py
-index 87a56cc03cc42df41babfe15195e84ab956a3a21..060d3816a5cc287ea61df55fd0696e49b621908f 100644
+index 6f112b854f72a8863dc5e7348f0154851d3dda96..8fdf2c5df7950c032bfcd36d89f7824e86ec9173 100644
 --- a/mkosi/bootloader.py
 +++ b/mkosi/bootloader.py
-@@ -264,10 +264,7 @@ def find_signed_grub_image(context: Context) -> Optional[Path]:
+@@ -268,10 +268,7 @@ def find_signed_grub_image(context: Context) -> Optional[Path]:
  
  
  def python_binary(config: Config) -> PathString:
@@ -78,10 +86,10 @@ index 87a56cc03cc42df41babfe15195e84ab956a3a21..060d3816a5cc287ea61df55fd0696e49
  
  def extract_pe_section(context: Context, binary: Path, section: str, output: Path) -> Path:
 diff --git a/mkosi/run.py b/mkosi/run.py
-index a0e2b9cf00b5e9e9d14b570b052f1b2807b46407..fe1a1cdee6f9a586a85a6894d7a97fa5688b29f7 100644
+index 422006d889802182d7e2f1734b2c342318583e7b..b9a1490bcd7780fea75d834e3ea4fb9a7033cc51 100644
 --- a/mkosi/run.py
 +++ b/mkosi/run.py
-@@ -378,7 +378,7 @@ def finalize_path(
+@@ -277,7 +277,7 @@ def finalize_path(
          # Make sure that /usr/bin and /usr/sbin are always in $PATH.
          path += [s for s in ("/usr/bin", "/usr/sbin") if s not in path]
      else:
@@ -90,7 +98,7 @@ index a0e2b9cf00b5e9e9d14b570b052f1b2807b46407..fe1a1cdee6f9a586a85a6894d7a97fa5
  
      if prefix_usr:
          path = [os.fspath(root / s.lstrip("/")) if s in ("/usr/bin", "/usr/sbin") else s for s in path]
-@@ -564,7 +564,7 @@ def sandbox_cmd(
+@@ -463,7 +463,7 @@ def sandbox_cmd(
          cmdline: list[PathString] = [
              *setup,
              *(["strace", "--detach-on=execve"] if ARG_DEBUG_SANDBOX.get() else []),
@@ -99,7 +107,7 @@ index a0e2b9cf00b5e9e9d14b570b052f1b2807b46407..fe1a1cdee6f9a586a85a6894d7a97fa5
              "--proc", "/proc",
              # We mounted a subdirectory of TMPDIR to /var/tmp so we unset TMPDIR so that /tmp or /var/tmp are
              # used instead.
-@@ -730,7 +730,7 @@ def chroot_options() -> list[PathString]:
+@@ -633,7 +633,7 @@ def chroot_options() -> list[PathString]:
          "--unshare-ipc",
          "--setenv", "container", "mkosi",
          "--setenv", "HOME", "/",
@@ -108,12 +116,12 @@ index a0e2b9cf00b5e9e9d14b570b052f1b2807b46407..fe1a1cdee6f9a586a85a6894d7a97fa5
          "--setenv", "BUILDROOT", "/",
      ]  # fmt: skip
  
-@@ -744,7 +744,7 @@ def chroot_cmd(
+@@ -647,7 +647,7 @@ def chroot_cmd(
  ) -> Iterator[list[PathString]]:
      with vartmpdir() as dir, resource_path(sys.modules[__package__ or __name__]) as module:
          cmdline: list[PathString] = [
 -            sys.executable, "-SI", module / "sandbox.py",
 +            @MKOSI_SANDBOX@,
-             "--bind", root, "/",
+             *root("/"),
              # We mounted a subdirectory of TMPDIR to /var/tmp so we unset TMPDIR so that /tmp or /var/tmp are
              # used instead.

--- a/pkgs/tools/virtualization/mkosi/0002-Fix-library-resolving.patch
+++ b/pkgs/tools/virtualization/mkosi/0002-Fix-library-resolving.patch
@@ -11,10 +11,10 @@ Signed-off-by: Moritz Sanft <58110325+msanft@users.noreply.github.com>
  1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/mkosi/sandbox.py b/mkosi/sandbox.py
-index bfcdb8bc62090235ebbe797982493194b575a5c0..4efee355a5f1ae036ccc5ba39595129a32705ee7 100755
+index c79b48739f3d7127375274bc0b1ef3463cae9032..1d7ad421f4534e25c6456c3a169ea9189668aefd 100755
 --- a/mkosi/sandbox.py
 +++ b/mkosi/sandbox.py
-@@ -86,7 +86,7 @@ class cap_user_data_t(ctypes.Structure):
+@@ -92,7 +92,7 @@ class cap_user_data_t(ctypes.Structure):
      ]
  
  
@@ -23,10 +23,10 @@ index bfcdb8bc62090235ebbe797982493194b575a5c0..4efee355a5f1ae036ccc5ba39595129a
  
  libc.syscall.restype = ctypes.c_long
  libc.unshare.argtypes = (ctypes.c_int,)
-@@ -198,7 +198,7 @@ def seccomp_suppress_chown() -> None:
-     owned by their own uid. To still allow non-root users to build images, if requested we install
-     a seccomp filter that makes calls to chown() and friends a noop.
-     """
+@@ -221,7 +221,7 @@ def seccomp_suppress(*, chown: bool = False, sync: bool = False) -> None:
+     if not chown and not sync:
+         return
+ 
 -    libseccomp = ctypes.CDLL("libseccomp.so.2")
 +    libseccomp = ctypes.CDLL("@LIBSECCOMP@")
      if libseccomp is None:

--- a/pkgs/tools/virtualization/mkosi/0003-Fix-QEMU-firmware-path.patch
+++ b/pkgs/tools/virtualization/mkosi/0003-Fix-QEMU-firmware-path.patch
@@ -9,10 +9,10 @@ Signed-off-by: Moritz Sanft <58110325+msanft@users.noreply.github.com>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/mkosi/qemu.py b/mkosi/qemu.py
-index 7be900f4e99d0db94fec6dfb2534ed23a6edcf80..e2c741d720bca5bf878ca229119471cacb72d3e1 100644
+index 0c406d818a9fa9dcce3be97d0c89e9df0d2a96fa..c134ab4a8bfba1e3564c831a5069be52d90ee15a 100644
 --- a/mkosi/qemu.py
 +++ b/mkosi/qemu.py
-@@ -199,7 +199,7 @@ def find_ovmf_firmware(config: Config, firmware: Firmware) -> Optional[OvmfConfi
+@@ -211,7 +211,7 @@ def find_ovmf_firmware(config: Config, firmware: Firmware) -> Optional[OvmfConfi
      if not firmware.is_uefi():
          return None
  

--- a/pkgs/tools/virtualization/mkosi/default.nix
+++ b/pkgs/tools/virtualization/mkosi/default.nix
@@ -66,7 +66,7 @@ let
 in
 buildPythonApplication rec {
   pname = "mkosi";
-  version = "25.3";
+  version = "25.3-unstable-2025-04-01";
   format = "pyproject";
 
   outputs = [
@@ -77,8 +77,8 @@ buildPythonApplication rec {
   src = fetchFromGitHub {
     owner = "systemd";
     repo = "mkosi";
-    tag = "v${version}";
-    hash = "sha256-CTOVFZORLrVqehhPCgOoEaU3fhwu8fO8jGDNLxoELgE=";
+    rev = "21850673a7f75125d516268ce379dae776dd816a";
+    hash = "sha256-3dhr9lFJpI8aN8HILaMvGuuTbmTVUqdaLAGxSpqciTs=";
   };
 
   patches =


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Fixes [a bug](https://github.com/systemd/mkosi/issues/3637) causing image builds not to work.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
