### PR TITLE
Nvtop 3.2.0

### DIFF
--- a/pkgs/tools/system/nvtop/build-nvtop.nix
+++ b/pkgs/tools/system/nvtop/build-nvtop.nix
@@ -19,6 +19,8 @@
   panfrost ? false,
   panthor ? false,
   ascend ? false,
+  v3d ? false,
+  tpu ? false,
 }:
 
 let
@@ -34,17 +36,19 @@ let
       }" \
       $out/bin/nvtop
   '';
-  needDrm = (amd || msm || panfrost || panthor);
+  needDrm = (amd || msm || panfrost || panthor || intel);
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "nvtop";
-  version = "3.1.0";
+  version = "3.2.0";
 
+  # between generation of multiple update PRs for each package flavor and manual updates I choose manual updates
+  # nixpkgs-update: no auto update
   src = fetchFromGitHub {
     owner = "Syllo";
     repo = "nvtop";
     rev = finalAttrs.version;
-    hash = "sha256-MkkBY2PR6FZnmRMqv9MWqwPWRgixfkUQW5TWJtHEzwA=";
+    hash = "sha256-8iChT55L2NSnHg8tLIry0rgi/4966MffShE0ib+2ywc=";
   };
 
   cmakeFlags = with lib.strings; [
@@ -58,6 +62,8 @@ stdenv.mkDerivation (finalAttrs: {
     (cmakeBool "PANFROST_SUPPORT" panfrost)
     (cmakeBool "PANTHOR_SUPPORT" panthor)
     (cmakeBool "ASCEND_SUPPORT" ascend)
+    (cmakeBool "V3D_SUPPORT" v3d)
+    (cmakeBool "TPU_SUPPORT" tpu) #requires libtpuinfo which is not packaged yet
   ];
   nativeBuildInputs = [
     cmake

--- a/pkgs/tools/system/nvtop/build-nvtop.nix
+++ b/pkgs/tools/system/nvtop/build-nvtop.nix
@@ -63,7 +63,7 @@ stdenv.mkDerivation (finalAttrs: {
     (cmakeBool "PANTHOR_SUPPORT" panthor)
     (cmakeBool "ASCEND_SUPPORT" ascend)
     (cmakeBool "V3D_SUPPORT" v3d)
-    (cmakeBool "TPU_SUPPORT" tpu) #requires libtpuinfo which is not packaged yet
+    (cmakeBool "TPU_SUPPORT" tpu) # requires libtpuinfo which is not packaged yet
   ];
   nativeBuildInputs = [
     cmake

--- a/pkgs/tools/system/nvtop/build-nvtop.nix
+++ b/pkgs/tools/system/nvtop/build-nvtop.nix
@@ -65,10 +65,14 @@ stdenv.mkDerivation (finalAttrs: {
     (cmakeBool "V3D_SUPPORT" v3d)
     (cmakeBool "TPU_SUPPORT" tpu) # requires libtpuinfo which is not packaged yet
   ];
-  nativeBuildInputs = [
-    cmake
-    gtest
-  ] ++ lib.optional nvidia addDriverRunpath;
+  nativeBuildInputs =
+    [
+      cmake
+    ]
+    ++ lib.optionals finalAttrs.doCheck [
+      gtest
+    ]
+    ++ lib.optional nvidia addDriverRunpath;
 
   buildInputs =
     [ ncurses ]
@@ -85,7 +89,8 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.optionalString needDrm drm-postFixup)
     + (lib.optionalString nvidia "addDriverRunpath $out/bin/nvtop");
 
-  doCheck = true;
+  # https://github.com/Syllo/nvtop/commit/33ec008e26a00227a666ccb11321e9971a50daf8
+  doCheck = !stdenv.hostPlatform.isDarwin;
 
   passthru = {
     tests.version = testers.testVersion {

--- a/pkgs/tools/system/nvtop/default.nix
+++ b/pkgs/tools/system/nvtop/default.nix
@@ -14,7 +14,10 @@ let
   ];
   # these GPU families are partially supported upstream, they are also tricky to build in nixpkgs
   # volunteers with specific hardware needed to build and test these package variants
-  additionalGPUFamilies = [ "ascend" "tpu" ];
+  additionalGPUFamilies = [
+    "ascend"
+    "tpu"
+  ];
   defaultSupport = builtins.listToAttrs (
     # apple can only build on darwin, and it can't build everything else, and vice versa
     builtins.map (gpu: {

--- a/pkgs/tools/system/nvtop/default.nix
+++ b/pkgs/tools/system/nvtop/default.nix
@@ -10,10 +10,11 @@ let
     "nvidia"
     "panfrost"
     "panthor"
+    "v3d"
   ];
   # these GPU families are partially supported upstream, they are also tricky to build in nixpkgs
   # volunteers with specific hardware needed to build and test these package variants
-  additionalGPUFamilies = [ "ascend" ];
+  additionalGPUFamilies = [ "ascend" "tpu" ];
   defaultSupport = builtins.listToAttrs (
     # apple can only build on darwin, and it can't build everything else, and vice versa
     builtins.map (gpu: {

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -1241,11 +1241,6 @@ mapAliases {
   nux = throw "nux has been removed because it has been abandoned for 4 years"; # Added 2025-03-22
   nvidia-podman = throw "podman should use the Container Device Interface (CDI) instead. See https://web.archive.org/web/20240729183805/https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html#configuring-podman"; # Added 2024-08-02
   nvidia-thrust = throw "nvidia-thrust has been removed because the project was deprecated; use cudaPackages.cuda_cccl";
-  nvtop = lib.warnOnInstantiate "nvtop has been renamed to nvtopPackages.full" nvtopPackages.full; # Added 2024-02-25
-  nvtop-amd = lib.warnOnInstantiate "nvtop-amd has been renamed to nvtopPackages.amd" nvtopPackages.amd; # Added 2024-02-25
-  nvtop-nvidia = lib.warnOnInstantiate "nvtop-nvidia has been renamed to nvtopPackages.nvidia" nvtopPackages.nvidia; # Added 2024-02-25
-  nvtop-intel = lib.warnOnInstantiate "nvtop-intel has been renamed to nvtopPackages.intel" nvtopPackages.intel; # Added 2024-02-25
-  nvtop-msm = lib.warnOnInstantiate "nvtop-msm has been renamed to nvtopPackages.msm" nvtopPackages.msm; # Added 2024-02-25
 
   ### O ###
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

* Updated nvtop based on ryantm automated PR https://github.com/NixOS/nixpkgs/pull/394325.
* Added support for V3D and TPU gpu architectures to the package
* Removed old aliases
* Disabled ryantm bot for the package with a comment, since update frequency is moderate and usually requires manual intervention anyway, and there is no simple way to disable an update for all packages except one (full).
* Tested full and amd variants on my laptop. As usual, some testing from folks with different gpu vendors is desirable.

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
