### PR TITLE
starship-sf64: init at 2.0.0

### DIFF
--- a/pkgs/by-name/st/starship-sf64/dont-fetch-stb.patch
+++ b/pkgs/by-name/st/starship-sf64/dont-fetch-stb.patch
@@ -1,0 +1,16 @@
+Submodule libultraship contains modified content
+diff --git a/libultraship/cmake/dependencies/common.cmake b/libultraship/cmake/dependencies/common.cmake
+index 596158c..c62d7b2 100644
+--- a/libultraship/cmake/dependencies/common.cmake
++++ b/libultraship/cmake/dependencies/common.cmake
+@@ -47,10 +47,6 @@ set(stormlib_optimizations_patch git apply ${CMAKE_CURRENT_SOURCE_DIR}/cmake/dep
+ endif()
+ 
+ #=================== STB ===================
+-set(STB_DIR ${CMAKE_BINARY_DIR}/_deps/stb)
+-file(DOWNLOAD "https://github.com/nothings/stb/raw/0bc88af4de5fb022db643c2d8e549a0927749354/stb_image.h" "${STB_DIR}/stb_image.h")
+-file(WRITE "${STB_DIR}/stb_impl.c" "#define STB_IMAGE_IMPLEMENTATION\n#include \"stb_image.h\"")
+-
+ add_library(stb STATIC)
+ 
+ target_sources(stb PRIVATE

--- a/pkgs/by-name/st/starship-sf64/git-deps.patch
+++ b/pkgs/by-name/st/starship-sf64/git-deps.patch
@@ -1,0 +1,45 @@
+Submodule tools/Torch contains modified content
+diff --git a/tools/Torch/CMakeLists.txt b/tools/Torch/CMakeLists.txt
+index 8055f91..a77ff3a 100644
+--- a/tools/Torch/CMakeLists.txt
++++ b/tools/Torch/CMakeLists.txt
+@@ -36,8 +36,7 @@ if(USE_STANDALONE)
+     # Because libgfxd is not a CMake project, we have to manually fetch it and add it to the build
+     FetchContent_Declare(
+         libgfxd
+-        GIT_REPOSITORY https://github.com/glankk/libgfxd.git
+-        GIT_TAG 96fd3b849f38b3a7c7b7f3ff03c5921d328e6cdf
++        URL @libgfxd_src@
+     )
+ 
+     FetchContent_GetProperties(libgfxd)
+@@ -205,8 +204,7 @@ set(YAML_CPP_BUILD_TESTS OFF)
+ set(YAML_CPP_DISABLE_UNINSTALL ON)
+ FetchContent_Declare(
+     yaml-cpp
+-    GIT_REPOSITORY https://github.com/jbeder/yaml-cpp.git
+-    GIT_TAG 28f93bdec6387d42332220afa9558060c8016795
++    URL @yaml-cpp_src@
+ )
+ set(YAML_CPP_BUILD_TESTS OFF)
+ FetchContent_MakeAvailable(yaml-cpp)
+@@ -219,8 +217,7 @@ endif()
+ if(USE_STANDALONE)
+ 	FetchContent_Declare(
+ 		spdlog
+-		GIT_REPOSITORY https://github.com/gabime/spdlog.git
+-		GIT_TAG 7e635fca68d014934b4af8a1cf874f63989352b7
++        URL @spdlog_src@
+ 	)
+ 
+ 	FetchContent_MakeAvailable(spdlog)
+@@ -234,8 +231,7 @@ endif()
+ set(tinyxml2_BUILD_TESTING OFF)
+ FetchContent_Declare(
+     tinyxml2
+-    GIT_REPOSITORY https://github.com/leethomason/tinyxml2.git
+-    GIT_TAG 10.0.0
++    URL @tinyxml2_src@
+     OVERRIDE_FIND_PACKAGE
+ )
+ FetchContent_MakeAvailable(tinyxml2)

--- a/pkgs/by-name/st/starship-sf64/package.nix
+++ b/pkgs/by-name/st/starship-sf64/package.nix
@@ -1,0 +1,265 @@
+{
+  lib,
+  fetchFromGitHub,
+  applyPatches,
+  writeTextFile,
+  fetchurl,
+  fetchpatch,
+  stdenv,
+  replaceVars,
+  yaml-cpp,
+  srcOnly,
+  cmake,
+  copyDesktopItems,
+  installShellFiles,
+  lsb-release,
+  makeWrapper,
+  ninja,
+  pkg-config,
+  bzip2,
+  libGL,
+  libvorbis,
+  libx11,
+  libzip,
+  nlohmann_json,
+  SDL2,
+  spdlog,
+  tinyxml-2,
+  zenity,
+  sdl_gamecontrollerdb,
+  starship-sf64,
+  makeDesktopItem,
+}:
+
+let
+
+  # The following are either normally fetched during build time or a specific version is required
+
+  dr_libs = fetchFromGitHub {
+    owner = "mackron";
+    repo = "dr_libs";
+    rev = "da35f9d6c7374a95353fd1df1d394d44ab66cf01";
+    hash = "sha256-ydFhQ8LTYDBnRTuETtfWwIHZpRciWfqGsZC6SuViEn0=";
+  };
+
+  imgui' = applyPatches {
+    src = fetchFromGitHub {
+      owner = "ocornut";
+      repo = "imgui";
+      tag = "v1.91.9b-docking";
+      hash = "sha256-mQOJ6jCN+7VopgZ61yzaCnt4R1QLrW7+47xxMhFRHLQ=";
+    };
+    patches = [
+      "${starship-sf64.src}/libultraship/cmake/dependencies/patches/imgui-fixes-and-config.patch"
+    ];
+  };
+
+  libgfxd = fetchFromGitHub {
+    owner = "glankk";
+    repo = "libgfxd";
+    rev = "008f73dca8ebc9151b205959b17773a19c5bd0da";
+    hash = "sha256-AmHAa3/cQdh7KAMFOtz5TQpcM6FqO9SppmDpKPTjTt8=";
+  };
+
+  prism = fetchFromGitHub {
+    owner = "KiritoDv";
+    repo = "prism-processor";
+    rev = "7ae724a6fb7df8cbf547445214a1a848aefef747";
+    hash = "sha256-G7koDUxD6PgZWmoJtKTNubDHg6Eoq8I+AxIJR0h3i+A=";
+  };
+
+  stb_impl = writeTextFile {
+    name = "stb_impl.c";
+    text = ''
+      #define STB_IMAGE_IMPLEMENTATION
+      #include "stb_image.h"
+    '';
+  };
+
+  stb' = fetchurl {
+    name = "stb_image.h";
+    url = "https://raw.githubusercontent.com/nothings/stb/0bc88af4de5fb022db643c2d8e549a0927749354/stb_image.h";
+    hash = "sha256-xUsVponmofMsdeLsI6+kQuPg436JS3PBl00IZ5sg3Vw=";
+  };
+
+  stormlib' = applyPatches {
+    src = fetchFromGitHub {
+      owner = "ladislav-zezula";
+      repo = "StormLib";
+      tag = "v9.25";
+      hash = "sha256-HTi2FKzKCbRaP13XERUmHkJgw8IfKaRJvsK3+YxFFdc=";
+    };
+    patches = [
+      "${starship-sf64.src}/libultraship/cmake/dependencies/patches/stormlib-optimizations.patch"
+    ];
+  };
+
+  thread_pool = fetchFromGitHub {
+    owner = "bshoshany";
+    repo = "thread-pool";
+    tag = "v4.1.0";
+    hash = "sha256-zhRFEmPYNFLqQCfvdAaG5VBNle9Qm8FepIIIrT9sh88=";
+  };
+
+  # Include cmake4 patch
+  # Remove when yaml-cpp.src is updated to include it
+  yaml-patched = applyPatches {
+    src = yaml-cpp.src;
+    patches = [
+      (fetchpatch {
+        name = "yaml-cpp-fix-cmake-4.patch";
+        url = "https://github.com/jbeder/yaml-cpp/commit/c2680200486572baf8221ba052ef50b58ecd816e.patch";
+        hash = "sha256-1kXRa+xrAbLEhcJxNV1oGHPmayj1RNIe6dDWXZA3mUA=";
+      })
+    ];
+  };
+
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "starship-sf64";
+  version = "2.0.0";
+
+  src = fetchFromGitHub {
+    owner = "HarbourMasters";
+    repo = "Starship";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-pjftFMUE3UQuFe6WJI+n9GllV9uT2bvhHaUICaPHz+Q=";
+    fetchSubmodules = true;
+  };
+
+  patches = [
+    # Don't fetch stb as we will patch our own
+    ./dont-fetch-stb.patch
+
+    # Can't fetch these torch deps in the sandbox
+    (replaceVars ./git-deps.patch {
+      libgfxd_src = fetchFromGitHub {
+        owner = "glankk";
+        repo = "libgfxd";
+        rev = "96fd3b849f38b3a7c7b7f3ff03c5921d328e6cdf";
+        hash = "sha256-dedZuV0BxU6goT+rPvrofYqTz9pTA/f6eQcsvpDWdvQ=";
+      };
+      spdlog_src = fetchFromGitHub {
+        owner = "gabime";
+        repo = "spdlog";
+        rev = "7e635fca68d014934b4af8a1cf874f63989352b7";
+        hash = "sha256-cxTaOuLXHRU8xMz9gluYz0a93O0ez2xOxbloyc1m1ns=";
+      };
+      yaml-cpp_src = srcOnly yaml-patched;
+      tinyxml2_src = srcOnly tinyxml-2;
+    })
+
+    # Revert upstream appimage fixes as this breaks loading at least on nixpkgs
+    ./revert-appimage-fixes.patch
+  ];
+
+  nativeBuildInputs = [
+    cmake
+    copyDesktopItems
+    installShellFiles
+    lsb-release
+    makeWrapper
+    ninja
+    pkg-config
+  ];
+
+  buildInputs = [
+    bzip2
+    libGL
+    libvorbis
+    libx11
+    libzip
+    nlohmann_json
+    SDL2
+    spdlog
+    tinyxml-2
+    zenity
+  ];
+
+  cmakeFlags = [
+    (lib.cmakeFeature "CMAKE_INSTALL_PREFIX" "${placeholder "out"}")
+    (lib.cmakeFeature "FETCHCONTENT_SOURCE_DIR_DR_LIBS" "${dr_libs}")
+    (lib.cmakeFeature "FETCHCONTENT_SOURCE_DIR_IMGUI" "${imgui'}")
+    (lib.cmakeFeature "FETCHCONTENT_SOURCE_DIR_LIBGFXD" "${libgfxd}")
+    (lib.cmakeFeature "FETCHCONTENT_SOURCE_DIR_PRISM" "${prism}")
+    (lib.cmakeFeature "FETCHCONTENT_SOURCE_DIR_STORMLIB" "${stormlib'}")
+    (lib.cmakeFeature "FETCHCONTENT_SOURCE_DIR_THREADPOOL" "${thread_pool}")
+    (lib.cmakeFeature "FETCHCONTENT_SOURCE_DIR_TINYXML2" "${tinyxml-2}")
+    (lib.cmakeFeature "FETCHCONTENT_SOURCE_DIR_YAML-CPP" "${yaml-patched}")
+  ];
+
+  strictDeps = true;
+
+  # Linking fails without this
+  hardeningDisable = [ "format" ];
+
+  preConfigure = ''
+    mkdir stb
+    cp ${stb'} ./stb/${stb'.name}
+    cp ${stb_impl} ./stb/${stb_impl.name}
+    substituteInPlace libultraship/cmake/dependencies/common.cmake \
+      --replace-fail "\''${STB_DIR}" "$(readlink -f ./stb)"
+  '';
+
+  postBuild = ''
+    cp ${sdl_gamecontrollerdb}/share/gamecontrollerdb.txt gamecontrollerdb.txt
+    ./TorchExternal/src/TorchExternal-build/torch pack ../port starship.o2r o2r
+  '';
+
+  postInstall = ''
+    mv Starship starship-sf64
+    installBin starship-sf64
+    mkdir -p $out/share/starship-sf64/
+    cp -r assets $out/share/starship-sf64/
+    install -Dm644 -t $out/share/starship-sf64 {starship.o2r,config.yml,gamecontrollerdb.txt}
+    install -Dm644 ../logo.png $out/share/pixmaps/starship-sf64.png
+    install -Dm644 -t $out/share/licenses/starship-sf64 ../LICENSE.md
+    install -Dm644 -t $out/share/licenses/starship-sf64/libgfxd ${libgfxd}/LICENSE
+    install -Dm644 -t $out/share/licenses/starship-sf64/libultraship ../libultraship/LICENSE
+    install -Dm644 -t $out/share/licenses/starship-sf64/thread_pool ${thread_pool}/LICENSE.txt
+  '';
+
+  # Unfortunately, Starship really wants a writable working directory
+  # Create $HOME/.local/share/starship-sf64 and symlink required files
+  # This is pretty hacky and works for now and perhaps upstream might support XDG later
+  # Also wrapProgram escapes $HOME to "/homeless-shelter" so use "~" for now
+
+  postFixup = ''
+    wrapProgram $out/bin/starship-sf64 \
+      --prefix PATH ":" ${lib.makeBinPath [ zenity ]} \
+      --run 'mkdir -p ~/.local/share/starship-sf64' \
+      --run "ln -sf $out/share/starship-sf64/starship.o2r ~/.local/share/starship-sf64/starship.o2r" \
+      --run "ln -sf $out/share/starship-sf64/config.yml ~/.local/share/starship-sf64/config.yml" \
+      --run "ln -sfT $out/share/starship-sf64/assets ~/.local/share/starship-sf64/assets" \
+      --run "ln -sf $out/share/starship-sf64/gamecontrollerdb.txt ~/.local/share/starship-sf64/gamecontrollerdb.txt" \
+      --run 'cd ~/.local/share/starship-sf64'
+  '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "Starship";
+      icon = "starship-sf64";
+      exec = "starship-sf64";
+      comment = finalAttrs.meta.description;
+      genericName = "starship-sf64";
+      desktopName = "Starship";
+      categories = [ "Game" ];
+    })
+  ];
+
+  meta = {
+    homepage = "https://github.com/HarbourMasters/Starship";
+    description = "SF64 PC Port";
+    mainProgram = "starship-sf64";
+    platforms = [ "x86_64-linux" ];
+    maintainers = with lib.maintainers; [ qubitnano ];
+    license = with lib.licenses; [
+      # libultraship, libgfxd, thread_pool, dr_libs, prism-processor
+      mit
+      # Starship
+      cc0
+      # Reverse engineering
+      unfree
+    ];
+  };
+})

