### PR TITLE
sstp: fix server certificate verification

### DIFF
--- a/pkgs/by-name/ss/sstp/package.nix
+++ b/pkgs/by-name/ss/sstp/package.nix
@@ -7,6 +7,8 @@
   libevent,
   openssl,
   autoreconfHook,
+  makeWrapper,
+  cacert,
 }:
 
 stdenv.mkDerivation {
@@ -34,13 +36,19 @@ stdenv.mkDerivation {
   nativeBuildInputs = [
     pkg-config
     autoreconfHook
+    makeWrapper
   ];
 
   buildInputs = [
     libevent
     openssl
     ppp
+    cacert
   ];
+
+  postInstall = ''
+    wrapProgram $out/sbin/sstpc --add-flags "--ca-cert ${cacert}/etc/ssl/certs/ca-bundle.crt"
+  '';
 
   meta = with lib; {
     description = "SSTP client for Linux";


### PR DESCRIPTION
- Added automatic `--ca-cert` flag pointing to NixOS's certificate bundle
- Fixed SSL verification failures 
- Wraps the correct binary path in `sbin/` instead of `bin/`

Closes #395206