### PR TITLE
lx-music-desktop: build from source, bump electron version

### DIFF
--- a/pkgs/by-name/lx/lx-music-desktop/electron-builder.patch
+++ b/pkgs/by-name/lx/lx-music-desktop/electron-builder.patch
@@ -1,0 +1,23 @@
+diff --git a/build-config/build-pack.js b/build-config/build-pack.js
+index 569252c..ccaef34 100644
+--- a/build-config/build-pack.js
++++ b/build-config/build-pack.js
+@@ -1,7 +1,5 @@
+ /* eslint-disable no-template-curly-in-string */
+-
+ const builder = require('electron-builder')
+-const beforePack = require('./build-before-pack')
+ const afterPack = require('./build-after-pack')
+ 
+ /**
+@@ -11,8 +9,9 @@ const afterPack = require('./build-after-pack')
+ const options = {
+   appId: 'cn.toside.music.desktop',
+   productName: 'lx-music-desktop',
+-  beforePack,
+   afterPack,
++  electronVersion: "@electron_version@",
++  electronDist: "./electron-dist",
+   protocols: {
+     name: 'lx-music-protocol',
+     schemes: [

--- a/pkgs/by-name/lx/lx-music-desktop/package.nix
+++ b/pkgs/by-name/lx/lx-music-desktop/package.nix
@@ -1,93 +1,98 @@
 {
   lib,
   stdenv,
-  fetchurl,
+  buildNpmPackage,
+
+  fetchFromGitHub,
+  replaceVars,
+
   makeWrapper,
 
-  dpkg,
-  libGL,
-  systemd,
-  electron_32,
-
+  electron_34,
   commandLineArgs ? "",
 }:
 
 let
+  # if we want to use later electron, we'll need to bump the `node-abi` npm package version
+  electron = electron_34;
+in
+buildNpmPackage rec {
   pname = "lx-music-desktop";
   version = "2.10.0";
 
-  buildUrl =
-    version: arch:
-    "https://github.com/lyswhut/lx-music-desktop/releases/download/v${version}/lx-music-desktop_${version}_${arch}.deb";
-
-  srcs = {
-    x86_64-linux = fetchurl {
-      url = buildUrl version "amd64";
-      hash = "sha256-btNB8XFCJij1wUVZoWaa55vZn5n1gsKSMnEbQPTd9lg=";
-    };
-
-    aarch64-linux = fetchurl {
-      url = buildUrl version "arm64";
-      hash = "sha256-GVTzxTV7bM4AWZ+Xfb70fyedDMIa9eX/YwnGkm3WOsk=";
-    };
-
-    armv7l-linux = fetchurl {
-      url = buildUrl version "armv7l";
-      hash = "sha256-3zttIk+A4BpG0W196LzgTJ5WeqWvLjqPFz6e9RCGlJo=";
-    };
+  src = fetchFromGitHub {
+    owner = "lyswhut";
+    repo = "lx-music-desktop";
+    tag = "v${version}";
+    hash = "sha256-8IzQEGdaeoBbCsZSPhVowipeBr4YHGm/G28qGHtCY/s=";
   };
 
-  host = stdenv.hostPlatform.system;
-  src = srcs.${host} or (throw "Unsupported system: ${host}");
-
-  runtimeLibs = lib.makeLibraryPath [
-    libGL
-    stdenv.cc.cc
+  patches = [
+    # set electron version and dist dir
+    # disable before-pack: it would copy prebuilt libraries
+    (replaceVars ./electron-builder.patch {
+      electron_version = electron.version;
+    })
   ];
-in
-stdenv.mkDerivation {
-  inherit pname version src;
 
   nativeBuildInputs = [
-    dpkg
     makeWrapper
   ];
 
-  runtimeDependencies = map lib.getLib [
-    systemd
-  ];
+  npmDepsHash = "sha256-awD8gu1AnhUn5uT/dITXjMVWNAwABAmcEVZOKukbWrI=";
+
+  makeCacheWritable = true;
+
+  env.ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
+
+  # we haven't set up npm_config_nodedir at this point
+  # and electron-rebuild will rebuild the native libs later anyway
+  npmFlags = [ "--ignore-scripts" ];
+
+  preBuild = ''
+    # delete prebuilt libs
+    rm -r build-config/lib
+
+    # don't spam the build logs
+    substituteInPlace build-config/pack.js \
+      --replace-fail 'new Spinnies({' 'new Spinnies({disableSpins:true,'
+
+    # this directory is configured to be used in the patch
+    cp -r ${electron.dist} electron-dist
+    chmod -R u+w electron-dist
+
+    export npm_config_nodedir=${electron.headers}
+    export npm_config_build_from_source="true"
+
+    npm rebuild --no-progress --verbose
+  '';
+
+  npmBuildScript = "pack:dir";
 
   installPhase = ''
     runHook preInstall
 
-    mkdir -p $out/bin $out/opt/lx-music-desktop
-    cp -r opt/lx-music-desktop/{resources,locales} $out/opt/lx-music-desktop
-    cp -r usr/share $out/share
-
-    substituteInPlace $out/share/applications/lx-music-desktop.desktop \
-        --replace-fail "/opt/lx-music-desktop/lx-music-desktop" "$out/bin/lx-music-desktop" \
+    mkdir -p "$out/opt/lx-music-desktop"
+    cp -r build/*-unpacked/{locales,resources{,.pak}} "$out/opt/lx-music-desktop"
+    rm "$out/opt/lx-music-desktop/resources/app-update.yml"
 
     runHook postInstall
   '';
 
   postFixup = ''
-    makeWrapper ${electron_32}/bin/electron $out/bin/lx-music-desktop \
+    makeWrapper ${lib.getExe electron} $out/bin/lx-music-desktop \
         --add-flags $out/opt/lx-music-desktop/resources/app.asar \
-        --prefix LD_LIBRARY_PATH : "${runtimeLibs}" \
         --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true}}" \
-        --add-flags ${lib.escapeShellArg commandLineArgs} \
+        --add-flags ${lib.escapeShellArg commandLineArgs}
   '';
 
   meta = with lib; {
+    broken = stdenv.hostPlatform.isDarwin;
     description = "Music software based on Electron and Vue";
     homepage = "https://github.com/lyswhut/lx-music-desktop";
     changelog = "https://github.com/lyswhut/lx-music-desktop/releases/tag/v${version}";
     license = licenses.asl20;
-    platforms = [
-      "x86_64-linux"
-      "aarch64-linux"
-      "armv7l-linux"
-    ];
+    platforms = electron.meta.platforms;
     sourceProvenance = with sourceTypes; [ binaryNativeCode ];
     mainProgram = "lx-music-desktop";
     maintainers = with maintainers; [ oosquare ];


### PR DESCRIPTION
Related: https://github.com/NixOS/nixpkgs/issues/295770

Because we build from source we can use `electron.headers` of any electron version, not just electron_32.

Don't want to debug darwin...

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
