### PR TITLE
equi{cord,bop}: build from git revisions again

### DIFF
--- a/pkgs/by-name/eq/equibop/package.nix
+++ b/pkgs/by-name/eq/equibop/package.nix
@@ -23,13 +23,19 @@
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "equibop";
-  version = "2.1.2";
+  version = "2.1.2"; # from package.json
 
   src = fetchFromGitHub {
     owner = "Equicord";
     repo = "Equibop";
-    tag = "v${finalAttrs.version}";
-    hash = "sha256-lDDGZUpW9LU5S/gzNJFIuVIk08pQlQLK07RwuzcYyjg=";
+    # Upstream does not consistently tag their releases. We use a hash
+    # even if they have releases, because chances are the "latest" tag
+    # will be outdated regardless. I tried asking them to do it, but it
+    # appears that there is no interest. Please manually update the rev
+    # and pnpmDeps hash each time a version has been bumped in upstream
+    # package.json, to at least have a resemblance of stable tagging.
+    rev = "3b3d65d62db8d1d2fd8b546e0f1a7d2fd80be0d9";
+    hash = "sha256-83nUdckfEZ4yUpEYQI/LU5cCJXpk8t4XL8Slu45vUNM=";
   };
 
   pnpmDeps = pnpm_9.fetchDeps {
@@ -39,7 +45,7 @@ stdenv.mkDerivation (finalAttrs: {
       src
       patches
       ;
-    hash = "sha256-MuCQJgUHyAKpKWM7lYE49zur+G+KtIVBVXCspWImnY8=";
+    hash = "sha256-4z32qbhaZuy64npXaeIBb0UmRLCv8XpwLfoQS9XE9gQ=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/eq/equicord/package.nix
+++ b/pkgs/by-name/eq/equicord/package.nix
@@ -10,18 +10,24 @@
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "equicord";
-  version = "1.11.4";
+  version = "1.11.9"; # from package.json
 
   src = fetchFromGitHub {
     owner = "Equicord";
     repo = "Equicord";
-    tag = "v${finalAttrs.version}";
-    hash = "sha256-BjAp+bubpG9tTo8y5LWcTCnpLbiyuY1Q6ZnprgeKoZg=";
+    # Upstream does not consistently tag their releases. We use a hash
+    # even if they have releases, because chances are the "latest" tag
+    # will be outdated regardless. I tried asking them to do it, but it
+    # appears that there is no interest. Please manually update the rev
+    # and pnpmDeps hash each time a version has been bumped in upstream
+    # package.json, to at least have a resemblance of stable tagging.
+    rev = "cf7dc5522d785a14878662d28153a5b90507bab1";
+    hash = "sha256-+IcyklSfSha/MFbVH/TbbxKW/4rUeFcJnlUm8jNavIM=";
   };
 
   pnpmDeps = pnpm_9.fetchDeps {
     inherit (finalAttrs) pname version src;
-    hash = "sha256-4uCo/pQ4f8k/7DNpCPDAeqfroZ9icFiTwapwS10uWkE=";
+    hash = "sha256-fjfzBy1Z7AUKA53yjjCQ6yasHc5QMaOBtXtXA5fNK5s=";
   };
 
   nativeBuildInputs = [
@@ -32,7 +38,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   env = {
     EQUICORD_REMOTE = "${finalAttrs.src.owner}/${finalAttrs.src.repo}";
-    EQUICORD_HASH = "${finalAttrs.src.tag}";
+    EQUICORD_HASH = "${finalAttrs.version}";
   };
 
   buildPhase = ''


### PR DESCRIPTION
Previously I have asked upstream to tag their releases, so that we may be able
to build Equicord and Equibop from tagged releases. While they did tag releases
for a while, it looks like both derivations are out of date because the trend
didn't stick. I've asked today if they'd be willing to tag their releases
properly, but the answer appears to be no.

Given the nature of the projects, I understand that tagging is not _too_
feasible. Unfortunate, but it is what it is. This PR changes both of the
derivations to _revisions_ that will **need to be updated manually**. I do not
like this, but I also don't want to remove either package as there are plenty of
users for each.

tl;dr: Update Equicord and Equibop to latest revisions, with version numbers
derived from `package.json` of each program. We can use unstable revisions, but
as upstream regularly reverts commits I think this is safer.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See
  [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests)
    (look inside
    [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or
    [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in
    [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or
    [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are
    [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package)
    to the relevant packages
- [x] Tested compilation of all packages that depend on this change using
      `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all
      changes have to be committed, also see
      [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in
      `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md)
  (or backporting
  [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md)
  and
  [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md)
  Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or
        breaking
  - [ ] (Module updates) Added a release notes entry if the change is
        significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS
        module
- [ ] Fits
      [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
