### PR TITLE
nixosTests.magic-wormhole-mailbox-server: migrate to runTest

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -676,7 +676,7 @@ in {
   ly = handleTest ./ly.nix {};
   maddy = discoverTests (import ./maddy { inherit handleTest; });
   maestral = handleTest ./maestral.nix {};
-  magic-wormhole-mailbox-server = handleTest ./magic-wormhole-mailbox-server.nix {};
+  magic-wormhole-mailbox-server = runTest ./magic-wormhole-mailbox-server.nix;
   magnetico = handleTest ./magnetico.nix {};
   mailcatcher = runTest ./mailcatcher.nix;
   mailhog = handleTest ./mailhog.nix {};

--- a/nixos/tests/magic-wormhole-mailbox-server.nix
+++ b/nixos/tests/magic-wormhole-mailbox-server.nix
@@ -1,47 +1,39 @@
-import ./make-test-python.nix (
-  { pkgs, ... }:
-  {
-    name = "magic-wormhole-mailbox-server";
-    meta = with pkgs.lib.maintainers; {
-      maintainers = [ mmahut ];
+{ lib, ... }:
+{
+  name = "magic-wormhole-mailbox-server";
+  meta.maintainers = [ lib.maintainers.mmahut ];
+
+  nodes = {
+    server = {
+      networking.firewall.allowedTCPPorts = [ 4000 ];
+      services.magic-wormhole-mailbox-server.enable = true;
     };
+    client_alice =
+      { pkgs, ... }:
+      {
+        networking.firewall.enable = false;
+        environment.systemPackages = [ pkgs.magic-wormhole ];
+      };
+    client_bob =
+      { pkgs, ... }:
+      {
+        environment.systemPackages = [ pkgs.magic-wormhole ];
+      };
+  };
 
-    nodes = {
-      server =
-        { ... }:
-        {
-          networking.firewall.allowedTCPPorts = [ 4000 ];
-          services.magic-wormhole-mailbox-server.enable = true;
-        };
+  testScript = ''
+    start_all()
 
-      client_alice =
-        { ... }:
-        {
-          networking.firewall.enable = false;
-          environment.systemPackages = [ pkgs.magic-wormhole ];
-        };
+    # Start the wormhole relay server
+    server.wait_for_unit("magic-wormhole-mailbox-server.service")
+    server.wait_for_open_port(4000)
 
-      client_bob =
-        { ... }:
-        {
-          environment.systemPackages = [ pkgs.magic-wormhole ];
-        };
-    };
+    # Create a secret file and send it to Bob
+    client_alice.succeed("echo mysecret > secretfile")
+    client_alice.succeed("wormhole --relay-url=ws://server:4000/v1 send -0 secretfile >&2 &")
 
-    testScript = ''
-      start_all()
-
-      # Start the wormhole relay server
-      server.wait_for_unit("magic-wormhole-mailbox-server.service")
-      server.wait_for_open_port(4000)
-
-      # Create a secret file and send it to Bob
-      client_alice.succeed("echo mysecret > secretfile")
-      client_alice.succeed("wormhole --relay-url=ws://server:4000/v1 send -0 secretfile >&2 &")
-
-      # Retrieve a secret file from Alice and check its content
-      client_bob.succeed("wormhole --relay-url=ws://server:4000/v1 receive -0 --accept-file")
-      client_bob.succeed("grep mysecret secretfile")
-    '';
-  }
-)
+    # Retrieve a secret file from Alice and check its content
+    client_bob.succeed("wormhole --relay-url=ws://server:4000/v1 receive -0 --accept-file")
+    client_bob.succeed("grep mysecret secretfile")
+  '';
+}


### PR DESCRIPTION
part of #386873

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review`

---
### `x86_64-linux`

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc