### PR TITLE
bstone: fix hardware acceleration issues

### DIFF
--- a/pkgs/by-name/bs/bstone/package.nix
+++ b/pkgs/by-name/bs/bstone/package.nix
@@ -3,8 +3,7 @@
   stdenv,
   fetchFromGitHub,
   cmake,
-  SDL2,
-  libGL,
+  sdl2-compat,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -23,8 +22,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   buildInputs = [
-    libGL
-    SDL2
+    sdl2-compat
   ];
 
   postInstall = ''


### PR DESCRIPTION
- Swaps from `SDL2` to `sdl2-compat` to resolve issues with OpenGL acceleration. See:
```
[ERROR] [VIDHW] (/build/source/src/bstone/src/bstone_r3r_mgr.cpp:25:renderer_initialize)
[ERROR] [VIDHW] (/build/source/src/bstone/src/bstone_r3r_mgr.cpp:85:do_renderer_initialize)
[ERROR] [VIDHW] (/build/source/src/bstone/src/bstone_gl_r3r.cpp:1331:make_gl_r3r)
[ERROR] [VIDHW] (/build/source/src/bstone/src/bstone_gl_r3r.cpp:398:GlR3rImpl)
[ERROR] [VIDHW] (/build/source/src/bstone/src/bstone_gl_r3r_utils.cpp:32:create_window_and_context)
[ERROR] [VIDHW] (/build/source/src/bstone/src/bstone_sys_window_sdl2.cpp:285:do_make_gl_context)
[ERROR] [VIDHW] (/build/source/src/bstone/src/bstone_sys_gl_context_sdl2.cpp:104:Sdl2GlContext)
[ERROR] [VIDHW] (/build/source/src/bstone/src/bstone_sys_gl_context_sdl2.cpp:168:get_attrib)
[ERROR] [VIDHW] (/build/source/src/bstone/src/bstone_sys_exception_sdl2.cpp:26:sdl2_ensure_result)
[ERROR] [VIDHW] (/build/source/src/bstone/src/bstone_sys_exception_sdl2.cpp:15:sdl2_fail) OpenGL error: 00000502
[ERROR] [VID] (/build/source/src/bstone/src/bstone_hw_video.cpp:1526:HwVideo)
[ERROR] [VID] (/build/source/src/bstone/src/bstone_hw_video.cpp:10340:initialize_video)
[ERROR] [VID] (/build/source/src/bstone/src/bstone_hw_video.cpp:2990:initialize_renderer)
[ERROR] [VID] (/build/source/src/bstone/src/bstone_hw_video.cpp:2967:initialize_renderer) Not found any 3D renderer.
[VID] Falling back to software accelerated video system.
```
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
