### PR TITLE
trilium-next-{desktop,server}: 0.92.4 -> 0.92.6

### DIFF
--- a/pkgs/by-name/tr/trilium-next-desktop/package.nix
+++ b/pkgs/by-name/tr/trilium-next-desktop/package.nix
@@ -15,7 +15,7 @@
 
 let
   pname = "trilium-next-desktop";
-  version = "0.92.4";
+  version = "0.92.6";
 
   triliumSource = os: arch: sha256: {
     url = "https://github.com/TriliumNext/Notes/releases/download/v${version}/TriliumNextNotes-v${version}-${os}-${arch}.zip";
@@ -26,10 +26,10 @@ let
   darwinSource = triliumSource "macos";
 
   # exposed like this for update.sh
-  x86_64-linux.sha256 = "12z6r38ab8jrjgic370q5v1y17m9brj38gfqdg05drf7a25xam8r";
-  aarch64-linux.sha256 = "0zsc7c7q07zml91sqvwgz8x3vql1mlhvb7msf7vx22w94dypzivf";
-  x86_64-darwin.sha256 = "09ipqfr77xqlgbzh2dvlidm532isg8jj8iwawjldq74ncbv8m5h0";
-  aarch64-darwin.sha256 = "031nz4f3rdjg3cyvadax4shchr7liyrzsn3ab6whsp3mhnb9wr9l";
+  x86_64-linux.sha256 = "1ky5w6iwqcsc66ywgamkfs9yd6bp51c3y69251pi4b365dwbglf5";
+  aarch64-linux.sha256 = "1zm6g2rkg31ahnn8y5h42vb632pqjg6d8kb4xkkrb4pp9h71sgjm";
+  x86_64-darwin.sha256 = "011y5vh0bfn73l8n4my5pdpgrvvicy1lvnjrb1qyaglg7gw2sy0r";
+  aarch64-darwin.sha256 = "05v6pk1h5y5kqwjkixji3a44dcr219320z0i6yvwv4d8mc943qhs";
 
   sources = {
     x86_64-linux = linuxSource "x64" x86_64-linux.sha256;

--- a/pkgs/by-name/tr/trilium-next-server/package.nix
+++ b/pkgs/by-name/tr/trilium-next-server/package.nix
@@ -7,12 +7,12 @@
 }:
 
 let
-  version = "0.92.4";
+  version = "0.92.6";
 
   serverSource_x64.url = "https://github.com/TriliumNext/Notes/releases/download/v${version}/TriliumNextNotes-Server-v${version}-linux-x64.tar.xz";
-  serverSource_x64.sha256 = "1bcacr5sxmrq9zvh8xjyr30y5mz0y6qyx2m18dblswdi0mbi7cv4";
+  serverSource_x64.sha256 = "1mh7q11hwp5vrbdrwb0apmxkiv90i3163m8a3cbv0jhd5amv9rjv";
   serverSource_arm64.url = "https://github.com/TriliumNext/Notes/releases/download/v${version}/TriliumNextNotes-Server-v${version}-linux-arm64.tar.xz";
-  serverSource_arm64.sha256 = "04mjkqywwdax46r8q8wygi9dxglz2qipmlrv3cqqpdvjm0yxh2g2";
+  serverSource_arm64.sha256 = "1w5208izjifcq4vsryjpmw2nr140fk2h802q9lkil1646r2b5lyg";
 
   serverSource =
     if stdenv.hostPlatform.isx86_64 then
@@ -56,8 +56,7 @@ stdenv.mkDerivation {
       --add-flags "src/main"
 
     # Clean up broken symlinks and build tools.
-    rm "$out"/share/trilium-server/node/bin/{npm,npx}
-    rm -r "$out"/share/trilium-server/node_modules/{@npmcli,@rollup,@babel,.bin}
+    rm -r "$out"/share/trilium-server/node_modules/{@npmcli,@rollup,@babel}
 
     runHook postInstall
   '';


### PR DESCRIPTION
New stable release

https://github.com/TriliumNext/Notes/releases/tag/v0.92.6
https://github.com/TriliumNext/Notes/releases/tag/v0.92.5-beta

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).