### PR TITLE
meshlab{,-unstable}: add darwin support

### DIFF
--- a/pkgs/by-name/le/levmar/package.nix
+++ b/pkgs/by-name/le/levmar/package.nix
@@ -17,6 +17,11 @@ stdenv.mkDerivation (finalAttrs: {
     substituteInPlace levmar.h --replace-fail "define HAVE_LAPACK" "undef HAVE_LAPACK"
     sed -i 's/LAPACKLIBS=.*/LAPACKLIBS=/' Makefile
     substituteInPlace Makefile --replace-fail "gcc" "${stdenv.cc.targetPrefix}cc"
+  ''
+  + lib.optionalString stdenv.cc.isClang ''
+    substituteInPlace compiler.h \
+      --replace-fail "#define LM_FINITE finite // ICC, GCC" \
+                     "#define LM_FINITE isfinite // ICC, GCC"
   '';
 
   installPhase = ''

--- a/pkgs/by-name/le/levmar/package.nix
+++ b/pkgs/by-name/le/levmar/package.nix
@@ -4,19 +4,19 @@
   fetchurl,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "levmar";
   version = "2.6";
 
   src = fetchurl {
-    url = "https://www.ics.forth.gr/~lourakis/levmar/${pname}-${version}.tgz";
-    sha256 = "1mxsjip9x782z6qa6k5781wjwpvj5aczrn782m9yspa7lhgfzx1v";
+    url = "https://www.ics.forth.gr/~lourakis/levmar/levmar-${finalAttrs.version}.tgz";
+    hash = "sha256-O/TvHqRHXe1TFejY/Jkqcl8ueUCnTKOw+QKdnm6Uutc=";
   };
 
-  patchPhase = ''
-    substituteInPlace levmar.h --replace "define HAVE_LAPACK" "undef HAVE_LAPACK"
+  postPatch = ''
+    substituteInPlace levmar.h --replace-fail "define HAVE_LAPACK" "undef HAVE_LAPACK"
     sed -i 's/LAPACKLIBS=.*/LAPACKLIBS=/' Makefile
-    substituteInPlace Makefile --replace "gcc" "${stdenv.cc.targetPrefix}cc"
+    substituteInPlace Makefile --replace-fail "gcc" "${stdenv.cc.targetPrefix}cc"
   '';
 
   installPhase = ''
@@ -29,6 +29,7 @@ stdenv.mkDerivation rec {
     description = "ANSI C implementations of Levenberg-Marquardt, usable also from C++";
     homepage = "https://www.ics.forth.gr/~lourakis/levmar/";
     license = lib.licenses.gpl2Plus;
+    maintainers = [ ];
     platforms = lib.platforms.all;
   };
-}
+})

--- a/pkgs/by-name/me/meshlab-unstable/package.nix
+++ b/pkgs/by-name/me/meshlab-unstable/package.nix
@@ -29,14 +29,15 @@ let
   tinygltf-src = fetchFromGitHub {
     owner = "syoyo";
     repo = "tinygltf";
-    rev = "v2.6.3";
+    tag = "v2.6.3";
     hash = "sha256-IyezvHzgLRyc3z8HdNsQMqDEhP+Ytw0stFNak3C8lTo=";
   };
+
   # requires submodules to build
   lib3mf-src = fetchFromGitHub {
     owner = "3MFConsortium";
     repo = "lib3mf";
-    rev = "v2.3.2";
+    tag = "v2.3.2";
     fetchSubmodules = true;
     hash = "sha256-pKjnN9H6/A2zPvzpFed65J+mnNwG/dkSE2/pW7IlN58=";
   };
@@ -50,7 +51,7 @@ stdenv.mkDerivation {
     repo = "meshlab";
     # note that this is in branch devel
     rev = "72142583980b6dbfc5b85c6cca226a72f48497a9";
-    sha256 = "1q7qga4d82pvpcbsp9pi2i7nzdbflhp6q0d3y31kpch9r3r9pzks";
+    hash = "sha256-ev6b8sgJsjvD8KMBbC6kbrVvTxTxpqsXu/sK1Ih6+OA=";
     # needed for an updated version of vcg in their submodule
     fetchSubmodules = true;
   };

--- a/pkgs/by-name/me/meshlab/package.nix
+++ b/pkgs/by-name/me/meshlab/package.nix
@@ -68,6 +68,7 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [
     cmake
     libsForQt5.wrapQtAppsHook
+    vcg # templated library
   ];
 
   buildInputs = [
@@ -89,7 +90,6 @@ stdenv.mkDerivation (finalAttrs: {
     xercesc
     tbb
     embree
-    vcg
     libigl
     corto
     openctm

--- a/pkgs/by-name/me/meshlab/package.nix
+++ b/pkgs/by-name/me/meshlab/package.nix
@@ -163,7 +163,7 @@ stdenv.mkDerivation (finalAttrs: {
     mainProgram = "meshlab";
     homepage = "https://www.meshlab.net/";
     license = lib.licenses.gpl3Only;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ yzx9 ];
     platforms = with lib.platforms; linux ++ darwin;
   };
 })

--- a/pkgs/by-name/me/meshlab/package.nix
+++ b/pkgs/by-name/me/meshlab/package.nix
@@ -33,6 +33,26 @@ let
     tag = "v2.6.3";
     hash = "sha256-IyezvHzgLRyc3z8HdNsQMqDEhP+Ytw0stFNak3C8lTo=";
   };
