### PR TITLE
dotnetCorePackages.combinePackages: add "metadata" to linked paths

### DIFF
--- a/pkgs/development/compilers/dotnet/combine-packages.nix
+++ b/pkgs/development/compilers/dotnet/combine-packages.nix
@@ -26,6 +26,7 @@ mkWrapper "sdk" (
     paths = dotnetPackages;
     pathsToLink = map (x: "/share/dotnet/${x}") [
       "host"
+      "metadata"
       "packs"
       "sdk"
       "sdk-manifests"


### PR DESCRIPTION
This enables users of `dotnetCorePackages.combinePackages` to install .NET workloads.

For background, in the .NET development ecosystem there is some tooling that is not bundled with the standard SDK known as "workloads". They contain stuff like wasm compilation tooling, available separately to keep the size the "core" SDK small. The intended method of workload installation is to run a command like `dotnet workloads install wasm-tools`, at which point `dotnet` downloads the required tools and installs them, by default, to the same location in which the dotnet SDK is installed.

Obviously this is no good in NixOS. Fortunately, there is a sort of roundabout-way for the SDK installation to indicate to the workload installer that any downloads should be stored in the user's home directory instead of where the SDK itself resides. Empty files with meaningful names are placed in `$DOTNET_ROOT/metadata/`, and indeed this is what the SDK packages now in nixpkgs do:

```bash
$ nix develop --impure --expr 'with builtins.getFlake "nixpkgs"; with legacyPackages.x86_64-linux; let dotnet = dotnetCorePackages.dotnet_8.sdk; in mkShell { packages = [ dotnet ]; DOTNET_ROOT = "${dotnet}/share/dotnet"; }'

$ tree $DOTNET_ROOT/metadata
/nix/store/f9fjbf61p8319py7zxbs1gmy8pkpd35v-dotnet-sdk-wrapped-8.0.114/share/dotnet/metadata
└── workloads
    └── 8.0.100
        └── userlocal

3 directories, 1 file
```

Now, it is common to have multiple SDKs installed in one environment, for example multiple major versions. To achieve this, nixpkgs includes a function to combine sdk packages together:

```bash
$ nix develop --impure --expr 'with builtins.getFlake "nixpkgs"; with legacyPackages.x86_64-linux; let dotnet = (with dotnetCorePackages; combinePackages [ dotnet_8.sdk dotnet_9.sdk ]); in mkShell { packages = [ dotnet ]; DOTNET_ROOT = "${dotnet}/share/dotnet"; }'

$ ls -lh $DOTNET_ROOT/
total 100K
-r-xr-xr-x 3 root root  75K Dec 31  1969 dotnet
dr-xr-xr-x 3 root root 4.0K Dec 31  1969 host
dr-xr-xr-x 8 root root 4.0K Dec 31  1969 packs
dr-xr-xr-x 2 root root 4.0K Dec 31  1969 sdk
dr-xr-xr-x 3 root root 4.0K Dec 31  1969 sdk-manifests
dr-xr-xr-x 4 root root 4.0K Dec 31  1969 shared
dr-xr-xr-x 2 root root 4.0K Dec 31  1969 templates

$ ls -lh $DOTNET_ROOT/sdk
total 8.0K
lrwxrwxrwx 2 root root 95 Dec 31  1969 8.0.114 -> /nix/store/f9fjbf61p8319py7zxbs1gmy8pkpd35v-dotnet-sdk-wrapped-8.0.114/share/dotnet/sdk/8.0.114
lrwxrwxrwx 2 root root 95 Dec 31  1969 9.0.104 -> /nix/store/v8964yrwsiwzq76v5iv8i8fh06dyk220-dotnet-sdk-wrapped-9.0.104/share/dotnet/sdk/9.0.104

$ dotnet workload install wasm-tools
Unhandled exception: System.IO.IOException: Read-only file system : '/nix/store/pjcjxawnxph89c6v615g4wx1kr1v6dbk-dotnet-combined/share/dotnet/metadata'
[...]

```

However, as we see above, it does not include the `metadata` directories that we can see in the first example. The `dotnetCorePackages.combinePackages` function just does not include it in its `pathsToLink` list, and this is what this commit changes.

With this commit:
```bash
$ nix develop --impure --expr 'with builtins.getFlake "/home/thomas/git/nixpkgs"; with legacyPackages.x86_64-linux; let dotnet = (with dotnetCorePackages; combinePackages [ dotnet_8.sdk dotnet_9.sdk ]); in mkShell { packages = [ dotnet ]; DOTNET_ROOT = "${dotnet}/share/dotnet"; }'

$ tree $DOTNET_ROOT/metadata
/nix/store/g4lppsrr9rjf0hlxv3znzg8642cpl0i7-dotnet-wrapped-combined/share/dotnet/metadata
└── workloads
    ├── 8.0.100 -> /nix/store/9p00p6idzjihchpk23gdxzyfk4js6kmq-dotnet-sdk-wrapped-8.0.111/share/dotnet/metadata/workloads/8.0.100
    └── 9.0.100 -> /nix/store/j762rrfgh4paigfnbvvphgwz5xrnb2h6-dotnet-sdk-wrapped-9.0.101/share/dotnet/metadata/workloads/9.0.100

4 directories, 0 files

$ dotnet workload install wasm-tools # now succeeds and installs the workload in a mixed-sdk environment
[...]
```
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
