### PR TITLE
rockcraft: 1.9.0 -> 1.10.0

### DIFF
--- a/pkgs/by-name/ro/rockcraft/package.nix
+++ b/pkgs/by-name/ro/rockcraft/package.nix
@@ -7,6 +7,7 @@
   testers,
   rockcraft,
   cacert,
+  writableTmpDirAsHomeHook,
 }:
 
 python3Packages.buildPythonApplication rec {
@@ -39,13 +40,9 @@ python3Packages.buildPythonApplication rec {
       pytest-mock
       pytest-subprocess
       pytestCheckHook
+      writableTmpDirAsHomeHook
     ]
     ++ [ dpkg ];
-
-  preCheck = ''
-    mkdir -p check-phase
-    export HOME="$(pwd)/check-phase"
-  '';
 
   disabledTests = [
     "test_project_all_platforms_invalid"

--- a/pkgs/by-name/ro/rockcraft/package.nix
+++ b/pkgs/by-name/ro/rockcraft/package.nix
@@ -11,13 +11,13 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "rockcraft";
-  version = "1.9.0";
+  version = "1.10.0";
 
   src = fetchFromGitHub {
     owner = "canonical";
     repo = "rockcraft";
     rev = version;
-    hash = "sha256-cgNKMxQrD9/OfmY5YEnpbNDstDdXqc/wdfCb4HvsgNM=";
+    hash = "sha256-LrUs6/YRQYU0o1kmNdBhafvDIyw91FnW8+9i0Jj5f+Y=";
   };
 
   pyproject = true;
@@ -51,6 +51,14 @@ python3Packages.buildPythonApplication rec {
     "test_project_all_platforms_invalid"
     "test_run_init_flask"
     "test_run_init_django"
+  ];
+
+  disabledTestPaths = [
+    # Relies upon info in the .git directory which is stripped by fetchFromGitHub,
+    # and the version is overridden anyway.
+    "tests/integration/test_version.py"
+    # Tests non-Nix native packaging
+    "tests/integration/test_setuptools.py"
   ];
 
   passthru = {

--- a/pkgs/by-name/sn/snapcraft/lxd-socket-path.patch
+++ b/pkgs/by-name/sn/snapcraft/lxd-socket-path.patch
@@ -1,7 +1,7 @@
-diff --git a/snapcraft_legacy/internal/build_providers/_lxd/_lxd.py b/snapcraft_legacy/internal/build_providers/_lxd/_lxd.py
-index 5fa4f898..41264ebb 100644
---- a/snapcraft_legacy/internal/build_providers/_lxd/_lxd.py
-+++ b/snapcraft_legacy/internal/build_providers/_lxd/_lxd.py
+diff --git i/snapcraft_legacy/internal/build_providers/_lxd/_lxd.py w/snapcraft_legacy/internal/build_providers/_lxd/_lxd.py
+index 5fa4f898b..41264ebb0 100644
+--- i/snapcraft_legacy/internal/build_providers/_lxd/_lxd.py
++++ w/snapcraft_legacy/internal/build_providers/_lxd/_lxd.py
 @@ -142,7 +142,7 @@ class LXD(Provider):
              build_provider_flags=build_provider_flags,
          )

--- a/pkgs/by-name/sn/snapcraft/package.nix
+++ b/pkgs/by-name/sn/snapcraft/package.nix
@@ -13,7 +13,7 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "snapcraft";
-  version = "8.7.3";
+  version = "8.8.0";
 
   pyproject = true;
 
@@ -21,7 +21,7 @@ python3Packages.buildPythonApplication rec {
     owner = "canonical";
     repo = "snapcraft";
     tag = version;
-    hash = "sha256-T39hhosZTttX8jMlF5ul9oBcsh+FKusepj0k2NMZHNU=";
+    hash = "sha256-54UOXEH3DxT1P/CRi09gEoq9si+x/1GHFuWRIyEvz3E=";
   };
 
   patches = [

--- a/pkgs/by-name/sn/snapcraft/set-channel-for-nix.patch
+++ b/pkgs/by-name/sn/snapcraft/set-channel-for-nix.patch
@@ -1,20 +1,13 @@
-diff --git a/snapcraft/providers.py b/snapcraft/providers.py
-index a999537a..dcd290a7 100644
---- a/snapcraft/providers.py
-+++ b/snapcraft/providers.py
-@@ -21,6 +21,7 @@ import sys
- from pathlib import Path
- from textwrap import dedent
- from typing import Dict, Optional
-+import platform
- 
- from craft_cli import emit
- from craft_providers import Provider, ProviderError, bases, executor
-@@ -178,14 +179,14 @@ def get_base_configuration(
+diff --git i/snapcraft/providers.py w/snapcraft/providers.py
+index 41ab6e8f1..ceaf7539b 100644
+--- i/snapcraft/providers.py
++++ w/snapcraft/providers.py
+@@ -177,14 +177,15 @@ def get_base_configuration(
      # injecting a snap on a non-linux system is not supported, so default to
      # install snapcraft from the store's stable channel
      snap_channel = get_managed_environment_snap_channel()
 -    if sys.platform != "linux" and not snap_channel:
++    import platform
 +    if snap_channel is None and (sys.platform != "linux" or "NixOS" in platform.version()):
          emit.progress(
 -            "Using snapcraft from snap store channel 'latest/stable' in instance "

--- a/pkgs/development/python-modules/craft-cli/default.nix
+++ b/pkgs/development/python-modules/craft-cli/default.nix
@@ -15,7 +15,7 @@
 
 buildPythonPackage rec {
   pname = "craft-cli";
-  version = "2.15.0";
+  version = "3.0.0";
 
   pyproject = true;
 
@@ -23,7 +23,7 @@ buildPythonPackage rec {
     owner = "canonical";
     repo = "craft-cli";
     tag = version;
-    hash = "sha256-L8hOQJhjVAMo/WxEHHEk2QorlSdDFMGdcL/Q3Pv6mT4=";
+    hash = "sha256-RAnvx5519iXZnJm8jtY635e0DEL7jnIgZtTCindqMTY=";
   };
 
   postPatch = ''
@@ -47,6 +47,11 @@ buildPythonPackage rec {
     pytest-mock
     pytestCheckHook
   ];
+
+  preCheck = ''
+    mkdir -p check-phase
+    export HOME="$(pwd)/check-phase"
+  '';
 
   pytestFlagsArray = [ "tests/unit" ];
 

--- a/pkgs/development/python-modules/craft-cli/default.nix
+++ b/pkgs/development/python-modules/craft-cli/default.nix
@@ -11,6 +11,7 @@
   pytest-check,
   pytest-mock,
   pytestCheckHook,
+  writableTmpDirAsHomeHook,
 }:
 
 buildPythonPackage rec {
@@ -46,12 +47,8 @@ buildPythonPackage rec {
     pytest-check
     pytest-mock
     pytestCheckHook
+    writableTmpDirAsHomeHook
   ];
-
-  preCheck = ''
-    mkdir -p check-phase
-    export HOME="$(pwd)/check-phase"
-  '';
 
   pytestFlagsArray = [ "tests/unit" ];
 

--- a/pkgs/development/python-modules/craft-platforms/default.nix
+++ b/pkgs/development/python-modules/craft-platforms/default.nix
@@ -14,7 +14,7 @@
 
 buildPythonPackage rec {
   pname = "craft-platforms";
-  version = "0.6.0";
+  version = "0.7.0";
   pyproject = true;
 
   disabled = pythonOlder "3.10";
@@ -23,7 +23,7 @@ buildPythonPackage rec {
     owner = "canonical";
     repo = "craft-platforms";
     tag = version;
-    hash = "sha256-/mnRFw79YMG34/0aQMi237KMNxWanyJixkEKq+zaSuE=";
+    hash = "sha256-BFs+LqcJWqKMgEr7IzyP5qME+zaV6EFc79ustOB1Cno=";
   };
 
   postPatch = ''


### PR DESCRIPTION


## Things done

Updates both snapcraft and rockcraft to their latest respective versions:

https://github.com/canonical/rockcraft/releases/tag/1.10.0
https://github.com/canonical/snapcraft/releases/tag/8.8.0

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
