### PR TITLE
Yewtube needs httpx less than 0.28

### DIFF
--- a/pkgs/by-name/ye/yewtube/package.nix
+++ b/pkgs/by-name/ye/yewtube/package.nix
@@ -1,10 +1,27 @@
 {
   lib,
-  python3Packages,
+  python3,
   fetchFromGitHub,
+  fetchPypi,
 }:
 
-python3Packages.buildPythonApplication rec {
+let
+  python = python3.override {
+    packageOverrides = self: super: {
+      # yewtube currently does not support httpx>=0.28.0, see:
+      # https://github.com/mps-youtube/yewtube/issues/1303
+      httpx = super.httpx.overridePythonAttrs rec {
+        version = "0.27.2";
+        src = fetchPypi {
+          pname = "httpx";
+          inherit version;
+          hash = "sha256-98K+HS88PDFg1EGAJAayBsK3b1lHsREV5t8QxsZeZsI=";
+        };
+      };
+    };
+  };
+in
+python.pkgs.buildPythonApplication rec {
   pname = "yewtube";
   version = "2.12.1";
 
@@ -22,7 +39,7 @@ python3Packages.buildPythonApplication rec {
       --replace "__version__ =" "__version__ = '${version}' #"
   '';
 
-  propagatedBuildInputs = with python3Packages; [
+  propagatedBuildInputs = with python.pkgs; [
     pyperclip
     requests
     youtube-search-python
@@ -30,7 +47,7 @@ python3Packages.buildPythonApplication rec {
     pylast
   ];
 
-  checkInputs = with python3Packages; [
+  checkInputs = with python.pkgs; [
     pytestCheckHook
     dbus-python
     pygobject3


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Hello,

Currently `yewtube` does not support `httpx>=0.28.0`, see:
https://github.com/NixOS/nixpkgs/issues/394572

These changes ensure that `http=0.27.2` is used in order to work around this issue.

I am new to Python packages overriding, so if I am doing it wrong, please advise.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
