### PR TITLE
nixos/misc/nixpkgs add setting nixpkgs.config.allowUnfreePackages = ["list" "of" "packages"]

### DIFF
--- a/nixos/modules/misc/nixpkgs.nix
+++ b/nixos/modules/misc/nixpkgs.nix
@@ -20,6 +20,9 @@ let
       rhs = optCall rhs_ { inherit pkgs; };
     in
     lib.recursiveUpdate lhs rhs
+    // lib.optionalAttrs (lhs ? allowUnfreePackages) {
+      allowUnfreePackages = lhs.allowUnfreePackages ++ (lib.attrByPath [ "allowUnfreePackages" ] [ ] rhs);
+    }
     // lib.optionalAttrs (lhs ? packageOverrides) {
       packageOverrides =
         pkgs:

--- a/nixos/modules/misc/nixpkgs/test-nixpkgs-config-allow-unfree.nix
+++ b/nixos/modules/misc/nixpkgs/test-nixpkgs-config-allow-unfree.nix
@@ -1,0 +1,124 @@
+# Test for allowUnfreePackages merging across multiple modules
+# Run with: nix-build -A nixosTests.nixpkgs-config-allow-unfree --show-trace
+
+{
+  evalMinimalConfig,
+  lib,
+}:
+let
+  eval =
+    modules:
+    evalMinimalConfig {
+      imports = [
+        ../nixpkgs.nix
+      ]
+      ++ modules;
+    };
+
+  getConfig = evalResult: evalResult.config.nixpkgs.config;
+
+  sortList = list: builtins.sort builtins.lessThan list;
+
+  assertEquals =
+    expected: actual:
+    let
+      prettyExpected = lib.generators.toPretty { } expected;
+      prettyActual = lib.generators.toPretty { } actual;
+    in
+    lib.assertMsg (expected == actual) "Expected ${prettyExpected} but got ${prettyActual}";
+
+  assertUnfreePackages =
+    listOfModules: expectedPackages:
+    let
+      config = getConfig (eval listOfModules);
+      actualAllowedUnfreePackages = sortList config.allowUnfreePackages;
+    in
+    assertEquals expectedPackages actualAllowedUnfreePackages;
+in
+lib.recurseIntoAttrs {
+
+  singleModuleTest =
+    assertUnfreePackages
+      [
+        {
+          nixpkgs.config.allowUnfreePackages = [
+            "package1"
+            "package2"
+          ];
+        }
+      ]
+      [
+        "package1"
+        "package2"
+      ];
+
+  multipleModulesMerging =
+    assertUnfreePackages
+      [
+        {
+          _file = "module1.nix";
+          nixpkgs.config.allowUnfreePackages = [
+            "package1"
+            "package2"
+          ];
+        }
+        {
+          _file = "module2.nix";
+          nixpkgs.config.allowUnfreePackages = [
+            "package3"
+            "package4"
+          ];
+        }
+        {
+          _file = "module3.nix";
+          nixpkgs.config.allowUnfreePackages = [ "package5" ];
+        }
+      ]
+      [
+        "package1"
+        "package2"
+        "package3"
+        "package4"
+        "package5"
+      ];
+
+  overlappingPackagesMerging =
+    assertUnfreePackages
+      [
+        {
+          _file = "moduleA.nix";
+          nixpkgs.config.allowUnfreePackages = [
+            "shared-package"
+            "unique-a"
+          ];
+        }
+        {
+          _file = "moduleB.nix";
+          nixpkgs.config.allowUnfreePackages = [
+            "shared-package"
+            "unique-b"
+          ];
+        }
+      ]
+      [
+        "shared-package"
+        "shared-package"
+        "unique-a"
+        "unique-b"
+      ];
+
+  emptyListMerging =
+    assertUnfreePackages
+      [
+        {
+          _file = "empty.nix";
+          nixpkgs.config.allowUnfreePackages = [ ];
+        }
+        {
+          _file = "non-empty.nix";
+          nixpkgs.config.allowUnfreePackages = [ "some-package" ];
+        }
+      ]
+      [ "some-package" ];
+
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1103,6 +1103,13 @@ in
     imports = [ ./nixos-rebuild-target-host.nix ];
   };
   nixpkgs = pkgs.callPackage ../modules/misc/nixpkgs/test.nix { inherit evalMinimalConfig; };
