### PR TITLE
xdg-desktop-portal-termfilechooser: 0.4.0 -> 1.0.5; add updateScript

### DIFF
--- a/pkgs/by-name/xd/xdg-desktop-portal-termfilechooser/package.nix
+++ b/pkgs/by-name/xd/xdg-desktop-portal-termfilechooser/package.nix
@@ -9,6 +9,7 @@
   inih,
   systemd,
   scdoc,
+  nix-update-script,
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "xdg-desktop-portal-termfilechooser";
@@ -36,12 +37,17 @@ stdenv.mkDerivation (finalAttrs: {
 
   mesonFlags = [ "-Dsd-bus-provider=libsystemd" ];
 
+  passthru.updateScript = nix-update-script { };
+
   meta = with lib; {
     description = "xdg-desktop-portal backend for choosing files with your favorite file chooser";
     homepage = "https://github.com/hunkyburrito/xdg-desktop-portal-termfilechooser";
     license = licenses.mit;
     platforms = platforms.linux;
-    maintainers = with lib.maintainers; [ body20002 ];
+    maintainers = with lib.maintainers; [
+      body20002
+      ltrump
+    ];
     mainProgram = "xdg-desktop-portal-termfilechooser";
   };
 })

--- a/pkgs/by-name/xd/xdg-desktop-portal-termfilechooser/package.nix
+++ b/pkgs/by-name/xd/xdg-desktop-portal-termfilechooser/package.nix
@@ -10,15 +10,15 @@
   systemd,
   scdoc,
 }:
-stdenv.mkDerivation {
+stdenv.mkDerivation (finalAttrs: {
   pname = "xdg-desktop-portal-termfilechooser";
-  version = "0.4.0";
+  version = "1.0.5";
 
   src = fetchFromGitHub {
     owner = "hunkyburrito";
     repo = "xdg-desktop-portal-termfilechooser";
-    rev = "c35af27e323a492cbb3b19bdd135657ae523caef";
-    hash = "sha256-9bxhKkk5YFBhR2ylcDzlvt4ltYuF174w00EJK5r3aY0=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-uwUND1K0UCztDS68APZf578zhvVm0BhL3f7dLrdKTHE=";
   };
 
   nativeBuildInputs = [
@@ -44,4 +44,4 @@ stdenv.mkDerivation {
     maintainers = with lib.maintainers; [ body20002 ];
     mainProgram = "xdg-desktop-portal-termfilechooser";
   };
-}
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Changelog: https://github.com/hunkyburrito/xdg-desktop-portal-termfilechooser/compare/c35af27e323a492cbb3b19bdd135657ae523caef...v1.0.5

Add update script. Add myself as maintainer :D.

@body20002

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
