### PR TITLE
maintainers: drop `dmrauh`

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6261,12 +6261,6 @@
     githubId = 875324;
     name = "David Johnson";
   };
-  dmrauh = {
-    email = "dmrauh@posteo.de";
-    github = "dmrauh";
-    githubId = 37698547;
-    name = "Dominik Michael Rauh";
-  };
   dmvianna = {
     email = "dmlvianna@gmail.com";
     github = "dmvianna";

--- a/pkgs/by-name/gr/gretl/package.nix
+++ b/pkgs/by-name/gr/gretl/package.nix
@@ -62,7 +62,7 @@ stdenv.mkDerivation (finalAttrs: {
       gretl is a cross-platform software package for econometric analysis,
       written in the C programming language.
     '';
-    maintainers = with lib.maintainers; [ dmrauh ];
+    maintainers = with lib.maintainers; [ ];
     platforms = lib.platforms.all;
   };
 })

--- a/pkgs/development/python-modules/mnist/default.nix
+++ b/pkgs/development/python-modules/mnist/default.nix
@@ -36,6 +36,6 @@ buildPythonPackage rec {
     description = "Python utilities to download and parse the MNIST dataset";
     homepage = "https://github.com/datapythonista/mnist";
     license = licenses.bsd3;
-    maintainers = with maintainers; [ dmrauh ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/simpy/default.nix
+++ b/pkgs/development/python-modules/simpy/default.nix
@@ -57,7 +57,6 @@ buildPythonPackage rec {
     description = "Process-based discrete-event simulation framework based on standard Python";
     license = [ lib.licenses.mit ];
     maintainers = with lib.maintainers; [
-      dmrauh
       shlevy
     ];
   };

--- a/pkgs/development/python-modules/webdavclient3/default.nix
+++ b/pkgs/development/python-modules/webdavclient3/default.nix
@@ -49,7 +49,7 @@ buildPythonPackage rec {
     description = "Easy to use WebDAV Client for Python 3.x";
     homepage = "https://github.com/ezhov-evgeny/webdav-client-python-3";
     license = licenses.mit;
-    maintainers = with maintainers; [ dmrauh ];
+    maintainers = with maintainers; [ ];
     mainProgram = "wdc";
   };
 }


### PR DESCRIPTION
Opening this PR following the work done in #394954 and #395221. I noticed that @dmrauh hasn't interacted with the `NixOS/nixpkgs` repository in the past four years. His Github profile doesn't show much activity either.

Reference to the last interactions: https://github.com/search?q=repo%3ANixOS%2Fnixpkgs+dmrauh&type=code

@dmrauh: if you happen to see this, could you kindly let us know if you're still interested in being involved with the project? Thanks!

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
