### PR TITLE
apacheKafka.tests: fix the eval

### DIFF
--- a/pkgs/servers/apache-kafka/default.nix
+++ b/pkgs/servers/apache-kafka/default.nix
@@ -19,28 +19,28 @@ let
       scalaVersion = "2.13";
       sha256 = "sha256-e4Uuk4vAneEM2W7KN1UljH0l+4nb3XYwVxdgfhg14qo=";
       jre = jdk17_headless;
-      nixosTest = nixosTests.kafka.kafka_4_0;
+      nixosTest = nixosTests.kafka.base.kafka_4_0;
     };
     "3_9" = {
       kafkaVersion = "3.9.0";
       scalaVersion = "2.13";
       sha256 = "sha256-q8REAt3xA+OPGbDktE5l2pqDG6nlj9dyUEGxqhaO6NE=";
       jre = jdk17_headless;
-      nixosTest = nixosTests.kafka.kafka_3_9;
+      nixosTest = nixosTests.kafka.base.kafka_3_9;
     };
     "3_8" = {
       kafkaVersion = "3.8.1";
       scalaVersion = "2.13";
       sha256 = "sha256-IhdChtYMqmKyVQbEhpRLxuBNjLLS8VCD0v60gjl3i2I=";
       jre = jdk17_headless;
-      nixosTest = nixosTests.kafka.kafka_3_8;
+      nixosTest = nixosTests.kafka.base.kafka_3_8;
     };
     "3_7" = {
       kafkaVersion = "3.7.1";
       scalaVersion = "2.13";
       sha256 = "sha256-YqyuShQ92YPcfrSATVdEugxQsZm1CPWZ7wAQIOJVj8k=";
       jre = jdk17_headless;
-      nixosTest = nixosTests.kafka.kafka_3_7;
+      nixosTest = nixosTests.kafka.base.kafka_3_7;
     };
   };
 


### PR DESCRIPTION
Without the change the eval fails as:

    $ nix build --no-link -f. apacheKafka.tests
    error:
       … while evaluating the attribute 'nixos'
         at pkgs/servers/apache-kafka/default.nix:94:9:
           93|         inherit (versionInfo) jre; # Used by the NixOS module to select the supported JRE
           94|         tests.nixos = versionInfo.nixosTest;
             |         ^
           95|       };

       … while evaluating the attribute 'nixosTest'
         at pkgs/servers/apache-kafka/default.nix:22:7:
           21|       jre = jdk17_headless;
           22|       nixosTest = nixosTests.kafka.kafka_4_0;
             |       ^
           23|     };

       (stack trace truncated; use '--show-trace' to show the full, detailed trace)

       error: attribute 'kafka_4_0' missing
       at pkgs/servers/apache-kafka/default.nix:22:19:
           21|       jre = jdk17_headless;
           22|       nixosTest = nixosTests.kafka.kafka_4_0;
             |                   ^
           23|     };


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
