### PR TITLE
live555: build dynamic, add check

### DIFF
--- a/pkgs/by-name/li/live555/package.nix
+++ b/pkgs/by-name/li/live555/package.nix
@@ -1,12 +1,17 @@
 {
-  lib,
+  buildPackages,
   cctools,
   fetchpatch,
   fetchurl,
+  lib,
+  live555,
   openssl,
+  runCommand,
   stdenv,
-  vlc,
 }:
+let
+  isStatic = stdenv.hostPlatform.isStatic;
+in
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "live555";
@@ -42,8 +47,8 @@ stdenv.mkDerivation (finalAttrs: {
     "PREFIX=${placeholder "out"}"
     "C_COMPILER=$(CC)"
     "CPLUSPLUS_COMPILER=$(CXX)"
-    "LIBRARY_LINK=$(AR) cr "
     "LINK=$(CXX) -o "
+    "LIBRARY_LINK=${if isStatic then "$(AR) cr " else "$(CC) -o "}"
   ];
 
   # Since NIX_CFLAGS_COMPILE affects both C and C++ toolchains, we set CXXFLAGS
@@ -83,7 +88,7 @@ stdenv.mkDerivation (finalAttrs: {
     let
       platform =
         if stdenv.hostPlatform.isLinux then
-          "linux"
+          if isStatic then "linux" else "linux-with-shared-libraries"
         else if stdenv.hostPlatform.isDarwin then
           "macosx-catalina"
         else
@@ -97,10 +102,33 @@ stdenv.mkDerivation (finalAttrs: {
       runHook postConfigure
     '';
 
-  passthru.tests = {
-    # Downstream dependency
-    inherit vlc;
-  };
+  doInstallCheck = true;
+  installCheckPhase = ''
+    if ! ($out/bin/openRTSP || :) 2>&1 | grep -q "Usage: "; then
+      echo "Executing example program failed" >&2
+      exit 1
+    else
+      echo "Example program executed successfully"
+    fi
+  '';
+
+  passthru.tests =
+    let
+      emulator = stdenv.hostPlatform.emulator buildPackages;
+    in
+    {
+      # The installCheck phase above cannot be ran in cross-compilation scenarios,
+      # therefore the passthru test
+      run-test-prog = runCommand "live555-run-test-prog" { } ''
+        if ! (${emulator} ${live555}/bin/openRTSP || :) 2>&1 | grep -q "Usage: "; then
+          echo "Executing example program failed" >&2
+          exit 1
+        else
+          echo "Example program executed successfully"
+          touch $out
+        fi
+      '';
+    };
 
   meta = {
     homepage = "http://www.live555.com/liveMedia/";


### PR DESCRIPTION
Tested for x86_64-linux native as well as armv7l and aarch64 cross.

- respect the stdenv.hostPlatform.isStatic flag instead of always building statically
- add installCheckPhase
- add passthru test


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
