### PR TITLE
nixVersions.nix_2_28: init at 2.28.1pre

### DIFF
--- a/pkgs/tools/package-management/nix/default.nix
+++ b/pkgs/tools/package-management/nix/default.nix
@@ -197,6 +197,20 @@ lib.makeExtensible (
 
       nix_2_27 = addTests "nix_2_27" self.nixComponents_2_27.nix-everything;
 
+      nixComponents_2_28 = nixDependencies.callPackage ./modular/packages.nix {
+        version = "2.28.1pre";
+        inherit (self.nix_2_24.meta) maintainers;
+        otherSplices = generateSplicesForNixComponents "nixComponents_2_28";
+        src = fetchFromGitHub {
+          owner = "NixOS";
+          repo = "nix";
+          rev = "9cdf72beaa77f1e6c0faed44872b83783051f20d";
+          hash = "sha256-0sk7cGOdfUA6/AamSsuURHdILxSyw+s2zl7CDaSsawo=";
+        };
+      };
+
+      nix_2_28 = addTests "nix_2_28" self.nixComponents_2_28.nix-everything;
+
       latest = self.nix_2_26;
 
       # The minimum Nix version supported by Nixpkgs

--- a/pkgs/tools/package-management/nix/modular/src/libmain/package.nix
+++ b/pkgs/tools/package-management/nix/modular/src/libmain/package.nix
@@ -6,6 +6,7 @@
 
   nix-util,
   nix-store,
+  nix-expr,
 
   # Configuration Options
 
@@ -18,11 +19,15 @@ mkMesonLibrary (finalAttrs: {
 
   workDir = ./.;
 
-  propagatedBuildInputs = [
-    nix-util
-    nix-store
-    openssl
-  ];
+  propagatedBuildInputs =
+    lib.optionals (lib.versionAtLeast version "2.28") [
+      nix-expr
+    ]
+    ++ [
+      nix-util
+      nix-store
+      openssl
+    ];
 
   meta = {
     platforms = lib.platforms.unix ++ lib.platforms.windows;


### PR DESCRIPTION
This includes an important fix that's not in a release yet, hence the "pre" version.

Addendum from Ericson2314: We've discussed for 25.05 going with the "monolithic build" for the main `nix_2_28`, but we want to land this right away to unblock preparing PRs to bump versions downstream.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
