### PR TITLE
python3Packages.httpx: unset SSL_CERT_FILE in hook

### DIFF
--- a/pkgs/development/python-modules/authlib/default.nix
+++ b/pkgs/development/python-modules/authlib/default.nix
@@ -51,11 +51,6 @@ buildPythonPackage rec {
     werkzeug
   ];
 
-  preCheck = ''
-    # httpx 0.28.0+ requires SSL_CERT_FILE or SSL_CERT_DIR
-    export SSL_CERT_FILE=${cacert}/etc/ssl/certs/ca-bundle.crt
-  '';
-
   pythonImportsCheck = [ "authlib" ];
 
   disabledTestPaths = [

--- a/pkgs/development/python-modules/confluent-kafka/default.nix
+++ b/pkgs/development/python-modules/confluent-kafka/default.nix
@@ -85,11 +85,6 @@ buildPythonPackage rec {
     respx
   ] ++ lib.flatten (lib.attrValues optional-dependencies);
 
-  preCheck = ''
-    # httpx since 0.28.0+ depends on SSL_CERT_FILE
-    SSL_CERT_FILE=${cacert}/etc/ssl/certs/ca-bundle.crt
-  '';
-
   pythonImportsCheck = [ "confluent_kafka" ];
 
   disabledTestPaths = [

--- a/pkgs/development/python-modules/httpx/default.nix
+++ b/pkgs/development/python-modules/httpx/default.nix
@@ -108,6 +108,10 @@ buildPythonPackage rec {
 
   __darwinAllowLocalNetworking = true;
 
+  # stdenv's fake SSL_CERT_FILE breaks default http transport constructor with:
+  # FileNotFoundError: [Errno 2] No such file or directory
+  setupHook = ./setup-hook.sh;
+
   meta = with lib; {
     changelog = "https://github.com/encode/httpx/blob/${src.rev}/CHANGELOG.md";
     description = "Next generation HTTP client";

--- a/pkgs/development/python-modules/httpx/setup-hook.sh
+++ b/pkgs/development/python-modules/httpx/setup-hook.sh
@@ -1,0 +1,5 @@
+httpxSslCertFileUnset() {
+    unset SSL_CERT_FILE
+}
+
+postHooks+=(httpxSslCertFileUnset)

--- a/pkgs/development/python-modules/hypercorn/default.nix
+++ b/pkgs/development/python-modules/hypercorn/default.nix
@@ -58,11 +58,6 @@ buildPythonPackage rec {
     pytestCheckHook
   ] ++ lib.flatten (lib.attrValues optional-dependencies);
 
-  preCheck = ''
-    # httpx since 0.28.0+ depends on SSL_CERT_FILE
-    SSL_CERT_FILE=${cacert}/etc/ssl/certs/ca-bundle.crt
-  '';
-
   __darwinAllowLocalNetworking = true;
 
   pythonImportsCheck = [ "hypercorn" ];

--- a/pkgs/development/python-modules/sanic/default.nix
+++ b/pkgs/development/python-modules/sanic/default.nix
@@ -80,9 +80,6 @@ buildPythonPackage rec {
     PATH="$out/bin:$PATH"
     PYTHONPATH=$PWD:$PYTHONPATH
 
-    # httpx since 0.28.0+ depends on SSL_CERT_FILE
-    SSL_CERT_FILE=${cacert}/etc/ssl/certs/ca-bundle.crt
-
     # needed for relative paths for some packages
     cd tests
   '';

--- a/pkgs/development/python-modules/speechrecognition/default.nix
+++ b/pkgs/development/python-modules/speechrecognition/default.nix
@@ -79,11 +79,6 @@ buildPythonPackage rec {
     respx
   ] ++ lib.flatten (lib.attrValues optional-dependencies);
 
-  preCheck = ''
-    # httpx since 0.28.0+ depends on SSL_CERT_FILE
-    SSL_CERT_FILE=${cacert}/etc/ssl/certs/ca-bundle.crt
-  '';
-
   pythonImportsCheck = [ "speech_recognition" ];
 
   disabledTests = [


### PR DESCRIPTION
This fixes downstream test failures. httpx always reads `SSL_CERT_FILE`, stdenv sets it to `/no-cert-file.crt` which does not exist.

Fixes #394380

## Things done

- Built on platform(s)
  - [x] x86_64-linux: `httpx`, others still building
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).