### PR TITLE
postsrsd: 1.12 -> 2.0.10 + corresponding service changes

### DIFF
--- a/doc/release-notes/rl-2505.section.md
+++ b/doc/release-notes/rl-2505.section.md
@@ -58,6 +58,10 @@
   OpenSMTPD 7.6.0 or later. The package has been removed in favor of a set of new
   `opensmtpd-table-*` packages.
 
+- `postsrsd` upgraded to `>= 2.0.0`, with some different behaviors and
+  configuration settings. Notably, it now defaults to listening on a socket
+  rather than a port. See [Migrating from version 1.x](https://github.com/roehling/postsrsd/blob/2.0.10/README.rst#migrating-from-version-1x) and [Postfix Setup](https://github.com/roehling/postsrsd?tab=readme-ov-file#postfix-setup) for details.
+
 - The hand written `perlPackages.SearchXapian` bindings have been dropped in favor of the (mostly compatible)
   `perlPackages.Xapian`.
 

--- a/nixos/modules/services/mail/postsrsd.nix
+++ b/nixos/modules/services/mail/postsrsd.nix
@@ -7,16 +7,52 @@
 let
 
   cfg = config.services.postsrsd;
+  runtimeDirectoryName = "postsrsd";
+  runtimeDirectory = "/run/${runtimeDirectoryName}";
+  # TODO: follow RFC 42, but we need a libconfuse format first:
+  #       https://github.com/NixOS/nixpkgs/issues/401565
+  # Arrays in `libconfuse` look like this: {"Life", "Universe", "Everything"}
+  # See https://www.nongnu.org/confuse/tutorial-html/ar01s03.html.
+  #
+  # Note: We're using `builtins.toJSON` to escape strings, but JSON strings
+  # don't have exactly the same semantics as libconfuse strings. For example,
+  # "${F}" gets treated as an env var reference, see above issue for details.
+  libconfuseDomains = "{ " + lib.concatMapStringsSep ", " builtins.toJSON cfg.domains + " }";
+  configFile = pkgs.writeText "postsrsd.conf" ''
+    secrets-file = "''${CREDENTIALS_DIRECTORY}/secrets-file"
+    domains = ${libconfuseDomains}
+    separator = "${cfg.separator}"
+    socketmap = "unix:${runtimeDirectory}/socket"
+
+    # Disable postsrsd's jailing in favor of confinement with systemd.
+    unprivileged-user = ""
+    chroot-dir = ""
+  '';
 
 in
 {
-
-  ###### interface
+  imports =
+    map
+      (
+        name:
+        lib.mkRemovedOptionModule [ "services" "postsrsd" name ] ''
+          `postsrsd` was upgraded to `>= 2.0.0`, with some different behaviors and configuration settings:
+            - NixOS Release Notes: https://nixos.org/manual/nixos/unstable/release-notes#sec-nixpkgs-release-25.05-incompatibilities
+            - NixOS Options Reference: https://nixos.org/manual/nixos/unstable/options#opt-services.postsrsd.enable
+            - Migration instructions: https://github.com/roehling/postsrsd/blob/2.0.10/README.rst#migrating-from-version-1x
+            - Postfix Setup: https://github.com/roehling/postsrsd/blob/2.0.10/README.rst#postfix-setup
+        ''
+      )
+      [
+        "domain"
+        "forwardPort"
+        "reversePort"
+        "timeout"
+        "excludeDomains"
+      ];
 
   options = {
-
     services.postsrsd = {
-
       enable = lib.mkOption {
         type = lib.types.bool;
         default = false;
@@ -29,9 +65,11 @@ in
         description = "Secret keys used for signing and verification";
       };
 
-      domain = lib.mkOption {
-        type = lib.types.str;
-        description = "Domain name for rewrite";
+      domains = lib.mkOption {
+        type = lib.types.listOf lib.types.str;
+        description = "Domain names for rewrite";
+        default = [ config.networking.hostName ];
+        defaultText = lib.literalExpression "[ config.networking.hostName ]";
       };
 
       separator = lib.mkOption {
@@ -42,36 +80,6 @@ in
         ];
         default = "=";
         description = "First separator character in generated addresses";
-      };
-
-      # bindAddress = lib.mkOption { # uncomment once 1.5 is released
-      #   type = lib.types.str;
-      #   default = "127.0.0.1";
-      #   description = "Socket listen address";
-      # };
-
-      forwardPort = lib.mkOption {
-        type = lib.types.int;
-        default = 10001;
-        description = "Port for the forward SRS lookup";
-      };
-
-      reversePort = lib.mkOption {
-        type = lib.types.int;
-        default = 10002;
-        description = "Port for the reverse SRS lookup";
-      };
-
-      timeout = lib.mkOption {
-        type = lib.types.int;
-        default = 1800;
-        description = "Timeout for idle client connections in seconds";
-      };
-
-      excludeDomains = lib.mkOption {
-        type = lib.types.listOf lib.types.str;
-        default = [ ];
-        description = "Origin domains to exclude from rewriting in addition to primary domain";
       };
 
       user = lib.mkOption {
@@ -85,17 +93,10 @@ in
         default = "postsrsd";
         description = "Group for the daemon";
       };
-
     };
-
   };
 
-  ###### implementation
-
   config = lib.mkIf cfg.enable {
-
-    services.postsrsd.domain = lib.mkDefault config.networking.hostName;
-
     users.users = lib.optionalAttrs (cfg.user == "postsrsd") {
       postsrsd = {
         group = cfg.group;
@@ -107,30 +108,42 @@ in
       postsrsd.gid = config.ids.gids.postsrsd;
     };
 
-    systemd.services.postsrsd = {
-      description = "PostSRSd SRS rewriting server";
-      after = [ "network.target" ];
-      before = [ "postfix.service" ];
-      wantedBy = [ "multi-user.target" ];
-
+    systemd.services.postsrsd-generate-secrets = {
       path = [ pkgs.coreutils ];
-
-      serviceConfig = {
-        ExecStart = ''${pkgs.postsrsd}/sbin/postsrsd "-s${cfg.secretsFile}" "-d${cfg.domain}" -a${cfg.separator} -f${toString cfg.forwardPort} -r${toString cfg.reversePort} -t${toString cfg.timeout} "-X${lib.concatStringsSep "," cfg.excludeDomains}"'';
-        User = cfg.user;
-        Group = cfg.group;
-        PermissionsStartOnly = true;
-      };
-
-      preStart = ''
-        if [ ! -e "${cfg.secretsFile}" ]; then
+      script = ''
+        if [ -e "${cfg.secretsFile}" ]; then
+          echo "Secrets file exists. Nothing to do!"
+        else
           echo "WARNING: secrets file not found, autogenerating!"
           DIR="$(dirname "${cfg.secretsFile}")"
           install -m 750 -o ${cfg.user} -g ${cfg.group} -d "$DIR"
           install -m 600 -o ${cfg.user} -g ${cfg.group} <(dd if=/dev/random bs=18 count=1 | base64) "${cfg.secretsFile}"
         fi
       '';
+      serviceConfig = {
+        Type = "oneshot";
+      };
     };
 
+    systemd.services.postsrsd = {
+      description = "PostSRSd SRS rewriting server";
+      after = [
+        "network.target"
+        "postsrsd-generate-secrets.service"
+      ];
+      before = [ "postfix.service" ];
+      wantedBy = [ "multi-user.target" ];
+      requires = [ "postsrsd-generate-secrets.service" ];
+      confinement.enable = true;
+
+      serviceConfig = {
+        ExecStart = "${lib.getExe pkgs.postsrsd} -C ${configFile}";
+        User = cfg.user;
+        Group = cfg.group;
+        PermissionsStartOnly = true;
+        RuntimeDirectory = runtimeDirectoryName;
+        LoadCredential = "secrets-file:${cfg.secretsFile}";
+      };
+    };
   };
 }

--- a/pkgs/by-name/po/postsrsd/package.nix
+++ b/pkgs/by-name/po/postsrsd/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  libconfuse,
   stdenv,
   fetchFromGitHub,
   cmake,
@@ -8,18 +9,20 @@
 
 stdenv.mkDerivation rec {
   pname = "postsrsd";
-  version = "1.12";
+  version = "2.0.10";
 
   src = fetchFromGitHub {
     owner = "roehling";
     repo = "postsrsd";
     rev = version;
-    sha256 = "sha256-aSI9TR1wSyMA0SKkbavk+IugRfW4ZEgpzrNiXn0F5ak=";
+    sha256 = "sha256-8uy7a3wUGuLE4+6ZPqbFMdPzm6IZqQSvpZzLYAkBxNg=";
   };
 
   cmakeFlags = [
     "-DGENERATE_SRS_SECRET=OFF"
     "-DINIT_FLAVOR=systemd"
+    "-DFETCHCONTENT_TRY_FIND_PACKAGE_MODE=ALWAYS"
+    "-DINSTALL_SYSTEMD_SERVICE=OFF"
   ];
 
   preConfigure = ''
@@ -29,6 +32,10 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [
     cmake
     help2man
+  ];
+
+  buildInputs = [
+    libconfuse
   ];
 
   meta = with lib; {


### PR DESCRIPTION
I've updated postsrsd: 1.12 -> 2.0.10, and updated the NixOS module accordingly. Unfortunately, I don't think it's possible to preserve exact backwards compatibility here. Let me know if you'd prefer that I keep the old `postsrsd1` package + service around with deprecation warnings..

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
