### PR TITLE
buildNpmPackage: add gitDepsLockfiles parameter

### DIFF
--- a/pkgs/build-support/node/build-npm-package/default.nix
+++ b/pkgs/build-support/node/build-npm-package/default.nix
@@ -10,6 +10,8 @@
 lib.extendMkDerivation {
   constructDrv = stdenv.mkDerivation;
 
+  excludeDrvArgNames = [ "gitDepsLockfiles" ];
+
   extendDrvArgs =
     finalAttrs:
     {
@@ -32,6 +34,12 @@ lib.extendMkDerivation {
       # Whether to force allow an empty dependency cache.
       # This can be enabled if there are truly no remote dependencies, but generally an empty cache indicates something is wrong.
       forceEmptyCache ? false,
+      # Lock files to be added to Git dependencies.
+      # Git dependencies that have install scripts but no `package-lock.json` file are not reproducible. This attribute set is
+      # used to inject a `package-lock.json` file into a Git dependency. Keys are the `resolved` strings of the dependencies
+      # (they can be found in the `package-lock.json` file of the main package) and values are paths to the `package-lock.json`
+      # files to inject.
+      gitDepsLockfiles ? { },
       # Whether to make the cache writable prior to installing dependencies.
       # Don't set this unless npm tries to write to the cache directory, as it can slow down the build.
       makeCacheWritable ? false,
@@ -56,6 +64,7 @@ lib.extendMkDerivation {
         inherit
           forceGitDeps
           forceEmptyCache
+          gitDepsLockfiles
           src
           srcs
           sourceRoot

--- a/pkgs/build-support/node/fetch-npm-deps/default.nix
+++ b/pkgs/build-support/node/fetch-npm-deps/default.nix
@@ -191,6 +191,7 @@
       hash ? "",
       forceGitDeps ? false,
       forceEmptyCache ? false,
+      gitDepsLockfiles ? { },
       nativeBuildInputs ? [ ],
       ...
     }@args:
@@ -208,9 +209,12 @@
 
       forceGitDeps_ = lib.optionalAttrs forceGitDeps { FORCE_GIT_DEPS = true; };
       forceEmptyCache_ = lib.optionalAttrs forceEmptyCache { FORCE_EMPTY_CACHE = true; };
+      gitDepsLockfiles_ = lib.mapAttrs' (
+        name: value: lib.nameValuePair ("NIX_NODEJS_BUILDNPMPACKAGE_LOCKFILE_" + name) value
+      ) gitDepsLockfiles;
     in
     stdenvNoCC.mkDerivation (
-      args
+      (lib.removeAttrs args [ "gitDepsLockfiles" ])
       // {
         inherit name;
 
@@ -261,5 +265,6 @@
       // hash_
       // forceGitDeps_
       // forceEmptyCache_
+      // gitDepsLockfiles_
     );
 }

--- a/pkgs/development/web/nodejs/node-npm-build-npm-package-logic.patch
+++ b/pkgs/development/web/nodejs/node-npm-build-npm-package-logic.patch
@@ -43,7 +43,7 @@ diff --git a/deps/npm/node_modules/pacote/lib/git.js b/deps/npm/node_modules/pac
 index 1fa8b1f96..a026bb50d 100644
 --- a/deps/npm/node_modules/pacote/lib/git.js
 +++ b/deps/npm/node_modules/pacote/lib/git.js
-@@ -188,6 +188,34 @@ class GitFetcher extends Fetcher {
+@@ -188,6 +188,35 @@ class GitFetcher extends Fetcher {
        }
        noPrepare.push(this.resolved)
  
@@ -60,7 +60,7 @@ index 1fa8b1f96..a026bb50d 100644
 +          Promise.resolve()
 +
 +        const npmWithNixFlags = (args, cmd) => spawn('bash', ['-c', 'npm ' + args + ` $npm${cmd}Flags "$\{npm${cmd}FlagsArray[@]}" $npmFlags "$\{npmFlagsArray[@]}" || [ -n "$forceGitDeps" ]`], { cwd: dir, env: { ...process.env, _PACOTE_NO_PREPARE_: noPrepare.join('\n') } }, { message: `\`npm ${args}\` failed` })
-+        const patchShebangs = () => spawn('bash', ['-c', 'source $stdenv/setup; patchShebangs node_modules'], { cwd: dir })
++        const patchShebangs = path => spawn('bash', ['-c', 'source $stdenv/setup; patchShebangs ' + path], { cwd: dir })
 +
 +        // the DirFetcher will do its own preparation to run the prepare scripts
 +        // All we have to do is put the deps in place so that it can succeed.
@@ -69,10 +69,11 @@ index 1fa8b1f96..a026bb50d 100644
 +        // to the rest of the build as possible.
 +        return copy
 +          .then(() => spawn('bash', ['-c', '$prefetchNpmDeps --fixup-lockfile package-lock.json || [ -n "$forceGitDeps" ]'], { cwd: dir }))
++          .then(() => patchShebangs('.'))
 +          .then(() => npmWithNixFlags('ci --ignore-scripts', 'Install'))
-+          .then(patchShebangs)
++          .then(() => patchShebangs('node_modules'))
 +          .then(() => npmWithNixFlags('rebuild', 'Rebuild'))
-+          .then(patchShebangs)
++          .then(() => patchShebangs('node_modules'))
 +      }
 +
        // the DirFetcher will do its own preparation to run the prepare scripts

--- a/pkgs/development/web/nodejs/node-npm-build-npm-package-logic.patch
+++ b/pkgs/development/web/nodejs/node-npm-build-npm-package-logic.patch
@@ -4,8 +4,9 @@ This introduces fixes for 4 issues:
 
 1. When node-gyp is included as a dependency in a project, any scripts that run it will not use the copy included in Node. This is problematic because we patch node-gyp to work without xcbuild on Darwin, leading to these packages failing to build with a sandbox on Darwin.
 2. When a Git dependency contains install scripts, it has to be built just like any other package. Thus, we need to patch shebangs appropriately, just like in npmConfigHook.
-3. We get useless warnings that clog up logs when using a v1 lockfile, so we silence them.
-4. npm looks at a hidden lockfile to determine if files have binaries to link into `node_modules/.bin`. When using a v1 lockfile offline, this lockfile does not contain enough info, leading to binaries for packages such as Webpack not being available to scripts. We used to work around this by making npm ignore the hidden lockfile by creating a file, but now we just disable the code path entirely.
+3. A Git dependency with install scripts but no lockfile cannot be installed reproducibly, so we add a way to inject a lockfile from fetchNpmDeps.
+4. We get useless warnings that clog up logs when using a v1 lockfile, so we silence them.
+5. npm looks at a hidden lockfile to determine if files have binaries to link into `node_modules/.bin`. When using a v1 lockfile offline, this lockfile does not contain enough info, leading to binaries for packages such as Webpack not being available to scripts. We used to work around this by making npm ignore the hidden lockfile by creating a file, but now we just disable the code path entirely.
 
 To update:
 1. Run `git diff` from an npm checkout
@@ -42,12 +43,21 @@ diff --git a/deps/npm/node_modules/pacote/lib/git.js b/deps/npm/node_modules/pac
 index 1fa8b1f96..a026bb50d 100644
 --- a/deps/npm/node_modules/pacote/lib/git.js
 +++ b/deps/npm/node_modules/pacote/lib/git.js
-@@ -188,6 +188,24 @@ class GitFetcher extends Fetcher {
+@@ -188,6 +188,34 @@ class GitFetcher extends Fetcher {
        }
        noPrepare.push(this.resolved)
  
 +      if (process.env['NIX_NODEJS_BUILDNPMPACKAGE']) {
++        const fs = require('node:fs/promises')
++        const path = require('node:path')
 +        const spawn = require('@npmcli/promise-spawn')
++
++        // allow injecting a package-lock.json file at this point for
++        // reproducibility.
++        const lockfile = process.env['NIX_NODEJS_BUILDNPMPACKAGE_LOCKFILE_' + this.resolved]
++        const copy = lockfile ?
++          fs.copyFile(lockfile, path.join(dir, 'package-lock.json')) :
++          Promise.resolve()
 +
 +        const npmWithNixFlags = (args, cmd) => spawn('bash', ['-c', 'npm ' + args + ` $npm${cmd}Flags "$\{npm${cmd}FlagsArray[@]}" $npmFlags "$\{npmFlagsArray[@]}" || [ -n "$forceGitDeps" ]`], { cwd: dir, env: { ...process.env, _PACOTE_NO_PREPARE_: noPrepare.join('\n') } }, { message: `\`npm ${args}\` failed` })
 +        const patchShebangs = () => spawn('bash', ['-c', 'source $stdenv/setup; patchShebangs node_modules'], { cwd: dir })
@@ -57,11 +67,12 @@ index 1fa8b1f96..a026bb50d 100644
 +        //
 +        // We ignore this.npmConfig to maintain an environment that's as close
 +        // to the rest of the build as possible.
-+        return spawn('bash', ['-c', '$prefetchNpmDeps --fixup-lockfile package-lock.json || [ -n "$forceGitDeps" ]'], { cwd: dir })
-+        .then(() => npmWithNixFlags('ci --ignore-scripts', 'Install'))
-+        .then(patchShebangs)
-+        .then(() => npmWithNixFlags('rebuild', 'Rebuild'))
-+        .then(patchShebangs)
++        return copy
++          .then(() => spawn('bash', ['-c', '$prefetchNpmDeps --fixup-lockfile package-lock.json || [ -n "$forceGitDeps" ]'], { cwd: dir }))
++          .then(() => npmWithNixFlags('ci --ignore-scripts', 'Install'))
++          .then(patchShebangs)
++          .then(() => npmWithNixFlags('rebuild', 'Rebuild'))
++          .then(patchShebangs)
 +      }
 +
        // the DirFetcher will do its own preparation to run the prepare scripts


### PR DESCRIPTION
## Background

Me and a friend are trying to package Overleaf and we're not sure how to proceed.

Overleaf has Git dependencies in its `package.json` file that have build scripts but do not have a `package-lock.json` file, and fetch-npm-deps doesn't support that because it would not be reproducible.

There is existing work in https://github.com/NixOS/nixpkgs/pull/216889 that adds a Python script that finds the Git dependencies in `package.json`, clones them, modifies the root `package.json` to point to the clones, then runs `npm install` to update the root `package-lock.json` with the Git dependencies' transitive (development) dependencies. Then that patched `package-lock.json` is committed to Nixpkgs.

While trying to reuse the work on this PR, I wondered if another approach would be to have each Git dependency have its own `package-lock.json` committed to Nixpkgs and inject them just before NPM runs `npm ci` for them. I think this approach could be cleaner cleaner because:
* There is already a patch for NPM to patch the shebangs just before `npm ci` is ran for Git dependencies.
* In theory, Git dependencies could have transitive devDependencies for the same package but different versions which would fail with a single `package-lock.json`.

## Implementation

This adds an option to `buildNpmPackage` to inject `package-json.lock` files for Git dependencies to allow for building NPM packages with Git dependencies that have install scripts but no `package-lock.json`.

While we're at it, we noticed that Overleaf has dependencies with install scripts with shebangs that don't work on NixOS. For example, see https://github.com/overleaf/codemirror-emacs/blob/7b2b409ed2ed081224bfe3c1726bdc9a43ab9205/bin/build.js#L1, so I added a commit that modifies the NPM patch to also run patchShebang at the root of the Git clone of the dependency before running "npm ci".

## Question

I'm making this PR to kindly ask for guidance on how to proceed for Overleaf. What do you think of this change? Or should we try to patch upstream? There are at least 5 Git dependencies to patch and the Overleaf developers don't always seem to respond quickly (sometimes they haven't responded to PRs in years unfortunately :cry:) so it could take time.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
