### PR TITLE
.devcontainer: apply nixfmt-rfc-style on save

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -15,7 +15,9 @@
         "jnoortheen.nix-ide"
       ],
       "settings": {
-        "nix.formatterPath": "nixfmt-rfc-style",
+        "[nix]": {
+            "editor.formatOnSave": true
+        },
         "nix.enableLanguageServer": true,
         "nix.serverPath": "nixd"
       }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,7 +5,8 @@
     "ghcr.io/devcontainers/features/nix:1": {
       // fails in the devcontainer sandbox, enable sandbox via config instead
       "multiUser": false,
-      "packages": "nixd,nixfmt-unstable",
+      "packages": "nixpkgs.nixd,nixpkgs.nixfmt-rfc-style",
+      "useAttributePath": true,
       "extraNixConfig": "experimental-features = nix-command flakes,sandbox = true"
     }
   },


### PR DESCRIPTION
This PR removes an invalid config and enables auto formatter on save.  
For now, applying nixfmt-rfc-style is required to be called in terminal or manually executing VSCode command `Format Document`. Can I apply it on save by repository default?

## Removing `"nix.formatterPath": "nixfmt-rfc-style"`

It is making an alert.

![スクリーンショット 2025-04-06 222155](https://github.com/user-attachments/assets/719c95ef-b65a-4e31-8288-46223ab671c7)

`formatterPath` does not support `nixfmt-rfc-style` specifier.

https://github.com/nix-community/vscode-nix-ide/blob/92fdb077e9f18cc0048b15b1c07e5d18d629f76c/package.json#L76-L85

Currently it is just ignored, because of setting LSP.

https://github.com/nix-community/vscode-nix-ide/blob/92fdb077e9f18cc0048b15b1c07e5d18d629f76c/README.md?plain=1#L63

I've tested on vscode + WSL2 + Docker + [features/nix#1.3.0](https://github.com/devcontainers/features/pkgs/container/features%2Fnix/279569102?tag=1.3.0).

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

cc: @FliegendeWurst ref: https://github.com/NixOS/nixpkgs/pull/373427

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
