### PR TITLE
python39: drop

### DIFF
--- a/doc/languages-frameworks/python.section.md
+++ b/doc/languages-frameworks/python.section.md
@@ -50,7 +50,6 @@ sets are
 
 * `pkgs.python27Packages`
 * `pkgs.python3Packages`
-* `pkgs.python39Packages`
 * `pkgs.python310Packages`
 * `pkgs.python311Packages`
 * `pkgs.python312Packages`

--- a/nixos/doc/manual/development/option-declarations.section.md
+++ b/nixos/doc/manual/development/option-declarations.section.md
@@ -158,14 +158,14 @@ lib.mkOption {
 ::: {#ex-options-declarations-util-mkPackageOption-extraDescription .example}
 ### `mkPackageOption` with additional description text
 ```nix
-mkPackageOption pkgs [ "python39Packages" "pytorch" ] {
+mkPackageOption pkgs [ "python312Packages" "torch" ] {
   extraDescription = "This is an example and doesn't actually do anything.";
 }
 # is like
 lib.mkOption {
   type = lib.types.package;
-  default = pkgs.python39Packages.pytorch;
-  defaultText = lib.literalExpression "pkgs.python39Packages.pytorch";
+  default = pkgs.python312Packages.torch;
+  defaultText = lib.literalExpression "pkgs.python312Packages.torch";
   description = "The pytorch package to use. This is an example and doesn't actually do anything.";
 }
 ```

--- a/pkgs/by-name/cj/cjdns/package.nix
+++ b/pkgs/by-name/cj/cjdns/package.nix
@@ -5,7 +5,7 @@
   rustPlatform,
   nodejs,
   which,
-  python39,
+  python3,
   libuv,
   util-linux,
   nixosTests,
@@ -37,7 +37,7 @@ rustPlatform.buildRustPackage rec {
   nativeBuildInputs =
     [
       which
-      python39
+      python3
       nodejs
       pkg-config
     ]
@@ -66,11 +66,11 @@ rustPlatform.buildRustPackage rec {
   passthru.tests.basic = nixosTests.cjdns;
 
   meta = with lib; {
+    broken = true; # outdated, incompatible with supported python versions
     homepage = "https://github.com/cjdelisle/cjdns";
     description = "Encrypted networking for regular people";
     license = licenses.gpl3Plus;
     maintainers = with maintainers; [ ehmry ];
     platforms = platforms.linux;
-    broken = stdenv.hostPlatform.isAarch64;
   };
 }

--- a/pkgs/development/compilers/flutter/engine/package.nix
+++ b/pkgs/development/compilers/flutter/engine/package.nix
@@ -37,7 +37,6 @@
   pkg-config,
   ninja,
   python312,
-  python39,
   gitMinimal,
   version,
   flutterVersion,
@@ -58,7 +57,7 @@ let
 
   constants = callPackage ./constants.nix { platform = stdenv.targetPlatform; };
 
-  python3 = if lib.versionAtLeast flutterVersion "3.20" then python312 else python39;
+  python3 = python312;
 
   src = callPackage ./source.nix {
     inherit

--- a/pkgs/development/cuda-modules/cuda/overrides.nix
+++ b/pkgs/development/cuda-modules/cuda/overrides.nix
@@ -159,7 +159,6 @@ filterAndCreateOverrides {
       expat,
       libxcrypt-legacy,
       ncurses6,
-      python39,
       python310,
       python311,
       python312,
@@ -176,7 +175,6 @@ filterAndCreateOverrides {
         ++ lib.lists.optionals (cudaAtLeast "12.5") [
           libxcrypt-legacy
           ncurses6
-          python39
           python310
           python311
           python312

--- a/pkgs/development/cuda-modules/cudatoolkit/default.nix
+++ b/pkgs/development/cuda-modules/cudatoolkit/default.nix
@@ -29,7 +29,6 @@
   patchelf,
   perl,
   python3, # FIXME: CUDAToolkit 10 may still need python27
-  python39,
   python310,
   python311,
   pulseaudio,
@@ -155,7 +154,6 @@ backendStdenv.mkDerivation rec {
       # libcrypt.so.1
       libxcrypt-legacy
       ncurses6
-      python39
       python310
       python311
     ];

--- a/pkgs/development/interpreters/python/cpython/default.nix
+++ b/pkgs/development/interpreters/python/cpython/default.nix
@@ -309,14 +309,9 @@ stdenv.mkDerivation (finalAttrs: {
     ]
     ++ buildInputs;
 
-  prePatch =
-    optionalString stdenv.hostPlatform.isDarwin ''
-      substituteInPlace configure --replace-fail '`/usr/bin/arch`' '"i386"'
-    ''
-    + optionalString (pythonOlder "3.9" && stdenv.hostPlatform.isDarwin && x11Support) ''
-      # Broken on >= 3.9; replaced with ./3.9/darwin-tcl-tk.patch
-      substituteInPlace setup.py --replace-fail /Library/Frameworks /no-such-path
-    '';
+  prePatch = optionalString stdenv.hostPlatform.isDarwin ''
+    substituteInPlace configure --replace-fail '`/usr/bin/arch`' '"i386"'
+  '';
 
   patches =
     [
@@ -771,14 +766,6 @@ stdenv.mkDerivation (finalAttrs: {
     doc = stdenv.mkDerivation {
       inherit src;
       name = "python${pythonVersion}-${version}-doc";
-
-      patches = optionals (pythonAtLeast "3.9" && pythonOlder "3.10") [
-        # https://github.com/python/cpython/issues/98366
-        (fetchpatch {
-          url = "https://github.com/python/cpython/commit/5612471501b05518287ed61c1abcb9ed38c03942.patch";
-          hash = "sha256-p41hJwAiyRgyVjCVQokMSpSFg/VDDrqkCSxsodVb6vY=";
-        })
-      ];
 
       postPatch = lib.optionalString (pythonAtLeast "3.9" && pythonOlder "3.11") ''
         substituteInPlace Doc/tools/extensions/pyspecific.py \

--- a/pkgs/development/interpreters/python/default.nix
+++ b/pkgs/development/interpreters/python/default.nix
@@ -44,18 +44,6 @@
       inherit passthruFun;
     };
 
-    python39 = callPackage ./cpython {
-      self = __splicedPackages.python39;
-      sourceVersion = {
-        major = "3";
-        minor = "9";
-        patch = "21";
-        suffix = "";
-      };
-      hash = "sha256-MSb1lZLJsNeYWEdV8r97CB+hyjXOem/qmAEI11KgW7E=";
-      inherit passthruFun;
-    };
-
     python310 = callPackage ./cpython {
       self = __splicedPackages.python310;
       sourceVersion = {

--- a/pkgs/development/python-modules/cx-freeze/default.nix
+++ b/pkgs/development/python-modules/cx-freeze/default.nix
@@ -33,7 +33,7 @@ buildPythonPackage rec {
     sed -i /patchelf/d pyproject.toml
     # Build system requirements
     substituteInPlace pyproject.toml \
-      --replace-fail "setuptools>=70.1,<75" "setuptools"
+      --replace-fail "setuptools>=70.1,<76" "setuptools"
   '';
 
   build-system = [

--- a/pkgs/games/crossfire/crossfire-server.nix
+++ b/pkgs/games/crossfire/crossfire-server.nix
@@ -9,7 +9,7 @@
   perl,
   check,
   pkg-config,
-  python39, # crossfire-server relies on a parser wich was removed in python >3.9
+  python3,
   version,
   rev,
   sha256,
@@ -39,7 +39,7 @@ stdenv.mkDerivation {
     perl
     check
     pkg-config
-    python39
+    python3
   ];
   hardeningDisable = [ "format" ];
 
@@ -49,13 +49,14 @@ stdenv.mkDerivation {
     sh autogen.sh
   '';
 
-  configureFlags = [ "--with-python=${python39}" ];
+  configureFlags = [ "--with-python=${python3}" ];
 
   postInstall = ''
     ln -s ${maps} "$out/share/crossfire/maps"
   '';
 
   meta = with lib; {
+    broken = true; # cfpython.c:63:10: fatal error: node.h: No such file or directory
     description = "Server for the Crossfire free MMORPG";
     homepage = "http://crossfire.real-time.com/";
     license = licenses.gpl2Plus;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7589,12 +7589,6 @@ with pkgs;
     bluezSupport = lib.meta.availableOn stdenv.hostPlatform bluez;
     x11Support = true;
   };
-  python39Full = python39.override {
-    self = python39Full;
-    pythonAttr = "python39Full";
-    bluezSupport = lib.meta.availableOn stdenv.hostPlatform bluez;
-    x11Support = true;
-  };
   python310Full = python310.override {
     self = python310Full;
     pythonAttr = "python310Full";
@@ -7639,7 +7633,6 @@ with pkgs;
   pythonInterpreters = callPackage ./../development/interpreters/python { };
   inherit (pythonInterpreters)
     python27
-    python39
     python310
     python311
     python312
@@ -7655,7 +7648,6 @@ with pkgs;
 
   # Python package sets.
   python27Packages = python27.pkgs;
-  python39Packages = python39.pkgs;
   python310Packages = python310.pkgs;
   python311Packages = python311.pkgs;
   python312Packages = recurseIntoAttrs python312.pkgs;

--- a/pkgs/top-level/python-aliases.nix
+++ b/pkgs/top-level/python-aliases.nix
@@ -38,14 +38,12 @@ mapAliases ({
   python2Packages = throw "do not use python2Packages when building Python packages, specify each used package as a separate argument"; # do not remove
   python27Packages = throw "do not use python27Packages when building Python packages, specify each used package as a separate argument"; # do not remove
   python3Packages = throw "do not use python3Packages when building Python packages, specify each used package as a separate argument"; # do not remove
-  python39Packages = throw "do not use python39Packages when building Python packages, specify each used package as a separate argument"; # do not remove
   python310Packages = throw "do not use python310Packages when building Python packages, specify each used package as a separate argument"; # do not remove
   python311Packages = throw "do not use python311Packages when building Python packages, specify each used package as a separate argument"; # do not remove
   python312Packages = throw "do not use python312Packages when building Python packages, specify each used package as a separate argument"; # do not remove
   python313Packages = throw "do not use python313Packages when building Python packages, specify each used package as a separate argument"; # do not remove
   python2 = throw "do not use python2 when building Python packages, use the generic python parameter instead"; # do not remove
   python3 = throw "do not use python3 when building Python packages, use the generic python parameter instead"; # do not remove
-  python39 = throw "do not use python39 when building Python packages, use the generic python parameter instead"; # do not remove
   python310 = throw "do not use python310 when building Python packages, use the generic python parameter instead"; # do not remove
   python311 = throw "do not use python311 when building Python packages, use the generic python parameter instead"; # do not remove
   python312 = throw "do not use python312 when building Python packages, use the generic python parameter instead"; # do not remove


### PR DESCRIPTION
This is the end of the road for Python 3.9 in nixpkgs. End of security suport after 2025-10-31, and therefore not suitable for NixOS 25.05.

This breaks
- cjdns (needs an update, but that wasn't straightforward) @ehmry
- crossfire-server (still not migrated away from that one parser) @ToxicFrog 

Still broken from Python 3.8
- gcc-arm-embedded (they will never migrate away from 3.8, will they?) @prusnak @prtzl 

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
