### PR TITLE
aws-workspaces: 4.7.0.4312 -> 2024.8.5191 FHS

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2505.section.md
+++ b/nixos/doc/manual/release-notes/rl-2505.section.md
@@ -260,6 +260,8 @@
 
 - `tauon` 7.9.0+ when launched for the first time, migrates its database to a new schema that is not backwards compatible. Older versions will refuse to start at all with that database afterwards. If you need to still use older tauon versions, make sure to back up `~/.local/share/TauonMusicBox`.
 
+- `aws-workspaces` has dropped support for PCoiP networking.
+
 - The `earlyoom` service is now using upstream systemd service, which enables
   hardening and filesystem isolation by default. If you need filesystem write
   access or want to access home directory via `killHook`, hardening setting can

--- a/pkgs/by-name/aw/aws-workspaces/package.nix
+++ b/pkgs/by-name/aw/aws-workspaces/package.nix
@@ -1,7 +1,6 @@
 {
   stdenv,
   lib,
-  makeWrapper,
   dpkg,
   fetchurl,
   autoPatchelfHook,
@@ -9,37 +8,125 @@
   libkrb5,
   lttng-ust,
   libpulseaudio,
-  gtk3,
-  openssl_1_1,
+  openssl,
   icu70,
-  webkitgtk_4_0,
   librsvg,
   gdk-pixbuf,
   libsoup_2_4,
   glib-networking,
+  gsettings-desktop-schemas,
   graphicsmagick_q16,
   libva,
   libusb1,
   hiredis,
-  xcbutil,
+  pcsclite,
+  jbigkit,
+  libvdpau,
+  libtiff,
+  ffmpeg_6,
+  lmdb,
+  protobufc,
+  zlib,
+  cairo,
+  fontconfig,
+  pango,
+  xorg,
+  libfido2,
+  webkitgtk_4_1,
+  copyDesktopItems,
+  wrapGAppsHook4,
+  atk,
+  fetchpatch,
+  glib,
+  sssd,
+  gtk3,
+  writeShellApplication,
 }:
 
