### PR TITLE
nusmw:  2.6.0 -> 2.7.0

### DIFF
--- a/pkgs/by-name/nu/nusmv/package.nix
+++ b/pkgs/by-name/nu/nusmv/package.nix
@@ -7,32 +7,32 @@
 
 stdenv.mkDerivation rec {
   pname = "NuSMV";
-  version = "2.6.0";
+  version = "2.7.0";
 
   src =
     with stdenv;
     fetchurl (
       if isx86_64 && isLinux then
         {
-          url = "https://nusmv.fbk.eu/distrib/NuSMV-${version}-linux64.tar.gz";
-          sha256 = "1370x2vwjndv9ham5q399nn84hvhm1gj1k7pq576qmh4pi12xc8i";
+          url = "https://nusmv.fbk.eu/distrib/${version}/NuSMV-${version}-linux64.tar.xz";
+          sha256 = "019d1pa5aw58n11is1024hs8d520b3pp2iyix78vp04yv7wd42l8";
         }
-      else if isx86_32 && isLinux then
+      else if isx86_64 && isDarwin then
         {
-          url = "https://nusmv.fbk.eu/distrib/NuSMV-${version}-linux32.tar.gz";
-          sha256 = "1qf41czwbqxlrmv0rv2daxgz2hljza5xks85sx3dhwpjy2iav9jb";
+          url = "https://nusmv.fbk.eu/distrib/${version}/NuSMV-${version}-macos-universal.tar.xz";
+          sha256 = "098wllv4yx284qv9nsi8kd5pgh10cr1hig01a1p2rxgfmrki52wm";
         }
       else
-        throw "only linux x86_64 and x86_32 are currently supported"
+        throw "only linux and mac x86_64 are currently supported"
     );
 
-  nativeBuildInputs = [ autoPatchelfHook ];
+  nativeBuildInputs = lib.optionals stdenv.isLinux [ autoPatchelfHook ];
 
   installPhase = ''
     install -m755 -D bin/NuSMV $out/bin/NuSMV
     install -m755 -D bin/ltl2smv $out/bin/ltl2smv
     cp -r include $out/include
-    cp -r share $out/share
+    cp -r lib $out/lib
   '';
 
   meta = with lib; {
@@ -40,6 +40,6 @@ stdenv.mkDerivation rec {
     homepage = "https://nusmv.fbk.eu/";
     maintainers = with maintainers; [ mgttlinger ];
     sourceProvenance = with sourceTypes; [ binaryNativeCode ];
-    platforms = platforms.linux;
+    platforms = platforms.linux ++ platforms.darwin;
   };
 }


### PR DESCRIPTION
- Removed x86_32 because binaries aren't available
- Added Darwin x86_64 binary


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

I mainly wanted the Darwin binaries available through Nix. With NuSMV 2.7.0 it turns out they aren't providing 32-bit binaries, so I removed that, too.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
