### PR TITLE
tpm2-pkcs11: fix fapi configure option; init tpm2-pkcs11-{fapi,esapi}

### DIFF
--- a/doc/release-notes/rl-2505.section.md
+++ b/doc/release-notes/rl-2505.section.md
@@ -325,6 +325,8 @@
 
 - GOverlay has been updated to 1.2, please check the [upstream changelog](https://github.com/benjamimgois/goverlay/releases) for more details.
 
+- `tpm2-pkcs11` now has the variant `tpm2-pkcs11-fapi`, which has been patched to default to the Feature API backend. It has also been split into `tpm2-pkcs11-esapi`, which _only_ supports the older Enhanced System API backend. Note the [differences](https://github.com/tpm2-software/tpm2-pkcs11/blob/1.9.1/docs/FAPI.md), and that `tpm2-pkcs11` itself still needs `TPM2_PKCS11_BACKEND=fapi` exported in order to use the Feature API, whereas `tpm2-pkcs11-fapi` does not, and `tpm2-pkcs11-esapi` just does not support fapi entirely.
+
 - For matrix homeserver Synapse we are now following the upstream recommendation to enable jemalloc as the memory allocator by default.
 
 - In `dovecot` package removed hard coding path to module directory.

--- a/pkgs/by-name/tp/tpm2-pkcs11-esapi/package.nix
+++ b/pkgs/by-name/tp/tpm2-pkcs11-esapi/package.nix
@@ -1,0 +1,12 @@
+{
+  tpm2-pkcs11,
+  ...
+}@args:
+
+tpm2-pkcs11.override (
+  args
+  // {
+    fapiSupport = false;
+    extraDescription = "Disables FAPI support, as if TPM2_PKCS11_BACKEND were always set to 'esysdb'.";
+  }
+)

--- a/pkgs/by-name/tp/tpm2-pkcs11-fapi/package.nix
+++ b/pkgs/by-name/tp/tpm2-pkcs11-fapi/package.nix
@@ -1,0 +1,13 @@
+{
+  tpm2-pkcs11,
+  ...
+}@args:
+
+tpm2-pkcs11.override (
+  args
+  // {
+    fapiSupport = true;
+    defaultToFapi = true;
+    extraDescription = "Enables fapi by default, as if TPM2_PKCS11_BACKEND defaulted to 'fapi'.";
+  }
+)

