### PR TITLE
desktoppr: init at 0.5

### DIFF
--- a/pkgs/by-name/de/desktoppr/package.nix
+++ b/pkgs/by-name/de/desktoppr/package.nix
@@ -1,0 +1,62 @@
+{
+  stdenv,
+  fetchFromGitHub,
+  fetchpatch,
+  swift,
+  swiftpm,
+  versionCheckHook,
+  lib,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "desktoppr";
+  version = "0.5";
+
+  src = fetchFromGitHub {
+    owner = "scriptingosx";
+    repo = "desktoppr";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-eEVcYSa1ntyX/Wdj4HUyXyXIrK+T11Thg23ntNoIgH0=";
+  };
+
+  patches = [
+    # Update version in the code from 0.5b (beta) to 0.5 (release)
+    (fetchpatch {
+      url = "https://github.com/scriptingosx/desktoppr/commit/419363c28c99eb0f391bf231813af5e507c35573.patch";
+      hash = "sha256-7A3hsXO0hZYlZMrX1U0zC2vy59M9H5OZebEbPY8E9fA=";
+      includes = [ "desktoppr/main.swift" ];
+    })
+    # Adds support for building with swiftpm
+    (fetchpatch {
+      url = "https://github.com/scriptingosx/desktoppr/commit/eaf08da7cdd5fe9aa656516b3a5a0a9ac9969e72.patch";
+      hash = "sha256-8sAUNnTGqQ2UHIFUPwTP0dd3QKgI0HfOrG0HzcIStMM=";
+    })
+  ];
+
+  nativeBuildInputs = [
+    swift
+    swiftpm
+  ];
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm755 "$(swiftpmBinPath)/desktoppr" -t "$out/bin"
+    runHook postInstall
+  '';
+
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+
+  versionCheckProgramArg = "version";
+  doInstallCheck = true;
+
+  meta = {
+    description = "Simple command line tool to read and set the desktop picture/wallpaper";
+    homepage = "https://github.com/scriptingosx/desktoppr";
+    platforms = lib.platforms.darwin;
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ andre4ik3 ];
+    mainProgram = "desktoppr";
+  };
+})


### PR DESCRIPTION
This PR adds [desktoppr](https://github.com/scriptingosx/desktoppr), a small utility to manage the desktop picture/wallpaper on macOS.

Two patches are included for the 0.5 version:

- [Patch to update the version in the output of `desktoppr version` as well](https://github.com/scriptingosx/desktoppr/commit/419363c28c99eb0f391bf231813af5e507c35573). The 0.5 release still has the version as 0.5b, this patch corrects that.
- Patch to add a `Package.swift` file so that it can be built with Swift Package Manager, instead of the Xcode build system (the project file doesn't seem to be compatible with the deprecated `xcbuild` tool in Nixpkgs). I made a PR for this patch upstream: https://github.com/scriptingosx/desktoppr/pull/31

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
