### PR TITLE
ocamlPackages.qcheck: 0.24 → 0.25

### DIFF
--- a/pkgs/development/ocaml-modules/batteries/default.nix
+++ b/pkgs/development/ocaml-modules/batteries/default.nix
@@ -3,6 +3,7 @@
   fetchFromGitHub,
   buildDunePackage,
   ocaml,
+  ounit,
   qtest,
   qcheck,
   num,
@@ -24,7 +25,10 @@ buildDunePackage rec {
   };
 
   nativeCheckInputs = [ qtest ];
-  checkInputs = [ qcheck ];
+  checkInputs = [
+    ounit
+    qcheck
+  ];
   propagatedBuildInputs = [
     camlp-streams
     num

--- a/pkgs/development/ocaml-modules/qcheck/alcotest.nix
+++ b/pkgs/development/ocaml-modules/qcheck/alcotest.nix
@@ -9,8 +9,6 @@ buildDunePackage {
 
   inherit (qcheck-core) version src patches;
 
-  duneVersion = "3";
-
   propagatedBuildInputs = [
     qcheck-core
     alcotest

--- a/pkgs/development/ocaml-modules/qcheck/core.nix
+++ b/pkgs/development/ocaml-modules/qcheck/core.nix
@@ -6,15 +6,15 @@
 
 buildDunePackage rec {
   pname = "qcheck-core";
-  version = "0.24";
+  version = "0.25";
 
   minimalOCamlVersion = "4.08";
 
   src = fetchFromGitHub {
     owner = "c-cube";
     repo = "qcheck";
-    rev = "v${version}";
-    hash = "sha256-iuFlmSeUhumeWhqHlaNqDjReRf8c4e76hhT27DK3+/g=";
+    tag = "v${version}";
+    hash = "sha256-Z89jJ21zm89wb9m5HthnbHdnE9iXLyaH9k8S+FAWkKQ=";
   };
 
   meta = {

--- a/pkgs/development/ocaml-modules/qcheck/default.nix
+++ b/pkgs/development/ocaml-modules/qcheck/default.nix
@@ -5,8 +5,6 @@ buildDunePackage {
 
   inherit (qcheck-ounit) version src patches;
 
-  duneVersion = "3";
-
   propagatedBuildInputs = [ qcheck-ounit ];
 
   meta = qcheck-ounit.meta // {

--- a/pkgs/development/ocaml-modules/qcheck/ounit.nix
+++ b/pkgs/development/ocaml-modules/qcheck/ounit.nix
@@ -1,7 +1,7 @@
 {
   buildDunePackage,
   qcheck-core,
-  ounit,
+  ounit2,
 }:
 
 buildDunePackage {
@@ -9,11 +9,9 @@ buildDunePackage {
 
   inherit (qcheck-core) version src patches;
 
-  duneVersion = "3";
-
   propagatedBuildInputs = [
     qcheck-core
-    ounit
+    ounit2
   ];
 
   meta = qcheck-core.meta // {

--- a/pkgs/development/ocaml-modules/qcheck/ppx_deriving_qcheck.nix
+++ b/pkgs/development/ocaml-modules/qcheck/ppx_deriving_qcheck.nix
@@ -1,6 +1,6 @@
 {
   buildDunePackage,
-  qcheck-core,
+  fetchFromGitHub,
   qcheck,
   ppxlib,
   ppx_deriving,
@@ -8,10 +8,14 @@
 
 buildDunePackage {
   pname = "ppx_deriving_qcheck";
+  version = "0.6";
 
-  inherit (qcheck-core) version src patches;
-
-  duneVersion = "3";
+  src = fetchFromGitHub {
+    owner = "c-cube";
+    repo = "qcheck";
+    tag = "v0.24";
+    hash = "sha256-iuFlmSeUhumeWhqHlaNqDjReRf8c4e76hhT27DK3+/g=";
+  };
 
   propagatedBuildInputs = [
     qcheck
@@ -19,7 +23,7 @@ buildDunePackage {
     ppx_deriving
   ];
 
-  meta = qcheck-core.meta // {
+  meta = qcheck.meta // {
     description = "PPX Deriver for QCheck";
   };
 }


### PR DESCRIPTION
## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