--- a/pkgs/by-name/st/starship-sf64/revert-appimage-fixes.patch
+++ b/pkgs/by-name/st/starship-sf64/revert-appimage-fixes.patch
@@ -1,0 +1,29 @@
+From aae7b7ca818ae4f438f315c9802a44adf6992215 Mon Sep 17 00:00:00 2001
+From: qubitnano <146656568+qubitnano@users.noreply.github.com>
+Date: Sun, 25 May 2025 12:51:27 -0400
+Subject: [PATCH] revert appimage fixes
+
+This breaks loading at least on nixpkgs
+---
+ src/port/Engine.cpp | 4 ----
+ 1 file changed, 4 deletions(-)
+
+diff --git a/src/port/Engine.cpp b/src/port/Engine.cpp
+index d2bee9ec..47b21533 100644
+--- a/src/port/Engine.cpp
++++ b/src/port/Engine.cpp
+@@ -70,11 +70,7 @@ GameEngine::GameEngine() {
+ 
+     std::vector<std::string> archiveFiles;
+     const std::string main_path = Ship::Context::GetPathRelativeToAppDirectory("sf64.o2r");
+-#ifdef __linux__
+-    const std::string assets_path = Ship::Context::GetPathRelativeToAppBundle("starship.o2r");
+-#else
+     const std::string assets_path = Ship::Context::GetPathRelativeToAppDirectory("starship.o2r");
+-#endif
+ 
+ 
+ #ifdef _WIN32
+-- 
+2.49.0
+


### PR DESCRIPTION
Closes https://github.com/NixOS/nixpkgs/issues/370290

https://github.com/HarbourMasters/Starship

Star Fox 64 PC port brought to you by the teams behind shipwright and 2ship2harkinian

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
