### PR TITLE
sbom-utility: Fix version, add shell completions

### DIFF
--- a/pkgs/by-name/sb/sbom-utility/name.patch
+++ b/pkgs/by-name/sb/sbom-utility/name.patch
@@ -1,0 +1,13 @@
+diff --git a/cmd/root.go b/cmd/root.go
+index 5ef5d46..e99b245 100644
+--- a/cmd/root.go
++++ b/cmd/root.go
+@@ -139,7 +139,7 @@ const (
+ )
+ 
+ var rootCmd = &cobra.Command{
+-	Use:           fmt.Sprintf("%s [command] [flags]", utils.GlobalFlags.Project),
++	Use:           fmt.Sprintf("sbom-utility [command] [flags]"),
+ 	SilenceErrors: false,
+ 	SilenceUsage:  false,
+ 	Short:         MSG_APP_NAME,

--- a/pkgs/by-name/sb/sbom-utility/package.nix
+++ b/pkgs/by-name/sb/sbom-utility/package.nix
@@ -2,11 +2,18 @@
   lib,
   buildGoModule,
   fetchFromGitHub,
+  fetchpatch,
+  versionCheckHook,
+  installShellFiles,
+  stdenv,
 }:
 
-buildGoModule rec {
-  pname = "sbom-utility";
+let
   version = "0.17.0";
+in
+buildGoModule {
+  pname = "sbom-utility";
+  inherit version;
 
   src = fetchFromGitHub {
     owner = "CycloneDX";
@@ -17,8 +24,38 @@ buildGoModule rec {
 
   vendorHash = "sha256-vyYSir5u6d5nv+2ScrHpasQGER4VFSoLb1FDUDIrtDM=";
 
+  patches = [
+    # work around https://github.com/CycloneDX/sbom-utility/issues/121, which otherwise
+    # breaks shell completions
+    ./name.patch
+    # Output logs to stderr rather than stdout.
+    # Patch of https://github.com/CycloneDX/sbom-utility/pull/122, adapted to apply
+    # against v0.17.0
+    ./stderr.patch
+  ];
+
+  ldflags = [
+    "-X main.Version=${version}"
+  ];
+
+  nativeBuildInputs = [
+    installShellFiles
+  ];
+
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+  doInstallCheck = true;
+
   preCheck = ''
     cd test
+  '';
+
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+    for shell in bash fish zsh; do
+      installShellCompletion --cmd sbom-utility \
+        --$shell <($out/bin/sbom-utility -q completion $shell)
+    done
   '';
 
   meta = with lib; {

--- a/pkgs/by-name/sb/sbom-utility/stderr.patch
+++ b/pkgs/by-name/sb/sbom-utility/stderr.patch
@@ -1,0 +1,67 @@
+diff --git a/log/log.go b/log/log.go
+index 2615f0a..c82b6c5 100644
+--- a/log/log.go
++++ b/log/log.go
+@@ -104,7 +104,7 @@ func NewDefaultLogger() *MiniLogger {
+ 		tagEnter:        DEFAULT_ENTER_TAG,
+ 		tagExit:         DEFAULT_EXIT_TAG,
+ 		tagColor:        color.New(color.FgMagenta),
+-		outputFile:      os.Stdout,
++		outputFile:      os.Stderr,
+ 		maxStrLength:    64,
+ 	}
+ 
+@@ -361,7 +361,7 @@ func (log MiniLogger) dumpInterface(lvl Level, tag string, value interface{}, sk
+ 			}
+ 
+ 			// TODO: use a general output writer (set to stdout, stderr, or file stream)
+-			fmt.Println(sb.String())
++			fmt.Fprintln(log.outputFile, sb.String())
+ 		} else {
+ 			os.Stderr.WriteString("Error: Unable to retrieve call stack. Exiting...")
+ 			os.Exit(-2)
+@@ -370,7 +370,7 @@ func (log MiniLogger) dumpInterface(lvl Level, tag string, value interface{}, sk
+ }
+ 
+ func (log MiniLogger) DumpString(value string) {
+-	fmt.Print(value)
++	fmt.Fprint(log.outputFile, value)
+ }
+ 
+ func (log MiniLogger) DumpStruct(structName string, field interface{}) error {
+@@ -389,7 +389,7 @@ func (log MiniLogger) DumpStruct(structName string, field interface{}) error {
+ 	}
+ 
+ 	// TODO: print to output stream
+-	fmt.Println(sb.String())
++	fmt.Fprintln(log.outputFile, sb.String())
+ 
+ 	return nil
+ }
+@@ -398,8 +398,8 @@ func (log MiniLogger) DumpArgs() {
+ 	args := os.Args
+ 	for i, a := range args {
+ 		// TODO: print to output stream
+-		fmt.Print(log.indentRunes)
+-		fmt.Printf("os.Arg[%d]: `%v`\n", i, a)
++		fmt.Fprint(log.outputFile, log.indentRunes)
++		fmt.Fprintf(log.outputFile, "os.Arg[%d]: `%v`\n", i, a)
+ 	}
+ }
+ 
+@@ -409,7 +409,7 @@ func (log MiniLogger) DumpSeparator(sep byte, repeat int) (string, error) {
+ 		for i := 0; i < repeat; i++ {
+ 			sb.WriteByte(sep)
+ 		}
+-		fmt.Println(sb.String())
++		fmt.Fprintln(log.outputFile, sb.String())
+ 		return sb.String(), nil
+ 	} else {
+ 		return "", errors.New("invalid repeat length (>80)")
+@@ -417,5 +417,5 @@ func (log MiniLogger) DumpSeparator(sep byte, repeat int) (string, error) {
+ }
+ 
+ func (log *MiniLogger) DumpStackTrace() {
+-	fmt.Println(string(debug.Stack()))
++	fmt.Fprintln(log.outputFile, string(debug.Stack()))
+ }


### PR DESCRIPTION
- inject version so `sbom-utility version` reports it correctly
- add version check hook
- generate shell completions (required some patches as upstream shell completion generation is broken)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
