### PR TITLE
mercurial: fix cross build

### DIFF
--- a/pkgs/by-name/me/mercurial/package.nix
+++ b/pkgs/by-name/me/mercurial/package.nix
@@ -45,6 +45,17 @@ let
       hash = "sha256-fqDoOeyDRSd90Z0HJQtEJhNNxdZoL/iAqGorCbTjjs0=";
     };
 
+    # fix cross-compile of Rust library
+    postPatch = lib.optionalString rustSupport ''
+      substituteInPlace setup.py \
+        --replace-fail "cargocmd = ['cargo', 'rustc', '--release']" \
+        "cargocmd = ['cargo', 'rustc', '--target', '${stdenv.hostPlatform.rust.rustcTarget}', '--release']" \
+        --replace-fail "rusttargetdir = os.path.join('rust', 'target', 'release')" \
+        "rusttargetdir = os.path.join('rust', 'target', '${stdenv.hostPlatform.rust.rustcTarget}', 'release')"
+      substituteInPlace Makefile \
+        --replace-fail 'rust/target/release' 'rust/target/${stdenv.hostPlatform.rust.rustcTarget}/release'
+    '';
+
     format = "other";
 
     passthru = { inherit python; }; # pass it so that the same version can be used in hg2git


### PR DESCRIPTION
Could be upstreamed, but I didn't spot any existing configuration options for cross builds.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux (cross)
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).