### PR TITLE
loadwatch: 1.1-1 -> 1.1-4

### DIFF
--- a/pkgs/by-name/lo/loadwatch/package.nix
+++ b/pkgs/by-name/lo/loadwatch/package.nix
@@ -1,28 +1,26 @@
 {
   lib,
   stdenv,
-  fetchgit,
+  fetchFromSourcehut,
 }:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation (finalAttrs: {
   pname = "loadwatch";
-  version = "1.1-1-g6d2544c";
+  version = "1.1-4-g868bd29";
 
-  src = fetchgit {
-    url = "git://woffs.de/git/fd/loadwatch.git";
-    sha256 = "1bhw5ywvhyb6snidsnllfpdi1migy73wg2gchhsfbcpm8aaz9c9b";
-    rev = "6d2544c0caaa8a64bbafc3f851e06b8056c30e6e";
+  src = fetchFromSourcehut {
+    owner = "~woffs";
+    repo = "loadwatch";
+    hash = "sha256-/4kfGdpYJWQyb7mRaVUpyQQC5VP96bDsBDfM3XhcJXw=";
+    rev = finalAttrs.version;
   };
 
-  installPhase = ''
-    mkdir -p $out/bin
-    install loadwatch lw-ctl $out/bin
-  '';
+  makeFlags = [ "bindir=$(out)/bin" ];
 
-  meta = with lib; {
+  meta = {
     description = "Run a program using only idle cycles";
-    license = licenses.gpl2Only;
-    maintainers = with maintainers; [ woffs ];
-    platforms = platforms.all;
+    license = lib.licenses.gpl2Only;
+    maintainers = with lib.maintainers; [ woffs ];
+    platforms = lib.platforms.all;
   };
-}
+})


### PR DESCRIPTION
- change source repo to sourcehut (more stable)
- fix unclean install
- fix build by lifting https://github.com/NixOS/nixpkgs/pull/396704 upstream:
  - add <string.h> include and HAVE_KSTAT template
  - update generated configure script
  - fix `make install`

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
