### PR TITLE
Revert "cosmic-*: use mold linker"

### DIFF
--- a/pkgs/by-name/co/cosmic-bg/package.nix
+++ b/pkgs/by-name/co/cosmic-bg/package.nix
@@ -1,72 +1,64 @@
 {
   lib,
   stdenv,
-  stdenvAdapters,
   fetchFromGitHub,
   rustPlatform,
   libcosmicAppHook,
   just,
   nasm,
   nix-update-script,
-
-  withMoldLinker ? stdenv.targetPlatform.isLinux,
 }:
 
-rustPlatform.buildRustPackage.override
-  { stdenv = if withMoldLinker then stdenvAdapters.useMoldLinker stdenv else stdenv; }
-  (finalAttrs: {
-    pname = "cosmic-bg";
-    version = "1.0.0-alpha.6";
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "cosmic-bg";
+  version = "1.0.0-alpha.6";
 
-    src = fetchFromGitHub {
-      owner = "pop-os";
-      repo = "cosmic-bg";
-      tag = "epoch-${finalAttrs.version}";
-      hash = "sha256-4b4laUXTnAbdngLVh8/dD144m9QrGReSEjRZoNR6Iks=";
-    };
+  src = fetchFromGitHub {
+    owner = "pop-os";
+    repo = "cosmic-bg";
+    tag = "epoch-${finalAttrs.version}";
+    hash = "sha256-4b4laUXTnAbdngLVh8/dD144m9QrGReSEjRZoNR6Iks=";
+  };
 
-    useFetchCargoVendor = true;
-    cargoHash = "sha256-GLXooTjcGq4MsBNnlpHBBUJGNs5UjKMQJGJuj9UO2wk=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-GLXooTjcGq4MsBNnlpHBBUJGNs5UjKMQJGJuj9UO2wk=";
 
-    nativeBuildInputs = [
-      just
-      libcosmicAppHook
-      nasm
+  nativeBuildInputs = [
+    just
+    libcosmicAppHook
+    nasm
+  ];
+
+  dontUseJustBuild = true;
+  dontUseJustCheck = true;
+
+  justFlags = [
+    "--set"
+    "prefix"
+    (placeholder "out")
+    "--set"
+    "bin-src"
+    "target/${stdenv.hostPlatform.rust.cargoShortTarget}/release/cosmic-bg"
+  ];
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [
+      "--version"
+      "unstable"
+      "--version-regex"
+      "epoch-(.*)"
     ];
+  };
 
-    dontUseJustBuild = true;
-    dontUseJustCheck = true;
-
-    justFlags = [
-      "--set"
-      "prefix"
-      (placeholder "out")
-      "--set"
-      "bin-src"
-      "target/${stdenv.hostPlatform.rust.cargoShortTarget}/release/cosmic-bg"
+  meta = {
+    homepage = "https://github.com/pop-os/cosmic-bg";
+    description = "Applies Background for the COSMIC Desktop Environment";
+    license = lib.licenses.mpl20;
+    maintainers = with lib.maintainers; [
+      nyabinary
+      HeitorAugustoLN
     ];
-
-    env."CARGO_TARGET_${stdenv.hostPlatform.rust.cargoEnvVarTarget}_RUSTFLAGS" =
-      lib.optionalString withMoldLinker "-C link-arg=-fuse-ld=mold";
-
-    passthru.updateScript = nix-update-script {
-      extraArgs = [
-        "--version"
-        "unstable"
-        "--version-regex"
-        "epoch-(.*)"
-      ];
-    };
-
-    meta = {
-      homepage = "https://github.com/pop-os/cosmic-bg";
-      description = "Applies Background for the COSMIC Desktop Environment";
-      license = lib.licenses.mpl20;
-      maintainers = with lib.maintainers; [
-        nyabinary
-        HeitorAugustoLN
-      ];
-      platforms = lib.platforms.linux;
-      mainProgram = "cosmic-bg";
-    };
-  })
+    platforms = lib.platforms.linux;
+    mainProgram = "cosmic-bg";
+  };
+})

--- a/pkgs/by-name/co/cosmic-launcher/package.nix
+++ b/pkgs/by-name/co/cosmic-launcher/package.nix
@@ -1,70 +1,64 @@
 {
   lib,
   stdenv,
-  stdenvAdapters,
   fetchFromGitHub,
   rustPlatform,
   just,
   libcosmicAppHook,
   nix-update-script,
-
-  withMoldLinker ? stdenv.targetPlatform.isLinux,
 }:
 
