### PR TITLE
gitoxide: 0.39.0 -> 0.42.0

### DIFF
--- a/pkgs/by-name/gi/gitoxide/fix-cargo-dependencies.patch
+++ b/pkgs/by-name/gi/gitoxide/fix-cargo-dependencies.patch
@@ -1,0 +1,24 @@
+diff -ur a/gix-packetline/Cargo.toml b/gix-packetline/Cargo.toml
+--- a/gix-packetline/Cargo.toml
++++ b/gix-packetline/Cargo.toml
+@@ -24,7 +24,7 @@
+ ## If set, all IO will become blocking. The same types will be used preventing side-by-side usage of blocking and non-blocking IO.
+ blocking-io = []
+ ## Implement IO traits from `futures-io`.
+-async-io = ["dep:futures-io", "dep:futures-lite", "dep:pin-project-lite"]
++async-io = ["dep:futures-io", "futures-lite", "dep:pin-project-lite"]
+ 
+ #! ### Other
+ ## Data structures implement `serde::Serialize` and `serde::Deserialize`.
+diff -ur a/gix-protocol/Cargo.toml b/gix-protocol/Cargo.toml
+--- a/gix-protocol/Cargo.toml
++++ b/gix-protocol/Cargo.toml
+@@ -34,7 +34,7 @@
+     "gix-transport/async-client",
+     "dep:async-trait",
+     "dep:futures-io",
+-    "dep:futures-lite",
++    "futures-lite",
+     "handshake",
+     "fetch"
+ ]

--- a/pkgs/by-name/gi/gitoxide/package.nix
+++ b/pkgs/by-name/gi/gitoxide/package.nix
@@ -21,7 +21,7 @@ rustPlatform.buildRustPackage rec {
   version = "0.39.0";
 
   src = fetchFromGitHub {
-    owner = "Byron";
+    owner = "GitoxideLabs";
     repo = "gitoxide";
     rev = "v${version}";
     hash = "sha256-xv4xGkrArJ/LTVLs2SYhvxhfNG6sjVm5nZWsi4s34iM=";
@@ -55,8 +55,8 @@ rustPlatform.buildRustPackage rec {
 
   meta = with lib; {
     description = "Command-line application for interacting with git repositories";
-    homepage = "https://github.com/Byron/gitoxide";
-    changelog = "https://github.com/Byron/gitoxide/blob/v${version}/CHANGELOG.md";
+    homepage = "https://github.com/GitoxideLabs/gitoxide";
+    changelog = "https://github.com/GitoxideLabs/gitoxide/blob/v${version}/CHANGELOG.md";
     license = with licenses; [
       mit # or
       asl20

--- a/pkgs/by-name/gi/gitoxide/package.nix
+++ b/pkgs/by-name/gi/gitoxide/package.nix
@@ -30,6 +30,10 @@ rustPlatform.buildRustPackage rec {
   useFetchCargoVendor = true;
   cargoHash = "sha256-q35MQGN/tvsK7gg0a/ljoVY6wedy7rwKlSakONgBIgk=";
 
+  patches = [
+    ./fix-cargo-dependencies.patch
+  ];
+
   nativeBuildInputs = [
     cmake
     pkg-config

--- a/pkgs/by-name/gi/gitoxide/package.nix
+++ b/pkgs/by-name/gi/gitoxide/package.nix
@@ -18,17 +18,17 @@ let
 in
 rustPlatform.buildRustPackage rec {
   pname = "gitoxide";
-  version = "0.39.0";
+  version = "0.42.0";
 
   src = fetchFromGitHub {
     owner = "GitoxideLabs";
     repo = "gitoxide";
     rev = "v${version}";
-    hash = "sha256-xv4xGkrArJ/LTVLs2SYhvxhfNG6sjVm5nZWsi4s34iM=";
+    hash = "sha256-hrCWt4cCnlH3NKH5Uugf/rvVN+YpbeZgZ/lhnQGZ2I0=";
   };
 
   useFetchCargoVendor = true;
-  cargoHash = "sha256-SRJkI61Z8revRWoschkUAJwcJfKB/U03+YfwEcnEIm8=";
+  cargoHash = "sha256-q35MQGN/tvsK7gg0a/ljoVY6wedy7rwKlSakONgBIgk=";
 
   nativeBuildInputs = [
     cmake


### PR DESCRIPTION
Release notes:
- https://github.com/GitoxideLabs/gitoxide/releases/tag/v0.42.0

References:
- https://github.com/NixOS/nixpkgs/pull/396226
- https://github.com/rust-secure-code/cargo-auditable/issues/124
- https://github.com/rust-lang/cargo/issues/12336

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
