### PR TITLE
segger-jlink: 810 -> 824, add Darwin support

### DIFF
--- a/pkgs/by-name/se/segger-jlink/package.nix
+++ b/pkgs/by-name/se/segger-jlink/package.nix
@@ -219,13 +219,13 @@ stdenv.mkDerivation (
 
     passthru.updateScript = ./update.py;
 
-    meta = with lib; {
+    meta = {
       description = "J-Link Software and Documentation pack";
       homepage = "https://www.segger.com/downloads/jlink/#J-LinkSoftwareAndDocumentationPack";
       changelog = "https://www.segger.com/downloads/jlink/ReleaseNotes_JLink.html";
-      license = licenses.unfree;
-      platforms = attrNames supported;
-      maintainers = with maintainers; [
+      license = lib.licenses.unfree;
+      platforms = lib.attrNames supported;
+      maintainers = with lib.maintainers; [
         FlorianFranzen
         h7x4
         stargate01

--- a/pkgs/by-name/se/segger-jlink/package.nix
+++ b/pkgs/by-name/se/segger-jlink/package.nix
@@ -20,7 +20,7 @@ let
 
   inherit (source) version;
 
-  url = "https://www.segger.com/downloads/jlink/JLink_Linux_V${version}_${platform.name}.tgz";
+  url = "https://www.segger.com/downloads/jlink/JLink_${platform.os}_V${version}_${platform.name}.${platform.ext}";
 
   src =
     assert

--- a/pkgs/by-name/se/segger-jlink/package.nix
+++ b/pkgs/by-name/se/segger-jlink/package.nix
@@ -55,117 +55,125 @@ let
 
   qt4-bundled = callPackage ./qt4-bundled.nix { inherit src version; };
 
-in
-stdenv.mkDerivation {
-  pname = "segger-jlink";
-  inherit src version;
-
-  nativeBuildInputs = [
-    autoPatchelfHook
-  ]
-  ++ lib.optionals (!headless) [
-    copyDesktopItems
-  ];
-
-  buildInputs = lib.optionals (!headless) [
-    qt4-bundled
-  ];
-
-  # Udev is loaded late at runtime
-  appendRunpaths = [
-    "${udev}/lib"
-  ];
-
-  dontConfigure = true;
-  dontBuild = true;
-
-  desktopItems = lib.optionals (!headless) (
-    map
-      (
-        entry:
-        (makeDesktopItem {
-          name = entry;
-          exec = entry;
-          icon = "applications-utilities";
-          desktopName = entry;
-          genericName = "SEGGER ${entry}";
-          categories = [ "Development" ];
-          type = "Application";
-          terminal = false;
-          startupNotify = false;
-        })
-      )
-      [
-        "JFlash"
-        "JFlashLite"
-        "JFlashSPI"
-        "JLinkConfig"
-        "JLinkGDBServer"
-        "JLinkLicenseManager"
-        "JLinkRTTViewer"
-        "JLinkRegistration"
-        "JLinkRemoteServer"
-        "JLinkSWOViewer"
-        "JLinkUSBWebServer"
-        "JMem"
-      ]
-  );
-
-  installPhase = ''
-    runHook preInstall
-
-    mkdir -p $out/opt/SEGGER/JLink
-
-    ${lib.optionalString (!headless) ''
-      # Install binaries and runtime files into /opt/SEGGER/JLink
-      mv J* ETC GDBServer Firmwares $out/opt/SEGGER/JLink
-
-      # Link executables into /bin/
-      mkdir -p $out/bin
-      for binr in $out/opt/SEGGER/JLink/*Exe; do
-        binrlink=''${binr#"$out/opt/SEGGER/JLink/"}
-        ln -s $binr $out/bin/$binrlink
-        # Create additional symlinks without "Exe" suffix
-        binrlink=''${binrlink/%Exe}
-        ln -s $binr $out/bin/$binrlink
-      done
-
-      # Copy special alias symlinks
-      for slink in $(find $out/opt/SEGGER/JLink/. -type l); do
-        cp -P -n $slink $out/bin || true
-        rm $slink
-      done
-    ''}
-
-    # Install libraries
-    install -Dm444 libjlinkarm.so* -t $out/lib
-    for libr in $out/lib/libjlinkarm.*; do
-      ln -s $libr $out/opt/SEGGER/JLink
-    done
-
-    # Install docs and examples
-    mkdir -p $out/share
-    mv Doc $out/share/docs
-    mv Samples $out/share/examples
-
-    # Install udev rules
-    install -Dm444 99-jlink.rules -t $out/lib/udev/rules.d/
-
-    runHook postInstall
-  '';
-
-  passthru.updateScript = ./update.py;
-
-  meta = with lib; {
-    description = "J-Link Software and Documentation pack";
-    homepage = "https://www.segger.com/downloads/jlink/#J-LinkSoftwareAndDocumentationPack";
-    changelog = "https://www.segger.com/downloads/jlink/ReleaseNotes_JLink.html";
-    license = licenses.unfree;
-    platforms = attrNames supported;
-    maintainers = with maintainers; [
-      FlorianFranzen
-      h7x4
-      stargate01
+  buildAttrsLinux = {
+    nativeBuildInputs = [
+      autoPatchelfHook
+    ]
+    ++ lib.optionals (!headless) [
+      copyDesktopItems
     ];
+
+    buildInputs = lib.optionals (!headless) [
+      qt4-bundled
+    ];
+
+    # Udev is loaded late at runtime
+    appendRunpaths = [
+      "${udev}/lib"
+    ];
+
+    desktopItems = lib.optionals (!headless) (
+      map
+        (
+          entry:
+          (makeDesktopItem {
+            name = entry;
+            exec = entry;
+            icon = "applications-utilities";
+            desktopName = entry;
+            genericName = "SEGGER ${entry}";
+            categories = [ "Development" ];
+            type = "Application";
+            terminal = false;
+            startupNotify = false;
+          })
+        )
+        [
+          "JFlash"
+          "JFlashLite"
+          "JFlashSPI"
+          "JLinkConfig"
+          "JLinkGDBServer"
+          "JLinkLicenseManager"
+          "JLinkRTTViewer"
+          "JLinkRegistration"
+          "JLinkRemoteServer"
+          "JLinkSWOViewer"
+          "JLinkUSBWebServer"
+          "JMem"
+        ]
+    );
+
+    installPhase = ''
+      runHook preInstall
+
+      mkdir -p $out/opt/SEGGER/JLink
+
+      ${lib.optionalString (!headless) ''
+        # Install binaries and runtime files into /opt/SEGGER/JLink
+        mv J* ETC GDBServer Firmwares $out/opt/SEGGER/JLink
+
+        # Link executables into /bin/
+        mkdir -p $out/bin
+        for binr in $out/opt/SEGGER/JLink/*Exe; do
+          binrlink=''${binr#"$out/opt/SEGGER/JLink/"}
+          ln -s $binr $out/bin/$binrlink
+          # Create additional symlinks without "Exe" suffix
+          binrlink=''${binrlink/%Exe}
+          ln -s $binr $out/bin/$binrlink
+        done
+
+        # Copy special alias symlinks
+        for slink in $(find $out/opt/SEGGER/JLink/. -type l); do
+          cp -P -n $slink $out/bin || true
+          rm $slink
+        done
+      ''}
+
+      # Install libraries
+      install -Dm444 libjlinkarm.so* -t $out/lib
+      for libr in $out/lib/libjlinkarm.*; do
+        ln -s $libr $out/opt/SEGGER/JLink
+      done
+
+      # Install docs and examples
+      mkdir -p $out/share
+      mv Doc $out/share/docs
+      mv Samples $out/share/examples
+
+      # Install udev rules
+      install -Dm444 99-jlink.rules -t $out/lib/udev/rules.d/
+
+      runHook postInstall
+    '';
   };
-}
+
+  buildAttrs = if stdenv.isLinux then buildAttrsLinux else throw "platform not supported";
+
+in
+stdenv.mkDerivation (
+  finalAttrs:
+  buildAttrs
+  // {
+    pname = "segger-jlink";
+    inherit src version;
+
+    dontConfigure = true;
+    dontBuild = true;
+
+    passthru.updateScript = ./update.py;
+
+    meta = with lib; {
+      description = "J-Link Software and Documentation pack";
+      homepage = "https://www.segger.com/downloads/jlink/#J-LinkSoftwareAndDocumentationPack";
+      changelog = "https://www.segger.com/downloads/jlink/ReleaseNotes_JLink.html";
+      license = licenses.unfree;
+      platforms = attrNames supported;
+      maintainers = with maintainers; [
+        FlorianFranzen
+        h7x4
+        stargate01
+      ];
+    };
+  }
+)

--- a/pkgs/by-name/se/segger-jlink/source.nix
+++ b/pkgs/by-name/se/segger-jlink/source.nix
@@ -1,27 +1,27 @@
 {
-  version = "810";
+  version = "824";
   x86_64-linux = {
     os = "Linux";
     name = "x86_64";
     ext = "tgz";
-    hash = "sha256-cnax7D4T5On356mZrd/waH62IXP6BNSJtCM0rw0RnDo=";
+    hash = "sha256-TsNlwApXdbkHEI+pG9NVK7pJkKdvFYGIGgn+9xJ9q8A=";
   };
   i686-linux = {
     os = "Linux";
     name = "i386";
     ext = "tgz";
-    hash = "sha256-ERpzSVK7IxriDTH1wkLsiioqV99fRkMIlg0Pd+V+h7g=";
+    hash = "sha256-Gs4iifvchFY0d39bhQ61lX/TPGjCKPRidkJQbva91gA=";
   };
   aarch64-linux = {
     os = "Linux";
     name = "arm64";
     ext = "tgz";
-    hash = "sha256-l+mxhK85GnGLKspXeEy2JOJ+fA8DVIr36tLVCBp7MhU=";
+    hash = "sha256-YowEzJ//idmZ4eznPNgEW142ApsnvkboGAWfDCHfIS0=";
   };
   armv7l-linux = {
     os = "Linux";
     name = "arm";
     ext = "tgz";
-    hash = "sha256-DFIaIq57HQbpur2vep1pO/VDOo913b17x3eWhq4wL40=";
+    hash = "sha256-mLl/qNtxMfFOe/M0fCZnnebei7E2ON4gvE9Q7XIufag=";
   };
 }

--- a/pkgs/by-name/se/segger-jlink/source.nix
+++ b/pkgs/by-name/se/segger-jlink/source.nix
@@ -24,4 +24,16 @@
     ext = "tgz";
     hash = "sha256-mLl/qNtxMfFOe/M0fCZnnebei7E2ON4gvE9Q7XIufag=";
   };
+  aarch64-darwin = {
+    os = "MacOSX";
+    name = "arm64";
+    ext = "pkg";
+    hash = "sha256-GKlWof4XdxEwW7G8YmhdfjjJpXEXICqWapI7fly8Uvg=";
+  };
+  x86_64-darwin = {
+    os = "MacOSX";
+    name = "x86_64";
+    ext = "pkg";
+    hash = "sha256-LWLUdzNVkN60qET7vhvLCoepg7kuHPqs2bZspRzZkGo=";
+  };
 }

--- a/pkgs/by-name/se/segger-jlink/source.nix
+++ b/pkgs/by-name/se/segger-jlink/source.nix
@@ -1,19 +1,27 @@
 {
   version = "810";
   x86_64-linux = {
+    os = "Linux";
     name = "x86_64";
+    ext = "tgz";
     hash = "sha256-cnax7D4T5On356mZrd/waH62IXP6BNSJtCM0rw0RnDo=";
   };
   i686-linux = {
+    os = "Linux";
     name = "i386";
+    ext = "tgz";
     hash = "sha256-ERpzSVK7IxriDTH1wkLsiioqV99fRkMIlg0Pd+V+h7g=";
   };
   aarch64-linux = {
+    os = "Linux";
     name = "arm64";
+    ext = "tgz";
     hash = "sha256-l+mxhK85GnGLKspXeEy2JOJ+fA8DVIr36tLVCBp7MhU=";
   };
   armv7l-linux = {
+    os = "Linux";
     name = "arm";
+    ext = "tgz";
     hash = "sha256-DFIaIq57HQbpur2vep1pO/VDOo913b17x3eWhq4wL40=";
   };
 }

--- a/pkgs/by-name/se/segger-jlink/update.py
+++ b/pkgs/by-name/se/segger-jlink/update.py
@@ -5,16 +5,18 @@ import requests
 import subprocess
 
 from bs4 import BeautifulSoup
+from collections import namedtuple
 from pathlib import Path
 from tempfile import NamedTemporaryFile
 from textwrap import indent, dedent
 
 
+Arch = namedtuple('Architecture', ['os', 'name', 'ext'])
 ARCH_MAP = {
-    'x86_64-linux': 'x86_64',
-    'i686-linux': 'i386',
-    'aarch64-linux': 'arm64',
-    'armv7l-linux': 'arm',
+    'x86_64-linux': Arch(os='Linux', name='x86_64', ext='tgz'),
+    'i686-linux': Arch(os='Linux', name='i386', ext='tgz'),
+    'aarch64-linux': Arch(os='Linux', name='arm64', ext='tgz'),
+    'armv7l-linux': Arch(os='Linux', name='arm', ext='tgz'),
 }
 
 
@@ -37,7 +39,11 @@ def find_latest_jlink_version() -> str:
     return version.removeprefix('V').replace('.', '')
 
 
-def nar_hash(url: str) -> str:
+def nar_hash(version: str, arch: Arch) -> str:
+    '''
+    Return the nar hash of 'version' for 'source'.
+    '''
+    url = f"https://www.segger.com/downloads/jlink/JLink_{arch.os}_V{version}_{arch.name}.{arch.ext}"
     try:
         response = requests.post(url, data={'accept_license_agreement': 'accepted'})
         response.raise_for_status()
@@ -56,21 +62,15 @@ def nar_hash(url: str) -> str:
     return output.strip()
 
 
-def calculate_package_hashes(version: str) -> list[tuple[str, str, str]]:
-    result = []
-    for (arch_nix, arch_web) in ARCH_MAP.items():
-        url = f"https://www.segger.com/downloads/jlink/JLink_Linux_V{version}_{arch_web}.tgz";
-        nhash = nar_hash(url)
-        result.append((arch_nix, arch_web, nhash))
-    return result
-
-
-def update_source(version: str, package_hashes: list[tuple[str, str, str]]):
+def update_source(version: str):
     content = f'version = "{version}";\n'
-    for arch_nix, arch_web, nhash in package_hashes:
+    for arch_nix, arch in ARCH_MAP.items():
+        nhash = nar_hash(version, arch)
         content += dedent(f'''
         {arch_nix} = {{
-          name = "{arch_web}";
+          os = "{arch.os}";
+          name = "{arch.name}";
+          ext = "{arch.ext}";
           hash = "{nhash}";
         }};''').strip() + '\n'
 
@@ -81,7 +81,4 @@ def update_source(version: str, package_hashes: list[tuple[str, str, str]]):
 
 
 if __name__ == '__main__':
-    version = find_latest_jlink_version()
-    package_hashes = calculate_package_hashes(version)
-    update_source(version, package_hashes)
-
+    update_source(find_latest_jlink_version())

--- a/pkgs/by-name/se/segger-jlink/update.py
+++ b/pkgs/by-name/se/segger-jlink/update.py
@@ -17,6 +17,8 @@ ARCH_MAP = {
     'i686-linux': Arch(os='Linux', name='i386', ext='tgz'),
     'aarch64-linux': Arch(os='Linux', name='arm64', ext='tgz'),
     'armv7l-linux': Arch(os='Linux', name='arm', ext='tgz'),
+    'aarch64-darwin': Arch(os='MacOSX', name='arm64', ext='pkg'),
+    'x86_64-darwin': Arch(os='MacOSX', name='x86_64', ext='pkg'),
 }
 
 


### PR DESCRIPTION
- Update segger-jlink 810 -> 824
- Add Darwin support

cc @NixOS/darwin-maintainers 

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [x] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).