### PR TITLE
gnutls: drop lzip and lzo dependencies

### DIFF
--- a/pkgs/development/libraries/gnutls/default.nix
+++ b/pkgs/development/libraries/gnutls/default.nix
@@ -3,7 +3,6 @@
   stdenv,
   fetchurl,
   zlib,
-  lzo,
   libtasn1,
   nettle,
   pkg-config,
@@ -141,7 +140,6 @@ stdenv.mkDerivation rec {
 
   buildInputs =
     [
-      lzo
       libtasn1
       libidn2
       zlib

--- a/pkgs/development/libraries/gnutls/default.nix
+++ b/pkgs/development/libraries/gnutls/default.nix
@@ -7,7 +7,6 @@
   libtasn1,
   nettle,
   pkg-config,
-  lzip,
   perl,
   gmp,
   autoconf,
@@ -143,7 +142,6 @@ stdenv.mkDerivation rec {
   buildInputs =
     [
       lzo
-      lzip
       libtasn1
       libidn2
       zlib
@@ -153,7 +151,7 @@ stdenv.mkDerivation rec {
       gettext
       libiconv
     ]
-    ++ lib.optional (withP11-kit) p11-kit
+    ++ lib.optional withP11-kit p11-kit
     ++ lib.optional (tpmSupport && stdenv.hostPlatform.isLinux) trousers;
 
   nativeBuildInputs =


### PR DESCRIPTION
gnutls used lzip only in their configure script for tarball distribution. This was dropped 8 years ago in e037d042acc91191fb2c1a9b7fe12abf8e795634 [1].

[1] https://gitlab.com/gnutls/gnutls/-/commit/e037d042acc91191fb2c1a9b7fe12abf8e795634

`lzo` support for gnutls in nixpkgs was removed in https://github.com/NixOS/nixpkgs/commit/775c412e573fa405da130b93363c8f8bc1d9e0b3.
Upstream did so 13 years ago in 69fd4dd53e25de3794ea368391fc35585a1808d1 [1].

[1] https://gitlab.com/gnutls/gnutls/-/commit/69fd4dd53e25de3794ea368391fc35585a1808d1

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
