### PR TITLE
postgres-lsp: 0-unstable-2024-03-24 -> 0.5.0

### DIFF
--- a/pkgs/by-name/po/postgres-lsp/package.nix
+++ b/pkgs/by-name/po/postgres-lsp/package.nix
@@ -2,38 +2,46 @@
   lib,
   rustPlatform,
   fetchFromGitHub,
-  protobuf,
 }:
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "postgres-lsp";
-  version = "0-unstable-2024-03-24";
+  version = "0.5.0";
 
   src = fetchFromGitHub {
-    owner = "supabase";
-    repo = "postgres_lsp";
-    rev = "43ca9b675cb152ca7f38cfa6aff6dd2131dfa9a2";
-    hash = "sha256-n7Qbt9fGzC0CcleAtTWDInPz4oaPjI+pvIPrR5EYJ9U=";
+    owner = "supabase-community";
+    repo = "postgres-language-server";
+    tag = finalAttrs.version;
+    hash = "sha256-JRCuqJvC+OBdYe2JORwOfghr7smVLsROwrhk5H+SSkc=";
     fetchSubmodules = true;
   };
 
   useFetchCargoVendor = true;
-  cargoHash = "sha256-9T3bm/TSjnFeF8iE4338I44espnFq6l36yOq8YFPaPQ=";
+  cargoHash = "sha256-lUZpjX3HljOXi0Wt2xZCUru8uinWlngLEs5wlqfFiJA=";
 
   nativeBuildInputs = [
-    protobuf
     rustPlatform.bindgenHook
   ];
 
-  cargoBuildFlags = [ "-p=postgres_lsp" ];
-  cargoTestFlags = finalAttrs.cargoBuildFlags;
+  env = {
+    SQLX_OFFLINE = 1;
 
-  RUSTC_BOOTSTRAP = 1; # We need rust unstable features
+    # As specified in the upstream: https://github.com/supabase-community/postgres-language-server/blob/main/.github/workflows/release.yml
+    RUSTFLAGS = "-C strip=symbols -C codegen-units=1";
+    PGT_VERSION = finalAttrs.version;
+  };
+
+  cargoBuildFlags = [ "-p=pgt_cli" ];
+  cargoTestFlags = finalAttrs.cargoBuildFlags;
+  checkFlags = [
+    # Tries to write to the file system relatively to the current path
+    "--skip=syntax_error"
+  ];
 
   meta = {
-    description = "Language Server for Postgres";
-    homepage = "https://github.com/supabase/postgres_lsp";
+    description = "Tools and language server for Postgres";
+    homepage = "https://pgtools.dev";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ figsoda ];
-    mainProgram = "postgres_lsp";
+    mainProgram = "postgrestools";
   };
 })

--- a/pkgs/by-name/po/postgres-lsp/package.nix
+++ b/pkgs/by-name/po/postgres-lsp/package.nix
@@ -4,8 +4,7 @@
   fetchFromGitHub,
   protobuf,
 }:
-
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "postgres-lsp";
   version = "0-unstable-2024-03-24";
 
@@ -26,15 +25,15 @@ rustPlatform.buildRustPackage rec {
   ];
 
   cargoBuildFlags = [ "-p=postgres_lsp" ];
-  cargoTestFlags = cargoBuildFlags;
+  cargoTestFlags = finalAttrs.cargoBuildFlags;
 
   RUSTC_BOOTSTRAP = 1; # We need rust unstable features
 
-  meta = with lib; {
+  meta = {
     description = "Language Server for Postgres";
     homepage = "https://github.com/supabase/postgres_lsp";
-    license = licenses.mit;
-    maintainers = with maintainers; [ figsoda ];
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ figsoda ];
     mainProgram = "postgres_lsp";
   };
-}
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
