### PR TITLE
 cosmic-packages: substitue /usr/share with /run/current-system/sw/share

### DIFF
--- a/pkgs/by-name/co/cosmic-bg/package.nix
+++ b/pkgs/by-name/co/cosmic-bg/package.nix
@@ -21,6 +21,11 @@ rustPlatform.buildRustPackage (finalAttrs: {
     hash = "sha256-4b4laUXTnAbdngLVh8/dD144m9QrGReSEjRZoNR6Iks=";
   };
 
+  postPatch = ''
+    substituteInPlace config/src/lib.rs data/v1/all src/wallpaper.rs \
+      --replace-fail '/usr/share' '/run/current-system/sw/share'
+  '';
+
   useFetchCargoVendor = true;
   cargoHash = "sha256-GLXooTjcGq4MsBNnlpHBBUJGNs5UjKMQJGJuj9UO2wk=";
 

--- a/pkgs/by-name/co/cosmic-greeter/package.nix
+++ b/pkgs/by-name/co/cosmic-greeter/package.nix
@@ -60,6 +60,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
   ];
 
   postPatch = ''
+    substituteInPlace src/greeter.rs \
+      --replace-fail '/usr/share' '/run/current-system/sw/share'
     substituteInPlace src/greeter.rs --replace-fail '/usr/bin/env' '${lib.getExe' coreutils "env"}'
   '';
 

--- a/pkgs/by-name/co/cosmic-osd/package.nix
+++ b/pkgs/by-name/co/cosmic-osd/package.nix
@@ -20,6 +20,11 @@ rustPlatform.buildRustPackage (finalAttrs: {
     hash = "sha256-ezOeRgqI/GOWFknUVZI7ZLEy1GYaBI+/An83HWKL6ho=";
   };
 
+  postPatch = ''
+    substituteInPlace src/components/app.rs \
+      --replace-fail '/usr/share' '/run/current-system/sw/share'
+  '';
+
   useFetchCargoVendor = true;
   cargoHash = "sha256-vYehF2RjPrTZiuGcRUe4XX3ftRo7f+SIoKizD/kOtR8=";
 

--- a/pkgs/by-name/co/cosmic-settings-daemon/package.nix
+++ b/pkgs/by-name/co/cosmic-settings-daemon/package.nix
@@ -21,6 +21,11 @@ rustPlatform.buildRustPackage (finalAttrs: {
     hash = "sha256-DtwW6RxHnNh87Xu0NCULfUsHNzYU9tHtFKE9HO3rvME=";
   };
 
+  postPatch = ''
+    substituteInPlace src/battery.rs src/pipewire.rs src/theme.rs \
+      --replace-fail '/usr/share' '/run/current-system/sw/share'
+  '';
+
   useFetchCargoVendor = true;
   cargoHash = "sha256-lGzQBL9IXbPsaKeVHp34xkm5FnTxWvfw4wg3El4LZdA=";
 

--- a/pkgs/by-name/co/cosmic-settings/package.nix
+++ b/pkgs/by-name/co/cosmic-settings/package.nix
@@ -36,6 +36,14 @@ rustPlatform.buildRustPackage (finalAttrs: {
     hash = "sha256-UKg3TIpyaqtynk6wLFFPpv69F74hmqfMVPra2+iFbvE=";
   };
 
+  postPatch = ''
+    substituteInPlace \
+      cosmic-settings/src/pages/desktop/appearance/icon_themes.rs \
+      cosmic-settings/src/pages/desktop/wallpaper/config.rs \
+      cosmic-settings/src/pages/system/users/mod.rs \
+      --replace-fail '/usr/share' '/run/current-system/sw/share'
+  '';
+
   useFetchCargoVendor = true;
   cargoHash = "sha256-mf/Cw3/RLrCYgsk7JKCU2+oPn1VPbD+4JzkUmbd47m8=";
 

--- a/pkgs/by-name/co/cosmic-workspaces-epoch/package.nix
+++ b/pkgs/by-name/co/cosmic-workspaces-epoch/package.nix
@@ -23,6 +23,11 @@ rustPlatform.buildRustPackage (finalAttrs: {
     hash = "sha256-3jivE0EaSddPxMYn9DDaYUMafPf60XeCwVeQegbt++c=";
   };
 
+  postPatch = ''
+    substituteInPlace src/view/mod.rs \
+      --replace-fail '/usr/share' '/run/current-system/sw/share'
+  '';
+
   useFetchCargoVendor = true;
   cargoHash = "sha256-l5y9bOG/h24EfiAFfVKjtzYCzjxU2TI8wh6HBUwoVcE=";
 

--- a/pkgs/by-name/xd/xdg-desktop-portal-cosmic/package.nix
+++ b/pkgs/by-name/xd/xdg-desktop-portal-cosmic/package.nix
@@ -61,6 +61,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   # Also modifies the functionality by replacing 'false' with 'true' to enable the portal to start properly.
   postPatch = ''
+    substituteInPlace src/screenshot.rs src/widget/screenshot.rs \
+      --replace-fail '/usr/share' '/run/current-system/sw/share'
     substituteInPlace data/org.freedesktop.impl.portal.desktop.cosmic.service \
       --replace-fail 'Exec=/bin/false' 'Exec=${lib.getExe' coreutils "true"}'
   '';


### PR DESCRIPTION
**Please ignore the `$pkg: add passthru.tests` commits.** I based the current branch off `add-passthru-tests-to-cosmic-pkgs` to prevent merge conflicts and also because there's higher chance that #397188 gets merged before this and therefore avoiding any nasty rebasing. It also means that the passthru.tests commits (once merged) will no longer be "ahead" of nixpkgs/master.

Creating this PR to have a review in parallel.

## Things done

When launching COSMIC, I get errors like so:
```
machine #   ERROR  shortcuts custom config error: GetKey("custom", Os { code: 2, kind: NotFound, message: "No such file or directory" })                                  
machine #     at /build/cosmic-settings-1.0.0-alpha.6-vendor/cosmic-settings-config-0.1.0/src/shortcuts/mod.rs:43 on main                                                 
machine #                                                                                                                                                                 
machine # error: XDG_RUNTIME_DIR is invalid or not set in the environment.                                                                                                
machine #   ERROR  Failed to process wayland Action.                                                                                                                      
machine #     at /build/cosmic-settings-1.0.0-alpha.6-vendor/iced_winit-0.14.0-dev/src/platform_specific/wayland/mod.rs:134 on main
```

It also solves minor issues like the backgrounds available in the `cosmic-wallpapers` but not showing up in `cosmic-settings`, etc.

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
