### PR TITLE
Nix modular packaging cleanup

### DIFF
--- a/pkgs/tools/package-management/nix/modular/README.md
+++ b/pkgs/tools/package-management/nix/modular/README.md
@@ -4,3 +4,14 @@ This directory follows a directory structure similar to that in the upstream rep
 to make comparisons easier.
 
 The files are maintained separately from the upstream repo, so differences are expected.
+
+## Comparison
+
+### No filesets
+
+Using filesets with a fetched source would require "IFD", as the fetching happens in a derivation, but the filtering must come afterwards, and be done by the evaluator.
+
+### `workDir` attribute
+
+The Nixpkgs for Nix does inherit the `workDir` attribute that determines the location of the subproject to build.
+It is compared to this directory to produce the correct relative path, similar to upstream.

--- a/pkgs/tools/package-management/nix/modular/doc/manual/package.nix
+++ b/pkgs/tools/package-management/nix/modular/doc/manual/package.nix
@@ -17,25 +17,11 @@
   version,
 }:
 
-let
-  inherit (lib) fileset;
-in
-
 mkMesonDerivation (finalAttrs: {
   pname = "nix-manual";
   inherit version;
 
   workDir = ./.;
-  fileset =
-    fileset.difference
-      (fileset.unions [
-        ../../.version
-        # Too many different types of files to filter for now
-        ../../doc/manual
-        ./.
-      ])
-      # Do a blacklist instead
-      ../../doc/manual/package.nix;
 
   # TODO the man pages should probably be separate
   outputs = [

--- a/pkgs/tools/package-management/nix/modular/packaging/components.nix
+++ b/pkgs/tools/package-management/nix/modular/packaging/components.nix
@@ -28,18 +28,6 @@ let
     pkg-config
     ;
 
-  baseVersion = version;
-
-  versionSuffix = lib.optionalString (!officialRelease) "pre";
-
-  fineVersionSuffix =
-    lib.optionalString (!officialRelease)
-      "pre${
-        builtins.substring 0 8 (src.lastModifiedDate or src.lastModified or "19700101")
-      }_${src.shortRev or "dirty"}";
-
-  fineVersion = baseVersion + fineVersionSuffix;
-
   root = ../.;
 
   # Indirection for Nixpkgs to override when package.nix files are vendored
@@ -217,8 +205,7 @@ in
 
 # This becomes the pkgs.nixComponents attribute set
 {
-  version = baseVersion + versionSuffix;
-  inherit versionSuffix;
+  inherit version;
   inherit maintainers;
 
   inherit filesetToSource;
@@ -365,15 +352,13 @@ in
 
   nix-cmd = callPackage ../src/libcmd/package.nix { };
 
-  nix-cli = callPackage ../src/nix/package.nix { version = fineVersion; };
+  nix-cli = callPackage ../src/nix/package.nix { };
 
-  nix-functional-tests = callPackage ../tests/functional/package.nix {
-    version = fineVersion;
-  };
+  nix-functional-tests = callPackage ../tests/functional/package.nix { };
 
-  nix-manual = callPackage ../doc/manual/package.nix { version = fineVersion; };
-  nix-internal-api-docs = callPackage ../src/internal-api-docs/package.nix { version = fineVersion; };
-  nix-external-api-docs = callPackage ../src/external-api-docs/package.nix { version = fineVersion; };
+  nix-manual = callPackage ../doc/manual/package.nix { };
+  nix-internal-api-docs = callPackage ../src/internal-api-docs/package.nix { };
+  nix-external-api-docs = callPackage ../src/external-api-docs/package.nix { };
 
   nix-perl-bindings = callPackage ../src/perl/package.nix { };
 

--- a/pkgs/tools/package-management/nix/modular/src/external-api-docs/package.nix
+++ b/pkgs/tools/package-management/nix/modular/src/external-api-docs/package.nix
@@ -9,32 +9,11 @@
   version,
 }:
 
-let
-  inherit (lib) fileset;
-in
-
 mkMesonDerivation (finalAttrs: {
   pname = "nix-external-api-docs";
   inherit version;
 
   workDir = ./.;
-  fileset =
-    let
-      cpp = fileset.fileFilter (file: file.hasExt "cc" || file.hasExt "h");
-    in
-    fileset.unions [
-      ./.version
-      ../../.version
-      ./meson.build
-      ./doxygen.cfg.in
-      ./README.md
-      # Source is not compiled, but still must be available for Doxygen
-      # to gather comments.
-      (cpp ../libexpr-c)
-      (cpp ../libflake-c)
-      (cpp ../libstore-c)
-      (cpp ../libutil-c)
-    ];
 
   nativeBuildInputs = [
     doxygen

--- a/pkgs/tools/package-management/nix/modular/src/internal-api-docs/package.nix
+++ b/pkgs/tools/package-management/nix/modular/src/internal-api-docs/package.nix
@@ -9,28 +9,11 @@
   version,
 }:
 
-let
-  inherit (lib) fileset;
-in
-
 mkMesonDerivation (finalAttrs: {
   pname = "nix-internal-api-docs";
   inherit version;
 
   workDir = ./.;
-  fileset =
-    let
-      cpp = fileset.fileFilter (file: file.hasExt "cc" || file.hasExt "hh");
-    in
-    fileset.unions [
-      ./.version
-      ../../.version
-      ./meson.build
-      ./doxygen.cfg.in
-      # Source is not compiled, but still must be available for Doxygen
-      # to gather comments.
-      (cpp ../.)
-    ];
 
   nativeBuildInputs = [
     doxygen

--- a/pkgs/tools/package-management/nix/modular/src/libcmd/package.nix
+++ b/pkgs/tools/package-management/nix/modular/src/libcmd/package.nix
@@ -30,25 +30,11 @@
   readlineFlavor ? if stdenv.hostPlatform.isWindows then "readline" else "editline",
 }:
 
-let
-  inherit (lib) fileset;
-in
-
 mkMesonLibrary (finalAttrs: {
   pname = "nix-cmd";
   inherit version;
 
   workDir = ./.;
-  fileset = fileset.unions [
-    ../../nix-meson-build-support
-    ./nix-meson-build-support
-    ../../.version
-    ./.version
-    ./meson.build
-    ./meson.options
-    (fileset.fileFilter (file: file.hasExt "cc") ./.)
-    (fileset.fileFilter (file: file.hasExt "hh") ./.)
-  ];
 
   buildInputs = [
     ({ inherit editline readline; }.${readlineFlavor})

--- a/pkgs/tools/package-management/nix/modular/src/libexpr-c/package.nix
+++ b/pkgs/tools/package-management/nix/modular/src/libexpr-c/package.nix
@@ -10,26 +10,11 @@
   version,
 }:
 
-let
-  inherit (lib) fileset;
-in
-
 mkMesonLibrary (finalAttrs: {
   pname = "nix-expr-c";
   inherit version;
 
   workDir = ./.;
-  fileset = fileset.unions [
-    ../../nix-meson-build-support
-    ./nix-meson-build-support
-    ../../.version
-    ./.version
-    ./meson.build
-    # ./meson.options
-    (fileset.fileFilter (file: file.hasExt "cc") ./.)
-    (fileset.fileFilter (file: file.hasExt "hh") ./.)
-    (fileset.fileFilter (file: file.hasExt "h") ./.)
-  ];
 
   propagatedBuildInputs = [
     nix-store-c

--- a/pkgs/tools/package-management/nix/modular/src/libexpr-test-support/package.nix
+++ b/pkgs/tools/package-management/nix/modular/src/libexpr-test-support/package.nix
@@ -13,25 +13,11 @@
   version,
 }:
 
-let
-  inherit (lib) fileset;
-in
-
 mkMesonLibrary (finalAttrs: {
   pname = "nix-util-test-support";
   inherit version;
 
   workDir = ./.;
-  fileset = fileset.unions [
-    ../../nix-meson-build-support
-    ./nix-meson-build-support
-    ../../.version
-    ./.version
-    ./meson.build
-    # ./meson.options
-    (fileset.fileFilter (file: file.hasExt "cc") ./.)
-    (fileset.fileFilter (file: file.hasExt "hh") ./.)
-  ];
 
   propagatedBuildInputs = [
     nix-store-test-support

--- a/pkgs/tools/package-management/nix/modular/src/libexpr-tests/package.nix
+++ b/pkgs/tools/package-management/nix/modular/src/libexpr-tests/package.nix
@@ -18,25 +18,11 @@
   resolvePath,
 }:
 
-let
-  inherit (lib) fileset;
-in
-
 mkMesonExecutable (finalAttrs: {
   pname = "nix-expr-tests";
   inherit version;
 
   workDir = ./.;
-  fileset = fileset.unions [
-    ../../nix-meson-build-support
-    ./nix-meson-build-support
-    ../../.version
-    ./.version
-    ./meson.build
-    # ./meson.options
-    (fileset.fileFilter (file: file.hasExt "cc") ./.)
-    (fileset.fileFilter (file: file.hasExt "hh") ./.)
-  ];
 
   buildInputs = [
     nix-expr

--- a/pkgs/tools/package-management/nix/modular/src/libexpr/package.nix
+++ b/pkgs/tools/package-management/nix/modular/src/libexpr/package.nix
@@ -31,29 +31,11 @@
   enableGC ? !stdenv.hostPlatform.isWindows,
 }:
 
-let
-  inherit (lib) fileset;
-in
-
 mkMesonLibrary (finalAttrs: {
   pname = "nix-expr";
   inherit version;
 
   workDir = ./.;
-  fileset = fileset.unions [
-    ../../nix-meson-build-support
-    ./nix-meson-build-support
-    ../../.version
-    ./.version
-    ./meson.build
-    ./meson.options
-    ./primops/meson.build
-    (fileset.fileFilter (file: file.hasExt "cc") ./.)
-    (fileset.fileFilter (file: file.hasExt "hh") ./.)
-    ./lexer.l
-    ./parser.y
-    (fileset.difference (fileset.fileFilter (file: file.hasExt "nix") ./.) ./package.nix)
-  ];
 
   nativeBuildInputs = [
     bison

--- a/pkgs/tools/package-management/nix/modular/src/libfetchers-tests/package.nix
+++ b/pkgs/tools/package-management/nix/modular/src/libfetchers-tests/package.nix
@@ -18,25 +18,11 @@
   resolvePath,
 }:
 
-let
-  inherit (lib) fileset;
-in
-
 mkMesonExecutable (finalAttrs: {
   pname = "nix-fetchers-tests";
   inherit version;
 
   workDir = ./.;
-  fileset = fileset.unions [
-    ../../nix-meson-build-support
-    ./nix-meson-build-support
-    ../../.version
-    ./.version
-    ./meson.build
-    # ./meson.options
-    (fileset.fileFilter (file: file.hasExt "cc") ./.)
-    (fileset.fileFilter (file: file.hasExt "hh") ./.)
-  ];
 
   buildInputs =
     [

--- a/pkgs/tools/package-management/nix/modular/src/libfetchers/package.nix
+++ b/pkgs/tools/package-management/nix/modular/src/libfetchers/package.nix
@@ -12,24 +12,11 @@
   version,
 }:
 
-let
-  inherit (lib) fileset;
-in
-
 mkMesonLibrary (finalAttrs: {
   pname = "nix-fetchers";
   inherit version;
 
   workDir = ./.;
-  fileset = fileset.unions [
-    ../../nix-meson-build-support
-    ./nix-meson-build-support
-    ../../.version
-    ./.version
-    ./meson.build
-    (fileset.fileFilter (file: file.hasExt "cc") ./.)
-    (fileset.fileFilter (file: file.hasExt "hh") ./.)
-  ];
 
   buildInputs = [
     libgit2

--- a/pkgs/tools/package-management/nix/modular/src/libflake-c/package.nix
+++ b/pkgs/tools/package-management/nix/modular/src/libflake-c/package.nix
@@ -11,26 +11,11 @@
   version,
 }:
 
-let
-  inherit (lib) fileset;
-in
-
 mkMesonLibrary (finalAttrs: {
   pname = "nix-flake-c";
   inherit version;
 
   workDir = ./.;
-  fileset = fileset.unions [
-    ../../nix-meson-build-support
-    ./nix-meson-build-support
-    ../../.version
-    ./.version
-    ./meson.build
-    # ./meson.options
-    (fileset.fileFilter (file: file.hasExt "cc") ./.)
-    (fileset.fileFilter (file: file.hasExt "hh") ./.)
-    (fileset.fileFilter (file: file.hasExt "h") ./.)
-  ];
 
   propagatedBuildInputs = [
     nix-expr-c

--- a/pkgs/tools/package-management/nix/modular/src/libflake-tests/package.nix
+++ b/pkgs/tools/package-management/nix/modular/src/libflake-tests/package.nix
@@ -18,25 +18,11 @@
   resolvePath,
 }:
 
-let
-  inherit (lib) fileset;
-in
-
 mkMesonExecutable (finalAttrs: {
   pname = "nix-flake-tests";
   inherit version;
 
   workDir = ./.;
-  fileset = fileset.unions [
-    ../../nix-meson-build-support
-    ./nix-meson-build-support
-    ../../.version
-    ./.version
-    ./meson.build
-    # ./meson.options
-    (fileset.fileFilter (file: file.hasExt "cc") ./.)
-    (fileset.fileFilter (file: file.hasExt "hh") ./.)
-  ];
 
   buildInputs = [
     nix-flake

--- a/pkgs/tools/package-management/nix/modular/src/libflake/package.nix
+++ b/pkgs/tools/package-management/nix/modular/src/libflake/package.nix
@@ -13,24 +13,11 @@
   version,
 }:
 
-let
-  inherit (lib) fileset;
-in
-
 mkMesonLibrary (finalAttrs: {
   pname = "nix-flake";
   inherit version;
 
   workDir = ./.;
-  fileset = fileset.unions [
-    ../../nix-meson-build-support
-    ./nix-meson-build-support
-    ../../.version
-    ./.version
-    ./meson.build
-    (fileset.fileFilter (file: file.hasExt "cc") ./.)
-    (fileset.fileFilter (file: file.hasExt "hh") ./.)
-  ];
 
   propagatedBuildInputs = [
     nix-store

--- a/pkgs/tools/package-management/nix/modular/src/libmain-c/package.nix
+++ b/pkgs/tools/package-management/nix/modular/src/libmain-c/package.nix
@@ -12,26 +12,11 @@
   version,
 }:
 
-let
-  inherit (lib) fileset;
-in
-
 mkMesonLibrary (finalAttrs: {
   pname = "nix-main-c";
   inherit version;
 
   workDir = ./.;
-  fileset = fileset.unions [
-    ../../nix-meson-build-support
-    ./nix-meson-build-support
-    ../../.version
-    ./.version
-    ./meson.build
-    # ./meson.options
-    (fileset.fileFilter (file: file.hasExt "cc") ./.)
-    (fileset.fileFilter (file: file.hasExt "hh") ./.)
-    (fileset.fileFilter (file: file.hasExt "h") ./.)
-  ];
 
   propagatedBuildInputs = [
     nix-util-c

--- a/pkgs/tools/package-management/nix/modular/src/libmain/package.nix
+++ b/pkgs/tools/package-management/nix/modular/src/libmain/package.nix
@@ -12,24 +12,11 @@
   version,
 }:
 
-let
-  inherit (lib) fileset;
-in
-
 mkMesonLibrary (finalAttrs: {
   pname = "nix-main";
   inherit version;
 
   workDir = ./.;
-  fileset = fileset.unions [
-    ../../nix-meson-build-support
-    ./nix-meson-build-support
-    ../../.version
-    ./.version
-    ./meson.build
-    (fileset.fileFilter (file: file.hasExt "cc") ./.)
-    (fileset.fileFilter (file: file.hasExt "hh") ./.)
-  ];
 
   propagatedBuildInputs = [
     nix-util

--- a/pkgs/tools/package-management/nix/modular/src/libstore-c/package.nix
+++ b/pkgs/tools/package-management/nix/modular/src/libstore-c/package.nix
@@ -10,26 +10,11 @@
   version,
 }:
 
-let
-  inherit (lib) fileset;
-in
-
 mkMesonLibrary (finalAttrs: {
   pname = "nix-store-c";
   inherit version;
 
   workDir = ./.;
-  fileset = fileset.unions [
-    ../../nix-meson-build-support
-    ./nix-meson-build-support
-    ../../.version
-    ./.version
-    ./meson.build
-    # ./meson.options
-    (fileset.fileFilter (file: file.hasExt "cc") ./.)
-    (fileset.fileFilter (file: file.hasExt "hh") ./.)
-    (fileset.fileFilter (file: file.hasExt "h") ./.)
-  ];
 
   propagatedBuildInputs = [
     nix-util-c

--- a/pkgs/tools/package-management/nix/modular/src/libstore-test-support/package.nix
+++ b/pkgs/tools/package-management/nix/modular/src/libstore-test-support/package.nix
@@ -13,25 +13,11 @@
   version,
 }:
 
-let
-  inherit (lib) fileset;
-in
-
 mkMesonLibrary (finalAttrs: {
   pname = "nix-store-test-support";
   inherit version;
 
   workDir = ./.;
-  fileset = fileset.unions [
-    ../../nix-meson-build-support
-    ./nix-meson-build-support
-    ../../.version
-    ./.version
-    ./meson.build
-    # ./meson.options
-    (fileset.fileFilter (file: file.hasExt "cc") ./.)
-    (fileset.fileFilter (file: file.hasExt "hh") ./.)
-  ];
 
   propagatedBuildInputs = [
     nix-util-test-support

--- a/pkgs/tools/package-management/nix/modular/src/libstore-tests/package.nix
+++ b/pkgs/tools/package-management/nix/modular/src/libstore-tests/package.nix
@@ -19,25 +19,11 @@
   filesetToSource,
 }:
 
-let
-  inherit (lib) fileset;
-in
-
 mkMesonExecutable (finalAttrs: {
   pname = "nix-store-tests";
   inherit version;
 
   workDir = ./.;
-  fileset = fileset.unions [
-    ../../nix-meson-build-support
-    ./nix-meson-build-support
-    ../../.version
-    ./.version
-    ./meson.build
-    # ./meson.options
-    (fileset.fileFilter (file: file.hasExt "cc") ./.)
-    (fileset.fileFilter (file: file.hasExt "hh") ./.)
-  ];
 
   # Hack for sake of the dev shell
   passthru.externalBuildInputs = [

--- a/pkgs/tools/package-management/nix/modular/src/libstore/package.nix
+++ b/pkgs/tools/package-management/nix/modular/src/libstore/package.nix
@@ -23,31 +23,11 @@
   embeddedSandboxShell ? stdenv.hostPlatform.isStatic,
 }:
 
-let
-  inherit (lib) fileset;
-in
-
 mkMesonLibrary (finalAttrs: {
   pname = "nix-store";
   inherit version;
 
   workDir = ./.;
-  fileset = fileset.unions [
-    ../../nix-meson-build-support
-    ./nix-meson-build-support
-    ../../.version
-    ./.version
-    ./meson.build
-    ./meson.options
-    ./linux/meson.build
-    ./unix/meson.build
-    ./windows/meson.build
-    (fileset.fileFilter (file: file.hasExt "cc") ./.)
-    (fileset.fileFilter (file: file.hasExt "hh") ./.)
-    (fileset.fileFilter (file: file.hasExt "sb") ./.)
-    (fileset.fileFilter (file: file.hasExt "md") ./.)
-    (fileset.fileFilter (file: file.hasExt "sql") ./.)
-  ];
 
   nativeBuildInputs = lib.optional embeddedSandboxShell unixtools.hexdump;
 

--- a/pkgs/tools/package-management/nix/modular/src/libutil-c/package.nix
+++ b/pkgs/tools/package-management/nix/modular/src/libutil-c/package.nix
@@ -9,26 +9,11 @@
   version,
 }:
 
-let
-  inherit (lib) fileset;
-in
-
 mkMesonLibrary (finalAttrs: {
   pname = "nix-util-c";
   inherit version;
 
   workDir = ./.;
-  fileset = fileset.unions [
-    ../../nix-meson-build-support
-    ./nix-meson-build-support
-    ../../.version
-    ./.version
-    ./meson.build
-    ./meson.options
-    (fileset.fileFilter (file: file.hasExt "cc") ./.)
-    (fileset.fileFilter (file: file.hasExt "hh") ./.)
-    (fileset.fileFilter (file: file.hasExt "h") ./.)
-  ];
 
   propagatedBuildInputs = [
     nix-util

--- a/pkgs/tools/package-management/nix/modular/src/libutil-test-support/package.nix
+++ b/pkgs/tools/package-management/nix/modular/src/libutil-test-support/package.nix
@@ -12,25 +12,11 @@
   version,
 }:
 
-let
-  inherit (lib) fileset;
-in
-
 mkMesonLibrary (finalAttrs: {
   pname = "nix-util-test-support";
   inherit version;
 
   workDir = ./.;
-  fileset = fileset.unions [
-    ../../nix-meson-build-support
-    ./nix-meson-build-support
-    ../../.version
-    ./.version
-    ./meson.build
-    # ./meson.options
-    (fileset.fileFilter (file: file.hasExt "cc") ./.)
-    (fileset.fileFilter (file: file.hasExt "hh") ./.)
-  ];
 
   propagatedBuildInputs = [
     nix-util

--- a/pkgs/tools/package-management/nix/modular/src/libutil-tests/package.nix
+++ b/pkgs/tools/package-management/nix/modular/src/libutil-tests/package.nix
@@ -18,25 +18,11 @@
   resolvePath,
 }:
 
-let
-  inherit (lib) fileset;
-in
-
 mkMesonExecutable (finalAttrs: {
   pname = "nix-util-tests";
   inherit version;
 
   workDir = ./.;
-  fileset = fileset.unions [
-    ../../nix-meson-build-support
-    ./nix-meson-build-support
-    ../../.version
-    ./.version
-    ./meson.build
-    # ./meson.options
-    (fileset.fileFilter (file: file.hasExt "cc") ./.)
-    (fileset.fileFilter (file: file.hasExt "hh") ./.)
-  ];
 
   buildInputs = [
     nix-util

--- a/pkgs/tools/package-management/nix/modular/src/libutil/package.nix
+++ b/pkgs/tools/package-management/nix/modular/src/libutil/package.nix
@@ -17,29 +17,11 @@
   version,
 }:
 
-let
-  inherit (lib) fileset;
-in
-
 mkMesonLibrary (finalAttrs: {
   pname = "nix-util";
   inherit version;
 
   workDir = ./.;
-  fileset = fileset.unions [
-    ../../nix-meson-build-support
-    ./nix-meson-build-support
-    ../../.version
-    ./.version
-    ./widecharwidth
-    ./meson.build
-    ./meson.options
-    ./linux/meson.build
-    ./unix/meson.build
-    ./windows/meson.build
-    (fileset.fileFilter (file: file.hasExt "cc") ./.)
-    (fileset.fileFilter (file: file.hasExt "hh") ./.)
-  ];
 
   buildInputs =
     [

--- a/pkgs/tools/package-management/nix/modular/src/nix/package.nix
+++ b/pkgs/tools/package-management/nix/modular/src/nix/package.nix
@@ -12,77 +12,11 @@
   version,
 }:
 
-let
-  inherit (lib) fileset;
-in
-
 mkMesonExecutable (finalAttrs: {
   pname = "nix";
   inherit version;
 
   workDir = ./.;
-  fileset = fileset.unions (
-    [
-      ../../nix-meson-build-support
-      ./nix-meson-build-support
-      ../../.version
-      ./.version
-      ./meson.build
-      ./meson.options
-
-      # Symbolic links to other dirs
-      ## exes
-      ./build-remote
-      ./doc
-      ./nix-build
-      ./nix-channel
-      ./nix-collect-garbage
-      ./nix-copy-closure
-      ./nix-env
-      ./nix-instantiate
-      ./nix-store
-      ## dirs
-      ./scripts
-      ../../scripts
-      ./misc
-      ../../misc
-
-      # Doc nix files for --help
-      ../../doc/manual/generate-manpage.nix
-      ../../doc/manual/utils.nix
-      ../../doc/manual/generate-settings.nix
-      ../../doc/manual/generate-store-info.nix
-
-      # Other files to be included as string literals
-      ../nix-channel/unpack-channel.nix
-      ../nix-env/buildenv.nix
-      ./get-env.sh
-      ./help-stores.md
-      ../../doc/manual/source/store/types/index.md.in
-      ./profiles.md
-      ../../doc/manual/source/command-ref/files/profiles.md
-
-      # Files
-    ]
-    ++
-      lib.concatMap
-        (dir: [
-          (fileset.fileFilter (file: file.hasExt "cc") dir)
-          (fileset.fileFilter (file: file.hasExt "hh") dir)
-          (fileset.fileFilter (file: file.hasExt "md") dir)
-        ])
-        [
-          ./.
-          ../build-remote
-          ../nix-build
-          ../nix-channel
-          ../nix-collect-garbage
-          ../nix-copy-closure
-          ../nix-env
-          ../nix-instantiate
-          ../nix-store
-        ]
-  );
 
   buildInputs = [
     nix-store

--- a/pkgs/tools/package-management/nix/modular/src/perl/package.nix
+++ b/pkgs/tools/package-management/nix/modular/src/perl/package.nix
@@ -12,30 +12,12 @@
   libsodium,
 }:
 
-let
-  inherit (lib) fileset;
-in
-
 perl.pkgs.toPerlModule (
   mkMesonDerivation (finalAttrs: {
     pname = "nix-perl";
     inherit version;
 
     workDir = ./.;
-    fileset = fileset.unions (
-      [
-        ./.version
-        ../../.version
-        ./MANIFEST
-        ./lib
-        ./meson.build
-        ./meson.options
-      ]
-      ++ lib.optionals finalAttrs.finalPackage.doCheck [
-        ./.yath.rc.in
-        ./t
-      ]
-    );
 
     nativeBuildInputs = [
       pkg-config

--- a/pkgs/tools/package-management/nix/modular/tests/functional/package.nix
+++ b/pkgs/tools/package-management/nix/modular/tests/functional/package.nix
@@ -27,22 +27,12 @@
   test-daemon ? null,
 }:
 
-let
-  inherit (lib) fileset;
-in
-
 mkMesonDerivation (
   finalAttrs:
   {
     inherit pname version;
 
     workDir = ./.;
-    fileset = fileset.unions [
-      ../../scripts/nix-profile.sh.in
-      ../../.version
-      ../../tests/functional
-      ./.
-    ];
 
     # Hack for sake of the dev shell
     passthru.externalNativeBuildInputs =


### PR DESCRIPTION
A step towards making the packaging of `nixVersions.nix_2_26` and higher more Nixpkgs-native.
This PR focuses on some simple changes.

Included:
- Remove unused fileset attributes from `package.nix` files
- Simplify `version` handing

Things scoped out for now:
- Package relevant meson layers separately for reuse elsewhere (e.g. systemd potentially)
- Simplify the source overriding solution to remove final traces of source filtering. Not-so-low hanging fruit, because changes to this require more testing.


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
