### PR TITLE
wxGTK32: add missing optional deps

### DIFF
--- a/pkgs/by-name/wx/wxGTK32/package.nix
+++ b/pkgs/by-name/wx/wxGTK32/package.nix
@@ -4,6 +4,7 @@
   curl,
   expat,
   fetchFromGitHub,
+  gspell,
   gst_all_1,
   gtk3,
   libGL,
@@ -12,9 +13,12 @@
   libXinerama,
   libXtst,
   libXxf86vm,
+  libnotify,
   libpng,
+  libsecret,
   libtiff,
   libjpeg_turbo,
+  libxkbcommon,
   zlib,
   pcre2,
   pkg-config,
@@ -66,11 +70,15 @@ stdenv.mkDerivation rec {
     ]
     ++ lib.optionals stdenv.hostPlatform.isLinux [
       curl
+      gspell # wxTextCtrl spell checking
       gtk3
       libSM
       libXinerama
       libXtst
       libXxf86vm
+      libnotify # wxNotificationMessage backend
+      libsecret # wxSecretStore backend
+      libxkbcommon # proper key codes in key events
       xorgproto
     ]
     ++ lib.optional withMesa libGLU
@@ -142,7 +150,10 @@ stdenv.mkDerivation rec {
       database support, HTML viewing and printing, and much more.
     '';
     license = licenses.wxWindows;
-    maintainers = with maintainers; [ tfmoraes ];
+    maintainers = with maintainers; [
+      tfmoraes
+      fliegendewurst
+    ];
     platforms = platforms.unix;
   };
 }


### PR DESCRIPTION
Several features in wxGTK were missing. Previous build log:

```
checking for XKBCOMMON... configure: WARNING: libxkbcommon not found, key codes in key events may be incorrect
checking for LIBSECRET... configure: WARNING: libsecret not found, wxSecretStore won't be available
checking for GSPELL... configure: WARNING: gspell-1 not found, spell checking in wxTextCtrl won't be available
checking for LIBNOTIFY... checking for LIBNOTIFY... configure: WARNING: libnotify not found, wxNotificationMessage will use generic implementation.
```

New build logs:

```
checking for XKBCOMMON... yes
checking for LIBSECRET... yes
checking for GSPELL... yes
checking for LIBNOTIFY... yes
```

Did not check whether the new stuff works. Don't know of any software that uses it, maybe the Discourse poster could help out here.

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).