### PR TITLE
ci: add zizmor check and configuration

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -40,6 +40,7 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           token: ${{ steps.app-token.outputs.token }}
+          persist-credentials: false
 
       - name: Log current API rate limits
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,6 +46,7 @@ jobs:
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
+          persist-credentials: false
           sparse-checkout: .github/actions
       - name: Checkout the merge commit
         uses: ./.github/actions/checkout

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -34,6 +34,7 @@ jobs:
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
+          persist-credentials: false
           path: trusted
           sparse-checkout: |
             ci/github-script
@@ -73,6 +74,7 @@ jobs:
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
+          persist-credentials: false
           sparse-checkout: .github/actions
       - name: Checkout merge and target commits
         uses: ./.github/actions/checkout

--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -34,6 +34,7 @@ jobs:
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
+          persist-credentials: false
           path: trusted
           sparse-checkout: |
             ci/supportedVersions.nix
@@ -41,6 +42,7 @@ jobs:
       - name: Check out the PR at the test merge commit
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
+          persist-credentials: false
           ref: ${{ inputs.mergedSha }}
           path: untrusted
           sparse-checkout: |
@@ -84,6 +86,7 @@ jobs:
 
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
+          persist-credentials: false
           sparse-checkout: .github/actions
       - name: Check out the PR at merged and target commits
         uses: ./.github/actions/checkout
@@ -155,6 +158,7 @@ jobs:
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
+          persist-credentials: false
           sparse-checkout: .github/actions
       - name: Check out the PR at the target commit
         uses: ./.github/actions/checkout
@@ -181,8 +185,9 @@ jobs:
       - name: Compare against the target branch
         env:
           AUTHOR_ID: ${{ github.event.pull_request.user.id }}
+          TARGET_SHA: ${{ inputs.mergedSha }}
         run: |
-          git -C nixpkgs/trusted diff --name-only ${{ inputs.mergedSha }} \
+          git -C nixpkgs/trusted diff --name-only "$TARGET_SHA" \
             | jq --raw-input --slurp 'split("\n")[:-1]' > touched-files.json
 
           # Use the target branch to get accurate maintainer info
@@ -318,6 +323,7 @@ jobs:
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
+          persist-credentials: false
           sparse-checkout: .github/actions
       - name: Checkout the merge commit
         uses: ./.github/actions/checkout

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -46,6 +46,7 @@ jobs:
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
+          persist-credentials: false
           sparse-checkout: |
             ci/github-script
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -26,6 +26,7 @@ jobs:
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
+          persist-credentials: false
           sparse-checkout: .github/actions
       - name: Checkout the merge commit
         uses: ./.github/actions/checkout
@@ -60,6 +61,7 @@ jobs:
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
+          persist-credentials: false
           sparse-checkout: .github/actions
       - name: Checkout the merge commit
         uses: ./.github/actions/checkout
@@ -87,6 +89,7 @@ jobs:
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
+          persist-credentials: false
           sparse-checkout: .github/actions
       - name: Checkout merge and target commits
         uses: ./.github/actions/checkout

--- a/.github/workflows/merge-group.yml
+++ b/.github/workflows/merge-group.yml
@@ -24,6 +24,7 @@ jobs:
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
+          persist-credentials: false
           sparse-checkout: |
             ci/supportedSystems.json
 

--- a/.github/workflows/periodic-merge-24h.yml
+++ b/.github/workflows/periodic-merge-24h.yml
@@ -43,4 +43,5 @@ jobs:
       from: ${{ matrix.pairs.from }}
       into: ${{ matrix.pairs.into }}
     name: ${{ matrix.pairs.name || format('{0} → {1}', matrix.pairs.from, matrix.pairs.into) }}
-    secrets: inherit
+    secrets:
+      NIXPKGS_CI_APP_PRIVATE_KEY: ${{ secrets.NIXPKGS_CI_APP_PRIVATE_KEY }}

--- a/.github/workflows/periodic-merge-6h.yml
+++ b/.github/workflows/periodic-merge-6h.yml
@@ -42,4 +42,5 @@ jobs:
       from: ${{ matrix.pairs.from }}
       into: ${{ matrix.pairs.into }}
     name: ${{ format('{0} → {1}', matrix.pairs.from, matrix.pairs.into) }}
