### PR TITLE
chromium,chromedriver: 135.0.7049.52 -> 135.0.7049.84

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/info.json
+++ b/pkgs/applications/networking/browsers/chromium/info.json
@@ -1,10 +1,10 @@
 {
   "chromium": {
-    "version": "135.0.7049.52",
+    "version": "135.0.7049.84",
     "chromedriver": {
-      "version": "135.0.7049.42",
-      "hash_darwin": "sha256-CixR0TvndAgxvXYbetIqKg6NRu/z3pJe+USCZ0pyQd4=",
-      "hash_darwin_aarch64": "sha256-WKDi97j1F9+I6RYOsdiXVrgVibZ3ZoVPljo1XAtw0o8="
+      "version": "135.0.7049.85",
+      "hash_darwin": "sha256-L4x/MSCbVt2UIQwbHREDV8br6DmdfuqTJ3//7opK2IU=",
+      "hash_darwin_aarch64": "sha256-vixXGqbc2UYpydg1RILhrtmr5DdbJ5I1sD8aNikejQU="
     },
     "deps": {
       "depot_tools": {
@@ -20,8 +20,8 @@
     "DEPS": {
       "src": {
         "url": "https://chromium.googlesource.com/chromium/src.git",
-        "rev": "9ba7e609d28c509a8ce9265c2247065d8d251173",
-        "hash": "sha256-PjvfckdlaMq9HWefGxFppgBumlqh7xoCoxYFwk/r630=",
+        "rev": "6c019e56001911b3fd467e03bf68c435924d62f4",
+        "hash": "sha256-BFw1o2cIHBeBudeigH6YTOuLGsp/+pTOeE1lXBO3aio=",
         "recompress": true
       },
       "src/third_party/clang-format/script": {
@@ -126,8 +126,8 @@
       },
       "src/third_party/dawn": {
         "url": "https://dawn.googlesource.com/dawn.git",
-        "rev": "bdc68b25b620d7302a955e2c38c548ebfe74ef31",
-        "hash": "sha256-R9SQiKUjLkLmPJwuWpw7fcibrWxSlXWkDsCra7Ci0UQ="
+        "rev": "53dfda5e9d07d58b43cea66b8153c55dd751ff88",
+        "hash": "sha256-zXxJZz2C4eDJ8beHDXJe0UCNesDw5R0ogFcsdiF8VIc="
       },
       "src/third_party/dawn/third_party/glfw": {
         "url": "https://chromium.googlesource.com/external/github.com/glfw/glfw",
@@ -616,8 +616,8 @@
       },
       "src/third_party/skia": {
         "url": "https://skia.googlesource.com/skia.git",
-        "rev": "b99f146a03d3c98049768fd91c2bbe6594b02b2c",
-        "hash": "sha256-tl1GDmcStkuKMmzzsYuRG6Nrk4xDqgYYBoa1VsQNOwY="
+        "rev": "6e445bdea696eb6b6a46681dfc1a63edaa517edb",
+        "hash": "sha256-mSup6nKsEPjJ/HBV7PwjBI4PP7/RdwFm/dnavKeRqzI="
       },
       "src/third_party/smhasher/src": {
         "url": "https://chromium.googlesource.com/external/smhasher.git",
@@ -706,8 +706,8 @@
       },
       "src/third_party/wasm_tts_engine/src": {
         "url": "https://chromium.googlesource.com/chromium/wasm-tts-engine",
-        "rev": "6ab3e63276a2d66ba3e7db4f87c5b7cb00e22130",
-        "hash": "sha256-ZcnKKnHsN1UyztAXClc2EUwfeX3yuLtMM2Zjwpnh62U="
+        "rev": "53d2aba6f0cf7db57e17edfc3ff6471871b0c125",
+        "hash": "sha256-t5eeehwspRLaowEMPLa8/lV5AHamXQBfH/un0DHLVAM="
       },
       "src/third_party/wayland/src": {
         "url": "https://chromium.googlesource.com/external/anongit.freedesktop.org/git/wayland/wayland.git",
@@ -751,8 +751,8 @@
       },
       "src/third_party/webrtc": {
         "url": "https://webrtc.googlesource.com/src.git",
-        "rev": "04413d62f754a7b1a3a2d8c3df23bcde040112b2",
-        "hash": "sha256-sFoBgpPeMJQNSjNp8dDEUlB/7lJUpIXTpu0eRq94cGk="
+        "rev": "9e5db68b15087eccd8d2493b4e8539c1657e0f75",
+        "hash": "sha256-gXdBDo+fzp6hJB8qyhscV7ajwSfCUeYvSxhL10g56rU="
       },
       "src/third_party/wuffs/src": {
         "url": "https://skia.googlesource.com/external/github.com/google/wuffs-mirror-release-c.git",


### PR DESCRIPTION
https://chromereleases.googleblog.com/2025/04/stable-channel-update-for-desktop_8.html

This update includes 2 security fixes.

CVEs:
CVE-2025-3066

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
