### PR TITLE
nixos/amdvlk: enable 32 bit drivers properly

### DIFF
--- a/nixos/modules/services/hardware/amdvlk.nix
+++ b/nixos/modules/services/hardware/amdvlk.nix
@@ -37,11 +37,15 @@ in
   };
 
   config = lib.mkIf cfg.enable {
-    hardware.graphics = {
-      enable = true;
-      extraPackages = [ cfg.package ];
-      extraPackages32 = [ cfg.support32Bit.package ];
-    };
+    hardware.graphics =
+      {
+        enable = true;
+        extraPackages = [ cfg.package ];
+      }
+      // lib.optionalAttrs cfg.support32Bit.enable {
+        enable32Bit = true;
+        extraPackages32 = [ cfg.support32Bit.package ];
+      };
 
     environment.sessionVariables = lib.mkIf cfg.supportExperimental.enable {
       AMDVLK_ENABLE_DEVELOPING_EXT = "all";


### PR DESCRIPTION
Closes https://github.com/NixOS/nixpkgs/issues/395087

CC @soumyadeep70