-    secrets: inherit
+    secrets:
+      NIXPKGS_CI_APP_PRIVATE_KEY: ${{ secrets.NIXPKGS_CI_APP_PRIVATE_KEY }}

--- a/.github/workflows/periodic-merge.yml
+++ b/.github/workflows/periodic-merge.yml
@@ -11,6 +11,9 @@ on:
         description: Target branch to merge into.
         required: true
         type: string
+    secrets:
+      NIXPKGS_CI_APP_PRIVATE_KEY:
+        required: true
 
 defaults:
   run:
@@ -32,6 +35,8 @@ jobs:
           permission-pull-requests: write
 
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
 
       - name: Find merge base between two branches
         if: contains(inputs.from, ' ')

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -34,6 +34,7 @@ jobs:
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
+          persist-credentials: false
           sparse-checkout-cone-mode: true # default, for clarity
           sparse-checkout: |
             ci/github-script

--- a/.github/workflows/reviewers.yml
+++ b/.github/workflows/reviewers.yml
@@ -29,6 +29,7 @@ jobs:
       - name: Check out the PR at the base commit
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
+          persist-credentials: false
           path: trusted
           sparse-checkout: ci
 
@@ -146,6 +147,7 @@ jobs:
         if: ${{ steps.app-token.outputs.token }}
         env:
           GH_TOKEN: ${{ github.token }}
+          APP_GH_TOKEN: ${{ steps.app-token.outputs.token }}
           REPOSITORY: ${{ github.repository }}
           NUMBER: ${{ github.event.number }}
           AUTHOR: ${{ github.event.pull_request.user.login }}
@@ -156,7 +158,7 @@ jobs:
           # There appears to be no API to request reviews based on GitHub IDs
           jq -r 'keys[]' comparison/maintainers.json \
             | while read -r id; do gh api /user/"$id" --jq .login; done \
-            | GH_TOKEN=${{ steps.app-token.outputs.token }} result/bin/request-reviewers.sh "$REPOSITORY" "$NUMBER" "$AUTHOR"
+            | GH_TOKEN="$APP_GH_TOKEN" result/bin/request-reviewers.sh "$REPOSITORY" "$NUMBER" "$AUTHOR"
 
       - name: Log current API rate limits (app-token)
         if: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,7 @@ jobs:
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
+          persist-credentials: false
           sparse-checkout-cone-mode: true # default, for clarity
           sparse-checkout: |
             ci/github-script

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,12 @@
+# This file defines the ignore rules for zizmor.
+#
+# For rules that contain a high number of false positives, prefer listing them here
+# instead of adding ignore comments. Note that zizmor cannot ignore by line-within-a-string, so
+# there are some ignore items that encompass multiple problems within one `run` block. An issue
+# tracking this is at https://github.com/woodruffw/zizmor/issues/648.
+#
+# For more info, see the documentation: https://woodruffw.github.io/zizmor/usage/#ignoring-results
+
+rules:
+  dangerous-triggers:
+    disable: true

--- a/ci/default.nix
+++ b/ci/default.nix
@@ -136,6 +136,8 @@ let
             [ "--config=${config}" ];
           includes = [ "*.md" ];
         };
+
+        programs.zizmor.enable = true;
       };
       fs = pkgs.lib.fileset;
       nixFilesSrc = fs.toSource {


### PR DESCRIPTION
`zizmor` is a tool that uses static analysis to find potential security issues in GitHub Actions [0]. (Yes, it's a bit absurd that GitHub made a CI system so complicated that tools like this were created, but I digress.)

Given our increase in GHA usage recently, I think this is a good step towards keeping our security posture in tip-top shape. (It also keeps with the theme of automating as many things as possible!)

There are a few false positives (stemming from two rules), so I've excluded them per-usage (well, mostly, see [1]) instead of globally or per-file, so that new usages of them get caught so we can determine if we can avoid using the footgun(s), or if we should ignore it.

[0]: https://woodruffw.github.io/zizmor/
[1]: https://github.com/woodruffw/zizmor/issues/648

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
