### PR TITLE
roon-server: 2.47.1510 -> 2.48.1517

### DIFF
--- a/pkgs/by-name/ro/roon-server/package.nix
+++ b/pkgs/by-name/ro/roon-server/package.nix
@@ -16,7 +16,7 @@
   stdenv,
 }:
 let
-  version = "2.47.1510";
+  version = "2.48.1517";
   urlVersion = builtins.replaceStrings [ "." ] [ "0" ] version;
 in
 stdenv.mkDerivation {
@@ -25,7 +25,7 @@ stdenv.mkDerivation {
 
   src = fetchurl {
     url = "https://download.roonlabs.com/updates/production/RoonServer_linuxx64_${urlVersion}.tar.bz2";
-    hash = "sha256-xuXQLniV2PKIeupfCH00j0e9mRxLocEraENqIUkdWNo=";
+    hash = "sha256-2H8lQykhzbHcEW/+Rj+4eQdUMUugUeXivz+/+MEAYxk=";
   };
 
   dontConfigure = true;


### PR DESCRIPTION
https://community.roonlabs.com/t/roon-2-48-build-1516-1517-and-arc-1-64-build-347-350-are-live/295727

Attention to prior maintainers @lovesegfault @Ramblurr @SailorSnoW 

## Things done

Updated url and hash

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin

- [X] Tested, as applicable:
  - tested operation across ARC and Roon Remotes (Windows, Android, iOS)
