### PR TITLE
python3Packages.pypdfium2: fix cross, reduce closure size

### DIFF
--- a/pkgs/development/python-modules/pypdfium2/fix-cc-detection.patch
+++ b/pkgs/development/python-modules/pypdfium2/fix-cc-detection.patch
@@ -1,0 +1,25 @@
+diff --git a/src/ctypesgen/__main__.py b/src/ctypesgen/__main__.py
+index 23ee014..2d0cfc1 100644
+--- a/src/ctypesgen/__main__.py
++++ b/src/ctypesgen/__main__.py
+@@ -89,17 +89,9 @@ def main_impl(args, cmd_str):
+         assert _is_relative_to(args.output, args.linkage_anchor)
+     
+     if args.cpp:
+-        assert shutil.which(args.cpp[0]), f"Given pre-processor {args.cpp[0]!r} is not available."
+-    else:
+-        if shutil.which("gcc"):
+-            args.cpp = ["gcc", "-E"]
+-        elif shutil.which("cpp"):
+-            args.cpp = ["cpp"]
+-        elif shutil.which("clang"):
+-            args.cpp = ["clang", "-E"]
+-        else:
+-            raise RuntimeError("C pre-processor auto-detection failed: neither gcc nor clang available.")
+-    
++        print("cpp argument ignored for nix build")
++    args.cpp = ["@cc@", "-E"]
++ 
+     # Important: must not use +=, this would mutate the original object, which is problematic when default=[] is used and ctypesgen called repeatedly from within python
+     args.compile_libdirs = args.compile_libdirs + args.universal_libdirs
+     args.runtime_libdirs = args.runtime_libdirs + args.universal_libdirs


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux (cross)
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).