### PR TITLE
kgeotag: 1.7.0 -> 1.8.0

### DIFF
--- a/pkgs/by-name/kg/kgeotag/package.nix
+++ b/pkgs/by-name/kg/kgeotag/package.nix
@@ -9,14 +9,14 @@
 
 stdenv.mkDerivation rec {
   pname = "kgeotag";
-  version = "1.7.0";
+  version = "1.8.0";
 
   src = fetchFromGitLab {
     domain = "invent.kde.org";
     repo = "kgeotag";
     owner = "graphics";
     rev = "v${version}";
-    hash = "sha256-/NYAR/18Dh+fphCBz/zFWj/xqEl28e77ZtV8LlcGyMI=";
+    hash = "sha256-3PEtwTGvyH5RFBWQ9LI7FNlet46JYiVp9w5VtVvB454=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
This updates the KGeoTag package from version 1.7.0 to the latest 1.8.0, which was released on 2025-03-09. It's a simple version and hash update.

meta.description for kgeotag is: Stand-alone photo geotagging program

meta.homepage for kgeotag is: https://kgeotag.kde.org/

meta.changelog for kgeotag is: https://invent.kde.org/graphics/kgeotag/-/blob/master/CHANGELOG.rst

I updated the version number and hash, built the package on NixOS 24.11 and manually tested the application.