### PR TITLE
hyphen: add Russian dictionary, update readmeFileName values

### DIFF
--- a/pkgs/development/libraries/hyphen/dictionaries.nix
+++ b/pkgs/development/libraries/hyphen/dictionaries.nix
@@ -44,7 +44,7 @@ let
         install -m644 "hyph_${dictFileName}.dic" "$out/share/hyphen"
         # docs
         install -dm755 "$out/share/doc/"
-        install -m644 "README_hyph_${readmeFileName}.txt" "$out/share/doc/${pname}.txt"
+        install -m644 "README_${readmeFileName}.txt" "$out/share/doc/${pname}.txt"
         runHook postInstall
       '';
     };
@@ -84,7 +84,7 @@ rec {
     shortName = "de-de";
     shortDescription = "German (Germany)";
     dictFileName = "de_DE";
-    readmeFileName = "de";
+    readmeFileName = "hyph_de";
   };
 
   de_AT = de-at;
@@ -93,7 +93,7 @@ rec {
     shortName = "de-at";
     shortDescription = "German (Austria)";
     dictFileName = "de_AT";
-    readmeFileName = "de";
+    readmeFileName = "hyph_de";
   };
 
   de_CH = de-ch;
@@ -102,6 +102,17 @@ rec {
     shortName = "de-ch";
     shortDescription = "German (Switzerland)";
     dictFileName = "de_CH";
-    readmeFileName = "de";
+    readmeFileName = "hyph_de";
+  };
+
+  # RUSSIAN
+
+  ru_RU = ru-ru;
+  ru-ru = mkDictFromLibreofficeGit {
+    subdir = "ru_RU";
+    shortName = "ru-ru";
+    shortDescription = "Russian (Russia)";
+    dictFileName = "ru_RU";
+    readmeFileName = "ru_RU";
   };
 }


### PR DESCRIPTION
For some reason README file for Russian has different naming upstream, therefore `readmeFileName` for all languages was changed to accommodate both naming schemes. I'm not sure if there is a cleaner way to handle this, other than report it upstream and wait for patch to be merged. Also, is this an update to `hyphen` package or to `hyphenDicts`...dictionary of packages?

I've tested this with

```nix
        {
          nixpkgs.overlays = let
            pkgs = import inputs.ru-hyphen {inherit system;};
          in [(_: _: {inherit (pkgs) hyphenDicts;})];
        }
```

Cc @theCapypara

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
