### PR TITLE
sip: Fixed non-deterministic timestamps in wheel files

### DIFF
--- a/pkgs/development/python-modules/sip/default.nix
+++ b/pkgs/development/python-modules/sip/default.nix
@@ -24,6 +24,11 @@ buildPythonPackage rec {
     hash = "sha256-eQS+UZDXh5lSVjt4o68OWPon2VJa9/U/k+rHqDtDPns=";
   };
 
+  patches = [
+    # Make wheel file generation deterministic https://github.com/NixOS/nixpkgs/issues/383885
+    ./sip-builder.patch
+  ];
+
   build-system = [
     setuptools
     setuptools-scm

--- a/pkgs/development/python-modules/sip/sip-builder.patch
+++ b/pkgs/development/python-modules/sip/sip-builder.patch
@@ -1,0 +1,28 @@
+--- a/sipbuild/builder.py	2025-04-21 12:19:34
++++ b/sipbuild/builder.py	2025-04-21 12:27:09
+@@ -177,16 +177,23 @@
+         saved_cwd = os.getcwd()
+         os.chdir(wheel_build_dir)
+ 
+-        from zipfile import ZipFile, ZIP_DEFLATED
++        from zipfile import ZipFile, ZipInfo, ZIP_DEFLATED
++        import time
+ 
++        epoch = int(os.environ.get('SOURCE_DATE_EPOCH', '946684800'))
++        zip_timestamp = time.gmtime(epoch)[:6]
++
+         with ZipFile(wheel_path, 'w', compression=ZIP_DEFLATED) as zf:
+             for dirpath, _, filenames in os.walk('.'):
+                 for filename in filenames:
+                     # This will result in a name with no leading '.'.
+                     name = os.path.relpath(os.path.join(dirpath, filename))
+ 
+-                    zf.write(name)
++                    zi = ZipInfo(name, zip_timestamp)
+ 
++                    with open(name, 'rb') as f:
++                        zf.writestr(zi, f.read())
++
+         os.chdir(saved_cwd)
+ 
+         return wheel_file


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
Should resolve #383885
@raboof please help review
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
