### PR TITLE
paretosecurity: 0.0.96 -> 0.1.3

### DIFF
--- a/nixos/modules/services/security/paretosecurity.nix
+++ b/nixos/modules/services/security/paretosecurity.nix
@@ -24,6 +24,17 @@
     # dependencies here. This creates the necessary symlinks in the proper locations.
     systemd.sockets.paretosecurity.wantedBy = [ "sockets.target" ];
 
+    # In NixOS, systemd services are configured with minimal PATH. However,
+    # paretosecurity helper looks for installed software to do its job, so
+    # it needs the full system PATH. For example, it runs `iptables` to see if
+    # firewall is configured. And it looks for various password managers to see
+    # if one is installed.
+    # The `paretosecurity-user` timer service that is configured lower has
+    # the same need.
+    systemd.services.paretosecurity.serviceConfig.Environment = [
+      "PATH=${config.system.path}/bin:${config.system.path}/sbin"
+    ];
+
     # Enable the tray icon and timer services if the trayIcon option is enabled
     systemd.user = lib.mkIf config.services.paretosecurity.trayIcon {
       services.paretosecurity-trayicon = {
@@ -31,6 +42,9 @@
       };
       services.paretosecurity-user = {
         wantedBy = [ "graphical-session.target" ];
+        serviceConfig.Environment = [
+          "PATH=${config.system.path}/bin:${config.system.path}/sbin"
+        ];
       };
       timers.paretosecurity-user = {
         wantedBy = [ "timers.target" ];

--- a/nixos/tests/paretosecurity.nix
+++ b/nixos/tests/paretosecurity.nix
@@ -29,6 +29,8 @@
         package = patchedPareto;
       };
 
+      networking.firewall.enable = true;
+
     };
 
   nodes.dashboard =
@@ -64,6 +66,12 @@
       services.displayManager.autoLogin = {
         enable = true;
         user = "alice";
+
+      };
+
+      virtualisation.resolution = {
+        x = 640;
+        y = 480;
       };
 
       environment.systemPackages = [ pkgs.xdotool ];
@@ -94,7 +102,6 @@
       + " --skip 21830a4e-84f1-48fe-9c5b-beab436b2cdb"  # Disk encryption
       + " --skip 44e4754a-0b42-4964-9cc2-b88b2023cb1e"  # Pareto Security is up to date
       + " --skip f962c423-fdf5-428a-a57a-827abc9b253e"  # Password manager installed
-      + " --skip 2e46c89a-5461-4865-a92e-3b799c12034a"  # Firewall is enabled
       + "'"
     )
 
@@ -117,7 +124,7 @@
     ]:
         status, out = xfce.systemctl("is-enabled " + unit, "alice")
         assert status == 0, f"Unit {unit} is not enabled (status: {status}): {out}"
-    xfce.succeed("xdotool mousemove 850 10")
+    xfce.succeed("xdotool mousemove 460 10")
     xfce.wait_for_text("Pareto Security")
     xfce.succeed("xdotool click 1")
     xfce.wait_for_text("Run Checks")

--- a/pkgs/by-name/pa/paretosecurity/package.nix
+++ b/pkgs/by-name/pa/paretosecurity/package.nix
@@ -9,16 +9,16 @@
 
 buildGoModule rec {
   pname = "paretosecurity";
-  version = "0.0.96";
+  version = "0.1.3";
 
   src = fetchFromGitHub {
     owner = "ParetoSecurity";
     repo = "agent";
     rev = version;
-    hash = "sha256-SyeIGSDvrnOvyOJ0zC8CulpaMa+iZeRaMTJUSydz2tw=";
+    hash = "sha256-ovyfHqLCf5U3UR1HfoA+UQhqLZ6IaILcpqptPRQsb60=";
   };
 
-  vendorHash = "sha256-O/OF3Y6HiiikMxf657k9eIM7UfkicIImAUxVVf/TgR8=";
+  vendorHash = "sha256-7mKAFkKGpBOjXc3J/sfF3k3pJF53tFybXZgbfJInuSY=";
   proxyVendor = true;
 
   ldflags = [


### PR DESCRIPTION
Also:
 * Fix PATH for systemd services
 * Make UI tests faster and more robust by setting low resolution


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
