### PR TITLE
inter-alia: init at 0-unstable-2024-01-12

### DIFF
--- a/pkgs/by-name/in/inter-alia/package.nix
+++ b/pkgs/by-name/in/inter-alia/package.nix
@@ -1,0 +1,54 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchFromGitHub,
+}:
+
+stdenvNoCC.mkDerivation {
+  pname = "inter-alia";
+  version = "0-unstable-2024-01-12";
+
+  src = fetchFromGitHub {
+    owner = "Shavian-info";
+    repo = "interalia";
+    rev = "5d182c4eb5511fec3879646c8b44c79ba338d53e";
+    hash = "sha256-q93cCrbKc72CH/2ybJPDY5wkUZvFyCKoyQe6WhL+kAU=";
+  };
+
+  outputs = [
+    "out"
+    "web"
+    "variable"
+    "variableweb"
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    install -D -m444 -t $out/share/fonts/opentype instance_otf/*.otf
+    install -D -m444 -t $out/share/fonts/truetype instance_ttf/*.ttf
+    install -D -m444 -t $web/share/fonts/webfont instance_woff2/*.woff2
+    install -D -m444 -t $variable/share/fonts/opentype variable_otf/*.otf
+    install -D -m444 -t $variable/share/fonts/truetype variable_ttf/*.ttf
+    install -D -m444 -t $variableweb/share/fonts/webfont variable_woff2/*.woff2
+
+    runHook postInstall
+  '';
+
+  meta = {
+    homepage = "https://shavian.info/shavian_fonts/";
+    description = "Expansion of Inter typeface to support the Shavian alphabet, old-style figures, & refinements to IPA glyphs";
+    longDescription = ''
+          Inter Alia is an expanded version of Rasmus Andersson's beautiful open source sans serif typeface, Inter. Inter was specially designed for user interfaces with focus on high legibility of small-to-medium sized text on computer screens.
+
+      Inter Alia builds on the features of Inter to add:
+
+          support for the Shavian alphabet with a newly designed set of glyphs, including the letters missing from Unicode (through character variants accessed by inserting 'Variation Selector 1' (U+FE00) after 𐑒, 𐑜, 𐑢, 𐑤, 𐑻, and 𐑺)
+          support for old-style figures or numerals, also known as text figures, with both proportional and tabular spacing
+          refinements to International Phonetic Alphabet glyphs and other less common glyphs.
+    '';
+    license = lib.licenses.ofl;
+    platforms = lib.platforms.all;
+    maintainers = with lib.maintainers; [ toastal ];
+  };
+}


### PR DESCRIPTION
There are tags in the repo but it doesn’t seem to follow a conventional scheme & is 2 years older than latest on-going commits


<!--
^ Please summarize the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

[^1]

[^1]: Please consider [giving up MS GitHub](https://sfconservancy.org/GiveUpGitHub/) or offering a non-proprietary, non-US-corporate-controlled mirror for this free software project. I wish to delete this Microsoft account in the future, but I need more projects like this to support alternative methods to send patches & contribute.