### PR TITLE
Sops + age plugin wrapper

### DIFF
--- a/pkgs/by-name/ag/age/package.nix
+++ b/pkgs/by-name/ag/age/package.nix
@@ -3,16 +3,22 @@
   buildGoModule,
   fetchFromGitHub,
   installShellFiles,
+  age-plugin-tpm,
+  age-plugin-ledger,
+  age-plugin-yubikey,
+  age-plugin-fido2-hmac,
+  makeWrapper,
+  runCommand,
 }:
 
-buildGoModule rec {
+buildGoModule (final: {
   pname = "age";
   version = "1.2.1";
 
   src = fetchFromGitHub {
     owner = "FiloSottile";
     repo = "age";
-    rev = "v${version}";
+    rev = "v${final.version}";
     hash = "sha256-9ZJdrmqBj43zSvStt0r25wjSfnvitdx3GYtM3urHcaA=";
   };
 
@@ -21,10 +27,12 @@ buildGoModule rec {
   ldflags = [
     "-s"
     "-w"
-    "-X main.Version=${version}"
+    "-X main.Version=${final.version}"
   ];
 
-  nativeBuildInputs = [ installShellFiles ];
+  nativeBuildInputs = [
+    installShellFiles
+  ];
 
   preInstall = ''
     installManPage doc/*.1
@@ -32,10 +40,10 @@ buildGoModule rec {
 
   doInstallCheck = true;
   installCheckPhase = ''
-    if [[ "$("$out/bin/${pname}" --version)" == "${version}" ]]; then
-      echo '${pname} smoke check passed'
+    if [[ "$("$out/bin/${final.pname}" --version)" == "${final.version}" ]]; then
+      echo '${final.pname} smoke check passed'
     else
-      echo '${pname} smoke check failed'
+      echo '${final.pname} smoke check failed'
       return 1
     fi
   '';
@@ -46,12 +54,34 @@ buildGoModule rec {
     "TestScript/plugin"
   ];
 
+  # group age plugins together
+  passthru.plugins = {
+    inherit
+      age-plugin-tpm
+      age-plugin-ledger
+      age-plugin-yubikey
+      age-plugin-fido2-hmac
+      ;
+  };
+
+  # convenience function for wrapping sops with plugins
+  passthru.withPlugins =
+    filter:
+    runCommand "age-${final.version}-with-plugins"
+      {
+        nativeBuildInputs = [ makeWrapper ];
+      }
+      ''
+        makeWrapper ${lib.getBin final.finalPackage}/bin/age $out/bin/age \
+          --prefix PATH : "${lib.makeBinPath (filter final.passthru.plugins)}"
+      '';
+
   meta = with lib; {
-    changelog = "https://github.com/FiloSottile/age/releases/tag/v${version}";
+    changelog = "https://github.com/FiloSottile/age/releases/tag/v${final.version}";
     homepage = "https://age-encryption.org/";
     description = "Modern encryption tool with small explicit keys";
     license = licenses.bsd3;
     mainProgram = "age";
     maintainers = with maintainers; [ tazjin ];
   };
-}
+})

--- a/pkgs/by-name/so/sops/package.nix
+++ b/pkgs/by-name/so/sops/package.nix
@@ -5,16 +5,19 @@
   installShellFiles,
   versionCheckHook,
   nix-update-script,
+  makeWrapper,
+  runCommand,
+  age,
 }:
 
-buildGoModule rec {
+buildGoModule (final: {
   pname = "sops";
   version = "3.10.1";
 
   src = fetchFromGitHub {
     owner = "getsops";
-    repo = pname;
-    tag = "v${version}";
+    repo = final.pname;
+    tag = "v${final.version}";
     hash = "sha256-LdsuN243oQ/L6LYgynb7Kw60alXn5IfUfhY0WaZFVCU=";
   };
 
@@ -25,10 +28,13 @@ buildGoModule rec {
   ldflags = [
     "-s"
     "-w"
-    "-X github.com/getsops/sops/v3/version.Version=${version}"
+    "-X github.com/getsops/sops/v3/version.Version=${final.version}"
   ];
 
-  nativeBuildInputs = [ installShellFiles ];
+  nativeBuildInputs = [
+    installShellFiles
+    makeWrapper
+  ];
 
   postInstall = ''
     installShellCompletion --cmd sops --bash ${./bash_autocomplete}
@@ -41,10 +47,22 @@ buildGoModule rec {
 
   passthru.updateScript = nix-update-script { };
 
+  # wrap sops with age plugins
+  passthru.withAgePlugins =
+    filter:
+    runCommand "sops-${final.version}-with-age-plugins"
+      {
+        nativeBuildInputs = [ makeWrapper ];
+      }
+      ''
+        makeWrapper ${lib.getBin final.finalPackage}/bin/sops $out/bin/sops \
+          --prefix PATH : "${lib.makeBinPath (filter age.passthru.plugins)}"
+      '';
+
   meta = {
     homepage = "https://getsops.io/";
     description = "Simple and flexible tool for managing secrets";
-    changelog = "https://github.com/getsops/sops/blob/v${version}/CHANGELOG.rst";
+    changelog = "https://github.com/getsops/sops/blob/v${final.version}/CHANGELOG.rst";
     mainProgram = "sops";
     maintainers = with lib.maintainers; [
       Scrumplex
@@ -52,4 +70,4 @@ buildGoModule rec {
     ];
     license = lib.licenses.mpl20;
   };
-}
+})


### PR DESCRIPTION
Introduces two new wrapper functions that allows for:

* grouping `age` with some plugins 
* wrapping `sops` with `age` and some plugins. 

For example: 

```nix
{
    ageWithPlugins = age.withPlugins (p: [
        p.age-plugin-tpm 
        p.age-plugin-ledger
    ]);

    sopsWithAgePlugins = sops.withAgePlugins (p: [
        p.age-plugin-tpm
        p.age-plugin-ledger
    ]);
}
```

## Things done

I did some manual testing in the repl, built the resulting derivations and checked the contents of the wrapper script. 

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
