### PR TITLE
Eclipse update automation

### DIFF
--- a/pkgs/applications/editors/eclipse/build-eclipse.nix
+++ b/pkgs/applications/editors/eclipse/build-eclipse.nix
@@ -120,6 +120,7 @@ stdenv.mkDerivation rec {
       "x86_64-linux"
       "aarch64-linux"
     ];
+    maintainers = [ lib.maintainers.jerith666 ];
   };
 
 }

--- a/pkgs/applications/editors/eclipse/build-eclipse.nix
+++ b/pkgs/applications/editors/eclipse/build-eclipse.nix
@@ -110,6 +110,8 @@ stdenv.mkDerivation rec {
     perl -i -p0e 's|-vm\nplugins/org.eclipse.justj.*/jre/bin.*\n||' $out/eclipse/eclipse.ini
   ''; # */
 
+  passthru.updateScript = ./update.sh;
+
   meta = {
     homepage = "https://www.eclipse.org/";
     inherit description;

--- a/pkgs/applications/editors/eclipse/default.nix
+++ b/pkgs/applications/editors/eclipse/default.nix
@@ -150,29 +150,6 @@ rec {
     };
   };
 
-  ### Eclipse Scala SDK
-
-  eclipse-scala-sdk =
-    (buildEclipseUnversioned.override
-      {
-        jdk = jdk8;
-        gtk = gtk2;
-      }
-      {
-        name = "eclipse-scala-sdk-4.7.0";
-        description = "Eclipse IDE for Scala Developers";
-        productVersion = "4.7";
-        src = fetchurl {
-          url = "https://downloads.typesafe.com/scalaide-pack/4.7.0-vfinal-oxygen-212-20170929/scala-SDK-4.7.0-vfinal-2.12-linux.gtk.x86_64.tar.gz";
-          sha256 = "1n5w2a7mh9ajv6fxcas1gpgwb04pdxbr9v5dzr67gsz5bhahq4ya";
-        };
-      }
-    ).overrideAttrs
-      (oa: {
-        # Only download for x86_64
-        meta.platforms = [ "x86_64-linux" ];
-      });
-
   ### Eclipse SDK
 
   eclipse-sdk = buildEclipse {

--- a/pkgs/applications/editors/eclipse/default.nix
+++ b/pkgs/applications/editors/eclipse/default.nix
@@ -28,12 +28,18 @@
 # for e in cpp dsl embedcpp modeling platform sdk java jee committers rcp; do for s in pkgs pkgsCross.aarch64-multiplatform; do echo; echo $s $e; nix-build -A ${s}.eclipses.eclipse-${e} -o eclipse-${s}-${e}; done; done
 
 let
-  platform_major = "4";
-  platform_minor = "34";
-  year = "2024";
-  month = "12"; # release month
-  buildmonth = "11"; # sometimes differs from release month
-  timestamp = "${year}${buildmonth}201800";
+  eclipses = lib.trivial.importJSON ./eclipses.json;
+  inherit (eclipses)
+    platform_major
+    platform_minor
+    year
+    # release month sometimes differs from build month
+    month
+    buildmonth
+    dayHourMinute
+    ;
+  timestamp = "${year}${buildmonth}${dayHourMinute}";
+
   gtk = gtk3;
   arch =
     if stdenv.hostPlatform.isx86_64 then
@@ -42,8 +48,6 @@ let
       "aarch64"
     else
       throw "don't know what platform suffix for ${stdenv.hostPlatform.system} will be";
-in
-rec {
 
   # work around https://bugs.eclipse.org/bugs/show_bug.cgi?id=476075#c3
   buildEclipseUnversioned = callPackage ./build-eclipse.nix {
@@ -70,165 +74,38 @@ rec {
       eclipseData // { productVersion = "${platform_major}.${platform_minor}"; }
     );
 
-  ### Eclipse CPP
+  generateEclipse =
+    id:
+    {
+      description,
+      hashes,
+      dropUrl,
+    }:
+    builtins.listToAttrs [
+      {
+        name = "eclipse-${lib.strings.toLower id}";
+        value = buildEclipse {
+          name = "eclipse-${lib.strings.toLower id}-${platform_major}.${platform_minor}";
+          inherit description;
+          src = fetchurl {
+            url =
+              if dropUrl then
+                "https://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/eclipse/downloads/drops${platform_major}/R-${platform_major}.${platform_minor}-${timestamp}/eclipse-${id}-${platform_major}.${platform_minor}-linux-gtk-${arch}.tar.gz"
+              else
+                "https://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/technology/epp/downloads/release/${year}-${month}/R/eclipse-${id}-${year}-${month}-R-linux-gtk-${arch}.tar.gz";
+            hash = hashes.${arch};
+          };
+        };
+      }
+    ];
 
-  eclipse-cpp = buildEclipse {
-    name = "eclipse-cpp-${platform_major}.${platform_minor}";
-    description = "Eclipse IDE for C/C++ Developers";
-    src = fetchurl {
-      url = "https://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/technology/epp/downloads/release/${year}-${month}/R/eclipse-cpp-${year}-${month}-R-linux-gtk-${arch}.tar.gz";
-      hash =
-        {
-          x86_64 = "sha256-d3MVeci4jF9adqvgepmZtzoPul+DTMtJlf7v92PMyq0=";
-          aarch64 = "sha256-gsOmF3bGthd7CEG+HxEQJqACfb+ErWU+fVO2MVR2cz8=";
-        }
-        .${arch};
-    };
-  };
+  generatedEclipses = lib.attrsets.concatMapAttrs generateEclipse eclipses.eclipses;
 
-  ### Eclipse DSL
-
-  eclipse-dsl = buildEclipse {
-    name = "eclipse-dsl-${platform_major}.${platform_minor}";
-    description = "Eclipse IDE for Java and DSL Developers";
-    src = fetchurl {
-      url = "https://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/technology/epp/downloads/release/${year}-${month}/R/eclipse-dsl-${year}-${month}-R-linux-gtk-${arch}.tar.gz";
-      hash =
-        {
-          x86_64 = "sha256-bJvODmesfkED5yHnaJGLZSeFctfVCQDA3lvH00S/zbk=";
-          aarch64 = "sha256-e0rWjD19tUyVJMMbb5THVj28o0HnBFssP0yCAQ5wKnA=";
-        }
-        .${arch};
-    };
-  };
-
-  ### Eclipse IDE for Embedded C/C++ Developers
-
-  eclipse-embedcpp = buildEclipse {
-    name = "eclipse-embedcpp-${platform_major}.${platform_minor}";
-    description = "Eclipse IDE for Embedded C/C++ Developers";
-    src = fetchurl {
-      url = "https://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/technology/epp/downloads/release/${year}-${month}/R/eclipse-embedcpp-${year}-${month}-R-linux-gtk-${arch}.tar.gz";
-      hash =
-        {
-          x86_64 = "sha256-+DfoJ+QAlI9Ioz4Wbj2LvtpV3vAXjl0wtZBNS9osOYw=";
-          aarch64 = "sha256-XCpIKoLhrodOJkLPY6uICpuYu5PBUp96MFQCeuOyOUA=";
-        }
-        .${arch};
-    };
-  };
-
-  ### Eclipse Modeling
-
-  eclipse-modeling = buildEclipse {
-    name = "eclipse-modeling-${platform_major}.${platform_minor}";
-    description = "Eclipse Modeling Tools";
-    src = fetchurl {
-      url = "https://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/technology/epp/downloads/release/${year}-${month}/R/eclipse-modeling-${year}-${month}-R-linux-gtk-${arch}.tar.gz";
-      hash =
-        {
-          x86_64 = "sha256-MUe5DU+3/4lzG1hykpgOX/46Pgp9qtoN9MOYk6EFK6o=";
-          aarch64 = "sha256-/tv7+RsRAFfV5zfU+uFNNlE1rrJavRFOhLYhSkIX0Ec=";
-        }
-        .${arch};
-    };
-  };
-
-  ### Eclipse Platform
-
-  eclipse-platform = buildEclipse {
-    name = "eclipse-platform-${platform_major}.${platform_minor}";
-    description = "Eclipse Platform ${year}-${month}";
-    src = fetchurl {
-      url = "https://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/eclipse/downloads/drops${platform_major}/R-${platform_major}.${platform_minor}-${timestamp}/eclipse-platform-${platform_major}.${platform_minor}-linux-gtk-${arch}.tar.gz";
-      hash =
-        {
-          x86_64 = "sha256-ZHJkIOAaz87z6Dz/6X62E7ckQIFDtzqgE5ODZeb/Rss=";
-          aarch64 = "sha256-dLLwLFTeUXoL9Pri4EB48nZGUH/zF2mCt6anv519aP4=";
-        }
-        .${arch};
-    };
-  };
-
-  ### Eclipse SDK
-
-  eclipse-sdk = buildEclipse {
-    name = "eclipse-sdk-${platform_major}.${platform_minor}";
-    description = "Eclipse ${year}-${month} Classic";
-    src = fetchurl {
-      url = "https://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/eclipse/downloads/drops${platform_major}/R-${platform_major}.${platform_minor}-${timestamp}/eclipse-SDK-${platform_major}.${platform_minor}-linux-gtk-${arch}.tar.gz";
-      hash =
-        {
-          x86_64 = "sha256-DhrNe9nx4RYAaq+NIHCBLX+bOn+dE13yF07hjuRzHZI=";
-          aarch64 = "sha256-OHE0vxjV9kp43Os2LCLuZFCMLWy3vnCChMC54TyXO9I=";
-        }
-        .${arch};
-    };
-  };
-
-  ### Eclipse Java
-
-  eclipse-java = buildEclipse {
-    name = "eclipse-java-${platform_major}.${platform_minor}";
-    description = "Eclipse IDE for Java Developers";
-    src = fetchurl {
-      url = "https://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/technology/epp/downloads/release/${year}-${month}/R/eclipse-java-${year}-${month}-R-linux-gtk-${arch}.tar.gz";
-      hash =
-        {
-          x86_64 = "sha256-z0hLFqdDSqhUmCiOp0fkTkiybOmCIA118JMBb90yEiY=";
-          aarch64 = "sha256-JzUgyfPEi9vq497gJhHuobb0TR113hC2suFvNKix7So=";
-        }
-        .${arch};
-    };
-  };
-
-  ### Eclipse Java EE
-
-  eclipse-jee = buildEclipse {
-    name = "eclipse-jee-${platform_major}.${platform_minor}";
-    description = "Eclipse IDE for Enterprise Java and Web Developers";
-    src = fetchurl {
-      url = "https://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/technology/epp/downloads/release/${year}-${month}/R/eclipse-jee-${year}-${month}-R-linux-gtk-${arch}.tar.gz";
-      hash =
-        {
-          x86_64 = "sha256-PxQ+jGTEs917IeWuTCgyyx7vAodZr4ju/aa4WQmoGQ0=";
-          aarch64 = "sha256-g4EHYFjoPONiGwreAmENcXWVinPkDAIE6KyVmZokQAo=";
-        }
-        .${arch};
-    };
-  };
-
-  ### Eclipse Committers
-
-  eclipse-committers = buildEclipse {
-    name = "eclipse-committers-${platform_major}.${platform_minor}";
-    description = "Eclipse IDE for Eclipse Committers and Eclipse Platform Plugin Developers";
-    src = fetchurl {
-      url = "https://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/technology/epp/downloads/release/${year}-${month}/R/eclipse-committers-${year}-${month}-R-linux-gtk-${arch}.tar.gz";
-      hash =
-        {
-          x86_64 = "sha256-g8ILZ9esbXbm+4bImFJkEwE/UNJT2HHCXx/8i+Lvb00=";
-          aarch64 = "sha256-arV2VgQypj8fSEpqGd8CbJ/FyKE6k+e4x7kXqShDKrw=";
-        }
-        .${arch};
-    };
-  };
-
-  ### Eclipse IDE for RCP and RAP Developers
-
-  eclipse-rcp = buildEclipse {
-    name = "eclipse-rcp-${platform_major}.${platform_minor}";
-    description = "Eclipse IDE for RCP and RAP Developers";
-    src = fetchurl {
-      url = "https://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/technology/epp/downloads/release/${year}-${month}/R/eclipse-rcp-${year}-${month}-R-linux-gtk-${arch}.tar.gz";
-      hash =
-        {
-          x86_64 = "sha256-qqOdASLe11FT4Eot7j/Yf02acHgblV77W3fqTOCrNSQ=";
-          aarch64 = "sha256-9yA2OLOcp3uKJ88OKqz7vCXMzS52om6ohUJkGZpkjE4=";
-        }
-        .${arch};
-    };
-  };
+in
+generatedEclipses
+// {
+  # expose this function so users can build their own eclipses if needed
+  inherit buildEclipse;
 
   ### Environments
 

--- a/pkgs/applications/editors/eclipse/eclipses.json
+++ b/pkgs/applications/editors/eclipse/eclipses.json
@@ -1,0 +1,90 @@
+{
+  "platform_major": "4",
+  "platform_minor": "34",
+  "year": "2024",
+  "month": "12",
+  "buildmonth": "11",
+  "dayHourMinute": "201800",
+  "eclipses": {
+    "cpp": {
+      "description": "Eclipse IDE for C/C++ Developers",
+      "dropUrl": false,
+      "hashes": {
+        "x86_64": "sha256-d3MVeci4jF9adqvgepmZtzoPul+DTMtJlf7v92PMyq0=",
+        "aarch64": "sha256-gsOmF3bGthd7CEG+HxEQJqACfb+ErWU+fVO2MVR2cz8="
+      }
+    },
+    "dsl": {
+      "description": "Eclipse IDE for Java and DSL Developers",
+      "dropUrl": false,
+      "hashes": {
+        "x86_64": "sha256-bJvODmesfkED5yHnaJGLZSeFctfVCQDA3lvH00S/zbk=",
+        "aarch64": "sha256-e0rWjD19tUyVJMMbb5THVj28o0HnBFssP0yCAQ5wKnA="
+      }
+    },
+    "embedcpp": {
+      "description": "Eclipse IDE for Embedded C/C++ Developers",
+      "dropUrl": false,
+      "hashes": {
+        "x86_64": "sha256-+DfoJ+QAlI9Ioz4Wbj2LvtpV3vAXjl0wtZBNS9osOYw=",
+        "aarch64": "sha256-XCpIKoLhrodOJkLPY6uICpuYu5PBUp96MFQCeuOyOUA="
+      }
+    },
+    "modeling": {
+      "description": "Eclipse Modeling Tools",
+      "dropUrl": false,
+      "hashes": {
+        "x86_64": "sha256-MUe5DU+3/4lzG1hykpgOX/46Pgp9qtoN9MOYk6EFK6o=",
+        "aarch64": "sha256-/tv7+RsRAFfV5zfU+uFNNlE1rrJavRFOhLYhSkIX0Ec="
+      }
+    },
+    "platform": {
+      "description": "Eclipse Platform ${year}-${month}",
+      "dropUrl": true,
+      "hashes": {
+        "x86_64": "sha256-ZHJkIOAaz87z6Dz/6X62E7ckQIFDtzqgE5ODZeb/Rss=",
+        "aarch64": "sha256-dLLwLFTeUXoL9Pri4EB48nZGUH/zF2mCt6anv519aP4="
+      }
+    },
+    "SDK": {
+      "description": "Eclipse ${year}-${month} Classic",
+      "dropUrl": true,
+      "hashes": {
+        "x86_64": "sha256-DhrNe9nx4RYAaq+NIHCBLX+bOn+dE13yF07hjuRzHZI=",
+        "aarch64": "sha256-OHE0vxjV9kp43Os2LCLuZFCMLWy3vnCChMC54TyXO9I="
+      }
+    },
+    "java": {
+      "description": "Eclipse IDE for Java Developers",
+      "dropUrl": false,
+      "hashes": {
+        "x86_64": "sha256-z0hLFqdDSqhUmCiOp0fkTkiybOmCIA118JMBb90yEiY=",
+        "aarch64": "sha256-JzUgyfPEi9vq497gJhHuobb0TR113hC2suFvNKix7So="
+      }
+    },
+    "jee": {
+      "description": "Eclipse IDE for Enterprise Java and Web Developers",
+      "dropUrl": false,
+      "hashes": {
+        "x86_64": "sha256-PxQ+jGTEs917IeWuTCgyyx7vAodZr4ju/aa4WQmoGQ0=",
+        "aarch64": "sha256-g4EHYFjoPONiGwreAmENcXWVinPkDAIE6KyVmZokQAo="
+      }
+    },
+    "committers": {
+      "description": "Eclipse IDE for Eclipse Committers and Eclipse Platform Plugin Developers",
+      "dropUrl": false,
+      "hashes": {
+        "x86_64": "sha256-g8ILZ9esbXbm+4bImFJkEwE/UNJT2HHCXx/8i+Lvb00=",
+        "aarch64": "sha256-arV2VgQypj8fSEpqGd8CbJ/FyKE6k+e4x7kXqShDKrw="
+      }
+    },
+    "rcp": {
+      "description": "Eclipse IDE for RCP and RAP Developers",
+      "dropUrl": false,
+      "hashes": {
+        "x86_64": "sha256-qqOdASLe11FT4Eot7j/Yf02acHgblV77W3fqTOCrNSQ=",
+        "aarch64": "sha256-9yA2OLOcp3uKJ88OKqz7vCXMzS52om6ohUJkGZpkjE4="
+      }
+    }
+  }
+}

--- a/pkgs/applications/editors/eclipse/update.sh
+++ b/pkgs/applications/editors/eclipse/update.sh
@@ -38,36 +38,27 @@ case "$buildmonth" in
     '11'|'01') month='12' ;;
 esac
 
-cat <<EOF
+ECLIPSES_JSON=$(dirname $0)/eclipses.json;
 
-paste the following into the 'let' block near the top of pkgs/applications/editors/eclipse/default.nix:
-
-  platform_major = "${platform_major}";
-  platform_minor = "${platform_minor}";
-  year = "${year}";
-  month = "${month}"; #release month
-  buildmonth = "${buildmonth}"; #sometimes differs from release month
-  timestamp = "\${year}\${buildmonth}${builddaytime}";
-EOF
-
-# strip existing download hashes
-
-sed -i 's/64 = ".*";$/64 = "";/g' pkgs/applications/editors/eclipse/default.nix
+t=$(mktemp);
+cat $ECLIPSES_JSON | jq ". + {platform_major: \"${platform_major}\",platform_minor: \"${platform_minor}\",year: \"${year}\",month: \"${month}\",buildmonth: \"${buildmonth}\",dayHourMinute: \"${builddaytime}\"}" > $t;
+mv $t $ECLIPSES_JSON;
 
 # prefetch new download hashes
 
-echo;
-echo "paste the following url + hash blocks into pkgs/applications/editors/eclipse/default.nix:";
-
-for url in $(grep 'url = ' pkgs/applications/editors/eclipse/default.nix | grep arch | cut -d '"' -f 2); do
-    u=$(echo "$url" | sed 's/&/\\&/g');
-    echo;
-    echo "        url = \"${url}\";";
-    echo "        hash = {";
+for id in $(cat $ECLIPSES_JSON | jq -r '.eclipses | keys | .[]'); do
     for arch in x86_64 aarch64; do
-        us=$(eval echo "$u");
-        h=$(nix store prefetch-file --json "$us" | jq -r .hash);
-        echo "          $arch = \"${h}\";";
+        if [ $(cat $ECLIPSES_JSON | jq -r ".eclipses.${id}.dropUrl") == "true" ]; then
+            url="https://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/eclipse/downloads/drops${platform_major}/R-${platform_major}.${platform_minor}-${timestamp}/eclipse-${id}-${platform_major}.${platform_minor}-linux-gtk-${arch}.tar.gz";
+        else
+            url="https://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/technology/epp/downloads/release/${year}-${month}/R/eclipse-${id}-${year}-${month}-R-linux-gtk-${arch}.tar.gz";
+        fi
+
+        echo "prefetching ${id} ${arch}";
+        h=$(nix store prefetch-file --json "$url" | jq -r .hash);
+
+        t=$(mktemp);
+        cat $ECLIPSES_JSON | jq -r ".eclipses.${id}.hashes.${arch} = \"${h}\"" > $t;
+        mv $t $ECLIPSES_JSON;
     done
-    echo '        }.${arch};';
 done


### PR DESCRIPTION
This extracts hard-to-edit metadata about each eclipse packaging into a new `eclipses.json` file, then recasts the `update.sh` script to update that file instead of dumping out snippets of nix code that have to be copy-pasted by hand.

I've confirmed that this produces updates to `eclipses.json` that let me build & run the 2025-03 release locally.  But I think the correct procedure is not to include that change in this PR, and let the auto-update machinery do it separately.

The last manual update was #366594.

cc @kirillrdy 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
