### PR TITLE
incus: build and expose documentation

### DIFF
--- a/nixos/modules/virtualisation/incus.nix
+++ b/nixos/modules/virtualisation/incus.nix
@@ -129,6 +129,7 @@ let
 
   environment = lib.mkMerge [
     {
+      INCUS_DOCUMENTATION = "${cfg.package.doc}/html";
       INCUS_EDK2_PATH = ovmf;
       INCUS_LXC_HOOK = "${cfg.lxcPackage}/share/lxc/hooks";
       INCUS_LXC_TEMPLATE_CONFIG = "${pkgs.lxcfs}/share/lxc/config";

--- a/nixos/tests/incus/ui.nix
+++ b/nixos/tests/incus/ui.nix
@@ -66,12 +66,16 @@ import ../make-test-python.nix (
 
     testScript = ''
       machine.wait_for_unit("incus.service")
+      machine.wait_for_unit("incus-preseed.service")
 
       # Check that the INCUS_UI environment variable is populated in the systemd unit
       machine.succeed("systemctl cat incus.service | grep 'INCUS_UI'")
 
       # Ensure the endpoint returns an HTML page with 'Incus UI' in the title
       machine.succeed("curl -kLs https://localhost:8443/ui | grep '<title>Incus UI</title>'")
+
+      # Ensure the documentation is rendering correctly
+      machine.succeed("curl -kLs https://localhost:8443/documentation/ | grep '<title>Incus documentation</title>'")
 
       # Ensure the application is actually rendered by the Javascript
       machine.succeed("PYTHONUNBUFFERED=1 selenium-script")

--- a/pkgs/by-name/in/incus/docs.patch
+++ b/pkgs/by-name/in/incus/docs.patch
@@ -1,0 +1,26 @@
+diff --git i/doc/conf.py w/doc/conf.py
+index 8d042818b..b4f0572bd 100644
+--- i/doc/conf.py
++++ w/doc/conf.py
+@@ -8,10 +8,6 @@ import yaml
+ from git import Repo
+ import filecmp
+ 
+-# Download and link swagger-ui files
+-if not os.path.isdir('.sphinx/deps/swagger-ui'):
+-    Repo.clone_from('https://github.com/swagger-api/swagger-ui', '.sphinx/deps/swagger-ui', depth=1)
+-
+ os.makedirs('.sphinx/_static/swagger-ui/', exist_ok=True)
+ 
+ if not os.path.islink('.sphinx/_static/swagger-ui/swagger-ui-bundle.js'):
+@@ -151,10 +147,6 @@ if os.path.exists("./related_topics.yaml"):
+     with open("./related_topics.yaml", "r") as fd:
+         myst_substitutions.update(yaml.safe_load(fd.read()))
+ 
+-intersphinx_mapping = {
+-    'cloud-init': ('https://cloudinit.readthedocs.io/en/latest/', None)
+-}
+-
+ if ("LOCAL_SPHINX_BUILD" in os.environ) and (os.environ["LOCAL_SPHINX_BUILD"] == "True"):
+     swagger_url_scheme = "/api/#{{path}}"
+ else:

--- a/pkgs/development/python-modules/canonical-sphinx-extensions/default.nix
+++ b/pkgs/development/python-modules/canonical-sphinx-extensions/default.nix
@@ -1,0 +1,44 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  setuptools,
+  beautifulsoup4,
+  docutils,
+  gitpython,
+  requests,
+  sphinx,
+}:
+
+buildPythonPackage rec {
+  pname = "canonical-sphinx-extensions";
+  version = "0.0.27";
+  pyproject = true;
+
+  src = fetchPypi {
+    pname = "canonical_sphinx_extensions";
+    inherit version;
+    hash = "sha256-ZorSmn+PAVS8xO7X3zk6u3W7pn3JB9w0PhFAXzv6l78=";
+  };
+
+  build-system = [
+    setuptools
+  ];
+
+  dependencies = [
+    beautifulsoup4
+    docutils
+    gitpython
+    requests
+    sphinx
+  ];
+
+  doCheck = false;
+
+  meta = {
+    description = "A collection of Sphinx extensions used by Canonical documentation";
+    homepage = "https://pypi.org/project/canonical-sphinx-extensions";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ ];
+  };
+}

--- a/pkgs/development/python-modules/pyspelling/default.nix
+++ b/pkgs/development/python-modules/pyspelling/default.nix
@@ -1,0 +1,49 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  hatchling,
+  beautifulsoup4,
+  html5lib,
+  lxml,
+  markdown,
+  pyyaml,
+  soupsieve,
+  wcmatch,
+}:
+
+buildPythonPackage rec {
+  pname = "pyspelling";
+  version = "2.10";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-rNZxM8G3zs1BDj1EieYfLksfC2rPGubEjCQPuyFynDc=";
+  };
+
+  build-system = [
+    hatchling
+  ];
+
+  dependencies = [
+    beautifulsoup4
+    html5lib
+    lxml
+    markdown
+    pyyaml
+    soupsieve
+    wcmatch
+  ];
+
+  pythonImportsCheck = [
+    "pyspelling"
+  ];
+
+  meta = {
+    description = "Spell checker";
+    homepage = "https://pypi.org/project/pyspelling";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ ];
+  };
+}

