### PR TITLE
nixos/iwd: move General.UseDefaultInterface to DriverQuirks.DefaultInterface

### DIFF
--- a/nixos/modules/services/networking/iwd.nix
+++ b/nixos/modules/services/networking/iwd.nix
@@ -20,7 +20,7 @@ let
   defaults = {
     # without UseDefaultInterface, sometimes wlan0 simply goes AWOL with NetworkManager
     # https://iwd.wiki.kernel.org/interface_lifecycle#interface_management_in_iwd
-    General.UseDefaultInterface =
+    DriverQuirks.UseDefaultInterface =
       with config.networking.networkmanager;
       (enable && (wifi.backend == "iwd"));
   };
@@ -59,6 +59,12 @@ in
         assertion = !config.networking.wireless.enable;
         message = ''
           Only one wireless daemon is allowed at the time: networking.wireless.enable and networking.wireless.iwd.enable are mutually exclusive.
+        '';
+      }
+      {
+        assertion = !(cfg.settings ? General && cfg.settings.General ? UseDefaultInterface);
+        message = ''
+          `networking.wireless.iwd.settings.General.UseDefaultInterface` has been deprecated. Use `networking.wireless.iwd.settings.DriverQuirks.UseDefaultInterface` instead.
         '';
       }
     ];


### PR DESCRIPTION
`General.UseDefaultInterface` was deprecated last year, with a
recommendation to move to `DriverQuirks.DefaultInterface` [0] [1] [2].

[0]: https://git.kernel.org/pub/scm/network/wireless/iwd.git/commit/?id=5c7777ff0fbcdee3c5d3a3cf6b1f375f2e820644
[1]: https://git.kernel.org/pub/scm/network/wireless/iwd.git/commit/?id=d223f49fbc622e5b2f270711619ecbd542bed12e
[2]: https://git.kernel.org/pub/scm/network/wireless/iwd.git/commit/?id=a27b7823df12c5d185b39aa7777c546843c1c96f
