### PR TITLE
python312Packages.*: torch.distributed is now enabled on darwin too

### DIFF
--- a/pkgs/development/python-modules/pylance/default.nix
+++ b/pkgs/development/python-modules/pylance/default.nix
@@ -105,18 +105,6 @@ buildPythonPackage rec {
     ++ lib.optionals (stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isAarch64) [
       # OSError: LanceError(IO): Resources exhausted: Failed to allocate additional 1245184 bytes for ExternalSorter[0]...
       "test_merge_insert_large"
-    ]
-    ++ lib.optionals stdenv.hostPlatform.isDarwin [
-      # AttributeError: module 'torch.distributed' has no attribute 'is_initialized'
-      "test_blob_api"
-      "test_convert_int_tensors"
-      "test_filtered_sampling_odd_batch_size"
-      "test_ground_truth"
-      "test_index_cast_centroids"
-      "test_index_with_no_centroid_movement"
-      "test_iter_filter"
-      "test_iter_over_dataset_fixed_shape_tensor"
-      "test_iter_over_dataset_fixed_size_lists"
     ];
 
   meta = {

--- a/pkgs/development/python-modules/pytorch-metric-learning/default.nix
+++ b/pkgs/development/python-modules/pytorch-metric-learning/default.nix
@@ -85,10 +85,6 @@ buildPythonPackage rec {
       "test_list_of_text"
       "test_untrained_indexer"
     ]
-    ++ lib.optionals stdenv.hostPlatform.isDarwin [
-      # AttributeError: module 'torch.distributed' has no attribute 'init_process_group'
-      "test_single_proc"
-    ]
     ++ lib.optionals cudaSupport [
       # crashes with SIGBART
       "test_accuracy_calculator_and_faiss_with_torch_and_numpy"

--- a/pkgs/development/python-modules/skorch/default.nix
+++ b/pkgs/development/python-modules/skorch/default.nix
@@ -72,11 +72,15 @@ buildPythonPackage rec {
       # tries to import `transformers` and download HuggingFace data
       "skorch/tests/test_hf.py"
     ]
-    ++ lib.optionals (stdenv.hostPlatform.system != "x86_64-linux") [
-      # torch.distributed is disabled by default in darwin
-      # aarch64-linux also failed these tests
-      "skorch/tests/test_history.py"
-    ];
+    ++ lib.optionals
+      (stdenv.hostPlatform.system != "x86_64-linux" && stdenv.hostPlatform.system != "aarch64-darwin")
+      [
+        # these tests fail when running in parallel for multiple platforms with:
+        # "RuntimeError: The server socket has failed to listen on any local
+        # network address because they use the same hardcoded port." For now,
+        # running for one platform per OS to avoid spurious failures.
+        "skorch/tests/test_history.py"
+      ];
 
   pythonImportsCheck = [ "skorch" ];
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
