### PR TITLE
dub-to-nix: strip git+ prefix from repository URLs

### DIFF
--- a/pkgs/build-support/dlang/dub-to-nix/dub-to-nix.py
+++ b/pkgs/build-support/dlang/dub-to-nix/dub-to-nix.py
@@ -60,7 +60,7 @@ for pname in depsDict:
         command = ["nix-prefetch-git", strippedRepo, version]
         rawRes = subprocess.run(command, check=True, text=True, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL).stdout
         sha256 = json.loads(rawRes)["sha256"]
-        lockedDepsDict[pname] = {"version": version, "repository": repository, "sha256": sha256}
+        lockedDepsDict[pname] = {"version": version, "repository": strippedRepo, "sha256": sha256}
     else:
         eprint(f"Fetching {pname}@{version}")
         url = f"https://code.dlang.org/packages/{pname}/{version}.zip"


### PR DESCRIPTION
Previously, Git dependencies with `git+` prefixed URLs caused build failures due to `fetchgit` receiving invalid URLs (git+https://...)
Fix - Striped `git+` prefix from repository URLs in generated JSON while maintaining validation of the original URL from `dub.selections.json`

Closes #395933
Maintainer: @TomaSajt