### PR TITLE
nixos/codeberg-pages: init

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1506,6 +1506,7 @@
   ./services/web-apps/calibre-web.nix
   ./services/web-apps/castopod.nix
   ./services/web-apps/coder.nix
+  ./services/web-apps/codeberg-pages.nix
   ./services/web-apps/changedetection-io.nix
   ./services/web-apps/chatgpt-retrieval-plugin.nix
   ./services/web-apps/cloudlog.nix

--- a/nixos/modules/services/web-apps/codeberg-pages.nix
+++ b/nixos/modules/services/web-apps/codeberg-pages.nix
@@ -1,0 +1,172 @@
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}:
+let
+  inherit (lib)
+    mkIf
+    mkOption
+    mkEnableOption
+    mkPackageOption
+    ;
+  inherit (lib) types;
+
+  cfg = config.services.codeberg-pages;
+in
+{
+  meta.maintainers = with lib.maintainers; [
+    NotAShelf
+  ];
+
+  options = {
+    services.codeberg-pages = {
+      enable = mkEnableOption "Codeberg pages server";
+      package = mkPackageOption pkgs "codeberg-pages" { };
+
+      stateDir = mkOption {
+        type = types.path;
+        default = "/var/lib/codeberg-pages";
+        example = "/opt/codeberg-pages";
+        description = "Directory in which state will be stored.";
+      };
+
+      user = mkOption {
+        type = types.str;
+        default = "codeberg-pages";
+        description = "User account under which Codeberg Pages will run.";
+      };
+
+      group = mkOption {
+        type = types.str;
+        default = "codeberg-pages";
+        description = "Group under under which Codeberg Pages will run.";
+      };
+
+      settings = mkOption {
+        # XXX: Codeberg pages does not appear to have any other types than ints,strings or booleans
+        # in its configuration format. Though it *also* expects booleans as "bool" so we should only
+        # accept strings and ints (for ports, etc.) If the configuration gets more complex in the
+        # future, then additional types must be provided here.
+        type =
+          with types;
+          submodule {
+            freeformType = attrsOf (oneOf [
+              str
+              int
+            ]);
+          };
+        default = { };
+        example = {
+          ACME_ACCEPT_TERMS = "true";
+          ENABLE_HTTP_SERVER = "true";
+
+          HOST = "[::]";
+          PORT = "443";
+
+          GITEA_ROOT = "https://git.exampledomain.tld";
+        };
+
+        description = ''
+          Configuration values to be passed to the codeberg pages server as environment
+          variables.
+
+          [pages-server documentation]: https://codeberg.org/Codeberg/pages-server#environment-variables
+          See [pages-server documentation] for available options. For sensitive values,
+          prefer using {option}`services.codberg-pages.environmentFile`.
+        '';
+      };
+
+      environmentFile = mkOption {
+        type = types.nullOr types.path;
+        default = null;
+        example = "/run/secret/pages-server.env";
+        description = ''
+          An environment file as defined in {manpage}`systemd.exec(5)`.
+          Sensitive information, such as {env}`GITEA_API_TOKEN`, may be passed
+          to the service without adding them to the world-readable Nix store.
+        '';
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    systemd = {
+      tmpfiles.settings = {
+        "10-codeberge-pages" = {
+          ${cfg.stateDir} = {
+            d = {
+              inherit (cfg) group user;
+              mode = "0750";
+            };
+          };
+        };
+      };
+
+      services.codeberg-pages = {
+        description = "Codeberg Pages Server";
+        documentation = [ "https://codeberg.org/Codeberg/pages-server" ];
+        wantedBy = [ "multi-user.target" ];
+        environment = cfg.settings;
+        serviceConfig = {
+          Type = "simple";
+          User = cfg.user;
+          Group = cfg.group;
+          WorkingDirectory = cfg.stateDir;
+          ReadWritePaths = [ cfg.stateDir ];
+          ExecStart = "${lib.getExe cfg.package}";
+          EnvironmentFile = lib.optional (cfg.environmentFile != null) cfg.environmentFile;
+          Restart = "on-failure";
+          # Security section directly mimics the one of Forgejo module
+          # Capabilities
+          CapabilityBoundingSet = "";
+          # Security
+          NoNewPrivileges = true;
+          # Sandboxing
+          ProtectSystem = "strict";
+          ProtectHome = true;
+          PrivateTmp = true;
+          PrivateDevices = true;
+          PrivateUsers = true;
+          ProtectHostname = true;
+          ProtectClock = true;
+          ProtectKernelTunables = true;
+          ProtectKernelModules = true;
+          ProtectKernelLogs = true;
+          ProtectControlGroups = true;
+          RestrictAddressFamilies = [
+            "AF_UNIX"
+            "AF_INET"
+            "AF_INET6"
+          ];
+          RestrictNamespaces = true;
+          LockPersonality = true;
+          MemoryDenyWriteExecute = true;
+          RestrictRealtime = true;
+          RestrictSUIDSGID = true;
+          RemoveIPC = true;
+          PrivateMounts = true;
+          # System Call Filtering
+          SystemCallArchitectures = "native";
+          SystemCallFilter = [
+            "~@cpu-emulation @debug @keyring @mount @obsolete @privileged @setuid"
+            "setrlimit"
+          ];
+        };
+      };
+    };
+
+    # Create user and group if user uses the default user and group.
+    users.users = mkIf (cfg.user == "codeberg-pages") {
+      codeberg-pages = {
+        group = cfg.group;
+        isSystemUser = true;
+      };
+    };
+
+    users.groups = mkIf (cfg.group == "codeberg-pages") {
+      codeberg-pages = { };
+    };
+  };
+}


### PR DESCRIPTION
[Codeberg Pages]: https://codeberg.org/Codeberg/pages-server

Adds a NixOS module for [Codeberg Pages].

Current implementation is still a bit rough around the edges, but the module
should be ready for a review regardless. I've set this as a draft until I can
get tests to work reliably, tips welcome. I also would like to harden the
service a little, but it seems particularly picky with its permissions.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See
  [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests)
    (look inside
    [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or
    [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in
    [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or
    [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are
    [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package)
    to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using
      `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all
      changes have to be committed, also see
      [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in
      `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md)
  (or backporting
  [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md)
  and
  [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md)
  Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or
        breaking
  - [ ] (Module updates) Added a release notes entry if the change is
        significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS
        module
- [ ] Fits
      [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
