### PR TITLE
android-file-transfer: 4.3 -> 4.4

### DIFF
--- a/pkgs/tools/filesystems/android-file-transfer/darwin-dont-vendor-dependencies.patch
+++ b/pkgs/tools/filesystems/android-file-transfer/darwin-dont-vendor-dependencies.patch
@@ -1,21 +1,21 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 8b05ab0..81e31f5 100644
+index 574b354..1a62874 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -236,16 +236,6 @@ endif()
-
- if (''${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+@@ -254,16 +254,6 @@ endif()
+ 
+ if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
  	set(MACOSX_BUNDLE_LIBS)
 -	if (OPENSSL_FOUND)
 -		list(APPEND MACOSX_BUNDLE_LIBS /usr/local/opt/openssl@1.1/lib/libcrypto.1.1.dylib)
 -	endif()
 -	if (TAGLIB_FOUND)
--		list(APPEND MACOSX_BUNDLE_LIBS /usr/local/opt/taglib/lib/libtag.1.dylib)
+-		list(APPEND MACOSX_BUNDLE_LIBS /usr/local/opt/taglib/lib/libtag.2.dylib)
 -	endif()
 -	if (FUSE_FOUND)
 -		list(APPEND MACOSX_BUNDLE_LIBS /usr/local/lib/libosxfuse.2.dylib)
 -	endif()
 -
  	set(MACOSX_BUNDLE_LIBS_INSTALL)
- 	set(MACOSX_BUNDLE_ROOT_DIR "''${CMAKE_INSTALL_PREFIX}/''${CMAKE_PROJECT_NAME}.app")
- 	message(STATUS "bundle root dir: ''${MACOSX_BUNDLE_ROOT_DIR}")
+ 	set(MACOSX_BUNDLE_ROOT_DIR "${CMAKE_INSTALL_PREFIX}/${CMAKE_PROJECT_NAME}.app")
+ 	message(STATUS "bundle root dir: ${MACOSX_BUNDLE_ROOT_DIR}")

--- a/pkgs/tools/filesystems/android-file-transfer/default.nix
+++ b/pkgs/tools/filesystems/android-file-transfer/default.nix
@@ -14,13 +14,13 @@
 
 mkDerivation rec {
   pname = "android-file-transfer";
-  version = "4.3";
+  version = "4.4";
 
   src = fetchFromGitHub {
     owner = "whoozle";
     repo = "android-file-transfer-linux";
     rev = "v${version}";
-    sha256 = "sha256-UOARMtOnG6tekmOsIWRZbl2y32mR0kPD6w7IHRG8VsU=";
+    sha256 = "sha256-1euoWM9KMauOkAp7g1FvY4olMiOg+La/Uk1QlQ3mKi8=";
   };
 
   patches = [ ./darwin-dont-vendor-dependencies.patch ];


### PR DESCRIPTION
## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