-rustPlatform.buildRustPackage.override
-  { stdenv = if withMoldLinker then stdenvAdapters.useMoldLinker stdenv else stdenv; }
-  (finalAttrs: {
-    pname = "cosmic-launcher";
-    version = "1.0.0-alpha.6";
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "cosmic-launcher";
+  version = "1.0.0-alpha.6";
 
-    src = fetchFromGitHub {
-      owner = "pop-os";
-      repo = "cosmic-launcher";
-      tag = "epoch-${finalAttrs.version}";
-      hash = "sha256-BtYnL+qkM/aw+Air5yOKH098V+TQByM5mh1DX7v+v+s=";
-    };
+  src = fetchFromGitHub {
+    owner = "pop-os";
+    repo = "cosmic-launcher";
+    tag = "epoch-${finalAttrs.version}";
+    hash = "sha256-BtYnL+qkM/aw+Air5yOKH098V+TQByM5mh1DX7v+v+s=";
+  };
 
-    useFetchCargoVendor = true;
-    cargoHash = "sha256-g7Qr3C8jQg65KehXAhftdXCpEukag0w12ClvZFkxfqs=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-g7Qr3C8jQg65KehXAhftdXCpEukag0w12ClvZFkxfqs=";
 
-    nativeBuildInputs = [
-      just
-      libcosmicAppHook
+  nativeBuildInputs = [
+    just
+    libcosmicAppHook
+  ];
+
+  dontUseJustBuild = true;
+  dontUseJustCheck = true;
+
+  justFlags = [
+    "--set"
+    "prefix"
+    (placeholder "out")
+    "--set"
+    "bin-src"
+    "target/${stdenv.hostPlatform.rust.cargoShortTarget}/release/cosmic-launcher"
+  ];
+
+  env."CARGO_TARGET_${stdenv.hostPlatform.rust.cargoEnvVarTarget}_RUSTFLAGS" = "--cfg tokio_unstable";
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [
+      "--version"
+      "unstable"
+      "--version-regex"
+      "epoch-(.*)"
     ];
+  };
 
-    dontUseJustBuild = true;
-    dontUseJustCheck = true;
-
-    justFlags = [
-      "--set"
-      "prefix"
-      (placeholder "out")
-      "--set"
-      "bin-src"
-      "target/${stdenv.hostPlatform.rust.cargoShortTarget}/release/cosmic-launcher"
+  meta = {
+    homepage = "https://github.com/pop-os/cosmic-launcher";
+    description = "Launcher for the COSMIC Desktop Environment";
+    mainProgram = "cosmic-launcher";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [
+      nyabinary
+      HeitorAugustoLN
     ];
-
-    env."CARGO_TARGET_${stdenv.hostPlatform.rust.cargoEnvVarTarget}_RUSTFLAGS" =
-      "--cfg tokio_unstable${lib.optionalString withMoldLinker " -C link-arg=-fuse-ld=mold"}";
-
-    passthru.updateScript = nix-update-script {
-      extraArgs = [
-        "--version"
-        "unstable"
-        "--version-regex"
-        "epoch-(.*)"
-      ];
-    };
-
-    meta = {
-      homepage = "https://github.com/pop-os/cosmic-launcher";
-      description = "Launcher for the COSMIC Desktop Environment";
-      mainProgram = "cosmic-launcher";
-      license = lib.licenses.gpl3Only;
-      maintainers = with lib.maintainers; [
-        nyabinary
-        HeitorAugustoLN
-      ];
-      platforms = lib.platforms.linux;
-    };
-  })
+    platforms = lib.platforms.linux;
+  };
+})

--- a/pkgs/by-name/co/cosmic-randr/package.nix
+++ b/pkgs/by-name/co/cosmic-randr/package.nix
@@ -1,73 +1,65 @@
 {
   lib,
   stdenv,
-  stdenvAdapters,
   fetchFromGitHub,
   rustPlatform,
   just,
   pkg-config,
   wayland,
   nix-update-script,
-
-  withMoldLinker ? stdenv.targetPlatform.isLinux,
 }:
 
