### PR TITLE
zoom-us: use `buildFHSEnv`, update, `xdg-desktop-portal`, minor improvements

### DIFF
--- a/pkgs/by-name/zo/zoom-us/package.nix
+++ b/pkgs/by-name/zo/zoom-us/package.nix
@@ -188,12 +188,7 @@ let
     version = versions.${system} or throwSystem;
 
     targetPkgs = pkgs: (linuxGetDependencies pkgs) ++ [ unpacked ];
-    extraPreBwrapCmds = ''
-      cd ${unpacked}/opt/zoom
-      unset QML2_IMPORT_PATH
-      unset QT_PLUGIN_PATH
-      unset QT_SCREEN_SCALE_FACTORS
-    '';
+    extraPreBwrapCmds = "unset QT_PLUGIN_PATH";
     extraBwrapArgs = [ "--ro-bind ${unpacked}/opt /opt" ];
     runScript = "/opt/zoom/ZoomLauncher";
 

--- a/pkgs/by-name/zo/zoom-us/package.nix
+++ b/pkgs/by-name/zo/zoom-us/package.nix
@@ -19,23 +19,23 @@ let
   # and often with different versions. We write them on three lines
   # like this (rather than using {}) so that the updater script can
   # find where to edit them.
-  versions.aarch64-darwin = "6.3.11.50104";
-  versions.x86_64-darwin = "6.3.11.50104";
-  versions.x86_64-linux = "6.3.11.7212";
+  versions.aarch64-darwin = "6.4.1.51520";
+  versions.x86_64-darwin = "6.4.1.51520";
+  versions.x86_64-linux = "6.4.1.587";
 
   srcs = {
     aarch64-darwin = fetchurl {
       url = "https://zoom.us/client/${versions.aarch64-darwin}/zoomusInstallerFull.pkg?archType=arm64";
       name = "zoomusInstallerFull.pkg";
-      hash = "sha256-RZVBq2TQcPs+8wx3YwwISVgaPvxS8hP93vxbJMpEhT0=";
+      hash = "sha256-igPyasH67eDe8hYIHCyZ/dk4P5zBbhYtFdQ2ww/QwO4=";
     };
     x86_64-darwin = fetchurl {
       url = "https://zoom.us/client/${versions.x86_64-darwin}/zoomusInstallerFull.pkg";
-      hash = "sha256-OwHVqQZVIQlasehX6UTD1fg1YZDAtvBZSdPq2Ze2JTA=";
+      hash = "sha256-EBGc64dy9WKyz6UAFGUrzFtrO+lho5xvIK13jzedUXc=";
     };
     x86_64-linux = fetchurl {
       url = "https://zoom.us/client/${versions.x86_64-linux}/zoom_x86_64.pkg.tar.xz";
-      hash = "sha256-wSXb2v2qXoLXctmjOZpL0SiOP8+ySwpTDpJmPrfQQco=";
+      hash = "sha256-xShPDJZZSawKag/OrUqTommIM8RwY1K6LVNEdnr2D94=";
     };
   };
 

--- a/pkgs/by-name/zo/zoom-us/package.nix
+++ b/pkgs/by-name/zo/zoom-us/package.nix
@@ -26,6 +26,7 @@
   nspr,
   nss,
   pango,
+  qt5,
   wayland,
   xorg,
   libxkbcommon,
@@ -94,6 +95,12 @@ let
       nspr
       nss
       pango
+      qt5.qt3d
+      qt5.qtgamepad
+      qt5.qtlottie
+      qt5.qtmultimedia
+      qt5.qtremoteobjects
+      qt5.qtxmlpatterns
       stdenv.cc.cc
       wayland
       xorg.libX11

--- a/pkgs/by-name/zo/zoom-us/package.nix
+++ b/pkgs/by-name/zo/zoom-us/package.nix
@@ -19,23 +19,23 @@ let
   # and often with different versions. We write them on three lines
   # like this (rather than using {}) so that the updater script can
   # find where to edit them.
