### PR TITLE
lib/options: introduce mkSubmoduleAttrsOption

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -493,6 +493,7 @@ let
         mkOption
         mkPackageOption
         mkPackageOptionMD
+        mkSubmoduleAttrsOption
         literalMD
         ;
       inherit (self.types)

--- a/lib/options.nix
+++ b/lib/options.nix
@@ -26,6 +26,7 @@ let
     optional
     optionals
     take
+    types
     ;
   inherit (lib.attrsets)
     attrByPath
@@ -344,6 +345,19 @@ rec {
     Previously used to create options with markdown documentation, which is no longer required.
   */
   mkPackageOptionMD = lib.warn "mkPackageOptionMD is deprecated and will be removed in 25.05; please use mkPackageOption." mkPackageOption;
+
+  /**
+    Make an option with `attrsOf (submodule submodule)` as its type.
+
+    This can reduce levels of parenthesis nesting significantly when
+    writing a module that supports multiple instances of some
+    component.
+  */
+  mkSubmoduleAttrsOption =
+    submodule:
+    mkOption {
+      type = types.attrsOf (types.submodule submodule);
+    };
 
   /**
     This option accepts arbitrary definitions, but it does not produce an option value.


### PR DESCRIPTION
This usage pattern is fairly common for implementing multi-instance structured objects in the module system:

mkOption { type = attrsOf (submodule foo); }

but results in many layers of nested parentheses and can be confusing to read, especially if RFC-style nixfmt is in use.

Using this function instead allows fewer levels of nested parentheses and indentation, reducing the amount of perceptual overhead needed to write a module (where do I have to put which closing parenthesis? And where do the semicolons go?) as well as the visual noise when reading them.

A common workaround in existing modules is to extract the options or the whole submodule into a let binding, but this detaches the structure of the option definitions from that of the corresponding config, so reading the code for a module involves much more jumping around.

cc @adisbladis

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
