### PR TITLE
actual-server: 25.3.1 -> 25.4.0

### DIFF
--- a/pkgs/by-name/ac/actual-server/package.nix
+++ b/pkgs/by-name/ac/actual-server/package.nix
@@ -7,20 +7,48 @@
   cacert,
   gitMinimal,
   nodejs_20,
+  python3,
   yarn,
   nixosTests,
   nix-update-script,
 }:
 let
-  version = "25.3.1";
+  version = "25.4.0";
   src = fetchFromGitHub {
+    name = "actualbudget-actual-source";
     owner = "actualbudget";
     repo = "actual";
     tag = "v${version}";
-    hash = "sha256-UZ2Z1tkMbGJwka//cIC0aG1KCcTSxUPLzctEaOhnKQA=";
+    hash = "sha256-+XYl4Bh0+8bs/FCqlig9egLg3SJCy2SRN2ovxWRE1Ok=";
+  };
+  translations = fetchFromGitHub {
+    name = "actualbudget-translations-source";
+    owner = "actualbudget";
+    repo = "translations";
+    # Note to updaters: this repo is not tagged, so just update this to the Git
+    # tip at the time the update is performed.
+    rev = "312fce7791e6722357e5d2f851407f4b7cf4ecb9";
+    hash = "sha256-kDArpSFiNJJF5ZGCtcn7Ci7wCpI1cTSknDZ4sQgy/Nc=";
   };
 
   yarn_20 = yarn.override { nodejs = nodejs_20; };
+
+  SUPPORTED_ARCHITECTURES = builtins.toJSON {
+    os = [
+      "darwin"
+      "linux"
+    ];
+    cpu = [
+      "arm"
+      "arm64"
+      "ia32"
+      "x64"
+    ];
+    libc = [
+      "glibc"
+      "musl"
+    ];
+  };
 
   # We cannot use fetchYarnDeps because that doesn't support yarn2/berry
   # lockfiles (see https://github.com/NixOS/nixpkgs/issues/254369)
@@ -34,22 +62,7 @@ let
       yarn_20
     ];
 
-    SUPPORTED_ARCHITECTURES = builtins.toJSON {
-      os = [
-        "darwin"
-        "linux"
-      ];
-      cpu = [
-        "arm"
-        "arm64"
-        "ia32"
-        "x64"
-      ];
-      libc = [
-        "glibc"
-        "musl"
-      ];
-    };
+    inherit SUPPORTED_ARCHITECTURES;
 
     buildPhase = ''
       runHook preBuild
@@ -57,9 +70,15 @@ let
       export HOME=$(mktemp -d)
       yarn config set enableTelemetry 0
       yarn config set cacheFolder $out
+      # At this stage we don't need binaries yet, so we can skip preinstall
+      # scripts here.
+      yarn config set enableScripts false
       yarn config set --json supportedArchitectures "$SUPPORTED_ARCHITECTURES"
 
-      yarn workspaces focus @actual-app/sync-server --production
+      # Install dependencies for all workspaces, and include devDependencies,
+      # to build web UI. Dependencies will be re-created in offline mode in the
+      # package's install phase.
+      yarn install --immutable
 
       runHook postBuild
     '';
@@ -76,14 +95,61 @@ let
 
     outputHashAlgo = "sha256";
     outputHashMode = "recursive";
