### PR TITLE
nixVersions.git: Reintroduce

### DIFF
--- a/pkgs/by-name/ni/nix-plugin-pijul/package.nix
+++ b/pkgs/by-name/ni/nix-plugin-pijul/package.nix
@@ -81,6 +81,7 @@ stdenv.mkDerivation (finalAttrs: {
     {
       stable = localRepoCheck nixVersions.stable;
       latest = localRepoCheck nixVersions.latest;
+      git = localRepoCheck nixVersions.git;
       nix_2_24 = localRepoCheck nixVersions.nix_2_24;
     };
 

--- a/pkgs/tools/package-management/nix/default.nix
+++ b/pkgs/tools/package-management/nix/default.nix
@@ -197,6 +197,20 @@ lib.makeExtensible (
 
       nix_2_28 = addTests "nix_2_28" self.nixComponents_2_28.nix-everything;
 
+      nixComponents_git = nixDependencies.callPackage ./modular/packages.nix rec {
+        version = "2.29pre20250407_${lib.substring 0 8 src.rev}";
+        inherit (self.nix_2_24.meta) maintainers;
+        otherSplices = generateSplicesForNixComponents "nixComponents_git";
+        src = fetchFromGitHub {
+          owner = "NixOS";
+          repo = "nix";
+          rev = "73d3159ba0b4b711c1f124a587f16e2486d685d7";
+          hash = "sha256-9wJXUGqXIqMjNyKWJKCcxrDHM/KxDkvJMwo6S3s+WuM=";
+        };
+      };
+
+      git = addTests "git" self.nixComponents_git.nix-everything;
+
       latest = self.nix_2_28;
 
       # The minimum Nix version supported by Nixpkgs
@@ -234,7 +248,6 @@ lib.makeExtensible (
         nix_2_27 = throw "nix_2_27 has been removed. use nix_2_28.";
 
         unstable = throw "nixVersions.unstable has been removed. use nixVersions.latest or the nix flake.";
-        git = throw "nixVersions.git has been removed. use nixVersions.latest or the nix flake.";
       }
     )
   )

--- a/pkgs/tools/package-management/nix/update-all.sh
+++ b/pkgs/tools/package-management/nix/update-all.sh
@@ -36,3 +36,9 @@ for name in $nix_versions; do
         break
     fi
 done
+
+commit_json=$(curl -s https://api.github.com/repos/NixOS/nix/commits/master) # format: 2024-11-01T10:18:53Z
+date_of_commit=$(echo "$commit_json" | jq -r '.commit.author.date')
+suffix="pre$(date -d "$date_of_commit" +%Y%m%d)_"
+sed -i -e "s|\"pre[0-9]\{8\}_|\"$suffix|g" "$SCRIPT_DIR/default.nix"
+nix-update --override-filename "$SCRIPT_DIR/default.nix" --version branch --build --commit "nixVersions.git"

--- a/pkgs/top-level/release-cross.nix
+++ b/pkgs/top-level/release-cross.nix
@@ -79,6 +79,7 @@ let
     gmp = nativePlatforms;
     libcCross = nativePlatforms;
     nix = nativePlatforms;
+    nixVersions.git = nativePlatforms;
     mesa = nativePlatforms;
     rustc = nativePlatforms;
     cargo = nativePlatforms;


### PR DESCRIPTION
It was removed in 68472b90a670e7fc692b053b51a3ac27d73bc632 because it was out of date, using the old build system. Now, it is up to date, and uses the Meson build system and the per-component build.

I am especially keen to get this is because once 2.28 uses the monolithic build (#393509) out of an abundance of caution, this is will be the only use of the per-component build, until the next Nix version (and Nix 2.28 on master after Nixpkgs 25.05 is forked off and released).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
