### PR TITLE
Revert "double-entry-generator: 2.7.1 -> 2.8.0"

### DIFF
--- a/pkgs/by-name/do/double-entry-generator/package.nix
+++ b/pkgs/by-name/do/double-entry-generator/package.nix
@@ -6,15 +6,15 @@
 }:
 buildGoModule rec {
   pname = "double-entry-generator";
-  version = "2.8.0";
+  version = "2.7.1";
   src = fetchFromGitHub {
     owner = "deb-sig";
     repo = "double-entry-generator";
-    hash = "sha256-sQiV+sdPTTiydlAbmVfMHijNnfAICMvd5ezAP+1CVWc=";
+    hash = "sha256-2Y8Spj1LAVZsUgChDYDCZ63pTH+nqs2ff9xcmC+gr0c=";
     rev = "v${version}";
   };
 
-  vendorHash = "sha256-/QMt8zPvHM9znUc0+iUC82bOUJoBmH+shJ9D7AHiQ1E=";
+  vendorHash = "sha256-Xedva9oGteOnv3rP4Wo3sOHIPyuy2TYwkZV2BAuxY4M=";
 
   excludedPackages = [ "hack" ];
 


### PR DESCRIPTION
Reverts NixOS/nixpkgs#396512

Upstream deleted the 2.8.0 tag.

https://github.com/NixOS/nixpkgs/pull/396512#issuecomment-2781407654