-    outputHash =
-      {
-        aarch64-darwin = "sha256-IJBfBA71PZeE/Zlu2kzQw8l/D4lVAV5I5loRyRfncKA=";
-        aarch64-linux = "sha256-djE2lt/o/7kd7ci2TW3mhjSptD3etChbvtdbiWqp/wo=";
-        x86_64-darwin = "sha256-AShd87VFwqDbJZoFJPg6HsdhTx7XMVdZ5sRWLXU8ldM=";
-        x86_64-linux = "sha256-me0v+RuoleOKFRyJ7iyLTKRnV2Cz2Q1MLc/SE2sSSH8=";
-      }
-      .${stdenv.hostPlatform.system} or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
+    outputHash = "sha256-Tac2gOkdc2tzNKB3ARMfJad1MkOphudvN74gI8bGMtY=";
+  };
+
+  webUi = stdenvNoCC.mkDerivation {
+    pname = "actual-server-webui";
+    inherit version;
+    srcs = [
+      src
+      translations
+    ];
+    sourceRoot = "${src.name}/";
+
+    nativeBuildInputs = [
+      nodejs_20
+      yarn_20
+    ];
+
+    inherit SUPPORTED_ARCHITECTURES;
+
+    postPatch = ''
+      ln -sv ../../../${translations.name} ./packages/desktop-client/locale
+      cp -r ${offlineCache}/node_modules ./node_modules
+
+      patchShebangs --build ./bin ./packages/*/bin
+
+      # Patch all references to `git` to a no-op `true`. This neuter automatic
+      # translation update.
+      substituteInPlace bin/package-browser \
+        --replace-fail "git" "true"
+
+      # Allow `remove-untranslated-languages` to do its job.
+      chmod -R u+w ./packages/desktop-client/locale
+    '';
+
+    buildPhase = ''
+      runHook preBuild
+
+      export HOME=$(mktemp -d)
+      yarn config set enableTelemetry 0
+      yarn config set cacheFolder ${offlineCache}
+      yarn config set --json supportedArchitectures "$SUPPORTED_ARCHITECTURES"
+
+      yarn build:server
+
+      runHook postBuild
+    '';
+
+    installPhase = ''
+      runHook preInstall
+
+      cp -r packages/desktop-client/build $out
+
+      runHook postInstall
+    '';
+    dontFixup = true;
   };
 in
 stdenv.mkDerivation {
@@ -92,15 +158,35 @@ stdenv.mkDerivation {
 
   nativeBuildInputs = [
     makeWrapper
+    (python3.withPackages (ps: [ ps.setuptools ])) # Used by node-gyp
     yarn_20
   ];
+
+  inherit SUPPORTED_ARCHITECTURES;
 
   installPhase = ''
     runHook preInstall
 
-    mkdir -p $out/{bin,lib,lib/actual/packages/sync-server}
-    cp -r ${offlineCache}/node_modules/ $out/lib/actual
+    mkdir -p $out/{bin,lib,lib/actual/packages/sync-server,lib/actual/packages/desktop-client}
     cp -r ./packages/sync-server/{app.js,src,migrations,package.json} $out/lib/actual/packages/sync-server
+    # sync-server uses package.json to determine path to web ui.
+    cp ./packages/desktop-client/package.json $out/lib/actual/packages/desktop-client
+    cp -r ${webUi} $out/lib/actual/packages/desktop-client/build
+
+    # Re-create node_modules/ to contain just production packages required for
+    # sync-server itself, using existing offline cache. This will also now build
+    # binaries.
+    export HOME=$(mktemp -d)
+    yarn config set enableNetwork false
+    yarn config set enableOfflineMode true
+    yarn config set enableTelemetry 0
+    yarn config set cacheFolder ${offlineCache}
+    yarn config set --json supportedArchitectures "$SUPPORTED_ARCHITECTURES"
+
+    export npm_config_nodedir=${nodejs_20}
+
+    yarn workspaces focus @actual-app/sync-server --production
+    cp -r ./node_modules $out/lib/actual/
 
     makeWrapper ${lib.getExe nodejs_20} "$out/bin/actual-server" \
       --add-flags "$out/lib/actual/packages/sync-server/app.js" \
@@ -110,7 +196,7 @@ stdenv.mkDerivation {
   '';
 
   passthru = {
-    inherit offlineCache;
+    inherit offlineCache webUi;
     tests = nixosTests.actual;
     passthru.updateScript = nix-update-script { };
   };


### PR DESCRIPTION
Release note available at [1].

This release now requires that the web UI is locally built rather than fetched from NPM. Thus, the following changes are made:

- `offlineCache` is made to install all dependencies of the workspace. The resulting "temporary" `node_modules/` is not suitable for final install, but can be used for web UI building.
- Web UI is built into a separated derivation, using `node_modules/` built in the previous step.
- In the final derivation, web UI is copied in, then the final `node_modules/` is created using `offlineCache`.

The 2-tier node_modules also allow us to avoid downloading architecture- dependent binaries during the generation of `offlineCache`, allowing us to eliminate per-architecture hash which allow easier upgrade.

[1]\: https://actualbudget.org/docs/releases#2540

Closes #397072

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