+  nixpkgs-config-allow-unfree =
+    pkgs.callPackage ../modules/misc/nixpkgs/test-nixpkgs-config-allow-unfree.nix
+      { inherit evalMinimalConfig; };
+  nixpkgs-config-allow-unfree-packages-and-predicate =
+    pkgs.callPackage ../../pkgs/stdenv/generic/check-meta-test.nix
+      { };
+  nixseparatedebuginfod = runTest ./nixseparatedebuginfod.nix;
   nixseparatedebuginfod2 = runTest ./nixseparatedebuginfod2.nix;
   node-red = runTest ./node-red.nix;
   nomad = runTest ./nomad.nix;

--- a/pkgs/stdenv/generic/check-meta-test.nix
+++ b/pkgs/stdenv/generic/check-meta-test.nix
@@ -1,0 +1,128 @@
+# Execute with
+#   nix-build -A nixosTests.nixpkgs-config-allow-unfree-packages-and-predicate --show-trace
+#
+# This test exercises the interaction between:
+#
+#   - nixos/modules/misc/nixpkgs.nix  (config merging, esp. allowUnfreePackages)
+#   - pkgs/stdenv/generic/check-meta.nix (allowUnfreePredicate logic)
+#
+# It checks how:
+#
+#   * config.allowUnfreePackages
+#   * config.allowUnfreePredicate
+#
+# interact to determine whether unfree packages are allowed.
+{
+  lib,
+  pkgs,
+}:
+
+let
+  inherit (lib)
+    assertMsg
+    generators
+    licenses
+    recurseIntoAttrs
+    ;
+
+  mkUnfreePkg = name: {
+    pname = name;
+    version = "1.0";
+    meta.license = licenses.unfree;
+  };
+  assertValidity =
+    {
+      nixpkgsConfig,
+      pkg,
+      expected ? true,
+    }:
+    let
+      testPkgs = import ../../.. {
+        system = pkgs.stdenv.hostPlatform.system;
+        config = nixpkgsConfig;
+      };
+      checkMeta = testPkgs.callPackage ./check-meta.nix { };
+      tryEval = expression: builtins.tryEval (builtins.deepSeq expression expression);
+      actual = tryEval (
+        checkMeta.assertValidity {
+          meta = pkg.meta;
+          attrs = pkg;
+        }
+      );
+      toPretty = generators.toPretty { };
+    in
+    assertMsg (actual.success == expected) ''
+      Expected validity of package ${lib.getName pkg} to be ${toPretty expected},
+      but got ${toPretty actual} with config:
+      ${toPretty nixpkgsConfig}
+    '';
+
+  runAssertions = assertions: lib.deepSeq assertions "";
+
+in
+recurseIntoAttrs {
+
+  allowOnlyFreePackagesByDefault = assertValidity {
+    nixpkgsConfig = { };
+    pkg = mkUnfreePkg "forbidden";
+    expected = false;
+  };
+
+  allowAllUnfreePackages = assertValidity {
+    nixpkgsConfig = {
+      allowUnfree = true;
+    };
+    pkg = mkUnfreePkg "allowed";
+  };
+
+  allowUnfreePackagesWithPredicate =
+    let
+      nixpkgsConfig = {
+        allowUnfreePredicate = pkg: lib.getName pkg == "allowed-by-predicate";
+      };
+    in
+    [
+      (assertValidity {
+        inherit nixpkgsConfig;
+        pkg = mkUnfreePkg "allowed-by-predicate";
+      })
+      (assertValidity {
+        inherit nixpkgsConfig;
+        pkg = mkUnfreePkg "allowed-by-nothing";
+        expected = false;
+      })
+    ];
+
+  allowUnfreeWithPackages = runAssertions [
+    (assertValidity {
+      nixpkgsConfig = {
+        allowUnfreePackages = [ "unfree" ];
+      };
+      pkg = mkUnfreePkg "unfree";
+      expected = true;
+    })
+  ];
+
+  allowUnfreePackagesOrPredicate =
+    let
+      nixpkgsConfig = {
+        allowUnfreePackages = [ "allowed-by-packages" ];
+        allowUnfreePredicate = pkg: lib.getName pkg == "allowed-by-predicate";
+      };
+    in
+    runAssertions [
+      (assertValidity {
+        inherit nixpkgsConfig;
+        pkg = mkUnfreePkg "allowed-by-packages";
+      })
+      (assertValidity {
+        inherit nixpkgsConfig;
+        pkg = mkUnfreePkg "allowed-by-predicate";
+      })
+      (assertValidity {
+        inherit nixpkgsConfig;
+        pkg = mkUnfreePkg "forbidden";
+        expected = false;
+      })
+    ];
+}

