### PR TITLE
hubble: fix cross build, re-enable tests, misc. cleanup

### DIFF
--- a/pkgs/by-name/hu/hubble/package.nix
+++ b/pkgs/by-name/hu/hubble/package.nix
@@ -1,4 +1,5 @@
 {
+  stdenv,
   lib,
   buildGo124Module,
   fetchFromGitHub,
@@ -19,7 +20,6 @@ buildGo124Module rec {
 
   nativeBuildInputs = [
     installShellFiles
-    versionCheckHook
   ];
 
   vendorHash = null;
@@ -32,27 +32,25 @@ buildGo124Module rec {
     "-X=github.com/cilium/cilium/hubble/pkg.Version=${version}"
   ];
 
-  # Test fails at Test_getFlowsRequestWithInvalidRawFilters in github.com/cilium/hubble/cmd/observe
-  # https://github.com/NixOS/nixpkgs/issues/178976
-  # https://github.com/cilium/hubble/pull/656
-  # https://github.com/cilium/hubble/pull/655
-  doCheck = false;
+  doCheck = true;
 
   doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgramArg = "version";
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd hubble \
       --bash <($out/bin/hubble completion bash) \
       --fish <($out/bin/hubble completion fish) \
       --zsh <($out/bin/hubble completion zsh)
   '';
 
-  meta = with lib; {
+  meta = {
     description = "Network, Service & Security Observability for Kubernetes using eBPF";
     homepage = "https://github.com/cilium/hubble/";
-    changelog = "https://github.com/cilium/hubble/releases/tag/${src.tag}";
-    license = licenses.asl20;
-    maintainers = with maintainers; [
+    changelog = "https://github.com/cilium/hubble/blob/${src.tag}/CHANGELOG.md";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [
       humancalico
       bryanasdev000
       FKouhai


### PR DESCRIPTION
Completion generation only works for native builds. #308283
Tests seem to work, linked PRs have been merged.
Changelog link changed to point to *full* changelog up to that version.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux (cross)
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).