### PR TITLE
nodejs_latest: 23.11.0 -> 24.0.0-rc.2

### DIFF
--- a/doc/release-notes/rl-2505.section.md
+++ b/doc/release-notes/rl-2505.section.md
@@ -185,6 +185,8 @@
 
 - `mkBinaryCache` now defaults to using `zstd` compression for the binary caches it creates. The previous `xz` compression method can be used by passing `compression = "xz";`.
 
+- `nodejs_latest` was updated from 23.x to 24.x. `nodejs_23` has been removed in favor of `nodejs_24`.
+
 - `nodePackages."@commitlint/config-conventional"` has been removed, as it is a library, and projects should depend on it instead.
 
 -  zigbee2mqtt is now available in version 2.x as `zigbee2mqtt_2`. In NixOS 25.11 we'll remove `zigbee2mqtt_1` and default to `zigbee2mqtt_2`. See the [breaking changes](https://github.com/Koenkk/zigbee2mqtt/discussions/24198) announcement for 2.0.0.

--- a/pkgs/by-name/ta/tailwindcss-language-server/package.nix
+++ b/pkgs/by-name/ta/tailwindcss-language-server/package.nix
@@ -2,7 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  nodejs_23,
+  nodejs_latest,
   pnpm_9,
   cacert,
 }:
@@ -33,12 +33,12 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   nativeBuildInputs = [
-    nodejs_23
+    nodejs_latest
     pnpm_9.configHook
   ];
 
   buildInputs = [
-    nodejs_23
+    nodejs_latest
   ];
 
   pnpmWorkspaces = [ "@tailwindcss/language-server..." ];

--- a/pkgs/by-name/wi/windsurf/update/update.mts
+++ b/pkgs/by-name/wi/windsurf/update/update.mts
@@ -1,6 +1,6 @@
 #!/usr/bin/env nix-shell
 /*
-#!nix-shell -i node --pure --packages cacert nodejs_23
+#!nix-shell -i node --pure --packages cacert nodejs_latest
 */
 import * as assert from "node:assert/strict";
 import * as fsPromises from "node:fs/promises";

--- a/pkgs/development/web/nodejs/nodejs.nix
+++ b/pkgs/development/web/nodejs/nodejs.nix
@@ -176,6 +176,8 @@ let
       done
     '';
 
+  downloadDir = if lib.strings.hasInfix "-rc." version then "download/rc" else "dist";
+
   package = stdenv.mkDerivation (
     finalAttrs:
     let
@@ -188,7 +190,7 @@ let
       inherit pname version;
 
       src = fetchurl {
-        url = "https://nodejs.org/dist/v${version}/node-v${version}.tar.xz";
+        url = "https://nodejs.org/${downloadDir}/v${version}/node-v${version}.tar.xz";
         inherit sha256;
       };
 
@@ -519,7 +521,7 @@ let
       passthru.tests = {
         version = testers.testVersion {
           package = self;
-          version = "v${version}";
+          version = "v${lib.head (lib.strings.splitString "-rc." version)}";
         };
       };
 

--- a/pkgs/development/web/nodejs/v24.nix
+++ b/pkgs/development/web/nodejs/v24.nix
@@ -17,8 +17,8 @@ let
 in
 buildNodejs {
   inherit enableNpm;
-  version = "23.11.0";
-  sha256 = "f2c5db21fc5d3c3d78c7e8823bff770cef0da8078c3b5ac4fa6d17d5a41be99d";
+  version = "24.0.0-rc.2";
+  sha256 = "729fca42bb7266031dd020f3935423ea8d4b4e2d119b34b608f1d079e5c1621a";
   patches =
     (
       if (stdenv.hostPlatform.emulatorAvailable buildPackages) then

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4209,14 +4209,14 @@ with pkgs;
   nodejs-slim_22 = callPackage ../development/web/nodejs/v22.nix { enableNpm = false; };
   corepack_22 = hiPrio (callPackage ../development/web/nodejs/corepack.nix { nodejs = nodejs_22; });
 
-  nodejs_23 = callPackage ../development/web/nodejs/v23.nix { };
-  nodejs-slim_23 = callPackage ../development/web/nodejs/v23.nix { enableNpm = false; };
-  corepack_23 = hiPrio (callPackage ../development/web/nodejs/corepack.nix { nodejs = nodejs_23; });
+  nodejs_24 = callPackage ../development/web/nodejs/v24.nix { };
+  nodejs-slim_24 = callPackage ../development/web/nodejs/v24.nix { enableNpm = false; };
+  corepack_24 = hiPrio (callPackage ../development/web/nodejs/corepack.nix { nodejs = nodejs_24; });
 
   # Update this when adding the newest nodejs major version!
-  nodejs_latest = nodejs_23;
-  nodejs-slim_latest = nodejs-slim_23;
-  corepack_latest = hiPrio corepack_23;
+  nodejs_latest = nodejs_24;
+  nodejs-slim_latest = nodejs-slim_24;
+  corepack_latest = hiPrio corepack_24;
 
   buildNpmPackage = callPackage ../build-support/node/build-npm-package { };
 


### PR DESCRIPTION
Opening things now so it can land before the 25.05 freeze. This removes `nodejs_23` (which is now in Maintenance mode, and will be EOL in June, i.e. during 25.05 lifetime) and initiates `nodejs_24` (still RC state, 24.0.0 is scheduled for April 22nd).
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
