### PR TITLE
perlPackages.SubHandlesVia: 0.050000 -> 0.050002

### DIFF
--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -31817,10 +31817,10 @@ with self;
 
   SubHandlesVia = buildPerlPackage {
     pname = "Sub-HandlesVia";
-    version = "0.050000";
+    version = "0.050002";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/T/TO/TOBYINK/Sub-HandlesVia-0.050000.tar.gz";
-      hash = "sha256-Lfk0k+L56VvleblQtuGf9ST5TIBhOq3AOohhHf91eU8=";
+      url = "mirror://cpan/authors/id/T/TO/TOBYINK/Sub-HandlesVia-0.050002.tar.gz";
+      hash = "sha256-PMWPrjBcCOEZziwz44SHBD5odSE4JkRBw1oxATTrUDg=";
     };
     propagatedBuildInputs = [
       ClassMethodModifiers


### PR DESCRIPTION
Fixes CVE-2025-30673.

https://metacpan.org/release/TOBYINK/Sub-HandlesVia-0.050002/source/Changes


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review pr 396536`

---
### `x86_64-linux`
<details>
  <summary>:x: 1 package failed to build:</summary>
  <ul>
    <li>rt</li>
  </ul>
</details>
<details>
  <summary>:white_check_mark: 32 packages built:</summary>
  <ul>
    <li>freecell-solver</li>
    <li>freecell-solver.dev</li>
    <li>freecell-solver.doc</li>
    <li>freecell-solver.man</li>
    <li>kdePackages.kpat</li>
    <li>kdePackages.kpat.debug</li>
    <li>kdePackages.kpat.dev</li>
    <li>kdePackages.kpat.devtools</li>
    <li>libsForQt5.kpat (plasma5Packages.kpat)</li>
    <li>perl538Packages.GnuPGInterface</li>
    <li>perl538Packages.GnuPGInterface.devdoc</li>
    <li>perl538Packages.MooXlate</li>
    <li>perl538Packages.MooXlate.devdoc</li>
    <li>perl538Packages.SubHandlesVia</li>
    <li>perl538Packages.SubHandlesVia.devdoc</li>
    <li>perl538Packages.TaskFreecellSolverTesting</li>
    <li>perl538Packages.TaskFreecellSolverTesting.devdoc</li>
    <li>perl538Packages.TestDataSplit</li>
    <li>perl538Packages.TestDataSplit.devdoc</li>
    <li>perl540Packages.GnuPGInterface</li>
    <li>perl540Packages.GnuPGInterface.devdoc</li>
    <li>perl540Packages.MooXlate</li>
    <li>perl540Packages.MooXlate.devdoc</li>
    <li>perl540Packages.SubHandlesVia</li>
    <li>perl540Packages.SubHandlesVia.devdoc</li>
    <li>perl540Packages.TaskFreecellSolverTesting</li>
    <li>perl540Packages.TaskFreecellSolverTesting.devdoc</li>
    <li>perl540Packages.TestDataSplit</li>
    <li>perl540Packages.TestDataSplit.devdoc</li>
    <li>pysolfc</li>
    <li>pysolfc.dist</li>
    <li>signing-party</li>
  </ul>
</details>
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
