### PR TITLE
nixos/tests/fluent-bit: add regression test for #395128

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -480,7 +480,7 @@ in
     imports = [ ./firefox.nix ];
     _module.args.firefoxPackage = pkgs.floorp;
   };
-  fluent-bit = handleTest ./fluent-bit.nix { };
+  fluent-bit = runTest ./fluent-bit.nix;
   fluentd = handleTest ./fluentd.nix { };
   fluidd = handleTest ./fluidd.nix { };
   fontconfig-default-fonts = handleTest ./fontconfig-default-fonts.nix { };

--- a/nixos/tests/fluent-bit.nix
+++ b/nixos/tests/fluent-bit.nix
@@ -13,7 +13,7 @@ import ./make-test-python.nix (
               inputs = [
                 {
                   name = "systemd";
-                  systemd_filter = "_SYSTEMD_UNIT=fluent-bit.service";
+                  systemd_filter = "_SYSTEMD_UNIT=fluent-bit-regression-395128.service";
                 }
               ];
               outputs = [
@@ -28,12 +28,35 @@ import ./make-test-python.nix (
         };
 
         systemd.services.fluent-bit.serviceConfig.LogsDirectory = "fluent-bit";
+
+        # Logs get compressed when larger than 1024 bytes
+        # Lets generate some logs that trigger that
+        # This causes libzstd to be dlopen'd by systemd which breaks fluent-bit 3.2.7+
+        # https://www.freedesktop.org/software/systemd/man/latest/journald.conf.html#Compress=
+        systemd.services.fluent-bit-regression-395128 = {
+          serviceConfig = {
+            Type = "oneshot";
+            RemainAfterExit = true;
+          };
+          script = ''
+            for i in {1..20}; do
+              (head -c 1200 < /dev/zero | tr '\0' 'A') && echo
+              sleep 1
+            done
+          '';
+        };
       };
 
     testScript = ''
       start_all()
 
       machine.wait_for_unit("fluent-bit.service")
+
+      # Regression test for https://github.com/NixOS/nixpkgs/pull/395128
+      with subtest("fluent-bit handles zstd-compressed journal logs"):
+        machine.succeed("systemctl start fluent-bit-regression-395128.service")
+        machine.succeed("systemctl show -p NRestarts fluent-bit.service | grep -q 'NRestarts=0'")
+
       machine.wait_for_file("/var/log/fluent-bit/fluent-bit.out")
     '';
   }

