### PR TITLE
libloot: 0.24.5 -> 0.25.5; limo: 1.1 -> 1.2

### DIFF
--- a/pkgs/by-name/li/libloot/package.nix
+++ b/pkgs/by-name/li/libloot/package.nix
@@ -24,7 +24,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "libloot";
-  version = "0.24.5";
+  version = "0.25.5";
   # Note: don't forget to also update the package versions in the passthru section
 
   outputs = [
@@ -36,7 +36,7 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "loot";
     repo = "libloot";
     rev = "refs/tags/${finalAttrs.version}";
-    hash = "sha256-SAnbp34DlGsq4nfaRHfCTGRSGQtv/rRgngvwma2tc7Q=";
+    hash = "sha256-l8AdqJ0lZH4rBcf4WV3ju+sIHYam6USXCXTqyRPzgeo=";
   };
 
   patches = [
@@ -102,10 +102,6 @@ stdenv.mkDerivation (finalAttrs: {
         # Due to storage size concerns of `glibcLocales`, we skip this
         "CompareFilenames.shouldBeCaseInsensitiveAndLocaleInvariant"
         "NormalizeFilename.shouldCaseFoldStringsAndBeLocaleInvariant"
-
-        # Some filesystem related test fail because they assume `std::filesystem::equivalent` works with non-existent paths
-        "Filesystem.equivalentShouldNotRequireThatBothPathsExist"
-        "Filesystem.equivalentShouldBeCaseSensitive"
       ];
     in
     "-${builtins.concatStringsSep ":" disabledTests}";
@@ -116,7 +112,7 @@ stdenv.mkDerivation (finalAttrs: {
     testing-plugins = fetchFromGitHub {
       owner = "Ortham";
       repo = "testing-plugins";
-      rev = "refs/tags/1.6.2";
+      tag = "1.6.2";
       hash = "sha256-3Aa98EwqpuGA3YlsRF8luWzXVEFO/rs6JXisXdLyIK4=";
     };
 
@@ -141,17 +137,17 @@ stdenv.mkDerivation (finalAttrs: {
 
     libloadorder = finalAttrs.passthru.buildRustFFIPackage rec {
       pname = "libloadorder";
-      version = "18.1.3";
+      version = "18.3.0";
 
       src = fetchFromGitHub {
         owner = "Ortham";
         repo = "libloadorder";
-        rev = "refs/tags/${version}";
-        hash = "sha256-qJ7gC4BkrXJiVcyA1BqlJSRzgc/7VmNBHtDq0ouJoTU=";
+        tag = version;
+        hash = "sha256-/8WOEt9dxKFTTZbhf5nt81jo/yHuALPxh/IwAOehi9w=";
       };
 
       useFetchCargoVendor = true;
-      cargoHash = "sha256-m3lyABr7tU0AeC6EZomBw1X722ezQg/cjSZh/ZhkiBw=";
+      cargoHash = "sha256-re/cKqf/CAD7feNIEuou4ZP8BNkArd5CvREx1610jig=";
 
       lang = "c++";
       header = "libloadorder.hpp";
@@ -164,7 +160,7 @@ stdenv.mkDerivation (finalAttrs: {
       src = fetchFromGitHub {
         owner = "Ortham";
         repo = "esplugin";
-        rev = "refs/tags/${version}";
+        tag = version;
         hash = "sha256-ygjSyixg+9HFFNV/G+w+TxGFTrjlWxlDt8phpCE8xyQ=";
       };
 
@@ -177,17 +173,17 @@ stdenv.mkDerivation (finalAttrs: {
 
     loot-condition-interpreter = finalAttrs.passthru.buildRustFFIPackage rec {
       pname = "loot-condition-interpreter";
-      version = "4.0.2";
+      version = "5.3.0";
 
       src = fetchFromGitHub {
         owner = "loot";
         repo = "loot-condition-interpreter";
-        rev = "refs/tags/${version}";
-        hash = "sha256-yXbe7ByYHvFpokRpV2pz2SX0986dpk5IpehwDUhoZKg=";
+        tag = version;
+        hash = "sha256-MvadQ4cWpzNgF/lUW5Jb758DvfRPGZ7s1W4MbO7nbIw=";
       };
 
       useFetchCargoVendor = true;
-      cargoHash = "sha256-d3JBpYI4XMkDnufvdyZkgtp7H4amMzM0dBEO6t9efGE=";
+      cargoHash = "sha256-m/vRnAJyMQOosxnjSUgHIY1RCkdB5+HFVqqzYVEpgOI=";
 
       lang = "c";
       header = "loot_condition_interpreter.h";
@@ -198,7 +194,7 @@ stdenv.mkDerivation (finalAttrs: {
       src = fetchFromGitHub {
         owner = "loot";
         repo = "yaml-cpp";
-        rev = "refs/tags/${version}";
+        tag = version;
         hash = "sha256-whYorebrLiDeO75LC2SMUX/8OD528BR0+DEgnJxxpoQ=";
       };
     };

--- a/pkgs/by-name/li/limo/package.nix
+++ b/pkgs/by-name/li/limo/package.nix
@@ -21,13 +21,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "limo";
-  version = "1.1";
+  version = "1.2";
 
   src = fetchFromGitHub {
     owner = "limo-app";
     repo = "limo";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-fzqIZ/BqOpPjo18qi4VidGg1ruhQLqfwoA/hidGPEao=";
+    hash = "sha256-hgtqpP1H9+TAuP5b/Wvx4mqeYRKyaluMlyzHEmIgSqo=";
   };
 
   patches = lib.optionals (!withUnrar) [


### PR DESCRIPTION
The `limo` package also had to be bumped because it doesn't work with the older libloot.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
