### PR TITLE
buffrs: init at 0.9.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5392,6 +5392,12 @@
     githubId = 64467514;
     name = "Daniel Krywult";
   };
+  danilobuerger = {
+    email = "info@danilobuerger.de";
+    github = "danilobuerger";
+    githubId = 996231;
+    name = "Danilo Bürger";
+  };
   daniyalsuri6 = {
     email = "daniyal.suri@gmail.com";
     github = "daniyalsuri6";

--- a/pkgs/by-name/bu/buffrs/package.nix
+++ b/pkgs/by-name/bu/buffrs/package.nix
@@ -1,0 +1,37 @@
+{
+  lib,
+  fetchFromGitHub,
+  rustPlatform,
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "buffrs";
+  version = "0.9.0";
+
+  src = fetchFromGitHub {
+    owner = "helsing-ai";
+    repo = "buffrs";
+    tag = "v${version}";
+    hash = "sha256-c9GjSqVp2wEFgoy8j+Gy5FA3SG4JYEfeSwPWjW81w3Y=";
+  };
+
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-E7kskULt2eOY+mZjh6jAftj8ciExUF7d1z1pePTBzvQ=";
+
+  # Disabling tests meant to work over the network, as they will fail
+  # inside the builder.
+  checkFlags = [
+    "--skip=cmd::install::upgrade::fixture"
+    "--skip=cmd::publish::lib::fixture"
+    "--skip=cmd::publish::local::fixture"
+    "--skip=cmd::tuto::fixture"
+  ];
+
+  meta = {
+    description = "Modern protobuf package management";
+    homepage = "https://github.com/helsing-ai/buffrs";
+    license = lib.licenses.asl20;
+    mainProgram = "buffrs";
+    maintainers = with lib.maintainers; [ danilobuerger ];
+  };
+}


### PR DESCRIPTION
From https://github.com/helsing-ai/buffrs:

Protocol buffers are agreeably a great way to define fully typed, language-independent API schemas with strong backward compatibility guarantees. They offer a neat experience for API consumers through generated bindings. The biggest problem associated with Protocol Buffers is their distribution.

How do you consume the raw protobuf files of one project reliably in another one?
How do you prevent transitive dependencies?
How do you publish to a unified registry with package format across languages?
One obvious way is to generate code bindings in the repository containing the Protocol Buffers and publish the generated bindings, but this is associated with problems such as language lock-in. You need to proactively publish bindings for any possible language your API consumers may use. Also, in strongly typed languages like Rust, it is hard to extend the behavior of generated code in consuming projects due to the orphan rule. Summing up: this approach works somehow but hurts frequently.

This is where Buffrs comes in: Buffrs solves this by defining a strict, package-based distribution mechanism and treats Protocol Buffers as a first-class citizen.

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
