### PR TITLE
python3Packages.certifi: make robust to empty NIX_SSL_CERT_FILE

### DIFF
--- a/pkgs/development/python-modules/certifi/env.patch
+++ b/pkgs/development/python-modules/certifi/env.patch
@@ -14,10 +14,10 @@ index 91f538b..1110ce0 100644
      _CACERT_CTX.__exit__(None, None, None)  # type: ignore[union-attr]
  
  
-+def get_cacert_path_from_environ():
++def get_cacert_path_from_environ() -> str | None:
 +    path = os.environ.get("NIX_SSL_CERT_FILE", None)
 +
-+    if path == "/no-cert-file.crt":
++    if path is None or path.strip() in ("", "/no-cert-file.crt"):
 +        return None
 +
 +    return path


### PR DESCRIPTION
The current packaging of python3Packages.certifi allows an empty-valued `NIX_SSL_CERT_FILE` to impact package behavior. For example:

```
> NIX_SSL_CERT_FILE= python -c 'import certifi; print(certifi.where())'

> python -c 'import certifi; print(certifi.where())'
/nix/store/8vlg7l1ipzjax230h10ipqgd0mvs6445-python3-3.11.11-env/lib/python3.11/site-packages/certifi/cacert.pem
```

This PR modifies the patch in the certifi package to treat empty-valued `NIX_SSL_CERT_FILE` variables as if they were not set at all. After building the updated package and setting the Python path accordingly:

```
> NIX_SSL_CERT_FILE= PYTHONPATH=$(realpath result/lib/python3.12/site-packages) python -c 'import certifi; print(certifi.where())'
/nix/store/6g827hdsn8a8g9z6jrar86hjq1hjn9dp-python3.12-certifi-2025.01.31/lib/python3.12/site-packages/certifi/cacert.pem
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
