### PR TITLE
xivlauncher: init module, add gamemode support

### DIFF
--- a/doc/release-notes/rl-2505.section.md
+++ b/doc/release-notes/rl-2505.section.md
@@ -326,6 +326,8 @@
 
 - `ddclient` was updated from 3.11.2 to 4.0.0 [Release notes](https://github.com/ddclient/ddclient/releases/tag/v4.0.0)
 
+- `xivlauncher` is now available as a module that can be enabled with `programs.xivlauncher.enable`. This will enable GameMode support within XIVLauncher if GameMode is enabled system-wide.
+
 ### NexusMods.App upgraded {#sec-nixpkgs-release-25.05-incompatibilities-nexusmods-app-upgraded}
 
 - `nexusmods-app` has been upgraded from version 0.6.3 to 0.8.3.

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -342,6 +342,7 @@
   ./programs/winbox.nix
   ./programs/wireshark.nix
   ./programs/xastir.nix
+  ./programs/xivlauncher.nix
   ./programs/wshowkeys.nix
   ./programs/xfconf.nix
   ./programs/xfs_quota.nix

--- a/nixos/modules/programs/xivlauncher.nix
+++ b/nixos/modules/programs/xivlauncher.nix
@@ -10,10 +10,19 @@ in
 {
   options.programs.xivlauncher = {
     enable = lib.mkEnableOption "Custom launcher for FFXIV";
+
+    enableGameMode = lib.mkOption {
+      type = lib.types.bool;
+      default = config.programs.gamemode.enable;
+      defaultText = lib.literalExpression "config.programs.gamemode.enable";
+      description = ''
+        Whether to enable GameMode to optimise system performance on demand.
+      '';
+    };
   };
 
   config = lib.mkIf cfg.enable {
-    environment.systemPackages = [ pkgs.xivlauncher ];
+    environment.systemPackages = [ (pkgs.xivlauncher.override { useGameMode = cfg.enableGameMode; }) ];
   };
 
   meta.maintainers = with lib.maintainers; [

--- a/nixos/modules/programs/xivlauncher.nix
+++ b/nixos/modules/programs/xivlauncher.nix
@@ -1,0 +1,24 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.programs.xivlauncher;
+in
+{
+  options.programs.xivlauncher = {
+    enable = lib.mkEnableOption "Custom launcher for FFXIV";
+  };
+
+  config = lib.mkIf cfg.enable {
+    environment.systemPackages = [ pkgs.xivlauncher ];
+  };
+
+  meta.maintainers = with lib.maintainers; [
+    sersorrel
+    witchof0x20
+    drakon64
+  ];
+}

--- a/pkgs/by-name/xi/xivlauncher/package.nix
+++ b/pkgs/by-name/xi/xivlauncher/package.nix
@@ -14,6 +14,7 @@
   makeDesktopItem,
   makeWrapper,
   useSteamRun ? true,
+  useGameMode ? false,
 }:
 
 let
@@ -72,7 +73,7 @@ buildDotnetModule rec {
       let
         steam-run =
           (steam.override {
-            extraPkgs = pkgs: [ pkgs.libunwind ];
+            extraPkgs = pkgs: [ pkgs.libunwind ] ++ lib.optional useGameMode pkgs.gamemode;
             extraProfile = ''
               unset TZ
             '';


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Add a module for XIVLauncher for enabling GameMode support.

This will also be useful in the event that NixOS DLSS support is ever merged into upstream XIVLauncher as this also requires overriding the package to work.

Fixes https://github.com/NixOS/nixpkgs/issues/317406.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
