### PR TITLE
freedownloadmanager: init at 6.26.1.6177

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -21532,6 +21532,11 @@
     githubId = 3598650;
     name = "Fritz Otlinghaus";
   };
+  scriptod = {
+    name = "Abdo Zain";
+    github = "scriptod911";
+    githubId = 70215102;
+  };
   Scrumplex = {
     name = "Sefa Eyeoglu";
     email = "contact@scrumplex.net";

--- a/pkgs/by-name/fr/freedownloadmanager/package.nix
+++ b/pkgs/by-name/fr/freedownloadmanager/package.nix
@@ -1,0 +1,104 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  dpkg,
+  kdePackages,
+  gtk3,
+  atk,
+  cairo,
+  gdk-pixbuf,
+  pango,
+  openssl,
+  icu,
+  mysql80,
+  libdrm,
+  autoPatchelfHook,
+  patchelf,
+  desktop-file-utils,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "freedownloadmanager";
+  version = "6.26.1.6177";
+
+  src = fetchurl {
+    url = "http://debrepo.freedownloadmanager.org/pool/main/f/freedownloadmanager/freedownloadmanager_${finalAttrs.version}_amd64.deb";
+    hash = "sha256-yjyRB/4vnVXB8ZmicZxsrENCCUtp7bRR0YY5x0JtmTg=";
+  };
+
+  nativeBuildInputs = [
+    dpkg
+    autoPatchelfHook
+    patchelf
+    kdePackages.wrapQtAppsHook
+    desktop-file-utils
+  ];
+
+  buildInputs = [
+    kdePackages.qtbase
+    kdePackages.qtdeclarative
+    kdePackages.qtmultimedia
+    kdePackages.qtwayland
+    kdePackages.qt5compat
+
+    gtk3
+    atk
+    cairo
+    gdk-pixbuf
+    pango
+
+    openssl
+    icu
+    mysql80
+    libdrm
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin $out/opt $out/share/applications $out/share/pixmaps
+
+    cp -r opt/freedownloadmanager $out/opt/
+    cp -r usr/share/applications/* $out/share/applications/
+
+    ln -s $out/opt/freedownloadmanager/fdm $out/bin/fdm
+    ln -s $out/opt/freedownloadmanager/icon.png $out/share/pixmaps/freedownloadmanager.png
+
+    local desktopFile="$out/share/applications/freedownloadmanager.desktop"
+
+    desktop-file-edit \
+      --set-key=Exec --set-value=fdm \
+      --set-key=Icon --set-value=freedownloadmanager \
+      "$desktopFile"
+
+    local sql_plugin_dir="$out/opt/freedownloadmanager/plugins/sqldrivers"
+    if [ -f "$sql_plugin_dir/libqsqlmimer.so" ]; then
+      patchelf --remove-needed libmimerapi.so "$sql_plugin_dir/libqsqlmimer.so" || echo "Warning: Failed to patch libqsqlmimer.so"
+    fi
+
+    if [ ! -f "$sql_plugin_dir/libqsqlmysql.so" ]; then
+      echo "Warning: MySQL plugin libqsqlmysql.so not found."
+    fi
+
+    runHook postInstall
+  '';
+
+  preFixup = ''
+    local lib_dir="$out/opt/freedownloadmanager/lib"
+    rm -vf $lib_dir/libQt6*.so.6
+    rm -vf $lib_dir/libicu*.so.*
+    rm -vf $lib_dir/libcrypto.so*
+    rm -vf $lib_dir/libssl.so*
+  '';
+
+  meta = {
+    description = "Download manager supporting many protocols";
+    homepage = "https://www.freedownloadmanager.org";
+    license = lib.licenses.unfree;
+    platforms = [ "x86_64-linux" ];
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    maintainers = with lib.maintainers; [ scriptod ];
+    mainProgram = "fdm";
+  };
+})


### PR DESCRIPTION
feat(freedownloadmanager): init at 6.19.0

Adds Free Download Manager (FDM), a proprietary download manager. Its homepage is https://www.freedownloadmanager.org/

Packaged by extracting the official .deb release using `dpkg-deb`. The
package relies on `autoPatchelfHook` and `wrapGAppsHook` for
integration.

Dependencies added include:
- libpulseaudio (required by bundled QtMultimedia)
- xcbutilcursor, xcbutilwm, xcbutilimage, xcbutilkeysyms,
  xcbutilrenderutil (required by bundled Qt platform plugins)
- libpqxx, unixODBC (dependencies of bundled Qt SQL plugins)
- Various GStreamer plugins (gst_all_1) for media handling.

The pre-built binaries include Qt SQL plugins (`libqsqlmimer.so`,
`libqsqlmysql.so`) that link against optional database libraries
(`libmimerapi.so`, `libmysqlclient.so.21`) which are not needed for FDM
and not readily available (Mimer) or desired as required dependencies.

I tried to use the standard `autoPatchelfIgnoreMissing` attribute to
ignore these libraries failed during testing (NixOS unstable channel `24.11`
as of 2025-04-05). I'm not exactly sure why but might relate to hook
interactions or specifics of the hook version used in this Nixpkgs revision.

So, as a workaround, `patchelf --remove-needed` is used manually
during the `installPhase` to remove these specific unwanted dependency
references from the affected Qt SQL plugin binaries. This does allow the
rest of `autoPatchelfHook` to succeed. Future maintainers might revisit
using `autoPatchelfIgnoreMissing` if hook behavior changes in later
Nixpkgs versions. So keep an eye out of for that.

**Notes:**
- The source URL uses `/latest/`, which might point to a different file
  in the future even for the same version, potentially breaking the
  hash. A stable, versioned URL is preferred if one can be found.
  Version 6.19.0 corresponds to the hash used as of testing.
- FDM is `unfree`.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html)) - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests)) - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests) - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages - [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage) - [x] Tested basic functionality of all binary files (usually in `./result/bin/`) - [ ] [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes) - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md). ---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc