### PR TITLE
warp-terminal: 0.2025.03.26.08.10.stable_02 -> 0.2025.04.02.08.11.stable_03

### DIFF
--- a/pkgs/by-name/wa/warp-terminal/versions.json
+++ b/pkgs/by-name/wa/warp-terminal/versions.json
@@ -1,14 +1,14 @@
 {
   "darwin": {
-    "hash": "sha256-tPb4Vax6dJFrX5VV1BEq70K4OvQPfMfNjPJZ22IeKW4=",
-    "version": "0.2025.03.26.08.10.stable_02"
+    "hash": "sha256-/zFB2lCTajshnIFexDDGrps2bir3Hj2Nq+4RO05HDvc=",
+    "version": "0.2025.04.02.08.11.stable_03"
   },
   "linux_x86_64": {
-    "hash": "sha256-R3Z71iNpvEQ1KIh62XbuRelHIWwXzovOLuMpzAs+55Q=",
-    "version": "0.2025.03.26.08.10.stable_02"
+    "hash": "sha256-wHiiKgTqAC30VMH0VhslmaNZyCwYEs6N915jlkxL8d8=",
+    "version": "0.2025.04.02.08.11.stable_03"
   },
   "linux_aarch64": {
-    "hash": "sha256-sKfMab7iNsb0W+4jDPLeG3g7b2rnL6Py//kCjFltutI=",
-    "version": "0.2025.03.26.08.10.stable_02"
+    "hash": "sha256-mjzS33bSHNwnUPPKswkbpbFOnuQu4+SeeCA8IcxE4tk=",
+    "version": "0.2025.04.02.08.11.stable_03"
   }
 }


### PR DESCRIPTION
## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
