### PR TITLE
haskell.compiler.ghc984: self-bootstrap on aarch64 musl

### DIFF
--- a/pkgs/development/compilers/ghc/9.8.4-binary.nix
+++ b/pkgs/development/compilers/ghc/9.8.4-binary.nix
@@ -1,0 +1,491 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  perl,
+  gcc,
+  ncurses6,
+  gmp,
+  libiconv,
+  numactl,
+  libffi,
+  llvmPackages,
+  coreutils,
+  targetPackages,
+
+  # minimal = true; will remove files that aren't strictly necessary for
+  # regular builds and GHC bootstrapping.
+  # This is "useful" for staying within hydra's output limits for at least the
+  # aarch64-linux architecture.
+  minimal ? false,
+}:
+
+# Prebuilt only does native
+assert stdenv.targetPlatform == stdenv.hostPlatform;
+
+let
+  downloadsUrl = "https://downloads.haskell.org/ghc";
+
+  # Copy sha256 from https://downloads.haskell.org/~ghc/9.8.4/SHA256SUMS
+  version = "9.8.4";
+
+  # Information about available bindists that we use in the build.
+  #
+  # # Bindist library checking
+  #
+  # The field `archSpecificLibraries` also provides a way for us get notified
+  # early when the upstream bindist changes its dependencies (e.g. because a
+  # newer Debian version is used that uses a new `ncurses` version).
+  #
+  # Usage:
+  #
+  # * You can find the `fileToCheckFor` of libraries by running `readelf -d`
+  #   on the compiler binary (`exePathForLibraryCheck`).
+  # * To skip library checking for an architecture,
+  #   set `exePathForLibraryCheck = null`.
+  # * To skip file checking for a specific arch specific library,
+  #   set `fileToCheckFor = null`.
+  ghcBinDists = {
+    # Binary distributions for the default libc (e.g. glibc, or libSystem on Darwin)
+    # nixpkgs uses for the respective system.
+    defaultLibc = {
+      i686-linux = {
+        variantSuffix = "";
+        src = {
+          url = "${downloadsUrl}/${version}/ghc-${version}-i386-deb10-linux.tar.xz";
+          sha256 = "e5efce16c654d5e702986258a87dd9531e1722b8051823c8ce1150ce3c5899ae";
+        };
+        exePathForLibraryCheck = "bin/ghc";
+        archSpecificLibraries = [
+          {
+            nixPackage = gmp;
+            fileToCheckFor = null;
+          }
+          {
+            nixPackage = ncurses6;
+            fileToCheckFor = "libtinfo.so.6";
+          }
+        ];
+      };
+      x86_64-linux = {
+        variantSuffix = "";
+        src = {
+          url = "${downloadsUrl}/${version}/ghc-${version}-x86_64-deb11-linux.tar.xz";
+          sha256 = "af151db8682b8c763f5a44f960f65453d794c95b60f151abc82dbdefcbe6f8ad";
+        };
+        exePathForLibraryCheck = "bin/ghc";
+        archSpecificLibraries = [
+          {
+            nixPackage = gmp;
+            fileToCheckFor = null;
+          }
+          {
+            nixPackage = ncurses6;
+            fileToCheckFor = "libtinfo.so.6";
+          }
+        ];
+      };
+      aarch64-linux = {
+        variantSuffix = "";
+        src = {
+          url = "${downloadsUrl}/${version}/ghc-${version}-aarch64-deb11-linux.tar.xz";
+          sha256 = "310204daf2df6ad16087be94b3498ca414a0953b29e94e8ec8eb4a5c9bf603d3";
+        };
+        exePathForLibraryCheck = "bin/ghc";
+        archSpecificLibraries = [
+          {
+            nixPackage = gmp;
+            fileToCheckFor = null;
+          }
+          {
+            nixPackage = ncurses6;
+            fileToCheckFor = "libtinfo.so.6";
+          }
+          {
+            nixPackage = numactl;
+            fileToCheckFor = null;
+          }
+        ];
+      };
+      x86_64-darwin = {
+        variantSuffix = "";
+        src = {
+          url = "${downloadsUrl}/${version}/ghc-${version}-x86_64-apple-darwin.tar.xz";
+          sha256 = "de7baacfb1513ab0e4ccf8911045cceee84bc8a4e39b89bd975ed3135e5f7d96";
+        };
+        exePathForLibraryCheck = null; # we don't have a library check for darwin yet
+        archSpecificLibraries = [
+          {
+            nixPackage = gmp;
+            fileToCheckFor = null;
+          }
+          {
+            nixPackage = ncurses6;
+            fileToCheckFor = null;
+          }
+          {
+            nixPackage = libiconv;
+            fileToCheckFor = null;
+          }
+        ];
+      };
+      aarch64-darwin = {
+        variantSuffix = "";
+        src = {
+          url = "${downloadsUrl}/${version}/ghc-${version}-aarch64-apple-darwin.tar.xz";
+          sha256 = "e2f12a922754fd28511512875bf6d9eb3e0cce7fc963a7266f6e1661aeabd7ed";
+        };
+        exePathForLibraryCheck = null; # we don't have a library check for darwin yet
+        archSpecificLibraries = [
+          {
+            nixPackage = gmp;
+            fileToCheckFor = null;
+          }
+          {
+            nixPackage = ncurses6;
+            fileToCheckFor = null;
+          }
+          {
+            nixPackage = libiconv;
+            fileToCheckFor = null;
+          }
+        ];
+      };
+    };
+    # Binary distributions for the musl libc for the respective system.
+    musl = {
+      aarch64-linux = {
+        variantSuffix = "-musl";
+        src = {
+          url = "${downloadsUrl}/${version}/ghc-${version}-aarch64-alpine3_18-linux.tar.xz";
+          sha256 = "b5c86a0cda0bd62d5eeeb52b1937c3bd00c70cd67dd74226ce787d5c429a4e62";
+        };
+        exePathForLibraryCheck = "bin/ghc";
+        archSpecificLibraries = [
+          {
+            nixPackage = gmp;
+            fileToCheckFor = null;
+          }
+          {
+            nixPackage = ncurses6;
+            fileToCheckFor = "libncursesw.so.6";
+          }
+        ];
+      };
+      x86_64-linux = {
+        variantSuffix = "-musl";
+        src = {
+          url = "${downloadsUrl}/${version}/ghc-${version}-x86_64-alpine3_12-linux.tar.xz";
+          sha256 = "e34bb16e8387509adc96a3d98b4a444bab425d12864c38a3629f2860b4bec2e7";
+        };
+        exePathForLibraryCheck = "bin/ghc";
+        archSpecificLibraries = [
+          {
+            nixPackage = gmp;
+            fileToCheckFor = null;
+          }
+          {
+            nixPackage = ncurses6;
+            fileToCheckFor = "libncursesw.so.6";
+          }
+        ];
+      };
+    };
+  };
+
+  distSetName = if stdenv.hostPlatform.isMusl then "musl" else "defaultLibc";
+
+  binDistUsed =
+    ghcBinDists.${distSetName}.${stdenv.hostPlatform.system}
+      or (throw "cannot bootstrap GHC on this platform ('${stdenv.hostPlatform.system}' with libc '${distSetName}')");
+
+  gmpUsed =
+    (builtins.head (
+      builtins.filter (
+        drv: lib.hasPrefix "gmp" (drv.nixPackage.name or "")
+      ) binDistUsed.archSpecificLibraries
+    )).nixPackage;
+
+  useLLVM = !(import ./common-have-ncg.nix { inherit lib stdenv version; });
+
+  libPath = lib.makeLibraryPath (
+    # Add arch-specific libraries.
+    map ({ nixPackage, ... }: nixPackage) binDistUsed.archSpecificLibraries
+  );
+
+  libEnvVar = lib.optionalString stdenv.hostPlatform.isDarwin "DY" + "LD_LIBRARY_PATH";
+
+  runtimeDeps =
+    [
+      targetPackages.stdenv.cc
+      targetPackages.stdenv.cc.bintools
+      coreutils # for cat
+    ]
+    ++ lib.optionals useLLVM [
+      (lib.getBin llvmPackages.llvm)
+    ]
+    # On darwin, we need unwrapped bintools as well (for otool)
+    ++ lib.optionals (stdenv.targetPlatform.linker == "cctools") [
+      targetPackages.stdenv.cc.bintools.bintools
+    ];
+
+in
+
+stdenv.mkDerivation {
+  inherit version;
+  pname = "ghc-binary${binDistUsed.variantSuffix}";
+
+  src = fetchurl binDistUsed.src;
+
+  nativeBuildInputs = [ perl ];
+
+  # Set LD_LIBRARY_PATH or equivalent so that the programs running as part
+  # of the bindist installer can find the libraries they expect.
+  # Cannot patchelf beforehand due to relative RPATHs that anticipate
+  # the final install location.
+  ${libEnvVar} = libPath;
+
+  postUnpack =
+    # Verify our assumptions of which `libtinfo.so` (ncurses) version is used,
+    # so that we know when ghc bindists upgrade that and we need to update the
+    # version used in `libPath`.
+    lib.optionalString (binDistUsed.exePathForLibraryCheck != null)
+      # Note the `*` glob because some GHCs have a suffix when unpacked, e.g.
+      # the musl bindist has dir `ghc-VERSION-x86_64-unknown-linux/`.
+      # As a result, don't shell-quote this glob when splicing the string.
+      (
+        let
+          buildExeGlob = ''ghc-${version}*/"${binDistUsed.exePathForLibraryCheck}"'';
+        in
+        lib.concatStringsSep "\n" [
+          (''
+            shopt -u nullglob
+            echo "Checking that ghc binary exists in bindist at ${buildExeGlob}"
+            if ! test -e ${buildExeGlob}; then
+              echo >&2 "GHC binary ${binDistUsed.exePathForLibraryCheck} could not be found in the bindist build directory (at ${buildExeGlob}) for arch ${stdenv.hostPlatform.system}, please check that ghcBinDists correctly reflect the bindist dependencies!"; exit 1;
+            fi
+          '')
+          (lib.concatMapStringsSep "\n" (
+            { fileToCheckFor, nixPackage }:
+            lib.optionalString (fileToCheckFor != null) ''
+              echo "Checking bindist for ${fileToCheckFor} to ensure that is still used"
+              if ! readelf -d ${buildExeGlob} | grep "${fileToCheckFor}"; then
+                echo >&2 "File ${fileToCheckFor} could not be found in ${binDistUsed.exePathForLibraryCheck} for arch ${stdenv.hostPlatform.system}, please check that ghcBinDists correctly reflect the bindist dependencies!"; exit 1;
+              fi
+
+              echo "Checking that the nix package ${nixPackage} contains ${fileToCheckFor}"
+              if ! test -e "${lib.getLib nixPackage}/lib/${fileToCheckFor}"; then
+                echo >&2 "Nix package ${nixPackage} did not contain ${fileToCheckFor} for arch ${stdenv.hostPlatform.system}, please check that ghcBinDists correctly reflect the bindist dependencies!"; exit 1;
+              fi
+            ''
+          ) binDistUsed.archSpecificLibraries)
+        ]
+      )
+    # GHC has dtrace probes, which causes ld to try to open /usr/lib/libdtrace.dylib
+    # during linking
+    + lib.optionalString stdenv.hostPlatform.isDarwin ''
+      export NIX_LDFLAGS+=" -no_dtrace_dof"
+      # not enough room in the object files for the full path to libiconv :(
+      for exe in $(find . -type f -executable); do
+        isMachO $exe || continue
+        ln -fs ${libiconv}/lib/libiconv.dylib $(dirname $exe)/libiconv.dylib
+        install_name_tool -change /usr/lib/libiconv.2.dylib @executable_path/libiconv.dylib -change /usr/local/lib/gcc/6/libgcc_s.1.dylib ${gcc.cc.lib}/lib/libgcc_s.1.dylib $exe
+      done
+    ''
+
+    # We have to patch the GMP paths for the ghc-bignum package, for hadrian by
+    # modifying the package-db directly
+    + ''
+      find . -name 'ghc-bignum*.conf' \
+          -exec sed -e '/^[a-z-]*library-dirs/a \    ${lib.getLib gmpUsed}/lib' -i {} \;
+    ''
+    # Similar for iconv and libffi on darwin
+    + lib.optionalString stdenv.hostPlatform.isDarwin ''
+      find . -name 'base*.conf' \
+          -exec sed -e '/^[a-z-]*library-dirs/a \    ${lib.getLib libiconv}/lib' -i {} \;
+
+      # To link RTS in the end we also need libffi now
+      find . -name 'rts*.conf' \
+          -exec sed -e '/^[a-z-]*library-dirs/a \    ${lib.getLib libffi}/lib' \
+                    -e 's@/Library/Developer/.*/usr/include/ffi@${lib.getDev libffi}/include@' \
+                    -i {} \;
+    ''
+    +
+      # aarch64 does HAVE_NUMA so -lnuma requires it in library-dirs in rts/package.conf.in
+      # FFI_LIB_DIR is a good indication of places it must be needed.
+      lib.optionalString (stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isAarch64) ''
+        find . -name package.conf.in \
+            -exec sed -i "s@FFI_LIB_DIR@FFI_LIB_DIR ${numactl.out}/lib@g" {} \;
+      ''
+    +
+      # Rename needed libraries and binaries, fix interpreter
+      lib.optionalString stdenv.hostPlatform.isLinux ''
+        find . -type f -executable -exec patchelf \
+            --interpreter ${stdenv.cc.bintools.dynamicLinker} {} \;
+      '';
+
+  # fix for `configure: error: Your linker is affected by binutils #16177`
+  preConfigure = lib.optionalString stdenv.targetPlatform.isAarch32 "LD=ld.gold";
+
+  # GHC has a patched config.sub and bindists' platforms should always work
+  dontUpdateAutotoolsGnuConfigScripts = true;
+
+  configurePlatforms = [ ];
+  configureFlags =
+    lib.optional stdenv.hostPlatform.isDarwin "--with-gcc=${./gcc-clang-wrapper.sh}"
+    # From: https://github.com/NixOS/nixpkgs/pull/43369/commits
+    ++ lib.optional stdenv.hostPlatform.isMusl "--disable-ld-override";
+
+  # No building is necessary, but calling make without flags ironically
+  # calls install-strip ...
+  dontBuild = true;
+
+  # Patch scripts to include runtime dependencies in $PATH.
+  postInstall =
+    ''
+      for i in "$out/bin/"*; do
+        test ! -h "$i" || continue
+        isScript "$i" || continue
+        sed -i -e '2i export PATH="${lib.makeBinPath runtimeDeps}:$PATH"' "$i"
+      done
+    ''
+    + lib.optionalString stdenv.targetPlatform.isDarwin ''
+      # Work around building with binary GHC on Darwin due to GHC’s use of `ar -L` when it
+      # detects `llvm-ar` even though the resulting archives are not supported by ld64.
+      # https://gitlab.haskell.org/ghc/ghc/-/issues/23188
+      # https://github.com/haskell/cabal/issues/8882
+      sed -i -e 's/,("ar supports -L", "YES")/,("ar supports -L", "NO")/' "$out/lib/ghc-${version}/lib/settings"
+    '';
+
+  # Apparently necessary for the ghc Alpine (musl) bindist:
+  # When we strip, and then run the
+  #     patchelf --set-rpath "${libPath}:$(patchelf --print-rpath $p)" $p
+  # below, running ghc (e.g. during `installCheckPhase)` gives some apparently
+  # corrupted rpath or whatever makes the loader work on nonsensical strings:
+  #     running install tests
+  #     Error relocating /nix/store/...-ghc-8.10.2-binary/lib/ghc-8.10.5/bin/ghc: : symbol not found
+  #     Error relocating /nix/store/...-ghc-8.10.2-binary/lib/ghc-8.10.5/bin/ghc: ir6zf6c9f86pfx8sr30n2vjy-ghc-8.10.2-binary/lib/ghc-8.10.5/bin/../lib/x86_64-linux-ghc-8.10.5/libHSexceptions-0.10.4-ghc8.10.5.so: symbol not found
+  #     Error relocating /nix/store/...-ghc-8.10.2-binary/lib/ghc-8.10.5/bin/ghc: y/lib/ghc-8.10.5/bin/../lib/x86_64-linux-ghc-8.10.5/libHStemplate-haskell-2.16.0.0-ghc8.10.5.so: symbol not found
+  #     Error relocating /nix/store/...-ghc-8.10.2-binary/lib/ghc-8.10.5/bin/ghc: 8.10.5/libHStemplate-haskell-2.16.0.0-ghc8.10.5.so: symbol not found
+  #     Error relocating /nix/store/...-ghc-8.10.2-binary/lib/ghc-8.10.5/bin/ghc: �: symbol not found
+  #     Error relocating /nix/store/...-ghc-8.10.2-binary/lib/ghc-8.10.5/bin/ghc: �?: symbol not found
+  #     Error relocating /nix/store/...-ghc-8.10.2-binary/lib/ghc-8.10.5/bin/ghc: 64-linux-ghc-8.10.5/libHSexceptions-0.10.4-ghc8.10.5.so: symbol not found
+  # This is extremely bogus and should be investigated.
+  dontStrip = if stdenv.hostPlatform.isMusl then true else false; # `if` for explicitness
+
+  # On Linux, use patchelf to modify the executables so that they can
+  # find editline/gmp.
+  postFixup =
+    lib.optionalString (stdenv.hostPlatform.isLinux && !(binDistUsed.isStatic or false)) (
+      if stdenv.hostPlatform.isAarch64 then
+        # Keep rpath as small as possible on aarch64 for patchelf#244.  All Elfs
+        # are 2 directories deep from $out/lib, so pooling symlinks there makes
+        # a short rpath.
+        ''
+          (cd $out/lib; ln -s ${lib.getLib gmpUsed}/lib/libgmp.so.10)
+        ''
+        + (
+          if stdenv.hostPlatform.isMusl then
+            ''
+              (cd $out/lib; ln -s ${ncurses6.out}/lib/libncursesw.so.6)
+            ''
+          else
+            ''
+              (cd $out/lib; ln -s ${ncurses6.out}/lib/libtinfo.so.6)
+            ''
+        )
+        + ''
+          for p in $(find "$out/lib" -type f -name "*\.so*"); do
+            (cd $out/lib; ln -s $p)
+          done
+
+          for p in $(find "$out/lib" -type f -executable); do
+            if isELF "$p"; then
+              echo "Patchelfing $p"
+              patchelf --set-rpath "\$ORIGIN:\$ORIGIN/../.." $p
+            fi
+          done
+        ''
+      else
+        ''
+          for p in $(find "$out" -type f -executable); do
+            if isELF "$p"; then
+              echo "Patchelfing $p"
+              patchelf --set-rpath "${libPath}:$(patchelf --print-rpath $p)" $p
+            fi
+          done
+        ''
+    )
+    + lib.optionalString stdenv.hostPlatform.isDarwin ''
+      # not enough room in the object files for the full path to libiconv :(
+      for exe in $(find "$out" -type f -executable); do
+        isMachO $exe || continue
+        ln -fs ${libiconv}/lib/libiconv.dylib $(dirname $exe)/libiconv.dylib
+        install_name_tool -change /usr/lib/libiconv.2.dylib @executable_path/libiconv.dylib -change /usr/local/lib/gcc/6/libgcc_s.1.dylib ${gcc.cc.lib}/lib/libgcc_s.1.dylib $exe
+      done
+
+      for file in $(find "$out" -name setup-config); do
+        substituteInPlace $file --replace /usr/bin/ranlib "$(type -P ranlib)"
+      done
+    ''
+    # Recache package db which needs to happen for Hadrian bindists
+    # where we modify the package db before installing
+    + ''
+      package_db=("$out"/lib/ghc-*/lib/package.conf.d)
+      "$out/bin/ghc-pkg" --package-db="$package_db" recache
+    '';
+
+  # GHC cannot currently produce outputs that are ready for `-pie` linking.
+  # Thus, disable `pie` hardening, otherwise `recompile with -fPIE` errors appear.
+  # See:
+  # * https://github.com/NixOS/nixpkgs/issues/129247
+  # * https://gitlab.haskell.org/ghc/ghc/-/issues/19580
+  hardeningDisable = [ "pie" ];
+
+  doInstallCheck = true;
+  installCheckPhase = ''
+    # Sanity check, can ghc create executables?
+    cd $TMP
+    mkdir test-ghc; cd test-ghc
+    cat > main.hs << EOF
+      {-# LANGUAGE TemplateHaskell #-}
+      module Main where
+      main = putStrLn \$([|"yes"|])
+    EOF
+    env -i $out/bin/ghc --make main.hs || exit 1
+    echo compilation ok
+    [ $(./main) == "yes" ]
+  '';
+
+  passthru = {
+    targetPrefix = "";
+    enableShared = true;
+
+    inherit llvmPackages;
+
+    # Our Cabal compiler name
+    haskellCompilerName = "ghc-${version}";
+
+    # Normal GHC derivations expose the hadrian derivation used to build them
+    # here. In the case of bindists we just make sure that the attribute exists,
+    # as it is used for checking if a GHC derivation has been built with hadrian.
+    hadrian = null;
+  };
+
+  meta = rec {
+    homepage = "http://haskell.org/ghc";
+    description = "Glasgow Haskell Compiler";
+    license = lib.licenses.bsd3;
+    # HACK: since we can't encode the libc / abi in platforms, we need
+    # to make the platform list dependent on the evaluation platform
+    # in order to avoid eval errors with musl which supports less
+    # platforms than the default libcs (i. e. glibc / libSystem).
+    # This is done for the benefit of Hydra, so `packagePlatforms`
+    # won't return any platforms that would cause an evaluation
+    # failure for `pkgsMusl.haskell.compiler.ghc922Binary`, as
+    # long as the evaluator runs on a platform that supports
+    # `pkgsMusl`.
+    platforms = builtins.attrNames ghcBinDists.${distSetName};
+    maintainers = lib.teams.haskell.members;
+  };
+}

--- a/pkgs/development/compilers/ghc/common-hadrian.nix
+++ b/pkgs/development/compilers/ghc/common-hadrian.nix
@@ -22,14 +22,12 @@
 
   # build-tools
   bootPkgs,
-  autoconf,
-  automake,
+  autoreconfHook,
   coreutils,
   fetchurl,
   fetchgit,
   perl,
   python3,
-  m4,
   sphinx,
   xattr,
   autoSignDarwinBinariesHook,
@@ -614,15 +612,12 @@ stdenv.mkDerivation (
 
     nativeBuildInputs =
       [
+        autoreconfHook
         perl
         hadrian
         bootPkgs.alex
         bootPkgs.happy
         bootPkgs.hscolour
-        # autoconf and friends are necessary for hadrian to create the bindist
-        autoconf
-        automake
-        m4
         # Python is used in a few scripts invoked by hadrian to generate e.g. rts headers.
         python3
         # Tool used to update GHC's settings file in postInstall

--- a/pkgs/development/compilers/ghc/common-hadrian.nix
+++ b/pkgs/development/compilers/ghc/common-hadrian.nix
@@ -238,7 +238,15 @@
           ])
           [
             ../../tools/haskell/hadrian/hadrian-9.8.1-allow-Cabal-3.10.patch
-          ];
+          ]
+      ++ lib.optionals (lib.versionAtLeast version "9.8" && lib.versionOlder version "9.12") [
+        (fetchpatch {
+          name = "enable-ignore-build-platform-mismatch.patch";
+          url = "https://gitlab.haskell.org/ghc/ghc/-/commit/4ee094d46effd06093090fcba70f0a80d2a57e6c.patch";
+          includes = [ "configure.ac" ];
+          hash = "sha256-L3FQvcm9QB59BOiR2g5/HACAufIG08HiT53EIOjj64g=";
+        })
+      ];
 
     stdenv = stdenvNoCC;
   },
