### PR TITLE
substituteAll: deprecate

### DIFF
--- a/doc/languages-frameworks/gnome.section.md
+++ b/doc/languages-frameworks/gnome.section.md
@@ -214,7 +214,7 @@ stdenv.mkDerivation {
 
 You can rely on applications depending on the library setting the necessary environment variables but that is often easy to miss. Instead we recommend to patch the paths in the source code whenever possible. Here are some examples:
 
-- []{#ssec-gnome-common-issues-unwrappable-package-gnome-shell-ext} [Replacing a `GI_TYPELIB_PATH` in GNOME Shell extension](https://github.com/NixOS/nixpkgs/blob/7bb8f05f12ca3cff9da72b56caa2f7472d5732bc/pkgs/desktops/gnome-3/core/gnome-shell-extensions/default.nix#L21-L24) – we are using `substituteAll` to include the path to a typelib into a patch.
+- []{#ssec-gnome-common-issues-unwrappable-package-gnome-shell-ext} [Replacing a `GI_TYPELIB_PATH` in GNOME Shell extension](https://github.com/NixOS/nixpkgs/blob/e981466fbb08e6231a1377539ff17fbba3270fda/pkgs/by-name/gn/gnome-shell-extensions/package.nix#L25-L32) – we are using `replaceVars` to include the path to a typelib into a patch.
 
 - []{#ssec-gnome-common-issues-unwrappable-package-gsettings} The following examples are hardcoding GSettings schema paths. To get the schema paths we use the functions
 
@@ -222,7 +222,7 @@ You can rely on applications depending on the library setting the necessary envi
 
   * `glib.makeSchemaPath` Takes a package output like `$out` and a derivation name. You should use this if the schemas you need to hardcode are in the same derivation.
 
-  []{#ssec-gnome-common-issues-unwrappable-package-gsettings-vala} [Hard-coding GSettings schema path in Vala plug-in (dynamically loaded library)](https://github.com/NixOS/nixpkgs/blob/7bb8f05f12ca3cff9da72b56caa2f7472d5732bc/pkgs/desktops/pantheon/apps/elementary-files/default.nix#L78-L86) – here, `substituteAll` cannot be used since the schema comes from the same package preventing us from pass its path to the function, probably due to a [Nix bug](https://github.com/NixOS/nix/issues/1846).
+  []{#ssec-gnome-common-issues-unwrappable-package-gsettings-vala} [Hard-coding GSettings schema path in Vala plug-in (dynamically loaded library)](https://github.com/NixOS/nixpkgs/blob/7bb8f05f12ca3cff9da72b56caa2f7472d5732bc/pkgs/desktops/pantheon/apps/elementary-files/default.nix#L78-L86) – here, `replaceVars` cannot be used since the schema comes from the same package preventing us from pass its path to the function, probably due to a [Nix bug](https://github.com/NixOS/nix/issues/1846).
 
   []{#ssec-gnome-common-issues-unwrappable-package-gsettings-c} [Hard-coding GSettings schema path in C library](https://github.com/NixOS/nixpkgs/blob/29c120c065d03b000224872251bed93932d42412/pkgs/development/libraries/glib-networking/default.nix#L31-L34) – nothing special other than using [Coccinelle patch](https://github.com/NixOS/nixpkgs/pull/67957#issuecomment-527717467) to generate the patch itself.
 

--- a/doc/redirects.json
+++ b/doc/redirects.json
@@ -8,6 +8,14 @@
   "ex-build-helpers-extendMkDerivation": [
     "index.html#ex-build-helpers-extendMkDerivation"
   ],
+  "ex-pkgs-replace-vars": [
+    "index.html#ex-pkgs-replace-vars",
+    "index.html#ex-pkgs-substituteAll",
+    "index.html#ex-pkgs-substitute-all-files"
+  ],
+  "ex-pkgs-replace-vars-with": [
+    "index.html#ex-pkgs-replace-vars-with"
+  ],
   "ex-shfmt": [
     "index.html#ex-shfmt"
   ],
@@ -34,6 +42,14 @@
   ],
   "no-broken-symlinks.sh": [
     "index.html#no-broken-symlinks.sh"
+  ],
+  "pkgs-replacevars": [
+    "index.html#pkgs-replacevars",
+    "index.html#pkgs-substituteall",
+    "index.html#pkgs-substituteallfiles"
+  ],
+  "pkgs-replacevarswith": [
+    "index.html#pkgs-replacevarswith"
   ],
   "preface": [
     "index.html#preface"
@@ -4192,18 +4208,6 @@
   ],
   "ex-pkgs-substitute": [
     "index.html#ex-pkgs-substitute"
-  ],
-  "pkgs-substituteall": [
-    "index.html#pkgs-substituteall"
-  ],
-  "ex-pkgs-substituteAll": [
-    "index.html#ex-pkgs-substituteAll"
-  ],
-  "pkgs-substituteallfiles": [
-    "index.html#pkgs-substituteallfiles"
-  ],
-  "ex-pkgs-substitute-all-files": [
-    "index.html#ex-pkgs-substitute-all-files"
   ],
   "part-development": [
     "index.html#part-development"

--- a/doc/release-notes/rl-2505.section.md
+++ b/doc/release-notes/rl-2505.section.md
@@ -112,7 +112,7 @@
 
 - All support for 32‐bit Darwin systems has been dropped.
 
-- `substituteAll` has been deprecated in favor of `replaceVars` and will be removed in the next release.
+- `substituteAll` and `substituteAllFiles` have been deprecated in favor of `replaceVars` and will be removed in the next release.
 
 - Default ICU version updated from 74 to 76
 

--- a/doc/release-notes/rl-2505.section.md
+++ b/doc/release-notes/rl-2505.section.md
@@ -112,6 +112,8 @@
 
 - All support for 32‐bit Darwin systems has been dropped.
 
+- `substituteAll` has been deprecated in favor of `replaceVars` and will be removed in the next release.
+
 - Default ICU version updated from 74 to 76
 
 - Apache Kafka was updated to `>= 4.0.0`. Please note that this is the first release which operates

--- a/pkgs/build-support/substitute-files/substitute-all-files.nix
+++ b/pkgs/build-support/substitute-files/substitute-all-files.nix
@@ -2,27 +2,32 @@
 
 args:
 
-stdenv.mkDerivation (
-  {
-    name = if args ? name then args.name else baseNameOf (toString args.src);
-    builder = builtins.toFile "builder.sh" ''
-      set -o pipefail
+# TODO(@wolfgangwalther): Remove substituteAllFiles after 25.05 branch-off.
+lib.warn
+  "substituteAllFiles is deprecated and will be removed in 25.11. Use replaceVars for each file instead."
+  (
+    stdenv.mkDerivation (
+      {
+        name = if args ? name then args.name else baseNameOf (toString args.src);
+        builder = builtins.toFile "builder.sh" ''
+          set -o pipefail
 
-      eval "$preInstall"
+          eval "$preInstall"
 
-      args=
+          args=
 
-      pushd "$src"
-      echo -ne "${lib.concatStringsSep "\\0" args.files}" | xargs -0 -n1 -I {} -- find {} -type f -print0 | while read -d "" line; do
-        mkdir -p "$out/$(dirname "$line")"
-        substituteAll "$line" "$out/$line"
-      done
-      popd
+          pushd "$src"
+          echo -ne "${lib.concatStringsSep "\\0" args.files}" | xargs -0 -n1 -I {} -- find {} -type f -print0 | while read -d "" line; do
+            mkdir -p "$out/$(dirname "$line")"
+            substituteAll "$line" "$out/$line"
+          done
+          popd
 
-      eval "$postInstall"
-    '';
-    preferLocalBuild = true;
-    allowSubstitutes = false;
-  }
-  // args
-)
+          eval "$postInstall"
+        '';
+        preferLocalBuild = true;
+        allowSubstitutes = false;
+      }
+      // args
+    )
+  )

--- a/pkgs/build-support/substitute/substitute-all.nix
+++ b/pkgs/build-support/substitute/substitute-all.nix
@@ -6,21 +6,24 @@ let
   isInvalidArgName = x: builtins.match "^[a-z][a-zA-Z0-9_]*$" x == null;
   invalidArgs = builtins.filter isInvalidArgName (builtins.attrNames args);
 in
-if invalidArgs == [ ] then
-  stdenvNoCC.mkDerivation (
-    {
-      name = if args ? name then args.name else baseNameOf (toString args.src);
-      builder = ./substitute-all.sh;
-      inherit (args) src;
-      preferLocalBuild = true;
-      allowSubstitutes = false;
-    }
-    // args
-  )
-else
-  throw ''
-    Argument names for `pkgs.substituteAll` must:
-      - start with a lower case ASCII letter
-      - only contain ASCII letters, digits and underscores
-    Found invalid argument names: ${lib.concatStringsSep ", " invalidArgs}.
-  ''
+# TODO(@wolfgangwalther): Remove substituteAll, the nix function, after 25.05 branch-off.
+lib.warn "substituteAll is deprecated and will be removed in 25.11. Use replaceVars instead." (
+  if invalidArgs == [ ] then
+    stdenvNoCC.mkDerivation (
+      {
+        name = if args ? name then args.name else baseNameOf (toString args.src);
+        builder = ./substitute-all.sh;
+        inherit (args) src;
+        preferLocalBuild = true;
+        allowSubstitutes = false;
+      }
+      // args
+    )
+  else
+    throw ''
+      Argument names for `pkgs.substituteAll` must:
+        - start with a lower case ASCII letter
+        - only contain ASCII letters, digits and underscores
+      Found invalid argument names: ${lib.concatStringsSep ", " invalidArgs}.
+    ''
+)

--- a/pkgs/by-name/bo/box2d/package.nix
+++ b/pkgs/by-name/bo/box2d/package.nix
@@ -3,7 +3,7 @@
   stdenv,
   fetchFromGitHub,
 
-  substituteAll,
+  replaceVars,
 
   # nativeBuildInputs
   cmake,
@@ -41,8 +41,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   patches = [
     # prevent CMake from trying to download some libraries from the internet
-    (substituteAll {
-      src = ./cmake_dont_fetch_enkits.patch;
+    (replaceVars ./cmake_dont_fetch_enkits.patch {
       enkits_src = fetchFromGitHub {
         owner = "dougbinks";
         repo = "enkiTS";

--- a/pkgs/by-name/fi/fim/package.nix
+++ b/pkgs/by-name/fi/fim/package.nix
@@ -4,7 +4,7 @@
   autoconf,
   automake,
   pkg-config,
-  substituteAll,
+  replaceVars,
   lib,
   perl,
   flex,
@@ -41,9 +41,11 @@ stdenv.mkDerivation rec {
 
   patches = [
     # build tools with a build compiler
-    (substituteAll {
-      src = ./native-tools.patch;
+    (replaceVars ./native-tools.patch {
       cc_for_build = lib.getExe buildPackages.stdenv.cc;
+      # patch context
+      FIM_WANT_CUSTOM_HARDCODED_CONSOLEFONT_TRUE = null;
+      HAVE_RUNNABLE_TESTS_TRUE = null;
     })
   ];
 

--- a/pkgs/by-name/re/recon-ng/package.nix
+++ b/pkgs/by-name/re/recon-ng/package.nix
@@ -2,7 +2,7 @@
   lib,
   fetchFromGitHub,
   python3,
-  substituteAll,
+  replaceVars,
   fetchpatch,
 }:
 python3.pkgs.buildPythonApplication rec {
@@ -49,8 +49,7 @@ python3.pkgs.buildPythonApplication rec {
 
   postPatch =
     let
-      setup = substituteAll {
-        src = ./setup.py;
+      setup = replaceVars ./setup.py {
         inherit pname version;
       };
     in

--- a/pkgs/by-name/su/supercell-wx/package.nix
+++ b/pkgs/by-name/su/supercell-wx/package.nix
@@ -26,7 +26,7 @@
   qt6,
   tbb_2021_11,
   tracy,
-  substituteAll,
+  replaceVars,
   python3,
 }:
 let
@@ -94,9 +94,8 @@ stdenv.mkDerivation (finalAttrs: {
   patches = [
     # These are for Nix compatibility {{{
     ./patches/use-find-package.patch # Replace some vendored dependencies with Nix provided versions
-    (substituteAll {
+    (replaceVars ./patches/skip-git-versioning.patch {
       # Skip tagging build with git version, and substitute it with the src revision (still uses current year timestamp)
-      src = ./patches/skip-git-versioning.patch;
       rev = finalAttrs.src.rev;
     })
     # Prevents using some Qt scripts that seemed to break the install step. Fixes missing link to some targets.

--- a/pkgs/development/libraries/xdg-desktop-portal/default.nix
+++ b/pkgs/development/libraries/xdg-desktop-portal/default.nix
@@ -27,7 +27,7 @@
   gst_all_1,
   libgudev,
   umockdev,
-  substituteAll,
+  replaceVars,
   enableGeoLocation ? true,
   enableSystemd ? true,
 }:
@@ -51,14 +51,12 @@ stdenv.mkDerivation (finalAttrs: {
   patches = [
     # The icon validator copied from Flatpak needs to access the gdk-pixbuf loaders
     # in the Nix store and cannot bind FHS paths since those are not available on NixOS.
-    (substituteAll {
-      src = ./fix-icon-validation.patch;
+    (replaceVars ./fix-icon-validation.patch {
       inherit (builtins) storeDir;
     })
 
     # Same for the sound validator, except the gdk-pixbuf part.
-    (substituteAll {
-      src = ./fix-sound-validation.patch;
+    (replaceVars ./fix-sound-validation.patch {
       inherit (builtins) storeDir;
     })
 

--- a/pkgs/development/rocm-modules/6/llvm/default.nix
+++ b/pkgs/development/rocm-modules/6/llvm/default.nix
@@ -15,7 +15,7 @@
   zlib,
   gcc-unwrapped,
   glibc,
-  substituteAll,
+  replaceVars,
   libffi,
   libxml2,
   removeReferencesTo,
@@ -319,8 +319,7 @@ rec {
             })
             # FIXME: Needed due to https://github.com/NixOS/nixpkgs/issues/375431
             # Once we can switch to overrideScope this can be removed
-            (substituteAll {
-              src = ./../../../compilers/llvm/common/clang/clang-at-least-16-LLVMgold-path.patch;
+            (replaceVars ./../../../compilers/llvm/common/clang/clang-at-least-16-LLVMgold-path.patch {
               libllvmLibdir = "${llvm.lib}/lib";
             })
           ];


### PR DESCRIPTION
One step towards #237216.

Q1: Should we adjust the [docs](https://nixos.org/manual/nixpkgs/stable/#pkgs-substituteall) immediately? If yes, just add a deprecation or remove them already and point to ... (ah, we don't have `replaceVars` in the docs, yet?).

Q2: What to do about [`substituteAllFiles`](https://nixos.org/manual/nixpkgs/unstable/#pkgs-substituteallfiles)? It's unused in nixpkgs, so we could deprecate it immediately as well? Although we don't have a replacement for it.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
