### PR TITLE
lib/attrsets: add mapAttrsToListRecursive(Cond) function

### DIFF
--- a/lib/attrsets.nix
+++ b/lib/attrsets.nix
@@ -4,7 +4,8 @@
 { lib }:
 
 let
-  inherit (builtins) head length;
+  inherit (builtins) head length typeOf;
+  inherit (lib.asserts) assertMsg;
   inherit (lib.trivial)
     oldestSupportedReleaseIsAtLeast
     mergeAttrs
@@ -1182,6 +1183,125 @@ rec {
           name: value:
           if isAttrs value && cond value then recurse (path ++ [ name ]) value else f (path ++ [ name ]) value
         );
+    in
+    recurse [ ] set;
+
+  /**
+    Apply a function to each leaf (non‐attribute‐set attribute) of a tree of
+    nested attribute sets, returning the results of the function as a list,
+    ordered lexicographically by their attribute paths.
+
+    Like `mapAttrsRecursive`, but concatenates the mapping function results
+    into a list.
+
+    # Inputs
+
+    `f`
+
+    : Mapping function which, given an attribute’s path and value, returns a
+      new value.
+
+      This value will be an element of the list returned by
+      `mapAttrsToListRecursive`.
+
+      The first argument to the mapping function is a list of attribute names
+      forming the path to the leaf attribute. The second argument is the leaf
+      attribute value, which will never be an attribute set.
+
+    `set`
+
+    : Attribute set to map over.
+
+    # Type
+
+    ```
+    mapAttrsToListRecursive :: ([String] -> a -> b) -> AttrSet -> [b]
+    ```
+
+    # Examples
+    :::{.example}
+    ## `lib.attrsets.mapAttrsToListRecursive` usage example
+
+    ```nix
+    mapAttrsToListRecursive (path: value: "${concatStringsSep "." path}=${value}")
+      { n = { a = "A"; m = { b = "B"; c = "C"; }; }; d = "D"; }
+    => [ "n.a=A" "n.m.b=B" "n.m.c=C" "d=D" ]
+    ```
+    :::
+  */
+  mapAttrsToListRecursive = mapAttrsToListRecursiveCond (_: _: true);
+
+  /**
+    Determine the nodes of a tree of nested attribute sets by applying a
+    predicate, then apply a function to the leaves, returning the results
+    as a list, ordered lexicographically by their attribute paths.
+
+    Like `mapAttrsToListRecursive`, but takes an additional predicate to
+    decide whether to recurse into an attribute set.
+
+    Unlike `mapAttrsRecursiveCond` this predicate receives the attribute path
+    as its first argument, in addition to the attribute set.
+
+    # Inputs
+
+    `pred`
+
+    : Predicate to decide whether to recurse into an attribute set.
+
+      If the predicate returns true, `mapAttrsToListRecursiveCond` recurses into
+      the attribute set. If the predicate returns false, it does not recurse
+      but instead applies the mapping function, treating the attribute set as
+      a leaf.
+
+      The first argument to the predicate is a list of attribute names forming
+      the path to the attribute set. The second argument is the attribute set.
+
+    `f`
+
+    : Mapping function which, given an attribute’s path and value, returns a
+      new value.
+
+      This value will be an element of the list returned by
+      `mapAttrsToListRecursiveCond`.
+
+      The first argument to the mapping function is a list of attribute names
+      forming the path to the leaf attribute. The second argument is the leaf
+      attribute value, which may be an attribute set if the predicate returned
+      false.
+
+    `set`
+
+    : Attribute set to map over.
+
+    # Type
+    ```
+    mapAttrsToListRecursiveCond :: ([String] -> AttrSet -> Bool) -> ([String] -> a -> b) -> AttrSet -> [b]
+    ```
+
+    # Examples
+    :::{.example}
+    ## `lib.attrsets.mapAttrsToListRecursiveCond` usage example
+
+    ```nix
+    mapAttrsToListRecursiveCond
+      (path: as: !(lib.isDerivation as))
+      (path: value: "--set=${lib.concatStringsSep "." path}=${toString value}")
+      {
+        rust.optimize = 2;
+        target = {
+          riscv64-unknown-linux-gnu.linker = pkgs.lld;
+        };
+      }
+    => [ "--set=rust.optimize=2" "--set=target.riscv64-unknown-linux-gnu.linker=/nix/store/sjw4h1k…" ]
+    ```
+    :::
+  */
+  mapAttrsToListRecursiveCond =
+    pred: f: set:
+    let
+      mapRecursive =
+        path: value: if isAttrs value && pred path value then recurse path value else [ (f path value) ];
+      recurse = path: set: concatMap (name: mapRecursive (path ++ [ name ]) set.${name}) (attrNames set);
     in
     recurse [ ] set;
 

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -206,6 +206,8 @@ let
         concatMapAttrs
         mapAttrsRecursive
         mapAttrsRecursiveCond
