### PR TITLE
libvlc: build reproducibly

### DIFF
--- a/pkgs/by-name/vl/vlc/deterministic-plugin-cache.diff
+++ b/pkgs/by-name/vl/vlc/deterministic-plugin-cache.diff
@@ -1,0 +1,28 @@
+diff --git a/src/modules/bank.c b/src/modules/bank.c
+index 52037d5b59..c94e71fef9 100644
+--- a/src/modules/bank.c
++++ b/src/modules/bank.c
+@@ -461,6 +461,11 @@ static void AllocatePluginDir (module_bank_t *bank, unsigned maxdepth,
+     closedir (dh);
+ }
+ 
++static int plugin_cmp(const void *first, const void *second)
++{
++    return strcmp((*(vlc_plugin_t **) first)->path, (*(vlc_plugin_t **) second)->path);
++}
++
+ /**
+  * Scans for plug-ins within a file system hierarchy.
+  * \param path base directory to browse
+@@ -500,8 +505,10 @@ static void AllocatePluginPath(vlc_object_t *obj, const char *path,
+             vlc_plugin_store(plugin);
+     }
+ 
+-    if (mode & CACHE_WRITE_FILE)
++    if (mode & CACHE_WRITE_FILE) {
++        qsort(bank.plugins, bank.size, sizeof(vlc_plugin_t *), plugin_cmp);
+         CacheSave(obj, path, bank.plugins, bank.size);
++    }
+ 
+     free(bank.plugins);
+ }

--- a/pkgs/by-name/vl/vlc/package.nix
+++ b/pkgs/by-name/vl/vlc/package.nix
@@ -245,6 +245,9 @@ stdenv.mkDerivation (finalAttrs: {
       url = "https://code.videolan.org/videolan/vlc/-/commit/ba5dc03aecc1d96f81b76838f845ebde7348cf62.diff";
       hash = "sha256-s6AI9O0V3AKOyw9LbQ9CgjaCi5m5+nLacKNLl5ZLC6Q=";
     })
+    # make the plugins.dat file generation reproducible
+    # upstream merge request: https://code.videolan.org/videolan/vlc/-/merge_requests/7149
+    ./deterministic-plugin-cache.diff
   ];
 
   postPatch =


### PR DESCRIPTION
VLC generates a cache file of all available plugins at build time. It previously listed them in filesystem iteration order, making the build unreproducible. By sorting the plugins by path, determinism is restored.

Fixes: https://github.com/NixOS/nixpkgs/issues/393651


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