--- a/nixos/tests/fluent-bit.nix
+++ b/nixos/tests/fluent-bit.nix
@@ -1,63 +1,56 @@
-import ./make-test-python.nix (
-  { lib, pkgs, ... }:
-  {
-    name = "fluent-bit";
-
-    nodes.machine =
-      { config, pkgs, ... }:
-      {
-        services.fluent-bit = {
-          enable = true;
-          settings = {
-            pipeline = {
-              inputs = [
-                {
-                  name = "systemd";
-                  systemd_filter = "_SYSTEMD_UNIT=fluent-bit-regression-395128.service";
-                }
-              ];
-              outputs = [
-                {
-                  name = "file";
-                  path = "/var/log/fluent-bit";
-                  file = "fluent-bit.out";
-                }
-              ];
-            };
-          };
-        };
-
-        systemd.services.fluent-bit.serviceConfig.LogsDirectory = "fluent-bit";
-
-        # Logs get compressed when larger than 1024 bytes
-        # Lets generate some logs that trigger that
-        # This causes libzstd to be dlopen'd by systemd which breaks fluent-bit 3.2.7+
-        # https://www.freedesktop.org/software/systemd/man/latest/journald.conf.html#Compress=
-        systemd.services.fluent-bit-regression-395128 = {
-          serviceConfig = {
-            Type = "oneshot";
-            RemainAfterExit = true;
-          };
-          script = ''
-            for i in {1..20}; do
-              (head -c 1200 < /dev/zero | tr '\0' 'A') && echo
-              sleep 1
-            done
-          '';
+# Regression test for https://github.com/NixOS/nixpkgs/pull/395128
+{
+  name = "fluent-bit";
+  nodes.machine = {
+    services.fluent-bit = {
+      enable = true;
+      settings = {
+        pipeline = {
+          inputs = [
+            {
+              name = "systemd";
+              systemd_filter = "_SYSTEMD_UNIT=fluent-bit-regression-395128.service";
+            }
+          ];
+          outputs = [
+            {
+              name = "file";
+              path = "/var/log/fluent-bit";
+              file = "fluent-bit.out";
+            }
+          ];
         };
       };
+    };
+    systemd.services.fluent-bit.serviceConfig.LogsDirectory = "fluent-bit";
 
-    testScript = ''
-      start_all()
+    # Logs get compressed when larger than 1024 bytes
+    # Lets generate some logs that trigger that
+    # This causes libzstd to be dlopen'd by systemd which breaks fluent-bit 3.2.7+
+    # https://www.freedesktop.org/software/systemd/man/latest/journald.conf.html#Compress=
+    systemd.services.fluent-bit-regression-395128 = {
+      serviceConfig = {
+        Type = "oneshot";
+        RemainAfterExit = true;
+      };
+      script = ''
+        for i in {1..20}; do
+          (head -c 1200 < /dev/zero | tr '\0' 'A') && echo
+          sleep 1
+        done
+      '';
+    };
+  };
 
-      machine.wait_for_unit("fluent-bit.service")
+  testScript = ''
+    start_all()
 
-      # Regression test for https://github.com/NixOS/nixpkgs/pull/395128
-      with subtest("fluent-bit handles zstd-compressed journal logs"):
-        machine.succeed("systemctl start fluent-bit-regression-395128.service")
-        machine.succeed("systemctl show -p NRestarts fluent-bit.service | grep -q 'NRestarts=0'")
+    machine.wait_for_unit("fluent-bit.service")
 
-      machine.wait_for_file("/var/log/fluent-bit/fluent-bit.out")
-    '';
-  }
-)
+    with subtest("fluent-bit handles zstd-compressed journal logs"):
+      machine.succeed("systemctl start fluent-bit-regression-395128.service")
+      machine.succeed("systemctl show -p NRestarts fluent-bit.service | grep -q 'NRestarts=0'")
+
+    machine.wait_for_file("/var/log/fluent-bit/fluent-bit.out")
+  '';
+}


### PR DESCRIPTION
## Things done


I tested that this fails before #395128 


```
machine # [   28.067840] fluent-bit[952]: [2025/04/03 00:48:52] [engine] caught signal (SIGSEGV)
machine # [   28.106852] fluent-bit[952]: #0  0xffffaf69d72f      in  _int_free_create_chunk() at ???:0
machine # [   28.116952] fluent-bit[952]: #1  0xffffaf69ed27      in  _int_free_merge_chunk() at ???:0
machine # [   28.127270] fluent-bit[952]: #2  0xffffaf69ef9b      in  _int_free() at ???:0
machine # [   28.136738] fluent-bit[952]: #3  0xffffaf6a178f      in  __libc_free() at ???:0
machine # [   28.146192] fluent-bit[952]: #4  0xffffaf40cabf      in  ZSTD_freeDCtx() at ???:0
machine # [   28.156682] fluent-bit[952]: #5  0xffffafc7498b      in  decompress_blob_zstd() at ???:0
machine # [   28.166576] fluent-bit[952]: #6  0xffffafbd8e87      in  journal_file_data_payload() at ???:0
machine # [   28.177307] fluent-bit[952]: #7  0xffffafbe80ef      in  sd_journal_enumerate_data() at ???:0
machine # [   28.188252] fluent-bit[952]: #8  0x4ea54f            in  in_systemd_collect() at ???:0
machine # [   28.198918] fluent-bit[952]: #9  0x47bf9f            in  flb_input_collector_fd() at ???:0
machine # [   28.210586] fluent-bit[952]: #10 0x4940eb            in  flb_engine_start() at ???:0
machine # [   28.220750] fluent-bit[952]: #11 0x470c6f            in  flb_lib_worker() at ???:0
machine # [   28.230031] fluent-bit[952]: #12 0xffffaf68f02b      in  start_thread() at ???:0
machine # [   28.239230] fluent-bit[952]: #13 0xffffaf6fe20b      in  thread_start() at ???:0
machine # [   28.249052] fluent-bit[952]: #14 0xffffffffffffffff  in  ???() at ???:0
machine # [   28.266068] systemd-coredump[972]: Process 952 (fluent-bit) of user 61496 terminated abnormally with signal 6/ABRT, processing...
machine # [   28.288362] systemd[1]: Started Process Core Dump (PID 972/UID 0).
machine # [   28.513582] systemd-coredump[973]: Process 952 (fluent-bit) of user 61496 dumped core.
machine # 
machine # Stack trace of thread 956:
machine # #0  0x0000ffffaf690f34 n/a (n/a + 0x0)
machine # #1  0x0000ffffaf690f20 n/a (n/a + 0x0)
machine # #2  0x0000ffffaf63b4dc n/a (n/a + 0x0)
machine # #3  0x0000ffffaf625a00 n/a (n/a + 0x0)
machine # #4  0x000000000046bce0 n/a (n/a + 0x0)
machine # #5  0x0000ffffb061f968 n/a (linux-vdso.so.1 + 0x968)
machine # #6  0x0000ffffaf69d730 n/a (n/a + 0x0)
machine # #7  0x0000ffffaf69d730 n/a (n/a + 0x0)
machine # #8  0x0000ffffaf69ed28 n/a (n/a + 0x0)
machine # #9  0x0000ffffaf69ef9c n/a (n/a + 0x0)
machine # #10 0x0000ffffaf6a1790 n/a (n/a + 0x0)
machine # #11 0x0000ffffaf40cac0 n/a (n/a + 0x0)
machine # #12 0x0000ffffafc7498c n/a (n/a + 0x0)
machine # #13 0x0000ffffafbd8e88 n/a (n/a + 0x0)
machine # #14 0x0000ffffafbe80f0 n/a (n/a + 0x0)
machine # #15 0x00000000004ea550 n/a (n/a + 0x0)
machine # #16 0x000000000047bfa0 n/a (n/a + 0x0)
machine # #17 0x00000000004940ec n/a (n/a + 0x0)
machine # #18 0x0000000000470c70 n/a (n/a + 0x0)
machine # #19 0x0000ffffaf68f02c n/a (n/a + 0x0)
machine # #20 0x0000ffffaf6fe20c n/a (n/a + 0x0)
machine # ELF object binary architecture: AARCH64
machine # 
machine # [   28.693573] systemd[1]: systemd-coredump@1-972-0.service: Deactivated successfully.
machine # [   28.729516] systemd[1]: fluent-bit.service: Main process exited, code=dumped, status=6/ABRT
machine # [   28.742001] systemd[1]: fluent-bit.service: Failed with result 'core-dump'.
machine # [   28.870945] systemd[1]: fluent-bit.service: Scheduled restart job, restart counter is at 2.
machine # [   28.893464] systemd[1]: Started Fluent Bit.
machine # [   28.962964] fluent-bit[980]: Fluent Bit v3.2.9
machine # [   28.968636] fluent-bit[980]: * Copyright (C) 2015-2025 The Fluent Bit Authors
machine # [   28.978946] fluent-bit[980]: * Fluent Bit is a CNCF sub-project under the umbrella of Fluentd
machine # [   28.989468] fluent-bit[980]: * https://fluentbit.io
machine # [   28.996160] fluent-bit[980]: ______ _                  _    ______ _ _           _____  _____
machine # [   29.007086] fluent-bit[980]: |  ___| |                | |   | ___ (_) |         |____ |/ __  \
machine # [   29.019023] fluent-bit[980]: | |_  | |_   _  ___ _ __ | |_  | |_/ /_| |_  __   __   / /`' / /'
machine # [   29.031148] fluent-bit[980]: |  _| | | | | |/ _ \ '_ \| __| | ___ \ | __| \ \ / /   \ \  / /
machine # [   29.041992] fluent-bit[980]: | |   | | |_| |  __/ | | | |_  | |_/ / | |_   \ V /.___/ /./ /___
machine # [   29.052712] fluent-bit[980]: \_|   |_|\__,_|\___|_| |_|\__| \____/|_|\__|   \_/ \____(_)_____/
machine # [   29.064138] fluent-bit[980]: [2025/04/03 00:48:52] [ info] [fluent bit] version=3.2.9, commit=, pid=980
machine # [   29.077142] fluent-bit[980]: [2025/04/03 00:48:52] [ info] [storage] ver=1.5.2, type=memory, sync=normal, checksum=off, max_chunks_up=128
machine # [   29.093847] fluent-bit[980]: [2025/04/03 00:48:52] [ info] [simd    ] disabled
machine # [   29.103536] fluent-bit[980]: [2025/04/03 00:48:52] [ info] [cmetrics] version=0.9.9
machine # [   29.113233] fluent-bit[980]: [2025/04/03 00:48:52] [ info] [ctraces ] version=0.6.1
machine # [   29.124265] fluent-bit[980]: [2025/04/03 00:48:52] [ info] [input:systemd:systemd.0] initializing
machine # [   29.134983] fluent-bit[980]: [2025/04/03 00:48:52] [ info] [input:systemd:systemd.0] storage_strategy='memory' (memory only)
machine # [   29.150894] fluent-bit[980]: [2025/04/03 00:48:52] [ info] [sp] stream processor started
machine # [   29.161993] fluent-bit[980]: [2025/04/03 00:48:52] [ info] [output:file:file.0] worker #0 started
machine # [   29.178801] fluent-bit-regression-395128-start[988]: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA>
machine # [   30.343918] fluent-bit-regression-395128-start[992]: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA>
machine # [   31.535648] fluent-bit-regression-395128-start[997]: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA>
machine # [   32.727355] fluent-bit-regression-395128-start[1001]: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA>
machine # [   33.927041] fluent-bit-regression-395128-start[1005]: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA>
machine # [   35.119261] fluent-bit-regression-395128-start[1010]: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA>
machine # [   36.331655] systemd[1]: Finished fluent-bit-regression-395128.service.
machine # [   36.349127] systemd[1]: Startup finished in 5.207s (kernel) + 31.093s (userspace) = 36.300s.
(finished: must succeed: systemctl start fluent-bit-regression-395128.service, in 24.17 seconds)
machine: must succeed: systemctl show -p NRestarts fluent-bit.service | grep -q 'NRestarts=0'
machine: output: 
Test "fluent-bit handles zstd-compressed journal logs" failed with error: "command `systemctl show -p NRestarts fluent-bit.service | grep -q 'NRestarts=0'` failed >
cleanup
kill machine (pid 11)
qemu-system-aarch64: terminating on signal 15 from pid 8 (/nix/store/cxhrrsf7spcgdkrxmlbfzc1bh46rzf7w-python3-3.12.9/bin/python3.12)
kill vlan (pid 9)
(finished: cleanup, in 0.01 seconds)
```

I tested that it succeeds after #395128 

```
(finished: must succeed: systemctl start fluent-bit-regression-395128.service, in 24.32 seconds)
machine: must succeed: systemctl show -p NRestarts fluent-bit.service | grep -q 'NRestarts=0'
(finished: must succeed: systemctl show -p NRestarts fluent-bit.service | grep -q 'NRestarts=0', in 0.08 seconds)
(finished: subtest: fluent-bit handles zstd-compressed journal logs, in 24.40 seconds)
machine: waiting for file '/var/log/fluent-bit/fluent-bit.out'
(finished: waiting for file '/var/log/fluent-bit/fluent-bit.out', in 0.03 seconds)
(finished: run the VM test script, in 44.98 seconds)
test script finished in 45.06s
cleanup
kill machine (pid 11)
qemu-system-aarch64: terminating on signal 15 from pid 8 (/nix/store/cxhrrsf7spcgdkrxmlbfzc1bh46rzf7w-python3-3.12.9/bin/python3.12)
kill vlan (pid 9)
(finished: cleanup, in 0.03 seconds)
/nix/store/3ib777y832fgr77fba77jd6h7rxxkhnd-vm-test-run-fluent-bit


```

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
