### PR TITLE
 nixos/gancio: fix quotes and indentation, exec into configured user

### DIFF
--- a/nixos/modules/services/web-apps/gancio.nix
+++ b/nixos/modules/services/web-apps/gancio.nix
@@ -176,7 +176,11 @@ in
         mkdir -p $out/bin
         echo '#!${pkgs.runtimeShell}
         cd /var/lib/gancio/
-        exec ${lib.getExe cfg.package} ''${1:--help}
+        sudo=exec
+        if [[ "$USER" != ${cfg.user} ]]; then
+          sudo="exec /run/wrappers/bin/sudo -u ${cfg.user}"
+        fi
+        $sudo ${lib.getExe cfg.package} ''${1:--help}
         ' > $out/bin/gancio
         chmod +x $out/bin/gancio
       '')

--- a/nixos/modules/services/web-apps/gancio.nix
+++ b/nixos/modules/services/web-apps/gancio.nix
@@ -57,7 +57,7 @@ in
             default = "http${
               lib.optionalString config.services.nginx.virtualHosts."${cfg.settings.hostname}".enableACME "s"
             }://${cfg.settings.hostname}";
-            defaultText = lib.literalExpression ''"https://''${cfg.settings.hostname}"'';
+            defaultText = lib.literalExpression ''"https://''${config.services.gancio.settings.hostname}"'';
             example = "https://demo.gancio.org/gancio";
             description = "The full URL under which the server is reachable.";
           };
@@ -89,9 +89,7 @@ in
               readOnly = true;
               type = types.nullOr types.str;
               default = if cfg.settings.db.dialect == "sqlite" then "/var/lib/gancio/db.sqlite" else null;
-              defaultText = ''
-                if cfg.settings.db.dialect == "sqlite" then "/var/lib/gancio/db.sqlite" else null
-              '';
+              defaultText = ''if config.services.gancio.settings.db.dialect == "sqlite" then "/var/lib/gancio/db.sqlite" else null'';
             };
             host = mkOption {
               description = ''
@@ -100,9 +98,7 @@ in
               readOnly = true;
               type = types.nullOr types.str;
               default = if cfg.settings.db.dialect == "postgres" then "/run/postgresql" else null;
-              defaultText = ''
-                if cfg.settings.db.dialect == "postgres" then "/run/postgresql" else null
-              '';
+              defaultText = ''if config.services.gancio.settings.db.dialect == "postgres" then "/run/postgresql" else null'';
             };
             database = mkOption {
               description = ''
@@ -111,9 +107,7 @@ in
               readOnly = true;
               type = types.nullOr types.str;
               default = if cfg.settings.db.dialect == "postgres" then cfg.user else null;
-              defaultText = ''
-                if cfg.settings.db.dialect == "postgres" then cfg.user else null
-              '';
+              defaultText = ''if config.services.gancio.settings.db.dialect == "postgres" then cfg.user else null'';
             };
           };
           log_level = mkOption {

--- a/nixos/modules/services/web-apps/gancio.nix
+++ b/nixos/modules/services/web-apps/gancio.nix
@@ -174,10 +174,10 @@ in
     environment.systemPackages = [
       (pkgs.runCommand "gancio" { } ''
         mkdir -p $out/bin
-        echo "#!${pkgs.runtimeShell}
-          cd /var/lib/gancio/
-          exec ${lib.getExe cfg.package} ''${1:---help}
-        " > $out/bin/gancio
+        echo '#!${pkgs.runtimeShell}
+        cd /var/lib/gancio/
+        exec ${lib.getExe cfg.package} ''${1:--help}
+        ' > $out/bin/gancio
         chmod +x $out/bin/gancio
       '')
     ];


### PR DESCRIPTION
I somehow missed the quotes when transferring this from our config to the PR 😓 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