@@ -602,7 +610,15 @@ stdenv.mkDerivation (
       ]
       ++ lib.optionals enableUnregisterised [
         "--enable-unregisterised"
-      ];
+      ]
+      ++
+        lib.optionals
+          (stdenv.buildPlatform.isAarch64 && stdenv.buildPlatform.isMusl && lib.versionOlder version "9.12")
+          [
+            # The bootstrap binaries for aarch64 musl were built for the wrong triple.
+            # https://gitlab.haskell.org/ghc/ghc/-/merge_requests/13182
+            "--enable-ignore-build-platform-mismatch"
+          ];
 
     # Make sure we never relax`$PATH` and hooks support for compatibility.
     strictDeps = true;

--- a/pkgs/top-level/haskell-packages.nix
+++ b/pkgs/top-level/haskell-packages.nix
@@ -374,8 +374,10 @@ in
       };
       ghc984 = callPackage ../development/compilers/ghc/9.8.4.nix {
         bootPkgs =
-          # For GHC 9.6 no armv7l bindists are available.
-          if stdenv.buildPlatform.isAarch32 then
+          if stdenv.buildPlatform.isAarch64 && stdenv.buildPlatform.isMusl then
+            bb.packages.ghc984Binary
+          else if stdenv.buildPlatform.isAarch32 then
+            # For GHC 9.6 no armv7l bindists are available.
             bb.packages.ghc963
           else if stdenv.buildPlatform.isPower64 && stdenv.buildPlatform.isLittleEndian then
             bb.packages.ghc963

--- a/pkgs/top-level/haskell-packages.nix
+++ b/pkgs/top-level/haskell-packages.nix
@@ -25,6 +25,7 @@ let
     "ghc8107Binary"
     "ghc924Binary"
     "ghc963Binary"
+    "ghc984Binary"
     # ghcjs
     "ghcjs"
     "ghcjs810"
@@ -95,6 +96,10 @@ in
       };
 
       ghc963Binary = callPackage ../development/compilers/ghc/9.6.3-binary.nix {
+        llvmPackages = pkgs.llvmPackages_15;
+      };
+
+      ghc984Binary = callPackage ../development/compilers/ghc/9.8.4-binary.nix {
         llvmPackages = pkgs.llvmPackages_15;
       };
 