--- a/pkgs/stdenv/generic/check-meta.nix
+++ b/pkgs/stdenv/generic/check-meta.nix
@@ -160,8 +160,17 @@ let
   # }
   # Defaults to allow all names defined in config.allowUnfreePackages
   allowUnfreePredicate =
-    config.allowUnfreePredicate
-      or (pkg: builtins.elem (lib.getName pkg) config.allowUnfreePackages or [ ]);
+    let
+      listPredicate = pkg: builtins.elem (lib.getName pkg) (config.allowUnfreePackages or [ ]);
+
+      # Be robust against misconfigured allowUnfreePredicate values such as null
+      explicitPredicate =
+        let
+          raw = config.allowUnfreePredicate or null;
+        in
+        if builtins.isFunction raw then raw else (_: false);
+    in
+    pkg: (listPredicate pkg) || (explicitPredicate pkg);
 
   # Check whether unfree packages are allowed and if not, whether the
   # package has an unfree license and is not explicitly allowed by the

--- a/pkgs/stdenv/generic/check-meta.nix
+++ b/pkgs/stdenv/generic/check-meta.nix
@@ -158,7 +158,10 @@ let
   #   allowUnfree = false;
   #   allowUnfreePredicate = (x: pkgs.lib.hasPrefix "vscode" x.name);
   # }
-  allowUnfreePredicate = config.allowUnfreePredicate or (x: false);
+  # Defaults to allow all names defined in config.allowUnfreePackages
+  allowUnfreePredicate =
+    config.allowUnfreePredicate
+      or (pkg: builtins.elem (lib.getName pkg) config.allowUnfreePackages or [ ]);
 
   # Check whether unfree packages are allowed and if not, whether the
   # package has an unfree license and is not explicitly allowed by the

--- a/pkgs/top-level/config.nix
+++ b/pkgs/top-level/config.nix
@@ -226,6 +226,23 @@ let
       '';
     };
 
+    allowUnfreePackages = mkOption {
+      type = with lib.types; listOf str;
+      default = [ ];
+      example = [ "ut1999" ];
+      description = ''
+        Allows specific unfree packages to be used.
+
+        This option composes with `nixpkgs.config.allowUnfreePredicate` by also allowing the listed package names.
+
+        Unlike `nixpkgs.config.allowUnfreePredicate`, this option merges additively, similar to `environment.systemPackages`.
+        This enables defining allowed unfree packages in multiple modules, close to where they are used.
+
+        This avoids the need to centralize all unfree package declarations or globally enable unfree packages via
+        `nixpkgs.config.allowUnfree = true`.
+      '';
+    };
+
     allowBroken = mkOption {
       type = types.bool;
       default = false;


### PR DESCRIPTION
Inspired by https://github.com/NixOS/nixpkgs/issues/197325 this adds a new option nixpkgs.allowUnfreePackages, which merges additively and can thus be defined in multiple modules close to where the unfree package is installed.

I would have liked ot name this option
`nixpkgs.config.allowUnfreePackages`, to define it closer to where the `allowUnfree` and `allowUnfreePredicate` options are defined, but I didn't see how this could be achived, given that `nixpkgs.config` is an attribute set or function instead of a module. I would welcome some guidance on how to do this.

I would also have liked to have an assertion that this setting should not be defined when `nixpkgs.config.allowUnfreePredicate or `nixpkgs.config.allowUnfree` is set, but I don't yet know how to do that. (And I would like to learn).

Closes #197325

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
