### PR TITLE
gitlab-ci-local: remove unused dependencies

### DIFF
--- a/pkgs/by-name/gi/gitlab-ci-local/package.nix
+++ b/pkgs/by-name/gi/gitlab-ci-local/package.nix
@@ -34,6 +34,29 @@ buildNpmPackage rec {
   '';
 
   postInstall = ''
+    NODE_MODULES=$out/lib/node_modules/gitlab-ci-local/node_modules
+
+    # Remove intermediate build files for re2 to reduce dependencies.
+    #
+    # This does not affect the behavior. On npm `re2` does not ship
+    # the build directory and downloads a prebuilt version of the
+    # `re2.node` binary. This method produces the same result.
+    find $NODE_MODULES/re2/build -type f ! -path "*/Release/re2.node" -delete
+    strip -x $NODE_MODULES/re2/build/Release/re2.node
+
+    # Remove files that depend on python3
+    #
+    # The node-gyp package is only used for building re2, so it is
+    # not needed at runtime. I did not remove the whole directory
+    # because of some dangling links to the node-gyp directory which
+    # is not required. It is possible to remove the directory and all
+    # the files that link to it, but I figured it was not worth
+    # tracking down the files.
+    #
+    # The re2/vendor directory is used for building the re2.node
+    # binary, so it is not needed at runtime.
+    rm -rf $NODE_MODULES/{node-gyp/gyp,re2/vendor}
+
     wrapProgram $out/bin/gitlab-ci-local \
       --prefix PATH : "${
         lib.makeBinPath [


### PR DESCRIPTION
This reduces the closure size.
- x86_64-linux: 1.2GB to 220MB
- x86_64-darwin: 1.9GB to 200MB

Dependencies removed:
- python3
- nodejs source
- gcc


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [x] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
