### PR TITLE
nixos/lib/test-driver: add wait_for_unit_active_state function

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -163,6 +163,7 @@ in
           [[ 143 = $(cat $failed/testBuildFailure.exit) ]]
           touch $out
         '';
+    unit-active-state = runTest ./nixos-test-driver/unit-active-state.nix;
   };
 
   # NixOS vm tests and non-vm unit tests

--- a/nixos/tests/nixos-test-driver/unit-active-state.nix
+++ b/nixos/tests/nixos-test-driver/unit-active-state.nix
@@ -1,0 +1,57 @@
+{
+  name = "nixos-test-driver.unit-active-state";
+  nodes.machine =
+    { pkgs, ... }:
+    {
+      systemd.services.test = {
+        serviceConfig.Type = "notify-reload";
+        path = [ pkgs.systemd ];
+        script = ''
+          set -x
+          startup() {
+            sleep 5
+            systemd-notify --ready --status="Started up"
+          }
+
+          process() {
+            systemd-notify --status="Processing"
+            sleep 5
+          }
+
+          reload() {
+            reloading=0
+            systemd-notify --reloading --status="Reloading"
+            sleep 5
+            systemd-notify --ready --status="Reloaded"
+            sleep 5
+          }
+
+          stop() {
+            systemd-notify --stop --status="Stopping"
+            sleep 5
+            exit 1
+          }
+
+          trap reload SIGHUP
+          trap stop SIGTERM
+
+          startup
+          while true; do
+            process
+          done
+        '';
+      };
+    };
+  testScript = ''
+    machine.wait_for_unit_active_state("test.service", "inactive", timeout=10)
+    machine.succeed("systemctl start --no-block test.service")
+    machine.wait_for_unit_active_state("test.service", "activating", timeout=10)
+    machine.wait_for_unit_active_state("test.service", "active", timeout=10)
+    machine.succeed("systemctl reload --no-block test.service")
+    machine.wait_for_unit_active_state("test.service", "reloading", timeout=10)
+    machine.wait_for_unit_active_state("test.service", "active")
+    machine.succeed("systemctl stop --no-block test.service", timeout=10)
+    machine.wait_for_unit_active_state("test.service", "deactivating", timeout=10)
+    machine.wait_for_unit_active_state("test.service", "failed", timeout=10)
+  '';
+}


### PR DESCRIPTION
Wait for a systemd unit to get into the given state. More generic version of `wait_for_unit` which only waits for the `"active"` state and throws on the `"failed"` and `"inactive"` state. This is useful to assert that a unit failed for example.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
