### PR TITLE
kikit: 1.7.1 -> 1.7.2, python3.pkgs.pcbnewtransition: 0.5.0 -> 0.5.2: Fix kikit build

### DIFF
--- a/pkgs/by-name/ki/kikit/default.nix
+++ b/pkgs/by-name/ki/kikit/default.nix
@@ -26,7 +26,7 @@ let
 in
 buildPythonApplication rec {
   pname = "kikit";
-  version = "1.7.1";
+  version = "1.7.2";
   pyproject = true;
 
   disabled = pythonOlder "3.7";
@@ -35,7 +35,7 @@ buildPythonApplication rec {
     owner = "yaqwsx";
     repo = "KiKit";
     tag = "v${version}";
-    hash = "sha256-GG0OXPoTy219QefQ7GwMen4u66lPob5DI8lU9sqwaRQ=";
+    hash = "sha256-mwe/CajmQD5nDNYtQXRQm4vIJJiY7P5uFrvn8Ngjqc4=";
   };
 
   build-system = [

--- a/pkgs/by-name/ki/kikit/default.nix
+++ b/pkgs/by-name/ki/kikit/default.nix
@@ -35,7 +35,13 @@ buildPythonApplication rec {
     owner = "yaqwsx";
     repo = "KiKit";
     tag = "v${version}";
-    hash = "sha256-mwe/CajmQD5nDNYtQXRQm4vIJJiY7P5uFrvn8Ngjqc4=";
+    hash = "sha256-HSAQJJqJMVh44wgOQm+0gteShLogklBFuIzWtoVTf9I=";
+    # Upstream uses versioneer, which relies on gitattributes substitution.
+    # This leads to non-reproducible archives on GitHub.
+    # See https://github.com/NixOS/nixpkgs/issues/84312
+    postFetch = ''
+      rm "$out/kikit/_version.py"
+    '';
   };
 
   build-system = [
@@ -74,6 +80,11 @@ buildPythonApplication rec {
   pythonImportsCheck = [
     "kikit"
   ];
+
+  postPatch = ''
+    # Recreate _version.py, deleted at fetch time due to non-reproducibility.
+    echo 'def get_versions(): return {"version": "${version}"}' > kikit/_version.py
+  '';
 
   preCheck = ''
     export PATH=$PATH:$out/bin

--- a/pkgs/by-name/ki/kikit/drop-versioneer.patch
+++ b/pkgs/by-name/ki/kikit/drop-versioneer.patch
@@ -1,0 +1,14 @@
+diff --git a/setup.py b/setup.py
+index 9351fc9..75dfb2c 100644
+--- a/setup.py
++++ b/setup.py
+@@ -66,9 +66,6 @@
+         "solidpython>=1.1.2",
+         "commentjson>=0.9"
+     ],
+-    setup_requires=[
+-        "versioneer"
+-    ],
+     extras_require={
+         "dev": ["pytest"],
+     },

--- a/pkgs/development/python-modules/pcbnewtransition/default.nix
+++ b/pkgs/development/python-modules/pcbnewtransition/default.nix
@@ -8,15 +8,15 @@
 }:
 buildPythonPackage rec {
   pname = "pcbnewtransition";
-  version = "0.5.0";
+  version = "0.5.2";
   format = "setuptools";
 
   disabled = pythonOlder "3.7";
 
   src = fetchPypi {
-    pname = "pcbnewTransition";
+    inherit pname;
     inherit version;
-    hash = "sha256-4XNcnQzUWpY0NEfS2bdtkedvG4lY79jaPe0QqTWNW6s=";
+    hash = "sha256-zLnvbu0G2mJKCHLCjbIKHBqSfdEyhR+1afkOFU++TfI=";
   };
 
   propagatedBuildInputs = [ kicad ];


### PR DESCRIPTION
Our kikit build is broken. Upgrading to 1.7.2 brings in support for KiCAD v9:
https://github.com/yaqwsx/KiKit/releases/tag/v1.7.2, as [we upgraded to
KiCAD v9 recently](https://github.com/NixOS/nixpkgs/pull/384150).

I've included the pcbnewtransition upgrade in this PR as the new version of kikit depends on `"pcbnewTransition >= 0.5.2, <=0.6"`: https://github.com/yaqwsx/KiKit/blob/v1.7.2/setup.py#L61.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
