### PR TITLE
as31: fix build with gcc14, fix src and meta.homepage, modernize

### DIFF
--- a/pkgs/by-name/as/as31/package.nix
+++ b/pkgs/by-name/as/as31/package.nix
@@ -6,13 +6,13 @@
   bison,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "as31";
   version = "2.3.1";
 
   src = fetchurl {
-    url = "mirror://debian/pool/main/a/as31/${pname}_${version}.orig.tar.gz";
-    name = "${pname}-${version}.tar.gz";
+    url = "mirror://debian/pool/main/a/as31/${finalAttrs.pname}_${finalAttrs.version}.orig.tar.gz";
+    name = "${finalAttrs.pname}-${finalAttrs.version}.tar.gz";
     hash = "sha256-zSEyWHFon5nyq717Mpmdv1XZ5Hz0e8ZABqsP8M83c1U=";
   };
 
@@ -41,12 +41,12 @@ stdenv.mkDerivation rec {
     bison
   ];
 
-  meta = with lib; {
+  meta = {
     homepage = "https://www.pjrc.com/tech/8051/tools/as31-doc.html";
     description = "8031/8051 assembler";
     mainProgram = "as31";
-    license = licenses.gpl2Plus;
-    maintainers = with maintainers; [ ];
-    platforms = platforms.unix;
+    license = lib.licenses.gpl2Plus;
+    maintainers = [ ];
+    platforms = lib.platforms.unix;
   };
-}
+})

--- a/pkgs/by-name/as/as31/package.nix
+++ b/pkgs/by-name/as/as31/package.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
   version = "2.3.1";
 
   src = fetchurl {
-    url = "http://wiki.erazor-zone.de/_media/wiki:projects:linux:as31:${pname}-${version}.tar.gz";
+    url = "mirror://debian/pool/main/a/as31/${pname}_${version}.orig.tar.gz";
     name = "${pname}-${version}.tar.gz";
     hash = "sha256-zSEyWHFon5nyq717Mpmdv1XZ5Hz0e8ZABqsP8M83c1U=";
   };
@@ -42,7 +42,7 @@ stdenv.mkDerivation rec {
   ];
 
   meta = with lib; {
-    homepage = "http://wiki.erazor-zone.de/wiki:projects:linux:as31";
+    homepage = "https://www.pjrc.com/tech/8051/tools/as31-doc.html";
     description = "8031/8051 assembler";
     mainProgram = "as31";
     license = licenses.gpl2Plus;

--- a/pkgs/by-name/as/as31/package.nix
+++ b/pkgs/by-name/as/as31/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchurl,
+  fetchpatch,
   bison,
 }:
 
