### PR TITLE
perlPackages.ExtUtilsPkgConfig: fix pkg-config use for cross

### DIFF
--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -12665,16 +12665,23 @@ with self;
       hash = "sha256-u+rO2ZXX2NEM/FGjpaZtpBzrK8BP7cq1DhDmMA6AHG4=";
     };
     nativeBuildInputs = [ buildPackages.pkg-config ];
-    propagatedBuildInputs = [ pkgs.pkg-config ];
+    propagatedNativeBuildInputs = [ pkgs.pkg-config ];
     postPatch = ''
       # no pkg-config binary when cross-compiling so the check fails
       substituteInPlace Makefile.PL \
         --replace "pkg-config" "$PKG_CONFIG"
+      # use correctly prefixed pkg-config binary
+      substituteInPlace lib/ExtUtils/PkgConfig.pm \
+        --replace-fail '`pkg-config' '`${stdenv.cc.targetPrefix}pkg-config' \
+        --replace-fail '"pkg-config' '"${stdenv.cc.targetPrefix}pkg-config' \
+        --replace-fail '/pkg-config' '/${stdenv.cc.targetPrefix}pkg-config'
     '';
     doCheck = false; # expects test_glib-2.0.pc in PKG_CONFIG_PATH
     meta = {
       description = "Simplistic interface to pkg-config";
+      homepage = "https://gitlab.gnome.org/GNOME/perl-extutils-pkgconfig";
       license = with lib.licenses; [ lgpl21Plus ];
+      maintainers = [ lib.maintainers.fliegendewurst ];
     };
   };
 


### PR DESCRIPTION
Propagate pkg-config into native build inputs, and use it with the correct prefix.

Built: `{,pkgsCross.aarch64-multiplatform.}perlPackages.GD perlPackages.{Cairo,Glib,GraphicsTIFF,ImageSane,X11XCB}` (only GD cross-compiles)

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux (cross)
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).