### PR TITLE
Use mkImageMediaOverride for filesystem attributes of various images

### DIFF
--- a/nixos/modules/installer/sd-card/sd-image.nix
+++ b/nixos/modules/installer/sd-card/sd-image.nix
@@ -185,7 +185,7 @@ in
   config = {
     hardware.enableAllHardware = true;
 
-    fileSystems = {
+    fileSystems = lib.mkImageMediaOverride {
       "/boot/firmware" = {
         device = "/dev/disk/by-label/${config.sdImage.firmwarePartitionName}";
         fsType = "vfat";

--- a/nixos/modules/virtualisation/azure-image.nix
+++ b/nixos/modules/virtualisation/azure-image.nix
@@ -113,7 +113,7 @@ in
       '';
     };
 
-    fileSystems = {
+    fileSystems = lib.mkImageMediaOverride {
       "/" = {
         device = "/dev/disk/by-label/${cfg.label}";
         inherit (cfg) label;

--- a/nixos/modules/virtualisation/digital-ocean-config.nix
+++ b/nixos/modules/virtualisation/digital-ocean-config.nix
@@ -39,7 +39,7 @@ with lib;
     in
     mkMerge [
       {
-        fileSystems."/" = lib.mkDefault {
+        fileSystems."/" = lib.mkImageMediaOverride {
           device = "/dev/disk/by-label/nixos";
           autoResize = true;
           fsType = "ext4";

--- a/nixos/modules/virtualisation/disk-image.nix
+++ b/nixos/modules/virtualisation/disk-image.nix
@@ -37,7 +37,7 @@ in
     boot.loader.systemd-boot.enable = lib.mkDefault cfg.efiSupport;
     boot.growPartition = lib.mkDefault true;
 
-    fileSystems = {
+    fileSystems = lib.mkImageMediaOverride {
       "/" = {
         device = "/dev/disk/by-label/nixos";
         autoResize = true;

--- a/nixos/modules/virtualisation/google-compute-config.nix
+++ b/nixos/modules/virtualisation/google-compute-config.nix
@@ -21,7 +21,7 @@ in
     ../profiles/qemu-guest.nix
   ];
 
-  fileSystems."/" = {
+  fileSystems."/" = lib.mkImageMediaOverride {
     fsType = "ext4";
     device = "/dev/disk/by-label/nixos";
     autoResize = true;

--- a/nixos/modules/virtualisation/hyperv-image.nix
+++ b/nixos/modules/virtualisation/hyperv-image.nix
@@ -73,15 +73,17 @@ in
       inherit config lib pkgs;
     };
 
-    fileSystems."/" = {
-      device = "/dev/disk/by-label/nixos";
-      autoResize = true;
-      fsType = "ext4";
-    };
+    fileSystems = lib.mkImageMediaOverride {
+      "/" = {
+        device = "/dev/disk/by-label/nixos";
+        autoResize = true;
+        fsType = "ext4";
+      };
 
-    fileSystems."/boot" = {
-      device = "/dev/disk/by-label/ESP";
-      fsType = "vfat";
+      "/boot" = {
+        device = "/dev/disk/by-label/ESP";
+        fsType = "vfat";
+      };
     };
 
     boot.growPartition = true;

--- a/nixos/modules/virtualisation/kubevirt.nix
+++ b/nixos/modules/virtualisation/kubevirt.nix
@@ -12,7 +12,7 @@
   ];
 
   config = {
-    fileSystems."/" = {
+    fileSystems."/" = lib.mkImageMediaOverride {
       device = "/dev/disk/by-label/nixos";
       fsType = "ext4";
       autoResize = true;

--- a/nixos/modules/virtualisation/linode-config.nix
+++ b/nixos/modules/virtualisation/linode-config.nix
@@ -1,10 +1,8 @@
 {
-  config,
   lib,
   pkgs,
   ...
 }:
-with lib;
 {
   imports = [ ../profiles/qemu-guest.nix ];
 
@@ -12,7 +10,7 @@ with lib;
     enable = true;
 
     settings.PermitRootLogin = "prohibit-password";
-    settings.PasswordAuthentication = mkDefault false;
+    settings.PasswordAuthentication = lib.mkDefault false;
   };
 
   networking = {
@@ -40,7 +38,7 @@ with lib;
     autoResize = true;
   };
 
-  swapDevices = mkDefault [ { device = "/dev/sdb"; } ];
+  swapDevices = lib.mkDefault [ { device = "/dev/sdb"; } ];
 
   # Enable LISH and Linode Booting w/ GRUB
   boot = {

--- a/nixos/modules/virtualisation/linode-config.nix
+++ b/nixos/modules/virtualisation/linode-config.nix
@@ -32,7 +32,7 @@
     sysstat
   ];
 
-  fileSystems."/" = {
+  fileSystems."/" = lib.mkImageMediaOverride {
     fsType = "ext4";
     device = "/dev/sda";
     autoResize = true;

--- a/nixos/modules/virtualisation/oci-common.nix
+++ b/nixos/modules/virtualisation/oci-common.nix
@@ -30,15 +30,17 @@ in
 
   boot.growPartition = true;
 
-  fileSystems."/" = {
-    device = "/dev/disk/by-label/nixos";
-    fsType = "ext4";
-    autoResize = true;
-  };
+  fileSystems = lib.mkImageMediaOverride {
+    "/" = {
+      device = "/dev/disk/by-label/nixos";
+      fsType = "ext4";
+      autoResize = true;
+    };
 
-  fileSystems."/boot" = lib.mkIf cfg.efi {
-    device = "/dev/disk/by-label/ESP";
-    fsType = "vfat";
+    "/boot" = lib.mkIf cfg.efi {
+      device = "/dev/disk/by-label/ESP";
+      fsType = "vfat";
+    };
   };
 
   boot.loader.efi.canTouchEfiVariables = false;

--- a/nixos/modules/virtualisation/openstack-config.nix
+++ b/nixos/modules/virtualisation/openstack-config.nix
@@ -33,18 +33,22 @@ in
   ];
 
   config = {
-    fileSystems."/" = mkIf (!cfg.zfs.enable) {
-      device = "/dev/disk/by-label/nixos";
-      fsType = "ext4";
-      autoResize = true;
-    };
+    fileSystems."/" = mkIf (!cfg.zfs.enable) (
+      lib.mkImageMediaOverride {
+        device = "/dev/disk/by-label/nixos";
+        fsType = "ext4";
+        autoResize = true;
+      }
+    );
 
-    fileSystems."/boot" = mkIf (cfg.efi || cfg.zfs.enable) {
-      # The ZFS image uses a partition labeled ESP whether or not we're
-      # booting with EFI.
-      device = "/dev/disk/by-label/ESP";
-      fsType = "vfat";
-    };
+    fileSystems."/boot" = mkIf (cfg.efi || cfg.zfs.enable) (
+      lib.mkImageMediaOverride {
+        # The ZFS image uses a partition labeled ESP whether or not we're
+        # booting with EFI.
+        device = "/dev/disk/by-label/ESP";
+        fsType = "vfat";
+      }
+    );
 
     boot.growPartition = true;
     boot.kernelParams = [ "console=tty1" ];

--- a/nixos/modules/virtualisation/openstack-options.nix
+++ b/nixos/modules/virtualisation/openstack-options.nix
@@ -70,12 +70,14 @@ in
           _: value: ((value.mount or null) != null)
         ) config.openstack.zfs.datasets;
       in
-      lib.mapAttrs' (
-        dataset: opts:
-        lib.nameValuePair opts.mount {
-          device = dataset;
-          fsType = "zfs";
-        }
-      ) mountable;
+      lib.mkImageMediaOverride (
+        lib.mapAttrs' (
+          dataset: opts:
+          lib.nameValuePair opts.mount {
+            device = dataset;
+            fsType = "zfs";
+          }
+        ) mountable
+      );
   };
 }

--- a/nixos/modules/virtualisation/proxmox-image.nix
+++ b/nixos/modules/virtualisation/proxmox-image.nix
@@ -352,14 +352,16 @@ with lib;
         ];
       };
 
-      fileSystems."/" = {
-        device = "/dev/disk/by-label/nixos";
-        autoResize = true;
-        fsType = "ext4";
-      };
-      fileSystems."/boot" = lib.mkIf hasBootPartition {
-        device = "/dev/disk/by-label/ESP";
-        fsType = "vfat";
+      fileSystems = lib.mkImageMediaOverride {
+        "/" = {
+          device = "/dev/disk/by-label/nixos";
+          autoResize = true;
+          fsType = "ext4";
+        };
+        "/boot" = lib.mkIf hasBootPartition {
+          device = "/dev/disk/by-label/ESP";
+          fsType = "vfat";
+        };
       };
 
       networking = mkIf cfg.cloudInit.enable {

--- a/nixos/modules/virtualisation/proxmox-image.nix
+++ b/nixos/modules/virtualisation/proxmox-image.nix
@@ -306,7 +306,13 @@ with lib;
           ''
             ${vma}/bin/vma create "${config.image.baseName}.vma" \
               -c ${
-                cfgFile "qemu-server.conf" (cfg.qemuConf // cfg.qemuExtraConf)
+                cfgFile "qemu-server.conf" (
+                  (builtins.removeAttrs cfg.qemuConf [ "diskSize" ])
+                  // {
+                    inherit (config.virtualisation) diskSize;
+                  }
+                  // cfg.qemuExtraConf
+                )
               }/qemu-server.conf drive-virtio0=$diskImage
             rm $diskImage
             ${pkgs.zstd}/bin/zstd "${config.image.baseName}.vma"

--- a/nixos/modules/virtualisation/virtualbox-image.nix
+++ b/nixos/modules/virtualisation/virtualbox-image.nix
@@ -275,7 +275,7 @@ in
     };
 
     fileSystems =
-      {
+      lib.mkImageMediaOverride {
         "/" = {
           device = "/dev/disk/by-label/nixos";
           autoResize = true;

--- a/nixos/modules/virtualisation/vmware-image.nix
+++ b/nixos/modules/virtualisation/vmware-image.nix
@@ -83,15 +83,17 @@ in
       inherit config lib pkgs;
     };
 
-    fileSystems."/" = {
-      device = "/dev/disk/by-label/nixos";
-      autoResize = true;
-      fsType = "ext4";
-    };
+    fileSystems = lib.mkImageMediaOverride {
+      "/" = {
+        device = "/dev/disk/by-label/nixos";
+        autoResize = true;
+        fsType = "ext4";
+      };
 
-    fileSystems."/boot" = {
-      device = "/dev/disk/by-label/ESP";
-      fsType = "vfat";
+      "/boot" = {
+        device = "/dev/disk/by-label/ESP";
+        fsType = "vfat";
+      };
     };
 
     boot.growPartition = true;


### PR DESCRIPTION
Before this change, users would typically encounter conflicting option definitions when trying to build an image for a generic nixos closure, i.e. `nixos-rebuild build-image --image-variant qemu --flake .#my-host`.

Overriding file system attributes with the values from image definitions by default allows images to be built and is probably closer to the users intention. If not, they can still use lib.mkForce.

Doing the same for bootloaders would be desirable IMO and was part of an earlier draft of this PR but is tricky to get right in terms of UX, due to defaulting to GRUB2 and the need to set (yet unexposed) values for `system.build.installBootLoader`

Deciding good defaults for other options is more complex, so we leave them as-is and let users deal with resulting conflicts.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
