### PR TITLE
adios2: init at 2.10.2

### DIFF
--- a/pkgs/by-name/ad/adios2/package.nix
+++ b/pkgs/by-name/ad/adios2/package.nix
@@ -1,0 +1,146 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  perl,
+  cmake,
+  ninja,
+  gfortran,
+  pkg-config,
+  python3,
+  python3Packages,
+  mpi,
+  bzip2,
+  lz4,
+  c-blosc2,
+  hdf5-mpi,
+  libfabric,
+  libpng,
+  libsodium,
+  pugixml,
+  sqlite,
+  zeromq,
+  zfp,
+  zlib,
+  zlib-ng,
+  zstd,
+  ucx,
+  yaml-cpp,
+  nlohmann_json,
+  llvmPackages,
+  pythonSupport ? false,
+  withExamples ? false,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  version = "2.10.2";
+  pname = "adios2";
+
+  src = fetchFromGitHub {
+    owner = "ornladios";
+    repo = "adios2";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-NVyw7xoPutXeUS87jjVv1YxJnwNGZAT4QfkBLzvQbwg=";
+  };
+
+  postPatch =
+    ''
+      patchShebangs cmake/install/post/generate-adios2-config.sh.in
+    ''
+    # Dynamic cast to nullptr on darwin platform, switch to unsafe reinterpret cast.
+    + lib.optionalString stdenv.hostPlatform.isDarwin ''
+      substituteInPlace bindings/Python/py11{Attribute,Engine,Variable}.cpp \
+        --replace-fail "dynamic_cast" "reinterpret_cast"
+    '';
+
+  nativeBuildInputs =
+    [
+      perl
+      cmake
+      ninja
+      gfortran
+      pkg-config
+    ]
+    ++ lib.optionals pythonSupport [
+      python3
+      python3Packages.pybind11
+    ];
+
+  buildInputs =
+    [
+      mpi
+      bzip2
+      lz4
+      c-blosc2
+      hdf5-mpi
+      libfabric
+      libpng
+      libsodium
+      pugixml
+      sqlite
+      zeromq
+      zfp
+      zlib
+      zlib-ng # required by c-blocs2
+      zstd # required by c-blocs2
+      yaml-cpp
+      nlohmann_json
+
+      # Todo: add these optional dependcies in nixpkgs.
+      # sz
+      # mgard
+      # catalyst
+    ]
+    ++ lib.optional (lib.meta.availableOn stdenv.hostPlatform ucx) ucx
+    # openmp required by zfp
+    ++ lib.optional stdenv.cc.isClang llvmPackages.openmp;
+
+  propagatedBuildInputs = lib.optionals pythonSupport [
+    (python3Packages.mpi4py.override { inherit mpi; })
+    python3Packages.numpy
+  ];
+
+  cmakeFlags = [
+    (lib.cmakeBool "ADIOS2_USE_HDF5" true)
+    (lib.cmakeBool "ADIOS2_USE_HDF5_VOL" true)
+    (lib.cmakeBool "BUILD_TESTING" false)
+    (lib.cmakeBool "ADIOS2_BUILD_EXAMPLES" withExamples)
+    (lib.cmakeBool "ADIOS2_USE_EXTERNAL_DEPENDENCIES" true)
+    (lib.cmakeFeature "CMAKE_INSTALL_BINDIR" "bin")
+    (lib.cmakeFeature "CMAKE_INSTALL_LIBDIR" "lib")
+    (lib.cmakeFeature "CMAKE_INSTALL_INCLUDEDIR" "include")
+    (lib.cmakeFeature "CMAKE_INSTALL_PYTHONDIR" python3.sitePackages)
+  ];
+
+  # equired for finding the generated adios2-config.cmake file
+  env.adios2_DIR = "${placeholder "out"}/lib/cmake/adios2";
+
+  # Ctest takes too much time, so we only perform some smoke Python tests.
+  doInstallCheck = pythonSupport;
+
+  preCheck =
+    ''
+      export PYTHONPATH=$out/${python3.sitePackages}:$PYTHONPATH
+    ''
+    + lib.optionalString (stdenv.hostPlatform.system == "aarch64-linux") ''
+      rm ../testing/adios2/python/TestBPWriteTypesHighLevelAPI.py
+    '';
+
+  pytestFlagsArray = [
+    "../testing/adios2/python/Test*.py"
+  ];
+
+  pythonImportsCheck = [ "adios2" ];
+
+  nativeInstallCheckInputs = lib.optionals pythonSupport [
+    python3Packages.pythonImportsCheckHook
+    python3Packages.pytestCheckHook
+  ];
+
+  meta = {
+    homepage = "https://adios2.readthedocs.io/en/latest/";
+    description = "The Adaptable Input/Output System version 2";
+    license = lib.licenses.asl20;
+    platforms = lib.platforms.unix;
+    maintainers = with lib.maintainers; [ qbisi ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -93,6 +93,14 @@ self: super: with self; {
 
   adguardhome = callPackage ../development/python-modules/adguardhome { };
 
+  adios2 = toPythonModule (
+    pkgs.adios2.override {
+      python3 = python;
+      python3Packages = self;
+      pythonSupport = true;
+    }
+  );
+
   adjusttext = callPackage ../development/python-modules/adjusttext { };
 
   adlfs = callPackage ../development/python-modules/adlfs { };


### PR DESCRIPTION
data engine for FEM software fenics-dolphinx.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
