### PR TITLE
jbofihe: fix build with gcc14, modernize

### DIFF
--- a/pkgs/by-name/jb/jbofihe/fix-gcc14-errors.patch
+++ b/pkgs/by-name/jb/jbofihe/fix-gcc14-errors.patch
@@ -1,0 +1,37 @@
+diff --git a/add_trace_to_tabc.pl b/add_trace_to_tabc.pl
+index 04be787..3186075 100644
+--- a/add_trace_to_tabc.pl
++++ b/add_trace_to_tabc.pl
+@@ -15,11 +15,11 @@
+ # COPYRIGHT
+ 
+ print <<EOF;
+-extern elide_trace_reduce(int, int);
+-extern elide_trace_shift(int,int);
+-extern report_trace_shift(int);
+-extern report_trace_reduce(int, int);
+-extern report_trace_error(short *yyss, short *yyssp);
++extern void elide_trace_reduce(int, int);
++extern void elide_trace_shift(int,int);
++extern void report_trace_shift(int);
++extern void report_trace_reduce(int, int);
++extern void report_trace_error(short *yyss, short *yyssp);
+ EOF
+ 
+ while (<>) {
+diff --git a/dfasyn/n2d.h b/dfasyn/n2d.h
+index b2159ba..6c56abb 100644
+--- a/dfasyn/n2d.h
++++ b/dfasyn/n2d.h
+@@ -181,6 +181,10 @@ Expr * new_xor_expr(Expr *c1, Expr *c2);
+ Expr * new_cond_expr(Expr *c1, Expr *c2, Expr *c3);
+ Expr * new_sym_expr(char *sym_name);
+ 
++int yyparse(void);
++void yyerror(char *);
++int yylex(void);
++
+ void define_symbol(Evaluator *x, char *name, Expr *e);
+ void define_result(Evaluator *x, char *string, Expr *e, int early);
+ void define_symresult(Evaluator *x, char *string, Expr *e, int early);
+

--- a/pkgs/by-name/jb/jbofihe/package.nix
+++ b/pkgs/by-name/jb/jbofihe/package.nix
@@ -18,6 +18,12 @@ stdenv.mkDerivation rec {
     sha256 = "1xx7x1256sjncyzx656jl6jl546vn8zz0siymqalz6v9yf341p98";
   };
 
+  patches = [
+    # fix build with gcc14:
+    # https://github.com/lojban/jbofihe/pull/19
+    ./fix-gcc14-errors.patch
+  ];
+
   nativeBuildInputs = [
     bison
     flex

--- a/pkgs/by-name/jb/jbofihe/package.nix
+++ b/pkgs/by-name/jb/jbofihe/package.nix
@@ -7,14 +7,14 @@
   perl,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "jbofihe";
   version = "0.43";
 
   src = fetchFromGitHub {
     owner = "lojban";
     repo = "jbofihe";
-    rev = "v${version}";
+    rev = "v${finalAttrs.version}";
     sha256 = "1xx7x1256sjncyzx656jl6jl546vn8zz0siymqalz6v9yf341p98";
   };
 
@@ -37,10 +37,10 @@ stdenv.mkDerivation rec {
     runHook postCheck
   '';
 
-  meta = with lib; {
+  meta = {
     description = "Parser & analyser for Lojban";
     homepage = "https://github.com/lojban/jbofihe";
-    license = licenses.gpl2Only;
-    maintainers = with maintainers; [ chkno ];
+    license = lib.licenses.gpl2Only;
+    maintainers = with lib.maintainers; [ chkno ];
   };
-}
+})


### PR DESCRIPTION
jbofihe: fix build with gcc14

- add patch fixing gcc14 errors:
`implicit-int`:
```
rpc_tab.c:1:8: error: type defaults to 'int' in declaration of
'elide_trace_reduce' [-Wimplicit-int]
    1 | extern elide_trace_reduce(int, int);
      |        ^~~~~~~~~~~~~~~~~~
rpc_tab.c:2:8: error: type defaults to 'int' in declaration of
'elide_trace_shift' [-Wimplicit-int]
    2 | extern elide_trace_shift(int,int);
      |        ^~~~~~~~~~~~~~~~~
rpc_tab.c:3:8: error: type defaults to 'int' in declaration of
'report_trace_shift' [-Wimplicit-int]
    3 | extern report_trace_shift(int);
      |        ^~~~~~~~~~~~~~~~~~
rpc_tab.c:4:8: error: type defaults to 'int' in declaration of
'report_trace_reduce' [-Wimplicit-int]
    4 | extern report_trace_reduce(int, int);
      |        ^~~~~~~~~~~~~~~~~~~
rpc_tab.c:5:8: error: type defaults to 'int' in declaration of
'report_trace_error' [-Wimplicit-int]
    5 | extern report_trace_error(short *yyss, short *yyssp);
      |        ^~~~~~~~~~~~~~~~~~
```

`implicit-function-declaration`:
```
parse.tab.c: In function 'yyparse':
parse.tab.c:1148:16: error: implicit declaration of function 'yylex'
[-Wimplicit-function-declaration]
 1148 |       yychar = yylex ();
      |                ^~~~~

parse.tab.c:1595:7: error: implicit declaration of function 'yyerror';
did you mean 'yyerrok'? [-Wimplicit-function-declaration]
 1595 |       yyerror (YY_("syntax error"));
      |       ^~~~~~~
      |       yyerrok

n2d.c: In function 'main':
n2d.c:1529:12: error: implicit declaration of function 'yyparse'
[-Wimplicit-function-declaration]
 1529 |   result = yyparse();
      |            ^~~~~~~
```
---

jbofihe: modernize

- replace `rec` with `finalAttrs`
- remove `with lib;` from `meta`

---

Fixes build failure of `jbofihe` since update to GCC 14 in #356812:
https://hydra.nixos.org/job/nixos/trunk-combined/nixpkgs.jbofihe.x86_64-linux
https://hydra.nixos.org/build/293018015

Log:
```text
rpc_tab.c:1:8: error: type defaults to 'int' in declaration of 'elide_trace_reduce' [-Wimplicit-int]
    1 | extern elide_trace_reduce(int, int);
      |        ^~~~~~~~~~~~~~~~~~
rpc_tab.c:2:8: error: type defaults to 'int' in declaration of 'elide_trace_shift' [-Wimplicit-int]
    2 | extern elide_trace_shift(int,int);
      |        ^~~~~~~~~~~~~~~~~
rpc_tab.c:3:8: error: type defaults to 'int' in declaration of 'report_trace_shift' [-Wimplicit-int]
    3 | extern report_trace_shift(int);
      |        ^~~~~~~~~~~~~~~~~~
rpc_tab.c:4:8: error: type defaults to 'int' in declaration of 'report_trace_reduce' [-Wimplicit-int]
    4 | extern report_trace_reduce(int, int);
      |        ^~~~~~~~~~~~~~~~~~~
rpc_tab.c:5:8: error: type defaults to 'int' in declaration of 'report_trace_error' [-Wimplicit-int]
    5 | extern report_trace_error(short *yyss, short *yyssp);
      |        ^~~~~~~~~~~~~~~~~~
make: *** [Makefile:54: rpc_tab.o] Error 1
```

After applying first part of the patch, error becomes:
```text
parse.tab.c: In function 'yyparse':
parse.tab.c:1148:16: error: implicit declaration of function 'yylex' [-Wimplicit-function-declaration]
 1148 |       yychar = yylex ();
      |                ^~~~~
parse.tab.c:1595:7: error: implicit declaration of function 'yyerror'; did you mean 'yyerrok'? [-Wimplicit-function-declaration]
 1595 |       yyerror (YY_("syntax error"));
      |       ^~~~~~~
      |       yyerrok
make[1]: *** [<builtin>: parse.tab.o] Error 1
make[1]: Leaving directory '/build/source/dfasyn'
make: *** [Makefile:148: dfasyn/dfasyn] Error 2
```

After fixing declarations of `yylex` and `yyerror`:
```text
n2d.c: In function 'main':
n2d.c:1529:12: error: implicit declaration of function 'yyparse' [-Wimplicit-function-declaration]
 1529 |   result = yyparse();
      |            ^~~~~~~
make[1]: *** [<builtin>: n2d.o] Error 1
make[1]: Leaving directory '/build/source/dfasyn'
make: *** [Makefile:148: dfasyn/dfasyn] Error 2
```
With full patch (`yyparse` declaration on top of other things) builds fine.

Tracking issue: #388196 

Made PR upstream with fixes (unlikely to get merged, last commit was 4 years ago): https://github.com/lojban/jbofihe/pull/19

---

Checked that it runs with test output from repo README (appears to work as intended):
```text
echo "mi klama le zarci" | ./result/bin/jbofihe -x -b

[ ( mi                )            << klama  >> ( le
[ ( I, me             ) [is, does] << go-ing >> ( the
[ ( klama1 (go-er(s)) )            <<        >> ( klama2 (destination(s))
1 2                   2            3         3  4

zarci            ) ]
trading place(s) ) ]
                 ) ]
                 4 1
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
