### PR TITLE
bashunit: init at 0.19.0

### DIFF
--- a/pkgs/by-name/ba/bashunit/package.nix
+++ b/pkgs/by-name/ba/bashunit/package.nix
@@ -1,0 +1,78 @@
+{
+  stdenvNoCC,
+  lib,
+  fetchFromGitHub,
+  bash,
+  which,
+  versionCheckHook,
+  coreutils,
+  makeBinaryWrapper,
+  nix-update-script,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "bashunit";
+  version = "0.19.0";
+  src = fetchFromGitHub {
+    owner = "TypedDevs";
+    repo = "bashunit";
+    tag = finalAttrs.version;
+    hash = "sha256-EoCCqESzmCW12AuAqA3qh2VcE8gyUPIGJEoCcZhMA/Y=";
+    forceFetchGit = true; # needed to include the tests directory for the check phase
+  };
+
+  nativeBuildInputs = [ makeBinaryWrapper ];
+
+  postConfigure = ''
+    patchShebangs src tests build.sh bashunit
+    substituteInPlace Makefile \
+      --replace-fail "SHELL=/bin/bash" "SHELL=${lib.getExe bash}"
+  '';
+
+  buildPhase = ''
+    runHook preBuild
+    ./build.sh
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    install -m755 -D bin/bashunit $out/bin/bashunit
+    runHook postInstall
+  '';
+
+  # some tests are currently broken on linux and it is not easy to disable them
+  # reenable them after https://github.com/TypedDevs/bashunit/pull/397 has been merged
+  doCheck = false;
+  nativeCheckInputs = [ which ];
+  checkPhase = ''
+    runHook preCheck
+    make test
+    runHook postCheck
+  '';
+
+  postFixup = ''
+    wrapProgram $out/bin/bashunit \
+      --prefix PATH : "${
+        lib.makeBinPath [
+          coreutils
+          which
+        ]
+      }"
+  '';
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+  versionCheckProgramArg = "--version";
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Simple testing framework for bash scripts";
+    homepage = "https://bashunit.typeddevs.com";
+    changelog = "https://github.com/TypedDevs/bashunit/releases/tag/${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ tricktron ];
+    mainProgram = "bashunit";
+  };
+})


### PR DESCRIPTION

Adds [bashunit](https://bashunit.typeddevs.com), A simple testing library for bash scripts, at 0.19.0.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
