### PR TITLE
modrinth-app: 0.9.0 -> 0.9.3

### DIFF
--- a/pkgs/by-name/mo/modrinth-app-unwrapped/package.nix
+++ b/pkgs/by-name/mo/modrinth-app-unwrapped/package.nix
@@ -17,7 +17,6 @@
 
 let
   pnpm = pnpm_9;
-
 in
 rustPlatform.buildRustPackage rec {
   pname = "modrinth-app-unwrapped";

--- a/pkgs/by-name/mo/modrinth-app-unwrapped/package.nix
+++ b/pkgs/by-name/mo/modrinth-app-unwrapped/package.nix
@@ -1,10 +1,25 @@
-{ lib, stdenv, cacert, cargo-tauri, desktop-file-utils, fetchFromGitHub
-, makeBinaryWrapper, nodejs, openssl, pkg-config, pnpm_9, rustPlatform, turbo
-, webkitgtk_4_1, }:
+{
+  lib,
+  stdenv,
+  cacert,
+  cargo-tauri,
+  desktop-file-utils,
+  fetchFromGitHub,
+  makeBinaryWrapper,
+  nodejs,
+  openssl,
+  pkg-config,
+  pnpm_9,
+  rustPlatform,
+  turbo,
+  webkitgtk_4_1,
+}:
 
-let pnpm = pnpm_9;
+let
+  pnpm = pnpm_9;
 
-in rustPlatform.buildRustPackage rec {
+in
+rustPlatform.buildRustPackage rec {
   pname = "modrinth-app-unwrapped";
   version = "0.9.3";
 
@@ -32,25 +47,31 @@ in rustPlatform.buildRustPackage rec {
     pnpm.configHook
   ] ++ lib.optional stdenv.hostPlatform.isDarwin makeBinaryWrapper;
 
-  buildInputs = [ openssl ]
-    ++ lib.optional stdenv.hostPlatform.isLinux webkitgtk_4_1;
+  buildInputs = [ openssl ] ++ lib.optional stdenv.hostPlatform.isLinux webkitgtk_4_1;
 
   # Tests fail on other, unrelated packages in the monorepo
-  cargoTestFlags = [ "--package" "theseus_gui" ];
+  cargoTestFlags = [
+    "--package"
+    "theseus_gui"
+  ];
 
-  env = { TURBO_BINARY_PATH = lib.getExe turbo; };
+  env = {
+    TURBO_BINARY_PATH = lib.getExe turbo;
+  };
 
-  postInstall = lib.optionalString stdenv.hostPlatform.isDarwin ''
-    makeBinaryWrapper "$out"/Applications/Modrinth\ App.app/Contents/MacOS/Modrinth\ App "$out"/bin/ModrinthApp
-  '' + lib.optionalString stdenv.hostPlatform.isLinux ''
-    desktop-file-edit \
-      --set-comment "Modrinth's game launcher" \
-      --set-key="StartupNotify" --set-value="true" \
-      --set-key="Categories" --set-value="Game;ActionGame;AdventureGame;Simulation;" \
-      --set-key="Keywords" --set-value="game;minecraft;mc;" \
-      --set-key="StartupWMClass" --set-value="ModrinthApp" \
-      $out/share/applications/Modrinth\ App.desktop
-  '';
+  postInstall =
+    lib.optionalString stdenv.hostPlatform.isDarwin ''
+      makeBinaryWrapper "$out"/Applications/Modrinth\ App.app/Contents/MacOS/Modrinth\ App "$out"/bin/ModrinthApp
+    ''
+    + lib.optionalString stdenv.hostPlatform.isLinux ''
+      desktop-file-edit \
+        --set-comment "Modrinth's game launcher" \
+        --set-key="StartupNotify" --set-value="true" \
+        --set-key="Categories" --set-value="Game;ActionGame;AdventureGame;Simulation;" \
+        --set-key="Keywords" --set-value="game;minecraft;mc;" \
+        --set-key="StartupWMClass" --set-value="ModrinthApp" \
+        $out/share/applications/Modrinth\ App.desktop
+    '';
 
   meta = {
     description = "Modrinth's game launcher";
@@ -59,7 +80,10 @@ in rustPlatform.buildRustPackage rec {
       and keep them up to date, all in one neat little package
     '';
     homepage = "https://modrinth.com";
-    license = with lib.licenses; [ gpl3Plus unfreeRedistributable ];
+    license = with lib.licenses; [
+      gpl3Plus
+      unfreeRedistributable
+    ];
     maintainers = with lib.maintainers; [ getchoo ];
     mainProgram = "ModrinthApp";
     platforms = with lib; platforms.linux ++ platforms.darwin;

--- a/pkgs/by-name/mo/modrinth-app-unwrapped/package.nix
+++ b/pkgs/by-name/mo/modrinth-app-unwrapped/package.nix
@@ -1,37 +1,22 @@
-{
-  lib,
-  stdenv,
-  cacert,
-  cargo-tauri,
-  desktop-file-utils,
-  fetchFromGitHub,
-  makeBinaryWrapper,
-  nodejs,
-  openssl,
-  pkg-config,
-  pnpm_9,
-  rustPlatform,
-  turbo,
-  webkitgtk_4_1,
-}:
+{ lib, stdenv, cacert, cargo-tauri, desktop-file-utils, fetchFromGitHub
+, makeBinaryWrapper, nodejs, openssl, pkg-config, pnpm_9, rustPlatform, turbo
+, webkitgtk_4_1, }:
 
-let
-  pnpm = pnpm_9;
-in
+let pnpm = pnpm_9;
 
-rustPlatform.buildRustPackage rec {
+in rustPlatform.buildRustPackage rec {
   pname = "modrinth-app-unwrapped";
-  version = "0.9.0";
+  version = "0.9.3";
 
   src = fetchFromGitHub {
     owner = "modrinth";
     repo = "code";
     tag = "v${version}";
-    hash = "sha256-uDG+WHeMY/quzF8mHBn5o8xod4/G5+S4/zD2lbqdN0M=";
+    hash = "sha256-h+zj4Hm7v8SU6Zy0rIWbOknXVdSDf8b1d4q6M12J5Lc=";
   };
 
   useFetchCargoVendor = true;
-  cargoHash = "sha256-D9hkdliyKc8m9i2D9pG3keGmZsx+rzrgVXZws9Ot24I=";
+  cargoHash = "sha256-RrXSBgVh4UZFHcgUWhUjE7rEm/RZFDSDCpXS22gVjZ0=";
 
   pnpmDeps = pnpm.fetchDeps {
     inherit pname version src;
@@ -47,31 +32,25 @@ rustPlatform.buildRustPackage rec {
     pnpm.configHook
   ] ++ lib.optional stdenv.hostPlatform.isDarwin makeBinaryWrapper;
 
-  buildInputs = [ openssl ] ++ lib.optional stdenv.hostPlatform.isLinux webkitgtk_4_1;
+  buildInputs = [ openssl ]
+    ++ lib.optional stdenv.hostPlatform.isLinux webkitgtk_4_1;
 
   # Tests fail on other, unrelated packages in the monorepo
-  cargoTestFlags = [
-    "--package"
-    "theseus_gui"
-  ];
+  cargoTestFlags = [ "--package" "theseus_gui" ];
 
-  env = {
-    TURBO_BINARY_PATH = lib.getExe turbo;
-  };
+  env = { TURBO_BINARY_PATH = lib.getExe turbo; };
 
-  postInstall =
-    lib.optionalString stdenv.hostPlatform.isDarwin ''
-      makeBinaryWrapper "$out"/Applications/Modrinth\ App.app/Contents/MacOS/Modrinth\ App "$out"/bin/ModrinthApp
-    ''
-    + lib.optionalString stdenv.hostPlatform.isLinux ''
-      desktop-file-edit \
-        --set-comment "Modrinth's game launcher" \
-        --set-key="StartupNotify" --set-value="true" \
-        --set-key="Categories" --set-value="Game;ActionGame;AdventureGame;Simulation;" \
-        --set-key="Keywords" --set-value="game;minecraft;mc;" \
-        --set-key="StartupWMClass" --set-value="ModrinthApp" \
-        $out/share/applications/Modrinth\ App.desktop
-    '';
+  postInstall = lib.optionalString stdenv.hostPlatform.isDarwin ''
+    makeBinaryWrapper "$out"/Applications/Modrinth\ App.app/Contents/MacOS/Modrinth\ App "$out"/bin/ModrinthApp
+  '' + lib.optionalString stdenv.hostPlatform.isLinux ''
+    desktop-file-edit \
+      --set-comment "Modrinth's game launcher" \
+      --set-key="StartupNotify" --set-value="true" \
+      --set-key="Categories" --set-value="Game;ActionGame;AdventureGame;Simulation;" \
+      --set-key="Keywords" --set-value="game;minecraft;mc;" \
+      --set-key="StartupWMClass" --set-value="ModrinthApp" \
+      $out/share/applications/Modrinth\ App.desktop
+  '';
 
   meta = {
     description = "Modrinth's game launcher";
@@ -80,10 +59,7 @@ rustPlatform.buildRustPackage rec {
       and keep them up to date, all in one neat little package
     '';
     homepage = "https://modrinth.com";
-    license = with lib.licenses; [
-      gpl3Plus
-      unfreeRedistributable
-    ];
+    license = with lib.licenses; [ gpl3Plus unfreeRedistributable ];
     maintainers = with lib.maintainers; [ getchoo ];
     mainProgram = "ModrinthApp";
     platforms = with lib; platforms.linux ++ platforms.darwin;


### PR DESCRIPTION
Diff: [modrinth/code@refs/tags/v0.9.0...v0.9.3](https://github.com/modrinth/code/compare/refs/tags/v0.9.0...v0.9.3)
<!-- 
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
