### PR TITLE
parca: add update script

### DIFF
--- a/pkgs/by-name/pa/parca/package.nix
+++ b/pkgs/by-name/pa/parca/package.nix
@@ -68,6 +68,11 @@ buildGoModule rec {
     cp -r ${ui}/share/parca/ui/* ui/packages/app/web/build
   '';
 
+  passthru = {
+    inherit ui;
+    updateScript = ./update.sh;
+  };
+
   meta = {
     mainProgram = "parca";
     description = "Continuous profiling for analysis of CPU and memory usage";

--- a/pkgs/by-name/pa/parca/update.sh
+++ b/pkgs/by-name/pa/parca/update.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -I nixpkgs=./. -i bash -p curl jq git pnpm_9
+# shellcheck shell=bash
+set -euo pipefail
+nixpkgs="$(pwd)"
+cd $(readlink -e $(dirname "${BASH_SOURCE[0]}"))
+
+# Update the hash of the parca source code in the Nix expression.
+update_parca_source() {
+    local version; version="$1"
+    echo "Updating parca source"
+
+    old_version="$(nix eval --json --impure --expr "(import $nixpkgs/default.nix {}).parca.version" | jq -r)"
+    sed -i "s|${old_version}|${version}|g" package.nix
+
+    old_hash="$(nix eval --json --impure --expr "(import $nixpkgs/default.nix {}).parca.src.outputHash" | jq -r)"
+    new_hash="$(nix-build --impure --expr "let src = (import $nixpkgs/default.nix {}).parca.src; in (src.overrideAttrs or (f: src // f src)) (_: { outputHash = \"\"; outputHashAlgo = \"sha256\"; })" 2>&1 | tr -s ' ' | grep -Po "got: \K.+$")" || true
+
+    sed -i "s|${old_hash}|${new_hash}|g" package.nix
+}
+
+# Update the hash of the parca ui pnpm dependencies in the Nix expression.
+update_pnpm_deps_hash() {
+    echo "Updating parca ui pnpm deps hash"
+
+    old_hash="$(nix eval --json --impure --expr "(import $nixpkgs/default.nix {}).parca.ui.pnpmDeps.outputHash" | jq -r)"
+    new_hash="$(nix-build --impure --expr "let src = (import $nixpkgs/default.nix {}).parca.ui.pnpmDeps; in (src.overrideAttrs or (f: src // f src)) (_: { outputHash = \"\"; outputHashAlgo = \"sha256\"; })" 2>&1 | tr -s ' ' | grep -Po "got: \K.+$")" || true
+
+    sed -i "s|${old_hash}|${new_hash}|g" package.nix
+}
+
+# Update the hash of the parca go dependencies in the Nix expression.
+update_go_deps_hash() {
+    echo "Updating parca go deps hash"
+
+    old_hash="$(nix eval --json --impure --expr "(import $nixpkgs/default.nix {}).parca.vendorHash" | jq -r)"
+    new_hash="$(nix-build --impure --expr "let src = (import $nixpkgs/default.nix {}).parca; in (src.overrideAttrs { vendorHash = \"\"; })" 2>&1 | tr -s ' ' | grep -Po "got: \K.+$")" || true
+
+    sed -i "s|${old_hash}|${new_hash}|g" package.nix
+}
+
+LATEST_TAG="$(curl -s ${GITHUB_TOKEN:+-u ":$GITHUB_TOKEN"} https://api.github.com/repos/parca-dev/parca/releases/latest | jq -r '.tag_name')"
+LATEST_VERSION="$(expr "$LATEST_TAG" : 'v\(.*\)')"
+CURRENT_VERSION="$(nix eval --json --impure --expr "(import $nixpkgs/default.nix {}).parca.version" | jq -r)"
+
+if [[ "$CURRENT_VERSION" == "$LATEST_VERSION" ]]; then
+    echo "parca is up to date: ${CURRENT_VERSION}"
+    exit 0
+fi
+
+update_parca_source "$LATEST_VERSION"
+update_pnpm_deps_hash
+update_go_deps_hash


### PR DESCRIPTION
## Things done

Because of the structure of the parca derivation, the auto-updater has not been able to bump it.

This change adds a script which bumps the source & hash, the pnpm deps hash and the go vendor hash.

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
