### PR TITLE
picolibc: init at 1.8.9

### DIFF
--- a/pkgs/by-name/pi/picolibc/package.nix
+++ b/pkgs/by-name/pi/picolibc/package.nix
@@ -1,0 +1,80 @@
+{
+  stdenv,
+  fetchFromGitHub,
+  lib,
+  meson,
+  ninja,
+  nix-update-script,
+
+  # General Build Options
+  multilib ? true,
+}:
+let
+  inherit (lib.strings) mesonBool mesonOption;
+in
+stdenv.mkDerivation (finalAttrs: {
+  name = "picolibc";
+  version = "1.8.9";
+  strictDeps = true;
+
+  outputs = [
+    "out"
+    "dev"
+  ];
+
+  src = fetchFromGitHub {
+    owner = "picolibc";
+    repo = "picolibc";
+    rev = "db4d0fe5952d5ecd714781e3212d4086d970735a";
+    hash = "sha256-W1zK9mLMfi5pbOpbSLxiB2qKdiyNjOSQu96NM94/fcY=";
+  };
+
+  nativeBuildInputs = [
+    meson
+    ninja
+  ];
+
+  # https://github.com/picolibc/picolibc/blob/e57b766cb5d80f23c20d05ab067001d85910f927/doc/os.md?plain=1#L183
+  mesonFlags = [
+    (mesonBool "multilib" multilib)
+    (mesonOption "specsdir" "${placeholder "dev"}/lib")
+    (mesonOption "tls-model" "global-dynamic")
+    (mesonOption "errno-function" "auto")
+    (mesonBool "picolib" false)
+    (mesonBool "picocrt" false)
+    (mesonBool "semihost" false)
+    (mesonBool "use-stdlib" true)
+    (mesonBool "posix-console" true)
+    (mesonBool "newlib-global-atexit" true)
+  ];
+
+  passthru = {
+    updateScript = nix-update-script { };
+    tests = {
+      arm = pkgsCross.arm-embedded.picolibc;
+    };
+  };
+
+  meta =
+    let
+      inherit (lib) licenses maintainers;
+    in
+    {
+      description = "C library designed for embedded 32- and 64- bit systems";
+      longDescription = ''
+        Picolibc is library offering standard C library APIs that targets
+        small embedded systems with limited RAM. Picolibc was formed by blending
+        code from [Newlib](http://sourceware.org/newlib/) and
+        [AVR Libc](https://www.nongnu.org/avr-libc/).
+      '';
+      homepage = "https://keithp.com/picolibc/";
+      changelog = "https://github.com/picolibc/picolibc/releases/tag/${finalAttrs.version}";
+      license = [
+        licenses.bsd2
+        licenses.bsd3
+      ];
+      maintainers = [ maintainers.RossSmyth ];
+      # https://github.com/picolibc/picolibc/tree/db4d0fe5952d5ecd714781e3212d4086d970735a?tab=readme-ov-file#supported-architectures
+      platforms = lib.platforms.all;
+    };
+})

--- a/pkgs/by-name/pi/picolibc/package.nix
+++ b/pkgs/by-name/pi/picolibc/package.nix
@@ -5,15 +5,97 @@
   meson,
   ninja,
   nix-update-script,
+  pkgsCross,
 
   # General Build Options
+  # https://github.com/picolibc/picolibc/blob/e57b766cb5d80f23c20d05ab067001d85910f927/meson_options.txt#L40-L57
   multilib ? true,
+  sanitize-bounds ? false,
+  sanitize-trap-on-error ? false,
+  profile ? false,
+  analyzer ? false,
+  assert-verbose ? true,
+  fast-strcmp ? true,
+
+  # Testing options
+  # https://github.com/picolibc/picolibc/blob/e57b766cb5d80f23c20d05ab067001d85910f927/meson_options.txt#L75
+  picolib ? stdenv.hostPlatform.isNone,
+  semihost ? stdenv.hostPlatform.isNone,
+
+  # Stdio Options
+  # https://github.com/picolibc/picolibc/blob/e57b766cb5d80f23c20d05ab067001d85910f927/meson_options.txt#L114
+  tinystdio ? true,
+  io-c99-formats ? true,
+  io-long-long ? false,
+  io-pos-args ? false,
+  io-long-double ? false,
+
+  # Tinystdio options
+  # https://github.com/picolibc/picolibc/blob/e57b766cb5d80f23c20d05ab067001d85910f927/meson_options.txt#L129
+  io-float-exact ? true,
+  atomic-ungetc ? true,
+  posix-console ? !stdenv.hostPlatform.isNone,
+  format-default ? "double",
+  printf-aliases ? true,
+  io-percent-b ? false,
+  printf-small-ultoa ? true,
+  printf-percent-n ? false,
+  minimal-io-long-long ? false,
+  fast-bufio ? false,
+  io-wchar ? false,
+
+  # Internaltionalization options
+  # https://github.com/picolibc/picolibc/blob/e57b766cb5d80f23c20d05ab067001d85910f927/meson_options.txt#L181
+  mb-capable ? false,
+  mb-extended-charsets ? false,
+  mb-ucs-charsets ? "auto",
+  mb-iso-charsets ? "auto",
+  mb-jis-charsets ? "auto",
+  mb-windows-charsets ? "auto",
+
+  # Startup/shutdown options
+  # https://github.com/picolibc/picolibc/blob/e57b766cb5d80f23c20d05ab067001d85910f927/meson_options.txt#L198
+  picocrt ? stdenv.hostPlatform.isNone,
+  picocrt-enable-mmu ? true,
+  picocrt-lib ? true,
+  picoexit ? true,
+  initfini-array ? true,
+  crt-runtime-size ? false,
+
+  # Legacy (non-picoexit) startup/shutdown options
+  # https://github.com/picolibc/picolibc/blob/e57b766cb5d80f23c20d05ab067001d85910f927/meson_options.txt#L217
+  newlib-atexit-dynamic-alloc ? false,
+  newlib-global-atexit ? !stdenv.hostPlatform.isNone,
+  newlib-register-fini ? false,
+
+  # Malloc options
+  # https://github.com/picolibc/picolibc/blob/e57b766cb5d80f23c20d05ab067001d85910f927/meson_options.txt#L228
+  newlib-nano-malloc ? true,
+  nano-malloc-clear-freed ? false,
+
+  # Locking options
+  # https://github.com/picolibc/picolibc/blob/e57b766cb5d80f23c20d05ab067001d85910f927/meson_options.txt#L237
+  single-thread ? false,
+
+  # TLS storage options
+  # https://github.com/picolibc/picolibc/blob/e57b766cb5d80f23c20d05ab067001d85910f927/meson_options.txt#L244
+  thread-local-storage ? "picolibc",
+  tls-model ? if stdenv.hostPlatform.isNone then "local-exec" else "global-dynamic",
+  newlib-global-errno ? false,
+  errno-function ? if stdenv.hostPlatform.isNone then "false" else "auto",
+  tls-rp2040 ? false,
+
+  # Math options
+  # https://github.com/picolibc/picolibc/blob/e57b766cb5d80f23c20d05ab067001d85910f927/meson_options.txt#L261
+  want-math-errno ? false,
 }:
 let
   inherit (lib.strings) mesonBool mesonOption;
+
+  canExecute = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
 in
 stdenv.mkDerivation (finalAttrs: {
-  name = "picolibc";
+  pname = "picolibc";
   version = "1.8.9";
   strictDeps = true;
 
@@ -24,8 +106,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchFromGitHub {
     owner = "picolibc";
-    repo = "picolibc";
-    rev = "db4d0fe5952d5ecd714781e3212d4086d970735a";
+    repo = finalAttrs.pname;
+    tag = finalAttrs.version;
     hash = "sha256-W1zK9mLMfi5pbOpbSLxiB2qKdiyNjOSQu96NM94/fcY=";
   };
 
@@ -34,19 +116,83 @@ stdenv.mkDerivation (finalAttrs: {
     ninja
   ];
 
+  # Default values taken from
+  # Build fails without using them.
   # https://github.com/picolibc/picolibc/blob/e57b766cb5d80f23c20d05ab067001d85910f927/doc/os.md?plain=1#L183
-  mesonFlags = [
-    (mesonBool "multilib" multilib)
-    (mesonOption "specsdir" "${placeholder "dev"}/lib")
-    (mesonOption "tls-model" "global-dynamic")
-    (mesonOption "errno-function" "auto")
-    (mesonBool "picolib" false)
-    (mesonBool "picocrt" false)
-    (mesonBool "semihost" false)
-    (mesonBool "use-stdlib" true)
-    (mesonBool "posix-console" true)
-    (mesonBool "newlib-global-atexit" true)
-  ];
+  mesonFlags =
+    [
+      (mesonBool "multilib" multilib)
+      (mesonBool "sanitize-bounds" sanitize-bounds)
+      (mesonBool "sanitize-trap-on-error" sanitize-trap-on-error)
+      (mesonBool "profile" profile)
+      (mesonBool "analyzer" analyzer)
+      (mesonBool "assert-verbose" assert-verbose)
+      (mesonBool "fast-strcmp" fast-strcmp)
+
+      # Testing options
+      (mesonBool "picolib" picolib)
+      (mesonBool "semihost" semihost)
+      (mesonBool "use-stdlib" true)
+
+      # Install options
+      (mesonOption "specsdir" "${placeholder "dev"}/lib")
+
+      (mesonBool "tinystdio" tinystdio)
+      (mesonBool "io-c99-formats" io-c99-formats)
+      (mesonBool "io-long-long" io-long-long)
+      (mesonBool "io-pos-args" io-pos-args)
+      (mesonBool "io-long-double" io-long-double)
+
+      (mesonBool "io-float-exact" io-float-exact)
+      (mesonBool "atomic-ungetc" atomic-ungetc)
+      (mesonBool "posix-console" posix-console)
+      (mesonOption "format-default" format-default)
+      (mesonBool "printf-aliases" printf-aliases)
+      (mesonBool "io-percent-b" io-percent-b)
+      (mesonBool "printf-small-ultoa" printf-small-ultoa)
+      (mesonBool "printf-percent-n" printf-percent-n)
+      (mesonBool "minimal-io-long-long" minimal-io-long-long)
+      (mesonBool "fast-bufio" fast-bufio)
+      (mesonBool "io-wchar" io-wchar)
+
+      (mesonBool "mb-capable" mb-capable)
+      (mesonBool "mb-extended-charsets" mb-extended-charsets)
+      (mesonOption "mb-ucs-charsets" mb-ucs-charsets)
+      (mesonOption "mb-iso-charsets" mb-iso-charsets)
+      (mesonOption "mb-jis-charsets" mb-jis-charsets)
+      (mesonOption "mb-windows-charsets" mb-windows-charsets)
+
+      (mesonBool "picocrt" picocrt)
+      (mesonBool "picocrt-enable-mmu" picocrt-enable-mmu)
+      (mesonBool "picocrt-lib" picocrt-lib)
+      (mesonBool "picoexit" picoexit)
+      (mesonBool "newlib-initfini-array" initfini-array)
+      (mesonBool "crt-runtime-size" crt-runtime-size)
+
+      (mesonBool "newlib-atexit-dynamic-alloc" newlib-atexit-dynamic-alloc)
+      (mesonBool "newlib-global-atexit" newlib-global-atexit)
+      (mesonBool "newlib-register-fini" newlib-register-fini)
+
+      (mesonBool "newlib-nano-malloc" newlib-nano-malloc)
+      (mesonBool "nano-malloc-clear-freed" nano-malloc-clear-freed)
+
+      (mesonBool "newlib-multithread" (!single-thread))
+
+      (mesonOption "thread-local-storage" thread-local-storage)
+      (mesonOption "tls-model" tls-model)
+      (mesonBool "newlib-global-errno" newlib-global-errno)
+      (mesonOption "errno-function" errno-function)
+      (mesonBool "tls-rp2040" tls-rp2040)
+
+      (mesonBool "want-math-errno" want-math-errno)
+    ]
+    ++ lib.optionals finalAttrs.doCheck [
+      (mesonBool "tests" true)
+      # Something is broken with this and I'm not sure what.
+      (mesonOption "tests-cdefs" "false")
+    ];
+
+  doCheck = canExecute;
 
   passthru = {
     updateScript = nix-update-script { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Added Picolibc with configuration options. 

Closes #368022

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

Also tested:
- `nix-build -A pkgsCross.arm-embedded.picolibc`
- `nix-build -A pkgsLLVM.picolibc`
~~- `nix-build -A pkgsCross.arm-embedded.pkgsLLVM.picolibc` (unsure if this is the right incantation?)~~

TODO (future PRs):
- Get tests running under emulated embedded arm (I have it building, but it overflows the "flash")
- Get this hooked up so it can be used as a libc

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
