### PR TITLE
koji: 2.2.0 -> 3.2.0

### DIFF
--- a/pkgs/by-name/ko/koji/package.nix
+++ b/pkgs/by-name/ko/koji/package.nix
@@ -1,38 +1,50 @@
 {
   lib,
+  stdenv,
   rustPlatform,
   fetchFromGitHub,
   pkg-config,
   perl,
   udev,
   openssl,
+  gitMinimal,
+  writableTmpDirAsHomeHook,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "koji";
-  version = "2.2.0";
+  version = "3.2.0";
 
   src = fetchFromGitHub {
-    owner = "its-danny";
+    owner = "cococonscious";
     repo = "koji";
-    rev = version;
-    hash = "sha256-2kBjHX7izo4loJ8oyPjE9FtCvUODC3Sm4T8ETIdeGZM=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-+xtq4btFbOfiyFMDHXo6riSBMhAwTLQFuE91MUHtg5Q=";
   };
 
   useFetchCargoVendor = true;
-  cargoHash = "sha256-ZHti7nMfHiYur1kjxj+ySIF4/l0UU9q2urabUWZyk6E=";
+  cargoHash = "sha256-WiFXDXLJc2ictv29UoRFRpIpAqeJlEBEOvThXhLXLJA=";
 
   OPENSSL_NO_VENDOR = 1;
 
   nativeBuildInputs = [
     pkg-config
     perl
-    udev
   ];
 
   buildInputs = [
-    openssl.dev
+    openssl
+  ] ++ lib.optionals stdenv.hostPlatform.isLinux [ udev ];
+
+  nativeCheckInputs = [
+    gitMinimal
+    writableTmpDirAsHomeHook
   ];
+
+  preCheck = ''
+    git config --global user.name 'nix-user'
+    git config --global user.email 'nix-user@example.com'
+  '';
 
   meta = {
     description = "Interactive CLI for creating conventional commits";
@@ -45,4 +57,4 @@ rustPlatform.buildRustPackage rec {
     mainProgram = "koji";
     platforms = lib.platforms.unix;
   };
-}
+})

--- a/pkgs/by-name/ko/koji/package.nix
+++ b/pkgs/by-name/ko/koji/package.nix
@@ -9,6 +9,8 @@
   openssl,
   gitMinimal,
   writableTmpDirAsHomeHook,
+  installShellFiles,
+  versionCheckHook,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
@@ -30,6 +32,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   nativeBuildInputs = [
     pkg-config
     perl
+    installShellFiles
   ];
 
   buildInputs = [
@@ -45,6 +48,17 @@ rustPlatform.buildRustPackage (finalAttrs: {
     git config --global user.name 'nix-user'
     git config --global user.email 'nix-user@example.com'
   '';
+
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+    installShellCompletion --cmd koji \
+      --bash <($out/bin/koji completions bash) \
+      --fish <($out/bin/koji completions fish) \
+      --zsh <($out/bin/koji completions zsh)
+  '';
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgram = "${placeholder "out"}/bin/${finalAttrs.meta.mainProgram}";
 
   meta = {
     description = "Interactive CLI for creating conventional commits";

--- a/pkgs/by-name/ko/koji/package.nix
+++ b/pkgs/by-name/ko/koji/package.nix
@@ -34,12 +34,15 @@ rustPlatform.buildRustPackage rec {
     openssl.dev
   ];
 
-  meta = with lib; {
+  meta = {
     description = "Interactive CLI for creating conventional commits";
     homepage = "https://github.com/its-danny/koji";
-    license = with licenses; [ mit ];
-    maintainers = with maintainers; [ ByteSudoer ];
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
+      ByteSudoer
+      WeetHet
+    ];
     mainProgram = "koji";
-    platforms = platforms.unix;
+    platforms = lib.platforms.unix;
   };
 }


### PR DESCRIPTION
- Updated the derivation to use `finalAttrs`
- Updated koji to 3.2.0, moving the source to the new location. 
- Moved `udev` to be linux only, fixing evaluation and building on darwin. 
- The 3.0.0 version added tests that need git to be somewhat set up, so I added that to the check phase. 
- For some reason, completions weren't set up, so I added a `postInstall` with them as well
- Added myself to maintainers

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
