### PR TITLE
selinux-refpolicy: init 2.20250213

### DIFF
--- a/pkgs/by-name/se/selinux-refpolicy/package.nix
+++ b/pkgs/by-name/se/selinux-refpolicy/package.nix
@@ -1,0 +1,63 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  gnum4,
+  python3,
+  getopt,
+  checkpolicy,
+  policycoreutils,
+  semodule-utils,
+  policyVersion ? null,
+  moduleVersion ? null,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "selinux-refpolicy";
+  version = "2.20250213";
+
+  src = fetchFromGitHub {
+    owner = "SELinuxProject";
+    repo = "refpolicy";
+    tag = "RELEASE_${lib.versions.major finalAttrs.version}_${lib.versions.minor finalAttrs.version}";
+    hash = "sha256-VsQRqigGwSVJ52uqFj1L2xzQqbWwQ/YaFI5Rsn/HbP8=";
+  };
+
+  nativeBuildInputs = [
+    gnum4
+    python3
+    getopt
+  ];
+
+  configurePhase = ''
+    runHook preConfigure
+    make conf ''${makeFlags[@]}
+    runHook postConfigure
+  '';
+
+  makeFlags =
+    [
+      "CHECKPOLICY=${lib.getExe checkpolicy}"
+      "CHECKMODULE=${lib.getExe' checkpolicy "checkmodule"}"
+      "SEMODULE=${lib.getExe' policycoreutils "semodule"}"
+      "SEMOD_PKG=${lib.getExe' semodule-utils "semodule_package"}"
+      "SEMOD_LNK=${lib.getExe' semodule-utils "semodule_link"}"
+      "SEMOD_EXP=${lib.getExe' semodule-utils "semodule_expand"}"
+      "DESTDIR=${placeholder "out"}"
+      "prefix=${placeholder "out"}"
+      "DISTRO=nixos"
+      "SYSTEMD=y"
+      "UBAC=y"
+    ]
+    ++ lib.optional (policyVersion != null) "OUTPUT_POLICY=${toString policyVersion}"
+    ++ lib.optional (moduleVersion != null) "OUTPUT_MODULE=${toString moduleVersion}";
+
+  installTargets = "all install install-headers install-docs";
+
+  meta = {
+    description = "SELinux Reference Policy v2";
+    homepage = "http://userspace.selinuxproject.org";
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ RossComputerGuy ];
+    license = lib.licenses.gpl2Only;
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Adds the SELinux reference policy so we have at least 1 SELinux policy to use as a default for NixOS. The policy is meant for FHS systems but we at least can add it in as a default. I plan on making a way to generate policies but it isn't mandatory for implementing SELinux into NixOS.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