+        mapAttrsToListRecursive
+        mapAttrsToListRecursiveCond
         genAttrs
         isDerivation
         toDerivation

--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -77,6 +77,8 @@ let
     makeIncludePath
     makeOverridable
     mapAttrs
+    mapAttrsToListRecursive
+    mapAttrsToListRecursiveCond
     mapCartesianProduct
     matchAttrs
     mergeAttrs
@@ -3234,6 +3236,118 @@ runTests {
       133
       233
       333
+    ];
+  };
+
+  testMapAttrsToListRecursive = {
+    expr = mapAttrsToListRecursive (p: v: "${concatStringsSep "." p}=${v}") {
+      a = {
+        b = "A";
+      };
+      c = {
+        d = "B";
+        e = {
+          f = "C";
+          g = "D";
+        };
+      };
+      h = {
+        i = {
+          j = {
+            k = "E";
+          };
+        };
+      };
+    };
+    expected = [
+      "a.b=A"
+      "c.d=B"
+      "c.e.f=C"
+      "c.e.g=D"
+      "h.i.j.k=E"
+    ];
+  };
+
+  testMapAttrsToListRecursiveWithLists = {
+    expr = mapAttrsToListRecursive (p: v: v) {
+      a = [ ];
+      b = {
+        c = [ [ ] ];
+      };
+      d = {
+        e = {
+          f = [ [ [ ] ] ];
+        };
+      };
+    };
+    expected = [
+      [ ]
+      [ [ ] ]
+      [ [ [ ] ] ]
+    ];
+  };
+
+  testMapAttrsToListRecursiveCond = {
+    expr = mapAttrsToListRecursiveCond (p: as: !(as ? stop)) (p: v: v) {
+      a = {
+        b = "A";
+      };
+      c = {
+        d = "B";
+        e = {
+          stop = null;
+          f = "C";
+          g = {
+            h = "D";
+          };
+        };
+      };
+    };
+    expected = [
+      "A"
+      "B"
+      {
+        stop = null;
+        f = "C";
+        g = {
+          h = "D";
+        };
+      }
+    ];
+  };
+
+  testMapAttrsToListRecursiveCondPath = {
+    expr = mapAttrsToListRecursiveCond (p: as: length p < 2) (p: v: v) {
+      a = {
+        b = "A";
+      };
+      c = {
+        d = "B";
+        e = {
+          f = "C";
+          g = "D";
+        };
+      };
+      h = {
+        i = {
+          j = {
+            k = "E";
+          };
+        };
+      };
+    };
+    expected = [
+      "A"
+      "B"
+      {
+        f = "C";
+        g = "D";
+      }
+      {
+        j = {
+          k = "E";
+        };
+      }
     ];
   };
 


### PR DESCRIPTION
I have been needing functionality to recursively transform an attribute set to a list quite often lately (for example in #391329), and I believe that having a generic implementation in `lib` might be useful.

Similar constructions are used in some of the generators in `lib`.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
