### PR TITLE
[24.11] openvpn: 2.6.12 -> 2.6.14

### DIFF
--- a/pkgs/tools/networking/openvpn/default.nix
+++ b/pkgs/tools/networking/openvpn/default.nix
@@ -22,11 +22,11 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "openvpn";
-  version = "2.6.12";
+  version = "2.6.13";
 
   src = fetchurl {
     url = "https://swupdate.openvpn.net/community/releases/openvpn-${finalAttrs.version}.tar.gz";
-    hash = "sha256-HGEP3etobjTxNnw0fgJ+QY4HUjoQ9NjOSiwq8vYaGSk=";
+    hash = "sha256-GvELhpIr18mYJ8wPFR3+loQze45evbOXU5FyhBrCSmo=";
   };
 
   nativeBuildInputs = [ pkg-config ];

--- a/pkgs/tools/networking/openvpn/default.nix
+++ b/pkgs/tools/networking/openvpn/default.nix
@@ -22,11 +22,11 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "openvpn";
-  version = "2.6.13";
+  version = "2.6.14";
 
   src = fetchurl {
     url = "https://swupdate.openvpn.net/community/releases/openvpn-${finalAttrs.version}.tar.gz";
-    hash = "sha256-GvELhpIr18mYJ8wPFR3+loQze45evbOXU5FyhBrCSmo=";
+    hash = "sha256-nramYYNS+ee3canTiuFjG17f7tbUAjPiQ+YC3fIZXno=";
   };
 
   nativeBuildInputs = [ pkg-config ];


### PR DESCRIPTION
This backports #374189 as well as #395526.

Looks like openvpn wasn't touched since the branch off.

When looking at what happened in master since then there were a couple of other commits related to "fix sandboxed darwin build":

$ git log --oneline upstream/release-24.11..upstream/master -- pkgs/tools/networking/openvpn/
f980e60f7cea (origin/update-openvpn, update-openvpn) openvpn: 2.6.13 -> 2.6.14
b636e02c3db4 openvpn: fix sandboxed darwin build (#374884)
fcbacedbf22c gnustep: propagate dependencies
4d96ec04543a gnustep: move GNUstep packages to by-name
ee0eae58c039 openvpn: fix sandboxed darwin build
2cacb1e62680 openvpn: 2.6.12 -> 2.6.13
1342a23c67e7 openvpn-auth-ldap: unpin LLVM17 (#373193)
4f0dadbf38ee treewide: format all inactive Nix files

But i would leave it with bumping the packages for now. It seems to build and the tests run.

Fixes CVE-2025-2704 (via the bump to 2.6.14)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
