### PR TITLE
gitlab-runner: 17.2.0 -> 17.10.1

### DIFF
--- a/pkgs/by-name/gi/gitlab-runner/package.nix
+++ b/pkgs/by-name/gi/gitlab-runner/package.nix
@@ -10,16 +10,16 @@
 
 buildGoModule (finalAttrs: {
   pname = "gitlab-runner";
-  version = "17.2.0";
+  version = "17.10.1";
 
   src = fetchFromGitLab {
     owner = "gitlab-org";
     repo = "gitlab-runner";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-a2Igy4DS3fYTvPW1vvDrH/DjMQ4lG9cm/P3mFr+y9s4=";
+    hash = "sha256-pLmDWZHxd9dNhmbcHJRBxPuY0IpcJoXz/fOJeP1lVlA=";
   };
 
-  vendorHash = "sha256-1MwHss76apA9KoFhEU6lYiUACrPMGYzjhds6nTyNuJI=";
+  vendorHash = "sha256-1NteDxcGjsC0kT/9u7BT065EN/rBhaNznegdPHZUKxo=";
 
   # For patchShebangs
   nativeBuildInputs = [ bash ];
@@ -33,32 +33,43 @@ buildGoModule (finalAttrs: {
     ''
       # Remove some tests that can't work during a nix build
 
-      # Requires to run in a git repo
+      # Needs the build directory to be a git repo
       sed -i "s/func TestCacheArchiverAddingUntrackedFiles/func OFF_TestCacheArchiverAddingUntrackedFiles/" commands/helpers/file_archiver_test.go
       sed -i "s/func TestCacheArchiverAddingUntrackedUnicodeFiles/func OFF_TestCacheArchiverAddingUntrackedUnicodeFiles/" commands/helpers/file_archiver_test.go
+      rm shells/abstract_test.go
 
       # No writable developer environment
-      rm common/build_test.go
       rm common/build_settings_test.go
+      rm common/build_test.go
       rm executors/custom/custom_test.go
 
-      # No docker during build
-      rm executors/docker/terminal_test.go
+      # No Docker during build
       rm executors/docker/docker_test.go
-      rm helpers/docker/auth/auth_test.go
       rm executors/docker/services_test.go
+      rm executors/docker/terminal_test.go
+      rm helpers/docker/auth/auth_test.go
+
+      # No Kubernetes during build
+      rm executors/kubernetes/feature_test.go
+      rm executors/kubernetes/kubernetes_test.go
+      rm executors/kubernetes/overwrites_test.go
     ''
     + lib.optionalString stdenv.buildPlatform.isDarwin ''
+      # Invalid bind arguments break Unix socket tests
+      sed -i "s/func TestRunnerWrapperCommand_createListener/func OFF_TestRunnerWrapperCommand_createListener/" commands/wrapper_test.go
+
       # No keychain access during build breaks X.509 certificate tests
-      rm helpers/certificate/x509_test.go
-      rm network/client_test.go
+      sed -i "s/func TestCertificate/func OFF_TestCertificate/" helpers/certificate/x509_test.go
+      sed -i "s/func TestClientInvalidSSL/func OFF_TestClientInvalidSSL/" network/client_test.go
     '';
 
   excludedPackages = [
-    # CI helper script for pushing images to Docker and ECR registries
+    # Nested dependency Go module, used with go.mod replace directive
     #
-    # https://gitlab.com/gitlab-org/gitlab-runner/-/merge_requests/4139
-    "./scripts/sync-docker-images"
+    # https://gitlab.com/gitlab-org/gitlab-runner/-/commit/57ea9df5d8a8deb78c8d1972930bbeaa80d05e78
+    "./helpers/runner_wrapper/api"
+    # Helper scripts for upstream Make targets, not intended for downstream consumers
+    "./scripts"
   ];
 
   ldflags =


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Update GitLab Runner from 17.2.0 to 17.10.1.

I'm not sure what the rationale is for the ongoing switch attempt from the `buildGoModules` default phases to upstream Make targets (https://github.com/NixOS/nixpkgs/pull/392089), but I assume there was some upstream change that appeared to make `buildGoModule` harder to use. The upstream Make files have a lot of questionable assumptions and impurities, so opting to stay with `buildGoModules` default phases here.

Note that this also removes all of the upstream helper binaries that are only intended to be used in their Make targets (e.g. `check-test-directives`, `pull-images-for-tests`, `update-feature-flags-docs`).

```text
/nix/store/hcp299vrzf484psknyz5l07j42wqrfv8-gitlab-runner-17.10.1
└── bin
    ├── clear-docker-cache
    ├── gitlab-runner
    └── gitlab-runner-helper
```

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
