### PR TITLE
nixosTests.bees: migrate to runTest

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -229,7 +229,7 @@ in
   bazarr = runTest ./bazarr.nix;
   bcachefs = runTestOn [ "x86_64-linux" "aarch64-linux" ] ./bcachefs.nix;
   beanstalkd = runTest ./beanstalkd.nix;
-  bees = handleTest ./bees.nix { };
+  bees = runTest ./bees.nix;
   benchexec = handleTest ./benchexec.nix { };
   binary-cache = runTest {
     imports = [ ./binary-cache.nix ];

--- a/nixos/tests/bees.nix
+++ b/nixos/tests/bees.nix
@@ -1,74 +1,72 @@
-import ./make-test-python.nix (
-  { lib, pkgs, ... }:
-  {
-    name = "bees";
+{ lib, pkgs, ... }:
+{
+  name = "bees";
 
-    nodes.machine =
-      { config, pkgs, ... }:
-      {
-        boot.initrd.postDeviceCommands = ''
-          ${pkgs.btrfs-progs}/bin/mkfs.btrfs -f -L aux1 /dev/vdb
-          ${pkgs.btrfs-progs}/bin/mkfs.btrfs -f -L aux2 /dev/vdc
-        '';
-        virtualisation.emptyDiskImages = [
-          4096
-          4096
-        ];
-        virtualisation.fileSystems = {
-          "/aux1" = {
-            # filesystem configured to be deduplicated
-            device = "/dev/disk/by-label/aux1";
-            fsType = "btrfs";
-          };
-          "/aux2" = {
-            # filesystem not configured to be deduplicated
-            device = "/dev/disk/by-label/aux2";
-            fsType = "btrfs";
-          };
+  nodes.machine =
+    { config, pkgs, ... }:
+    {
+      boot.initrd.postDeviceCommands = ''
+        ${pkgs.btrfs-progs}/bin/mkfs.btrfs -f -L aux1 /dev/vdb
+        ${pkgs.btrfs-progs}/bin/mkfs.btrfs -f -L aux2 /dev/vdc
+      '';
+      virtualisation.emptyDiskImages = [
+        4096
+        4096
+      ];
+      virtualisation.fileSystems = {
+        "/aux1" = {
+          # filesystem configured to be deduplicated
+          device = "/dev/disk/by-label/aux1";
+          fsType = "btrfs";
         };
-        services.beesd.filesystems = {
-          aux1 = {
-            spec = "LABEL=aux1";
-            hashTableSizeMB = 16;
-            verbosity = "debug";
-          };
+        "/aux2" = {
+          # filesystem not configured to be deduplicated
+          device = "/dev/disk/by-label/aux2";
+          fsType = "btrfs";
         };
       };
+      services.beesd.filesystems = {
+        aux1 = {
+          spec = "LABEL=aux1";
+          hashTableSizeMB = 16;
+          verbosity = "debug";
+        };
+      };
+    };
 
-    testScript =
-      let
-        someContentIsShared =
-          loc:
-          pkgs.writeShellScript "some-content-is-shared" ''
-            [[ $(btrfs fi du -s --raw ${lib.escapeShellArg loc}/dedup-me-{1,2} | awk 'BEGIN { count=0; } NR>1 && $3 == 0 { count++ } END { print count }') -eq 0 ]]
-          '';
-      in
-      ''
-        # shut down the instance started by systemd at boot, so we can test our test procedure
-        machine.succeed("systemctl stop beesd@aux1.service")
+  testScript =
+    let
+      someContentIsShared =
+        loc:
+        pkgs.writeShellScript "some-content-is-shared" ''
+          [[ $(btrfs fi du -s --raw ${lib.escapeShellArg loc}/dedup-me-{1,2} | awk 'BEGIN { count=0; } NR>1 && $3 == 0 { count++ } END { print count }') -eq 0 ]]
+        '';
+    in
+    ''
+      # shut down the instance started by systemd at boot, so we can test our test procedure
+      machine.succeed("systemctl stop beesd@aux1.service")
 
-        machine.succeed(
-            "dd if=/dev/urandom of=/aux1/dedup-me-1 bs=1M count=8",
-            "cp --reflink=never /aux1/dedup-me-1 /aux1/dedup-me-2",
-            "cp --reflink=never /aux1/* /aux2/",
-            "sync",
-        )
-        machine.fail(
-            "${someContentIsShared "/aux1"}",
-            "${someContentIsShared "/aux2"}",
-        )
-        machine.succeed("systemctl start beesd@aux1.service")
+      machine.succeed(
+          "dd if=/dev/urandom of=/aux1/dedup-me-1 bs=1M count=8",
+          "cp --reflink=never /aux1/dedup-me-1 /aux1/dedup-me-2",
+          "cp --reflink=never /aux1/* /aux2/",
+          "sync",
+      )
+      machine.fail(
+          "${someContentIsShared "/aux1"}",
+          "${someContentIsShared "/aux2"}",
+      )
+      machine.succeed("systemctl start beesd@aux1.service")
 
-        # assert that "Set Shared" column is nonzero
-        machine.wait_until_succeeds(
-            "${someContentIsShared "/aux1"}",
-        )
-        machine.fail("${someContentIsShared "/aux2"}")
+      # assert that "Set Shared" column is nonzero
+      machine.wait_until_succeeds(
+          "${someContentIsShared "/aux1"}",
+      )
+      machine.fail("${someContentIsShared "/aux2"}")
 
-        # assert that 16MB hash table size requested was honored
-        machine.succeed(
-            "[[ $(stat -c %s /aux1/.beeshome/beeshash.dat) = $(( 16 * 1024 * 1024)) ]]"
-        )
-      '';
-  }
-)
+      # assert that 16MB hash table size requested was honored
+      machine.succeed(
+          "[[ $(stat -c %s /aux1/.beeshome/beeshash.dat) = $(( 16 * 1024 * 1024)) ]]"
+      )
+    '';
+}


### PR DESCRIPTION
Part of #386873

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
