### PR TITLE
dprint-plugins: fix updater with filling pname and version

### DIFF
--- a/pkgs/by-name/dp/dprint/plugins/default.nix
+++ b/pkgs/by-name/dp/dprint/plugins/default.nix
@@ -13,7 +13,12 @@ let
       maintainers ? [ lib.maintainers.phanirithvij ],
     }:
     fetchurl {
-      inherit hash url;
+      inherit
+        hash
+        url
+        pname
+        version
+        ;
       name = "${pname}-${version}.wasm";
       meta = {
         inherit


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

This PR attempts to fix [failing automatic updates](https://nixpkgs-update-logs.nix-community.org/dprint-plugins.dprint-plugin-json/2025-03-31.log) which is pointed out in https://github.com/NixOS/nixpkgs/pull/395955#issue-2971551785.

Currently given pname and the version are only used for building `name`, not setting the `pname` and `version`.

https://github.com/NixOS/nixpkgs/blob/c661447ed3c66687d93a844712b1c3df21e139b9/pkgs/build-support/fetchurl/default.nix#L203-L205

This command runs on both definition.

```bash
nix-shell ./maintainers/scripts/update.nix --argstr package dprint-plugins.dprint-plugin-jupyter
```

However nixpkgs-update does not run on missing version pattern.

```bash
nix run --option extra-substituters 'https://nix-community.cachix.org/' --option extra-trusted-public-keys 'nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs=' github:ryantm/nixpkgs-update -- update 'dprint-plugins.dprint-plugin-jupyter 0.1.5 0.2.0'
```

```plaintext
The derivation has no 'version' attribute, so do not know how to figure out the version while doing an updateScript update
```

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [x] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

cc: @phanirithvij

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
