### PR TITLE
TEST: this is a pull to trigger tests for nixos/modules/services/databases/mysql.nix

### DIFF
--- a/nixos/modules/services/databases/mysql.nix
+++ b/nixos/modules/services/databases/mysql.nix
@@ -388,6 +388,7 @@ in
         # Needed for the mysql_install_db command in the preStart script
         # which calls the hostname command.
         # SOME DIFF
+        pkgs.htop
         pkgs.nettools
       ];
 

--- a/nixos/modules/services/databases/mysql.nix
+++ b/nixos/modules/services/databases/mysql.nix
@@ -387,6 +387,7 @@ in
       path = [
         # Needed for the mysql_install_db command in the preStart script
         # which calls the hostname command.
+        # SOME DIFF
         pkgs.nettools
       ];
 


### PR DESCRIPTION
DONT MERGE!

it is used to get logs for aarch64-linux

to check what's wrong with https://github.com/NixOS/nixpkgs/pull/388978

I suspect that `388978` is just fine and we only hit an timeout because aarch64 is slower than x86 ... but it never was noticed as hydra do build them and has a bigger timeout limit ...

... so please dont close it until ofborg did run for that architecture and produced the desired log :)