### PR TITLE
pomerium: 0.28.0 -> 0.29.2

### DIFF
--- a/pkgs/by-name/po/pomerium/0001-envoy-allow-specification-of-external-binary.patch
+++ b/pkgs/by-name/po/pomerium/0001-envoy-allow-specification-of-external-binary.patch
@@ -1,14 +1,14 @@
-From 54e426127a35ea6c88bf0ba882f97f0712533ef5 Mon Sep 17 00:00:00 2001
+From dfb6e2797e7c9166c8dd3dc0d87a4d91474244c7 Mon Sep 17 00:00:00 2001
 From: Morgan Helton <mhelton@gmail.com>
 Date: Sun, 26 May 2024 12:17:01 -0500
 Subject: [PATCH] envoy: allow specification of external binary
 
 ---
- pkg/envoy/envoy.go | 17 ++++++++++-------
- 1 file changed, 10 insertions(+), 7 deletions(-)
+ pkg/envoy/envoy.go | 20 ++++++++++++++++----
+ 1 file changed, 16 insertions(+), 4 deletions(-)
 
 diff --git a/pkg/envoy/envoy.go b/pkg/envoy/envoy.go
-index 66cf71ae..8d81090e 100644
+index 8224f364..bb8b6506 100644
 --- a/pkg/envoy/envoy.go
 +++ b/pkg/envoy/envoy.go
 @@ -8,9 +8,9 @@ import (
@@ -22,7 +22,7 @@ index 66cf71ae..8d81090e 100644
  	"path/filepath"
  	"regexp"
  	"strconv"
-@@ -34,8 +34,12 @@ import (
+@@ -35,8 +35,17 @@ import (
  
  const (
  	configFileName = "envoy-config.yaml"
@@ -32,20 +32,22 @@ index 66cf71ae..8d81090e 100644
  
 +var OverrideEnvoyPath = ""
 +
- type serverOptions struct {
- 	services string
- 	logLevel config.LogLevel
-@@ -59,17 +63,16 @@ type Server struct {
- 
- // NewServer creates a new server with traffic routed by envoy.
- func NewServer(ctx context.Context, src config.Source, builder *envoyconfig.Builder) (*Server, error) {
--	if err := preserveRlimitNofile(); err != nil {
--		log.Ctx(ctx).Debug().Err(err).Msg("couldn't preserve RLIMIT_NOFILE before starting Envoy")
--	}
-+	envoyPath := OverrideEnvoyPath
-+	wd := filepath.Join(os.TempDir(), workingDirectoryName)
++type serverOptions struct {
++	services string
++	logLevel config.LogLevel
++}
++
+ // A Server is a pomerium proxy implemented via envoy.
+ type Server struct {
+ 	ServerOptions
+@@ -94,14 +103,17 @@ func NewServer(ctx context.Context, src config.Source, builder *envoyconfig.Buil
+ 		log.Ctx(ctx).Debug().Err(err).Msg("couldn't preserve RLIMIT_NOFILE before starting Envoy")
+ 	}
  
 -	envoyPath, err := Extract()
++	envoyPath := OverrideEnvoyPath
++	wd := filepath.Join(os.TempDir(), workingDirectoryName)
++
 +	err := os.MkdirAll(wd, embeddedEnvoyPermissions)
  	if err != nil {
 -		return nil, fmt.Errorf("extracting envoy: %w", err)
@@ -53,11 +55,12 @@ index 66cf71ae..8d81090e 100644
  	}
  
  	srv := &Server{
--		wd:        path.Dir(envoyPath),
-+		wd:        wd,
- 		builder:   builder,
- 		grpcPort:  src.GetConfig().GRPCPort,
- 		httpPort:  src.GetConfig().HTTPPort,
+ 		ServerOptions: options,
+-		wd:            path.Dir(envoyPath),
++		wd:            wd,
+ 		builder:       builder,
+ 		grpcPort:      src.GetConfig().GRPCPort,
+ 		httpPort:      src.GetConfig().HTTPPort,
 -- 
-2.47.0
+2.48.1
 

--- a/pkgs/by-name/po/pomerium/package.json
+++ b/pkgs/by-name/po/pomerium/package.json
@@ -43,7 +43,7 @@
     "@types/react-dom": "^17.0.11",
     "@typescript-eslint/eslint-plugin": "^5.10.2",
     "@typescript-eslint/parser": "^5.59.11",
-    "esbuild": "^0.21.1",
+    "esbuild": "^0.25.0",
     "eslint": "7.32.0",
     "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-react": "^7.28.0",

--- a/pkgs/by-name/po/pomerium/package.nix
+++ b/pkgs/by-name/po/pomerium/package.nix
@@ -19,15 +19,15 @@ let
 in
 buildGo123Module rec {
   pname = "pomerium";
-  version = "0.28.0";
+  version = "0.29.2";
   src = fetchFromGitHub {
     owner = "pomerium";
     repo = "pomerium";
     rev = "v${version}";
-    hash = "sha256-Uj/mVklFRaoDNQjCFS5NW/AhSU+7V1XxPiZBAUuly7s=";
+    hash = "sha256-FortINGa0JNUxVeGiJ6i+cbmapMZeCXPY9hWox+Y49o=";
   };
 
-  vendorHash = "sha256-s6EZUZoGNBpy5RaLAPiCCCVFli+YzZ0PHJ/aH3s4APA=";
+  vendorHash = "sha256-K9LcGvANajoVKEDIswahD0mT5845qGZzafmWMKkVn8Q=";
 
   ui = mkYarnPackage {
     inherit version;

--- a/pkgs/by-name/po/pomerium/yarn-hash
+++ b/pkgs/by-name/po/pomerium/yarn-hash
@@ -1,1 +1,1 @@
-0bdrczn8mj5iidmba7xzkcyvsnwmbvcvrc1vgks2x4pxqbfyxaiv
+1fqb1bcsg0k6xazr6v19jav11fl99mm3p9w53hl5xflb974m2lg0


### PR DESCRIPTION
https://github.com/pomerium/pomerium/compare/v0.28.0...v0.29.2
- rebase patch facilitating use of envoy from nixpkgs

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
