### PR TITLE
frr: fix cross compilation

### DIFF
--- a/pkgs/by-name/fr/frr/package.nix
+++ b/pkgs/by-name/fr/frr/package.nix
@@ -119,6 +119,7 @@ stdenv.mkDerivation (finalAttrs: {
       openssl
       pam
       pcre2
+      protobufc
       python3
       readline
       rtrlib


### PR DESCRIPTION
FRR cross compilation (aarch64-multiplatform) was broken:
```
error: builder for '/nix/store/wns4wlpjiqnk5c737lslj4xywlsbjsl1-frr-aarch64-unknown-linux-gnu-10.3.drv' failed with exit code 1;
       last 25 log lines:
       > checking for sys/sysctl.h... no
       > checking for sys/sockio.h... no
       > checking for sys/conf.h... no
       > checking for ucontext.h... yes
       > checking for ucontext_t.uc_mcontext.uc_regs... no
       > checking for ucontext_t.uc_mcontext.regs... yes
       > checking for ucontext_t.uc_mcontext.regs.nip... no
       > checking for ucontext_t.uc_mcontext.gregs... no
       > checking which operating system interface to use... Linux
       > checking for aarch64-unknown-linux-gnu-gcc option to enable large file support... none needed
       > checking for strlcat... yes
       > checking for strlcpy... yes
       > checking for getgrouplist... yes
       > checking for openat... yes
       > checking for unlinkat... yes
       > checking for posix_fallocate... yes
       > checking for sendmmsg... yes
       > checking for explicit_bzero... yes
       > checking for struct mmsghdr.msg_hdr... yes
       > checking for protoc... no
       > checking for protoc-c... protoc-c
       > checking for PROTOBUF_C (libprotobuf-c >= 1.1.0)... no
       > configure: error: in '/build/source':
       > configure: error: minimum version (1.1.0) of libprotobuf-c not found.  Install minimum required version of protobuf-c.
       > See 'config.log' for more details
       For full logs, run 'nix log /nix/store/wns4wlpjiqnk5c737lslj4xywlsbjsl1-frr-aarch64-unknown-linux-gnu-10.3.drv'.
```

Adding protobufc to buildInputs fixes it.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
