### PR TITLE
libhydrogen: init at 0-unstable-2025-04-06 (bbca575b)

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -23540,6 +23540,13 @@
     githubId = 1901799;
     name = "Nathan van Doorn";
   };
+  tanya1866 = {
+    email = "tanyaarora@tutamail.com";
+    matrix = "@tanya1866:matrix.org";
+    github = "tanya1866";
+    githubId = 119473725;
+    name = "Tanya Arora";
+  };
   taranarmo = {
     email = "taranarmo@gmail.com";
     github = "taranarmo";

--- a/pkgs/by-name/li/libhydrogen/package.nix
+++ b/pkgs/by-name/li/libhydrogen/package.nix
@@ -30,7 +30,10 @@ stdenv.mkDerivation (finalAttrs: {
     "INCLUDE_INSTALL_DIR=${placeholder "dev"}/include"
     "LIBRARY_INSTALL_DIR=${placeholder "out"}/lib"
     "PKGCONFIG_INSTALL_DIR=${placeholder "dev"}/lib/pkgconfig"
+    "lib"
   ];
+
+  checkTarget = "test";
 
   postInstall = ''
     mkdir -p "$dev/lib/pkgconfig"
@@ -47,10 +50,6 @@ stdenv.mkDerivation (finalAttrs: {
 
   preCheck = ''
     export LD_LIBRARY_PATH=$PWD:$LD_LIBRARY_PATH
-  '';
-
-  checkPhase = ''
-    tests/tests
   '';
 
   passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;

--- a/pkgs/by-name/li/libhydrogen/package.nix
+++ b/pkgs/by-name/li/libhydrogen/package.nix
@@ -1,0 +1,66 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  testers,
+  pkg-config,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "libhydrogen";
+  version = "0-unstable-2025-04-06";
+
+  src = fetchFromGitHub {
+    owner = "jedisct1";
+    repo = "libhydrogen";
+    rev = "bbca575b62510bfdc6dd927a4bfa7df4a51cb846";
+    hash = "sha256-sLOE3oR53hmvRqIPD5PU9Q04TFqw2KuWT1OQBA/KdRc=";
+  };
+
+  outputs = [
+    "out"
+    "dev"
+  ];
+
+  nativeBuildInputs = [ pkg-config ];
+  enableParallelBuilding = true;
+
+  makeFlags = [
+    "PREFIX=${placeholder "out"}"
+    "INCLUDE_INSTALL_DIR=${placeholder "dev"}/include"
+    "LIBRARY_INSTALL_DIR=${placeholder "out"}/lib"
+    "PKGCONFIG_INSTALL_DIR=${placeholder "dev"}/lib/pkgconfig"
+  ];
+
+  postInstall = ''
+    mkdir -p "$dev/lib/pkgconfig"
+    cat > "$dev/lib/pkgconfig/libhydrogen.pc" <<EOF
+    Name: libhydrogen
+    Description: Lightweight cryptographic library
+    Version: ${finalAttrs.version}
+    Libs: -L$out/lib -lhydrogen
+    Cflags: -I$dev/include
+    EOF
+  '';
+
+  doCheck = true;
+
+  preCheck = ''
+    export LD_LIBRARY_PATH=$PWD:$LD_LIBRARY_PATH
+  '';
+
+  checkPhase = ''
+    tests/tests
+  '';
+
+  passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+
+  meta = {
+    description = "Lightweight, secure, easy-to-use crypto library suitable for constrained environments";
+    homepage = "https://github.com/jedisct1/libhydrogen";
+    license = lib.licenses.isc;
+    maintainers = [ lib.maintainers.tanya1866 ];
+    pkgConfigModules = [ "libhydrogen" ];
+    platforms = lib.platforms.all;
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
libhydrogen: init at 2024-04-06 (bbca575b)

This adds [libhydrogen](https://github.com/jedisct1/libhydrogen), a lightweight cryptographic library focused on simplicity and security. 
The package uses git commit `bbca575b62510bfdc6dd927a4bfa7df4a51cb846` from 2024-04-06 since upstream doesn't make versioned releases.
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->
**Meta**  
- License: ISC  
- Homepage: https://github.com/jedisct1/libhydrogen  
- Maintainer: @tanya1866
- Platforms: linux (tested), darwin (untested but should work)
---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