--- a/pkgs/development/python-modules/sphinx-remove-toctrees/default.nix
+++ b/pkgs/development/python-modules/sphinx-remove-toctrees/default.nix
@@ -1,0 +1,60 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  hatchling,
+  sphinx,
+  pre-commit,
+  ipython,
+  myst-parser,
+  sphinx-book-theme,
+  pytest,
+}:
+
+buildPythonPackage rec {
+  pname = "sphinx-remove-toctrees";
+  version = "1.0.0.post1";
+  pyproject = true;
+
+  src = fetchPypi {
+    pname = "sphinx_remove_toctrees";
+    inherit version;
+    hash = "sha256-SAjR7fFRwG7/bSw5Iux+vJ/Tqhdi3hsuFnSjf1rJzi0=";
+  };
+
+  build-system = [
+    hatchling
+  ];
+
+  dependencies = [
+    sphinx
+  ];
+
+  optional-dependencies = {
+    code_style = [
+      pre-commit
+    ];
+    docs = [
+      ipython
+      myst-parser
+      sphinx-book-theme
+    ];
+    tests = [
+      ipython
+      myst-parser
+      pytest
+      sphinx-book-theme
+    ];
+  };
+
+  pythonImportsCheck = [
+    "sphinx_remove_toctrees"
+  ];
+
+  meta = {
+    description = "Reduce your documentation build size by selectively removing toctrees from pages";
+    homepage = "https://pypi.org/project/sphinx-remove-toctrees/";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ ];
+  };
+}

--- a/pkgs/development/python-modules/sphinx-reredirects/default.nix
+++ b/pkgs/development/python-modules/sphinx-reredirects/default.nix
@@ -1,0 +1,41 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  setuptools,
+  sphinx,
+}:
+
+buildPythonPackage rec {
+  pname = "sphinx-reredirects";
+  version = "0.1.6";
+  pyproject = true;
+
+  src = fetchPypi {
+    pname = "sphinx_reredirects";
+    inherit version;
+    hash = "sha256-xJHLpUX2e+lpdQhyeBjYYmYmNmJFrmRFb+KfN+m76mQ=";
+  };
+
+  build-system = [
+    setuptools
+  ];
+
+  dependencies = [
+    sphinx
+  ];
+
+  pythonImportsCheck = [
+    "sphinx_reredirects"
+  ];
+
+  meta = {
+    description = "Handles redirects for moved pages in Sphinx documentation projects";
+    homepage = "https://pypi.org/project/sphinx-reredirects";
+    license = with lib.licenses; [
+      bsd3
+      mit
+    ];
+    maintainers = with lib.maintainers; [ ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -13326,6 +13326,8 @@ self: super: with self; {
 
   pyspellchecker = callPackage ../development/python-modules/pyspellchecker { };
 
+  pyspelling = callPackage ../development/python-modules/pyspelling { };
+
   pyspf = callPackage ../development/python-modules/pyspf { };
 
   pyspice = callPackage ../development/python-modules/pyspice { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -16171,6 +16171,8 @@ self: super: with self; {
 
   sphinx-pytest = callPackage ../development/python-modules/sphinx-pytest { };
 
+  sphinx-reredirects = callPackage ../development/python-modules/sphinx-reredirects { };
+
   sphinx-rtd-dark-mode = callPackage ../development/python-modules/sphinx-rtd-dark-mode { };
 
   sphinx-rtd-theme = callPackage ../development/python-modules/sphinx-rtd-theme { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2192,6 +2192,10 @@ self: super: with self; {
 
   canmatrix = callPackage ../development/python-modules/canmatrix { };
 
+  canonical-sphinx-extensions =
+    callPackage ../development/python-modules/canonical-sphinx-extensions
+      { };
+
   canonicaljson = callPackage ../development/python-modules/canonicaljson { };
 
   canopen = callPackage ../development/python-modules/canopen { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -16175,6 +16175,8 @@ self: super: with self; {
 
   sphinx-reredirects = callPackage ../development/python-modules/sphinx-reredirects { };
 
+  sphinx-remove-toctrees = callPackage ../development/python-modules/sphinx-remove-toctrees { };
+
   sphinx-rtd-dark-mode = callPackage ../development/python-modules/sphinx-rtd-dark-mode { };
 
   sphinx-rtd-theme = callPackage ../development/python-modules/sphinx-rtd-theme { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

The cloud-init documentation is likely still broken, but this should enable most of the documentation in the UI. I looked into building cloud-init's docs so that we can pull `objects.inv` from our own package, but it's a bit more involved than I was ready to tackle.

Partial: #389787

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
