### PR TITLE
zzuf: fix build with gcc14, modernize

### DIFF
--- a/pkgs/by-name/zz/zzuf/package.nix
+++ b/pkgs/by-name/zz/zzuf/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  fetchpatch,
   pkg-config,
   autoreconfHook,
 }:
@@ -16,6 +17,17 @@ stdenv.mkDerivation rec {
     rev = "v${version}";
     sha256 = "0li1s11xf32dafxq1jbnc8c63313hy9ry09dja2rymk9mza4x2n9";
   };
+
+  patches = [
+    # fix build with gcc14
+    # https://src.fedoraproject.org/rpms/zzuf/c/998c7e5e632ea4c635a53437a01bfb48cbd744ac
+    (fetchpatch {
+      url = "https://src.fedoraproject.org/rpms/zzuf/raw/998c7e5e632ea4c635a53437a01bfb48cbd744ac/f/zzuf-zzat-c99.patch";
+      hash = "sha256-pQQzwsIjKg+9g+dnhFGn2PUlxHlQ5Mj+e4a1D1k2oEo=";
+    })
+    # https://src.fedoraproject.org/rpms/zzuf/c/ca7e406989e7ff461600084f2277ad15a8c00058
+    ./zzuf-glibc.patch
+  ];
 
   nativeBuildInputs = [
     pkg-config

--- a/pkgs/by-name/zz/zzuf/package.nix
+++ b/pkgs/by-name/zz/zzuf/package.nix
@@ -7,15 +7,15 @@
   autoreconfHook,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "zzuf";
   version = "0.15";
 
   src = fetchFromGitHub {
     owner = "samhocevar";
     repo = "zzuf";
-    rev = "v${version}";
-    sha256 = "0li1s11xf32dafxq1jbnc8c63313hy9ry09dja2rymk9mza4x2n9";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-yYpO1K9pVp+Fki0Bn5OHI4xhGGJ2yYC7U00M10PQIVI=";
   };
 
   patches = [
@@ -34,11 +34,11 @@ stdenv.mkDerivation rec {
     autoreconfHook
   ];
 
-  meta = with lib; {
+  meta = {
     description = "Transparent application input fuzzer";
     homepage = "http://caca.zoy.org/wiki/zzuf";
-    license = licenses.wtfpl;
-    platforms = platforms.linux;
-    maintainers = with maintainers; [ lihop ];
+    license = lib.licenses.wtfpl;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ lihop ];
   };
-}
+})

--- a/pkgs/by-name/zz/zzuf/zzuf-glibc.patch
+++ b/pkgs/by-name/zz/zzuf/zzuf-glibc.patch
@@ -1,0 +1,13 @@
+diff --git a/configure.ac b/configure.ac
+index 0915a5c..8ba501c 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -79,7 +79,6 @@ AC_CHECK_FUNCS(mmap getpagesize)
+ AC_CHECK_FUNCS(getc_unlocked getchar_unlocked fgetc_unlocked fread_unlocked fgets_unlocked)
+ AC_CHECK_FUNCS(__getdelim __srefill __filbuf __srget __uflow)
+ AC_CHECK_FUNCS(open64 lseek64 mmap64 fopen64 freopen64 ftello64 fseeko64 fsetpos64)
+-AC_CHECK_FUNCS(__open64 __lseek64 __fopen64 __freopen64 __ftello64 __fseeko64 __fsetpos64)
+ AC_CHECK_FUNCS(__fgets_chk __fgets_unlocked_chk __fread_chk __fread_unlocked_chk __read_chk __recv_chk __recvfrom_chk)
+ AC_CHECK_FUNCS(CreateFileA CreateFileW ReOpenFile ReadFile CloseHandle)
+ AC_CHECK_FUNCS(AllocConsole AttachConsole SetConsoleMode WriteConsoleOutputA WriteConsoleOutputW)
+


### PR DESCRIPTION
zzuf: fix build with gcc14

- add patch from fedora:
https://src.fedoraproject.org/rpms/zzuf/c/998c7e5e632ea4c635a53437a01bfb48cbd744ac
fixing `implicit-function-declaration` error:
```
zzat.c: In function 'run':
zzat.c:482:32: error: implicit declaration of function '_IO_getc'
  482 |             MY_FREAD(ch = (n = _IO_getc(f)), &ch, (n != EOF));
      |                                ^~~~~~~~
```

- add patch from fedora (vendored because patch is in format that does not apply with `fetchpatch`):
https://src.fedoraproject.org/rpms/zzuf/c/ca7e406989e7ff461600084f2277ad15a8c00058
fixing `implicit-function-declaration` error:
```
zzat.c:565:26: error: implicit declaration of function '__fseeko64'; did you mean 'fseeko64'?
  565 |             MY_FSEEK(l = __fseeko64(f, l1, SEEK_CUR),
      |                          ^~~~~~~~~~
```

---

zzuf: modernize

- replace `rec` with `finalAttrs`
- remove `with lib;` from `meta`
- replace `rev` with `tag` in `src`
- replace `sha256` with `hash` in `src`

---

Fixes build failure of `zzuf`, fails since `2025-01-14` (update to GCC 14 in #356812):
https://hydra.nixos.org/job/nixos/trunk-combined/nixpkgs.zzuf.x86_64-linux
https://hydra.nixos.org/build/282627928

Log:
```text
zzat.c: In function 'run':
zzat.c:482:32: error: implicit declaration of function '_IO_getc' [8;;https://gcc.gnu.org/onlinedocs/gcc-14.2.0/gcc/Warning-Options.html#index-Wimplicit-function-declaration-Wimplicit-function-declaration8;;]
  482 |             MY_FREAD(ch = (n = _IO_getc(f)), &ch, (n != EOF));
      |                                ^~~~~~~~
...
zzat.c:565:26: error: implicit declaration of function '__fseeko64'; did you mean 'fseeko64'? [8;;https://gcc.gnu.org/onlinedocs/gcc-14.2.0/gcc/Warning-Options.html#index-Wimplicit-function-declaration-Wimplicit-function-declaration8;;]
  565 |             MY_FSEEK(l = __fseeko64(f, l1, SEEK_CUR),
      |                          ^~~~~~~~~~
...
make[2]: *** [Makefile:660: zzat.o] Error 1
make[2]: Leaving directory '/build/source/src'
make[1]: *** [Makefile:420: all-recursive] Error 1
make[1]: Leaving directory '/build/source'
make: *** [Makefile:352: all] Error 2
```

Second patch does not apply as is with `fetchpatch`, because of a weird format:
https://src.fedoraproject.org/rpms/zzuf/raw/ca7e406989e7ff461600084f2277ad15a8c00058/f/zzuf-0.15-glibc.patch
(removed same line as patch does and `git diff` generated one that applies)


Tracking issue: #388196


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
