### PR TITLE
mdformat: 0.7.19 -> 0.7.22 and mdformat-admon: 2.0.6 -> 2.1.1

### DIFF
--- a/pkgs/development/python-modules/mdformat-admon/default.nix
+++ b/pkgs/development/python-modules/mdformat-admon/default.nix
@@ -11,7 +11,7 @@
 
 buildPythonPackage rec {
   pname = "mdformat-admon";
-  version = "2.0.6";
+  version = "2.1.1";
   pyproject = true;
 
   disabled = pythonOlder "3.8";
@@ -20,7 +20,7 @@ buildPythonPackage rec {
     owner = "KyleKing";
     repo = "mdformat-admon";
     tag = "v${version}";
-    hash = "sha256-YyEiqry1dAm/2EEuQjPFEfdpLI+NiLhVcyx4jAyXs4E=";
+    hash = "sha256-y0TNyje2OXBY4oo9kBePlqSZAU36vbQQKZUPm/u6DAc=";
   };
 
   nativeBuildInputs = [ flit-core ];

--- a/pkgs/development/python-modules/mdformat-gfm-alerts/default.nix
+++ b/pkgs/development/python-modules/mdformat-gfm-alerts/default.nix
@@ -37,5 +37,6 @@ buildPythonPackage rec {
     changelog = "https://github.com/KyleKing/mdformat-gfm-alerts/releases/tag/v${version}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ sigmanificient ];
+    broken = true; # broken test due to changes in mdformat; compare https://github.com/KyleKing/mdformat-admon/issues/25
   };
 }

--- a/pkgs/development/python-modules/mdformat-mkdocs/default.nix
+++ b/pkgs/development/python-modules/mdformat-mkdocs/default.nix
@@ -4,7 +4,6 @@
   fetchFromGitHub,
   flit-core,
   mdformat,
-  mdformat-admon,
   mdformat-gfm,
   mdit-py-plugins,
   more-itertools,
@@ -31,7 +30,6 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [
     mdformat
-    mdformat-admon
     mdformat-gfm
     mdit-py-plugins
     more-itertools

--- a/pkgs/development/python-modules/mdformat-toc/default.nix
+++ b/pkgs/development/python-modules/mdformat-toc/default.nix
@@ -38,5 +38,6 @@ buildPythonPackage rec {
       aldoborrero
       polarmutex
     ];
+    broken = true; # broken test due to changes in mdformat; compare https://github.com/KyleKing/mdformat-admon/issues/25
   };
 }

--- a/pkgs/development/python-modules/mdformat/default.nix
+++ b/pkgs/development/python-modules/mdformat/default.nix
@@ -12,7 +12,7 @@
 
 buildPythonPackage rec {
   pname = "mdformat";
-  version = "0.7.19";
+  version = "0.7.22";
   pyproject = true;
 
   disabled = pythonOlder "3.8";
@@ -21,7 +21,7 @@ buildPythonPackage rec {
     owner = "executablebooks";
     repo = "mdformat";
     tag = version;
-    hash = "sha256-t2yx8cIq8es3XOc2nbHPKjUUium5+RPZuD8oNWZxVV0=";
+    hash = "sha256-WvbGCqfzh7KlNXIGJq09goiyLzVgU7c1+qmsLrIW38k=";
   };
 
   build-system = [ setuptools ];


### PR DESCRIPTION
The hash of mdformat was not updated properly and currently the 0.7.18 hash is set.
mdformat changed some behavior and mdformat-admon needed a fix for its test (https://github.com/KyleKing/mdformat-admon/issues/25).

This PR supersedes https://github.com/NixOS/nixpkgs/pull/383077.

Both bumps should be done in one step.

## Things done
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