@@ -428,8 +433,13 @@ in
       ghc912 = compiler.ghc9121;
       ghcHEAD = callPackage ../development/compilers/ghc/head.nix {
         bootPkgs =
-          # No suitable bindist packaged yet
-          bb.packages.ghc9101;
+          # No armv7l bindists are available.
+          if stdenv.buildPlatform.isAarch32 then
+            bb.packages.ghc984
+          else if stdenv.buildPlatform.isPower64 && stdenv.buildPlatform.isLittleEndian then
+            bb.packages.ghc984
+          else
+            bb.packages.ghc984Binary;
         inherit (buildPackages.python3Packages) sphinx;
         # Need to use apple's patched xattr until
         # https://github.com/xattr/xattr/issues/44 and
@@ -508,6 +518,12 @@ in
         buildHaskellPackages = bh.packages.ghc963Binary;
         ghc = bh.compiler.ghc963Binary;
         compilerConfig = callPackage ../development/haskell-modules/configuration-ghc-9.6.x.nix { };
+        packageSetConfig = bootstrapPackageSet;
+      };
+      ghc984Binary = callPackage ../development/haskell-modules {
+        buildHaskellPackages = bh.packages.ghc984Binary;
+        ghc = bh.compiler.ghc984Binary;
+        compilerConfig = callPackage ../development/haskell-modules/configuration-ghc-9.8.x.nix { };
         packageSetConfig = bootstrapPackageSet;
       };
       ghc8107 = callPackage ../development/haskell-modules {


### PR DESCRIPTION
GHC only provides bootstrap binaries for aarch64 musl since 9.8.x, so we can't bootstrap with the recommended 9.6.x in that case. Fortunately, bootstrapping with 9.8.x seems to work fine.

Some notes:

- So far I've only confirmed that 9.8.4 builds. I've changed 9.8.1–9.8.3 as well, assuming that they'll build too.
- I've left every other platform bootstrapping 9.8 with 9.6. Is that the right thing to do, or would it be better to bootstrap with 9.8 across the board for consistency?
- I haven't made any attempt to factor out common stuff between the expressions for the bootstrap binaries, as it doesn't look like this has been done before. They also all seem to need slightly different fixups, and them presumably very limited maintenance thereafter, so probably not worth it?


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
