### PR TITLE
kitty: fix unreproducible build (manpage dates, fish completions)

### DIFF
--- a/pkgs/by-name/ki/kitty/fix-fish-completion-ordering.patch
+++ b/pkgs/by-name/ki/kitty/fix-fish-completion-ordering.patch
@@ -1,0 +1,18 @@
+--- a/tools/cli/fish.go	2025-04-04 23:43:16
++++ b/tools/cli/fish.go	2025-04-04 23:44:13
+@@ -4,6 +4,7 @@
+ 
+ import (
+ 	"fmt"
++	"sort"
+ 	"strings"
+ 
+ 	"kitty/tools/cli/markup"
+@@ -22,6 +23,7 @@
+ 	}
+ 	if len(commands) == 0 {
+ 		commands = append(commands, utils.Keys(all_commands)...)
++		sort.Strings(commands)
+ 	}
+ 	script := strings.Builder{}
+ 	script.WriteString(`function __ksi_completions

--- a/pkgs/by-name/ki/kitty/fix-timestamp-reproducibility.patch
+++ b/pkgs/by-name/ki/kitty/fix-timestamp-reproducibility.patch
@@ -1,0 +1,35 @@
+--- a/tools/cli/help.go	2025-04-04 23:55:53
++++ b/tools/cli/help.go	2025-04-04 23:56:59
+@@ -9,6 +9,7 @@
+ 	"os/exec"
+ 	"slices"
+ 	"strings"
++	"strconv"
+ 	"time"
+ 
+ 	"golang.org/x/sys/unix"
+@@ -133,6 +134,15 @@
+ 	pager.Stdout = os.Stdout
+ 	pager.Stderr = os.Stderr
+ 	_ = pager.Run()
++}
++
++func getDeterministicTimestamp() time.Time {
++	if epochStr, exists := os.LookupEnv("SOURCE_DATE_EPOCH"); exists {
++			if epoch, err := strconv.ParseInt(epochStr, 10, 64); err == nil {
++					return time.Unix(epoch, 0).UTC()
++			}
++	}
++	return time.Now()
+ }
+ 
+ func (self *Command) GenerateManPages(level int, recurse bool) (err error) {
+@@ -149,7 +159,7 @@
+ 		return err
+ 	}
+ 	defer outf.Close()
+-	fmt.Fprintf(outf, `.TH "%s" "1" "%s" "%s" "%s"`, name, time.Now().Format("Jan 02, 2006"), kitty.VersionString, "kitten Manual")
++	fmt.Fprintf(outf, `.TH "%s" "1" "%s" "%s" "%s"`, name, getDeterministicTimestamp().Format("Jan 02, 2006"), kitty.VersionString, "kitten Manual")
+ 	fmt.Fprintln(outf)
+ 	fmt.Fprintln(outf, ".SH Name")
+ 	fmt.Fprintln(outf, name, "\\-", escape_text_for_man(self.ShortDescription))

--- a/pkgs/by-name/ki/kitty/package.nix
+++ b/pkgs/by-name/ki/kitty/package.nix
@@ -159,6 +159,12 @@ buildPythonApplication rec {
     # Skip `test_ssh_bootstrap_with_different_launchers` when launcher is `zsh` since it causes:
     # OSError: master_fd is in error condition
     ./disable-test_ssh_bootstrap_with_different_launchers.patch
+
+    # Makes man page generation respect SOURCE_DATE_EPOCH. Drop on next kitty release https://github.com/kovidgoyal/kitty/pull/8509
+    ./fix-timestamp-reproducibility.patch
+
+    # Ensures deterministic ordering of fish shell completions. Drop on next kitty release https://github.com/kovidgoyal/kitty/pull/8509
+    ./fix-fish-completion-ordering.patch
   ];
 
   hardeningDisable = [


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Should resolve #383872
@raboof please help review
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
