### PR TITLE
lib/modules: export `class` inside `specialArgs`

### DIFF
--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -257,6 +257,7 @@ let
                     config
                     specialArgs
                     ;
+                  _class = class;
                 }
                 // specialArgs
               );

--- a/lib/tests/modules.sh
+++ b/lib/tests/modules.sh
@@ -681,6 +681,18 @@ checkConfigOutput '^true$' config.viaConfig ./mkDefinition.nix
 checkConfigOutput '^true$' config.mkMerge ./mkDefinition.nix
 checkConfigOutput '^true$' config.mkForce ./mkDefinition.nix
 
+# specialArgs._class
+checkConfigOutput '"nixos"' config.nixos.config.foo ./specialArgs-class.nix
+checkConfigOutput '"bar"' config.conditionalImportAsNixos.config.foo ./specialArgs-class.nix
+checkConfigError 'attribute .*bar.* not found' config.conditionalImportAsNixos.config.bar ./specialArgs-class.nix
+checkConfigError 'attribute .*foo.* not found' config.conditionalImportAsDarwin.config.foo ./specialArgs-class.nix
+checkConfigOutput '"foo"' config.conditionalImportAsDarwin.config.bar ./specialArgs-class.nix
+checkConfigOutput '"nixos"' config.sub.nixos.foo ./specialArgs-class.nix
+checkConfigOutput '"bar"' config.sub.conditionalImportAsNixos.foo ./specialArgs-class.nix
+checkConfigError 'attribute .*bar.* not found' config.sub.conditionalImportAsNixos.bar ./specialArgs-class.nix
+checkConfigError 'attribute .*foo.* not found' config.sub.conditionalImportAsDarwin.foo ./specialArgs-class.nix
+checkConfigOutput '"foo"' config.sub.conditionalImportAsDarwin.bar ./specialArgs-class.nix
+
 cat <<EOF
 ====== module tests ======
 $pass Pass

--- a/lib/tests/modules/assert-module-class-is-nixos.nix
+++ b/lib/tests/modules/assert-module-class-is-nixos.nix
@@ -1,0 +1,3 @@
+{ _class, ... }:
+assert _class == "nixos";
+{ }

--- a/lib/tests/modules/class-check.nix
+++ b/lib/tests/modules/class-check.nix
@@ -5,7 +5,9 @@
       nixosOk = lib.mkOption {
         type = lib.types.submoduleWith {
           class = "nixos";
-          modules = [ ];
+          modules = [
+            ./assert-module-class-is-nixos.nix
+          ];
         };
       };
       # Same but will have bad definition
@@ -45,6 +47,7 @@
       class = "nixos";
       modules = [
         ./module-class-is-nixos.nix
+        ./assert-module-class-is-nixos.nix
       ];
     };
 

--- a/lib/tests/modules/expose-module-class.nix
+++ b/lib/tests/modules/expose-module-class.nix
@@ -1,0 +1,8 @@
+{ _class, lib, ... }:
+{
+  options = {
+    foo = lib.mkOption {
+      default = _class;
+    };
+  };
+}

--- a/lib/tests/modules/polymorphic-module.nix
+++ b/lib/tests/modules/polymorphic-module.nix
@@ -1,0 +1,23 @@
+{ _class, lib, ... }:
+let
+  nixosModule =
+    { ... }:
+    {
+      options.foo = lib.mkOption {
+        default = "bar";
+      };
+    };
+  darwinModule =
+    { ... }:
+    {
+      options.bar = lib.mkOption {
+        default = "foo";
+      };
+    };
+in
+{
+  imports = [
+    (lib.optionalAttrs (_class == "nixos") nixosModule)
+    (lib.optionalAttrs (_class == "darwin") darwinModule)
+  ];
+}

--- a/lib/tests/modules/specialArgs-class.nix
+++ b/lib/tests/modules/specialArgs-class.nix
@@ -1,0 +1,54 @@
+{ lib, ... }:
+{
+  options = {
+    sub = {
+      nixos = lib.mkOption {
+        type = lib.types.submoduleWith {
+          class = "nixos";
+          modules = [
+            ./expose-module-class.nix
+          ];
+        };
+        default = { };
+      };
+
+      conditionalImportAsNixos = lib.mkOption {
+        type = lib.types.submoduleWith {
+          class = "nixos";
+          modules = [
+            ./polymorphic-module.nix
+          ];
+        };
+        default = { };
+      };
+
+      conditionalImportAsDarwin = lib.mkOption {
+        type = lib.types.submoduleWith {
+          class = "darwin";
+          modules = [
+            ./polymorphic-module.nix
+          ];
+        };
+        default = { };
+      };
+    };
+  };
+  config = {
+    _module.freeformType = lib.types.anything;
+
+    nixos = lib.evalModules {
+      class = "nixos";
+      modules = [ ./expose-module-class.nix ];
+    };
+
+    conditionalImportAsNixos = lib.evalModules {
+      class = "nixos";
+      modules = [ ./polymorphic-module.nix ];
+    };
+
+    conditionalImportAsDarwin = lib.evalModules {
+      class = "darwin";
+      modules = [ ./polymorphic-module.nix ];
+    };
+  };
+}


### PR DESCRIPTION
I think this would be useful for writing module system-aware/polymorphic modules

```
{ _class, lib, ... }: {
  config = lib.mkMerge [
    ({ environment.etc = ...; })
    (lib.mkIf (_class == "nixos") {
      virtualisation = {
        ...
    })
  };
}
```

Currently `type` is exported as `moduleType` so maybe this should be exported as `moduleClass` to reduce the chance of collision with any downstream users already adding an argument called `class`

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