-  versions.aarch64-darwin = "6.4.5.53616";
-  versions.x86_64-darwin = "6.4.5.53616";
-  versions.x86_64-linux = "6.4.5.1259";
+  versions.aarch64-darwin = "6.4.6.53970";
+  versions.x86_64-darwin = "6.4.6.53970";
+  versions.x86_64-linux = "6.4.6.1370";
 
   srcs = {
     aarch64-darwin = fetchurl {
       url = "https://zoom.us/client/${versions.aarch64-darwin}/zoomusInstallerFull.pkg?archType=arm64";
       name = "zoomusInstallerFull.pkg";
-      hash = "sha256-Rd/2MZQ0NwZWQ9g0b99axB1IrNB4HBpf51nQ7UmO9/0=";
+      hash = "sha256-yNsiFZNte4432d8DUyDhPUOVbLul7gUdvr+3qK/Y+tk=";
     };
     x86_64-darwin = fetchurl {
       url = "https://zoom.us/client/${versions.x86_64-darwin}/zoomusInstallerFull.pkg";
-      hash = "sha256-oBfUPOiuyXAyusCUL4r/aYf0rU/myBu8QlkCnYyVi2w=";
+      hash = "sha256-Ut93qQFFN0d58wXD5r8u0B17HbihFg3FgY3a1L8nsIA=";
     };
     x86_64-linux = fetchurl {
       url = "https://zoom.us/client/${versions.x86_64-linux}/zoom_x86_64.pkg.tar.xz";
-      hash = "sha256-oAsK92yTaLdi9YfIcMkTevrSsKr2nClcMjOBo5VYIEg=";
+      hash = "sha256-Y+8garSqDcKLCVv1cTiqGEfrGKpK3UoXIq8X4E8CF+8=";
     };
   };
 

--- a/pkgs/by-name/zo/zoom-us/package.nix
+++ b/pkgs/by-name/zo/zoom-us/package.nix
@@ -2,9 +2,6 @@
   stdenv,
   lib,
   fetchurl,
-  makeWrapper,
-  xar,
-  cpio,
   pulseaudioSupport ? true,
   xdgDesktopPortalSupport ? true,
   callPackage,
@@ -12,88 +9,37 @@
 }:
 
 let