@@ -18,6 +19,12 @@ stdenv.mkDerivation rec {
   patches = [
     # Check return value of getline in run.c
     ./0000-getline-break.patch
+
+    # fix build with gcc14
+    (fetchpatch {
+      url = "https://salsa.debian.org/debian/as31/-/raw/76735fbf1fb00ce70ffd98385137908b7bd9bd5c/debian/patches/update_sizebuf_types.patch";
+      hash = "sha256-ERrPdY0afKwXmdSLoWmWR55nKfvmieGlz+nhwFWRnrM=";
+    })
   ];
 
   postPatch = ''


### PR DESCRIPTION
as31: fix build with gcc14

- add patch from debian:
https://salsa.debian.org/debian/as31/-/blob/76735fbf1fb00ce70ffd98385137908b7bd9bd5c/debian/patches/update_sizebuf_types.patch
fixing `incompatible-pointer-types` errors with gcc14:
```
run.c: In function 'run_as31':
run.c:109:41: error: passing argument 2 of 'getline' from incompatible pointer type
  109 |                 if (getline(&lineBuffer,&sizeBuf,finPre) == -1)
      |                                         ^~~~~~~~
      |                                         |
      |                                         int *
In file included from /nix/store/kj8hbqx4ds9qm9mq7hyikxyfwwg13kzj-glibc-2.40-36-dev/include/stdio.h:966,
                 from run.c:2:
/nix/store/kj8hbqx4ds9qm9mq7hyikxyfwwg13kzj-glibc-2.40-36-dev/include/bits/stdio.h:118:36:
note: expected 'size_t *' {aka 'long unsigned int *'} but argument is of type 'int *'
  118 | getline (char **__lineptr, size_t *__n, FILE *__stream)
      |                            ~~~~~~~~^~~
run.c:135:68: error: passing argument 2 of 'getline' from incompatible pointer type
  135 |                                         if (getline(&incLineBuffer,&incSizeBuf,includeFile) == -1)
      |                                                                    ^~~~~~~~~~~
      |                                                                    |
      |                                                                    int *
/nix/store/kj8hbqx4ds9qm9mq7hyikxyfwwg13kzj-glibc-2.40-36-dev/include/bits/stdio.h:118:36:
note: expected 'size_t *' {aka 'long unsigned int *'} but argument is of type 'int *'
  118 | getline (char **__lineptr, size_t *__n, FILE *__stream)
      |                            ~~~~~~~~^~~
```

---

as31: fix src and meta.homepage

- change `src` to debian mirror (hash did not change), because previous
url requires auth now:
```
nix-build -A as31.src --check
trying http://wiki.erazor-zone.de/_media/wiki:projects:linux:as31:as31-2.3.1.tar.gz
...
curl: (22) The requested URL returned error: 401
error: cannot download as31-2.3.1.tar.gz from any mirror
```

- change `meta.homepage` because previous url requires auth now:
```
curl "http://wiki.erazor-zone.de/wiki:projects:linux:as31" -v
...
< HTTP/1.1 401 Unauthorized
```

---

as31: modernize

- replace `rec` with `finalAttrs`
- remove `with lib;` from `meta`

---

Fixes build failure of `as31` since `2025-01-14` (update to GCC 14 in #356812):
https://hydra.nixos.org/job/nixos/trunk-combined/nixpkgs.as31.x86_64-linux
https://hydra.nixos.org/build/282556936

Log:
```text
run.c: In function 'run_as31':
run.c:109:41: error: passing argument 2 of 'getline' from incompatible pointer type [8;;https://gcc.gnu.org/onlinedocs/gcc-14.2.0/gcc/Warning-Options.html#index-Wincompatible-pointer-types-Wincompatible-pointer-types8;;]
  109 |                 if (getline(&lineBuffer,&sizeBuf,finPre) == -1)
      |                                         ^~~~~~~~
      |                                         |
      |                                         int *
In file included from /nix/store/kj8hbqx4ds9qm9mq7hyikxyfwwg13kzj-glibc-2.40-36-dev/include/stdio.h:966,
                 from run.c:2:
/nix/store/kj8hbqx4ds9qm9mq7hyikxyfwwg13kzj-glibc-2.40-36-dev/include/bits/stdio.h:118:36: note: expected 'size_t *' {aka 'long unsigned int *'} but argument is of type 'int *'
  118 | getline (char **__lineptr, size_t *__n, FILE *__stream)
      |                            ~~~~~~~~^~~
run.c:135:68: error: passing argument 2 of 'getline' from incompatible pointer type [8;;https://gcc.gnu.org/onlinedocs/gcc-14.2.0/gcc/Warning-Options.html#index-Wincompatible-pointer-types-Wincompatible-pointer-types8;;]
  135 |                                         if (getline(&incLineBuffer,&incSizeBuf,includeFile) == -1)
      |                                                                    ^~~~~~~~~~~
      |                                                                    |
      |                                                                    int *
/nix/store/kj8hbqx4ds9qm9mq7hyikxyfwwg13kzj-glibc-2.40-36-dev/include/bits/stdio.h:118:36: note: expected 'size_t *' {aka 'long unsigned int *'} but argument is of type 'int *'
  118 | getline (char **__lineptr, size_t *__n, FILE *__stream)
      |                            ~~~~~~~~^~~
make[1]: *** [Makefile:163: run.o] Error 1
make[1]: Leaving directory '/build/as31-2.3.1/as31'
make: *** [Makefile:115: all-recursive] Error 1
```

Tracking issue: #388196

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
