### PR TITLE
python3Packages.pyssim: modernize

### DIFF
--- a/pkgs/development/python-modules/pyssim/default.nix
+++ b/pkgs/development/python-modules/pyssim/default.nix
@@ -7,12 +7,17 @@
   pillow,
   pywavelets,
   fetchpatch,
+  setuptools,
 }:
 
 buildPythonPackage rec {
   pname = "pyssim";
   version = "0.7";
-  format = "setuptools";
+  pyproject = true;
+
+  build-system = [
+    setuptools
+  ];
 
   dependencies = [
     numpy
@@ -24,8 +29,8 @@ buildPythonPackage rec {
   # PyPI tarball doesn't contain test images so let's use GitHub
   src = fetchFromGitHub {
     owner = "jterrace";
-    repo = pname;
-    rev = "v${version}";
+    repo = "pyssim";
+    tag = "v${version}";
     sha256 = "sha256-LDNIugQeRqNsAZ5ZxS/NxHokEAwefpfRutTRpR0IcXk=";
   };
 
@@ -39,17 +44,20 @@ buildPythonPackage rec {
 
   # Tests are copied from .github/workflows/python-package.yml
   checkPhase = ''
+    runHook preCheck
     $out/bin/pyssim test-images/test1-1.png test-images/test1-1.png | grep 1
     $out/bin/pyssim test-images/test1-1.png test-images/test1-2.png | grep 0.998
     $out/bin/pyssim test-images/test1-1.png "test-images/*" | grep -E " 1| 0.998| 0.672| 0.648" | wc -l | grep 4
     $out/bin/pyssim --cw --width 128 --height 128 test-images/test1-1.png test-images/test1-1.png | grep 1
     $out/bin/pyssim --cw --width 128 --height 128 test-images/test3-orig.jpg test-images/test3-rot.jpg | grep 0.938
+    runHook postCheck
   '';
 
   meta = {
     description = "Module for computing Structured Similarity Image Metric (SSIM) in Python";
     mainProgram = "pyssim";
     homepage = "https://github.com/jterrace/pyssim";
+    changelog = "https://github.com/jterrace/pyssim/blob/${src.tag}/CHANGES.md";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ jluttine ];
   };


### PR DESCRIPTION
Could also move to pkgs/by-name, since this is only an application (?)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).