-rustPlatform.buildRustPackage.override
-  { stdenv = if withMoldLinker then stdenvAdapters.useMoldLinker stdenv else stdenv; }
-  (finalAttrs: {
-    pname = "cosmic-randr";
-    version = "1.0.0-alpha.6";
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "cosmic-randr";
+  version = "1.0.0-alpha.6";
 
-    src = fetchFromGitHub {
-      owner = "pop-os";
-      repo = "cosmic-randr";
-      tag = "epoch-${finalAttrs.version}";
-      hash = "sha256-Sqxe+vKonsK9MmJGtbrZHE7frfrjkHXysm0WQt7WSU4=";
-    };
+  src = fetchFromGitHub {
+    owner = "pop-os";
+    repo = "cosmic-randr";
+    tag = "epoch-${finalAttrs.version}";
+    hash = "sha256-Sqxe+vKonsK9MmJGtbrZHE7frfrjkHXysm0WQt7WSU4=";
+  };
 
-    useFetchCargoVendor = true;
-    cargoHash = "sha256-UQ/fhjUiniVeHRQYulYko4OxcWB6UhFuxH1dVAfAzIY=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-UQ/fhjUiniVeHRQYulYko4OxcWB6UhFuxH1dVAfAzIY=";
 
-    nativeBuildInputs = [
-      just
-      pkg-config
+  nativeBuildInputs = [
+    just
+    pkg-config
+  ];
+
+  buildInputs = [ wayland ];
+
+  dontUseJustBuild = true;
+  dontUseJustCheck = true;
+
+  justFlags = [
+    "--set"
+    "prefix"
+    (placeholder "out")
+    "--set"
+    "bin-src"
+    "target/${stdenv.hostPlatform.rust.cargoShortTarget}/release/cosmic-randr"
+  ];
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [
+      "--version"
+      "unstable"
+      "--version-regex"
+      "epoch-(.*)"
     ];
+  };
 
-    buildInputs = [ wayland ];
-
-    dontUseJustBuild = true;
-    dontUseJustCheck = true;
-
-    justFlags = [
-      "--set"
-      "prefix"
-      (placeholder "out")
-      "--set"
-      "bin-src"
-      "target/${stdenv.hostPlatform.rust.cargoShortTarget}/release/cosmic-randr"
+  meta = {
+    homepage = "https://github.com/pop-os/cosmic-randr";
+    description = "Library and utility for displaying and configuring Wayland outputs";
+    license = lib.licenses.mpl20;
+    maintainers = with lib.maintainers; [
+      nyabinary
+      HeitorAugustoLN
     ];
-
-    env."CARGO_TARGET_${stdenv.hostPlatform.rust.cargoEnvVarTarget}_RUSTFLAGS" =
-      lib.optionalString withMoldLinker "-C link-arg=-fuse-ld=mold";
-
-    passthru.updateScript = nix-update-script {
-      extraArgs = [
-        "--version"
-        "unstable"
-        "--version-regex"
-        "epoch-(.*)"
-      ];
-    };
-
-    meta = {
-      homepage = "https://github.com/pop-os/cosmic-randr";
-      description = "Library and utility for displaying and configuring Wayland outputs";
-      license = lib.licenses.mpl20;
-      maintainers = with lib.maintainers; [
-        nyabinary
-        HeitorAugustoLN
-      ];
-      platforms = lib.platforms.linux;
-      mainProgram = "cosmic-randr";
-    };
-  })
+    platforms = lib.platforms.linux;
+    mainProgram = "cosmic-randr";
+  };
+})

--- a/pkgs/by-name/co/cosmic-settings/package.nix
+++ b/pkgs/by-name/co/cosmic-settings/package.nix
@@ -1,7 +1,6 @@
 {
   lib,
   stdenv,
-  stdenvAdapters,
   fetchFromGitHub,
   rustPlatform,
   cmake,
@@ -19,90 +18,83 @@
   cosmic-randr,
   xkeyboard_config,
   nix-update-script,
-
-  withMoldLinker ? stdenv.targetPlatform.isLinux,
 }:
 let
   libcosmicAppHook' = (libcosmicAppHook.__spliced.buildHost or libcosmicAppHook).override {
     includeSettings = false;
   };
 in
