### PR TITLE
python312Packages.opencv-python[-headless]: mark as broken on x86_64-darwin

### DIFF
--- a/pkgs/development/python-modules/opencv-python-headless/default.nix
+++ b/pkgs/development/python-modules/opencv-python-headless/default.nix
@@ -10,5 +10,11 @@ mkPythonMetaPackage {
   optional-dependencies = opencv4.optional-dependencies or { };
   meta = {
     inherit (opencv4.meta) description homepage;
+    badPlatforms = [
+      # ImportError: dlopen(/nix/store/rlkm45snzxvqfvpxwk7bfi5x1df89i63-opencv-4.11.0/lib/python3.12/site-packages/cv2/python-3.12/cv2.cpython-312-darwin.so, 0x0002): Symbol not found: __ZTINSt3__117bad_function_callE
+      #   Referenced from: <FFAD12B0-6FC6-3AD9-A5E3-75865D785E79> /nix/store/rlkm45snzxvqfvpxwk7bfi5x1df89i63-opencv-4.11.0/lib/libopencv_imgcodecs.4.11.0.dylib
+      #   Expected in:     <F0AC1571-049A-3F10-BA96-5C6AD56E68C0> /System/Library/Frameworks/AppKit.framework/Versions/C/AppKit
+      "x86_64-darwin"
+    ];
   };
 }

--- a/pkgs/development/python-modules/opencv-python/default.nix
+++ b/pkgs/development/python-modules/opencv-python/default.nix
@@ -10,5 +10,11 @@ mkPythonMetaPackage {
   optional-dependencies = opencv4.optional-dependencies or { };
   meta = {
     inherit (opencv4.meta) description homepage;
+    badPlatforms = [
+      # ImportError: dlopen(/nix/store/rlkm45snzxvqfvpxwk7bfi5x1df89i63-opencv-4.11.0/lib/python3.12/site-packages/cv2/python-3.12/cv2.cpython-312-darwin.so, 0x0002): Symbol not found: __ZTINSt3__117bad_function_callE
+      #   Referenced from: <FFAD12B0-6FC6-3AD9-A5E3-75865D785E79> /nix/store/rlkm45snzxvqfvpxwk7bfi5x1df89i63-opencv-4.11.0/lib/libopencv_imgcodecs.4.11.0.dylib
+      #   Expected in:     <F0AC1571-049A-3F10-BA96-5C6AD56E68C0> /System/Library/Frameworks/AppKit.framework/Versions/C/AppKit
+      "x86_64-darwin"
+    ];
   };
 }


### PR DESCRIPTION
## Things done

Causes several downstream packages to fail (`layoutparser`, `easyocr`, ...)

```
    from cv2 import getPerspectiveTransform as _getPerspectiveTransform
E   ImportError: dlopen(/nix/store/rlkm45snzxvqfvpxwk7bfi5x1df89i63-opencv-4.11.0/lib/python3.12/site-packages/cv2/python-3.12/cv2.cpython-312-darwin.so, 0x0002): Symbol not found: __ZTINSt3__117bad_function_callE
E     Referenced from: <FFAD12B0-6FC6-3AD9-A5E3-75865D785E79> /nix/store/rlkm45snzxvqfvpxwk7bfi5x1df89i63-opencv-4.11.0/lib/libopencv_imgcodecs.4.11.0.dylib
E     Expected in:     <F0AC1571-049A-3F10-BA96-5C6AD56E68C0> /System/Library/Frameworks/AppKit.framework/Versions/C/AppKit
```

cc @emilazy

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
