### PR TITLE
python313Packages.passlib: restore old name in distinfo

### DIFF
--- a/pkgs/development/python-modules/bundlewrap/default.nix
+++ b/pkgs/development/python-modules/bundlewrap/default.nix
@@ -31,12 +31,6 @@ buildPythonPackage rec {
   };
 
   build-system = [ setuptools ];
-
-  pythonRemoveDeps = [
-    # distinfo renamed to libpass, but still imports as passlib
-    "passlib"
-  ];
-
   dependencies = [
     setuptools
     cryptography

--- a/pkgs/development/python-modules/libpass/default.nix
+++ b/pkgs/development/python-modules/libpass/default.nix
@@ -1,0 +1,60 @@
+{
+  argon2-cffi,
+  bcrypt,
+  buildPythonPackage,
+  cryptography,
+  fetchFromGitHub,
+  hatchling,
+  lib,
+  pytest-archon,
+  pytest-xdist,
+  pytestCheckHook,
+  typing-extensions,
+}:
+
+buildPythonPackage rec {
+  pname = "libpass";
+  version = "1.9.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "ThirVondukr";
+    repo = "passlib";
+    tag = version;
+    hash = "sha256-Q5OEQkty0/DugRvF5LA+PaDDlF/6ysx4Nel5K2kH5s4=";
+  };
+
+  build-system = [ hatchling ];
+
+  dependencies = [
+    typing-extensions
+  ];
+
+  optional-dependencies = {
+    argon2 = [ argon2-cffi ];
+    bcrypt = [ bcrypt ];
+    totp = [ cryptography ];
+  };
+
+  nativeCheckInputs = [
+    pytest-archon
+    pytest-xdist
+    pytestCheckHook
+  ] ++ lib.flatten (lib.attrValues optional-dependencies);
+
+  pythonImportsCheck = [ "passlib" ];
+
+  disabledTests = [
+    # timming sensitive
+    "test_dummy_verify"
+    "test_encrypt_cost_timing"
+  ];
+
+  meta = {
+    changelog = "https://github.com/ThirVondukr/passlib/blob/${src.tag}/CHANGELOG.md";
+    description = "Comprehensive password hashing framework supporting over 30 schemes";
+    homepage = "https://github.com/ThirVondukr/passlib";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ dotlambda ];
+  };
+}

--- a/pkgs/development/python-modules/mitmproxy/default.nix
+++ b/pkgs/development/python-modules/mitmproxy/default.nix
@@ -51,6 +51,7 @@ buildPythonPackage rec {
   };
 
   pythonRelaxDeps = [
+    "h2"
     "passlib"
     "protobuf"
     "pyparsing"

--- a/pkgs/development/python-modules/passlib/default.nix
+++ b/pkgs/development/python-modules/passlib/default.nix
@@ -1,58 +1,14 @@
 {
-  lib,
-  buildPythonPackage,
-  fetchFromGitHub,
-  argon2-cffi,
-  bcrypt,
-  cryptography,
-  hatchling,
-  pytestCheckHook,
-  pytest-archon,
-  pytest-xdist,
-  typing-extensions,
+  libpass,
+  mkPythonMetaPackage,
 }:
 
-buildPythonPackage rec {
+mkPythonMetaPackage {
   pname = "passlib";
-  version = "1.9.0";
-  pyproject = true;
-
-  src = fetchFromGitHub {
-    owner = "ThirVondukr";
-    repo = "passlib";
-    tag = version;
-    hash = "sha256-Q5OEQkty0/DugRvF5LA+PaDDlF/6ysx4Nel5K2kH5s4=";
-  };
-
-  build-system = [ hatchling ];
-
-  dependencies = [ typing-extensions ];
-
-  optional-dependencies = {
-    argon2 = [ argon2-cffi ];
-    bcrypt = [ bcrypt ];
-    totp = [ cryptography ];
-  };
-
-  nativeCheckInputs = [
-    pytestCheckHook
-    pytest-archon
-    pytest-xdist
-  ] ++ lib.flatten (lib.attrValues optional-dependencies);
-
-  pythonImportsCheck = [ "passlib" ];
-
-  disabledTests = [
-    # timming sensitive
-    "test_dummy_verify"
-    "test_encrypt_cost_timing"
-  ];
-
+  inherit (libpass) version;
+  dependencies = [ libpass ];
+  optional-dependencies = libpass.optional-dependencies or { };
   meta = {
-    changelog = "https://github.com/ThirVondukr/passlib/blob/${src.tag}/CHANGELOG.md";
-    description = "Password hashing library for Python";
-    homepage = "https://github.com/ThirVondukr/passlib";
-    license = lib.licenses.bsd3;
-    maintainers = with lib.maintainers; [ dotlambda ];
+    inherit (libpass.meta) changelog description homepage;
   };
 }

--- a/pkgs/servers/mail/mailman/package.nix
+++ b/pkgs/servers/mail/mailman/package.nix
@@ -26,11 +26,6 @@ buildPythonPackage rec {
     setuptools
   ];
 
-  pythonRemoveDeps = [
-    # distinfo renamed to libpass
-    "passlib"
-  ];
-
   dependencies = with python3.pkgs; [
     aiosmtpd
     alembic

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7718,6 +7718,8 @@ self: super: with self; {
     }
   );
 
+  libpass = callPackage ../development/python-modules/libpass { };
+
   libpcap = callPackage ../development/python-modules/libpcap {
     pkgsLibpcap = pkgs.libpcap; # Needs the C library
   };


### PR DESCRIPTION
See https://github.com/ThirVondukr/passlib/commit/3aa413190081fa4627f67dd7a61fce18838f1135#r154867574
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
