### PR TITLE
[Backport release-24.11] sdl3-image: init at 3.2.4

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6976,6 +6976,12 @@
     githubId = 30512529;
     name = "Evils";
   };
+  evythedemon = {
+    name = "Evy Garden";
+    github = "EvysGarden";
+    githubId = 92547295;
+    email = "evysgarden@protonmail.com";
+  };
   ewok = {
     email = "ewok@ewok.ru";
     github = "ewok-old";

--- a/pkgs/by-name/sd/sdl3-image/package.nix
+++ b/pkgs/by-name/sd/sdl3-image/package.nix
@@ -1,0 +1,67 @@
+{
+  lib,
+  sdl3,
+  darwin,
+  libavif,
+  libtiff,
+  libwebp,
+  stdenv,
+  cmake,
+  fetchFromGitHub,
+  validatePkgConfig,
+  # Boolean flags
+  enableTests ? true,
+  enableImageIO ? stdenv.hostPlatform.isDarwin,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "sdl3-image";
+  version = "3.2.4";
+
+  outputs = [
+    "lib"
+    "dev"
+    "out"
+  ];
+
+  src = fetchFromGitHub {
+    owner = "libsdl-org";
+    repo = "SDL_image";
+    tag = "release-${finalAttrs.version}";
+    hash = "sha256-/orQ+YfH0CV8DOqXFMF9fOT4YaVpC1t55xM3j520Png=";
+  };
+
+  strictDeps = true;
+  doCheck = true;
+
+  nativeBuildInputs = [
+    cmake
+    validatePkgConfig
+  ];
+
+  buildInputs = [
+    sdl3
+    libtiff
+    libwebp
+    libavif
+  ] ++ (lib.optional stdenv.hostPlatform.isDarwin darwin.apple_sdk.frameworks.Foundation);
+
+  cmakeFlags = [
+    # fail when a dependency could not be found
+    (lib.cmakeBool "SDLIMAGE_STRICT" true)
+    # disable shared dependencies as they're opened at runtime using SDL_LoadObject otherwise.
+    (lib.cmakeBool "SDLIMAGE_DEPS_SHARED" false)
+    # enable imageio backend
+    (lib.cmakeBool "SDLIMAGE_BACKEND_IMAGEIO" enableImageIO)
+    # enable tests
+    (lib.cmakeBool "SDLIMAGE_TESTS" enableTests)
+  ];
+
+  meta = {
+    description = "SDL image library";
+    homepage = "https://github.com/libsdl-org/SDL_image";
+    license = lib.licenses.zlib;
+    maintainers = with lib.maintainers; [ evythedemon ];
+    inherit (sdl3.meta) platforms;
+  };
+})

--- a/pkgs/by-name/sd/sdl3-image/package.nix
+++ b/pkgs/by-name/sd/sdl3-image/package.nix
@@ -9,8 +9,11 @@
   cmake,
   fetchFromGitHub,
   validatePkgConfig,
+  libpng,
+  libjpeg,
   # Boolean flags
   enableTests ? true,
+  enableSTB ? true,
   enableImageIO ? stdenv.hostPlatform.isDarwin,
 }:
 
@@ -39,18 +42,26 @@ stdenv.mkDerivation (finalAttrs: {
     validatePkgConfig
   ];
 
-  buildInputs = [
-    sdl3
-    libtiff
-    libwebp
-    libavif
-  ] ++ (lib.optional stdenv.hostPlatform.isDarwin darwin.apple_sdk.frameworks.Foundation);
+  buildInputs =
+    [
+      sdl3
+      libtiff
+      libwebp
+      libavif
+    ]
+    ++ (lib.optional stdenv.hostPlatform.isDarwin darwin.apple_sdk.frameworks.Foundation)
+    ++ (lib.optionals (!enableSTB) [
+      libpng
+      libjpeg
+    ]);
 
   cmakeFlags = [
     # fail when a dependency could not be found
     (lib.cmakeBool "SDLIMAGE_STRICT" true)
     # disable shared dependencies as they're opened at runtime using SDL_LoadObject otherwise.
     (lib.cmakeBool "SDLIMAGE_DEPS_SHARED" false)
+    # disable stbi
+    (lib.cmakeBool "SDLIMAGE_BACKEND_STB" enableSTB)
     # enable imageio backend
     (lib.cmakeBool "SDLIMAGE_BACKEND_IMAGEIO" enableImageIO)
     # enable tests

--- a/pkgs/by-name/sd/sdl3-image/package.nix
+++ b/pkgs/by-name/sd/sdl3-image/package.nix
@@ -10,6 +10,7 @@
   validatePkgConfig,
   libpng,
   libjpeg,
+  nix-update-script,
   # Boolean flags
   enableTests ? true,
   enableSTB ? true,
@@ -65,6 +66,13 @@ stdenv.mkDerivation (finalAttrs: {
     # enable tests
     (lib.cmakeBool "SDLIMAGE_TESTS" enableTests)
   ];
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [
+      "--version-regex"
+      "release-(3\\..*)"
+    ];
+  };
 
   meta = {
     description = "SDL image library";

--- a/pkgs/by-name/sd/sdl3-image/package.nix
+++ b/pkgs/by-name/sd/sdl3-image/package.nix
@@ -70,7 +70,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "SDL image library";
     homepage = "https://github.com/libsdl-org/SDL_image";
     license = lib.licenses.zlib;
-    maintainers = with lib.maintainers; [ evythedemon ];
+    maintainers = [ lib.maintainers.evythedemon ];
     inherit (sdl3.meta) platforms;
   };
 })

--- a/pkgs/by-name/sd/sdl3-image/package.nix
+++ b/pkgs/by-name/sd/sdl3-image/package.nix
@@ -1,7 +1,6 @@
 {
   lib,
   sdl3,
-  darwin,
   libavif,
   libtiff,
   libwebp,
@@ -49,7 +48,6 @@ stdenv.mkDerivation (finalAttrs: {
       libwebp
       libavif
     ]
-    ++ (lib.optional stdenv.hostPlatform.isDarwin darwin.apple_sdk.frameworks.Foundation)
     ++ (lib.optionals (!enableSTB) [
       libpng
       libjpeg


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Original pull requests:
+ https://github.com/NixOS/nixpkgs/pull/384531
+ https://github.com/NixOS/nixpkgs/pull/400078

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