+
+  downloads = [
+    "DLL_EMBREE"
+    "SOURCE_BOOST"
+    "SOURCE_CGAL"
+    "SOURCE_EMBREE"
+    "SOURCE_LEVMAR"
+    "SOURCE_LIB3DS"
+    "SOURCE_LIBE57"
+    "SOURCE_LIBIGL"
+    "SOURCE_MUPARSER"
+    "SOURCE_NEXUS"
+    "SOURCE_OPENCTM"
+    "SOURCE_QHULL"
+    "SOURCE_STRUCTURE_SYNTH"
+    "SOURCE_TINYGLTF"
+    "SOURCE_U3D"
+    "SOURCE_XERCE"
+  ];
+  cmakeFlagsDisallowDownload = lib.map (x: "-DMESHLAB_ALLOW_DOWNLOAD_${x}=OFF") downloads;
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "meshlab";
@@ -96,7 +116,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   cmakeFlags = [
     "-DVCGDIR=${vcg.src}"
-  ];
+  ]
+  ++ cmakeFlagsDisallowDownload;
 
   postFixup = ''
     patchelf --add-needed $out/lib/meshlab/libmeshlab-common.so $out/bin/.meshlab-wrapped

--- a/pkgs/by-name/me/meshlab/package.nix
+++ b/pkgs/by-name/me/meshlab/package.nix
@@ -30,20 +30,25 @@ let
   tinygltf-src = fetchFromGitHub {
     owner = "syoyo";
     repo = "tinygltf";
-    rev = "v2.6.3";
+    tag = "v2.6.3";
     hash = "sha256-IyezvHzgLRyc3z8HdNsQMqDEhP+Ytw0stFNak3C8lTo=";
   };
 in
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "meshlab";
   version = "2023.12";
 
   src = fetchFromGitHub {
     owner = "cnr-isti-vclab";
     repo = "meshlab";
-    rev = "MeshLab-${version}";
-    sha256 = "sha256-AdUAWS741RQclYaSE3Tz1/I0YSinNAnfSaqef+Tib8Y=";
+    tag = "MeshLab-${finalAttrs.version}";
+    hash = "sha256-AdUAWS741RQclYaSE3Tz1/I0YSinNAnfSaqef+Tib8Y=";
   };
+
+  nativeBuildInputs = [
+    cmake
+    libsForQt5.wrapQtAppsHook
+  ];
 
   buildInputs = [
     libGLU
@@ -69,11 +74,6 @@ stdenv.mkDerivation rec {
     corto
     openctm
     structuresynth
-  ];
-
-  nativeBuildInputs = [
-    cmake
-    libsForQt5.wrapQtAppsHook
   ];
 
   preConfigure = ''
@@ -116,4 +116,4 @@ stdenv.mkDerivation rec {
     maintainers = [ ];
     platforms = with lib.platforms; linux;
   };
-}
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13008,6 +13008,11 @@ with pkgs;
 
   mercurialFull = mercurial.override { fullBuild = true; };
 
+  meshlab = callPackage ../by-name/me/meshlab/package.nix {
+    stdenv = if stdenv.hostPlatform.isDarwin then llvmPackages_18.stdenv else stdenv;
+    llvmPackages = llvmPackages_18;
+  };
+
   meshcentral = callPackage ../tools/admin/meshcentral { };
 
   michabo = libsForQt5.callPackage ../applications/misc/michabo { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13013,6 +13013,11 @@ with pkgs;
     llvmPackages = llvmPackages_18;
   };
 
+  meshlab-unstable = callPackage ../by-name/me/meshlab-unstable/package.nix {
+    stdenv = if stdenv.hostPlatform.isDarwin then llvmPackages_18.stdenv else stdenv;
+    llvmPackages = llvmPackages_18;
+  };
+
   meshcentral = callPackage ../tools/admin/meshcentral { };
 
   michabo = libsForQt5.callPackage ../applications/misc/michabo { };


### PR DESCRIPTION
This PR adds Darwin support for MeshLab.

* I noticed that MeshLab 25.07 has been released — I can upgrade to it after this PR is merged.
* LLVM 18 is a workaround for issues with vcglib (#427236) and some other parts of the code. It should work fine in the new version.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [x] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
