### PR TITLE
centrifugo: 5.4.9 -> 6.1.0

### DIFF
--- a/doc/release-notes/rl-2505.section.md
+++ b/doc/release-notes/rl-2505.section.md
@@ -110,6 +110,8 @@
 
 - `pkgs.nextcloud28` has been removed since it's out of support upstream.
 
+- `centrifugo` was updated to v6, which uses a new config format. See [upstream documentation](https://centrifugal.dev/docs/getting-started/migration_v6) for migration.
+
 - `teleport` has been upgraded from major version 16 to major version 17.
   Refer to [upstream upgrade instructions](https://goteleport.com/docs/upgrading/overview/)
   and [release notes for v17](https://goteleport.com/docs/changelog/#1701-11152024).

--- a/nixos/modules/services/networking/centrifugo.nix
+++ b/nixos/modules/services/networking/centrifugo.nix
@@ -65,6 +65,14 @@ in
   };
 
   config = lib.mkIf cfg.enable {
+    assertions = [
+      {
+        assertion =
+          (lib.versionAtLeast cfg.package.version "6") -> (!(cfg.settings ? name) && !(cfg.settings ? port));
+        message = "`services.centrifugo.settings` is v5 config, must be compatible with centrifugo v6 config format";
+      }
+    ];
+
     systemd.services.centrifugo = {
       description = "Centrifugo messaging server";
       wantedBy = [ "multi-user.target" ];

--- a/nixos/tests/centrifugo.nix
+++ b/nixos/tests/centrifugo.nix
@@ -10,7 +10,10 @@ in
 { lib, ... }:
 {
   name = "centrifugo";
-  meta.maintainers = [ lib.maintainers.tie ];
+  meta.maintainers = [
+    lib.maintainers.tie
+    lib.maintainers.valodim
+  ];
 
   nodes = lib.listToAttrs (
     lib.imap0 (index: name: {

--- a/nixos/tests/centrifugo.nix
+++ b/nixos/tests/centrifugo.nix
@@ -21,12 +21,15 @@ in
           services.centrifugo = {
             enable = true;
             settings = {
-              inherit name;
-              port = centrifugoPort;
-              # See https://centrifugal.dev/docs/server/engines#redis-sharding
-              engine = "redis";
-              # Connect to local Redis shard via Unix socket.
-              redis_address =
+              node = {
+                inherit name;
+              };
+              http_server.port = centrifugoPort;
+              http_api.insecure = true;
+              usage_stats.disabled = true;
+
+              engine.type = "redis";
+              engine.redis.address =
                 let
                   toRedisAddresses = map (name: "${name}:${toString redisPort}");
                 in
@@ -35,8 +38,6 @@ in
                   "unix://${config.services.redis.servers.centrifugo.unixSocket}"
                 ]
                 ++ toRedisAddresses (lib.drop (index + 1) nodes);
-              usage_stats_disable = true;
-              api_insecure = true;
             };
             extraGroups = [
               config.services.redis.servers.centrifugo.user

--- a/pkgs/by-name/ce/centrifugo/package.nix
+++ b/pkgs/by-name/ce/centrifugo/package.nix
@@ -30,9 +30,9 @@ buildGoModule rec {
   ldflags = [
     "-s"
     "-w"
-    "-X=github.com/centrifugal/centrifugo/v5/internal/build.Version=${version}"
-    "-X=github.com/centrifugal/centrifugo/v5/internal/build.UsageStatsEndpoint=${statsEndpoint}"
-    "-X=github.com/centrifugal/centrifugo/v5/internal/build.UsageStatsToken=${statsToken}"
+    "-X=github.com/centrifugal/centrifugo/v6/internal/build.Version=${version}"
+    "-X=github.com/centrifugal/centrifugo/v6/internal/build.UsageStatsEndpoint=${statsEndpoint}"
+    "-X=github.com/centrifugal/centrifugo/v6/internal/build.UsageStatsToken=${statsToken}"
   ];
 
   excludedPackages = [

--- a/pkgs/by-name/ce/centrifugo/package.nix
+++ b/pkgs/by-name/ce/centrifugo/package.nix
@@ -16,16 +16,16 @@ let
 in
 buildGoModule rec {
   pname = "centrifugo";
-  version = "5.4.9";
+  version = "6.1.0";
 
   src = fetchFromGitHub {
     owner = "centrifugal";
     repo = "centrifugo";
     rev = "v${version}";
-    hash = "sha256-FDtAkoN1bdqVUEP0obbXBfQfVRpZN5YXbU1KT1yXWuI=";
+    hash = "sha256-7hh9wcM9cMfQ2W2PlDitTdJD9ftZt/KO/B+wV/c588U=";
   };
 
-  vendorHash = "sha256-WfYN7bhtOPDp2UeB/WqtN3dD3+WO9lIxnXe2iTqn000=";
+  vendorHash = "sha256-hl1BznajnaOXMrlSqksqPdJih29yRDYW9IsyV9mSN20=";
 
   ldflags = [
     "-s"

--- a/pkgs/by-name/ce/centrifugo/package.nix
+++ b/pkgs/by-name/ce/centrifugo/package.nix
@@ -56,7 +56,10 @@ buildGoModule rec {
     homepage = "https://centrifugal.dev";
     changelog = "https://github.com/centrifugal/centrifugo/releases/tag/v${version}";
     license = lib.licenses.asl20;
-    maintainers = [ lib.maintainers.tie ];
+    maintainers = [
+      lib.maintainers.tie
+      lib.maintainers.valodim
+    ];
     mainProgram = "centrifugo";
   };
 }


### PR DESCRIPTION
## Things done

Adaptation of centrifugo v6 update, picking up #375750

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
