### PR TITLE
nixos/homebox: add 'database.createLocally'

### DIFF
--- a/nixos/modules/services/web-apps/homebox.nix
+++ b/nixos/modules/services/web-apps/homebox.nix
@@ -35,6 +35,15 @@ in
         [documentation](https://homebox.software/en/configure-homebox.html).
       '';
     };
+    database = {
+      createLocally = lib.mkOption {
+        type = lib.types.bool;
+        default = false;
+        description = ''
+          Configure local PostgreSQL database server for Homebox.
+        '';
+      };
+    };
   };
 
   config = mkIf cfg.enable {
@@ -43,15 +52,37 @@ in
       group = "homebox";
     };
     users.groups.homebox = { };
-    services.homebox.settings = {
-      HBOX_STORAGE_DATA = mkDefault "/var/lib/homebox/data";
-      HBOX_DATABASE_DRIVER = mkDefault "sqlite3";
-      HBOX_DATABASE_SQLITE_PATH = mkDefault "/var/lib/homebox/data/homebox.db?_pragma=busy_timeout=999&_pragma=journal_mode=WAL&_fk=1";
-      HBOX_OPTIONS_ALLOW_REGISTRATION = mkDefault "false";
-      HBOX_OPTIONS_CHECK_GITHUB_RELEASE = mkDefault "false";
-      HBOX_MODE = mkDefault "production";
+    services.homebox.settings = lib.mkMerge [
+      (lib.mapAttrs (_: mkDefault) {
+        HBOX_STORAGE_DATA = "/var/lib/homebox/data";
+        HBOX_DATABASE_DRIVER = "sqlite3";
+        HBOX_DATABASE_SQLITE_PATH = "/var/lib/homebox/data/homebox.db?_pragma=busy_timeout=999&_pragma=journal_mode=WAL&_fk=1";
+        HBOX_OPTIONS_ALLOW_REGISTRATION = "false";
+        HBOX_OPTIONS_CHECK_GITHUB_RELEASE = "false";
+        HBOX_MODE = "production";
+      })
+
+      (lib.mkIf cfg.database.createLocally {
+        HBOX_DATABASE_DRIVER = "postgres";
+        HBOX_DATABASE_HOST = "/run/postgresql";
+        HBOX_DATABASE_USERNAME = "homebox";
+        HBOX_DATABASE_DATABASE = "homebox";
+        HBOX_DATABASE_PORT = toString config.services.postgresql.settings.port;
+      })
+    ];
+    services.postgresql = lib.mkIf cfg.database.createLocally {
+      enable = true;
+      ensureDatabases = [ "homebox" ];
+      ensureUsers = [
+        {
+          name = "homebox";
+          ensureDBOwnership = true;
+        }
+      ];
     };
     systemd.services.homebox = {
+      requires = lib.optional cfg.database.createLocally "postgresql.service";
+      after = lib.optional cfg.database.createLocally "postgresql.service";
       environment = cfg.settings;
       serviceConfig = {
         User = "homebox";

--- a/nixos/modules/services/web-apps/homebox.nix
+++ b/nixos/modules/services/web-apps/homebox.nix
@@ -82,6 +82,7 @@ in
         ProcSubset = "pid";
         ProtectSystem = "strict";
         RestrictAddressFamilies = [
+          "AF_UNIX"
           "AF_INET"
           "AF_INET6"
           "AF_NETLINK"

--- a/nixos/modules/services/web-apps/homebox.nix
+++ b/nixos/modules/services/web-apps/homebox.nix
@@ -52,7 +52,6 @@ in
       HBOX_MODE = mkDefault "production";
     };
     systemd.services.homebox = {
-      after = [ "network.target" ];
       environment = cfg.settings;
       serviceConfig = {
         User = "homebox";


### PR DESCRIPTION
Add support for configuring a local PostgreSQL database.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
This is necessary to use PostgreSQL with a local socket.