### PR TITLE
lib.types.submodule: Disable check during docs generation

### DIFF
--- a/lib/types.nix
+++ b/lib/types.nix
@@ -290,6 +290,15 @@ let
       unparenthesize: t:
       if unparenthesize (t.descriptionClass or null) then t.description else "(${t.description})";
 
+    noCheckForDocsModule = {
+      # When generating documentation, our goal isn't to check anything.
+      # Quite the opposite in fact. Generating docs is somewhat of a
+      # challenge, evaluating modules in a *lacking* context. Anything
+      # that makes the docs avoid an error is a win.
+      config._module.check = lib.mkForce false;
+      _file = "<built-in module that disables checks for the purpose of documentation generation>";
+    };
+
     # When adding new types don't forget to document them in
     # nixos/doc/manual/development/option-types.section.md!
     types = rec {
@@ -1209,7 +1218,14 @@ let
         in
         mkOptionType {
           inherit name;
-          description = if description != null then description else freeformType.description or name;
+          description =
+            if description != null then
+              description
+            else
+              let
+                docsEval = base.extendModules { modules = [ noCheckForDocsModule ]; };
+              in
+              docsEval._module.freeformType.description or name;
           check = x: isAttrs x || isFunction x || path.check x;
           merge =
             loc: defs:
@@ -1222,7 +1238,18 @@ let
           };
           getSubOptions =
             prefix:
-            (base.extendModules { inherit prefix; }).options
+            let
+              docsEval = (
+                base.extendModules {
+                  inherit prefix;
+                  modules = [ noCheckForDocsModule ];
+                }
+              );
+              # Intentionally shadow the freeformType from the possibly *checked*
+              # configuration. See `noCheckForDocsModule` comment.
+              inherit (docsEval._module) freeformType;
+            in
+            docsEval.options
             // optionalAttrs (freeformType != null) {
               # Expose the sub options of the freeform type. Note that the option
               # discovery doesn't care about the attribute name used here, so this


### PR DESCRIPTION
- Fixes #396849 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
