### PR TITLE
sccmhunter: 1.0.8 -> 1.0.9

### DIFF
--- a/pkgs/by-name/sc/sccmhunter/package.nix
+++ b/pkgs/by-name/sc/sccmhunter/package.nix
@@ -5,14 +5,14 @@
 }:
 python3Packages.buildPythonApplication rec {
   pname = "sccmhunter";
-  version = "1.0.8";
+  version = "1.0.9";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "garrettfoster13";
     repo = "sccmhunter";
-    rev = "v.1.0.8";
-    hash = "sha256-WCrC9YdiTx1qwsnylFK/6pjdwErimjcsJ0gSHegvkzo=";
+    rev = "v${version}";
+    hash = "sha256-Db+kBLy2ejIKKjCskAE4arppk/sq9qQ3w1nCQmeLYhs=";
   };
 
   build-system = with python3Packages; [


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Package works properly:

```
$ nix-build -A sccmhunter
/nix/store/psgw2jrh4dk7vh8aribi8fabdf9az7yk-sccmhunter-1.0.9

$ /nix/store/psgw2jrh4dk7vh8aribi8fabdf9az7yk-sccmhunter-1.0.9/bin/sccmhunter.py --help
SCCMHunter v1.0.9 by @unsigned_sh0rt
                                                                                                                            
 Usage: sccmhunter [OPTIONS] COMMAND [ARGS]...                                                                              
                                                                                                                            
╭─ Options ────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│ --help  -h        Show this message and exit.                                                                            │
╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
╭─ Commands ───────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│ find    Enumerate LDAP for SCCM assets.                                                                                  │
│ http    Abuse client enrollment.                                                                                         │
│ mssql   MSSQL relay abuse.                                                                                               │
│ smb     Profile and Enumerate SMB shares of discovered SCCM servers.                                                     │
│ show    Show and/or recon table results.                                                                                 │
│ admin   Run administrative commands through the AdminService API.                                                        │
│ dpapi   Extract SCCM secrets from DPAPI encrypted blobs, requires Local Administrator privileges.                        │
╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
```

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
