### PR TITLE
mcp-server-fetch: init at 2025.3.28

### DIFF
--- a/pkgs/development/python-modules/mcp-server-fetch/default.nix
+++ b/pkgs/development/python-modules/mcp-server-fetch/default.nix
@@ -1,0 +1,52 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  hatchling,
+  markdownify,
+  mcp,
+  protego,
+  pydantic,
+  readabilipy,
+  requests,
+  callPackage,
+}:
+buildPythonPackage rec {
+  pname = "mcp-server-fetch";
+  version = "2025.3.28";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "modelcontextprotocol";
+    repo = "servers";
+    tag = version;
+    hash = "sha256-6362x1vFLDMvcPNeS91juO/nZB51el48zOamIQrSeZw=";
+  };
+  sourceRoot = "${src.name}/src/fetch";
+
+  build-system = [
+    hatchling
+  ];
+
+  dependencies = [
+    markdownify
+    mcp
+    protego
+    pydantic
+    readabilipy
+    requests
+  ];
+
+  passthru.tests = {
+    help = callPackage ./tests/help.nix { };
+  };
+
+  meta = {
+    description = "Model Context Protocol server providing tools to fetch and convert web content for usage by LLMs";
+    homepage = "https://github.com/modelcontextprotocol/servers/tree/main/src/fetch";
+    changelog = "https://github.com/modelcontextprotocol/servers/releases/tag/${version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ josh ];
+    mainProgram = "mcp-server-fetch";
+  };
+}

--- a/pkgs/development/python-modules/mcp-server-fetch/tests/help.nix
+++ b/pkgs/development/python-modules/mcp-server-fetch/tests/help.nix
@@ -1,0 +1,12 @@
+{
+  runCommand,
+  mcp-server-fetch,
+}:
+runCommand "mcp-server-fetch-help"
+  {
+    nativeBuildInputs = [ mcp-server-fetch ];
+  }
+  ''
+    mcp-server-fetch --help
+    touch "$out"
+  ''

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8512,6 +8512,8 @@ self: super: with self; {
 
   mcp = callPackage ../development/python-modules/mcp { };
 
+  mcp-server-fetch = callPackage ../development/python-modules/mcp-server-fetch { };
+
   mcpadapt = callPackage ../development/python-modules/mcpadapt { };
 
   mcstatus = callPackage ../development/python-modules/mcstatus { };


### PR DESCRIPTION
This is one of a number of MCP servers that are part of the core [modelcontextprotocol/servers](https://github.com/modelcontextprotocol/servers) monorepo. I'd love to get some of the others upstreamed to nixpkgs as well. I am curious if there's any nixpkg pior art for how to best handle monorepos, if it makes sense for there to be centralized `fetchFromGitHub` pin or individually for each package. This package is published on [PyPI as mcp-server-fetch](https://pypi.org/project/mcp-server-fetch/) which is how I settled on the name.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