-rustPlatform.buildRustPackage.override
-  { stdenv = if withMoldLinker then stdenvAdapters.useMoldLinker stdenv else stdenv; }
-  (finalAttrs: {
-    pname = "cosmic-settings";
-    version = "1.0.0-alpha.6";
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "cosmic-settings";
+  version = "1.0.0-alpha.6";
 
-    src = fetchFromGitHub {
-      owner = "pop-os";
-      repo = "cosmic-settings";
-      tag = "epoch-${finalAttrs.version}";
-      hash = "sha256-UKg3TIpyaqtynk6wLFFPpv69F74hmqfMVPra2+iFbvE=";
-    };
+  src = fetchFromGitHub {
+    owner = "pop-os";
+    repo = "cosmic-settings";
+    tag = "epoch-${finalAttrs.version}";
+    hash = "sha256-UKg3TIpyaqtynk6wLFFPpv69F74hmqfMVPra2+iFbvE=";
+  };
 
-    useFetchCargoVendor = true;
-    cargoHash = "sha256-mf/Cw3/RLrCYgsk7JKCU2+oPn1VPbD+4JzkUmbd47m8=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-mf/Cw3/RLrCYgsk7JKCU2+oPn1VPbD+4JzkUmbd47m8=";
 
-    nativeBuildInputs = [
-      cmake
-      just
-      libcosmicAppHook'
-      pkg-config
-      rustPlatform.bindgenHook
-      util-linux
+  nativeBuildInputs = [
+    cmake
+    just
+    libcosmicAppHook'
+    pkg-config
+    rustPlatform.bindgenHook
+    util-linux
+  ];
+
+  buildInputs = [
+    expat
+    fontconfig
+    freetype
+    libinput
+    pipewire
+    pulseaudio
+    udev
+  ];
+
+  dontUseJustBuild = true;
+  dontUseJustCheck = true;
+
+  justFlags = [
+    "--set"
+    "prefix"
+    (placeholder "out")
+    "--set"
+    "bin-src"
+    "target/${stdenv.hostPlatform.rust.cargoShortTarget}/release/cosmic-settings"
+  ];
+
+  preFixup = ''
+    libcosmicAppWrapperArgs+=(
+      --prefix PATH : ${lib.makeBinPath [ cosmic-randr ]}
+      --set-default X11_BASE_RULES_XML ${xkeyboard_config}/share/X11/xkb/rules/base.xml
+      --set-default X11_BASE_EXTRA_RULES_XML ${xkeyboard_config}/share/X11/xkb/rules/extra.xml
+    )
+  '';
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [
+      "--version"
+      "unstable"
+      "--version-regex"
+      "epoch-(.*)"
     ];
+  };
 
-    buildInputs = [
-      expat
-      fontconfig
-      freetype
-      libinput
-      pipewire
-      pulseaudio
-      udev
+  meta = {
+    description = "Settings for the COSMIC Desktop Environment";
+    homepage = "https://github.com/pop-os/cosmic-settings";
+    license = lib.licenses.gpl3Only;
+    mainProgram = "cosmic-settings";
+    maintainers = with lib.maintainers; [
+      nyabinary
+      HeitorAugustoLN
     ];
-
-    dontUseJustBuild = true;
-    dontUseJustCheck = true;
-
-    justFlags = [
-      "--set"
-      "prefix"
-      (placeholder "out")
-      "--set"
-      "bin-src"
-      "target/${stdenv.hostPlatform.rust.cargoShortTarget}/release/cosmic-settings"
-    ];
-
-    env."CARGO_TARGET_${stdenv.hostPlatform.rust.cargoEnvVarTarget}_RUSTFLAGS" =
-      lib.optionalString withMoldLinker "-C link-arg=-fuse-ld=mold";
-
-    preFixup = ''
-      libcosmicAppWrapperArgs+=(
-        --prefix PATH : ${lib.makeBinPath [ cosmic-randr ]}
-        --set-default X11_BASE_RULES_XML ${xkeyboard_config}/share/X11/xkb/rules/base.xml
-        --set-default X11_BASE_EXTRA_RULES_XML ${xkeyboard_config}/share/X11/xkb/rules/extra.xml
-      )
-    '';
-
-    passthru.updateScript = nix-update-script {
-      extraArgs = [
-        "--version"
-        "unstable"
-        "--version-regex"
-        "epoch-(.*)"
-      ];
-    };
-
-    meta = {
-      description = "Settings for the COSMIC Desktop Environment";
-      homepage = "https://github.com/pop-os/cosmic-settings";
-      license = lib.licenses.gpl3Only;
-      mainProgram = "cosmic-settings";
-      maintainers = with lib.maintainers; [
-        nyabinary
-        HeitorAugustoLN
-      ];
-      platforms = lib.platforms.linux;
-    };
-  })
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
In Nixpkgs, we consider the linker a property of the platform. Individual packages should not be using toolchains other than the ones that are part of the platform without a strong justification.  In this case, the only justification appears to have been that upstream uses this linker.  Just like we don't force every package whose upstream happens to use Clang in their own builds to build with Clang in Nixpkgs rather than the platform compiler, upstream's choice alone isn't grounds for overriding the platform linker here.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
