### PR TITLE
gradle: Improve toolchains test

### DIFF
--- a/pkgs/development/tools/build-managers/gradle/default.nix
+++ b/pkgs/development/tools/build-managers/gradle/default.nix
@@ -307,7 +307,7 @@ rec {
                     substituteInPlace ./build.gradle --replace-fail '@JAVA_VERSION@' '${javaVersion}'
                     env GRADLE_USER_HOME=$TMPDIR/gradle org.gradle.native.dir=$TMPDIR/native \
                     gradle run --no-daemon --quiet --console plain > $out
-                    grep -q "JAVA_VERSION: ${javaVersion}" $out || exit 1
+                    test "$(<$out)" = "${javaVersion}"
                   '';
             } // gradle.tests;
           }

--- a/pkgs/development/tools/build-managers/gradle/default.nix
+++ b/pkgs/development/tools/build-managers/gradle/default.nix
@@ -306,7 +306,7 @@ rec {
                     cp -a $src/* .
                     substituteInPlace ./build.gradle --replace-fail '@JAVA_VERSION@' '${javaVersion}'
                     env GRADLE_USER_HOME=$TMPDIR/gradle org.gradle.native.dir=$TMPDIR/native \
-                     gradle run --no-daemon --quiet --console plain > $out
+                    gradle run --no-daemon --quiet --console plain > $out
                     grep -q "JAVA_VERSION: ${javaVersion}" $out || exit 1
                   '';
             } // gradle.tests;

--- a/pkgs/development/tools/build-managers/gradle/default.nix
+++ b/pkgs/development/tools/build-managers/gradle/default.nix
@@ -288,7 +288,7 @@ rec {
             tests = {
               toolchains =
                 let
-                  javaVersion = lib.substring 0 2 (lib.getVersion jdk23);
+                  javaVersion = lib.versions.major (lib.getVersion jdk23);
                 in
                 runCommand "detects-toolchains-from-nix-env"
                   {

--- a/pkgs/development/tools/build-managers/gradle/tests/toolchains/build.gradle
+++ b/pkgs/development/tools/build-managers/gradle/tests/toolchains/build.gradle
@@ -1,0 +1,11 @@
+plugins {
+    id('application')
+}
+
+java {
+    toolchain.languageVersion.set(JavaLanguageVersion.of(@JAVA_VERSION@))
+}
+
+application {
+    mainClass = 'Main'
+}

--- a/pkgs/development/tools/build-managers/gradle/tests/toolchains/src/main/java/Main.java
+++ b/pkgs/development/tools/build-managers/gradle/tests/toolchains/src/main/java/Main.java
@@ -1,0 +1,5 @@
+public class Main {
+    public static void main(String[] args) {
+        System.out.println("JAVA_VERSION: " + System.getProperty("java.version"));
+    }
+}

--- a/pkgs/development/tools/build-managers/gradle/tests/toolchains/src/main/java/Main.java
+++ b/pkgs/development/tools/build-managers/gradle/tests/toolchains/src/main/java/Main.java
@@ -1,5 +1,5 @@
 public class Main {
     public static void main(String[] args) {
-        System.out.println("JAVA_VERSION: " + System.getProperty("java.version"));
+        System.out.println(System.getProperty("java.version"));
     }
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8317,7 +8317,6 @@ with pkgs;
   gnumake = callPackage ../development/tools/build-managers/gnumake { };
   gradle-packages = import ../development/tools/build-managers/gradle {
     inherit
-      jdk11
       jdk17
       jdk21
       jdk23


### PR DESCRIPTION
Previously the test relied on the output of the javaToolchains task and
therefore on the way that toolchains are passed to Gradle. This was
brittle in case we want to change the way of how we supply toolchains to
Gradle (see e.g. #366929).

After this change, instead of inspecting the output of javaToolchains,
the toolchains test now tries to assemble a project using a toolchain
that was passed via the gradle.override.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