-  inherit (stdenv.hostPlatform) system;
-  throwSystem = throw "Unsupported system: ${system}";
+  unpacked = stdenv.mkDerivation (finalAttrs: {
+    pname = "zoom";
+    version = "6.4.6.1370";
 
-  # Zoom versions are released at different times for each platform
-  # and often with different versions. We write them on three lines
-  # like this (rather than using {}) so that the updater script can
-  # find where to edit them.
-  versions.aarch64-darwin = "6.4.6.53970";
-  versions.x86_64-darwin = "6.4.6.53970";
-  versions.x86_64-linux = "6.4.6.1370";
-
-  srcs = {
-    aarch64-darwin = fetchurl {
-      url = "https://zoom.us/client/${versions.aarch64-darwin}/zoomusInstallerFull.pkg?archType=arm64";
-      name = "zoomusInstallerFull.pkg";
-      hash = "sha256-yNsiFZNte4432d8DUyDhPUOVbLul7gUdvr+3qK/Y+tk=";
-    };
-    x86_64-darwin = fetchurl {
-      url = "https://zoom.us/client/${versions.x86_64-darwin}/zoomusInstallerFull.pkg";
-      hash = "sha256-Ut93qQFFN0d58wXD5r8u0B17HbihFg3FgY3a1L8nsIA=";
-    };
-    x86_64-linux = fetchurl {
-      url = "https://zoom.us/client/${versions.x86_64-linux}/zoom_x86_64.pkg.tar.xz";
+    src = fetchurl {
+      url = "https://zoom.us/client/${finalAttrs.version}/zoom_x86_64.pkg.tar.xz";
       hash = "sha256-Y+8garSqDcKLCVv1cTiqGEfrGKpK3UoXIq8X4E8CF+8=";
     };
-  };
 
-  unpacked = stdenv.mkDerivation {
-    pname = "zoom";
-    version = versions.${system} or throwSystem;
+    dontUnpack = true;
 
-    src = srcs.${system} or throwSystem;
-
-    dontUnpack = stdenv.hostPlatform.isLinux;
-    unpackPhase = lib.optionalString stdenv.hostPlatform.isDarwin ''
-      xar -xf $src
-      zcat < zoomus.pkg/Payload | cpio -i
-    '';
-
-    # Note: In order to uncover missing libraries
-    # on x86_64-linux, add "pkgs" to this file's arguments
+    # Note: In order to uncover missing libraries,
+    # add "pkgs" to this file's arguments
     # (at the top of this file), then add these attributes here:
     # > buildInputs = linuxGetDependencies pkgs;
     # > dontAutoPatchelf = true;
     # > dontWrapQtApps = true;
+    # > nativeBuildInputs = [ pkgs.autoPatchelfHook ];
     # > preFixup = ''
     # >   addAutoPatchelfSearchPath $out/opt/zoom
     # >   autoPatchelf $out/opt/zoom/{cef,Qt,*.so*,aomhost,zoom,zopen,ZoomLauncher,ZoomWebviewHost}
     # > '';
-    # ...and finally "pkgs.autoPatchelfHook"
-    # to `nativeBuildInputs` right below.
     # Then build `zoom-us.unpacked`:
     # `autoPatchelfHook` will report missing library files.
-    nativeBuildInputs = lib.optionals stdenv.hostPlatform.isDarwin [
-      makeWrapper
-      xar
-      cpio
-    ];
 
     installPhase = ''
       runHook preInstall
-      ${
-        rec {
-          aarch64-darwin = ''
-            mkdir -p $out/Applications
-            cp -R zoom.us.app $out/Applications/
-          '';
-          # darwin steps same on both architectures
-          x86_64-darwin = aarch64-darwin;
-          x86_64-linux = ''
-            mkdir $out
-            tar -C $out -xf $src
-            mv $out/usr/* $out/
-          '';
-        }
-        .${system} or throwSystem
-      }
+      mkdir $out
+      tar -C $out -xf $src
+      mv $out/usr/* $out/
       runHook postInstall
-    '';
-
-    postFixup = lib.optionalString stdenv.hostPlatform.isDarwin ''
-      makeWrapper $out/Applications/zoom.us.app/Contents/MacOS/zoom.us $out/bin/zoom
     '';
 
     dontPatchELF = true;
@@ -107,18 +53,13 @@ let
       description = "zoom.us video conferencing application";
       sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
       license = lib.licenses.unfree;
-      platforms = builtins.attrNames srcs;
+      platforms = [ "x86_64-linux" ];
       maintainers = with lib.maintainers; [
         danbst
         tadfisher
       ];
-      mainProgram = "zoom";
     };
-  };
-  packages.aarch64-darwin = unpacked;
-  packages.x86_64-darwin = unpacked;
-
-  # linux definitions
+  });
 
   linuxGetDependencies =
     pkgs:
@@ -191,35 +132,35 @@ let
       pkgs.xdg-desktop-portal-xapp
     ];
 
-  # We add the `unpacked` zoom archive to the FHS env
-  # and also bind-mount its `/opt` directory.
-  # This should assist Zoom in finding all its
-  # files in the places where it expects them to be.
-  packages.x86_64-linux = buildFHSEnv {
-    pname = "zoom"; # Will also be the program's name!
-    version = versions.${system} or throwSystem;
-
-    targetPkgs = pkgs: (linuxGetDependencies pkgs) ++ [ unpacked ];
-    extraPreBwrapCmds = "unset QT_PLUGIN_PATH";
-    extraBwrapArgs = [ "--ro-bind ${unpacked}/opt /opt" ];
-    runScript = "/opt/zoom/ZoomLauncher";
-
-    extraInstallCommands = ''
-      cp -Rt $out/ ${unpacked}/share
-      substituteInPlace \
-          $out/share/applications/Zoom.desktop \
-          --replace-fail Exec={/usr/bin/,}zoom
-
-      # Backwards compatibility: we used to call it zoom-us
-      ln -s $out/bin/{zoom,zoom-us}
-    '';
-
-    passthru = unpacked.passthru // {
-      inherit unpacked;
-    };
-    inherit (unpacked) meta;
-  };
-
 in
 
-packages.${system} or throwSystem
+# We add the `unpacked` zoom archive to the FHS env
+# and also bind-mount its `/opt` directory.
+# This should assist Zoom in finding all its
+# files in the places where it expects them to be.
+buildFHSEnv rec {
+  pname = "zoom"; # Will also be the program's name!
+  inherit (unpacked) version;
+
+  targetPkgs = pkgs: (linuxGetDependencies pkgs) ++ [ unpacked ];
+  extraPreBwrapCmds = "unset QT_PLUGIN_PATH";
+  extraBwrapArgs = [ "--ro-bind ${unpacked}/opt /opt" ];
+  runScript = "/opt/zoom/ZoomLauncher";
+
+  extraInstallCommands = ''
+    cp -Rt $out/ ${unpacked}/share
+    substituteInPlace \
+        $out/share/applications/Zoom.desktop \
+        --replace-fail Exec={/usr/bin/,}zoom
+
+    # Backwards compatibility: we used to call it zoom-us
+    ln -s $out/bin/{zoom,zoom-us}
+  '';
+
+  passthru = unpacked.passthru // {
+    inherit unpacked;
+  };
+  meta = unpacked.meta // {
+    mainProgram = pname;
+  };
+}

--- a/pkgs/by-name/zo/zoom-us/package.nix
+++ b/pkgs/by-name/zo/zoom-us/package.nix
@@ -186,7 +186,7 @@ stdenv.mkDerivation {
     + lib.optionalString stdenv.hostPlatform.isLinux ''
       # Desktop File
       substituteInPlace $out/share/applications/Zoom.desktop \
-          --replace-fail "Exec=/usr/bin/zoom" "Exec=$out/bin/zoom"
+          --replace-fail Exec={/usr/bin/,}zoom
 
       for i in aomhost zopen ZoomLauncher ZoomWebviewHost; do
         if [ -f $out/opt/zoom/$i ]; then

--- a/pkgs/by-name/zo/zoom-us/package.nix
+++ b/pkgs/by-name/zo/zoom-us/package.nix
@@ -6,6 +6,7 @@
   xar,
   cpio,
   pulseaudioSupport ? true,
+  xdgDesktopPortalSupport ? true,
   callPackage,
   buildFHSEnv,
 }:
@@ -177,6 +178,17 @@ let
     ++ lib.optionals pulseaudioSupport [
       pkgs.libpulseaudio
       pkgs.pulseaudio
+    ]
+    ++ lib.optionals xdgDesktopPortalSupport [
+      pkgs.kdePackages.xdg-desktop-portal-kde
+      pkgs.lxqt.xdg-desktop-portal-lxqt
+      pkgs.plasma5Packages.xdg-desktop-portal-kde
+      pkgs.xdg-desktop-portal
+      pkgs.xdg-desktop-portal-gnome
+      pkgs.xdg-desktop-portal-gtk
+      pkgs.xdg-desktop-portal-hyprland
+      pkgs.xdg-desktop-portal-wlr
+      pkgs.xdg-desktop-portal-xapp
     ];
 
   # We add the `unpacked` zoom archive to the FHS env

--- a/pkgs/by-name/zo/zoom-us/package.nix
+++ b/pkgs/by-name/zo/zoom-us/package.nix
@@ -19,23 +19,23 @@ let
   # and often with different versions. We write them on three lines
   # like this (rather than using {}) so that the updater script can
   # find where to edit them.
-  versions.aarch64-darwin = "6.4.1.51520";
-  versions.x86_64-darwin = "6.4.1.51520";
-  versions.x86_64-linux = "6.4.1.587";
+  versions.aarch64-darwin = "6.4.3.52139";
+  versions.x86_64-darwin = "6.4.3.52139";
+  versions.x86_64-linux = "6.4.3.827";
 
   srcs = {
     aarch64-darwin = fetchurl {
       url = "https://zoom.us/client/${versions.aarch64-darwin}/zoomusInstallerFull.pkg?archType=arm64";
       name = "zoomusInstallerFull.pkg";
-      hash = "sha256-igPyasH67eDe8hYIHCyZ/dk4P5zBbhYtFdQ2ww/QwO4=";
+      hash = "sha256-bnuOyENfJLyGPwgPSdbU51SG/OXbMqd3gcwhMZoyIGA=";
     };
     x86_64-darwin = fetchurl {
       url = "https://zoom.us/client/${versions.x86_64-darwin}/zoomusInstallerFull.pkg";
-      hash = "sha256-EBGc64dy9WKyz6UAFGUrzFtrO+lho5xvIK13jzedUXc=";
+      hash = "sha256-L6WYRty3h9wgxp/lkW+BzgwSUcfWxP8h0/dwrkVClfU=";
     };
     x86_64-linux = fetchurl {
       url = "https://zoom.us/client/${versions.x86_64-linux}/zoom_x86_64.pkg.tar.xz";
-      hash = "sha256-xShPDJZZSawKag/OrUqTommIM8RwY1K6LVNEdnr2D94=";
+      hash = "sha256-KPTLWlXOEEWGODzolzhnluOq6YQ9+DMC6n80umf/nf0=";
     };
   };
 

--- a/pkgs/by-name/zo/zoom-us/package.nix
+++ b/pkgs/by-name/zo/zoom-us/package.nix
@@ -237,14 +237,14 @@ stdenv.mkDerivation {
   passthru.updateScript = ./update.sh;
   passthru.tests.startwindow = callPackage ./test.nix { };
 
-  meta = with lib; {
+  meta = {
     homepage = "https://zoom.us/";
     changelog = "https://support.zoom.com/hc/en/article?id=zm_kb&sysparm_article=KB0061222";
     description = "zoom.us video conferencing application";
-    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
-    license = licenses.unfree;
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    license = lib.licenses.unfree;
     platforms = builtins.attrNames srcs;
-    maintainers = with maintainers; [
+    maintainers = with lib.maintainers; [
       danbst
       tadfisher
     ];

--- a/pkgs/by-name/zo/zoom-us/package.nix
+++ b/pkgs/by-name/zo/zoom-us/package.nix
@@ -19,23 +19,23 @@ let
   # and often with different versions. We write them on three lines
   # like this (rather than using {}) so that the updater script can
   # find where to edit them.
-  versions.aarch64-darwin = "6.4.3.52139";
-  versions.x86_64-darwin = "6.4.3.52139";
-  versions.x86_64-linux = "6.4.3.827";
+  versions.aarch64-darwin = "6.4.5.53616";
+  versions.x86_64-darwin = "6.4.5.53616";
+  versions.x86_64-linux = "6.4.5.1259";
 
   srcs = {
     aarch64-darwin = fetchurl {
       url = "https://zoom.us/client/${versions.aarch64-darwin}/zoomusInstallerFull.pkg?archType=arm64";
       name = "zoomusInstallerFull.pkg";
-      hash = "sha256-bnuOyENfJLyGPwgPSdbU51SG/OXbMqd3gcwhMZoyIGA=";
+      hash = "sha256-Rd/2MZQ0NwZWQ9g0b99axB1IrNB4HBpf51nQ7UmO9/0=";
     };
     x86_64-darwin = fetchurl {
       url = "https://zoom.us/client/${versions.x86_64-darwin}/zoomusInstallerFull.pkg";
-      hash = "sha256-L6WYRty3h9wgxp/lkW+BzgwSUcfWxP8h0/dwrkVClfU=";
+      hash = "sha256-oBfUPOiuyXAyusCUL4r/aYf0rU/myBu8QlkCnYyVi2w=";
     };
     x86_64-linux = fetchurl {
       url = "https://zoom.us/client/${versions.x86_64-linux}/zoom_x86_64.pkg.tar.xz";
-      hash = "sha256-KPTLWlXOEEWGODzolzhnluOq6YQ9+DMC6n80umf/nf0=";
+      hash = "sha256-oAsK92yTaLdi9YfIcMkTevrSsKr2nClcMjOBo5VYIEg=";
     };
   };
 

--- a/pkgs/by-name/zo/zoom-us/test.nix
+++ b/pkgs/by-name/zo/zoom-us/test.nix
@@ -22,7 +22,7 @@ let
             | tee window-names
         grep -q "Zoom Workplace" window-names
       }
-      # don't let zoom eat all RAM, like it did
+      # Don't let zoom eat all RAM, like it did, cf.
       # https://github.com/NixOS/nixpkgs/issues/371488
       prlimit --{as,data}=$((4*2**30)):$((4*2**30)) zoom-us &
       for _ in {0..900} ; do
@@ -31,8 +31,8 @@ let
         fi
         sleep 1
       done
-      # if libraries are missing, the window still appears,
-      # but disappears again immediatelly; check for that too:
+      # If libraries are missing, the window still appears,
+      # but then disappears again immediately; check for that also.
       sleep 20
       is_zoom_window_present
     '';

--- a/pkgs/by-name/zo/zoom-us/update.sh
+++ b/pkgs/by-name/zo/zoom-us/update.sh
@@ -3,32 +3,4 @@
 
 set -eu -o pipefail
 
-scriptDir=$(cd "${BASH_SOURCE[0]%/*}" && pwd)
-nixpkgs=$(realpath "$scriptDir"/../../../..)
-
-echo >&2 "=== Obtaining version data from https://zoom.us/rest/download ..."
-linux_data=$(curl -Ls 'https://zoom.us/rest/download?os=linux' | jq .result.downloadVO)
-mac_data=$(curl -Ls 'https://zoom.us/rest/download?os=mac' | jq .result.downloadVO)
-
-version_aarch64_darwin=$(jq -r .zoomArm64.version <<<"$mac_data")
-version_x86_64_darwin=$(jq -r .zoom.version <<<"$mac_data")
-version_x86_64_linux=$(jq -r .zoom.version <<<"$linux_data")
-
-echo >&2 "=== Downloading packages and computing hashes..."
-# We precalculate the hashes before calling update-source-version
-# because it attempts to calculate each architecture's package's hash
-# by running `nix-build --system <architecture> -A zoom-us.src` which
-# causes cross compiling headaches; using nix-prefetch-url with
-# hard-coded URLs is simpler.  Keep these URLs in sync with the ones
-# in package.nix where `srcs` is defined.
-hash_aarch64_darwin=$(nix hash to-sri --type sha256 $(nix-prefetch-url --type sha256 "https://zoom.us/client/${version_aarch64_darwin}/zoomusInstallerFull.pkg?archType=arm64"))
-hash_x86_64_darwin=$(nix hash to-sri --type sha256 $(nix-prefetch-url --type sha256 "https://zoom.us/client/${version_x86_64_darwin}/zoomusInstallerFull.pkg"))
-hash_x86_64_linux=$(nix hash to-sri --type sha256 $(nix-prefetch-url --type sha256 "https://zoom.us/client/${version_x86_64_linux}/zoom_x86_64.pkg.tar.xz"))
-
-echo >&2 "=== Updating package.nix ..."
-# update-source-version expects to be at the root of nixpkgs
-(cd "$nixpkgs" && update-source-version zoom-us "$version_aarch64_darwin" $hash_aarch64_darwin --system=aarch64-darwin --version-key=versions.aarch64-darwin)
-(cd "$nixpkgs" && update-source-version zoom-us "$version_x86_64_darwin" $hash_x86_64_darwin --system=x86_64-darwin --version-key=versions.x86_64-darwin)
-(cd "$nixpkgs" && update-source-version zoom-us "$version_x86_64_linux" $hash_x86_64_linux --system=x86_64-linux --version-key=versions.x86_64-linux)
-
-echo >&2 "=== Done!"
+update-source-version zoom-us $(curl -Ls 'https://zoom.us/rest/download?os=linux' | jq -r .result.downloadVO.zoom.version) --source-key=unpacked.src


### PR DESCRIPTION
The most recent [Zoom updates](https://github.com/NixOS/nixpkgs/pull/393649) yield a Zoom package that [fails to function](https://github.com/NixOS/nixpkgs/pull/393649#issuecomment-2782940887).  In a nutshell:

*   The `zoom` program is resistant to `patchelf` even in the old version.  [Some trickery with the dynamic elf loader wrapping `zoom` was required to make it work](https://github.com/NixOS/nixpkgs/pull/381281).
*   The new version's `ZoomLauncher` program is now also "unpatchable" and requires the same trickery.
*   The new version's `ZoomWebviewHost` program is now also "unpatchable", but [I failed to fix it even with wrapping with the elf loader, `LD_LIBRARY_PATH`, and argv0 modifications](https://github.com/NixOS/nixpkgs/pull/393649#issuecomment-2782940887). Note/Reference: [There has been trouble with `ZoomWebviewHost` in the past](https://github.com/NixOS/nixpkgs/issues/344931), but those lessons didn't help me here.

Maybe there is a way to get Zoom working with `patchelf`/`ld.so`/`LD_LIBRARY_PATH` and similar wrappings, but I ultimatelly failed to discover it.  To me, it seems newer Zoom versions insist quite strongly on an FHS-compatible environment.

So the pull request at hand does that: It wraps zoom with `buildFHSEnv`.  With that change, Zoom works without any additional wrappers or (library) path modifications, so most of the patching code used previously disappears.  Besides:

*   Zoom is updated to the current release (by cherry-picking commits from https://github.com/NixOS/nixpkgs/pull/393649 ).
*   Support for `xdg-desktop-portal` is added, fixing https://github.com/NixOS/nixpkgs/issues/359533 .  This [wasn't possible without the FHS environment](https://github.com/NixOS/nixpkgs/pull/381281#issuecomment-2654701506).  However, [that might improve with an upcoming Zoom release](https://github.com/NixOS/nixpkgs/issues/359533#issuecomment-2751724354) (provided that release is usable at all).
*   [The `Exec=` entry in the `.desktop` file is turned into a relative path](https://github.com/NixOS/nixpkgs/issues/308324)
*   Some missing Qt5 libraries are added (discovered with `autoPatchelfHook`).
*   Some `QT5_*` environment variables apparently no longer need to be unset.
*   [Tiny improvements to the test derivation's code](https://github.com/NixOS/nixpkgs/pull/381281#discussion_r1956512725).

Notifying maintainers: @danbst @tadfisher
Notifying @philiptaron per https://github.com/NixOS/nixpkgs/pull/381281#pullrequestreview-2618440109 (thanks again!)

Reference to Zoom meta issue: https://github.com/NixOS/nixpkgs/issues/107495

~~I'm setting this as draft for now as I'm not sure [whether we should wait for the next release](https://github.com/NixOS/nixpkgs/issues/359533#issuecomment-2751724354).~~

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

`nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"` wants to rebuild 4k packages and was therefore skipped.

**More**: I prepared the following testing environment:

* x86-64
* built the package as is, i.e., without cherry-picking/rebasing the commit(s) somewhere else
* placed the resulting package into `systemPackages` of
    * an existing and up-to-date NixOS 24.11 installation with X11/Plasma5/Pulseaudio
    * an existing and up-to-date NixOS unstable installation with X11/Xfce/Pulseaudio (inside a VirtualBox)
* Login in X11/Plasma5 with PulseAudio

Tested the following functions successfully:

- [x] sidebar loads (albeit empty on my installation, cf. https://github.com/NixOS/nixpkgs/issues/344931 )
- [x] audio is "detected" by zoom: microphone VU-meter shows amplitude (not tested in VirtualBox)
- [x] audio is produced: "Test speaker" generates audible ting-a-ling (not tested in VirtualBox)
- [x] other participant's audio in video conference is audible (not tested in VirtualBox)
- [x] other participants can hear me (not tested in VirtualBox)
- [x] sending camera picture in video conference works
- [x] participant's camera video is received in video conference
- [x] screen sharing sends screen to other participants
- [x] participant's shared screen is displayed
- [x] "Participants" dialog box is shown (cf. https://github.com/NixOS/nixpkgs/pull/116355 )
- [x] reading team chat messages works as expected
- [x] SSO works: Zoom starts Firefox, then Firefox calls back to Zoom after login, as usual

I did not test the following functions/mechanisms/bindings, but it would probably be good to have them tested:

- [ ] writing team chat messages
- [ ] the sidebar being non-empty
- [ ] `xdg-desktop-portal` (cf. https://github.com/NixOS/nixpkgs/issues/359533 )
- [ ] Pipewire
- [ ] Wayland
- [ ] Darwin

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
