### PR TITLE
koodo-reader: 1.7.4 -> 2.0.9

### DIFF
--- a/pkgs/by-name/ko/koodo-reader/package.nix
+++ b/pkgs/by-name/ko/koodo-reader/package.nix
@@ -3,44 +3,54 @@
   stdenv,
   fetchFromGitHub,
   fetchYarnDeps,
+  makeDesktopItem,
+
+  copyDesktopItems,
+  cctools,
+  makeWrapper,
+  nodejs,
   yarnConfigHook,
   yarnBuildHook,
-  nodejs,
-  makeDesktopItem,
-  copyDesktopItems,
-  makeWrapper,
   wrapGAppsHook3,
-  electron,
+  xcbuild,
+
+  electron_35,
 }:
 
+let
+  electron = electron_35; # don't use latest electron to avoid going over the supported abi numbers
+in
 stdenv.mkDerivation (finalAttrs: {
   pname = "koodo-reader";
-  version = "1.7.4";
+  version = "2.0.9";
 
   src = fetchFromGitHub {
     owner = "troyeguo";
     repo = "koodo-reader";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-rLW5FS8xM7Z49AaLq0KzBCoRgAVxwTDCHQFdIaEyygA=";
+    hash = "sha256-t93yRd9TrtGZogjpSy0Bse0cM5BFyMaSxFYQFZZyvPM=";
   };
 
   offlineCache = fetchYarnDeps {
-    yarnLock = "${finalAttrs.src}/yarn.lock";
-    hash = "sha256-58mxYt2wD6SGzhvo9c44CPmdX+/tLnbJCMPafo4txbY=";
+    inherit (finalAttrs) src;
+    hash = "sha256-NCnIayneTJqkNHHO98iS4bp7mlV3WHXF9Z7F5zKpD8I=";
   };
 
   nativeBuildInputs = [
     makeWrapper
+    nodejs
+    (nodejs.python.withPackages (ps: [ ps.setuptools ]))
     yarnConfigHook
     yarnBuildHook
-    nodejs
   ]
   ++ lib.optionals (!stdenv.hostPlatform.isDarwin) [
     copyDesktopItems
     wrapGAppsHook3
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    cctools
+    xcbuild
   ];
-
-  dontWrapGApps = true;
 
   env.ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
 
@@ -50,6 +60,14 @@ stdenv.mkDerivation (finalAttrs: {
   postBuild = ''
     cp -r ${electron.dist} electron-dist
     chmod -R u+w electron-dist
+
+    # we need to build cpu-features with the non-electron headers first
+    export npm_config_nodedir=${nodejs}
+    npm rebuild --verbose cpu-features
+
+    export npm_config_nodedir=${electron.headers}
+    npm run postinstall
+
     yarn --offline run electron-builder --dir \
       -c.electronDist=electron-dist \
       -c.electronVersion=${electron.version}
@@ -74,6 +92,8 @@ stdenv.mkDerivation (finalAttrs: {
 
     runHook postInstall
   '';
+
+  dontWrapGApps = true;
 
   # we use makeShellWrapper instead of the makeBinaryWrapper provided by wrapGAppsHook for proper shell variable expansion
   postFixup = lib.optionalString (!stdenv.hostPlatform.isDarwin) ''


### PR DESCRIPTION
The app now has node-gyp based native deps so I needed to add python, electron-headers, and some other hacks.

https://github.com/koodo-reader/koodo-reader/releases

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
