### PR TITLE
nexusmods-app: 0.8.3 -> 0.9.2

### DIFF
--- a/doc/release-notes/rl-2505.section.md
+++ b/doc/release-notes/rl-2505.section.md
@@ -328,7 +328,7 @@
 
 ### NexusMods.App upgraded {#sec-nixpkgs-release-25.05-incompatibilities-nexusmods-app-upgraded}
 
-- `nexusmods-app` has been upgraded from version 0.6.3 to 0.8.3.
+- `nexusmods-app` has been upgraded from version 0.6.3 to 0.9.2.
 
   - Before upgrading, you **must reset all app state** (mods, games, settings, etc). NexusMods.App will crash if any state from a version older than 0.7.0 is still present.
 

--- a/pkgs/by-name/ne/nexusmods-app/deps.json
+++ b/pkgs/by-name/ne/nexusmods-app/deps.json
@@ -1606,8 +1606,8 @@
   },
   {
     "pname": "NexusMods.Archives.Nx",
-    "version": "0.6.3",
-    "hash": "sha256-E4bOexmmPqMJoXs2gDAhgierGAFyc2JVrP3HBn3KAXs="
+    "version": "0.6.4",
+    "hash": "sha256-jDOCZ6VWPqcKE6gqqAdkyLL3G2g6pbG78mpMRhgYx2o="
   },
   {
     "pname": "NexusMods.Hashing.xxHash3",

--- a/pkgs/by-name/ne/nexusmods-app/package.nix
+++ b/pkgs/by-name/ne/nexusmods-app/package.nix
@@ -24,12 +24,12 @@ let
 in
 buildDotnetModule (finalAttrs: {
   inherit pname;
-  version = "0.8.3";
+  version = "0.9.2";
 
   src = fetchgit {
     url = "https://github.com/Nexus-Mods/NexusMods.App.git";
     rev = "refs/tags/v${finalAttrs.version}";
-    hash = "sha256-b6Tpwy0DepbT80+Jil8celeiNN3W+5prt57NjgLD+u0=";
+    hash = "sha256-Xb/i25l0jLn87OeouD0+CRv11d8aOn7Sr69z3TkS6I4=";
     fetchSubmodules = true;
     fetchLFS = true;
   };
@@ -65,12 +65,6 @@ buildDotnetModule (finalAttrs: {
   postPatch = ''
     # for some reason these tests fail (intermittently?) with a zero timestamp
     touch tests/NexusMods.UI.Tests/WorkspaceSystem/*.verified.png
-
-    # Bump StrawberryShake so we can drop .NET 8
-    # See https://github.com/Nexus-Mods/NexusMods.App/pull/2830
-    substituteInPlace Directory.Packages.props \
-      --replace-fail 'Include="StrawberryShake.Server" Version="14.1.0"' \
-                     'Include="StrawberryShake.Server" Version="15.0.3"'
   '';
 
   makeWrapperArgs = [


### PR DESCRIPTION


- Bump version: 0.8.3 -> 0.9.2
- Upstream changelogs:
  - [0.9.1](https://github.com/Nexus-Mods/NexusMods.App/releases/tag/v0.9.1)
  - [0.9.2](https://github.com/Nexus-Mods/NexusMods.App/releases/tag/v0.9.2)
- [Previous update PR](https://github.com/NixOS/nixpkgs/pull/392764)

## Notes for end-users

> [!NOTE]
> Since 0.8.2, all games except Stardew Valley have been moved behind the "Unsupported Games" flag in Settings. If you were modding any other games in a previous release, you will need to enable this option to continue managing your mods.

> [!TIP]
> When upgrading from version 0.7.0 or newer, it _should_ be safe to upgrade **without** resetting/uninstalling.

> [!CAUTION]
> When upgrading from a **version older than 0.7.0**, you will need a fresh start.
> If you have configuration leftover from an old version, the updated app will crash.
>
> See upstream's guide on [how to uninstall the app](https://nexus-mods.github.io/NexusMods.App/users/Uninstall).

<details><summary>Resetting tips</summary>
<p>

You can reset all modded games and wipe your nexusmods-app config using:
```
NexusMods.App uninstall-app
```
- This should be done **before** updating the app.
- **Be careful**: There's no way to recover a wiped config!

If you've run the appimage version from upstream, or a pre-0.6 nixpkgs version, you may also need to remove old desktop entries to avoid other issues:
```
rm ~/.local/share/applications/com.nexusmods.app.desktop
```

</p>
</details>

> [!CAUTION]
> Known issues are listed in the changelogs ([0.9.1](https://github.com/Nexus-Mods/NexusMods.App/releases/tag/v0.9.1), [0.9.2](https://github.com/Nexus-Mods/NexusMods.App/releases/tag/v0.9.2)), but include:
> - The sort order for some columns does not work as expected.
> - The game version is not checked when adding a collection, meaning you can install outdated mods without being warned.
> - The table header sorting and active tab states are not saved and are reset each time the view is loaded.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
- [ ] Tested, as applicable:
  - [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [x] (Package updates) Updated existing a release notes entry
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