--- a/pkgs/by-name/tp/tpm2-pkcs11/default-to-fapi.patch
+++ b/pkgs/by-name/tp/tpm2-pkcs11/default-to-fapi.patch
@@ -1,0 +1,33 @@
+From 648f0d08953152185e13feaca4feda02f8665341 Mon Sep 17 00:00:00 2001
+From: Morgan Jones <me@numin.it>
+Date: Wed, 9 Apr 2025 00:12:47 -0700
+Subject: [PATCH] backend: default to fapi
+
+---
+ src/lib/backend.c | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/src/lib/backend.c b/src/lib/backend.c
+index 128f58b..8404afe 100644
+--- a/src/lib/backend.c
++++ b/src/lib/backend.c
+@@ -15,12 +15,12 @@ static enum backend get_backend(void) {
+ 
+     const char *env = getenv("TPM2_PKCS11_BACKEND");
+ 
+-    if (!env || !strcasecmp(env, "esysdb")) {
+-        return backend_esysdb;
++    if (!env || !strcasecmp(env, "fapi")) {
++        return backend_fapi;
+     }
+ 
+-    if (!strcasecmp(env, "fapi")) {
+-        return backend_fapi;
++    if (!strcasecmp(env, "esysdb")) {
++        return backend_esysdb;
+     }
+ 
+     return backend_error;
+-- 
+2.47.0
+

--- a/pkgs/by-name/tp/tpm2-pkcs11/package.nix
+++ b/pkgs/by-name/tp/tpm2-pkcs11/package.nix
@@ -26,14 +26,18 @@
   swtpm,
   tpm2-abrmd,
   tpm2-openssl,
-  tpm2-pkcs11, # for passthru abrmd tests
+  tpm2-pkcs11, # for passthru tests
+  tpm2-pkcs11-esapi,
+  tpm2-pkcs11-fapi,
   tpm2-tools,
   tpm2-tss,
   which,
   xxd,
   abrmdSupport ? false,
   fapiSupport ? true,
+  defaultToFapi ? false,
   enableFuzzing ? false,
+  extraDescription ? null,
 }:
 
 let
@@ -51,7 +55,9 @@ chosenStdenv.mkDerivation (finalAttrs: {
   };
 
   # Disable Java‐based tests because of missing dependencies
-  patches = [ ./disable-java-integration.patch ];
+  patches =
+    lib.singleton ./disable-java-integration.patch
+    ++ lib.optional defaultToFapi ./default-to-fapi.patch;
 
   postPatch = ''
     echo ${lib.escapeShellArg finalAttrs.version} >VERSION
@@ -80,12 +86,14 @@ chosenStdenv.mkDerivation (finalAttrs: {
     [
       (lib.enableFeature finalAttrs.doCheck "unit")
       (lib.enableFeature finalAttrs.doCheck "integration")
+
+      # Strangely, it uses --with-fapi=yes|no instead of a normal configure flag.
+      "--with-fapi=${if fapiSupport then "yes" else "no"}"
     ]
     ++ lib.optionals enableFuzzing [
       "--enable-fuzzing"
       "--disable-hardening"
-    ]
-    ++ lib.optional fapiSupport "--with-fapi";
+    ];
 
   strictDeps = true;
 
@@ -178,6 +186,10 @@ chosenStdenv.mkDerivation (finalAttrs: {
 
       # Enable tests to load TPM2 OpenSSL module
       export OPENSSL_MODULES="${openssl-modules}/lib/ossl-modules"
+    ''
+    + lib.optionalString defaultToFapi ''
+      # Need to change the default since the tests expect the other way.
+      export TPM2_PKCS11_BACKEND=esysdb
     '';
 
   postInstall = ''
@@ -211,13 +223,24 @@ chosenStdenv.mkDerivation (finalAttrs: {
     '';
 
   passthru = {
-    tests.tpm2-pkcs11-abrmd = tpm2-pkcs11.override {
-      abrmdSupport = true;
+    tests = {
+      inherit tpm2-pkcs11-esapi tpm2-pkcs11-fapi;
+      tpm2-pkcs11-abrmd = tpm2-pkcs11.override {
+        abrmdSupport = true;
+      };
+      tpm2-pkcs11-esapi-abrmd = tpm2-pkcs11-esapi.override {
+        abrmdSupport = true;
+      };
+      tpm2-pkcs11-fapi-abrmd = tpm2-pkcs11-fapi.override {
+        abrmdSupport = true;
+      };
     };
   };
 
   meta = {
-    description = "PKCS#11 interface for TPM2 hardware";
+    description =
+      "PKCS#11 interface for TPM2 hardware."
+      + lib.optionalString (extraDescription != null) " ${extraDescription}";
     homepage = "https://github.com/tpm2-software/tpm2-pkcs11";
     license = lib.licenses.bsd2;
     platforms = lib.platforms.linux;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

tpm2-pkcs11: fix fapi configure option; split tpm2-pkcs11-{esapi,fapi}
    
Per documentation at: https://github.com/tpm2-software/tpm2-pkcs11/blob/master/docs/FAPI.md the ESAPI support for tpm2-pkcs11 creates a fundamentally different package, so split it into two new attributes: tpm2-pkcs11-esapi and tpm2-pkcs11-fapi.

The existing package is unchanged, supporting both FAPI and esysdb, and also requiring TPM2_PKCS11_BACKEND=fapi to be exported to use FAPI.

The tpm2-pkcs11-esapi attribute has fapi support compiled out and uses esysdb all the time.
    
The tpm2-pkcs11-fapi attribute takes the extra step of applying a patch that causes tpm2-pkcs11 to default to using FAPI, without needing to export TPM2_PKCS11_BACKEND=fapi. However, TPM2_PKCS11_BACKEND=esysdb can still be exported and will work.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
