### PR TITLE
various: fix missing libX11 after SDL2 replacement

### DIFF
--- a/pkgs/applications/audio/schismtracker/default.nix
+++ b/pkgs/applications/audio/schismtracker/default.nix
@@ -7,6 +7,7 @@
   perl,
   pkg-config,
   SDL2,
+  libX11,
   libXext,
   Cocoa,
   utf8proc,
@@ -57,6 +58,7 @@ stdenv.mkDerivation rec {
   buildInputs =
     [
       SDL2
+      libX11
       utf8proc
     ]
     ++ lib.optionals stdenv.hostPlatform.isLinux [

--- a/pkgs/applications/editors/libresprite/default.nix
+++ b/pkgs/applications/editors/libresprite/default.nix
@@ -15,6 +15,7 @@
   libpng,
   libwebp,
   libarchive,
+  libX11,
   pixman,
   tinyxml-2,
   zlib,
@@ -56,6 +57,7 @@ stdenv.mkDerivation (finalAttrs: {
       libpng
       libwebp
       libarchive
+      libX11
       pixman
       tinyxml-2
       zlib

--- a/pkgs/applications/graphics/vengi-tools/default.nix
+++ b/pkgs/applications/graphics/vengi-tools/default.nix
@@ -20,6 +20,7 @@
   libjpeg,
   libuuid,
   libuv,
+  libX11,
   lua5_4,
   lzfse,
   opencl-headers,
@@ -68,6 +69,7 @@ stdenv.mkDerivation (finalAttrs: {
       lua5_4
       lzfse
       SDL2
+      libX11
       SDL2_mixer
     ]
     ++ lib.optional stdenv.hostPlatform.isLinux wayland-protocols

--- a/pkgs/applications/networking/browsers/lagrange/default.nix
+++ b/pkgs/applications/networking/browsers/lagrange/default.nix
@@ -9,6 +9,7 @@
   harfbuzz,
   libogg,
   libwebp,
+  libX11,
   mpg123,
   opusfile,
   SDL2,
@@ -44,6 +45,7 @@ stdenv.mkDerivation (finalAttrs: {
       harfbuzz
       libogg
       libwebp
+      libX11
       mpg123
       opusfile
       SDL2

--- a/pkgs/by-name/ar/aranym/package.nix
+++ b/pkgs/by-name/ar/aranym/package.nix
@@ -4,6 +4,7 @@
   autoreconfHook,
   fetchFromGitHub,
   libGLU,
+  libX11,
   pkg-config,
   stdenv,
 }:
@@ -26,6 +27,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   buildInputs = [
     libGLU
+    libX11
     SDL2
   ];
 

--- a/pkgs/by-name/dh/dhewm3/package.nix
+++ b/pkgs/by-name/dh/dhewm3/package.nix
@@ -10,6 +10,7 @@
   libjpeg,
   libogg,
   libvorbis,
+  libX11,
   openal,
   curl,
   copyDesktopItems,
@@ -44,6 +45,7 @@ stdenv.mkDerivation rec {
     SDL2
     libGLU
     libGL
+    libX11
     zlib
     libjpeg
     libogg

--- a/pkgs/by-name/et/etlegacy-unwrapped/package.nix
+++ b/pkgs/by-name/et/etlegacy-unwrapped/package.nix
@@ -15,6 +15,7 @@
   libogg,
   libpng,
   libtheora,
+  libX11,
   lua5_4,
   minizip,
   openal,
@@ -62,6 +63,7 @@ stdenv.mkDerivation {
     libogg
     libpng
     libtheora
+    libX11
     lua5_4
     minizip
     openal

--- a/pkgs/by-name/ez/ezquake/package.nix
+++ b/pkgs/by-name/ez/ezquake/package.nix
@@ -9,6 +9,7 @@
   libjpeg,
   libGLU,
   libGL,
+  libX11,
   libsndfile,
   libXxf86vm,
   pcre,
@@ -40,6 +41,7 @@ stdenv.mkDerivation rec {
     libGLU
     libGL
     libsndfile
+    libX11
     libXxf86vm
     pcre
     SDL2

--- a/pkgs/by-name/fl/flex-launcher/package.nix
+++ b/pkgs/by-name/fl/flex-launcher/package.nix
@@ -4,6 +4,7 @@
   SDL2,
   SDL2_ttf,
   SDL2_image,
+  libX11,
   cmake,
   validatePkgConfig,
   inih,
@@ -31,6 +32,7 @@ stdenv.mkDerivation (finalAttrs: {
     SDL2
     SDL2_ttf
     SDL2_image
+    libX11
     inih
   ];
 

--- a/pkgs/by-name/fu/furnace/package.nix
+++ b/pkgs/by-name/fu/furnace/package.nix
@@ -63,6 +63,7 @@ stdenv.mkDerivation (finalAttrs: {
       libsndfile
       rtmidi
       SDL2
+      libX11
       zlib
       portaudio
     ]

--- a/pkgs/by-name/ge/gemrb/package.nix
+++ b/pkgs/by-name/ge/gemrb/package.nix
@@ -15,6 +15,7 @@
   libpng,
   libvlc,
   libvorbis,
+  libX11,
   openal,
   python3,
   zlib,
@@ -60,6 +61,7 @@ stdenv.mkDerivation (finalAttrs: {
     libpng
     libvlc
     libvorbis
+    libX11
     openal
     python3
     zlib

--- a/pkgs/by-name/go/gource/package.nix
+++ b/pkgs/by-name/go/gource/package.nix
@@ -13,6 +13,7 @@
   glew,
   libGLU,
   libGL,
+  libX11,
   boost,
   glm,
   tinyxml,
@@ -43,6 +44,7 @@ stdenv.mkDerivation rec {
     SDL2_image
     libGLU
     libGL
+    libX11
     boost
     glm
     freetype

--- a/pkgs/by-name/lo/logstalgia/package.nix
+++ b/pkgs/by-name/lo/logstalgia/package.nix
@@ -12,6 +12,7 @@
   glew,
   libGLU,
   libGL,
+  libX11,
   boost,
   glm,
   freetype,
@@ -33,6 +34,7 @@ stdenv.mkDerivation rec {
     ftgl
     libpng
     libjpeg
+    libX11
     pcre
     SDL2_image
     libGLU

--- a/pkgs/by-name/ma/manaplus/package.nix
+++ b/pkgs/by-name/ma/manaplus/package.nix
@@ -13,6 +13,7 @@
   curl,
   libxml2,
   libpng,
+  libX11,
   pkg-config,
   libGL,
   autoreconfHook,
@@ -53,6 +54,7 @@ stdenv.mkDerivation (finalAttrs: {
     curl
     libGL
     libpng
+    libX11
     libxml2
     physfs
     zlib

--- a/pkgs/by-name/me/megaglest/package.nix
+++ b/pkgs/by-name/me/megaglest/package.nix
@@ -117,6 +117,7 @@ stdenv.mkDerivation {
   buildInputs = [
     curl
     SDL2
+    xorg.libX11
     xercesc
     openal
     lua

--- a/pkgs/by-name/op/openjk/package.nix
+++ b/pkgs/by-name/op/openjk/package.nix
@@ -9,6 +9,7 @@
   zlib,
   libpng,
   libGL,
+  libX11,
   SDL2,
   unstableGitUpdater,
 }:
@@ -64,6 +65,7 @@ stdenv.mkDerivation {
     zlib
     libpng
     libGL
+    libX11
     SDL2
   ];
 

--- a/pkgs/by-name/op/openmsx/package.nix
+++ b/pkgs/by-name/op/openmsx/package.nix
@@ -14,6 +14,7 @@
   libpng,
   libtheora,
   libvorbis,
+  libX11,
   python3,
   tcl,
   zlib,
@@ -40,6 +41,7 @@ stdenv.mkDerivation (finalAttrs: {
     SDL2
     SDL2_image
     SDL2_ttf
+    libX11
     alsa-lib
     freetype
     glew

--- a/pkgs/by-name/op/openrw/package.nix
+++ b/pkgs/by-name/op/openrw/package.nix
@@ -16,6 +16,7 @@
   libGL,
   libGLU,
   libmad,
+  libX11,
   openal,
 
   unstableGitUpdater,
@@ -52,6 +53,7 @@ stdenv.mkDerivation {
     libGL
     libGLU
     libmad
+    libX11
     openal
   ];
 

--- a/pkgs/by-name/pp/ppsspp/package.nix
+++ b/pkgs/by-name/pp/ppsspp/package.nix
@@ -9,6 +9,7 @@
   libffi,
   libsForQt5,
   libzip,
+  libX11,
   makeDesktopItem,
   makeWrapper,
   pkg-config,
@@ -69,6 +70,7 @@ stdenv.mkDerivation (finalAttrs: {
   buildInputs =
     [
       SDL2
+      libX11
       glew
       libzip
       zlib

--- a/pkgs/by-name/ri/rigel-engine/package.nix
+++ b/pkgs/by-name/ri/rigel-engine/package.nix
@@ -3,6 +3,7 @@
   stdenv,
   fetchFromGitHub,
   cmake,
+  libX11,
   SDL2,
   SDL2_mixer,
   buildOpenGLES ? false,
@@ -25,6 +26,7 @@ stdenv.mkDerivation {
   ];
 
   buildInputs = [
+    libX11
     SDL2
     SDL2_mixer
   ];

--- a/pkgs/by-name/ta/tangerine/package.nix
+++ b/pkgs/by-name/ta/tangerine/package.nix
@@ -6,6 +6,7 @@
   cmake,
   ncurses,
   SDL2,
+  libX11,
 }:
 
 stdenv.mkDerivation {
@@ -31,6 +32,7 @@ stdenv.mkDerivation {
   buildInputs = [
     ncurses
     SDL2
+    libX11
   ];
 
   meta = with lib; {

--- a/pkgs/by-name/tr/trigger-control/package.nix
+++ b/pkgs/by-name/tr/trigger-control/package.nix
@@ -7,6 +7,7 @@
   makeWrapper,
   pkg-config,
   SDL2,
+  libX11,
   dbus,
   libdecor,
   libnotify,
@@ -36,6 +37,7 @@ stdenv.mkDerivation (finalAttrs: {
   buildInputs =
     [
       SDL2
+      libX11
       dbus
       libnotify
     ]

--- a/pkgs/by-name/wa/wargus/stratagus.nix
+++ b/pkgs/by-name/wa/wargus/stratagus.nix
@@ -4,10 +4,10 @@
   fetchFromGitHub,
   cmake,
   pkg-config,
-  makeWrapper,
   zlib,
   bzip2,
   libpng,
+  libX11,
   lua5_1,
   toluapp,
   SDL2,
@@ -41,6 +41,7 @@ stdenv.mkDerivation rec {
     SDL2_image
     SDL2_mixer
     libGL
+    libX11
   ];
   cmakeFlags = [
     "-DCMAKE_CXX_FLAGS=-Wno-error=format-overflow"

--- a/pkgs/development/libraries/mlt/default.nix
+++ b/pkgs/development/libraries/mlt/default.nix
@@ -14,6 +14,7 @@
   libsamplerate,
   libvorbis,
   libxml2,
+  libX11,
   makeWrapper,
   movit,
   opencv4,
@@ -109,9 +110,11 @@ stdenv.mkDerivation rec {
     ]
     ++ lib.optionals enableSDL1 [
       SDL
+      libX11
     ]
     ++ lib.optionals enableSDL2 [
       SDL2
+      libX11
     ];
 
   outputs = [

--- a/pkgs/games/exult/default.nix
+++ b/pkgs/games/exult/default.nix
@@ -10,6 +10,7 @@
   libogg,
   libtool,
   libvorbis,
+  libX11,
   pkg-config,
   zlib,
   enableTools ? false,
@@ -48,6 +49,7 @@ stdenv.mkDerivation rec {
       SDL2
       libogg
       libvorbis
+      libX11
       zlib
     ]
     ++ lib.optionals stdenv.hostPlatform.isDarwin [

--- a/pkgs/games/scummvm/default.nix
+++ b/pkgs/games/scummvm/default.nix
@@ -16,6 +16,7 @@
   libvorbis,
   libGLU,
   libGL,
+  libX11,
   SDL2,
   zlib,
   Cocoa,
@@ -65,6 +66,7 @@ stdenv.mkDerivation rec {
       libtheora
       libvorbis
       SDL2
+      libX11
       zlib
     ];
 

--- a/pkgs/games/stuntrally/default.nix
+++ b/pkgs/games/stuntrally/default.nix
@@ -8,6 +8,7 @@
   mygui,
   ois,
   SDL2,
+  libX11,
   libvorbis,
   pkg-config,
   makeWrapper,
@@ -72,6 +73,7 @@ stdenv.mkDerivation rec {
     stuntrally_mygui
     ois
     SDL2
+    libX11
     libvorbis
     enet
     libXcursor

--- a/pkgs/games/super-tux-kart/default.nix
+++ b/pkgs/games/super-tux-kart/default.nix
@@ -16,6 +16,7 @@
   freetype,
   libjpeg,
   libpng,
+  libX11,
   harfbuzz,
   mcpp,
   wiiuse,
@@ -106,6 +107,7 @@ stdenv.mkDerivation rec {
       curl
       libjpeg
       libpng
+      libX11
       harfbuzz
       mcpp
       wiiuse


### PR DESCRIPTION
SDL2 propagated `libX11`. After https://github.com/NixOS/nixpkgs/pull/393386, various packages are missing `libX11`. Specifically those packages using the `SDL_syswm.h` header.

This PR adds `libX11` back to all packages with sources containing a reference to the critical header file.
Please note some of these fixes might not be required if the header file is never loaded in nix! There is two ways to go about this: Either just add `libX11` to restore the old status (doesn't break things), or go through all the 80-something packages testing whether they need fixing. I am happy to do either.

pinging @K900 and @marcin-serwin who discussed the drop of libX11 from propagation.

I am opening this as a draft until we decided whether we want to specifically only add this to the packages actually loading the `SDL_syswm` header.

List of packages containing code referring to the header: https://termbin.com/ajqw

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
