### PR TITLE
letsdns: init at 1.2.1

### DIFF
--- a/pkgs/by-name/le/letsdns/package.nix
+++ b/pkgs/by-name/le/letsdns/package.nix
@@ -1,0 +1,58 @@
+{
+  lib,
+  python3Packages,
+  fetchFromGitHub,
+  versionCheckHook,
+  nix-update-script,
+}:
+let
+  version = "1.2.1";
+in
+python3Packages.buildPythonApplication {
+  pname = "letsdns";
+  inherit version;
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "LetsDNS";
+    repo = "letsdns";
+    tag = version;
+    hash = "sha256-TwGVm7sEOPvUqtvaAuIU/X5W3H4VAC8dskNunt8UO0I=";
+  };
+
+  build-system = [
+    python3Packages.setuptools
+  ];
+
+  nativeCheckInputs = [
+    python3Packages.pytestCheckHook
+    versionCheckHook
+  ];
+
+  dependencies = with python3Packages; [
+    cryptography
+    dnspython
+    requests
+  ];
+
+  disabledTestPaths = [
+    # These tests require upstream certificates
+    "tests/test_action.py"
+  ];
+
+  env = {
+    UNITTEST_CONF = "tests/citest.conf";
+  };
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Manage DANE TLSA records in DNS servers";
+    homepage = "https://www.letsdns.de/";
+    downloadPage = "https://github.com/LetsDNS/letsdns";
+    changelog = "https://github.com/LetsDNS/letsdns/releases/tag/${version}";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ rseichter ];
+    mainProgram = "letsdns";
+  };
+}


### PR DESCRIPTION
New package, submitted by upstream developer. LetsDNS manages DANE TLSA records in DNS servers. Upstream documentation is available [here](https://www.letsdns.de/).

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
