### PR TITLE
Fix #396993 by tracking the new minified name of the `ServerTransferFailed` status code

### DIFF
--- a/pkgs/applications/editors/vscode/extensions/ms-vscode-remote.remote-ssh/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/ms-vscode-remote.remote-ssh/default.nix
@@ -61,7 +61,7 @@ let
 
     if ! nodeVersion=$($serverNode -v); then
       echo "Unable to fix Node binary, quitting"
-      fail_with_exitcode ''${o.InstallExitCode.ServerTransferFailed}
+      fail_with_exitcode ''${f.UnifiedStatusCode.ServerTransferFailed}
     fi
 
     ${lib.optionalString useLocalExtensions ''


### PR DESCRIPTION
This fixes #396993. The `ms-vscode-remote.remote-ssh` package patches in a chunk of shell script which refers to an exit status code `o.InstallExitCode.ServerTransferFailed`, which has apparently been moved to a new `UnifiedStatusCode` object under the minified variable name `f`.

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

I tested this by locally copying the package into my dotfiles. Note that I updated to remote-ssh 0.119.0 but I think this works on 0.118.0 as well: https://github.com/Dridus/dotfiles/commit/21d0cac53ac693cfc08fb5661f1a1b0ee0c6f451#diff-577528337f6e4888e9a63d89f154429666383ada280df31e5eea2460265c6a49

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
