### PR TITLE
cosmic-ext-alternative-startup: init at 0-unstable-2024-11-24; cosmic-ext-extra-sessions: init at 0-unstable-2025-04-02

### DIFF
--- a/nixos/modules/services/desktop-managers/cosmic.nix
+++ b/nixos/modules/services/desktop-managers/cosmic.nix
@@ -13,8 +13,11 @@
 
 let
   cfg = config.services.desktopManager.cosmic;
+
+  extraSessionPkgs = map (name: pkgs.cosmic-ext-extra-sessions.${name}) cfg.extraSessions;
   notExcluded = pkg: utils.disablePackageByName pkg config.environment.cosmic.excludePackages;
   excludedCorePkgs = lib.lists.intersectLists corePkgs config.environment.cosmic.excludePackages;
+
   # **ONLY ADD PACKAGES WITHOUT WHICH COSMIC CRASHES, NOTHING ELSE**
   corePkgs =
     with pkgs;
@@ -22,7 +25,6 @@ let
       cosmic-applets
       cosmic-applibrary
       cosmic-bg
-      cosmic-comp
       cosmic-files
       config.services.displayManager.cosmic-greeter.package
       cosmic-idle
@@ -36,6 +38,7 @@ let
       cosmic-settings-daemon
       cosmic-workspaces-epoch
     ]
+    ++ lib.optionals cfg.defaultSession [ cosmic-comp ]
     ++ lib.optionals cfg.xwayland.enable [
       # Why would you want to enable XWayland but exclude the package
       # providing XWayland support? Doesn't make sense. Add `xwayland` to the
@@ -49,6 +52,26 @@ in
   options = {
     services.desktopManager.cosmic = {
       enable = lib.mkEnableOption "COSMIC desktop environment";
+
+      defaultSession = lib.mkEnableOption "the default COSMIC session" // {
+        default = true;
+      };
+
+      extraSessions = lib.mkOption {
+        type = lib.types.listOf (
+          lib.types.enum [
+            "niri"
+            "sway"
+            "miracle"
+          ]
+        );
+        default = [ ];
+        example = [
+          "niri"
+          "sway"
+        ];
+        description = "Alternative sessions to install for the COSMIC environment.";
+      };
 
       showExcludedPkgsWarning = lib.mkEnableOption "the warning for excluding core packages" // {
         default = true;
@@ -68,6 +91,17 @@ in
   };
 
   config = lib.mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = cfg.defaultSession || cfg.extraSessions != [ ];
+        message = "COSMIC is enabled, but no session is configured. Enable `services.desktopManager.cosmic.defaultSession` or specify `services.desktopManager.cosmic.extraSessions`.";
+      }
+    ];
+
+    programs.niri.enable = lib.mkIf (builtins.elem "niri" cfg.extraSessions) true;
+    programs.sway.enable = lib.mkIf (builtins.elem "sway" cfg.extraSessions) true;
+    programs.wayland.miracle-wm.enable = lib.mkIf (builtins.elem "miracle" cfg.extraSessions) true;
+
     # Environment packages
     environment.pathsToLink = [
       "/share/backgrounds"
@@ -77,6 +111,7 @@ in
     ];
     environment.systemPackages = utils.removePackagesByName (
       corePkgs
+      ++ extraSessionPkgs
       ++ (
         with pkgs;
         [
@@ -148,7 +183,8 @@ in
     security.polkit.enable = true;
     security.rtkit.enable = true;
     services.accounts-daemon.enable = true;
-    services.displayManager.sessionPackages = [ pkgs.cosmic-session ];
+    services.displayManager.sessionPackages =
+      (lib.optionals cfg.defaultSession [ pkgs.cosmic-session ]) ++ extraSessionPkgs;
     services.libinput.enable = true;
     services.upower.enable = true;
     # Required for screen locker

--- a/pkgs/by-name/co/cosmic-ext-alternative-startup/package.nix
+++ b/pkgs/by-name/co/cosmic-ext-alternative-startup/package.nix
@@ -1,0 +1,27 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+}:
+rustPlatform.buildRustPackage {
+  pname = "cosmic-ext-alternative-startup";
+  version = "0-unstable-2024-11-24";
+
+  src = fetchFromGitHub {
+    owner = "Drakulix";
+    repo = "cosmic-ext-alternative-startup";
+    rev = "8ceda00197c7ec0905cf1dccdc2d67d738e45417";
+    hash = "sha256-0kqn3hZ58uQMl39XXF94yQS1EWmGIK45/JFTAigg/3M=";
+  };
+
+  cargoHash = "sha256-DeMkAG2iINGden0Up013M9mWDN4QHrF+FXoNqpGB+mg=";
+
+  meta = {
+    description = "Alternative entry point for COSMIC session compositor IPC interface";
+    homepage = "https://github.com/Drakulix/cosmic-ext-alternative-startup";
+    license = lib.licenses.gpl3Only;
+    mainProgram = "cosmic-ext-alternative-startup";
+    maintainers = [ lib.maintainers.HeitorAugustoLN ];
+    platforms = lib.platforms.linux;
+  };
+}

--- a/pkgs/by-name/co/cosmic-ext-extra-sessions/package.nix
+++ b/pkgs/by-name/co/cosmic-ext-extra-sessions/package.nix
@@ -1,0 +1,113 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  symlinkJoin,
+  cosmic-ext-alternative-startup,
+  cosmic-session,
+  dbus,
+  nix-update-script,
+}:
+let
+  version = "0-unstable-2025-04-02";
+
+  src = fetchFromGitHub {
+    owner = "Drakulix";
+    repo = "cosmic-ext-extra-sessions";
+    rev = "66e065728d81eab86171e542dad08fb628c88494";
+    hash = "sha256-6JiWdBry63NrnmK3mt9gGSDAcyx/f6L5QsIgZSUakQI=";
+  };
+
+  makeSession =
+    {
+      compositorName ? lib.toSentenceCase name,
+      name,
+    }:
+    let
+      pname = "cosmic-ext-${name}";
+      desktopFile = "${pname}.desktop";
+      sessionCommand = "start-${pname}";
+    in
+    stdenv.mkDerivation {
+      inherit pname src version;
+
+      postPatch = ''
+        substituteInPlace ${name}/${desktopFile} \
+          --replace-fail "/usr/${
+            lib.optionalString (name == "niri") "local/"
+          }bin/${sessionCommand}" "${placeholder "out"}/bin/${sessionCommand}"
+
+        substituteInPlace ${name}/${sessionCommand} \
+          --replace-fail '/usr/bin/dbus-run-session' '${lib.getExe' dbus "dbus-run-session"}' \
+          --replace-fail "/usr/bin/cosmic-session" "${lib.getExe cosmic-session}"
+
+        ${lib.optionalString (name == "sway") ''
+            substituteInPlace ${name}/${sessionCommand} \
+              --replace-fail "/etc/sway/config-cosmic" "${placeholder "out"}/etc/sway/config-cosmic"
+
+          substituteInPlace ${name}/config-cosmic \
+            --replace-fail '/usr/bin/cosmic-ext-alternative-startup' '${lib.getExe cosmic-ext-alternative-startup}'
+        ''}
+      '';
+
+      installPhase = ''
+        runHook preInstall
+
+        install -Dm644 ${name}/${desktopFile} $out/share/wayland-sessions/${desktopFile}
+        install -Dm755 ${name}/${sessionCommand} $out/bin/${sessionCommand}
+
+        ${lib.optionalString (name == "sway") ''
+          install -Dm644 ${name}/config-cosmic $out/etc/sway/config-cosmic
+        ''}
+
+        runHook postInstall
+      '';
+
+      passthru.providedSessions = [ "cosmic-ext-${name}" ];
+
+      meta = {
+        description = "Unofficial ${compositorName} alternative session for COSMIC Desktop";
+        homepage = "https://github.com/Drakulix/cosmic-ext-extra-sessions";
+        license = lib.licenses.gpl3Only;
+        mainProgram = sessionCommand;
+        maintainers = [ lib.maintainers.HeitorAugustoLN ];
+        platforms = lib.platforms.linux;
+      };
+    };
+
+  sessions = {
+    miracle = makeSession { name = "miracle"; };
+    niri = makeSession { name = "niri"; };
+    sway = makeSession { name = "sway"; };
+  };
+in
+symlinkJoin {
+  pname = "cosmic-ext-extra-sessions";
+  inherit version;
+
+  paths = builtins.attrValues sessions;
+
+  passthru = sessions // {
+    inherit makeSession;
+
+    providedSessions = lib.pipe sessions [
+      (lib.mapAttrsToList (_: pkg: pkg.passthru.providedSessions))
+      lib.flatten
+    ];
+
+    updateScript = nix-update-script {
+      extraArgs = [
+        "--version"
+        "branch=HEAD"
+      ];
+    };
+  };
+
+  meta = {
+    description = "Unofficial alternative sessions for COSMIC Desktop";
+    homepage = "https://github.com/Drakulix/cosmic-ext-extra-sessions";
+    license = lib.licenses.gpl3Only;
+    maintainers = [ lib.maintainers.HeitorAugustoLN ];
+    platforms = lib.platforms.linux;
+  };
+}

