### PR TITLE
ygot: init at 0.30.0

### DIFF
--- a/pkgs/by-name/yg/ygot/package.nix
+++ b/pkgs/by-name/yg/ygot/package.nix
@@ -1,0 +1,60 @@
+{
+  lib,
+  stdenv,
+  buildPackages,
+  buildGoModule,
+  fetchFromGitHub,
+  installShellFiles,
+  nix-update-script,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "ygot";
+  version = "0.30.0";
+
+  src = fetchFromGitHub {
+    owner = "openconfig";
+    repo = "ygot";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-nV0vh4KZtXEMc8BNRkrRVwgb59KWahkqROxu9/7xP/E=";
+  };
+
+  vendorHash = "sha256-MxyjO/uptmBXz+JWgRcP/SWeEWyz9pNA9eM4Rul45cM=";
+
+  excludedPackages = [
+    "demo/*"
+    "exampleoc"
+    "integration_tests/"
+  ];
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  postInstall =
+    ''
+      # The normal binary names are far too generic
+      mv $out/bin/generator $out/bin/ygot_generator
+      mv $out/bin/proto_generator $out/bin/ygot_proto_generator
+    ''
+    + lib.optionalString (stdenv.hostPlatform.emulatorAvailable buildPackages) (
+      let
+        emulator = stdenv.hostPlatform.emulator buildPackages;
+      in
+      ''
+        installShellCompletion --cmd gnmidiff \
+          --bash <(${emulator} $out/bin/gnmidiff completion bash) \
+          --zsh <(${emulator} $out/bin/gnmidiff completion zsh) \
+          --fish <(${emulator} $out/bin/gnmidiff completion fish)
+      ''
+    );
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Collection of Go utilities for interacting with YANG modules";
+    homepage = "https://github.com/openconfig/ygot";
+    changelog = "https://github.com/openconfig/ygot/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.asl20;
+    maintainers = [ lib.maintainers.haylin ];
+    mainProgram = "ygot_generator";
+  };
+})


### PR DESCRIPTION
## Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
