### PR TITLE
nixos-rebuild{-ng,}: Don't eval nixos closure before validating image variants.

### DIFF
--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/__init__.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/__init__.py
@@ -396,7 +396,7 @@ def execute(argv: list[str]) -> None:
                     raise NRError(
                         "please specify one of the following "
                         + "supported image variants via --image-variant:\n"
-                        + "\n".join(f"- {v}" for v in variants.keys())
+                        + "\n".join(f"- {v}" for v in variants)
                     )
 
             match action:
@@ -518,7 +518,19 @@ def execute(argv: list[str]) -> None:
                         "Done. The virtual machine can be started by running", vm_path
                     )
                 case Action.BUILD_IMAGE:
-                    disk_path = path_to_config / variants[args.image_variant]
+                    if flake:
+                        image_name = nix.get_build_image_name_flake(
+                            flake,
+                            args.image_variant,
+                            eval_flags=flake_common_flags,
+                        )
+                    else:
+                        image_name = nix.get_build_image_name(
+                            build_attr,
+                            args.image_variant,
+                            instantiate_flags=flake_common_flags,
+                        )
+                    disk_path = path_to_config / image_name
                     print_result("Done. The disk image can be found in", disk_path)
 
         case Action.EDIT:

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/models.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/models.py
@@ -8,7 +8,7 @@ from typing import Any, Callable, ClassVar, Self, TypedDict, override
 
 from .process import Remote, run_wrapper
 
-type ImageVariants = dict[str, str]
+type ImageVariants = list[str]
 
 
 class NRError(Exception):

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_main.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_main.py
@@ -347,12 +347,7 @@ def test_execute_nix_build_image_flake(mock_run: Mock, tmp_path: Path) -> None:
             return CompletedProcess(
                 [],
                 0,
-                """
-                {
-                  "azure": "nixos-image-azure-25.05.20250102.6df2492-x86_64-linux.vhd",
-                  "vmware": "nixos-image-vmware-25.05.20250102.6df2492-x86_64-linux.vmdk"
-                }
-                """,
+                '"nixos-image-azure-25.05.20250102.6df2492-x86_64-linux.vhd"',
             )
         elif args[0] == "nix":
             return CompletedProcess([], 0, str(config_path))
@@ -372,7 +367,7 @@ def test_execute_nix_build_image_flake(mock_run: Mock, tmp_path: Path) -> None:
         ]
     )
 
-    assert mock_run.call_count == 2
+    assert mock_run.call_count == 3
     mock_run.assert_has_calls(
         [
             call(
@@ -382,7 +377,7 @@ def test_execute_nix_build_image_flake(mock_run: Mock, tmp_path: Path) -> None:
                     "--json",
                     "/path/to/config#nixosConfigurations.hostname.config.system.build.images",
                     "--apply",
-                    "builtins.mapAttrs (n: v: v.passthru.filePath)",
+                    "builtins.attrNames",
                 ],
                 check=True,
                 stdout=PIPE,
@@ -396,6 +391,17 @@ def test_execute_nix_build_image_flake(mock_run: Mock, tmp_path: Path) -> None:
                     "build",
                     "--print-out-paths",
                     "/path/to/config#nixosConfigurations.hostname.config.system.build.images.azure",
+                ],
+                check=True,
+                stdout=PIPE,
+                **DEFAULT_RUN_KWARGS,
+            ),
+            call(
+                [
+                    "nix",
+                    "eval",
+                    "--json",
+                    "/path/to/config#nixosConfigurations.hostname.config.system.build.images.azure.passthru.filePath",
                 ],
                 check=True,
                 stdout=PIPE,

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_nix.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_nix.py
@@ -353,7 +353,7 @@ def test_get_build_image_variants(mock_run: Mock, tmp_path: Path) -> None:
               value = import <nixpkgs/nixos>;
               set = if builtins.isFunction value then value {} else value;
             in
-              builtins.mapAttrs (n: v: v.passthru.filePath) set.config.system.build.images
+              builtins.attrNames set.config.system.build.images
             """),
         ],
         stdout=PIPE,
@@ -376,7 +376,7 @@ def test_get_build_image_variants(mock_run: Mock, tmp_path: Path) -> None:
               value = import "{tmp_path}";
               set = if builtins.isFunction value then value {{}} else value;
             in
-              builtins.mapAttrs (n: v: v.passthru.filePath) set.preAttr.config.system.build.images
+              builtins.attrNames set.preAttr.config.system.build.images
             """),
             "--inst-flag",
         ],
@@ -411,7 +411,7 @@ def test_get_build_image_variants_flake(mock_run: Mock) -> None:
             "--json",
             "flake.nix#myAttr.config.system.build.images",
             "--apply",
-            "builtins.mapAttrs (n: v: v.passthru.filePath)",
+            "builtins.attrNames",
             "--eval-flag",
         ],
         stdout=PIPE,


### PR DESCRIPTION
Because we want to be able to list variants even if one of them might
not eval correctly.

The eager evaluation was caused by us querying for the resulting image
file name to early and is fixed by calling nix-instantiate/nix eval
twice now, once for the variants, once for the image file name.

fixes #394626


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
