### PR TITLE
moneydance: 2024.1_5118 -> 2024.4_5253

### DIFF
--- a/pkgs/by-name/mo/moneydance/package.nix
+++ b/pkgs/by-name/mo/moneydance/package.nix
@@ -15,11 +15,13 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "moneydance";
-  version = "2024.1_5118";
+  version = "2024.4_5253";
 
   src = fetchzip {
-    url = "https://infinitekind.com/stabledl/2024_5118/moneydance-linux.tar.gz";
-    hash = "sha256-wwSb3CuhuXB4I9jq+TpLPbd1k9UzqQbAaZkGKgi+nns=";
+    url = "https://infinitekind.com/stabledl/${
+      lib.replaceStrings [ "_" ] [ "." ] finalAttrs.version
+    }/moneydance-linux.tar.gz";
+    hash = "sha256-xOdkuaN17ss9tTSXgU//s6cBm2jGEgP9eTtvW0k3VWQ=";
   };
 
   # We must use wrapGAppsHook (since Java GUIs on Linux use GTK), but by
@@ -76,7 +78,9 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     homepage = "https://infinitekind.com/moneydance";
-    changelog = "https://infinitekind.com/stabledl/2024_5118/changelog.txt";
+    changelog = "https://infinitekind.com/stabledl/${
+      lib.replaceStrings [ "_" ] [ "." ] finalAttrs.version
+    }/changelog-stable.txt";
     description = "Easy to use and full-featured personal finance app that doesn't compromise your privacy";
     sourceProvenance = [ lib.sourceTypes.binaryBytecode ];
     license = lib.licenses.unfree;


### PR DESCRIPTION
bug fix release: https://infinitekind.com/stabledl/2024.4.5253/changelog-stable.txt

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).