### PR TITLE
bluespec: Fix wrong executable name for bsc

### DIFF
--- a/pkgs/by-name/bl/bluespec/package.nix
+++ b/pkgs/by-name/bl/bluespec/package.nix
@@ -223,6 +223,7 @@ stdenv.mkDerivation rec {
   '';
 
   doCheck = true;
+  doInstallCheck = true;
 
   # TODO To fix check-suite:
   # On darwin
@@ -279,6 +280,13 @@ stdenv.mkDerivation rec {
         exit 1
       fi
     )
+  '';
+
+  installCheckPhase = ''
+    output="$($out/bin/bsc 2>&1 || true)"
+    echo "bsc output:"
+    echo "$output"
+    echo "$output" | grep -q "to get help"
   '';
 
   meta = {

--- a/pkgs/by-name/bl/bluespec/package.nix
+++ b/pkgs/by-name/bl/bluespec/package.nix
@@ -22,7 +22,7 @@
   asciidoctor,
   texliveFull,
   which,
-  makeWrapper,
+  makeBinaryWrapper,
   cctools,
   targetPackages,
   # install -m 644 lib/libstp.dylib /private/tmp/nix-build-bluespec-2024.07.drv-5/source/inst/lib/SAT
@@ -168,7 +168,7 @@ stdenv.mkDerivation rec {
       pkg-config
       texliveFull
       tcl
-      makeWrapper
+      makeBinaryWrapper
     ]
     ++ lib.optionals stdenv.hostPlatform.isDarwin [
       # https://github.com/B-Lang-org/bsc/blob/main/src/comp/bsc.hs#L1838
@@ -212,9 +212,12 @@ stdenv.mkDerivation rec {
 
   postFixup = ''
     # https://github.com/B-Lang-org/bsc/blob/65e3a87a17f6b9cf38cbb7b6ad7a4473f025c098/src/comp/bsc.hs#L1839
-    wrapProgram $out/bin/bsc --prefix PATH : ${
-      lib.makeBinPath (if stdenv.hostPlatform.isDarwin then [ cctools ] else [ targetPackages.stdenv.cc ])
-    }
+    # `/bin/bsc` is a bash script which the script name to call the binary in the `/bin/core` directory
+    # thus wrapping `/bin/bsc` messes up the scriptname detection in it.
+    wrapProgram $out/bin/core/bsc \
+      --prefix PATH : ${
+        lib.makeBinPath (if stdenv.hostPlatform.isDarwin then [ cctools ] else [ targetPackages.stdenv.cc ])
+      }
   '';
 
   doCheck = true;

--- a/pkgs/by-name/bl/bluespec/package.nix
+++ b/pkgs/by-name/bl/bluespec/package.nix
@@ -160,15 +160,17 @@ stdenv.mkDerivation rec {
     [
       automake
       autoconf
-      asciidoctor
       bison
       flex
       ghcWithPackages
       perl
       pkg-config
-      texliveFull
       tcl
       makeBinaryWrapper
+    ]
+    ++ lib.optionals withDocs [
+      texliveFull
+      asciidoctor
     ]
     ++ lib.optionals stdenv.hostPlatform.isDarwin [
       # https://github.com/B-Lang-org/bsc/blob/main/src/comp/bsc.hs#L1838


### PR DESCRIPTION
and also use `makeBinaryWrapper` because it inherits argv0 better.
Wrapping `/bin/bsc` with `makeBinaryWrapper` didn't fix the scriptname
issue.
```
Error Bluespec executable not found: /nix/store/nhsa69in3vhyjx2hxnilzkqmb8j2m2mp-bluespec-2024.07/bin/core/.bsc-wrapped
```


My bad, I overlooked testing the binary itself after wrapping :sweat_smile: 

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
