### PR TITLE
procmail: always use system `strstr`

### DIFF
--- a/pkgs/by-name/pr/procmail/package.nix
+++ b/pkgs/by-name/pr/procmail/package.nix
@@ -16,6 +16,9 @@ stdenv.mkDerivation rec {
   };
 
   patches = [
+    # Avoid benchmarking the build machine to determine compilation results
+    # https://build.opensuse.org/projects/server:mail/packages/procmail/files/reproducible.patch?expand=1
+    ./reproducible.patch
     # Fix clang-16 and gcc-14 build failures:
     #   https://github.com/BuGlessRB/procmail/pull/7
     (fetchpatch {

--- a/pkgs/by-name/pr/procmail/reproducible.patch
+++ b/pkgs/by-name/pr/procmail/reproducible.patch
@@ -1,0 +1,40 @@
+https://bugzilla.opensuse.org/show_bug.cgi?id=1041534
+
+Avoid benchmarking the build machine
+to determine compilation results
+
+Index: procmail-3.24/src/autoconf
+===================================================================
+--- procmail-3.24.orig/src/autoconf
++++ procmail-3.24/src/autoconf
+@@ -951,6 +951,7 @@ void*realloc(),*malloc();
+ #endif
+ int main()
+ { char*p=malloc(1),*q=0;
++#if 0
+   size_t len,last,max=BLKSIZ*64;	      /* 1M on non-SMALLHEAP systems */
+   int count=0;
+   for(last=len=INITIAL;len<=max+INITIAL;len+=BLKSIZ)
+@@ -968,6 +969,7 @@ int main()
+    { puts("#define INEFFICIENTrealloc");
+      exit(1);
+    }
++#endif
+   exit(0);
+ }
+ HERE
+@@ -1248,10 +1250,9 @@ int main(argc,argv)int argc;const char*a
+ 	if(!iter)
+ 	   iter=1;
+ 	printf("\
+-/* Your system's strstr() is %.2f times %sER than my C-routine */\n",
+-	 syscnt>=iter?(double)syscnt/iter:(double)iter/syscnt,
+-	 syscnt>=iter?"SLOW":"FAST");
+-	if(syscnt>iter+iter/16)		  /* if at least 1.0625 times slower */
++/* Your system's strstr() is %sER than my C-routine */\n",
++	 "FAST");
++	if(0)		  /* always use system strstr to have reproducible binaries */
+ 	   printf("\
+ #define SLOWstrstr\t\t\t      /* using my substitute instead */\n");
+       }
+


### PR DESCRIPTION
The upstream procmail build system uses a small benchmark to determine what `strstr` implementation to use: the system one or a bespoke one.

We'd like our packaging to be deterministic, so this patch (credits to Bernhard Wiedemann of openSUSE) fixes the detection to always use the system `strstr`.

Potentially fixes https://github.com/NixOS/nixpkgs/issues/384714


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
