### PR TITLE
haskellPackages.cabal2nix-unstable: 2025-03-03 -> 2025-04-01

### DIFF
--- a/maintainers/scripts/haskell/regenerate-hackage-packages.sh
+++ b/maintainers/scripts/haskell/regenerate-hackage-packages.sh
@@ -89,7 +89,6 @@ compiler_config="$(nix-build -A haskellPackages.cabal2nix-unstable.compilerConfi
 
 echo "Running hackage2nix to regenerate pkgs/development/haskell-modules/hackage-packages.nix …"
 run_hackage2nix
-nixfmt pkgs/development/haskell-modules/hackage-packages.nix
 
 if [[ "$REGENERATE_TRANSITIVE" -eq 1 ]]; then
 
@@ -103,6 +102,7 @@ run_hackage2nix
 
 fi
 
+nixfmt pkgs/development/haskell-modules/hackage-packages.nix
 
 if [[ "$DO_COMMIT" -eq 1 ]]; then
 git add pkgs/development/haskell-modules/configuration-hackage2nix/transitive-broken.yaml

--- a/pkgs/development/haskell-modules/cabal2nix-unstable.nix
+++ b/pkgs/development/haskell-modules/cabal2nix-unstable.nix
@@ -2,6 +2,7 @@
 {
   mkDerivation,
   aeson,
+  ansi-terminal,
   ansi-wl-pprint,
   base,
   bytestring,
@@ -34,16 +35,17 @@
 }:
 mkDerivation {
   pname = "cabal2nix";
-  version = "unstable-2025-03-03";
+  version = "unstable-2025-04-01";
   src = fetchzip {
-    url = "https://github.com/NixOS/cabal2nix/archive/001aa9757c178c7d3069bc828cfea41b550c26ef.tar.gz";
-    sha256 = "1f5kxhbr78h4d0i4lhfkqijc783jlrpfrv7gq2x37c94p213agg4";
+    url = "https://github.com/NixOS/cabal2nix/archive/9dacfdb1ddb22f8e24c984541724784016d5231b.tar.gz";
+    sha256 = "1hyfmkhicy2ha9ax0vb4ml11f6z7k9mqydm5s1g06b1z64jf4y7r";
   };
   postUnpack = "sourceRoot+=/cabal2nix; echo source root reset to $sourceRoot";
   isLibrary = true;
   isExecutable = true;
   libraryHaskellDepends = [
     aeson
+    ansi-terminal
     ansi-wl-pprint
     base
     bytestring

--- a/pkgs/development/haskell-modules/configuration-hackage2nix/transitive-broken.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/transitive-broken.yaml
@@ -1578,7 +1578,6 @@ dont-distribute-packages:
  - haskell-docs
  - haskell-eigen-util
  - haskell-ftp
- - haskell-language-server
  - haskell-lsp
  - haskell-lsp-client
  - haskell-pdf-presenter

--- a/pkgs/development/haskell-modules/configuration-nix.nix
+++ b/pkgs/development/haskell-modules/configuration-nix.nix
@@ -1654,16 +1654,7 @@ builtins.intersectAttrs super {
     librarySystemDepends = (drv.librarySystemDepends or [ ]) ++ [ pkgs.libpq ];
   }) super.postgresql-libpq-configure;
 
-  postgresql-libpq-pkgconfig =
-    addPkgconfigDepend
-      # Building postgresql-libpq with PG17 in pkgsStatic works fine, but downstream can't link against it with:
-      # > /nix/store/7ir63m9sbqzflf3yfynn45i109w6a5iz-x86_64-unknown-linux-musl-binutils-2.43.1/bin/x86_64-unknown-linux-musl-ld:
-      #   /nix/store/vj7fwxbyvs15zrjbb9vafxbwmc05hl70-postgresql-static-x86_64-unknown-linux-musl-17.2-dev/lib/libpq.a(fe-connect.o):
-      #   in function `PQsetClientEncoding':
-      # > (.text.PQsetClientEncoding+0xdf): undefined reference to `pg_encoding_to_char'
-      # Falling back to v16 to work around it.
-      (if pkgs.stdenv.hostPlatform.isStatic then pkgs.postgresql_16 else pkgs.libpq)
-      super.postgresql-libpq-pkgconfig;
+  postgresql-libpq-pkgconfig = addPkgconfigDepend pkgs.libpq super.postgresql-libpq-pkgconfig;
 
   # Test failure is related to a GHC implementation detail of primitives and doesn't
   # cause actual problems in dependent packages, see https://github.com/lehins/pvar/issues/4


### PR DESCRIPTION
Motivation: to get https://github.com/NixOS/cabal2nix/pull/652 in here.

Had to fix the position of `nixfmt` in the `regnerate-hackage-packages.sh` script as well - I only ran `--fast` the first time and didn't notice `hackage2nix` would run a second time later.

The last commit fixing `postgresql-libpq-pkgconfig` in `pkgsStatic` can currently not be tested on this branch, because it relies on a commit on staging, so things will start to work once we merge haskell-updates. Putting this here, because it's related to `libpq` as well.

Most of the packages switched from postgresql to libpq appear to be marked broken anyway, so to a certain degree this is only cosmetic...

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
