### PR TITLE
nixVersions.stable: 2.24 -> 2.28

### DIFF
--- a/pkgs/by-name/at/attic-client/package.nix
+++ b/pkgs/by-name/at/attic-client/package.nix
@@ -2,7 +2,7 @@
   lib,
   rustPlatform,
   fetchFromGitHub,
-  nixForLinking,
+  nixVersions,
   nixosTests,
   boost,
   pkg-config,
@@ -29,7 +29,7 @@ rustPlatform.buildRustPackage {
 
   buildInputs =
     [
-      nixForLinking
+      nixVersions.nix_2_24
       boost
     ]
     ++ lib.optionals stdenv.hostPlatform.isDarwin (
@@ -44,7 +44,7 @@ rustPlatform.buildRustPackage {
   useFetchCargoVendor = true;
 
   ATTIC_DISTRIBUTOR = "nixpkgs";
-  NIX_INCLUDE_PATH = "${lib.getDev nixForLinking}/include";
+  NIX_INCLUDE_PATH = "${lib.getDev nixVersions.nix_2_24}/include";
 
   # Attic interacts with Nix directly and its tests require trusted-user access
   # to nix-daemon to import NARs, which is not possible in the build sandbox.

--- a/pkgs/by-name/li/libblake3/package.nix
+++ b/pkgs/by-name/li/libblake3/package.nix
@@ -4,7 +4,13 @@
   cmake,
   fetchFromGitHub,
   tbb_2021_11,
-  useTBB ? true,
+
+  # Until we have a release with
+  # https://github.com/BLAKE3-team/BLAKE3/pull/461 and similar, or those
+  # PRs are patched onto this current release. Even then, I think we
+  # still need to disable for MinGW build because
+  # https://github.com/BLAKE3-team/BLAKE3/issues/467
+  useTBB ? false,
 }:
 
 stdenv.mkDerivation (finalAttrs: {

--- a/pkgs/by-name/ni/nickel/package.nix
+++ b/pkgs/by-name/ni/nickel/package.nix
@@ -6,7 +6,7 @@
   python3,
   versionCheckHook,
   pkg-config,
-  nix,
+  nixVersions,
   nix-update-script,
   enableNixImport ? true,
 }:
@@ -39,7 +39,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     ];
 
   buildInputs = lib.optionals enableNixImport [
-    nix
+    nixVersions.nix_2_24
     boost
   ];
 

--- a/pkgs/by-name/ni/nix-heuristic-gc/package.nix
+++ b/pkgs/by-name/ni/nix-heuristic-gc/package.nix
@@ -3,7 +3,7 @@
 {
   lib,
   fetchFromGitHub,
-  nix,
+  nixVersions,
   boost,
   python3Packages,
 }:
@@ -19,12 +19,12 @@ python3Packages.buildPythonPackage rec {
 
   # NIX_SYSTEM suggested at
   # https://github.com/NixOS/nixpkgs/issues/386184#issuecomment-2692433531
-  NIX_SYSTEM = nix.stdenv.hostPlatform.system;
-  NIX_CFLAGS_COMPILE = [ "-I${lib.getDev nix}/include/nix" ];
+  NIX_SYSTEM = nixVersions.nix_2_24.stdenv.hostPlatform.system;
+  NIX_CFLAGS_COMPILE = [ "-I${lib.getDev nixVersions.nix_2_24}/include/nix" ];
 
   buildInputs = [
     boost
-    nix
+    nixVersions.nix_2_24
     python3Packages.pybind11
     python3Packages.setuptools
   ];

--- a/pkgs/by-name/ni/nix-plugins/package.nix
+++ b/pkgs/by-name/ni/nix-plugins/package.nix
@@ -2,7 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  nix,
+  nixVersions,
   cmake,
   pkg-config,
   boost,
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
   ];
 
   buildInputs = [
-    nix
+    nixVersions.nix_2_24
     boost
   ];
 

--- a/pkgs/development/tools/language-servers/nixd/default.nix
+++ b/pkgs/development/tools/language-servers/nixd/default.nix
@@ -8,7 +8,7 @@
   llvmPackages,
   meson,
   ninja,
-  nixForLinking,
+  nixVersions,
   nix-update-script,
   nixd,
   nixf,
@@ -101,12 +101,12 @@ in
       ];
 
       buildInputs = [
-        nixForLinking
+        nixVersions.nix_2_24
         gtest
         boost
       ];
 
-      env.CXXFLAGS = "-include ${nixForLinking.dev}/include/nix/config.h";
+      env.CXXFLAGS = "-include ${nixVersions.nix_2_24.dev}/include/nix/config.h";
 
       passthru.tests.pkg-config = testers.hasPkgConfigModules {
         package = nixt;
@@ -127,7 +127,7 @@ in
       sourceRoot = "${common.src.name}/nixd";
 
       buildInputs = [
-        nixForLinking
+        nixVersions.nix_2_24
         nixf
         nixt
         llvmPackages.llvm
@@ -137,7 +137,7 @@ in
 
       nativeBuildInputs = common.nativeBuildInputs ++ [ cmake ];
 
-      env.CXXFLAGS = "-include ${nixForLinking.dev}/include/nix/config.h";
+      env.CXXFLAGS = "-include ${nixVersions.nix_2_24.dev}/include/nix/config.h";
 
       # See https://github.com/nix-community/nixd/issues/519
       doCheck = false;

--- a/pkgs/tools/package-management/nix-du/default.nix
+++ b/pkgs/tools/package-management/nix-du/default.nix
@@ -3,7 +3,7 @@
   stdenv,
   fetchFromGitHub,
   rustPlatform,
-  nixForLinking,
+  nixVersions,
   nlohmann_json,
   boost,
   graphviz,
@@ -27,13 +27,13 @@ rustPlatform.buildRustPackage rec {
 
   doCheck = true;
   nativeCheckInputs = [
-    nixForLinking
+    nixVersions.nix_2_24
     graphviz
   ];
 
   buildInputs = [
     boost
-    nixForLinking
+    nixVersions.nix_2_24
     nlohmann_json
   ] ++ lib.optionals stdenv.hostPlatform.isDarwin [ Security ];
 

--- a/pkgs/tools/package-management/nix/default.nix
+++ b/pkgs/tools/package-management/nix/default.nix
@@ -228,7 +228,7 @@ lib.makeExtensible (
           nix;
 
       # Read ./README.md before bumping a major release
-      stable = addFallbackPathsCheck self.nix_2_24;
+      stable = addFallbackPathsCheck self.nix_2_28;
     }
     // lib.optionalAttrs config.allowAliases (
       lib.listToAttrs (


### PR DESCRIPTION
NB: this is a draft PR. Changes will be made.
- Switch to a monolithic build instead, as agreed with release managers
- Pin dependents to older versions as needed
- 2.28.1

Note also that 2.28 is a continuation of 2.27 with significant changes in the header locations only.
- [See announcement](https://discourse.nixos.org/t/nix-2-28-0-released/62660)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