+let
+  # To remove when https://github.com/NixOS/nixpkgs/pull/345659 has landed
+  custom_jbigkit = jbigkit.overrideAttrs (oldAttrs: {
+    patches = oldAttrs.patches ++ [
+      (fetchpatch {
+        url = "https://gitlab.archlinux.org/archlinux/packaging/packages/jbigkit/-/raw/main/jbigkit-2.1-shared_lib.patch";
+        hash = "sha256-+efeeKg3FJ/TjSOj58kD+DwnaCm3zhGzKLfUes/d5rg=";
+      })
+      (fetchpatch {
+        url = "https://gitlab.archlinux.org/archlinux/packaging/packages/jbigkit/-/raw/main/jbigkit-2.1-ldflags.patch";
+        hash = "sha256-ik3NifyuhDHnIMTrNLAKInPgu2F5u6Gvk9daqrn8ZhY=";
+      })
+      # Archlinux patch: update coverity
+      (fetchpatch {
+        url = "https://gitlab.archlinux.org/archlinux/packaging/packages/jbigkit/-/raw/main/jbigkit-2.1-coverity.patch";
+        hash = "sha256-APm9A2f4sMufuY3cnL9HOcSCa9ov3pyzgQTTKLd49/E=";
+      })
+      # Archlinux patch: fix build warnings
+      (fetchpatch {
+        url = "https://gitlab.archlinux.org/archlinux/packaging/packages/jbigkit/-/raw/main/jbigkit-2.1-build_warnings.patch";
+        hash = "sha256-lDEJ1bvZ+zR7K4CiTq+aXJ8PGjILE3W13kznLLlGOOg=";
+      })
+    ];
+
+    makeFlags = [
+      "AR=${lib.getBin stdenv.cc.bintools.bintools}/bin/${stdenv.cc.targetPrefix}ar"
+      "CC=${stdenv.cc}/bin/${stdenv.cc.targetPrefix}cc"
+      "DESTDIR=${placeholder "out"}"
+      "RANLIB=${lib.getBin stdenv.cc.bintools.bintools}/bin/${stdenv.cc.targetPrefix}ranlib"
+    ];
+
+    installPhase = ''
+      runHook preInstall
+
+      install -vDm 644 libjbig/*.h -t "$out/include/"
+      install -vDm 755 pbmtools/{jbgtopbm{,85},pbmtojbg{,85}} -t "$out/bin/"
+      install -vDm 644 pbmtools/*.1* -t "$out/share/man/man1/"
+
+      install -vDm 755 libjbig/*.so.* -t "$out/lib/"
+      for lib in libjbig.so libjbig85.so; do
+        ln -sv "$lib.${oldAttrs.version}" "$out/lib/$lib"
+        ln -sv "$out/lib/$lib.${oldAttrs.version}" "$out/lib/$lib.0"
+      done
+
+      runHook postInstall
+    '';
+  });
+
+  # Source: https://github.com/jthomaschewski/pkgbuilds/pull/3
+  # Credits to https://github.com/rwolfson
+  custom_lsb_release = writeShellApplication {
+    name = "lsb_release";
+
+    text = ''
+      # "Fake" lsb_release script
+      # This only exists so that "lsb_release -r" will return the below string
+      # when placed in the $PATH
+
+      if [ "$#" -ne 1 ] || [ "$1" != "-r" ] ; then
+          echo "Expected only '-r' argument"
+          exit 1
+      fi
+
+      echo "Release: 22.04"
+    '';
+  };
+in
 stdenv.mkDerivation (finalAttrs: {
   pname = "aws-workspaces";
-  version = "4.7.0.4312";
+  version = "2024.8.5191";
 
   src = fetchurl {
-    # Check new version at https://d3nt0h4h6pmmc4.cloudfront.net/ubuntu/dists/focal/main/binary-amd64/Packages
     urls = [
-      "https://d3nt0h4h6pmmc4.cloudfront.net/ubuntu/dists/focal/main/binary-amd64/workspacesclient_${finalAttrs.version}_amd64.deb"
-      "https://archive.org/download/workspacesclient_${finalAttrs.version}_amd64/workspacesclient_${finalAttrs.version}_amd64.deb"
+      # Check new version at https://d3nt0h4h6pmmc4.cloudfront.net/ubuntu/dists/jammy/main/binary-amd64/Packages
+      "https://d3nt0h4h6pmmc4.cloudfront.net/ubuntu/dists/jammy/main/binary-amd64/workspacesclient_${finalAttrs.version}_amd64.deb"
+      "https://d3nt0h4h6pmmc4.cloudfront.net/new_workspacesclient_jammy_amd64.deb"
     ];
-    hash = "sha256-G0o5uFnEkiUWmkTMUHlVcidw+2x8e/KmMfVBE7oLXV8=";
+    hash = "sha256-BDxMycVgWciJZe8CtElXaWVnqYDQO5NmawK10GvP2+k=";
   };
 
   nativeBuildInputs = [
     autoPatchelfHook
-    makeWrapper
+    copyDesktopItems
+    wrapGAppsHook4
   ];
 
   # Crashes at startup when stripping:
@@ -48,62 +135,83 @@ stdenv.mkDerivation (finalAttrs: {
 
   buildInputs = [
     (lib.getLib stdenv.cc.cc)
-    libkrb5
+    atk
+    cairo
     curl
-    lttng-ust
-    libpulseaudio
-    gtk3
-    openssl_1_1.out
-    icu70
-    webkitgtk_4_0
-    librsvg
+    custom_jbigkit
+    ffmpeg_6.lib
     gdk-pixbuf
-    libsoup_2_4
+    glib
     glib-networking
     graphicsmagick_q16
+    gsettings-desktop-schemas
+    gtk3
     hiredis
+    icu70
+    libfido2
+    libkrb5
+    libpulseaudio
+    librsvg
+    libsoup_2_4
+    libtiff
     libusb1
     libva
-    xcbutil
+    libvdpau
+    lmdb
+    lttng-ust
+    openssl
+    pango
+    pcsclite
+    protobufc
+    sssd
+    webkitgtk_4_1
+    xorg.libxcb
+    zlib
   ];
 
   unpackPhase = ''
+    runHook preUnpack
     ${dpkg}/bin/dpkg -x $src $out
-  '';
-
-  preFixup = ''
-    patchelf --replace-needed liblttng-ust.so.0 liblttng-ust.so $out/lib/libcoreclrtraceptprovider.so
-    patchelf --replace-needed libGraphicsMagick++-Q16.so.12 libGraphicsMagick++.so.12 $out/usr/lib/x86_64-linux-gnu/pcoip-client/vchan_plugins/libvchan-plugin-clipboard.so
-    patchelf --replace-needed libhiredis.so.0.14 libhiredis.so $out/lib/libpcoip_core.so
+    mv $out/usr/share $out/share
+    runHook postUnpack
   '';
 
   installPhase = ''
     runHook preInstall
-
     mkdir -p $out/bin $out/lib
-    mv $out/opt/workspacesclient/* $out/lib
+    mv $out/usr/lib/x86_64-linux-gnu/workspacesclient/dcv $out/lib/
+
     rm -rf $out/opt
 
-    wrapProgram $out/lib/workspacesclient \
-      --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath finalAttrs.buildInputs}" \
-      --set GDK_PIXBUF_MODULE_FILE "${librsvg.out}/lib/gdk-pixbuf-2.0/2.10.0/loaders.cache" \
-      --set GIO_EXTRA_MODULES "${glib-networking.out}/lib/gio/modules"
+    # We introduce a dependency on the source file so that it need not be redownloaded everytime
+    echo $src >> "$out/share/workspace_dependencies.pin"
 
-    mv $out/lib/workspacesclient $out/bin
+    # Remove the vendored-in libgio-2.0.so.0, so the system one is used
+    # The vendored-in version has libselinux.so.1 linked, which doesn't exist natively on NixOS
+    rm $out/lib/dcv/libgio-2.0.so.0
+
+    wrapProgram $out/usr/bin/workspacesclient \
+      --prefix PATH : "$out/lib/dcv":"${lib.makeBinPath [ custom_lsb_release ]}" \
+      --prefix LD_LIBRARY_PATH : "$out/lib/dcv":"${lib.makeLibraryPath finalAttrs.buildInputs}" \
+      --set-default FONTCONFIG_FILE "${fontconfig.out}/etc/fonts/fonts.conf" \
+      --set-default FONTCONFIG_PATH "${fontconfig.out}/etc/fonts" \
+      --set WEBKIT_DISABLE_DMABUF_RENDERER 1
+
+    mv $out/usr/bin/workspacesclient $out/bin/workspacesclient
 
     runHook postInstall
   '';
 
-  meta = with lib; {
+  meta = {
     description = "Client for Amazon WorkSpaces, a managed, secure Desktop-as-a-Service (DaaS) solution";
     homepage = "https://clients.amazonworkspaces.com";
-    license = licenses.unfree;
+    license = lib.licenses.unfree;
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
     mainProgram = "workspacesclient";
-    maintainers = with maintainers; [
+    maintainers = with lib.maintainers; [
       mausch
       dylanmtaylor
     ];
     platforms = [ "x86_64-linux" ]; # TODO Mac support
-    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
   };
 })

--- a/pkgs/by-name/aw/aws-workspaces/package.nix
+++ b/pkgs/by-name/aw/aws-workspaces/package.nix
@@ -46,53 +46,6 @@
 }:
 
 let
-  # To remove when https://github.com/NixOS/nixpkgs/pull/345659 has landed
-  custom_jbigkit = jbigkit.overrideAttrs (oldAttrs: {
-    patches = oldAttrs.patches ++ [
-      (fetchpatch {
-        url = "https://gitlab.archlinux.org/archlinux/packaging/packages/jbigkit/-/raw/main/jbigkit-2.1-shared_lib.patch";
-        hash = "sha256-+efeeKg3FJ/TjSOj58kD+DwnaCm3zhGzKLfUes/d5rg=";
-      })
-      (fetchpatch {
-        url = "https://gitlab.archlinux.org/archlinux/packaging/packages/jbigkit/-/raw/main/jbigkit-2.1-ldflags.patch";
-        hash = "sha256-ik3NifyuhDHnIMTrNLAKInPgu2F5u6Gvk9daqrn8ZhY=";
-      })
-      # Archlinux patch: update coverity
-      (fetchpatch {
-        url = "https://gitlab.archlinux.org/archlinux/packaging/packages/jbigkit/-/raw/main/jbigkit-2.1-coverity.patch";
-        hash = "sha256-APm9A2f4sMufuY3cnL9HOcSCa9ov3pyzgQTTKLd49/E=";
-      })
-      # Archlinux patch: fix build warnings
-      (fetchpatch {
-        url = "https://gitlab.archlinux.org/archlinux/packaging/packages/jbigkit/-/raw/main/jbigkit-2.1-build_warnings.patch";
-        hash = "sha256-lDEJ1bvZ+zR7K4CiTq+aXJ8PGjILE3W13kznLLlGOOg=";
-      })
-    ];
-
-    makeFlags = [
-      "AR=${lib.getBin stdenv.cc.bintools.bintools}/bin/${stdenv.cc.targetPrefix}ar"
-      "CC=${stdenv.cc}/bin/${stdenv.cc.targetPrefix}cc"
-      "DESTDIR=${placeholder "out"}"
-      "RANLIB=${lib.getBin stdenv.cc.bintools.bintools}/bin/${stdenv.cc.targetPrefix}ranlib"
-    ];
-
-    installPhase = ''
-      runHook preInstall
-
-      install -vDm 644 libjbig/*.h -t "$out/include/"
-      install -vDm 755 pbmtools/{jbgtopbm{,85},pbmtojbg{,85}} -t "$out/bin/"
-      install -vDm 644 pbmtools/*.1* -t "$out/share/man/man1/"
-
-      install -vDm 755 libjbig/*.so.* -t "$out/lib/"
-      for lib in libjbig.so libjbig85.so; do
-        ln -sv "$lib.${oldAttrs.version}" "$out/lib/$lib"
-        ln -sv "$out/lib/$lib.${oldAttrs.version}" "$out/lib/$lib.0"
-      done
-
-      runHook postInstall
-    '';
-  });
-
   # Source: https://github.com/jthomaschewski/pkgbuilds/pull/3
   # Credits to https://github.com/rwolfson
   custom_lsb_release = writeShellApplication {
@@ -141,7 +94,7 @@ stdenv.mkDerivation (finalAttrs: {
     atk
     cairo
     curl
-    custom_jbigkit
+    jbigkit
     ffmpeg_6.lib
     gdk-pixbuf
     glib

--- a/pkgs/by-name/aw/aws-workspaces/package.nix
+++ b/pkgs/by-name/aw/aws-workspaces/package.nix
@@ -1,51 +1,22 @@
 {
   stdenv,
   lib,
-  libpsl,
-  dpkg,
-  fetchurl,
-  autoPatchelfHook,
-  curl,
-  libkrb5,
-  lttng-ust,
-  libpulseaudio,
-  openssl,
-  icu70,
-  librsvg,
-  gdk-pixbuf,
-  libsoup_3,
-  glib-networking,
-  gsettings-desktop-schemas,
-  graphicsmagick_q16,
-  libva,
-  libusb1,
-  hiredis,
-  pcsclite,
-  jbigkit,
-  libvdpau,
-  libtiff,
-  ffmpeg_6,
-  lmdb,
-  protobufc,
-  zlib,
-  cairo,
-  fontconfig,
-  pango,
-  publicsuffixList ? (import <nixpkgs> { }).publicsuffix-list,
-  xorg,
-  libfido2,
-  webkitgtk_4_1,
-  copyDesktopItems,
-  wrapGAppsHook4,
-  atk,
-  fetchpatch,
-  glib,
-  sssd,
-  gtk3,
+  callPackage,
   writeShellApplication,
+  buildFHSEnv,
+  webkitgtk_4_1,
+  gtk3,
+  pango,
+  atk,
+  cairo,
+  gdk-pixbuf,
+  protobufc,
+  cyrus_sasl,
 }:
 
 let
+  workspacesclient = callPackage ./workspacesclient.nix { };
+
   # Source: https://github.com/jthomaschewski/pkgbuilds/pull/3
   # Credits to https://github.com/rwolfson
   custom_lsb_release = writeShellApplication {
@@ -64,109 +35,40 @@ let
       echo "Release: 22.04"
     '';
   };
-in
-stdenv.mkDerivation (finalAttrs: {
   pname = "aws-workspaces";
-  version = "2024.8.5191";
 
-  src = fetchurl {
-    urls = [
-      # Check new version at https://d3nt0h4h6pmmc4.cloudfront.net/ubuntu/dists/jammy/main/binary-amd64/Packages
-      "https://d3nt0h4h6pmmc4.cloudfront.net/ubuntu/dists/jammy/main/binary-amd64/workspacesclient_${finalAttrs.version}_amd64.deb"
-      "https://d3nt0h4h6pmmc4.cloudfront.net/new_workspacesclient_jammy_amd64.deb"
+in
+buildFHSEnv {
+  inherit pname;
+  inherit (workspacesclient) version;
+
+  runScript = "${workspacesclient}/bin/workspacesclient";
+
+  includeClosures = true;
+
+  targetPkgs =
+    pkgs: with pkgs; [
+      workspacesclient
+      custom_lsb_release
+      webkitgtk_4_1
+      gtk3
+      pango
+      atk
+      cairo
+      gdk-pixbuf
+      protobufc
+      cyrus_sasl
     ];
-    hash = "sha256-BDxMycVgWciJZe8CtElXaWVnqYDQO5NmawK10GvP2+k=";
-  };
 
-  nativeBuildInputs = [
-    dpkg
-    autoPatchelfHook
-    copyDesktopItems
-    wrapGAppsHook4
-    glib
+  extraBwrapArgs = [
+    # provide certificates where Debian-style OpenSSL can find them
+    "--symlink /etc/ssl/certs/ca-certificates.crt /etc/ssl/cert.pem"
   ];
 
-  # Crashes at startup when stripping:
-  # "Failed to create CoreCLR, HRESULT: 0x80004005"
-  dontStrip = true;
-
-  buildInputs = [
-    (lib.getLib stdenv.cc.cc)
-    atk
-    cairo
-    curl
-    jbigkit
-    ffmpeg_6.lib
-    gdk-pixbuf
-    glib
-    glib-networking
-    graphicsmagick_q16
-    gsettings-desktop-schemas
-    gtk3
-    hiredis
-    icu70
-    libfido2
-    libkrb5
-    libpulseaudio
-    librsvg
-    libsoup_3
-    libtiff
-    libusb1
-    libva
-    libpsl
-    libvdpau
-    lmdb
-    lttng-ust
-    openssl
-    pango
-    publicsuffixList
-    pcsclite
-    protobufc
-    sssd
-    webkitgtk_4_1
-    xorg.libxcb
-    zlib
-  ];
-
-  installPhase = ''
-    runHook preInstall
-
-    mkdir -p $out/libexec
-    cp -R usr/* $out/
-    mv $out/lib/x86_64-linux-gnu/workspacesclient/dcv $out/libexec/
-    rm -rf $out/opt
-
-    # We introduce a dependency on the source file so that it need not be redownloaded everytime
-    echo $src >> "$out/share/workspace_dependencies.pin"
-
-    # Remove the vendored-in libgio-2.0.so.0, so the system one is used
-    # The vendored-in version has libselinux.so.1 linked, which doesn't exist natively on NixOS
-    rm $out/libexec/dcv/libgio-2.0.so.0
-
-    glib-compile-schemas $out/share/glib-2.0/schemas/
-
-    mkdir -p $out/share/publicsuffix
-    cp ${publicsuffixList}/share/publicsuffix/public_suffix_list.dat $out/share/publicsuffix/
-
-    runHook postInstall
+  # expected executable doesn't match the name of this package
+  extraInstallCommands = ''
+    mv $out/bin/${pname} $out/bin/workspacesclient
   '';
 
-  preFixup = ''
-    gappsWrapperArgs+=(
-      --prefix PATH : "$out/libexec/dcv":"${lib.makeBinPath [ custom_lsb_release ]}" \
-    )
-  '';
-
-  meta = {
-    description = "Client for Amazon WorkSpaces, a managed, secure Desktop-as-a-Service (DaaS) solution";
-    homepage = "https://clients.amazonworkspaces.com";
-    license = lib.licenses.unfree;
-    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
-    mainProgram = "workspacesclient";
-    maintainers = with lib.maintainers; [
-      mausch
-      dylanmtaylor
-    ];
-    platforms = [ "x86_64-linux" ]; # TODO Mac support
-  };
-})
+  meta = workspacesclient.meta;
+}

--- a/pkgs/by-name/aw/aws-workspaces/workspacesclient.nix
+++ b/pkgs/by-name/aw/aws-workspaces/workspacesclient.nix
@@ -1,0 +1,72 @@
+{
+  stdenv,
+  lib,
+  fetchurl,
+  dpkg,
+  makeWrapper,
+  glib-networking,
+}:
+
+let
+  dcv-path = "lib/x86_64-linux-gnu/workspacesclient/dcv";
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "workspacesclient";
+  version = "2024.8.5191";
+
+  src = fetchurl {
+    urls = [
+      # Check new version at https://d3nt0h4h6pmmc4.cloudfront.net/ubuntu/dists/jammy/main/binary-amd64/Packages
+      "https://d3nt0h4h6pmmc4.cloudfront.net/ubuntu/dists/jammy/main/binary-amd64/workspacesclient_${finalAttrs.version}_amd64.deb"
+      "https://d3nt0h4h6pmmc4.cloudfront.net/new_workspacesclient_jammy_amd64.deb"
+    ];
+    hash = "sha256-BDxMycVgWciJZe8CtElXaWVnqYDQO5NmawK10GvP2+k=";
+  };
+
+  nativeBuildInputs = [
+    dpkg
+    makeWrapper
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out
+    cp -R usr/* $out/
+
+    # We introduce a dependency on the source file so that it need not be redownloaded everytime
+    echo $src >> "$out/share/workspace_dependencies.pin"
+
+    runHook postInstall
+  '';
+
+  postFixup = ''
+    # provide network support
+    wrapProgram "$out/bin/workspacesclient" \
+      --set GIO_EXTRA_MODULES ${glib-networking}/lib/gio/modules \
+
+    # dcvclient does not setup the environment correctly.
+    # Instead wrap the binary directly the correct environment paths
+    mv $out/${dcv-path}/dcvclientbin $out/${dcv-path}/dcvclient
+    wrapProgram $out/${dcv-path}/dcvclient \
+      --suffix LD_LIBRARY_PATH : $out/${dcv-path} \
+      --suffix GIO_EXTRA_MODULES : ${dcv-path}/gio/modules \
+      --set DCV_SASL_PLUGIN_DIR $out/${dcv-path}/sasl2 \
+
+    # shrink the install by removing all vendored libraries which will be provided by Nixpkgs
+    find $out/${dcv-path} -name lib\* ! -name libdcv\* ! -name libgioopenssl\* | xargs rm
+  '';
+
+  meta = {
+    description = "Client for Amazon WorkSpaces, a managed, secure Desktop-as-a-Service (DaaS) solution";
+    homepage = "https://clients.amazonworkspaces.com";
+    license = lib.licenses.unfree;
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    mainProgram = "workspacesclient";
+    maintainers = with lib.maintainers; [
+      mausch
+      dylanmtaylor
+    ];
+    platforms = [ "x86_64-linux" ]; # TODO Mac support
+  };
+})


### PR DESCRIPTION
AWS WorkSpaces Client has changed significantly following the 4.x releases. Only DCV networking is supported, PCoiP has been dropped, and this support is provided by a dependant executable `dcvclient` which `workspacesclient` requires to be placed in a known absolute path. For that reason this package has been reworked to use `buildFHSEnv`.

https://docs.aws.amazon.com/workspaces/latest/userguide/amazon-workspaces-linux-client.html#linux-requirements documents the removal of PCoiP support.

Release notes: https://docs.aws.amazon.com/workspaces/latest/userguide/amazon-workspaces-linux-client.html#linux-release-notes

This is based on work by drupol (https://github.com/NixOS/nixpkgs/pull/344875) and jaredcrean (https://github.com/jaredcrean/nixpkgs/tree/aws-workspace-2024.8.5191)

I have retained their commits in this history as well as my changes before and after the FHS rework. Let me know if any of these should be squashed.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
