### PR TITLE
ocamlPackages.gettext: 0.4.2 → 0.5.0

### DIFF
--- a/pkgs/development/ocaml-modules/ocaml-gettext/camomile.nix
+++ b/pkgs/development/ocaml-modules/ocaml-gettext/camomile.nix
@@ -1,11 +1,9 @@
 {
   lib,
   buildDunePackage,
-  ocaml,
   ocaml_gettext,
   camomile,
-  ounit,
-  fileutils,
+  ounit2,
 }:
 
 buildDunePackage {
@@ -13,15 +11,12 @@ buildDunePackage {
   inherit (ocaml_gettext) src version;
 
   propagatedBuildInputs = [
-    (camomile.override { version = "1.0.2"; })
+    camomile
     ocaml_gettext
   ];
 
-  doCheck = lib.versionAtLeast ocaml.version "4.08";
-  checkInputs = [
-    ounit
-    fileutils
-  ];
+  doCheck = true;
+  checkInputs = [ ounit2 ];
 
   meta = (builtins.removeAttrs ocaml_gettext.meta [ "mainProgram" ]) // {
     description = "Internationalization library using camomile (i18n)";

--- a/pkgs/development/ocaml-modules/ocaml-gettext/default.nix
+++ b/pkgs/development/ocaml-modules/ocaml-gettext/default.nix
@@ -1,22 +1,30 @@
 {
   lib,
   fetchurl,
+  fetchpatch,
+  applyPatches,
   buildDunePackage,
   cppo,
   gettext,
   fileutils,
-  ounit,
+  ounit2,
 }:
 
 buildDunePackage rec {
   pname = "gettext";
-  version = "0.4.2";
+  version = "0.5.0";
 
-  minimalOCamlVersion = "4.03";
-
-  src = fetchurl {
-    url = "https://github.com/gildor478/ocaml-gettext/releases/download/v${version}/gettext-v${version}.tbz";
-    sha256 = "19ynsldb21r539fiwz1f43apsdnx7hj2a2d9qr9wg2hva9y2qrwb";
+  src = applyPatches {
+    src = fetchurl {
+      url = "https://github.com/gildor478/ocaml-gettext/releases/download/v${version}/gettext-${version}.tbz";
+      hash = "sha256-CN2d9Vsq8YOOIxK+S+lCtDddvBjCrtDKGSRIh1DjT10=";
+    };
+    # Disable dune sites
+    # See https://github.com/gildor478/ocaml-gettext/pull/37
+    patches = fetchpatch {
+      url = "https://github.com/gildor478/ocaml-gettext/commit/5462396bee53cb13d8d6fde4c6d430412a17b64d.patch";
+      hash = "sha256-tOR+xgZTadvNeQpZnFTJEvZglK8P+ySvYnE3c1VWvKQ=";
+    };
   };
 
   nativeBuildInputs = [ cppo ];
@@ -26,12 +34,10 @@ buildDunePackage rec {
     fileutils
   ];
 
-  # Tests for version 0.4.2 are not compatible with OUnit 2.2.6
+  # Tests of version 0.5.0 fail
   doCheck = false;
 
-  checkInputs = [ ounit ];
-
-  dontStrip = true;
+  checkInputs = [ ounit2 ];
 
   meta = with lib; {
     description = "OCaml Bindings to gettext";

--- a/pkgs/development/ocaml-modules/ocaml-gettext/stub.nix
+++ b/pkgs/development/ocaml-modules/ocaml-gettext/stub.nix
@@ -1,31 +1,22 @@
 {
   lib,
   buildDunePackage,
-  ocaml,
   ocaml_gettext,
   dune-configurator,
-  ounit,
+  ounit2,
 }:
 
-lib.throwIf (lib.versionAtLeast ocaml.version "5.0")
-  "gettext-stub is not available for OCaml ${ocaml.version}"
+buildDunePackage {
+  pname = "gettext-stub";
+  inherit (ocaml_gettext) src version;
 
-  buildDunePackage
-  {
+  minimalOCamlVersion = "4.14";
 
-    pname = "gettext-stub";
+  buildInputs = [ dune-configurator ];
+  propagatedBuildInputs = [ ocaml_gettext ];
 
-    inherit (ocaml_gettext) src version;
+  doCheck = true;
+  checkInputs = [ ounit2 ];
 
-    minimalOCamlVersion = "4.06";
-
-    buildInputs = [ dune-configurator ];
-
-    propagatedBuildInputs = [ ocaml_gettext ];
-
-    doCheck = lib.versionAtLeast ocaml.version "4.08";
-
-    checkInputs = [ ounit ];
-
-    meta = builtins.removeAttrs ocaml_gettext.meta [ "mainProgram" ];
-  }
+  meta = builtins.removeAttrs ocaml_gettext.meta [ "mainProgram" ];
+}


### PR DESCRIPTION
Compatibility with OCaml 5.3

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
