### PR TITLE
loadwatch: fix build

### DIFF
--- a/pkgs/by-name/lo/loadwatch/fix-c99-failure.patch
+++ b/pkgs/by-name/lo/loadwatch/fix-c99-failure.patch
@@ -1,0 +1,12 @@
+diff --git a/lw-ctl.c b/lw-ctl.c
+index 236761b..013bd24 100644
+--- a/lw-ctl.c
++++ b/lw-ctl.c
+@@ -4,6 +4,7 @@
+ #include <sys/un.h>
+ #include <errno.h>
+ #include <stdlib.h>
++#include <string.h>
+ 
+ void send_cmd(char *sockname, char *cmd)
+ {

--- a/pkgs/by-name/lo/loadwatch/missing-kstat-template-autoheader.patch
+++ b/pkgs/by-name/lo/loadwatch/missing-kstat-template-autoheader.patch
@@ -1,0 +1,12 @@
+diff --git a/configure.in b/configure.in
+index 4dacc3e..40f8e3f 100644
+--- a/configure.in
++++ b/configure.in
+@@ -8,6 +8,7 @@ AC_PROG_INSTALL
+ 
+ dnl Checks for libraries.
+ AC_CHECK_LIB(elf, elf_begin, [LIBS="$LIBS -lelf"])
++AH_TEMPLATE([HAVE_KSTAT], [Define if kstat is available.])
+ AC_CHECK_LIB(kstat, kstat_open, [AC_DEFINE(HAVE_KSTAT) LIBS="$LIBS -lkstat"])
+ 
+ dnl Checks for header files.

--- a/pkgs/by-name/lo/loadwatch/package.nix
+++ b/pkgs/by-name/lo/loadwatch/package.nix
@@ -2,27 +2,40 @@
   lib,
   stdenv,
   fetchgit,
+  autoreconfHook,
 }:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation (finalAttrs: {
   pname = "loadwatch";
   version = "1.1-1-g6d2544c";
 
   src = fetchgit {
-    url = "git://woffs.de/git/fd/loadwatch.git";
-    sha256 = "1bhw5ywvhyb6snidsnllfpdi1migy73wg2gchhsfbcpm8aaz9c9b";
+    url = "https://git.sr.ht/~woffs/loadwatch";
+    hash = "sha256-K7H0lUL1suU0hOyJx8fxL9YQ23WUWt2i1WZ5uLkvHK4=";
     rev = "6d2544c0caaa8a64bbafc3f851e06b8056c30e6e";
   };
+
+  patches = [
+    # autoheader fails when template is not defined
+    ./missing-kstat-template-autoheader.patch
+    # implicit <string.h> not allowed in c99 mode
+    ./fix-c99-failure.patch
+  ];
+
+  nativeBuildInputs = [
+    # conftest program uses main() with implicit return type
+    autoreconfHook
+  ];
 
   installPhase = ''
     mkdir -p $out/bin
     install loadwatch lw-ctl $out/bin
   '';
 
-  meta = with lib; {
+  meta = {
     description = "Run a program using only idle cycles";
-    license = licenses.gpl2Only;
-    maintainers = with maintainers; [ woffs ];
-    platforms = platforms.all;
+    license = lib.licenses.gpl2Only;
+    maintainers = with lib.maintainers; [ woffs ];
+    platforms = lib.platforms.all;
   };
-}
+})


### PR DESCRIPTION
Fix a missing <string.h> include; regenerate configure script to use a
compliant conftest program with explicit main() return type.

Also, modernized the derivation and updated the git repo url.

Signed-off-by: Ihar Hrachyshka <ihar.hrachyshka@gmail.com>


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
