### PR TITLE
music-assistant: 2.4.4 -> 2.5.0

### DIFF
--- a/pkgs/by-name/mu/music-assistant/frontend.nix
+++ b/pkgs/by-name/mu/music-assistant/frontend.nix
@@ -7,12 +7,12 @@
 
 buildPythonPackage rec {
   pname = "music-assistant-frontend";
-  version = "2.12.2";
+  version = "2.14.8";
   pyproject = true;
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-aa400lMs6zxC5QhZS27gFUWpRanyC3sFi815iDEiSPk=";
+    hash = "sha256-YUir/YBBbggsQUh5b6qSG5fpAa25jJmgcSsf0EZ8rhw=";
   };
 
   postPatch = ''

--- a/pkgs/by-name/mu/music-assistant/package.nix
+++ b/pkgs/by-name/mu/music-assistant/package.nix
@@ -16,13 +16,13 @@ let
       music-assistant-frontend = self.callPackage ./frontend.nix { };
 
       music-assistant-models = super.music-assistant-models.overridePythonAttrs (oldAttrs: rec {
-        version = "1.1.34";
+        version = "1.1.45";
 
         src = fetchFromGitHub {
           owner = "music-assistant";
           repo = "models";
           tag = version;
-          hash = "sha256-UxokPUnYET1XyRok0FH7e8G3RpCMvOigY4huw6Tfllo=";
+          hash = "sha256-R1KkMe9dVl5J1DjDsFhSYVebpiqBkXZSqkLrd7T8gFg=";
         };
 
         postPatch = ''
@@ -44,14 +44,14 @@ in
 
 python.pkgs.buildPythonApplication rec {
   pname = "music-assistant";
-  version = "2.4.4";
+  version = "2.5.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "music-assistant";
     repo = "server";
     tag = version;
-    hash = "sha256-rxXEsR4EfJZp3OFGHcSRaJp1egt2OT15P8V35v35KmU=";
+    hash = "sha256-yugtL3dCuGb2OSTy49V4mil9EnfACcGrYCA1rW/lo+4=";
   };
 
   patches = [

--- a/pkgs/by-name/mu/music-assistant/providers.nix
+++ b/pkgs/by-name/mu/music-assistant/providers.nix
@@ -1,7 +1,7 @@
 # Do not edit manually, run ./update-providers.py
 
 {
-  version = "2.4.4";
+  version = "2.5.0";
   providers = {
     airplay = ps: [
     ];
@@ -20,6 +20,8 @@
         pyblu
       ];
     builtin = ps: [
+    ];
+    builtin_player = ps: [
     ];
     chromecast =
       ps: with ps; [
@@ -44,6 +46,8 @@
       ps: with ps; [
         python-fullykiosk
       ];
+    gpodder = ps: [
+    ];
     hass =
       ps: with ps; [
         hass-client
@@ -52,10 +56,18 @@
     ];
     ibroadcast = ps: [
     ]; # missing ibroadcastaio
+    itunes_podcasts = ps: [
+    ];
     jellyfin =
       ps: with ps; [
         aiojellyfin
       ];
+    lastfm_scrobble =
+      ps: with ps; [
+        pylast
+      ];
+    listenbrainz_scrobble = ps: [
+    ]; # missing liblistenbrainz
     musicbrainz = ps: [
     ];
     opensubsonic =
@@ -68,10 +80,8 @@
       ps: with ps; [
         plexapi
       ];
-    podcastfeed =
-      ps: with ps; [
-        podcastparser
-      ];
+    podcastfeed = ps: [
+    ];
     qobuz = ps: [
     ];
     radiobrowser =
@@ -80,14 +90,11 @@
       ];
     siriusxm = ps: [
     ]; # missing sxm
-    slimproto =
-      ps: with ps; [
-        aioslimproto
-      ];
     snapcast =
       ps: with ps; [
         bidict
         snapcast
+        websocket-client
       ];
     sonos =
       ps: with ps; [
@@ -106,6 +113,10 @@
       ];
     spotify_connect = ps: [
     ];
+    squeezelite =
+      ps: with ps; [
+        aioslimproto
+      ];
     template_player_provider = ps: [
     ];
     test = ps: [
@@ -114,7 +125,7 @@
     ];
     tidal =
       ps: with ps; [
-        tidalapi
+        pkce
       ];
     tunein = ps: [
     ];
@@ -123,6 +134,6 @@
         duration-parser
         yt-dlp
         ytmusicapi
-      ];
+      ]; # missing bgutil-ytdlp-pot-provider
   };
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Changelog: https://github.com/music-assistant/server/releases/tag/2.5.0

Running the provider update script showed:

```
$ nix --show-trace --extra-experimental-features nix-command eval -f /home/autrimpo/src/nixpkgs/default.nix --json music-assistant.version
Error parsing /tmp/tmpfm8mthyu/server-2.5.0/music_assistant/providers/snapcast/snapweb/manifest.json Field "type" of type ProviderType is missing in ProviderManifest instance

$ nix --show-trace --extra-experimental-features nix-command eval -f /home/autrimpo/src/nixpkgs/default.nix --json music-assistant.python.pkgs.audible.version

 - yt-dlp==2025.3.27 not satisifed by version 2025.3.31
 - defusedxml==0.7.1 not satisifed by version 0.8.0rc2
 - pycryptodome==3.22.0 not satisifed by version 3.21.0
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
