### PR TITLE
nixos/mptcpd: generate config declaratively

### DIFF
--- a/nixos/modules/services/networking/mptcpd.nix
+++ b/nixos/modules/services/networking/mptcpd.nix
@@ -5,11 +5,9 @@
   ...
 }:
 let
-
   cfg = config.services.mptcpd;
-
+  settingsFormat = pkgs.formats.ini { };
 in
-
 {
 
   options = {
@@ -20,15 +18,57 @@ in
 
       package = lib.mkPackageOption pkgs "mptcpd" { };
 
+      settings = lib.mkOption {
+        type = settingsFormat.type;
+        default = { };
+        example = lib.literalExpression ''
+          {
+            core = {
+              "addr-flags" = "subflow";
+              "notify-flags" = "existing,skip_link_local,skip_loopback,check_route";
+              "load-plugins" = "addr_adv,sspi";
+            };
+          }
+        '';
+        description = ''
+          mptcpd configuration written to {file}`/etc/mptcpd/mptcpd.conf`.
+
+          See {manpage}`mptcpd(8)` for details about available options and syntax.
+        '';
+      };
+
     };
 
   };
 
   config = lib.mkIf cfg.enable {
 
+    # Disable NetworkManager from configuring the MPTCP endpoints.
+    # See https://github.com/multipath-tcp/mptcpd/blob/48942b2110805af236ca41164fde67830efd7507/README.md?plain=1#L19-L38
+    networking.networkmanager.connectionConfig = {
+      "connection.mptcp-flags" = 1;
+    };
+
+    environment.etc."mptcpd/mptcpd.conf".source = settingsFormat.generate "mptcpd.conf" cfg.settings;
+
     environment.systemPackages = [ cfg.package ];
 
+    services.mptcpd.settings = {
+      core = {
+        log = lib.mkDefault "journal";
+        "plugin-dir" = "${cfg.package}/lib/mptcpd";
+        "path-manager" = lib.mkDefault "addr_adv";
+      };
+    };
+
     systemd.packages = [ cfg.package ];
+    systemd.services.mptcp = {
+      wantedBy = [ "multi-user.target" ];
+      serviceConfig.ExecStart = [
+        ""
+        "${cfg.package}/libexec/mptcpd"
+      ];
+    };
 
   };
 

--- a/pkgs/by-name/mp/mptcpd/package.nix
+++ b/pkgs/by-name/mp/mptcpd/package.nix
@@ -47,7 +47,13 @@ stdenv.mkDerivation (finalAttrs: {
   postConfigure = "doxygen -u";
 
   configureFlags = [
+    "--sysconfdir=/etc"
     "--with-systemdsystemunitdir=${placeholder "out"}/lib/systemd/system"
+  ];
+
+  installFlags = [
+    # The NixOS module generates /etc/mptcpd/mptcpd.conf declaratively.
+    "pkgsysconfdir=$out/etc/mptcpd"
   ];
 
   # fix: 'Fontconfig error: Cannot load default config file: No such file: (null)'


### PR DESCRIPTION
## Summary

- generate `/etc/mptcpd/mptcpd.conf` declaratively from `services.mptcpd.settings`
- keep mptcpd compiled to read `/etc/mptcpd/mptcpd.conf`, while redirecting upstream's installed sample config to `$TMPDIR` during package install
- enable the packaged `mptcp.service` and restart it when the generated config changes
- disable NetworkManager MPTCP endpoint management when mptcpd is enabled

## Motivation

mptcpd reads a compiled-in system config path. In Nixpkgs, the package should not install files into the real `/etc`, and on NixOS the module should own the runtime config under `/etc`.

This replaces the earlier command-line flag approach with a generated INI config file. The package still configures `--sysconfdir=/etc` so the daemon looks in the expected runtime location, but `pkgsysconfdir` is redirected to `$TMPDIR` during install because the NixOS module provides the actual config file.

## Testing

- `nixfmt pkgs/by-name/mp/mptcpd/package.nix nixos/modules/services/networking/mptcpd.nix`
- `git diff --check`
- `nix-build /home/qbisi/nixpkgs -A mptcpd --no-out-link`
- evaluated a minimal NixOS config with `services.mptcpd.enable = true`
- checked the built package has no `$out/etc`
- checked the built binary still contains `/etc/mptcpd/mptcpd.conf`

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`?
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - package build with `nix-build -A mptcpd --no-out-link`
  - module evaluation for `services.mptcpd.enable = true`
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`
- [ ] Tested basic functionality of all binary files
- [ ] Added a release notes entry if the change is major or breaking
- [x] Fits CONTRIBUTING.md