### PR TITLE
python3Packages.pytest-retry: init at 1.7.0

### DIFF
--- a/pkgs/development/python-modules/debugpy/default.nix
+++ b/pkgs/development/python-modules/debugpy/default.nix
@@ -11,6 +11,7 @@
   pytestCheckHook,
   pytest-xdist,
   pytest-timeout,
+  pytest-retry,
   importlib-metadata,
   psutil,
   untangle,
@@ -99,6 +100,7 @@ buildPythonPackage rec {
     pytestCheckHook
     pytest-xdist
     pytest-timeout
+    pytest-retry
 
     ## Used by test helpers:
     importlib-metadata
@@ -129,7 +131,12 @@ buildPythonPackage rec {
   '';
 
   # Override default arguments in pytest.ini
-  pytestFlagsArray = [ "--timeout=0" ];
+  pytestFlags = [ "--timeout=0" ];
+
+  disabledTests = [
+    # hanging test (flaky)
+    "test_systemexit"
+  ];
 
   # Fixes hanging tests on Darwin
   __darwinAllowLocalNetworking = true;

--- a/pkgs/development/python-modules/pytest-retry/default.nix
+++ b/pkgs/development/python-modules/pytest-retry/default.nix
@@ -1,0 +1,40 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  pytest,
+  pytestCheckHook,
+  setuptools,
+}:
+
+buildPythonPackage rec {
+  pname = "pytest-retry";
+  version = "1.7.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "str0zzapreti";
+    repo = "pytest-retry";
+    tag = version;
+    hash = "sha256-Gf+L7zvC1FGAm0Wd6E6fV3KynassoGyHSD0CPgEJ02k=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [ pytest ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  pythonImportsCheck = [ "pytest_retry" ];
+
+  meta = {
+    description = "Plugin for retrying flaky tests in CI environments";
+    longDescription = ''
+      This plugin adds a decorator to mark tests as flaky: `@pytest.mark.flaky(retries=3, delay=1)`.
+    '';
+    homepage = "https://github.com/str0zzapreti/pytest-retry";
+    changelog = "https://github.com/str0zzapreti/pytest-retry/releases/tag/${src.tag}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ fliegendewurst ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -13649,6 +13649,8 @@ self: super: with self; {
 
   pytest-responses = callPackage ../development/python-modules/pytest-responses { };
 
+  pytest-retry = callPackage ../development/python-modules/pytest-retry { };
+
   pytest-reverse = callPackage ../development/python-modules/pytest-reverse { };
 
   pytest-ruff = callPackage ../development/python-modules/pytest-ruff { };


### PR DESCRIPTION
Previously, debugpy complained:

```
/build/source/tests/debugpy/test_run.py:253: PytestUnknownMarkWarning: Unknown pytest.mark.flaky - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
  @pytest.mark.flaky(retries=2, delay=1)
```

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).