### PR TITLE
boost: drop unused expat dependency

### DIFF
--- a/pkgs/development/libraries/boost/generic.nix
+++ b/pkgs/development/libraries/boost/generic.nix
@@ -2,7 +2,6 @@
   lib,
   stdenv,
   icu,
-  expat,
   zlib,
   bzip2,
   zstd,
@@ -87,8 +86,6 @@ let
       "variant=${variant}"
       "threading=${threading}"
       "link=${link}"
-      "-sEXPAT_INCLUDE=${expat.dev}/include"
-      "-sEXPAT_LIBPATH=${expat.out}/lib"
     ]
     ++ lib.optionals (lib.versionAtLeast version "1.85") [
       (
@@ -340,7 +337,6 @@ stdenv.mkDerivation {
   ] ++ lib.optional stdenv.hostPlatform.isDarwin fixDarwinDylibNames;
   buildInputs =
     [
-      expat
       zlib
       bzip2
       libiconv


### PR DESCRIPTION
The `expat` was removed upstream in 10135eeab5f7cd28e43f00699dea724231cd7556 [1]. Boost used SVN at the time making precise timeline checks bothersome, but it seems the first release including this drop was in late 2010.

Nixpkgs had the expat include logic in 00b296762a808243b4868a1c74aceb87a5ec8e90 for version 1.43. We no longer maintain such ancient versions of boost, yet the logic was still there.

[1] https://github.com/boostorg/graph/commit/10135eeab5f7cd28e43f00699dea724231cd7556

## checklist
- [x] find a potentially unused dependency with `nix-check-deps`
- [x] upstream package has a commit/PR removing the dependency
- [x] upstream package has a release that includes the commit/PR doing the remove
- [ ] upstream has a changelog documenting the removal of a dependency (or feature that was the sole last user of a dependency)
- [x] upstream code does not refer to the dependency (code search tools might be useful here)
- [x] why did nixpkgs add the dependency? This helps understanding impact of what might potentially break.
    - `git blame`
    - historical issues
    - historical PRs
    - old upstream build scripts referring to the dependency
- [ ] impact assessment
    - what depends on a package?
    - do all the tests still run?
    - [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review) can help, but is not a definitive answer. It just builds, it does not execute.
- [x] open a pull request against nixpkgs. Be sure to also follow guidelines on [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md)
- [x] add the `closure size` tag to your pull request
- [x] explain why it is safe to drop the dependency, explain the testing and research done.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
