### PR TITLE
selinux: fix various issues

### DIFF
--- a/pkgs/by-name/li/libselinux/package.nix
+++ b/pkgs/by-name/li/libselinux/package.nix
@@ -121,6 +121,11 @@ stdenv.mkDerivation (finalAttrs: {
 
   installTargets = [ "install" ] ++ lib.optional enablePython "install-pywrap";
 
+  preFixup = lib.optionalString enablePython ''
+    mv $out/${python3.sitePackages}/selinux/* $py/${python3.sitePackages}/selinux/
+    rm -rf $out/lib/python*
+  '';
+
   meta = removeAttrs libsepol.meta [ "outputsToInstall" ] // {
     description = "SELinux core library";
   };

--- a/pkgs/by-name/li/libsemanage/package.nix
+++ b/pkgs/by-name/li/libsemanage/package.nix
@@ -11,7 +11,7 @@
   audit,
   enablePython ? true,
   swig ? null,
-  python ? null,
+  python3 ? null,
 }:
 
 stdenv.mkDerivation rec {
@@ -39,7 +39,7 @@ stdenv.mkDerivation rec {
       pkg-config
     ]
     ++ lib.optionals enablePython [
-      python
+      python3
       swig
     ];
 
@@ -48,7 +48,7 @@ stdenv.mkDerivation rec {
     libselinux
     bzip2
     audit
-  ] ++ lib.optional enablePython python;
+  ] ++ lib.optional enablePython python3;
 
   makeFlags = [
     "PREFIX=$(out)"
@@ -57,7 +57,7 @@ stdenv.mkDerivation rec {
     "MAN5DIR=$(man)/share/man/man5"
     "PYTHON=python"
     "PYPREFIX=python"
-    "PYTHONLIBDIR=$(py)/${python.sitePackages}"
+    "PYTHONLIBDIR=$(py)/${python3.sitePackages}"
     "DEFAULT_SEMANAGE_CONF_LOCATION=$(out)/etc/selinux/semanage.conf"
   ];
 

--- a/pkgs/by-name/li/libsepol/package.nix
+++ b/pkgs/by-name/li/libsepol/package.nix
@@ -49,7 +49,10 @@ stdenv.mkDerivation rec {
     description = "SELinux binary policy manipulation library";
     homepage = "http://userspace.selinuxproject.org";
     platforms = platforms.linux;
-    maintainers = with maintainers; [ RossComputerGuy ];
+    maintainers = with maintainers; [
+      RossComputerGuy
+      numinit
+    ];
     license = lib.licenses.gpl2Plus;
     pkgConfigModules = [ "libselinux" ];
   };

--- a/pkgs/by-name/se/selinux-python/package.nix
+++ b/pkgs/by-name/se/selinux-python/package.nix
@@ -102,7 +102,10 @@ stdenv.mkDerivation (finalAttrs: {
     description = "SELinux policy core utilities written in Python";
     license = licenses.gpl2Plus;
     homepage = "https://selinuxproject.org";
-    maintainers = with lib.maintainers; [ RossComputerGuy ];
+    maintainers = with lib.maintainers; [
+      RossComputerGuy
+      numinit
+    ];
     platforms = platforms.linux;
   };
 })

--- a/pkgs/by-name/se/selinux-python/package.nix
+++ b/pkgs/by-name/se/selinux-python/package.nix
@@ -3,47 +3,67 @@
   stdenv,
   fetchurl,
   python3,
+  gettext,
   libselinux,
   libsemanage,
   libsepol,
   setools,
 }:
 
-# this is python3 only because setools only supports python3
-stdenv.mkDerivation rec {
+let
+  selinuxPython3 = python3.withPackages (
+    ps: with ps; [
+      pip
+      setuptools
+    ]
+  );
+in
+stdenv.mkDerivation (finalAttrs: {
   pname = "selinux-python";
-  version = "3.3";
+  version = "3.8.1";
 
   inherit (libsepol) se_url;
 
   src = fetchurl {
-    url = "${se_url}/${version}/selinux-python-${version}.tar.gz";
-    sha256 = "1v244hpb45my303793xa4kcn7qnxjgxn4ja7rdn9k1q361hi1nca";
+    url = "${finalAttrs.se_url}/${finalAttrs.version}/selinux-python-${finalAttrs.version}.tar.gz";
+    hash = "sha256-dJAlv6SqDgCb8//EVdVloY1Ntxz+eWvkQFghcXIGwlo=";
   };
 
   strictDeps = true;
 
   nativeBuildInputs = [
-    python3
-    python3.pkgs.distutils
+    selinuxPython3
     python3.pkgs.wrapPython
+    gettext
   ];
-  buildInputs = [ libsepol ];
-  propagatedBuildInputs = [
+
+  buildInputs = [
+    python3
+    libsepol
     libselinux
-    libsemanage
+  ];
+
+  pythonPath = [
+    python3.pkgs.libselinux.py
+    libsemanage.py
     setools
-    python3.pkgs.ipy
   ];
 
   postPatch = ''
-    substituteInPlace sepolicy/Makefile --replace "echo --root" "echo --prefix"
-    substituteInPlace sepolgen/src/share/Makefile --replace "/var/lib/sepolgen" \
-                                                            "\$PREFIX/var/lib/sepolgen"
+    # We would like to disable build isolation so we use the provided setuptools (this is part of a `pip install` command)
+    substituteInPlace sepolicy/Makefile --replace-fail 'echo --root' 'echo --no-build-isolation --root'
+
+    # Replace hardcoded paths.
+    substituteInPlace sepolgen/src/share/Makefile --replace-fail "/var/lib/sepolgen" \
+                                                            '$(PREFIX)/var/lib/sepolgen'
+    substituteInPlace po/Makefile --replace-fail "/usr/bin/install" "install"
   '';
 
   makeFlags = [
     "PREFIX=$(out)"
+    # This makes pip successfully install it (note the test -n "$(DESTDIR)" nonsense)
+    # https://github.com/SELinuxProject/selinux/blob/d1e3170556e1023e07b3c071ce89543ead6ba6f8/python/sepolicy/Makefile#L30
+    "DESTDIR=/"
     "LOCALEDIR=$(out)/share/locale"
     "BASHCOMPLETIONDIR=$(out)/share/bash-completion/completions"
     "PYTHON=python"
@@ -51,8 +71,31 @@ stdenv.mkDerivation rec {
     "LIBSEPOLA=${lib.getLib libsepol}/lib/libsepol.a"
   ];
 
+  preFixup = ''
+    patchShebangs --host $out/bin/*
+  '';
+
   postFixup = ''
     wrapPythonPrograms
+  '';
+
+  doInstallCheck = true;
+
+  installCheckPhase = ''
+    # Version hasn't changed in 17 years, if it suddenly does these tests deserve to break
+    $out/bin/audit2allow --version | grep -Fm1 'audit2allow .1'
+    $out/bin/audit2why --version | grep -Fm1 'audit2allow .1'
+    $out/bin/sepolgen-ifgen --version | grep -Fm1 'sepolgen-ifgen .1'
+
+    # "chcat: Requires a mls enabled system" or help, which includes chcat
+    { $out/bin/chcat --help || true; } | grep -Fm1 'chcat'
+
+    $out/bin/semanage --help | grep -Fm1 'semanage'
+    $out/bin/sepolgen --help | grep -Fm1 'sepolicy'
+    $out/bin/sepolicy --help | grep -Fm1 'sepolicy'
+
+    # Should at least run, even if we can't provide it a policy file and need to provide /dev/zero
+    { $out/bin/sepolgen-ifgen-attr-helper test /dev/null 2>&1 || true; } | grep -Fm1 'error(s) encountered' >/dev/null
   '';
 
   meta = with lib; {
@@ -62,4 +105,4 @@ stdenv.mkDerivation rec {
     maintainers = with lib.maintainers; [ RossComputerGuy ];
     platforms = platforms.linux;
   };
-}
+})

--- a/pkgs/os-specific/linux/libsemanage/default.nix
+++ b/pkgs/os-specific/linux/libsemanage/default.nix
@@ -32,11 +32,17 @@ stdenv.mkDerivation rec {
 
   strictDeps = true;
 
-  nativeBuildInputs = [
-    bison
-    flex
-    pkg-config
-  ] ++ lib.optional enablePython swig;
+  nativeBuildInputs =
+    [
+      bison
+      flex
+      pkg-config
+    ]
+    ++ lib.optionals enablePython [
+      python
+      swig
+    ];
+
   buildInputs = [
     libsepol
     libselinux

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13040,10 +13040,6 @@ with pkgs;
 
   cryptodev = linuxPackages.cryptodev;
 
-  libsemanage = callPackage ../os-specific/linux/libsemanage {
-    python = python3;
-  };
-
   librasterlite2 = callPackage ../development/libraries/librasterlite2 {
     inherit (darwin.apple_sdk.frameworks) ApplicationServices;
   };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Resurrect an old branch to correct a handful of issues with the selinux utils in nixpkgs:

- Python output of libselinux was not in the correct split output
- libsemanage Python native library name was wrong
- selinux-python was woefully out of date and also broken in multiple exciting ways
- libsemanage wasn't in by-name, and had python2 overridden to python3 (no one could have been using it in general before now, but especially with python2)
- Add install checks for all selinux-python utils

To test, recommend building the attribute `selinux-python`.

cc (and paired with) @RossComputerGuy - we figured that these changes are fairly unambiguously fixing things so fastlined them into staging

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
