### PR TITLE
pesign: fix build with gcc14, modernize

### DIFF
--- a/pkgs/by-name/pe/pesign/package.nix
+++ b/pkgs/by-name/pe/pesign/package.nix
@@ -12,14 +12,14 @@
   mandoc,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "pesign";
   version = "116";
 
   src = fetchFromGitHub {
     owner = "rhboot";
     repo = "pesign";
-    rev = version;
+    tag = finalAttrs.version;
     hash = "sha256-cuOSD/ZHkilgguDFJviIZCG8kceRWw2JgssQuWN02Do=";
   };
 
@@ -59,12 +59,12 @@ stdenv.mkDerivation rec {
     rm -rf $out/run
   '';
 
-  meta = with lib; {
+  meta = {
     description = "Signing tools for PE-COFF binaries. Compliant with the PE and Authenticode specifications";
     homepage = "https://github.com/rhboot/pesign";
-    license = licenses.gpl2Only;
-    maintainers = with maintainers; [ raitobezarius ];
+    license = lib.licenses.gpl2Only;
+    maintainers = with lib.maintainers; [ raitobezarius ];
     # efivar is currently Linux-only.
-    platforms = platforms.linux;
+    platforms = lib.platforms.linux;
   };
-}
+})

--- a/pkgs/by-name/pe/pesign/package.nix
+++ b/pkgs/by-name/pe/pesign/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  fetchpatch2,
   pkg-config,
   nss,
   efivar,
@@ -21,6 +22,15 @@ stdenv.mkDerivation rec {
     rev = version;
     hash = "sha256-cuOSD/ZHkilgguDFJviIZCG8kceRWw2JgssQuWN02Do=";
   };
+
+  patches = [
+    # fix build with gcc14
+    # https://github.com/rhboot/pesign/pull/119
+    (fetchpatch2 {
+      url = "https://github.com/rhboot/pesign/commit/1f9e2fa0b4d872fdd01ca3ba81b04dfb1211a187.patch?full_index=1";
+      hash = "sha256-viVM4Z0jAEAWC3EdJVHcWe21aQskH5XE85lOd6Xd/qU=";
+    })
+  ];
 
   # nss-util is missing because it is already contained in nss
   # Red Hat seems to be shipping a separate nss-util:


### PR DESCRIPTION
pesign: fix build with gcc14

- add patch from upstream commit:
https://github.com/rhboot/pesign/commit/1f9e2fa0b4d872fdd01ca3ba81b04dfb1211a187
that fixes `calloc-transposed-args` error with gcc14:
```
pesigcheck.c: In function 'check_signature':
pesigcheck.c:243:34: error: 'calloc' sizes specified with 'sizeof' in the
earlier argument and not in the later argument
[-Werror=calloc-transposed-args]
  243 |         reasonps = calloc(sizeof(struct reason), 512);
      |                                  ^~~~~~
pesigcheck.c:243:34: note: earlier argument should specify number of
elements, later size of each element
pesigcheck.c:284:53: error: 'calloc' sizes specified with 'sizeof' in the
 earlier argument and not in the later argument
[-Werror=calloc-transposed-args]
  284 |                         new_reasons = calloc(sizeof(struct reason), num_reasons);
      |                                                     ^~~~~~
pesigcheck.c:284:53: note: earlier argument should specify number of
elements, later size of each element
```

---

pesign: modernize

- replace `rec` with `finalAttrs`
- remove `with lib;` from `meta`
- replace `rev` with `tag` in `src`

---

Fixes build failure or `pesign` since update to GCC 14 in #356812:
https://hydra.nixos.org/job/nixos/trunk-combined/nixpkgs.pesign.x86_64-linux
https://hydra.nixos.org/build/293052069

Log:
```text
pesigcheck.c: In function 'check_signature':
pesigcheck.c:243:34: error: 'calloc' sizes specified with 'sizeof' in the earlier argument and not in the later argument [-Werror=calloc-transposed-args]
  243 |         reasonps = calloc(sizeof(struct reason), 512);
      |                                  ^~~~~~
pesigcheck.c:243:34: note: earlier argument should specify number of elements, later size of each element
pesigcheck.c:284:53: error: 'calloc' sizes specified with 'sizeof' in the earlier argument and not in the later argument [-Werror=calloc-transposed-args]
  284 |                         new_reasons = calloc(sizeof(struct reason), num_reasons);
      |                                                     ^~~~~~
pesigcheck.c:284:53: note: earlier argument should specify number of elements, later size of each element
cc1: all warnings being treated as errors
make[1]: *** [/build/source/Make.rules:34: pesigcheck.o] Error 1
make[1]: Leaving directory '/build/source/src'
make: *** [Makefile:29: all] Error 2
```

Tracking issue: #388196 
Upstream PR with fix: https://github.com/rhboot/pesign/pull/119

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
