### PR TITLE
sauerbraten: fix installPhase symlink source

### DIFF
--- a/pkgs/by-name/sa/sauerbraten/package.nix
+++ b/pkgs/by-name/sa/sauerbraten/package.nix
@@ -65,7 +65,7 @@ stdenv.mkDerivation rec {
     cp -r "../docs/"* $out/share/doc/sauerbraten/
     cp sauer_client sauer_server $out/share/sauerbraten/
     cp -r ../packages ../data $out/share/sauerbraten/
-    ln -s $out/share/sauerbraten/cube.png $out/share/icon/sauerbraten.png
+    ln -s $out/share/sauerbraten/data/cube.png $out/share/icon/sauerbraten.png
 
     makeWrapper $out/share/sauerbraten/sauer_server $out/bin/sauerbraten_server \
       --chdir "$out/share/sauerbraten"


### PR DESCRIPTION
Without this change, package installation fails with the following error:

```nix
error: builder for '/nix/store/bqfjr440pyysyrz19qnbvfhjm946l09l-sauerbraten-2020-12-29.drv' failed with exit code 1;
       last 25 log lines:
       >    63 |                     memcpy(curmesh->verts, verts.getbuf(), verts.length()*sizeof(vert)); \
       >       |                           ^
       > engine/obj.h:103:37: note: in expansion of macro 'FLUSHMESH'
       >   103 |                         if(curmesh) FLUSHMESH;
       >       |                                     ^~~~~~~~~
       > engine/obj.h:62:61: note: destination object of size 9223372036854775807 allocated by 'operator new []'
       >    62 |                     curmesh->verts = new vert[verts.length()]; \
       >       |                                                             ^
       > engine/obj.h:103:37: note: in expansion of macro 'FLUSHMESH'
       >   103 |                         if(curmesh) FLUSHMESH;
       >       |                                     ^~~~~~~~~
       > g++ -O3 -fomit-frame-pointer -ffast-math -Wall -fsigned-char -fno-exceptions -fno-rtti -o sauer_client shared/crypto.o shared/geom.o shared/glemu.o shared/stream.o shared/tools.o shared/zip.o engine/3dgui.o engine/bih.o engine/blend.o engine/blob.o engine/client.o engine/command.o engine/console.o engine/cubeloader.o engine/decal.o engine/dynlight.o engine/glare.o engine/grass.o engine/lightmap.o engine/main.o engine/material.o engine/menus.o engine/movie.o engine/normal.o engine/octa.o engine/octaedit.o engine/octarender.o engine/physics.o engine/pvs.o engine/rendergl.o engine/rendermodel.o engine/renderparticles.o engine/rendersky.o engine/rendertext.o engine/renderva.o engine/server.o engine/serverbrowser.o engine/shader.o engine/shadowmap.o engine/sound.o engine/texture.o engine/water.o engine/world.o engine/worldio.o fpsgame/ai.o fpsgame/client.o fpsgame/entities.o fpsgame/fps.o fpsgame/monster.o fpsgame/movable.o fpsgame/render.o fpsgame/scoreboard.o fpsgame/server.o fpsgame/waypoint.o fpsgame/weapon.o -Lenet -lenet -L/usr/X11R6/lib -lX11 `sdl2-config --libs` -lSDL2_image -lSDL2_mixer -lz -lGL -lrt
       > buildPhase completed in 1 minutes 36 seconds
       > Running phase: installPhase
       > Copying '/nix/store/9r2vfk11028yviqiml1679hpiyqavkfq-sauerbraten.desktop/share/applications/sauerbraten.desktop' into '/nix/store/w4zjn50jrj7vmaaygk2rw5bxl7sd43y6-sauerbraten-2020-12-29/share/applications'
       > installPhase completed in 7 minutes 6 seconds
       > Running phase: fixupPhase
       > shrinking RPATHs of ELF executables and libraries in /nix/store/w4zjn50jrj7vmaaygk2rw5bxl7sd43y6-sauerbraten-2020-12-29
       > shrinking /nix/store/w4zjn50jrj7vmaaygk2rw5bxl7sd43y6-sauerbraten-2020-12-29/share/sauerbraten/sauer_client
       > shrinking /nix/store/w4zjn50jrj7vmaaygk2rw5bxl7sd43y6-sauerbraten-2020-12-29/share/sauerbraten/sauer_server
       > checking for references to /build/ in /nix/store/w4zjn50jrj7vmaaygk2rw5bxl7sd43y6-sauerbraten-2020-12-29...
       > patching script interpreter paths in /nix/store/w4zjn50jrj7vmaaygk2rw5bxl7sd43y6-sauerbraten-2020-12-29
       > stripping (with command strip and flags -S -p) in  /nix/store/w4zjn50jrj7vmaaygk2rw5bxl7sd43y6-sauerbraten-2020-12-29/bin
       > ERROR: noBrokenSymlinks: the symlink /nix/store/w4zjn50jrj7vmaaygk2rw5bxl7sd43y6-sauerbraten-2020-12-29/share/icon/sauerbraten.png points to a missing target: /nix/store/w4zjn50jrj7vmaaygk2rw5bxl7sd43y6-sauerbraten-2020-12-29/share/sauerbraten/cube.png
       > ERROR: noBrokenSymlinks: found 1 dangling symlinks, 0 reflexive symlinks and 0 unreadable symlinks
       For full logs, run 'nix log /nix/store/bqfjr440pyysyrz19qnbvfhjm946l09l-sauerbraten-2020-12-29.drv'.
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
