### PR TITLE
tailscale: fix masked systemd service

### DIFF
--- a/nixos/modules/services/networking/tailscale.nix
+++ b/nixos/modules/services/networking/tailscale.nix
@@ -144,17 +144,13 @@ in
         pkgs.getent # for `getent` to look up user shells
         pkgs.kmod # required to pass tailscale's v6nat check
       ] ++ lib.optional config.networking.resolvconf.enable config.networking.resolvconf.package;
-      serviceConfig.Environment =
-        [
-          "PORT=${toString cfg.port}"
-          ''"FLAGS=--tun ${lib.escapeShellArg cfg.interfaceName} ${lib.concatStringsSep " " cfg.extraDaemonFlags}"''
-        ]
-        ++ (lib.optionals (cfg.permitCertUid != null) [
-          "TS_PERMIT_CERT_UID=${cfg.permitCertUid}"
-        ])
-        ++ (lib.optionals (cfg.disableTaildrop) [
-          "TS_DISABLE_TAILDROP=true"
-        ]);
+      serviceConfig = {
+        ExecStart = "${cfg.package}/bin/tailscaled --tun ${lib.escapeShellArg cfg.interfaceName} ${toString cfg.extraDaemonFlags}";
+        Environment =
+          [ "PORT=${toString cfg.port}" ]
+          ++ (lib.optionals (cfg.permitCertUid != null) [ "TS_PERMIT_CERT_UID=${cfg.permitCertUid}" ])
+          ++ (lib.optionals (cfg.disableTaildrop) [ "TS_DISABLE_TAILDROP=true" ]);
+      };
       # Restart tailscaled with a single `systemctl restart` at the
       # end of activation, rather than a `stop` followed by a later
       # `start`. Activation over Tailscale can hang for tens of


### PR DESCRIPTION
The `tailscaled.service` is masked due to the upstream systemd unit being installed as part of the NixOS module via `systemd.packages = [ cfg.package ], conflicting with the NixOS module’s service definition.

Fix: Added explicit `ExecStart` to the `systemd.services.tailscaled` definition, overriding the upstream unit’s settings.

Closes #396157
Maintainers: @martinbaillie @06kellyjac @mfrw @pyrox0