### PR TITLE
nixos/dhcpcd: fix typo in documentation

### DIFF
--- a/nixos/modules/services/networking/dhcpcd.nix
+++ b/nixos/modules/services/networking/dhcpcd.nix
@@ -226,7 +226,7 @@ in
         (IPv4 or IPv6) to be assigned. If set to "both", dhcpcd will wait for
         both an IPv4 and an IPv6 address before forking.
         The option "if-carrier-up" is equivalent to "any" if either ethernet
-        is plugged nor WiFi is powered, and to "background" otherwise.
+        is plugged or WiFi is powered, and to "background" otherwise.
       '';
     };
 


### PR DESCRIPTION
The manpage of dhcpcd says:

>If any interface reports a working carrier then dhcpcd will try to obtain a lease before forking to the background, otherwise it will fork right away.

## Things done

Nothing, it's a typo…