### PR TITLE
otb: 10.0-unstable-2025-02-13 -> 10.0-unstable-2025-04-03

### DIFF
--- a/pkgs/by-name/ot/otb/package.nix
+++ b/pkgs/by-name/ot/otb/package.nix
@@ -27,6 +27,7 @@
   tinyxml,
 
   # otb modules
+  enableFFTW ? false,
   enableFeatureExtraction ? true,
   enableHyperspectral ? true,
   enableLearning ? true,
@@ -50,10 +51,16 @@ let
   # filter out gdcm, libminc from list of ITK deps as it's not needed for OTB
   itkVersion = "5.3.0";
   itkMajorMinorVersion = lib.versions.majorMinor itkVersion;
-  itkDepsToRemove = [
-    "gdcm"
-    "libminc"
-  ];
+  itkDepsToRemove =
+    [
+      "gdcm"
+      "libminc"
+    ]
+    ++ optionals (!enableFFTW) [
+      # remove fftw to avoid GPL contamination
+      # https://gitlab.orfeo-toolbox.org/orfeotoolbox/otb/-/issues/2454#note_112821
+      "fftw"
+    ];
   itkIsInDepsToRemove = dep: builtins.any (d: d == dep.name) itkDepsToRemove;
 
   # remove after https://gitlab.orfeo-toolbox.org/orfeotoolbox/otb/-/issues/2451
@@ -196,8 +203,8 @@ let
 
     propagatedBuildInputs =
       lib.lists.filter (pkg: !(itkIsInDepsToRemove pkg)) oldArgs.propagatedBuildInputs or [ ]
-      ++ [
-        # the only missing dependency for OTB from itk propagated list
+      ++ lib.optionals enableFFTW [
+        # the only missing dependency for OTB from itk propagated list if FFTW option is enabled
         fftwFloat
       ];
 
@@ -208,13 +215,13 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "otb";
-  version = "10.0-unstable-2025-02-13";
+  version = "10.0-unstable-2025-04-03";
 
   src = fetchFromGitHub {
     owner = "orfeotoolbox";
     repo = "otb";
-    rev = "34c96ef53bb94985a1358d5c3de1a5ac6dfecf18";
-    hash = "sha256-QCLuUryVi+r8sQGxvrh9G91uLxuRju6l3LxVJO3VzXM=";
+    rev = "93649b68f54975a1a48a0acd49f2602a55fc8032";
+    hash = "sha256-S6yhV//qlKdWWcT9J1p64WuVS0QNepIYTr/t4JvyEwE=";
   };
 
   patches = [
@@ -254,6 +261,7 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.cmakeBool "OTBGroup_ThirdParty" enableThirdParty)
     (lib.cmakeBool "OTB_WRAP_PYTHON" enablePython)
     (lib.cmakeBool "BUILD_TESTING" finalAttrs.doInstallCheck)
+    (lib.cmakeBool "OTB_USE_FFTW" enableFFTW)
   ];
 
   propagatedBuildInputs =
@@ -267,7 +275,6 @@ stdenv.mkDerivation (finalAttrs: {
       muparserx
       opencv
       otb-itk
-      otb-shark
       perl
       tinyxml
     ]


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

Removed `fftw` from the OTB default build [c.f](https://gitlab.orfeo-toolbox.org/orfeotoolbox/otb/-/issues/2454). 

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
