### PR TITLE
gitlab-runner: Add main program, version check hook, and Nix update script. Fix Darwin builds.

### DIFF
--- a/pkgs/by-name/gi/gitlab-runner/package.nix
+++ b/pkgs/by-name/gi/gitlab-runner/package.nix
@@ -1,80 +1,103 @@
 {
   lib,
+  stdenv,
+  bash,
   buildGoModule,
   fetchFromGitLab,
-  bash,
+  nix-update-script,
+  versionCheckHook,
 }:
 
-let
-  version = "17.2.0";
-in
-buildGoModule rec {
-  inherit version;
+buildGoModule (finalAttrs: {
   pname = "gitlab-runner";
-
-  commonPackagePath = "gitlab.com/gitlab-org/gitlab-runner/common";
-  ldflags = [
-    "-X ${commonPackagePath}.NAME=gitlab-runner"
-    "-X ${commonPackagePath}.VERSION=${version}"
-    "-X ${commonPackagePath}.REVISION=v${version}"
-  ];
-
-  # For patchShebangs
-  buildInputs = [ bash ];
-
-  vendorHash = "sha256-1MwHss76apA9KoFhEU6lYiUACrPMGYzjhds6nTyNuJI=";
+  version = "17.2.0";
 
   src = fetchFromGitLab {
     owner = "gitlab-org";
     repo = "gitlab-runner";
-    rev = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-a2Igy4DS3fYTvPW1vvDrH/DjMQ4lG9cm/P3mFr+y9s4=";
   };
+
+  vendorHash = "sha256-1MwHss76apA9KoFhEU6lYiUACrPMGYzjhds6nTyNuJI=";
+
+  # For patchShebangs
+  nativeBuildInputs = [ bash ];
 
   patches = [
     ./fix-shell-path.patch
     ./remove-bash-test.patch
   ];
 
-  prePatch = ''
-    # Remove some tests that can't work during a nix build
+  prePatch =
+    ''
+      # Remove some tests that can't work during a nix build
 
-    # Requires to run in a git repo
-    sed -i "s/func TestCacheArchiverAddingUntrackedFiles/func OFF_TestCacheArchiverAddingUntrackedFiles/" commands/helpers/file_archiver_test.go
-    sed -i "s/func TestCacheArchiverAddingUntrackedUnicodeFiles/func OFF_TestCacheArchiverAddingUntrackedUnicodeFiles/" commands/helpers/file_archiver_test.go
+      # Requires to run in a git repo
+      sed -i "s/func TestCacheArchiverAddingUntrackedFiles/func OFF_TestCacheArchiverAddingUntrackedFiles/" commands/helpers/file_archiver_test.go
+      sed -i "s/func TestCacheArchiverAddingUntrackedUnicodeFiles/func OFF_TestCacheArchiverAddingUntrackedUnicodeFiles/" commands/helpers/file_archiver_test.go
 
-    # No writable developer environment
-    rm common/build_test.go
-    rm common/build_settings_test.go
-    rm executors/custom/custom_test.go
+      # No writable developer environment
+      rm common/build_test.go
+      rm common/build_settings_test.go
+      rm executors/custom/custom_test.go
 
-    # No docker during build
-    rm executors/docker/terminal_test.go
-    rm executors/docker/docker_test.go
-    rm helpers/docker/auth/auth_test.go
-    rm executors/docker/services_test.go
-  '';
+      # No docker during build
+      rm executors/docker/terminal_test.go
+      rm executors/docker/docker_test.go
+      rm helpers/docker/auth/auth_test.go
+      rm executors/docker/services_test.go
+    ''
+    + lib.optionalString stdenv.buildPlatform.isDarwin ''
+      # No keychain access during build breaks X.509 certificate tests
+      rm helpers/certificate/x509_test.go
+      rm network/client_test.go
+    '';
 
   excludedPackages = [
     # CI helper script for pushing images to Docker and ECR registries
+    #
     # https://gitlab.com/gitlab-org/gitlab-runner/-/merge_requests/4139
     "./scripts/sync-docker-images"
   ];
 
-  postInstall = ''
-    install packaging/root/usr/share/gitlab-runner/clear-docker-cache $out/bin
-  '';
+  ldflags =
+    let
+      ldflagsPackageVariablePrefix = "gitlab.com/gitlab-org/gitlab-runner/common";
+    in
+    [
+      "-X ${ldflagsPackageVariablePrefix}.NAME=gitlab-runner"
+      "-X ${ldflagsPackageVariablePrefix}.VERSION=${finalAttrs.version}"
+      "-X ${ldflagsPackageVariablePrefix}.REVISION=${finalAttrs.src.tag}"
+    ];
 
   preCheck = ''
     # Make the tests pass outside of GitLab CI
     export CI=0
   '';
 
-  meta = with lib; {
-    description = "GitLab Runner the continuous integration executor of GitLab";
-    license = licenses.mit;
-    homepage = "https://docs.gitlab.com/runner/";
-    platforms = platforms.unix ++ platforms.darwin;
-    maintainers = with maintainers; [ zimbatm ] ++ teams.gitlab.members;
+  # Many tests start servers which bind to ports
+  __darwinAllowLocalNetworking = true;
+
+  postInstall = ''
+    install packaging/root/usr/share/gitlab-runner/clear-docker-cache $out/bin
+  '';
+
+  doInstallCheck = true;
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  versionCheckProgramArg = "--version";
+
+  passthru = {
+    updateScript = nix-update-script { };
   };
-}
+
+  meta = {
+    description = "GitLab Runner the continuous integration executor of GitLab";
+    homepage = "https://docs.gitlab.com/runner";
+    license = lib.licenses.mit;
+    mainProgram = "gitlab-runner";
+    maintainers = with lib.maintainers; [ zimbatm ] ++ lib.teams.gitlab.members;
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

- Add main program.
- Add version check hook.
- Add Nix update script.
- Fix Darwin builds.
  - Allow local networking.
  - Remove X.509 tests.
- Minor cleanup.
  - Switch from `rec` to `finalAttrs`.
  - Switch fetcher from `rev` to `tag`.
  - Reorder attributes according to [stdenv phase ordering](https://nixos.org/manual/nixpkgs/stable#sec-stdenv-phases).
  - Remove `meta.platforms` to use the one included with `buildGoModule`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
