### PR TITLE
obs-studio-plugins.obs-color-monitor: 0.8.2 -> 0.9.0

### DIFF
--- a/pkgs/applications/video/obs-studio/plugins/obs-color-monitor.nix
+++ b/pkgs/applications/video/obs-studio/plugins/obs-color-monitor.nix
@@ -9,13 +9,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "obs-color-monitor";
-  version = "0.8.2";
+  version = "0.9.0";
 
   src = fetchFromGitHub {
     owner = "norihiro";
     repo = "obs-color-monitor";
     tag = finalAttrs.version;
-    hash = "sha256-cVMpmkcw8GzNGyd80g1oKmyiEYGMcRtWtDj9MC7RYf8=";
+    hash = "sha256-EIp1GQ5dKN43D7xodX/ucYcJm994eKsnidFlbLKWHuI=";
   };
 
   nativeBuildInputs = [ cmake ];
@@ -39,6 +39,5 @@ stdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.gpl2Only;
     platforms = lib.platforms.linux;
     maintainers = with lib.maintainers; [ hlad ];
-    broken = true;
   };
 })


### PR DESCRIPTION
fix for OBS Studio 31 https://github.com/norihiro/obs-color-monitor/commit/955fd85b73102e4c66aef527e9924465775e0635

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
