### PR TITLE
Revert "python313Packages.bring-api: 1.0.2 -> 1.1.0"

### DIFF
--- a/pkgs/development/python-modules/bring-api/default.nix
+++ b/pkgs/development/python-modules/bring-api/default.nix
@@ -17,7 +17,7 @@
 
 buildPythonPackage rec {
   pname = "bring-api";
-  version = "1.1.0";
+  version = "1.0.2";
   pyproject = true;
 
   disabled = pythonOlder "3.11";
@@ -26,7 +26,7 @@ buildPythonPackage rec {
     owner = "miaucl";
     repo = "bring-api";
     tag = version;
-    hash = "sha256-OxY9G7zy5VSpTOARoManJNvMg6ghIK0KJunanSgXKm0=";
+    hash = "sha256-GBRPC4oTCTy8MdGNsPYrgB8Lji0ojRL3Z4ELTe543PY=";
   };
 
   build-system = [ setuptools ];


### PR DESCRIPTION
Reverts NixOS/nixpkgs#391829 because I accidentally merged it into master.