### PR TITLE
libmp3splt: fix buffer overflow

### DIFF
--- a/pkgs/by-name/li/libmp3splt/fix-buffer-overflow.patch
+++ b/pkgs/by-name/li/libmp3splt/fix-buffer-overflow.patch
@@ -1,0 +1,106 @@
+From 2c0bb6891349ed880634352e4551ed48002e53eb Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?S=C3=A9rgio=20M=2E=20Basto?= <sergio@serjux.com>
+Date: Fri, 4 Aug 2023 13:54:03 +0100
+Subject: [PATCH] fix snprintf overflow
+
+fix *** buffer overflow detected ***: terminated
+
+fix #367
+---
+ src/oformat_parser.c | 20 ++++++++++----------
+ 1 file changed, 10 insertions(+), 10 deletions(-)
+
+diff --git a/src/oformat_parser.c b/src/oformat_parser.c
+index 7bc5edcf..3775d035 100644
+--- a/src/oformat_parser.c
++++ b/src/oformat_parser.c
+@@ -534,7 +534,7 @@ int splt_of_put_output_format_filename(splt_state *state, int current_split)
+               int max_number_of_digits = splt_u_get_requested_num_of_digits(state,
+                   state->oformat.format[i], &requested_num_of_digits, SPLT_FALSE);
+ 
+-              snprintf(temp + offset, temp_len, "%s", format);
++              snprintf(temp + offset, temp_len - offset, "%s", format);
+ 
+               fm_length = strlen(temp) + 1 + max_number_of_digits;
+               if ((fm = malloc(fm_length * sizeof(char))) == NULL)
+@@ -564,7 +564,7 @@ int splt_of_put_output_format_filename(splt_state *state, int current_split)
+           //
+           if (artist_or_performer != NULL)
+           {
+-            snprintf(temp+2,temp_len, "%s", state->oformat.format[i]+2);
++            snprintf(temp+2,temp_len-2, "%s", state->oformat.format[i]+2);
+ 
+             int artist_length = 0;
+             artist_length = strlen(artist_or_performer);
+@@ -609,7 +609,7 @@ int splt_of_put_output_format_filename(splt_state *state, int current_split)
+           //
+           if (artist != NULL)
+           {
+-            snprintf(temp+2,temp_len, "%s", state->oformat.format[i]+2);
++            snprintf(temp+2,temp_len-2, "%s", state->oformat.format[i]+2);
+ 
+             int artist_length = 0;
+             artist_length = strlen(artist);
+@@ -655,7 +655,7 @@ int splt_of_put_output_format_filename(splt_state *state, int current_split)
+           {
+             int album_length = 0;
+             album_length = strlen(album);
+-            snprintf(temp+2, temp_len, "%s", state->oformat.format[i]+2);
++            snprintf(temp+2, temp_len-2, "%s", state->oformat.format[i]+2);
+ 
+             fm_length = strlen(temp) + album_length + 1;
+           }
+@@ -699,7 +699,7 @@ int splt_of_put_output_format_filename(splt_state *state, int current_split)
+           {
+             int genre_length = 0;
+             genre_length = strlen(genre);
+-            snprintf(temp+2, temp_len, "%s", state->oformat.format[i]+2);
++            snprintf(temp+2, temp_len-2, "%s", state->oformat.format[i]+2);
+ 
+             fm_length = strlen(temp) + genre_length + 1;
+           }
+@@ -743,7 +743,7 @@ int splt_of_put_output_format_filename(splt_state *state, int current_split)
+           {
+             int title_length = 0;
+             title_length = strlen(title);
+-            snprintf(temp+2, temp_len, "%s", state->oformat.format[i]+2);
++            snprintf(temp+2, temp_len-2, "%s", state->oformat.format[i]+2);
+ 
+             fm_length = strlen(temp) + title_length + 1;
+           }
+@@ -787,7 +787,7 @@ int splt_of_put_output_format_filename(splt_state *state, int current_split)
+           {
+             int performer_length = 0;
+             performer_length = strlen(performer);
+-            snprintf(temp+2, temp_len, "%s", state->oformat.format[i]+2);
++            snprintf(temp+2, temp_len-2, "%s", state->oformat.format[i]+2);
+ 
+             fm_length = strlen(temp) + performer_length + 1;
+           }
+@@ -862,7 +862,7 @@ int splt_of_put_output_format_filename(splt_state *state, int current_split)
+             const char *format =
+               splt_u_get_format_ptr(state->oformat.format[i], temp, NULL);
+ 
+-            snprintf(temp + 4, temp_len, "%s", format + 2);
++            snprintf(temp + 4, temp_len-4, "%s", format + 2);
+             fm_length = strlen(temp) + 1 + max_num_of_digits;
+           }
+           else
+@@ -903,7 +903,7 @@ int splt_of_put_output_format_filename(splt_state *state, int current_split)
+             original_filename = strdup(splt_su_get_fname_without_path(splt_t_get_filename_to_split(state)));
+             if (original_filename)
+             {
+-              snprintf(temp+2,temp_len, "%s", state->oformat.format[i]+2);
++              snprintf(temp+2,temp_len-2 , "%s", state->oformat.format[i]+2);
+ 
+               splt_su_cut_extension(original_filename);
+ 
+@@ -934,7 +934,7 @@ int splt_of_put_output_format_filename(splt_state *state, int current_split)
+ 
+             if (last_dir)
+             {
+-              snprintf(temp+2, temp_len, "%s", state->oformat.format[i]+2);
++              snprintf(temp+2, temp_len-2, "%s", state->oformat.format[i]+2);
+ 
+               int last_dir_length = strlen(last_dir);
+ 

--- a/pkgs/by-name/li/libmp3splt/package.nix
+++ b/pkgs/by-name/li/libmp3splt/package.nix
@@ -16,6 +16,11 @@ stdenv.mkDerivation rec {
     sha256 = "1p1mn2hsmj5cp40fnc8g1yfvk72p8pjxi866gjdkgjsqrr7xdvih";
   };
 
+  patches = [
+    # Fix buffer overflow in string formatting: https://github.com/mp3splt/mp3splt/pull/368
+    ./fix-buffer-overflow.patch
+  ];
+
   outputs = [
     "out"
     "dev"


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

mp3splt is currently broken due to this issue: https://github.com/mp3splt/mp3splt/issues/367

There's a pull request that fixes it but it hasn't been merged since 2023: https://github.com/mp3splt/mp3splt/pull/368/

This commit applies the patch.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
