### PR TITLE
ansible: add passlib dependency

### DIFF
--- a/pkgs/development/python-modules/ansible/default.nix
+++ b/pkgs/development/python-modules/ansible/default.nix
@@ -15,6 +15,7 @@
   textfsm,
   ttp,
   xmltodict,
+  passlib,
 
   # optionals
   withJunos ? false,
@@ -47,6 +48,7 @@ buildPythonPackage {
     [
       # Support ansible collections by default, make all others optional
       # ansible.netcommon
+      passlib
       jxmlease
       ncclient
       netaddr


### PR DESCRIPTION
Adds the missing passlib dependency to Ansible, required for password_hash functionality.

Closes #395702
Maintainers: 