### PR TITLE
[24.11] cargo-auditable: 0.6.2 -> 0.6.5

### DIFF
--- a/pkgs/development/compilers/rust/cargo-auditable.nix
+++ b/pkgs/development/compilers/rust/cargo-auditable.nix
@@ -1,4 +1,11 @@
-{ lib, buildPackages, fetchFromGitHub, makeRustPlatform, installShellFiles, stdenv }:
+{
+  lib,
+  buildPackages,
+  fetchFromGitHub,
+  makeRustPlatform,
+  installShellFiles,
+  stdenv,
+}:
 
 let
   args = rec {
@@ -24,7 +31,10 @@ let
       mainProgram = "cargo-auditable";
       homepage = "https://github.com/rust-secure-code/cargo-auditable";
       changelog = "https://github.com/rust-secure-code/cargo-auditable/blob/v${version}/cargo-auditable/CHANGELOG.md";
-      license = with licenses; [ mit /* or */ asl20 ];
+      license = with licenses; [
+        mit # or
+        asl20
+      ];
       maintainers = with maintainers; [ figsoda ];
       broken = stdenv.hostPlatform != stdenv.buildPlatform;
     };
@@ -37,21 +47,27 @@ let
     };
   };
 
-  bootstrap = rustPlatform.buildRustPackage (args // {
-    auditable = false;
-  });
+  bootstrap = rustPlatform.buildRustPackage (
+    args
+    // {
+      auditable = false;
+    }
+  );
 in
 
-rustPlatform.buildRustPackage.override { cargo-auditable = bootstrap; } (args // {
-  nativeBuildInputs = [
-    installShellFiles
-  ];
+rustPlatform.buildRustPackage.override { cargo-auditable = bootstrap; } (
+  args
+  // {
+    nativeBuildInputs = [
+      installShellFiles
+    ];
 
-  postInstall = ''
-    installManPage cargo-auditable/cargo-auditable.1
-  '';
+    postInstall = ''
+      installManPage cargo-auditable/cargo-auditable.1
+    '';
 
-  passthru = {
-    inherit bootstrap;
-  };
-})
+    passthru = {
+      inherit bootstrap;
+    };
+  }
+)

--- a/pkgs/development/compilers/rust/cargo-auditable.nix
+++ b/pkgs/development/compilers/rust/cargo-auditable.nix
@@ -1,44 +1,30 @@
-{
-  lib,
-  buildPackages,
-  fetchFromGitHub,
-  fetchpatch,
-  makeRustPlatform,
-  installShellFiles,
-  stdenv,
-}:
+{ lib, buildPackages, fetchFromGitHub, makeRustPlatform, installShellFiles, stdenv }:
 
 let
   args = rec {
     pname = "cargo-auditable";
-    version = "0.6.2";
+    version = "0.6.5";
 
     src = fetchFromGitHub {
       owner = "rust-secure-code";
       repo = pname;
       rev = "v${version}";
-      sha256 = "sha256-ERIzx9Fveanq7/aWcB2sviTxIahvSu0sTwgpGf/aYE8=";
+      sha256 = "sha256-zjv2/qZM0vRyz45DeKRtPHaamv2iLtjpSedVTEXeDr8=";
     };
 
-    patches = [
-      (fetchpatch {
-        name = "rust-1.77-tests.patch";
-        url = "https://github.com/rust-secure-code/cargo-auditable/commit/5317a27244fc428335c4e7a1d066ae0f65f0d496.patch";
-        hash = "sha256-UblGseiSC/2eE4rcnTgYzxAMrutHFSdxKTHqKj1mX5o=";
-      })
-    ];
+    cargoHash = "sha256-uNoqWT3gVslGEPcyrfFeOquvSlLzZbPO4yM1YJeD8N4=";
 
-    cargoHash = "sha256-4o3ctun/8VcBRuj+j0Yaawdkyn6Z6LPp+FTyhPxQWU8=";
+    checkFlags = [
+      # requires wasm32-unknown-unknown target
+      "--skip=test_wasm"
+    ];
 
     meta = with lib; {
       description = "Tool to make production Rust binaries auditable";
       mainProgram = "cargo-auditable";
       homepage = "https://github.com/rust-secure-code/cargo-auditable";
       changelog = "https://github.com/rust-secure-code/cargo-auditable/blob/v${version}/cargo-auditable/CHANGELOG.md";
-      license = with licenses; [
-        mit # or
-        asl20
-      ];
+      license = with licenses; [ mit /* or */ asl20 ];
       maintainers = with maintainers; [ figsoda ];
       broken = stdenv.hostPlatform != stdenv.buildPlatform;
     };
@@ -51,27 +37,21 @@ let
     };
   };
 
-  bootstrap = rustPlatform.buildRustPackage (
-    args
-    // {
-      auditable = false;
-    }
-  );
+  bootstrap = rustPlatform.buildRustPackage (args // {
+    auditable = false;
+  });
 in
 
-rustPlatform.buildRustPackage.override { cargo-auditable = bootstrap; } (
-  args
-  // {
-    nativeBuildInputs = [
-      installShellFiles
-    ];
+rustPlatform.buildRustPackage.override { cargo-auditable = bootstrap; } (args // {
+  nativeBuildInputs = [
+    installShellFiles
+  ];
 
-    postInstall = ''
-      installManPage cargo-auditable/cargo-auditable.1
-    '';
+  postInstall = ''
+    installManPage cargo-auditable/cargo-auditable.1
+  '';
 
-    passthru = {
-      inherit bootstrap;
-    };
-  }
-)
+  passthru = {
+    inherit bootstrap;
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Backport https://github.com/NixOS/nixpkgs/pull/355792 to NixOS 24.11.

This is required for supporting Rust Edition 2024. While this is not natively supported by NixOS 24.11, it is supported when using a Rust overlay.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
