### PR TITLE
prometheus-solaredge-exporter: init at 0.1.5

### DIFF
--- a/pkgs/by-name/pr/prometheus-solaredge-exporter/package.nix
+++ b/pkgs/by-name/pr/prometheus-solaredge-exporter/package.nix
@@ -1,0 +1,46 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  nix-update-script,
+  versionCheckHook,
+}:
+buildGoModule (finalAttrs: {
+  pname = "prometheus-solaredge-exporter";
+  version = "0.1.5";
+
+  src = fetchFromGitHub {
+    owner = "paepckehh";
+    repo = "solaredge_exporter";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-Aw6rMXE0jgqdUScQcFplNnpglwl13BRdTEN1gMQJSd0=";
+  };
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X=github.com/prometheus/common/version.BuildDate=1970-01-01T00:00:00Z"
+    "-X github.com/prometheus/common/version.BuildUser=nix@nixpkgs"
+    "-X github.com/prometheus/common/version.Branch=master"
+    "-X github.com/prometheus/common/version.Revision=${finalAttrs.src.rev}"
+    "-X github.com/prometheus/common/version.Version=${finalAttrs.version}"
+  ];
+
+  vendorHash = "sha256-ltCjuihbm0/bj2SPkiITTHzYmcQsX12xvt+OpYROivU=";
+
+  passthru.updateScript = nix-update-script { };
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+  versionCheckProgram = "${placeholder "out"}/bin/${finalAttrs.meta.mainProgram}";
+  versionCheckProgramArg = "--version";
+
+  meta = {
+    changelog = "https://github.com/paepckehh/solaredge_exporter/releases/tag/v${finalAttrs.version}";
+    homepage = "https://paepcke.de/solaredge_exporter";
+    description = "Prometheus exporter for solaredge solar inverter local tcp modbus interface";
+    license = lib.licenses.mit;
+    mainProgram = "solaredge_exporter";
+    maintainers = with lib.maintainers; [ paepcke ];
+  };
+})


### PR DESCRIPTION
https://github.com/paepckehh/solaredge_exporter
(tldr; prometheus exporter, iot, solar inverter, de-cloud, local first, selfhost, tcp, modbus, grafana dashboards)
- package produces one statistically linked dependency free  binary file (golang)
- follows upstream repo updates, verify build binary / version via versionCheckHook
- package will allow grafana dashboards, eg: https://www.handverdrahtet.org/2020/10/photovoltaic-dashboard-with-grafana.html
- next: pkg commit: native nixos integration via: services.prometheus,exporter.solaredge.enable = true;

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [X] `sandbox = true`
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
