### PR TITLE
androidenv: fix weird package naming and add versions

### DIFF
--- a/doc/release-notes/rl-2505.section.md
+++ b/doc/release-notes/rl-2505.section.md
@@ -327,6 +327,11 @@
 
 - `titaniumenv`, `titanium`, and `titanium-alloy` have been removed due to lack of maintenance in Nixpkgs []{#sec-nixpkgs-release-25.05-incompatibilities-titanium-removed}.
 
+- androidenv has been improved:
+  - All versions specified in composeAndroidPackages now track the latest. Android packages are automatically updated on unstable, and run the androidenv test suite on every update.
+  - Many androidenv packages are now searchable on [search.nixos.org](https://search.nixos.org).
+  - We now use the latest Google repositories, which should improve aarch64-darwin compatibility. The SDK now additionally evaluates on aarch64-linux, though not all packages are functional.
+
 - `gerbera` now has wavpack support.
 
 - GOverlay has been updated to 1.2, please check the [upstream changelog](https://github.com/benjamimgois/goverlay/releases) for more details.

--- a/nixos/doc/manual/release-notes/rl-2505.section.md
+++ b/nixos/doc/manual/release-notes/rl-2505.section.md
@@ -34,11 +34,6 @@
   - A new `pkgs.mattermost.buildPlugin` function has been added, which allows plugins to be built from source, including webapp frontends with a supported package-lock.json. See the Mattermost NixOS test and [manual](https://nixos.org/manual/nixpkgs/unstable/#sec-mattermost-plugins-build) for an example.
   - Note that the Mattermost module will create an account _without_ a well-known UID if the username differs from the default (`mattermost`). If you used Mattermost with a nonstandard username, you may want to review the module changes before upgrading.
 
-- androidenv has been updated:
-  - All versions specified in composeAndroidPackages now track latest. Android packages are automatically updated on unstable, and run the androidenv test suite on every update.
-  - Some androidenv packages are now searchable on [search.nixos.org](https://search.nixos.org).
-  - We now use the latest Google repositories, which should improve aarch64-darwin compatibility. The SDK now additionally evaluates on aarch64-linux, though not all packages are functional.
-
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
 
 ## New Modules {#sec-release-25.05-new-modules}

--- a/pkgs/development/mobile/androidenv/compose-android-packages.nix
+++ b/pkgs/development/mobile/androidenv/compose-android-packages.nix
@@ -257,14 +257,19 @@ let
     ++ extraLicenses
   );
 
-  # put a much nicer error message that includes the available options.
-  check-version =
+  # Returns true if the given version exists.
+  hasVersion =
     packages: package: version:
-    if lib.hasAttrByPath [ package version ] packages then
-      packages.${package}.${version}
+    lib.hasAttrByPath [ package (toString version) ] packages;
+
+  # Displays a nice error message that includes the available options if a version doesn't exist.
+  checkVersion =
+    packages: package: version:
+    if hasVersion packages package version then
+      packages.${package}.${toString version}
     else
       throw ''
-        The version ${version} is missing in package ${package}.
+        The version ${toString version} is missing in package ${package}.
         The only available versions are ${
           builtins.concatStringsSep ", " (builtins.attrNames packages.${package})
         }.
@@ -415,7 +420,7 @@ lib.recurseIntoAttrs rec {
       arch
       meta
       ;
-    package = check-version allArchives.packages "platform-tools" platformToolsVersion;
+    package = checkVersion allArchives.packages "platform-tools" platformToolsVersion;
   };
 
   tools = callPackage ./tools.nix {
@@ -425,7 +430,7 @@ lib.recurseIntoAttrs rec {
       arch
       meta
       ;
-    package = check-version allArchives.packages "tools" toolsVersion;
+    package = checkVersion allArchives.packages "tools" toolsVersion;
 
     postInstall = ''
       ${linkPlugin {
@@ -449,7 +454,7 @@ lib.recurseIntoAttrs rec {
         arch
         meta
         ;
-      package = check-version allArchives.packages "build-tools" version;
+      package = checkVersion allArchives.packages "build-tools" version;
 
       postInstall = ''
         ${linkPlugin {
@@ -468,7 +473,7 @@ lib.recurseIntoAttrs rec {
       arch
       meta
       ;
-    package = check-version allArchives.packages "emulator" emulatorVersion;
+    package = checkVersion allArchives.packages "emulator" emulatorVersion;
 
     postInstall = ''
       ${linkSystemImages {
@@ -483,14 +488,14 @@ lib.recurseIntoAttrs rec {
   platforms = map (
     version:
     deployAndroidPackage {
-      package = check-version allArchives.packages "platforms" (toString version);
+      package = checkVersion allArchives.packages "platforms" version;
     }
   ) platformVersions;
 
   sources = map (
     version:
     deployAndroidPackage {
-      package = check-version allArchives.packages "sources" (toString version);
+      package = checkVersion allArchives.packages "sources" version;
     }
   ) platformVersions;
 
@@ -545,7 +550,7 @@ lib.recurseIntoAttrs rec {
         arch
         meta
         ;
-      package = check-version allArchives.packages "cmake" version;
+      package = checkVersion allArchives.packages "cmake" version;
     }
   ) cmakeVersions;
 
@@ -581,27 +586,23 @@ lib.recurseIntoAttrs rec {
   # The "default" NDK bundle.
   ndk-bundle = if ndk-bundles == [ ] then null else lib.head ndk-bundles;
 
-  # Makes a Google API bundle.
-  google-apis =
-    map
-      (
-        version:
-        deployAndroidPackage {
-          package = (check-version allArchives "addons" (toString version)).google_apis;
-        }
-      )
-      (
-        builtins.filter (platformVersion: lib.versionOlder (toString platformVersion) "26") platformVersions
-      ); # API level 26 and higher include Google APIs by default
+  # Makes a Google API bundle from supported versions.
+  google-apis = map (
+    version:
+    deployAndroidPackage {
+      package = (checkVersion allArchives "addons" version).google_apis;
+    }
+  ) (lib.filter (hasVersion allArchives "addons") platformVersions);
 
+  # Makes a Google TV addons bundle from supported versions.
   google-tv-addons = map (
     version:
     deployAndroidPackage {
-      package = (check-version allArchives "addons" (toString version)).google_tv_addon;
+      package = (checkVersion allArchives "addons" version).google_tv_addon;
     }
-  ) platformVersions;
+  ) (lib.filter (hasVersion allArchives "addons") platformVersions);
 
-  cmdline-tools-package = check-version allArchives.packages "cmdline-tools" cmdLineToolsVersion;
+  cmdline-tools-package = checkVersion allArchives.packages "cmdline-tools" cmdLineToolsVersion;
 
   # This derivation deploys the tools package and symlinks all the desired
   # plugins that we want to use. If the license isn't accepted, prints all the licenses

--- a/pkgs/development/mobile/androidenv/examples/shell.nix
+++ b/pkgs/development/mobile/androidenv/examples/shell.nix
@@ -51,6 +51,7 @@ let
     includeEmulator = "if-supported";
     includeNDK = "if-supported";
     useGoogleAPIs = true;
+    useGoogleTVAddOns = true;
 
     # Make sure everything from the last decade works since we are not using system images.
     numLatestPlatformVersions = 10;


### PR DESCRIPTION
Some of the system images and NDK packages looked like: `androidenv.androidPkgs.all.system_images.v35.google_apis_playstore.x_86___64`. `androidenv.androidPkgs.all.packages.ndk.v21_0_6011959_rc_2`

Now they look like:
`androidenv.androidPkgs.all.system-images.v35.google_apis_playstore.x86_64`. `androidenv.androidPkgs.all.packages.ndk.v21_0_6011959-rc2`

They should also have the versions correctly attached now for s.n.o.

Closes #397610.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
