### PR TITLE
nixVersions.git: 2025-04-07 -> 2025-04-09

### DIFF
--- a/pkgs/tools/package-management/nix/default.nix
+++ b/pkgs/tools/package-management/nix/default.nix
@@ -189,14 +189,14 @@ lib.makeExtensible (
       };
 
       nixComponents_git = nixDependencies.callPackage ./modular/packages.nix rec {
-        version = "2.29pre20250407_${lib.substring 0 8 src.rev}";
+        version = "2.29pre20250409_${lib.substring 0 8 src.rev}";
         inherit (self.nix_2_24.meta) maintainers;
         otherSplices = generateSplicesForNixComponents "nixComponents_git";
         src = fetchFromGitHub {
           owner = "NixOS";
           repo = "nix";
-          rev = "73d3159ba0b4b711c1f124a587f16e2486d685d7";
-          hash = "sha256-9wJXUGqXIqMjNyKWJKCcxrDHM/KxDkvJMwo6S3s+WuM=";
+          rev = "e76bbe413e86e3208bb9824e339d59af25327101";
+          hash = "sha256-Aqnj5+sA7B4ZRympuyfWPPK83iomKHEHMYhlwslI8iA=";
         };
       };
 

--- a/pkgs/tools/package-management/nix/modular/packaging/components.nix
+++ b/pkgs/tools/package-management/nix/modular/packaging/components.nix
@@ -201,6 +201,8 @@ let
       }
     );
 
+  whenAtLeast = v: thing: if lib.versionAtLeast version v then thing else null;
+
 in
 
 # This becomes the pkgs.nixComponents attribute set
@@ -336,6 +338,7 @@ in
   nix-store-tests = callPackage ../src/libstore-tests/package.nix { };
 
   nix-fetchers = callPackage ../src/libfetchers/package.nix { };
+  ${whenAtLeast "2.29pre" "nix-fetchers-c"} = callPackage ../src/libfetchers-c/package.nix { };
   nix-fetchers-tests = callPackage ../src/libfetchers-tests/package.nix { };
 
   nix-expr = callPackage ../src/libexpr/package.nix { };

--- a/pkgs/tools/package-management/nix/modular/packaging/everything.nix
+++ b/pkgs/tools/package-management/nix/modular/packaging/everything.nix
@@ -6,6 +6,8 @@
 
   maintainers,
 
+  version,
+
   nix-util,
   nix-util-c,
   nix-util-tests,
@@ -15,6 +17,7 @@
   nix-store-tests,
 
   nix-fetchers,
+  nix-fetchers-c,
   nix-fetchers-tests,
 
   nix-expr,
@@ -63,14 +66,20 @@ let
         nix-cmd
         ;
     }
-    // lib.optionalAttrs
-      (!stdenv.hostPlatform.isStatic && stdenv.buildPlatform.canExecute stdenv.hostPlatform)
-      {
-        # Currently fails in static build
-        inherit
-          nix-perl-bindings
-          ;
-      };
+    // lib.optionalAttrs (lib.versionAtLeast version "2.29pre") {
+      inherit
+        nix-fetchers-c
+        ;
+    }
+    //
+      lib.optionalAttrs
+        (!stdenv.hostPlatform.isStatic && stdenv.buildPlatform.canExecute stdenv.hostPlatform)
+        {
+          # Currently fails in static build
+          inherit
+            nix-perl-bindings
+            ;
+        };
 
   devdoc = buildEnv {
     name = "nix-${nix-cli.version}-devdoc";
@@ -225,20 +234,26 @@ stdenv.mkDerivation (finalAttrs: {
       "out"
       "man"
     ];
-    pkgConfigModules = [
-      "nix-cmd"
-      "nix-expr"
-      "nix-expr-c"
-      "nix-fetchers"
-      "nix-flake"
-      "nix-flake-c"
-      "nix-main"
-      "nix-main-c"
-      "nix-store"
-      "nix-store-c"
-      "nix-util"
-      "nix-util-c"
-    ];
+    pkgConfigModules =
+      [
+        "nix-cmd"
+        "nix-expr"
+        "nix-expr-c"
+        "nix-fetchers"
+      ]
+      ++ lib.optionals (lib.versionAtLeast version "2.29pre") [
+        "nix-fetchers-c"
+      ]
+      ++ [
+        "nix-flake"
+        "nix-flake-c"
+        "nix-main"
+        "nix-main-c"
+        "nix-store"
+        "nix-store-c"
+        "nix-util"
+        "nix-util-c"
+      ];
   };
 
 })

--- a/pkgs/tools/package-management/nix/modular/src/libfetchers-c/package.nix
+++ b/pkgs/tools/package-management/nix/modular/src/libfetchers-c/package.nix
@@ -1,0 +1,34 @@
+{
+  lib,
+  mkMesonLibrary,
+
+  nix-store-c,
+  nix-expr-c,
+  nix-util-c,
+  nix-fetchers,
+
+  # Configuration Options
+
+  version,
+}:
+
+mkMesonLibrary (finalAttrs: {
+  pname = "nix-fetchers-c";
+  inherit version;
+
+  workDir = ./.;
+
+  propagatedBuildInputs = [
+    nix-util-c
+    nix-expr-c
+    nix-store-c
+    nix-fetchers
+  ];
+
+  mesonFlags = [ ];
+
+  meta = {
+    platforms = lib.platforms.unix ++ lib.platforms.windows;
+  };
+
+})

--- a/pkgs/tools/package-management/nix/modular/src/libfetchers-tests/package.nix
+++ b/pkgs/tools/package-management/nix/modular/src/libfetchers-tests/package.nix
@@ -5,6 +5,7 @@
   mkMesonExecutable,
 
   nix-fetchers,
+  nix-fetchers-c,
   nix-store-test-support,
 
   libgit2,
@@ -30,6 +31,9 @@ mkMesonExecutable (finalAttrs: {
       nix-store-test-support
       rapidcheck
       gtest
+    ]
+    ++ lib.optionals (lib.versionAtLeast version "2.29pre") [
+      nix-fetchers-c
     ]
     ++ lib.optionals (lib.versionAtLeast version "2.27") [
       libgit2

--- a/pkgs/tools/package-management/nix/modular/src/libflake-c/package.nix
+++ b/pkgs/tools/package-management/nix/modular/src/libflake-c/package.nix
@@ -4,6 +4,7 @@
 
   nix-store-c,
   nix-expr-c,
+  nix-fetchers-c,
   nix-flake,
 
   # Configuration Options
@@ -17,11 +18,17 @@ mkMesonLibrary (finalAttrs: {
 
   workDir = ./.;
 
-  propagatedBuildInputs = [
-    nix-expr-c
-    nix-store-c
-    nix-flake
-  ];
+  propagatedBuildInputs =
+    [
+      nix-expr-c
+      nix-store-c
+    ]
+    ++ lib.optionals (lib.versionAtLeast version "2.29pre") [
+      nix-fetchers-c
+    ]
+    ++ [
+      nix-flake
+    ];
 
   mesonFlags = [
   ];


### PR DESCRIPTION
This adds the nix-fetchers-c library (C API) which may be of interest. Technically, since 2.28 is not packaged with these files at this time, the conditionals are redundant, but I'd like this commit to serve as a blueprint for future updates, and I'd like to keep options open for 2.28 packaging.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
