### PR TITLE
python312Packages.pysdl2: 0.9.17 -> 0.9.17-unstable-2025-04-03, fix for sdl2-compat

### DIFF
--- a/pkgs/development/python-modules/pysdl2/default.nix
+++ b/pkgs/development/python-modules/pysdl2/default.nix
@@ -21,7 +21,7 @@
 
 buildPythonPackage rec {
   pname = "pysdl2";
-  version = "0.9.17";
+  version = "0.9.17-unstable-2025-04-03";
   pyproject = true;
 
   pythonImportsCheck = [ "sdl2" ];
@@ -29,23 +29,29 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "py-sdl";
     repo = "py-sdl2";
-    tag = version;
-    hash = "sha256-FqVgDGpImLN2a51TnU6eKjLK3rwW3ujdzOkK58ERBbE=";
+    rev = "6414ee1c5f4a6eb91b71f5f9e35d469eee395b9f";
+    hash = "sha256-E6Jpuin4bqDkvFTaZTsTNkNQJd2e5fuTf2oLsQ71uQ0=";
   };
 
   patches = [
     (replaceVars ./PySDL2-dll.patch (
-      builtins.mapAttrs
+      (builtins.mapAttrs
         (_: pkg: "${pkg}/lib/lib${pkg.pname}${stdenv.hostPlatform.extensions.sharedLibrary}")
         {
           inherit
-            SDL2
             SDL2_ttf
             SDL2_image
             SDL2_gfx
             SDL2_mixer
             ;
         }
+      )
+      // {
+        # sdl2-compat has the pname sdl2-compat,
+        # but the shared object is named libSDL2.so for compatibility reasons.
+        # This requires making the shared object path for SDL2 not depend on pname.
+        SDL2 = (pkg: "${pkg}/lib/libSDL2${stdenv.hostPlatform.extensions.sharedLibrary}") SDL2;
+      }
     ))
   ];
 
@@ -75,10 +81,34 @@ buildPythonPackage rec {
   disabledTests = [
     # GetPrefPath for OrgName/AppName is None
     "test_SDL_GetPrefPath"
+
+    # broken with sdl2-compat
+    "test_SDL_AddDelHintCallback"
+    "test_SDL_HasIntersectionF"
+    "test_SDL_IntersectFRect"
+    "test_SDL_UnionFRect"
+    "test_SDL_EncloseFPoints"
+    "test_SDL_IntersectFRectAndLine"
+    "test_SDL_GetSetTextureScaleMode"
+    "test_init"
+    "test_logical_size"
+    "test_copy"
+
+    # sdl2-compat fails on these in our build sandbox
+    "test_create_sprite"
+    "test_create_software_sprite"
+    "test_create_texture_sprite"
+    "test_from_image"
+    "test_from_surface"
+    "test_from_text"
+
+    "test_SDL_Init"
+    "test_SDL_InitSubSystem"
+    "test_SDL_SetWindowIcon"
   ];
 
   meta = {
-    changelog = "https://github.com/py-sdl/py-sdl2/releases/tag/${src.tag}";
+    changelog = "https://github.com/py-sdl/py-sdl2/compare/0.9.17..${src.rev}";
     description = "Wrapper around the SDL2 library and as such similar to the discontinued PySDL project";
     homepage = "https://github.com/py-sdl/py-sdl2";
     license = lib.licenses.publicDomain;


### PR DESCRIPTION
pysdl2 is mostly unmaintained. However, i wanted to fix it instead of dropping it outright - we can still drop it later. Upstream fixed a couple tests with sdl2-compat, but not all tests work on sdl2-compat in our build sandbox. This is partially due to sdl2-compat not explicitly expecting an x11 display, which means it returns errors on some method calls.

This PR skips the tests that are broken with sdl2-compat, and fixes the shared object file being loaded to work properly with sdl2-compat.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
