### PR TITLE
Update WasabiWallet v2.0.8.1 -> v2.5.1

### DIFF
--- a/pkgs/by-name/wa/wasabiwallet/package.nix
+++ b/pkgs/by-name/wa/wasabiwallet/package.nix
@@ -27,18 +27,18 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "wasabiwallet";
-  version = "2.0.8.1";
+  version = "2.5.1";
 
   src = fetchurl {
-    url = "https://github.com/zkSNACKs/WalletWasabi/releases/download/v${version}/Wasabi-${version}.tar.gz";
-    sha256 = "sha256-9q93C8Q4MKrpvAs6cb4sgo3PDVhk9ZExeHIZ9Qm8P2w=";
+    url = "https://github.com/WalletWasabi/WalletWasabi/releases/download/v${version}/Wasabi-${version}-linux-x64.tar.gz";
+    sha256 = "sha256-DTgxLg8NwjHX085Ai6zxXgjL3x8ZHqVIpvxk/KRl+7w=";
   };
 
   dontBuild = true;
 
   desktopItem = makeDesktopItem {
     name = "wasabi";
-    exec = "wasabiwallet";
+    exec = "wasabiwallet-desktop";
     desktopName = "Wasabi";
     genericName = "Bitcoin wallet";
     comment = meta.description;
@@ -58,13 +58,15 @@ stdenv.mkDerivation rec {
 
   installPhase = ''
     mkdir -p $out/opt/${pname} $out/bin $out/share/applications
-    cp -Rv . $out/opt/${pname}
 
-    makeWrapper "$out/opt/${pname}/wassabee" "$out/bin/${pname}" \
-      --suffix "LD_LIBRARY_PATH" : "${lib.makeLibraryPath runtimeLibs}"
+    # The weird path is an upstream packaging error and could be fixed in the upcoming release
+    cp -Rv ./runner/work/WalletWasabi/WalletWasabi/build/linux-x64/* $out/opt/${pname}
 
-    makeWrapper "$out/opt/${pname}/wassabeed" "$out/bin/${pname}d" \
-      --suffix "LD_LIBRARY_PATH" : "${lib.makeLibraryPath runtimeLibs}"
+    for nameMap in "wassabee:desktop" "wassabeed:daemon" "wcoordinator:coordinator" "wbackend:backend"; do
+      IFS=":" read -r filename wrappedname <<< "$nameMap"
+      makeWrapper "$out/opt/${pname}/$filename" "$out/bin/${pname}-$wrappedname" \
+        --suffix "LD_LIBRARY_PATH" : "${lib.makeLibraryPath runtimeLibs}"
+    done
 
     cp -v $desktopItem/share/applications/* $out/share/applications
   '';


### PR DESCRIPTION
## Description of changes

I updated the version to the latest v2.5.1 and also included two new executables:
 
 * `wasabiwallet-coordinator` (Wasabi Wallet coinjoin coordinator) and
 * `wasabiwallet-backend` (Wasabi Wallet backend)
 
I also renamed the executables:

 * `wassabeed` renamed as `wasabiwallet-daemon` and
 * `wassabee` renamed as `wasabiwallet-desktop`

Release note: https://github.com/zkSNACKs/WalletWasabi/releases/tag/v2.5.1
 
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [24.11 Release notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md))
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

--------------

**Maintainer pings**

cc @mmahut for [testing](https://github.com/ryantm/nixpkgs-update/blob/main/doc/nixpkgs-maintainer-faq.md#r-ryantm-opened-a-pr-for-my-package-what-do-i-do).