### PR TITLE
qvge: 0.6.3 -> 0.6.3-unstable-2024-04-08

### DIFF
--- a/pkgs/applications/graphics/qvge/default.nix
+++ b/pkgs/applications/graphics/qvge/default.nix
@@ -12,13 +12,14 @@
 
 stdenv.mkDerivation rec {
   pname = "qvge";
-  version = "0.6.3";
+  version = "0.6.3-unstable-2024-04-08";
 
   src = fetchFromGitHub {
     owner = "ArsMasiuk";
-    repo = pname;
-    tag = "v${version}";
-    sha256 = "sha256-rtbUAp3l0VZsu+D9HCHM3q0UkDLflw50rYRq/LP4Wu4=";
+    repo = "qvge";
+    #tag = "v${version}";
+    rev = "5751948358d407673cfda10f52892683be143d42";
+    hash = "sha256-Rh8ahS/9x2aWu4THjLKoog58+yJoCQ6GETaAQTW4Hq8=";
   };
 
   sourceRoot = "${src.name}/src";

--- a/pkgs/applications/graphics/qvge/set-graphviz-path.patch
+++ b/pkgs/applications/graphics/qvge/set-graphviz-path.patch
@@ -1,7 +1,7 @@
 diff --git i/commonui/CNodeEditorUIController.cpp w/commonui/CNodeEditorUIController.cpp
 index 7dacd48..64983e4 100644
---- i/commonui/CNodeEditorUIController.cpp
-+++ w/commonui/CNodeEditorUIController.cpp
+--- i/qvgeui/CNodeEditorUIController.cpp
++++ w/qvgeui/CNodeEditorUIController.cpp
 @@ -123,7 +123,7 @@ CNodeEditorUIController::CNodeEditorUIController(CMainWindow *parent) :
  	QString pathToGraphviz = QCoreApplication::applicationDirPath() + "/../tools/graphviz";
  	m_optionsData.graphvizPath = QFileInfo(pathToGraphviz).absoluteFilePath();


### PR DESCRIPTION
There are quite a few bugfixes there (and then the development got frozen, but in a better shape than last release, as far as I can see)

## Things done


- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
