### PR TITLE
ferretdb: 1.24.0 -> 2.2.0, init intelrdfpmathlib, init documentdb-ferretdb

### DIFF
--- a/pkgs/by-name/fe/ferretdb/package.nix
+++ b/pkgs/by-name/fe/ferretdb/package.nix
@@ -8,13 +8,13 @@
 
 buildGoModule (finalAttrs: {
   pname = "ferretdb";
-  version = "1.24.0";
+  version = "2.2.0";
 
   src = fetchFromGitHub {
     owner = "FerretDB";
     repo = "FerretDB";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-WMejspnk2PvJhvNGi4h+DF+fzipuOMcS1QWim5DnAhQ=";
+    hash = "sha256-erJSmiCzIFRbgolIx7waYmxz0xc0hyZiFhGj7E2ng1M=";
   };
 
   postPatch = ''
@@ -22,7 +22,7 @@ buildGoModule (finalAttrs: {
     echo nixpkgs     > build/version/package.txt
   '';
 
-  vendorHash = "sha256-GT6e9yd6LF6GFlGBWVAmcM6ysB/6cIGLbnM0hxfX5TE=";
+  vendorHash = "sha256-wbSa/oKyOTfIgkLfz/QrJriIhAkGWgmiP1VLRZjsReY=";
 
   env.CGO_ENABLED = 0;
 

--- a/pkgs/by-name/in/intelrdfpmathlib/package.nix
+++ b/pkgs/by-name/in/intelrdfpmathlib/package.nix
@@ -1,0 +1,34 @@
+{
+  stdenv,
+  fetchurl,
+  fetchpatch,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "IntelRDFPMathLib";
+  version = "20U3";
+
+  src = fetchurl {
+    url = "http://www.netlib.org/misc/intel/IntelRDFPMathLib${finalAttrs.version}.tar.gz";
+    hash = "sha256-E/aSSy7XHfmxN6ffmHBqDcw7Q8KDoOMvi26tykMFE2o=";
+  };
+  sourceRoot = "LIBRARY";
+
+  patches = [
+    (fetchpatch {
+      url = "https://salsa.debian.org/debian/intelrdfpmath/-/raw/042b4056499b0e60e67bd9a19fb641f898e72d9f/debian/patches/debian-arches.patch";
+      stripLen = 1;
+      hash = "sha256-wCwAyXUmWY4XzzI0OeqKILdq9CI0mn5v2/gu8b57pR4=";
+    })
+  ];
+
+  installPhase = ''
+    install -D -t $out/lib *.a
+    install -D -t $out/include src/bid_conf.h
+    install -D -t $out/include src/bid_functions.h
+  '';
+
+  meta = {
+    description = "Intel Decimal Floating-Point Math Library";
+  };
+})

--- a/pkgs/servers/sql/postgresql/ext/documentdb-ferretdb.nix
+++ b/pkgs/servers/sql/postgresql/ext/documentdb-ferretdb.nix
@@ -1,0 +1,50 @@
+{
+  stdenv,
+  fetchFromGitHub,
+  fetchpatch,
+  pkg-config,
+  mongoc,
+  pcre2,
+  intelrdfpmathlib,
+  openssl,
+  postgresqlBuildExtension,
+  libkrb5,
+  rum,
+}:
+postgresqlBuildExtension (finalAttrs: {
+  pname = "documentdb";
+  version = "0.103.0-ferretdb-2.2.0";
+
+  src = fetchFromGitHub {
+    owner = "ferretdb";
+    repo = "documentdb";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-ewbSr7MBPTxOjGsA2DrBCqmQkbJ5ioobPcH4QKzgsnI=";
+  };
+  env = {
+    NIX_CFLAGS_COMPILE = "-Wno-error";
+    NIX_CFLAGS_LINK = "-lbid";
+    BUILD_SOURCEBRANCH = finalAttrs.src.tag;
+    BUILD_SOURCEVERSION = "NixOS";
+  };
+
+  postPatch = ''
+    patchShebangs scripts
+  '';
+
+  postInstall = ''
+    ln -s ${rum}/lib/rum.so $out/lib/rum.so
+  '';
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  buildInputs = [
+    mongoc
+    pcre2
+    intelrdfpmathlib
+    openssl
+    libkrb5
+  ];
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

It's not yet working (in the NixOS Test):

```
postgres[884]: [884] LOG:  Initialized documentdb_core extension
postgres[884]: [884] LOG:  Initialized pg_documentdb extension
[...]
ferretdb[829]: 2025-04-01T15:57:42.049Z       ERROR+1 mongoerrors/mongoerrors.go:148  Unmapped error code     {"arg":"","error":"lazyerror([msg_saslstart.go:55 handler.(*Handler).MsgSASLStart] [msg_saslstart.go:145 handler.(*Handler).saslStart] [pool.go:94 documentdb.(*Pool).WithConn] [pool.go:83 documentdb.(*Pool).Acquire] [pool_new.go:118 documentdb.newPgxPoolCheckConn] ERROR: schema \"documentdb_api\" does not exist (SQLSTATE 3F000) (please check DocumentDB installation))","name":"listener"}

```

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
