### PR TITLE
mkvtoolnix: 87.0 -> 91.0

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10672,8 +10672,6 @@ with pkgs;
       ;
   };
 
-  mkvtoolnix = qt6Packages.callPackage ../applications/video/mkvtoolnix { };
-
   mkvtoolnix-cli = mkvtoolnix.override {
     withGUI = false;
   };


### PR DESCRIPTION
- Update mkvtoolnix from 87.0 to 91.0
- Switch source URL to Codeberg (upstream moved)
- Update hash for new release
- Remove unused libiconv dependency
- Use Qt6 components (qt6.qtbase/qtmultimedia)
- Add nix-update-script
- Fix meta attributes
- Move to pkgs/by-name

Closes #395490
Maintainers: @codyopel @rnhmjoj