### PR TITLE
pixieditor: init at 2.0.0.98-dev

### DIFF
--- a/pkgs/by-name/pi/pixieditor/package.nix
+++ b/pkgs/by-name/pi/pixieditor/package.nix
@@ -1,0 +1,99 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchurl,
+  dpkg,
+  autoPatchelfHook,
+  libgcc,
+  fontconfig,
+  lttng-ust_2_12,
+  icu,
+  xorg,
+  openssl,
+  vulkan-loader,
+  libGL,
+  makeWrapper,
+  nix-update-script,
+}:
+
+# TODO: build from source;
+# -nixpkgs seemingly does not support building .NET projects that use workloads
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "pixieditor";
+  version = "2.0.0.98-dev";
+
+  src = fetchurl {
+    url = "https://github.com/PixiEditor/PixiEditor-development-channel/releases/download/${finalAttrs.version}/PixiEditor-${lib.removeSuffix "-dev" finalAttrs.version}-amd64-linux.deb";
+    sha256 = "sha256-cJp31/u9MDZECoMRBoAya4e/OdV1JsfjLXw4hPvoqR0=";
+  };
+
+  nativeBuildInputs = [
+    dpkg
+    autoPatchelfHook
+    makeWrapper
+  ];
+
+  buildInputs = [
+    libgcc.lib
+    fontconfig.lib
+    lttng-ust_2_12
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p "$out/bin"
+    mv ./usr/{lib,share} "$out"
+    makeWrapper $out/lib/pixieditor/PixiEditor $out/bin/pixieditor \
+      --prefix PATH : "$out/lib/pixieditor" \
+      --prefix LD_LIBRARY_PATH : "$out/lib/pixieditor" \
+      --prefix LD_LIBRARY_PATH : "${
+        lib.makeLibraryPath (
+          finalAttrs.buildInputs
+          ++ [
+            vulkan-loader
+            libGL
+            xorg.libX11
+            xorg.libICE
+            xorg.libSM
+            xorg.libXi
+            xorg.libXcursor
+            xorg.libXext
+            xorg.libXrandr
+            openssl
+            icu
+          ]
+        )
+      }" \
+      --set DOTNET_ROOT "$out/lib/pixieditor"
+
+    runHook postInstall
+  '';
+
+  # strip breaks .NET binaries
+  dontStrip = true;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Universal editor for all your 2D needs";
+    longDescription = ''
+      PixiEditor is a universal 2D platform that aims to provide you with tools and features for all your 2D needs.
+      Create beautiful sprites for your games, animations, edit images, create logos. All packed in an eye-friendly dark theme
+    '';
+    homepage = "https://pixieditor.net/";
+    changelog = "https://forum.pixieditor.net/tags/c/open-beta/7/changelog";
+    license = lib.licenses.lgpl3Only;
+    mainProgram = "pixieditor";
+    platforms = [
+      "x86_64-linux"
+    ];
+    sourceProvenance = with lib.sourceTypes; [
+      binaryNativeCode
+      binaryBytecode
+    ];
+    maintainers = with lib.maintainers; [
+      griffi-gh
+    ];
+  };
+})


### PR DESCRIPTION
PixiEditor v2 Open Beta channel

https://pixieditor.net/

![image](https://github.com/user-attachments/assets/9a46bdc0-6ad7-4049-a3bb-fde2dd12e4ef)

![image](https://github.com/user-attachments/assets/9e4d9786-e6c2-49b1-b2cc-1305421f006c)


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
