### PR TITLE
nixos/glance: allow specifying secret settings

### DIFF
--- a/nixos/modules/services/web-apps/glance.nix
+++ b/nixos/modules/services/web-apps/glance.nix
@@ -8,15 +8,27 @@ let
   cfg = config.services.glance;
 
   inherit (lib)
-    mkEnableOption
-    mkPackageOption
-    mkOption
-    mkIf
+    catAttrs
+    concatMapStrings
     getExe
+    mkEnableOption
+    mkIf
+    mkOption
+    mkPackageOption
     types
     ;
 
+  inherit (builtins)
+    concatLists
+    isAttrs
+    isList
+    attrNames
+    getAttr
+    ;
+
   settingsFormat = pkgs.formats.yaml { };
+  settingsFile = settingsFormat.generate "glance.yaml" cfg.settings;
+  mergedSettingsFile = "/run/glance/glance.yaml";
 in
 {
   options.services.glance = {
@@ -69,7 +81,9 @@ in
                       { type = "calendar"; }
                       {
                         type = "weather";
-                        location = "Nivelles, Belgium";
+                        location = {
+                          _secret = "/var/lib/secrets/glance/location";
+                        };
                       }
                     ];
                   }
@@ -84,6 +98,13 @@ in
         Configuration written to a yaml file that is read by glance. See
         <https://github.com/glanceapp/glance/blob/main/docs/configuration.md>
         for more.
+
+        Settings containing secret data should be set to an
+        attribute set containing the attribute
+        <literal>_secret</literal> - a string pointing to a file
+        containing the value the option should be set to. See the
+        example in `services.glance.settings.pages` at the weather widget
+        with a location secret to get a better picture of this.
       '';
     };
 
@@ -102,13 +123,41 @@ in
       description = "Glance feed dashboard server";
       wantedBy = [ "multi-user.target" ];
       after = [ "network.target" ];
+      path = [ pkgs.replace-secret ];
 
       serviceConfig = {
-        ExecStart =
+        ExecStartPre =
           let
-            glance-yaml = settingsFormat.generate "glance.yaml" cfg.settings;
+            findSecrets =
+              data:
+              if isAttrs data then
+                if data ? _secret then
+                  [ data ]
+                else
+                  concatLists (map (attr: findSecrets (getAttr attr data)) (attrNames data))
+              else if isList data then
+                concatLists (map findSecrets data)
+              else
+                [ ];
+            secretPaths = catAttrs "_secret" (findSecrets cfg.settings);
+            mkSecretReplacement = secretPath: ''
+              replace-secret ${
+                lib.escapeShellArgs [
+                  "_secret: ${secretPath}"
+                  secretPath
+                  mergedSettingsFile
+                ]
+              }
+            '';
+            secretReplacements = concatMapStrings mkSecretReplacement secretPaths;
           in
-          "${getExe cfg.package} --config ${glance-yaml}";
+          # Use "+" to run as root because the secrets may not be accessible to glance
+          "+"
+          + pkgs.writeShellScript "glance-start-pre" ''
+            install -m 600 -o $USER ${settingsFile} ${mergedSettingsFile}
+            ${secretReplacements}
+          '';
+        ExecStart = "${getExe cfg.package} --config ${mergedSettingsFile}";
         WorkingDirectory = "/var/lib/glance";
         StateDirectory = "glance";
         RuntimeDirectory = "glance";

--- a/nixos/tests/glance.nix
+++ b/nixos/tests/glance.nix
@@ -5,19 +5,47 @@
 
   nodes = {
     machine_default =
-      { pkgs, ... }:
+      { ... }:
       {
         services.glance = {
           enable = true;
         };
       };
 
-    machine_custom_port =
+    machine_configured =
       { pkgs, ... }:
+      let
+        # Do not use this in production. This will make the secret world-readable
+        # in the Nix store
+        secrets.glance-location.path = builtins.toString (
+          pkgs.writeText "location-secret" "Nivelles, Belgium"
+        );
+      in
       {
         services.glance = {
           enable = true;
-          settings.server.port = 5678;
+          settings = {
+            server.port = 5678;
+            pages = [
+              {
+                name = "Home";
+                columns = [
+                  {
+                    size = "full";
+                    widgets = [
+                      { type = "calendar"; }
+                      {
+                        type = "weather";
+                        location = {
+                          _secret = secrets.glance-location.path;
+                        };
+                      }
+                    ];
+                  }
+                ];
+              }
+            ];
+          };
         };
       };
   };
@@ -25,23 +53,31 @@
   extraPythonPackages =
     p: with p; [
       beautifulsoup4
+      pyyaml
+      types-pyyaml
       types-beautifulsoup4
     ];
 
   testScript = ''
     from bs4 import BeautifulSoup
+    import yaml
 
     machine_default.start()
     machine_default.wait_for_unit("glance.service")
     machine_default.wait_for_open_port(8080)
 
-    machine_custom_port.start()
-    machine_custom_port.wait_for_unit("glance.service")
-    machine_custom_port.wait_for_open_port(5678)
+    machine_configured.start()
+    machine_configured.wait_for_unit("glance.service")
+    machine_configured.wait_for_open_port(5678)
 
     soup = BeautifulSoup(machine_default.succeed("curl http://localhost:8080"))
     expected_version = "v${config.nodes.machine_default.services.glance.package.version}"
     assert any(a.text == expected_version for a in soup.select(".footer a"))
+
+    yaml_contents = machine_configured.succeed("cat /run/glance/glance.yaml")
+    yaml_parsed = yaml.load(yaml_contents, Loader=yaml.FullLoader)
+    location = yaml_parsed["pages"][0]["columns"][0]["widgets"][1]["location"]
+    assert location == "Nivelles, Belgium"
   '';
 
   meta.maintainers = [ lib.maintainers.drupol ];


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This allows users to specify any glance settings value as secret, by wrapping the file path in an object with a special `_secret` name. These files will be read by root, and a final `glance.yaml` file will be generated that has the secrets substituted, it is only accessible to glance. 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
