### PR TITLE
treewide: fix python packages broken from adding throws in python-aliases.nix

### DIFF
--- a/pkgs/applications/misc/bitwarden-menu/default.nix
+++ b/pkgs/applications/misc/bitwarden-menu/default.nix
@@ -1,8 +1,9 @@
 {
   lib,
   buildPythonApplication,
-  python3Packages,
   fetchPypi,
+  hatch-vcs,
+  hatchling,
   pynput,
   xdg-base-dirs,
 }:
@@ -18,7 +19,7 @@ buildPythonApplication rec {
     hash = "sha256-vUlNqSVdGhfN5WjDjf1ub32Y2WoBndIdFzfCNwo5+Vg=";
   };
 
-  nativeBuildInputs = with python3Packages; [
+  nativeBuildInputs = [
     hatch-vcs
     hatchling
   ];

--- a/pkgs/applications/misc/remarkable/remarkable-mouse/default.nix
+++ b/pkgs/applications/misc/remarkable/remarkable-mouse/default.nix
@@ -2,7 +2,10 @@
   lib,
   buildPythonApplication,
   fetchPypi,
-  python3Packages,
+  libevdev,
+  paramiko,
+  pynput,
+  screeninfo,
 }:
 
 buildPythonApplication rec {
@@ -14,7 +17,7 @@ buildPythonApplication rec {
     hash = "sha256-82P9tE3jiUlKBGZCiWDoL+9VJ06Bc+If+aMfcEEU90U=";
   };
 
-  propagatedBuildInputs = with python3Packages; [
+  propagatedBuildInputs = [
     screeninfo
     paramiko
     pynput

--- a/pkgs/applications/science/robotics/sumorobot-manager/default.nix
+++ b/pkgs/applications/science/robotics/sumorobot-manager/default.nix
@@ -1,7 +1,7 @@
 {
   lib,
   stdenv,
-  python3,
+  python,
   qt5,
   fetchFromGitHub,
   wrapPython,
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
     sha256 = "07snhwmqqp52vdgr66vx50zxx0nmpmns5cdjgh50hzlhji2z1fl9";
   };
 
-  buildInputs = [ python3 ];
+  buildInputs = [ python ];
   pythonPath = [
     pyqt5.dev
     pyserial

--- a/pkgs/by-name/li/libmamba/package.nix
+++ b/pkgs/by-name/li/libmamba/package.nix
@@ -16,7 +16,7 @@
   zstd,
   nix-update-script,
   bzip2,
-  python3Packages,
+  python3,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -32,7 +32,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [
     cmake
-    python3Packages.python
+    python3
   ];
 
   buildInputs = [

--- a/pkgs/development/python-modules/fenics/default.nix
+++ b/pkgs/development/python-modules/fenics/default.nix
@@ -5,20 +5,22 @@
   fetchpatch,
   blas,
   boost186,
+  buildPythonPackage,
   cmake,
   doxygen,
   eigen,
   hdf5,
+  isPy27,
   lapack,
   mpi,
   mpi4py,
   numpy,
   pkg-config,
+  pkgconfig,
   ply,
   pybind11,
   pytest,
   python,
-  pythonPackages,
   scotch,
   setuptools,
   six,
@@ -33,7 +35,7 @@
 let
   version = "2019.1.0";
 
-  dijitso = pythonPackages.buildPythonPackage {
+  dijitso = buildPythonPackage {
     pname = "dijitso";
     inherit version;
     src = fetchurl {
@@ -61,7 +63,7 @@ let
     };
   };
 
-  fiat = pythonPackages.buildPythonPackage {
+  fiat = buildPythonPackage {
     pname = "fiat";
     inherit version;
     src = fetchurl {
@@ -101,7 +103,7 @@ let
     };
   };
 
-  ufl = pythonPackages.buildPythonPackage {
+  ufl = buildPythonPackage {
     pname = "ufl";
     inherit version;
     src = fetchurl {
@@ -126,7 +128,7 @@ let
     };
   };
 
-  ffc = pythonPackages.buildPythonPackage {
+  ffc = buildPythonPackage {
     pname = "ffc";
     inherit version;
     src = fetchurl {
@@ -257,10 +259,10 @@ let
       license = lib.licenses.lgpl3;
     };
   };
-  python-dolfin = pythonPackages.buildPythonPackage rec {
+  python-dolfin = buildPythonPackage rec {
     pname = "dolfin";
     inherit version;
-    disabled = pythonPackages.isPy27;
+    disabled = isPy27;
     src = dolfin.src;
     sourceRoot = "${pname}-${version}/python";
     nativeBuildInputs = [
@@ -286,8 +288,8 @@ let
       mpi4py
       numpy
       ufl
-      pythonPackages.pkgconfig
-      pythonPackages.pybind11
+      pkgconfig
+      pybind11
     ];
     doCheck = false; # Tries to orte_ess_init and call ssh to localhost
     passthru.tests = {

--- a/pkgs/development/python-modules/libmambapy/default.nix
+++ b/pkgs/development/python-modules/libmambapy/default.nix
@@ -1,6 +1,6 @@
 {
   lib,
-  pythonPackages,
+  python,
   buildPythonPackage,
   cmake,
   ninja,
@@ -39,7 +39,7 @@ buildPythonPackage {
   };
 
   buildInputs = [
-    (libmamba.override { python3Packages = pythonPackages; })
+    (libmamba.override { python3 = python; })
     curl
     zstd
     bzip2

--- a/pkgs/development/python-modules/mkdocs-linkcheck/default.nix
+++ b/pkgs/development/python-modules/mkdocs-linkcheck/default.nix
@@ -1,9 +1,10 @@
 {
   lib,
+  aiohttp,
   buildPythonPackage,
   fetchFromGitHub,
   pythonOlder,
-  pythonPackages,
+  requests,
 }:
 
 buildPythonPackage {
@@ -20,7 +21,7 @@ buildPythonPackage {
     hash = "sha256-z59F7zUKZKIQSiTlE6wGbGDecPMeruNgltWUYfDf8jY=";
   };
 
-  propagatedBuildInputs = with pythonPackages; [
+  propagatedBuildInputs = [
     aiohttp
     requests
   ];

--- a/pkgs/development/python-modules/semgrep/default.nix
+++ b/pkgs/development/python-modules/semgrep/default.nix
@@ -4,7 +4,6 @@
   fetchFromGitHub,
   semgrep-core,
   buildPythonPackage,
-  pythonPackages,
 
   pytestCheckHook,
   git,
@@ -12,27 +11,32 @@
   # python packages
   attrs,
   boltons,
-  colorama,
   click,
   click-option-group,
+  colorama,
+  defusedxml,
+  flaky,
   glom,
+  jsonschema,
+  opentelemetry-api,
+  opentelemetry-exporter-otlp-proto-http,
+  opentelemetry-instrumentation-requests,
+  opentelemetry-sdk,
+  packaging,
+  peewee,
+  pytest-freezegun,
+  pytest-mock,
+  pytest-snapshot,
+  python-lsp-jsonrpc,
   requests,
   rich,
   ruamel-yaml,
-  tqdm,
-  packaging,
-  jsonschema,
-  wcmatch,
-  peewee,
-  defusedxml,
-  urllib3,
-  typing-extensions,
-  python-lsp-jsonrpc,
   tomli,
-  opentelemetry-api,
-  opentelemetry-sdk,
-  opentelemetry-exporter-otlp-proto-http,
-  opentelemetry-instrumentation-requests,
+  tqdm,
+  types-freezegun,
+  typing-extensions,
+  urllib3,
+  wcmatch,
 }:
 
 # testing locally post build:
@@ -106,18 +110,15 @@ buildPythonPackage rec {
 
   doCheck = true;
 
-  nativeCheckInputs =
-    [
-      git
-      pytestCheckHook
-    ]
-    ++ (with pythonPackages; [
-      flaky
-      pytest-snapshot
-      pytest-mock
-      pytest-freezegun
-      types-freezegun
-    ]);
+  nativeCheckInputs = [
+    git
+    pytestCheckHook
+    flaky
+    pytest-snapshot
+    pytest-mock
+    pytest-freezegun
+    types-freezegun
+  ];
 
   disabledTestPaths = [
     "tests/default/e2e"

--- a/pkgs/games/gscrabble/default.nix
+++ b/pkgs/games/gscrabble/default.nix
@@ -6,7 +6,8 @@
   wrapGAppsHook3,
   gst_all_1,
   gobject-introspection,
-  python3Packages,
+  gst-python,
+  pygobject3,
   adwaita-icon-theme,
 }:
 
@@ -37,7 +38,7 @@ buildPythonApplication {
     gtk3
   ];
 
-  propagatedBuildInputs = with python3Packages; [
+  propagatedBuildInputs = [
     gst-python
     pygobject3
   ];

--- a/pkgs/servers/persistent-evdev/default.nix
+++ b/pkgs/servers/persistent-evdev/default.nix
@@ -2,7 +2,8 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  python3Packages,
+  evdev,
+  pyudev,
 }:
 
 buildPythonPackage rec {
@@ -17,7 +18,7 @@ buildPythonPackage rec {
     sha256 = "d0i6DL/qgDELet4ew2lyVqzd9TApivRxL3zA3dcsQXY=";
   };
 
-  propagatedBuildInputs = with python3Packages; [
+  propagatedBuildInputs = [
     evdev
     pyudev
   ];

--- a/pkgs/tools/admin/awsume/default.nix
+++ b/pkgs/tools/admin/awsume/default.nix
@@ -1,6 +1,6 @@
 {
   lib,
-  python3,
+  python,
   installShellFiles,
   buildPythonApplication,
   fetchFromGitHub,
@@ -44,9 +44,9 @@ buildPythonApplication rec {
 
   postInstall = ''
     installShellCompletion --cmd awsume \
-      --bash <(PYTHONPATH=./awsume/configure ${python3}/bin/python3 -c"import autocomplete; print(autocomplete.SCRIPTS['bash'])") \
-      --zsh <(PYTHONPATH=./awsume/configure ${python3}/bin/python3 -c"import autocomplete; print(autocomplete.ZSH_AUTOCOMPLETE_FUNCTION)") \
-      --fish <(PYTHONPATH=./awsume/configure ${python3}/bin/python3 -c"import autocomplete; print(autocomplete.SCRIPTS['fish'])") \
+      --bash <(PYTHONPATH=./awsume/configure ${python}/bin/python3 -c"import autocomplete; print(autocomplete.SCRIPTS['bash'])") \
+      --zsh <(PYTHONPATH=./awsume/configure ${python}/bin/python3 -c"import autocomplete; print(autocomplete.ZSH_AUTOCOMPLETE_FUNCTION)") \
+      --fish <(PYTHONPATH=./awsume/configure ${python}/bin/python3 -c"import autocomplete; print(autocomplete.SCRIPTS['fish'])") \
 
     rm -f $out/bin/awsume.bat
   '';

--- a/pkgs/tools/games/mymcplus/default.nix
+++ b/pkgs/tools/games/mymcplus/default.nix
@@ -1,11 +1,11 @@
 {
   lib,
   fetchFromSourcehut,
-  pythonPackages,
+  python3Packages,
   wrapGAppsHook3,
 }:
 
-pythonPackages.buildPythonApplication rec {
+python3Packages.buildPythonApplication rec {
   pname = "mymcplus";
   version = "3.0.5";
 
@@ -20,7 +20,7 @@ pythonPackages.buildPythonApplication rec {
     wrapGAppsHook3
   ];
 
-  propagatedBuildInputs = with pythonPackages; [
+  propagatedBuildInputs = with python3Packages; [
     pyopengl
     wxpython
   ];

--- a/pkgs/tools/graphics/pixel2svg/default.nix
+++ b/pkgs/tools/graphics/pixel2svg/default.nix
@@ -2,10 +2,11 @@
   lib,
   buildPythonPackage,
   fetchurl,
-  python310Packages,
+  pillow,
+  svgwrite,
 }:
 
-python310Packages.buildPythonPackage rec {
+buildPythonPackage rec {
   pname = "pixel2svg";
   version = "0.3.0";
 
@@ -14,7 +15,7 @@ python310Packages.buildPythonPackage rec {
     sha256 = "sha256-aqcTTmZKcdRdVd8GGz5cuaQ4gjPapVJNtiiZu22TZgQ=";
   };
 
-  propagatedBuildInputs = with python310Packages; [
+  propagatedBuildInputs = [
     pillow
     svgwrite
   ];

--- a/pkgs/tools/misc/thinkpad-scripts/default.nix
+++ b/pkgs/tools/misc/thinkpad-scripts/default.nix
@@ -2,7 +2,7 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  python3Packages,
+  setuptools,
 }:
 
 buildPythonPackage rec {
@@ -16,7 +16,7 @@ buildPythonPackage rec {
     sha256 = "08adx8r5pwwazbnfahay42l5f203mmvcn2ipz5hg8myqc9jxm2ky";
   };
 
-  propagatedBuildInputs = with python3Packages; [ setuptools ];
+  propagatedBuildInputs = [ setuptools ];
 
   meta = {
     description = "Screen rotation, docking and other scripts for ThinkPad® X220 and X230 Tablet";

--- a/pkgs/tools/misc/xflux/gui.nix
+++ b/pkgs/tools/misc/xflux/gui.nix
@@ -2,7 +2,7 @@
   lib,
   fetchFromGitHub,
   buildPythonApplication,
-  python3Packages,
+  python,
   wrapGAppsHook3,
   xflux,
   gtk3,
@@ -54,7 +54,7 @@ buildPythonApplication rec {
   postFixup = ''
     wrapGAppsHook
     wrapPythonPrograms
-    patchPythonScript $out/${python3Packages.python.sitePackages}/fluxgui/fluxapp.py
+    patchPythonScript $out/${python.sitePackages}/fluxgui/fluxapp.py
   '';
 
   meta = {

--- a/pkgs/tools/networking/maubot/default.nix
+++ b/pkgs/tools/networking/maubot/default.nix
@@ -4,13 +4,17 @@
   fetchpatch,
   callPackage,
   runCommand,
-  python3,
+  python,
   encryptionSupport ? true,
   sqliteSupport ? true,
 }:
 
 let
-  python = python3.override {
+  # save for overriding it
+  python' = python;
+in
+let
+  python = python'.override {
     self = python;
     packageOverrides = final: prev: {
       # SQLAlchemy>=1,<1.4

--- a/pkgs/tools/virtualization/mkosi/default.nix
+++ b/pkgs/tools/virtualization/mkosi/default.nix
@@ -2,7 +2,6 @@
   lib,
   fetchFromGitHub,
   stdenv,
-  python3,
   systemd,
   pandoc,
   kmod,
@@ -16,6 +15,7 @@
   replaceVars,
 
   # Python packages
+  python,
   setuptools,
   setuptools-scm,
   wheel,
@@ -46,7 +46,7 @@ let
     withKernelInstall = true;
   };
 
-  python3pefile = python3.withPackages (_: [ pefile ]);
+  python3pefile = python.withPackages (_: [ pefile ]);
 
   deps =
     [

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5959,7 +5959,7 @@ with pkgs;
     llvmPackages = crystal.llvmPackages;
   };
 
-  devpi-client = python3Packages.callPackage ../development/tools/devpi-client { };
+  devpi-client = callPackage ../development/tools/devpi-client { };
 
   devpi-server = python3Packages.callPackage ../development/tools/devpi-server { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -363,7 +363,7 @@ with pkgs;
     openexr = openexr_3;
   };
 
-  databricks-sql-cli = python3Packages.callPackage ../applications/misc/databricks-sql-cli { };
+  databricks-sql-cli = callPackage ../applications/misc/databricks-sql-cli { };
 
   deck = callPackage ../by-name/de/deck/package.nix {
     buildGoModule = buildGo123Module;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18626,7 +18626,7 @@ with pkgs;
     inherit (ocaml-ng.ocamlPackages_4_14) ocaml;
   };
 
-  nextinspace = python3Packages.callPackage ../applications/science/misc/nextinspace { };
+  nextinspace = callPackage ../applications/science/misc/nextinspace { };
 
   ns-3 = callPackage ../development/libraries/science/networking/ns-3 { python = python3; };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19227,7 +19227,7 @@ with pkgs;
 
   terraform-landscape = callPackage ../applications/networking/cluster/terraform-landscape { };
 
-  tftui = python3Packages.callPackage ../applications/networking/cluster/tftui { };
+  tftui = callPackage ../applications/networking/cluster/tftui { };
 
   trufflehog = callPackage ../tools/security/trufflehog {
     buildGoModule = buildGo123Module;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18679,7 +18679,7 @@ with pkgs;
   autotiling = python3Packages.callPackage ../misc/autotiling { };
 
   avell-unofficial-control-center =
-    python3Packages.callPackage ../applications/misc/avell-unofficial-control-center
+    callPackage ../applications/misc/avell-unofficial-control-center
       { };
 
   brgenml1lpr = pkgsi686Linux.callPackage ../misc/cups/drivers/brgenml1lpr { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1850,7 +1850,7 @@ with pkgs;
 
   certipy = with python3Packages; toPythonApplication certipy-ad;
 
-  catcli = python3Packages.callPackage ../tools/filesystems/catcli { };
+  catcli = callPackage ../tools/filesystems/catcli { };
 
   chipsec = callPackage ../tools/security/chipsec {
     kernel = null;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -284,7 +284,7 @@ with pkgs;
     extraPackages = [ jdk17 ];
   };
 
-  asitop = pkgs.python3Packages.callPackage ../os-specific/darwin/asitop { };
+  asitop = callPackage ../os-specific/darwin/asitop { };
 
   cve = with python3Packages; toPythonApplication cvelib;
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5464,7 +5464,7 @@ with pkgs;
 
   twurl = callPackage ../tools/misc/twurl { };
 
-  ubidump = python3Packages.callPackage ../tools/filesystems/ubidump { };
+  ubidump = callPackage ../tools/filesystems/ubidump { };
 
   ubpm = libsForQt5.callPackage ../applications/misc/ubpm { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1175,7 +1175,7 @@ with pkgs;
 
   mpy-utils = python3Packages.callPackage ../tools/misc/mpy-utils { };
 
-  mymcplus = python3Packages.callPackage ../tools/games/mymcplus { };
+  mymcplus = callPackage ../tools/games/mymcplus { };
 
   networkd-notify = python3Packages.callPackage ../tools/networking/networkd-notify {
     systemd = pkgs.systemd;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -403,7 +403,7 @@ with pkgs;
 
   inherit (gridlock) nyarr;
 
-  html5validator = python3Packages.callPackage ../applications/misc/html5validator { };
+  html5validator = callPackage ../applications/misc/html5validator { };
 
   inspec = callPackage ../tools/misc/inspec { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5460,7 +5460,7 @@ with pkgs;
     python3Packages.callPackage ../applications/misc/twitch-chat-downloader
       { };
 
-  twtxt = python3Packages.callPackage ../applications/networking/twtxt { };
+  twtxt = callPackage ../applications/networking/twtxt { };
 
   twurl = callPackage ../tools/misc/twurl { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4192,7 +4192,7 @@ with pkgs;
 
   nanoemoji = with python3Packages; toPythonApplication nanoemoji;
 
-  netexec = python3Packages.callPackage ../tools/security/netexec { };
+  netexec = callPackage ../tools/security/netexec { };
 
   netdata = callPackage ../tools/system/netdata {
     protobuf = protobuf_21;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17448,7 +17448,7 @@ with pkgs;
 
   gscrabble = python3Packages.callPackage ../games/gscrabble { };
 
-  gshogi = python3Packages.callPackage ../games/gshogi { };
+  gshogi = callPackage ../games/gshogi { };
 
   qtads = qt5.callPackage ../games/qtads { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17627,7 +17627,7 @@ with pkgs;
     protobuf = protobuf_21;
   };
 
-  pysolfc = python3Packages.callPackage ../games/pysolfc { };
+  pysolfc = callPackage ../games/pysolfc { };
 
   quake3wrapper = callPackage ../games/quake3/wrapper { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1206,7 +1206,7 @@ with pkgs;
 
   shaperglot = with python3Packages; toPythonApplication shaperglot;
 
-  snagboot = python3.pkgs.callPackage ../applications/misc/snagboot { };
+  snagboot = callPackage ../applications/misc/snagboot { };
 
   slipstream = callPackage ../tools/games/slipstream {
     jdk = jdk8;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8593,7 +8593,7 @@ with pkgs;
     )
       haskellPackages.haskell-ci;
 
-  nimbo = with python3Packages; callPackage ../applications/misc/nimbo { };
+  nimbo = callPackage ../applications/misc/nimbo { };
 
   nixbang = callPackage ../development/tools/misc/nixbang {
     pythonPackages = python3Packages;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7800,7 +7800,7 @@ self: super: with self; {
       p.override {
         enablePython = true;
         python3 = python;
-        python3Packages = pythonPackages;
+        python3Packages = self;
       }
     )
     (p: p.py)


### PR DESCRIPTION
Fixes all packages broken by https://github.com/NixOS/nixpkgs/pull/394838

I used the following nix script to find packages that their evaluation were broken by the pr above

<details><summary>Code</summary>
<p>

```nix
let
  nixpkgsArgs = {
    config = {
      allowBroken = true;
      allowUnfree = true;
      allowUnsupportedSystem = true;
    };
    overlays = [];
    system = "x86_64-linux";
  };

  beforeNixpkgs = import (builtins.fetchTarball {
    url = "https://github.com/NixOS/nixpkgs/archive/5f0f90f2cad31897661caef263f98a30b1a1d1bc.tar.gz";
    sha256 = "0gxmr24i27izjzqx2iba9wz801dr7kpb0lq8xh0yj06fh8g4zhci";
  }) nixpkgsArgs;
  afterNixpkgs = import (builtins.fetchTarball {
    url = "https://github.com/NixOS/nixpkgs/archive/4c69dd5e83277af36bfbac8c21d1dd8196b87012.tar.gz";
    sha256 = "1mvxr04j5nhs56j2l3l5jh701ak1nidf4d0cxf01dfpyx5nd3slx";
  }) nixpkgsArgs;

  lib = beforeNixpkgs.lib;

  forEveryPackageCond = attrset: attrset.recurseForDerivations or false;
  forEveryPackageMapper = attrpath: _: let
    getPackage = packageSet: let
      package = lib.attrsets.getAttrFromPath attrpath packageSet;
    in
      if lib.isDerivation package then package.outPath
      else package;

    beforePackage = builtins.tryEval (getPackage beforeNixpkgs);
    afterPackage = builtins.tryEval (getPackage afterNixpkgs);
  in
    if !beforePackage.success && !afterPackage.success then "keep-fail"
    else if beforePackage.success && afterPackage.success then "keep-pass"
    else if beforePackage.success && !afterPackage.success then "regression"
    else if !beforePackage.success && afterPackage.success then "fix"
    else "unreachable";

  attrsetOfTests = lib.mapAttrsRecursiveCond forEveryPackageCond forEveryPackageMapper beforeNixpkgs;
  attrsetOfTests' = lib.filterAttrsRecursive (attrpath: value: let
      value' = builtins.tryEval value;
    in
      if !value'.success then false
      else if lib.isAttrs value'.value then true else {
      "keep-fail" = false;
      "keep-pass" = false;
      "regression" = true;
      "fix" = true;
      "unreachable" = true;
    }."${value}"
  ) attrsetOfTests;

  removeEmptyRecursively = lib.fixedPoints.converge (
    lib.attrsets.filterAttrsRecursive (n: v: v != { })
  );
in {
  result = removeEmptyRecursively attrsetOfTests';
  nonfiltered = attrsetOfTests;
  inherit beforeNixpkgs afterNixpkgs;
}
```

</p>
</details> 

<details><summary>Result</summary>
<p>

```nix
{
  asitop = "regression";
  avell-unofficial-control-center = "regression";
  awsume = "regression";
  bitwarden-menu = "regression";
  buildbot = "regression";
  buildbot-full = "regression";
  buildbot-plugins = {
    badges = "regression";
    buildbot-pkg = "regression";
    console-view = "regression";
    grid-view = "regression";
    override = "regression";
    overrideDerivation = "regression";
    recurseForDerivations = "regression";
    waterfall-view = "regression";
    wsgi-dashboards = "regression";
    www = "regression";
  };
  buildbot-ui = "regression";
  buildbot-worker = "regression";
  buildbotPackages = {
    buildbot = "regression";
    buildbot-full = "regression";
    buildbot-pkg = "regression";
    buildbot-plugins = {
      badges = "regression";
      buildbot-pkg = "regression";
      console-view = "regression";
      grid-view = "regression";
      override = "regression";
      overrideDerivation = "regression";
      recurseForDerivations = "regression";
      waterfall-view = "regression";
      wsgi-dashboards = "regression";
      www = "regression";
    };
    buildbot-ui = "regression";
    buildbot-worker = "regression";
    python = "regression";
  };
  catcli = "regression";
  cloud-init = "regression";
  cxxtest = "regression";
  databricks-sql-cli = "regression";
  devpi-client = "regression";
  esphome = "regression";
  gitlint = "regression";
  gscrabble = "regression";
  gshogi = "regression";
  html5validator = "regression";
  mkosi = "regression";
  mkosi-full = "regression";
  mymcplus = "regression";
  netexec = "regression";
  nextinspace = "regression";
  nimbo = "regression";
  opentimestamps-client = "regression";
  persistent-evdev = "regression";
  pixel2svg = "regression";
  platformio = "regression";
  platformio-core = "regression";
  pysolfc = "regression";
  python312Packages = {
    conda = "regression";
    conda-libmamba-solver = "regression";
    fenics = "regression";
    libmambapy = "regression";
    libselinux = "regression";
    mkdocs-linkcheck = "regression";
    pythonPackages = "regression";
    semgrep = "regression";
    whispers = "regression";
  };
  python313Packages = {
    conda = "regression";
    conda-libmamba-solver = "regression";
    fenics = "regression";
    language-tool-python = "fix";
    libmambapy = "regression";
    libselinux = "regression";
    mkdocs-linkcheck = "regression";
    pythonPackages = "regression";
    semgrep = "regression";
    whispers = "regression";
  };
  remarkable-mouse = "regression";
  route-detect = "regression";
  semgrep = "regression";
  snagboot = "regression";
  sumorobot-manager = "regression";
  swaggerhole = "regression";
  tftui = "regression";
  thinkpad-scripts = "regression";
  twtxt = "regression";
  ubidump = "regression";
  vpn-slice = "regression";
  whispers = "regression";
  xflux-gui = "regression";
  zeroad = "regression";
  zeroad-unwrapped = "regression";
  zyn-fusion = "regression";
  zynaddsubfx = "regression";
  zynaddsubfx-fltk = "regression";
  zynaddsubfx-ntk = "regression";
}
```

</p>
</details> 

supercedes https://github.com/NixOS/nixpkgs/pull/395731 https://github.com/NixOS/nixpkgs/pull/395733 https://github.com/NixOS/nixpkgs/pull/395844

partially supercedes https://github.com/NixOS/nixpkgs/pull/395723

fixes https://github.com/NixOS/nixpkgs/issues/395712

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
