### PR TITLE
netexec: fix eval; modernize

### DIFF
--- a/pkgs/tools/security/netexec/default.nix
+++ b/pkgs/tools/security/netexec/default.nix
@@ -2,30 +2,44 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  python3,
+  buildPythonApplication,
+  pytestCheckHook,
+  # Deps
+  poetry-core,
+  poetry-dynamic-versioning,
+  aardwolf,
+  aioconsole,
+  aiosqlite,
+  argcomplete,
+  asyauth,
+  beautifulsoup4,
+  bloodhound-py,
+  dploot,
+  dsinternals,
+  lsassy,
+  masky,
+  minikerberos,
+  msgpack,
+  msldap,
+  neo4j,
+  paramiko,
+  pyasn1-modules,
+  pylnk3,
+  pynfsclient,
+  pypsrp,
+  pypykatz,
+  python-dateutil,
+  python-libnmap,
+  pywerview,
+  requests,
+  rich,
+  sqlalchemy,
+  termcolor,
+  terminaltables,
+  xmltodict,
+  impacket,
 }:
-let
-  python = python3.override {
-    self = python;
-    packageOverrides = self: super: {
-      impacket = super.impacket.overridePythonAttrs {
-        version = "0.12.0.dev1-unstable-2023-11-30";
-        src = fetchFromGitHub {
-          owner = "Pennyw0rth";
-          repo = "impacket";
-          rev = "d370e6359a410063b2c9c68f6572c3b5fb178a38";
-          hash = "sha256-Jozn4lKAnLQ2I53+bx0mFY++OH5P4KyqVmrS5XJUY3E=";
-        };
-        # Fix version to be compliant with Python packaging rules
-        postPatch = ''
-          substituteInPlace setup.py \
-            --replace 'version="{}.{}.{}.{}{}"' 'version="{}.{}.{}"'
-        '';
-      };
-    };
-  };
-in
-python.pkgs.buildPythonApplication rec {
+buildPythonApplication rec {
   pname = "netexec";
   version = "1.3.0";
   pyproject = true;
@@ -50,12 +64,12 @@ python.pkgs.buildPythonApplication rec {
       --replace-fail '{ git = "https://github.com/Pennyw0rth/NfsClient" }' '"*"'
   '';
 
-  build-system = with python.pkgs; [
+  build-system = [
     poetry-core
     poetry-dynamic-versioning
   ];
 
-  dependencies = with python.pkgs; [
+  dependencies = [
     aardwolf
     aioconsole
     aiosqlite
@@ -65,7 +79,6 @@ python.pkgs.buildPythonApplication rec {
     bloodhound-py
     dploot
     dsinternals
-    impacket
     lsassy
     masky
     minikerberos
@@ -89,7 +102,7 @@ python.pkgs.buildPythonApplication rec {
     xmltodict
   ];
 
-  nativeCheckInputs = with python.pkgs; [ pytestCheckHook ];
+  nativeCheckInputs = [ pytestCheckHook ];
 
   # Tests no longer works out-of-box with 1.3.0
   doCheck = false;

--- a/pkgs/tools/security/netexec/default.nix
+++ b/pkgs/tools/security/netexec/default.nix
@@ -111,12 +111,12 @@ buildPythonApplication rec {
     export HOME=$(mktemp -d)
   '';
 
-  meta = with lib; {
+  meta = {
     description = "Network service exploitation tool (maintained fork of CrackMapExec)";
     homepage = "https://github.com/Pennyw0rth/NetExec";
     changelog = "https://github.com/Pennyw0rth/NetExec/releases/tag/v${version}";
-    license = licenses.bsd2;
-    maintainers = with maintainers; [ vncsb ];
+    license = lib.licenses.bsd2;
+    maintainers = with lib.maintainers; [ vncsb ];
     mainProgram = "nxc";
     # FIXME: failing fixupPhase:
     # $ Rewriting #!/nix/store/<hash>-python3-3.11.7/bin/python3.11 to #!/nix/store/<hash>-python3-3.11.7


### PR DESCRIPTION
Fixes evaluation failure with "error: do not use python3Packages when building Python packages, specify each used package as a separate argument" after #394838. Also snuck in a quick removal for nested `with lib;` :)

Fixes #395712

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
