### PR TITLE
postgresqlPackages.pg_auto_failover: 2.1 -> 2.2

### DIFF
--- a/pkgs/servers/sql/postgresql/ext/pg_auto_failover.nix
+++ b/pkgs/servers/sql/postgresql/ext/pg_auto_failover.nix
@@ -8,13 +8,13 @@
 
 postgresqlBuildExtension rec {
   pname = "pg_auto_failover";
-  version = "2.1";
+  version = "2.2";
 
   src = fetchFromGitHub {
     owner = "citusdata";
     repo = "pg_auto_failover";
     tag = "v${version}";
-    hash = "sha256-OIWykfFbVskrkPG/zSmZtZjc+W956KSfIzK7f5QOqpI=";
+    hash = "sha256-lsnVry+5n08kLOun8u0B7XFvI5ijTKJtFJ84fixMHe4=";
   };
 
   buildInputs = postgresql.buildInputs;
@@ -27,8 +27,5 @@ postgresqlBuildExtension rec {
     maintainers = [ ];
     platforms = postgresql.meta.platforms;
     license = lib.licenses.postgresql;
-    # PostgreSQL 17 support issue upstream: https://github.com/hapostgres/pg_auto_failover/issues/1048
-    # Check after next package update.
-    broken = lib.versionAtLeast postgresql.version "17" && version == "2.1";
   };
 }


### PR DESCRIPTION
Changelog:
https://github.com/hapostgres/pg_auto_failover/releases/tag/v2.2

Supports PostgreSQL 17.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
