### PR TITLE
nixosTests: init cosmic modules

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -338,6 +338,7 @@ in
   containers-unified-hierarchy = handleTest ./containers-unified-hierarchy.nix { };
   convos = handleTest ./convos.nix { };
   corerad = handleTest ./corerad.nix { };
+  cosmic = runTest ./cosmic/cosmic.nix;
   coturn = handleTest ./coturn.nix { };
   couchdb = handleTest ./couchdb.nix { };
   crabfit = handleTest ./crabfit.nix { };

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -339,6 +339,7 @@ in
   convos = handleTest ./convos.nix { };
   corerad = handleTest ./corerad.nix { };
   cosmic = runTest ./cosmic/cosmic.nix;
+  cosmic-autologin = runTest ./cosmic/autologin.nix;
   coturn = handleTest ./coturn.nix { };
   couchdb = handleTest ./couchdb.nix { };
   crabfit = handleTest ./crabfit.nix { };

--- a/nixos/tests/cosmic/autologin.nix
+++ b/nixos/tests/cosmic/autologin.nix
@@ -1,0 +1,60 @@
+{ pkgs, ... }:
+
+{
+  name = "cosmic-autologin";
+  meta = with pkgs.lib.maintainers; {
+    maintainers = [ thefossguy ];
+  };
+
+  nodes.machine =
+    { config, ... }:
+    {
+      imports = [ ./config-base.nix ];
+
+      services.displayManager.autoLogin = {
+        enable = true;
+        user = config.users.users.alice.name;
+      };
+    };
+
+  testScript =
+    { nodes, ... }:
+    let
+      user = nodes.machine.users.users.alice;
+    in
+    ''
+      with subtest("cosmic-greeter initialisation"):
+          machine.wait_for_unit("graphical.target")
+          # _One_ of the final processes to start as part of the
+          # `cosmic-session` target is the Workspaces applet. So, wait
+          # for it to start. The process existing means that COSMIC
+          # now handles any opened windows from now on.
+          machine.wait_until_succeeds("pgrep --uid ${toString user.uid} --full 'cosmic-panel-button com.system76.CosmicWorkspaces'")
+
+      # The best way to test for Wayland and XWayland is to launch
+      # the GUI applications and see the results yourself.
+      with subtest("Launch applications"):
+          # key: binary_name
+          # value: "app-id" as reported by `lswt`
+          gui_apps_to_launch = {}
+
+          # We want to ensure that the first-party applications
+          # start/launch properly.
+          #gui_apps_to_launch['cosmic-edit'] = 'com.system76.CosmicEdit' # `cosmic-edit` crashes, disable temporarily
+          gui_apps_to_launch['cosmic-files'] = 'com.system76.CosmicFiles'
+          gui_apps_to_launch['cosmic-player'] = 'com.system76.CosmicPlayer'
+          gui_apps_to_launch['cosmic-settings'] = 'com.system76.CosmicSettings'
+          gui_apps_to_launch['cosmic-store'] = 'com.system76.CosmicStore'
+          gui_apps_to_launch['cosmic-term'] = 'com.system76.CosmicTerm'
+
+          for gui_app in gui_apps_to_launch:
+              # Note: $DISPLAY is usually `:0` (**not `:1`**) with autologin
+              machine.succeed(f"su - ${user.name} -c 'DISPLAY=:0 {gui_app} >&2 &'", timeout=5)
+              # Nix builds the following non-commented expression to the following:
+              #                              `su - alice -c 'WAYLAND_DISPLAY=wayland-1 XDG_RUNTIME_DIR=/run/user/1000 lswt --json | jq ".toplevels" | grep "^    \\"app-id\\": \\"{gui_apps_to_launch[gui_app]}\\"$"' `
+              machine.wait_until_succeeds(f''''su - ${user.name} -c 'WAYLAND_DISPLAY=wayland-1 XDG_RUNTIME_DIR=/run/user/${toString user.uid} lswt --json | jq ".toplevels" | grep "^    \\"app-id\\": \\"{gui_apps_to_launch[gui_app]}\\"$"' '''', timeout=30)
+              machine.succeed(f"pkill {gui_app}", timeout=5)
+
+      machine.shutdown()
+    '';
+}

--- a/nixos/tests/cosmic/config-base.nix
+++ b/nixos/tests/cosmic/config-base.nix
@@ -1,0 +1,45 @@
+{ pkgs, ... }:
+
+{
+  imports = [ ../common/user-account.nix ];
+
+  services = {
+    displayManager.cosmic-greeter.enable = true;
+
+    # For `cosmic-store` to be added to `environment.systemPackages`
+    # and for it to work correctly because Flatpak is a runtime
+    # dependency of `cosmic-store`.
+    flatpak.enable = true;
+
+    desktopManager.cosmic = {
+      enable = true;
+
+      # Yes, XWayland is enabled by default at the moment, but let's
+      # force enable it in case the default changes down the road, for
+      # whatever reason.
+      xwayland.enable = true;
+    };
+  };
+
+  environment.systemPackages = with pkgs; [
+    # These two packages are used to check if a window was opened
+    # under the COSMIC session or not. Kinda important.
+    # TODO: Move the check from the test module to
+    # `nixos/lib/test-driver/src/test_driver/machine.py` so more
+    # Wayland-only testing can be done using the existing testing
+    # infrastructure.
+    jq
+    lswt
+  ];
+
+  # So far, all COSMIC tests launch a few GUI applications. In doing
+  # so, the default allocated memory to the guest of 1024M quickly
+  # poses a very high risk of an OOM-shutdown which is worse than an
+  # OOM-kill. Because now, the test failed, but not for a genuine
+  # reason, but an OOM-shutdown. That's an inconclusive failure
+  # which might possibly mask an actual failure. Not enabling
+  # systemd-oomd because we need said applications running for a
+  # few seconds. So instead, bump the allocated memory to the guest
+  # from 1024M to 4x; 4096M.
+  virtualisation.memorySize = 4096;
+}

--- a/nixos/tests/cosmic/cosmic.nix
+++ b/nixos/tests/cosmic/cosmic.nix
@@ -1,0 +1,62 @@
+{ pkgs, ... }:
+
+{
+  name = "cosmic";
+  meta = with pkgs.lib.maintainers; {
+    maintainers = [ thefossguy ];
+  };
+
+  nodes.machine =
+    { ... }:
+    {
+      imports = [ ./config-base.nix ];
+    };
+
+  testScript =
+    { nodes, ... }:
+    let
+      user = nodes.machine.users.users.alice;
+    in
+    ''
+      from time import sleep
+
+      machine.wait_for_unit("graphical.target")
+      # Sleep for 10 seconds for ensuring that `greetd` loads the
+      # password prompt for the login screen properly.
+      sleep(10)
+
+      with subtest("cosmic-session login"):
+          machine.send_chars("${user.password}\n", delay=0.2)
+          # _One_ of the final processes to start as part of the
+          # `cosmic-session` target is the Workspaces applet. So, wait
+          # for it to start. The process existing means that COSMIC
+          # now handles any opened windows from now on.
+          machine.wait_until_succeeds("pgrep --uid ${toString user.uid} --full 'cosmic-panel-button com.system76.CosmicWorkspaces'")
+
+      # The best way to test for Wayland and XWayland is to launch
+      # the GUI applications and see the results yourself.
+      with subtest("Launch applications"):
+          # key: binary_name
+          # value: "app-id" as reported by `lswt`
+          gui_apps_to_launch = {}
+
+          # We want to ensure that the first-party applications
+          # start/launch properly.
+          #gui_apps_to_launch['cosmic-edit'] = 'com.system76.CosmicEdit' # `cosmic-edit` crashes, disable temporarily
+          gui_apps_to_launch['cosmic-files'] = 'com.system76.CosmicFiles'
+          gui_apps_to_launch['cosmic-player'] = 'com.system76.CosmicPlayer'
+          gui_apps_to_launch['cosmic-settings'] = 'com.system76.CosmicSettings'
+          gui_apps_to_launch['cosmic-store'] = 'com.system76.CosmicStore'
+          gui_apps_to_launch['cosmic-term'] = 'com.system76.CosmicTerm'
+
+          for gui_app in gui_apps_to_launch:
+              # Note: $DISPLAY is usually `:1` with manual login
+              machine.succeed(f"su - ${user.name} -c 'DISPLAY=:1 {gui_app} >&2 &'", timeout=5)
+              # Nix builds the following non-commented expression to the following:
+              #                              `su - alice -c 'WAYLAND_DISPLAY=wayland-1 XDG_RUNTIME_DIR=/run/user/1000 lswt --json | jq ".toplevels" | grep "^    \\"app-id\\": \\"{gui_apps_to_launch[gui_app]}\\"$"' `
+              machine.wait_until_succeeds(f''''su - ${user.name} -c 'WAYLAND_DISPLAY=wayland-1 XDG_RUNTIME_DIR=/run/user/${toString user.uid} lswt --json | jq ".toplevels" | grep "^    \\"app-id\\": \\"{gui_apps_to_launch[gui_app]}\\"$"' '''', timeout=30)
+              machine.succeed(f"pkill {gui_app}", timeout=5)
+
+      machine.shutdown()
+    '';
+}


### PR DESCRIPTION
## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

cc: @nyabinary @a-kenji @HeitorAugustoLN @GaetanLepage @ahoneybun 

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
