### PR TITLE
nixos/containers: fix shell error when privateUsers=no

### DIFF
--- a/nixos/modules/virtualisation/nixos-containers.nix
+++ b/nixos/modules/virtualisation/nixos-containers.nix
@@ -122,9 +122,12 @@ let
     NIX_BIND_OPT=""
     if [ -n "$PRIVATE_USERS" ]; then
       extraFlags+=("--private-users=$PRIVATE_USERS")
-      if [ "$PRIVATE_USERS" = "pick" ] || { [ "$PRIVATE_USERS" != "identity" ] && [ "$PRIVATE_USERS" -gt 0 ]; }; then
-        # when user namespacing is enabled, we use `idmap` mount option
-        # so that bind mounts under /nix get proper owner (and not nobody/nogroup).
+      if [[
+        "$PRIVATE_USERS" = "pick"
+        || ("$PRIVATE_USERS" =~ ^[[:digit:]]+$ && "$PRIVATE_USERS" -gt 0)
+      ]]; then
+        # when user namespacing is enabled, we use `idmap` mount option so that
+        # bind mounts under /nix get proper owner (and not nobody/nogroup).
         NIX_BIND_OPT=":idmap"
       fi
     fi


### PR DESCRIPTION
Details in #387773. Credits to [amarshall](https://github.com/amarshall) for the first jab at this.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] ~~x86_64-darwin~~
  - [ ] ~~aarch64-darwin~~
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

```
% for t in nixos/tests/containers-* ; do echo nix-build -A nixosTests.$(basename ${t%%.nix}) ; done | parallel -j 8 --halt now,fail=1 --joblog joblog.txt
% cat joblog.txt 
Seq     Host    Starttime       JobRuntime      Send    Receive Exitval Signal  Command
2       :       1743815959.913      11.704      0       79      0       0       nix-build -A nixosTests.containers-custom-pkgs
3       :       1743815959.916      11.907      0       77      0       0       nix-build -A nixosTests.containers-ephemeral
7       :       1743815959.930      15.780      0       77      0       0       nix-build -A nixosTests.containers-ip
5       :       1743815959.923      16.218      0       73      0       0       nix-build -A nixosTests.containers-hosts
8       :       1743815959.933      19.679      0       76      0       0       nix-build -A nixosTests.containers-macvlans
10      :       1743815971.828      16.376      0       63      0       0       nix-build -A nixosTests.containers-nested
9       :       1743815971.622      24.634      0       73      0       0       nix-build -A nixosTests.containers-names
14      :       1743815988.208      11.611      0       87      0       0       nix-build -A nixosTests.containers-require-bind-mounts
13      :       1743815979.616      29.046      0       78      0       0       nix-build -A nixosTests.containers-reloadable
11      :       1743815975.715      37.819      0       87      0       0       nix-build -A nixosTests.containers-physical_interfaces
4       :       1743815959.919      60.763      0       78      0       0       nix-build -A nixosTests.containers-extra_veth
17      :       1743816008.665      12.896      0       85      0       0       nix-build -A nixosTests.containers-unified-hierarchy
15      :       1743815996.262      28.495      0       86      0       0       nix-build -A nixosTests.containers-restart_networking
1       :       1743815959.910      68.810      0       74      0       0       nix-build -A nixosTests.containers-bridge
12      :       1743815976.147      56.155      0       79      0       0       nix-build -A nixosTests.containers-portforward
16      :       1743815999.824      57.641      0       73      0       0       nix-build -A nixosTests.containers-tmpfs
6       :       1743815959.926     157.001      0       78      0       0       nix-build -A nixosTests.containers-imperative
% 
``` 

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
