### PR TITLE
Adding mtime=0 to arandr to improve deterministic build

### DIFF
--- a/pkgs/by-name/ar/arandr/gzip-timestamp-fix.patch
+++ b/pkgs/by-name/ar/arandr/gzip-timestamp-fix.patch
@@ -1,0 +1,15 @@
+--- setup.py	2025-04-01 11:24:54.530984662 +0000
++++ setup.py	2025-04-01 13:54:46.961341548 +0000
+ 
+@@ -111,9 +111,11 @@
+                 info('compressing man page to %s', gzfile)
+ 
+                 if not self.dry_run:
+-                    compressed = gzip.open(gzfile, 'w', 9)
+-                    compressed.write(manpage)
+-                    compressed.close()
++                    with open(gzfile, 'wb') as file:
++                        with gzip.GzipFile(fileobj=file, mode='wb', filename='', mtime=0, compresslevel=9) as compressed:
++                            compressed.write(manpage)
++                            compressed.close()
++                            file.close()

--- a/pkgs/by-name/ar/arandr/package.nix
+++ b/pkgs/by-name/ar/arandr/package.nix
@@ -1,6 +1,7 @@
 {
   lib,
   fetchurl,
+  fetchFromGitLab,
   python3Packages,
   gobject-introspection,
   gsettings-desktop-schemas,
@@ -16,10 +17,20 @@ buildPythonApplication rec {
   pname = "arandr";
   version = "0.1.11";
 
-  src = fetchurl {
-    url = "https://christian.amsuess.com/tools/arandr/files/${pname}-${version}.tar.gz";
-    hash = "sha256-5Mu+Npi7gSs5V3CHAXS+AJS7rrOREFqBH5X0LrGCrgI=";
+  #src = fetchurl {
+    #url = "https://christian.amsuess.com/tools/arandr/files/${pname}-${version}.tar.gz";
+    #hash = "sha256-5Mu+Npi7gSs5V3CHAXS+AJS7rrOREFqBH5X0LrGCrgI=";
+  #};
+
+  src = fetchFromGitLab {
+    owner = "arandr";
+    repo = "arandr";
+    rev = version;
+    hash = "sha256-nQtfOKAnWKsy2DmvtRGJa4+Y9uGgX41BeHpd9m4d9YA=";
   };
+
+  patches = [ ./gzip-timestamp-fix.patch ]; # patch that set mtime=0 in setup.py
+  patchFlags = [ "-p0" ];
 
   preBuild = ''
     rm -rf data/po/*


### PR DESCRIPTION
<!--
^ Created a patch that added mtime=0 to arandr's package setup.py to improve deterministic build for manpage for #383869  ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
