### PR TITLE
python3Packages.hypothesis: fix downstream flaky test failures

### DIFF
--- a/pkgs/development/python-modules/hypothesis/setup-hook.sh
+++ b/pkgs/development/python-modules/hypothesis/setup-hook.sh
@@ -1,0 +1,5 @@
+hypothesisActivateProfileForCI() {
+    export CI=1
+}
+
+postHooks+=(hypothesisActivateProfileForCI)

--- a/pkgs/development/python-modules/mutagen/default.nix
+++ b/pkgs/development/python-modules/mutagen/default.nix
@@ -3,6 +3,7 @@
   buildPythonPackage,
   pythonOlder,
   fetchPypi,
+  fetchpatch,
 
   # build-system
   setuptools,
@@ -28,6 +29,15 @@ buildPythonPackage rec {
     inherit pname version;
     hash = "sha256-cZ+t7wqXjDG0zzyVYmGzxYtpSLMgIweKIRex3gnw/Jk=";
   };
+
+  patches = [
+    # fix compatibility with hypothesis CI profile
+    # (remove on next release)
+    (fetchpatch {
+      url = "https://github.com/quodlibet/mutagen/commit/967212631719de1aeccbd6855c5b6d03f271fdfe.patch";
+      hash = "sha256-jfCz8qTGZpnP6ICMB9K/Dgyp9TQeMuDq+V6kPFA3Q44=";
+    })
+  ];
 
   outputs = [
     "out"


### PR DESCRIPTION
Fixes #393637

See upstream https://github.com/HypothesisWorks/hypothesis/pull/4152

## Things done

yet to do: remove env.CI = 1 in downstream packages (e.g. cramjam)

- Built on platform(s)
  - [x] x86_64-linux: `python31{0,1,2,3}Packages.hypothesis`, `pypy31{0,1}Packages.hypothesis`
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).