--- a/pkgs/by-name/co/cosmic-ext-extra-sessions/package.nix
+++ b/pkgs/by-name/co/cosmic-ext-extra-sessions/package.nix
@@ -4,6 +4,7 @@
   fetchFromGitHub,
   symlinkJoin,
   cosmic-ext-alternative-startup,
+  cosmic-ext-sway-daemon,
   cosmic-session,
   dbus,
   nix-update-script,
@@ -46,7 +47,8 @@ let
               --replace-fail "/etc/sway/config-cosmic" "${placeholder "out"}/etc/sway/config-cosmic"
 
           substituteInPlace ${name}/config-cosmic \
-            --replace-fail '/usr/bin/cosmic-ext-alternative-startup' '${lib.getExe cosmic-ext-alternative-startup}'
+            --replace-fail "/usr/bin/cosmic-ext-alternative-startup" "${lib.getExe cosmic-ext-alternative-startup}" \
+            --replace-fail "/usr/bin/cosmic-ext-sway-daemon" "${lib.getExe cosmic-ext-sway-daemon}"
         ''}
       '';
 

--- a/pkgs/by-name/co/cosmic-ext-sway-daemon/package.nix
+++ b/pkgs/by-name/co/cosmic-ext-sway-daemon/package.nix
@@ -1,0 +1,14 @@
+{ rustPlatform, cosmic-ext-extra-sessions }:
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "cosmic-ext-sway-daemon";
+  inherit (cosmic-ext-extra-sessions.sway) src version;
+
+  sourceRoot = "${finalAttrs.src.name}/sway/cosmic-ext-sway-daemon";
+
+  cargoHash = "sha256-JDZecMs9lfeRT0MA30CaHCJTEwdNM2jNR26VSPPnlQE=";
+
+  meta = cosmic-ext-extra-sessions.sway.meta // {
+    description = "Unofficial Sway alternative session daemon for COSMIC Desktop";
+    mainProgram = "cosmic-ext-sway-daemon";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
