### PR TITLE
treewide: adopt android packages as NixOS/android

### DIFF
--- a/pkgs/applications/editors/android-studio-for-platform/common.nix
+++ b/pkgs/applications/editors/android-studio-for-platform/common.nix
@@ -188,7 +188,7 @@ runCommand drvName
       # binaries are also distributed as proprietary software (unlike the
       # source-code itself).
       platforms = [ "x86_64-linux" ];
-      maintainers = with maintainers; [ robbins ];
+      maintainers = teams.android.members ++ (with maintainers; [ robbins ]);
       mainProgram = pname;
     };
   }

--- a/pkgs/applications/editors/android-studio/common.nix
+++ b/pkgs/applications/editors/android-studio/common.nix
@@ -323,13 +323,12 @@ let
           # source-code itself).
           platforms = [ "x86_64-linux" ];
           maintainers =
-            with lib.maintainers;
             rec {
-              stable = [
-                alapshin
-                johnrtitor
-                numinit
-              ];
+              stable =
+                lib.teams.android.members
+                ++ (with lib.maintainers; [
+                  alapshin
+                ]);
               beta = stable;
               canary = stable;
               dev = stable;

--- a/pkgs/by-name/an/android-studio-tools/package.nix
+++ b/pkgs/by-name/an/android-studio-tools/package.nix
@@ -51,7 +51,7 @@ stdenvNoCC.mkDerivation {
     downloadPage = "https://developer.android.com/studio";
     changelog = "https://developer.android.com/studio/releases";
     license = lib.licenses.unfree;
-    maintainers = with lib.maintainers; [ pandapip1 ];
+    maintainers = lib.teams.android.members ++ (with lib.maintainers; [ pandapip1 ]);
     platforms = lib.platforms.all;
     sourceProvenance = with lib.sourceTypes; [ fromSource ]; # The 'binaries' are actually shell scripts
   };

--- a/pkgs/by-name/an/android-udev-rules/package.nix
+++ b/pkgs/by-name/an/android-udev-rules/package.nix
@@ -30,6 +30,6 @@ stdenv.mkDerivation rec {
     description = "Android udev rules list aimed to be the most comprehensive on the net";
     platforms = platforms.linux;
     license = licenses.gpl3Plus;
-    maintainers = with maintainers; [ abbradar ];
+    maintainers = lib.teams.android.members ++ (with maintainers; [ abbradar ]);
   };
 }

--- a/pkgs/development/androidndk-pkgs/androidndk-pkgs.nix
+++ b/pkgs/development/androidndk-pkgs/androidndk-pkgs.nix
@@ -74,7 +74,7 @@ let
   );
 in
 
-rec {
+lib.recurseIntoAttrs rec {
   # Misc tools
   binaries = stdenv.mkDerivation {
     pname = "${targetPrefix}ndk-toolchain";
@@ -138,6 +138,11 @@ rec {
 
       patchShebangs $out/bin
     '';
+    meta = {
+      description = "The Android NDK toolchain, tuned for other platforms";
+      license = with lib.licenses; [ unfree ];
+      maintainers = lib.teams.android.members;
+    };
   };
 
   binutils = wrapBintoolsWith {

--- a/pkgs/development/androidndk-pkgs/default.nix
+++ b/pkgs/development/androidndk-pkgs/default.nix
@@ -53,7 +53,7 @@ let
     };
 in
 
-{
+lib.recurseIntoAttrs {
   "21" = makeNdkPkgs "21.0.6113669" pkgs.llvmPackages_14; # "9"
   "23" = makeNdkPkgs "23.1.7779620" pkgs.llvmPackages_14; # "12"
   # Versions below 24 use a version not available in nixpkgs/old version which could be removed in the near future so use 14 for them as this is only used to get the hardening flags.

--- a/pkgs/development/mobile/androidenv/default.nix
+++ b/pkgs/development/mobile/androidenv/default.nix
@@ -36,9 +36,6 @@ lib.recurseIntoAttrs rec {
     description = "Android SDK tools, packaged in Nixpkgs";
     license = lib.licenses.unfree;
     platforms = lib.platforms.all;
-    maintainers = with lib.maintainers; [
-      numinit
-      hadilq
-    ];
+    maintainers = lib.teams.android.members;
   };
 }

--- a/pkgs/tools/misc/android-tools/default.nix
+++ b/pkgs/tools/misc/android-tools/default.nix
@@ -79,6 +79,6 @@ stdenv.mkDerivation rec {
       unicode-dfs-2015
     ];
     platforms = platforms.unix;
-    maintainers = with maintainers; [ primeos ];
+    maintainers = teams.android.members ++ (with maintainers; [ primeos ]);
   };
 }


### PR DESCRIPTION
Just a cosmetic change, this brings android studio and other packages under the wing of @NixOS/android .

It makes sense that we take ownership of all "official" android things on Nixpkgs. This ensures we get bug reports, and they remain up to date.

Not sure if I should have included `git-repo`, thoughts?
