### PR TITLE
psfeditor: init at 0-unstable-2025-04-07

### DIFF
--- a/pkgs/by-name/ps/psfeditor/package.nix
+++ b/pkgs/by-name/ps/psfeditor/package.nix
@@ -1,0 +1,50 @@
+{
+  lib,
+  stdenv,
+  qt5,
+  fetchFromGitHub,
+  unstableGitUpdater,
+}:
+
+stdenv.mkDerivation {
+  pname = "psfeditor";
+  version = "0-unstable-2025-04-07";
+
+  src = fetchFromGitHub {
+    owner = "ideras";
+    repo = "PSFEditor";
+    rev = "1942494a110b100e7609c10e0e3c2a7258cd20d4";
+    hash = "sha256-+A0XHwQ0yjTaj4ua0Y6OnsIYkaRD3dj/NonJnusykao=";
+  };
+
+  buildInputs = [
+    qt5.qtbase
+  ];
+
+  nativeBuildInputs = with qt5; [
+    qmake
+    wrapQtAppsHook
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    install -d $out/bin
+    install ./PSFEditor $out/bin/
+
+    runHook postInstall
+  '';
+
+  passthru.updateScript = unstableGitUpdater { };
+
+  meta = {
+    description = "PC Screen font editor";
+    homepage = "https://github.com/ideras/PSFEditor";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [
+      kachick
+    ];
+    mainProgram = "PSFEditor";
+    platforms = lib.platforms.linux;
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This PR introduces [PSFEditor](https://github.com/ideras/PSFEditor),
a GUI-based editor for .psf font files.

It is particularly useful for addressing console font issues, such as customizing or investigating fonts like Cozette.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable: # This is GUI app and not providing --version flag 
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
