### PR TITLE
python313Packages.gluonts: init at 0.16.1

### DIFF
--- a/pkgs/development/python-modules/gluonts/default.nix
+++ b/pkgs/development/python-modules/gluonts/default.nix
@@ -1,0 +1,113 @@
+{
+  stdenv,
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+
+  # dependencies
+  numpy,
+  pandas,
+  pydantic,
+  tqdm,
+  toolz,
+
+  # optional dependencies (torch)
+  torch,
+  lightning,
+  scipy,
+
+  # test
+  pytestCheckHook,
+  distutils,
+  matplotlib,
+  pyarrow,
+  statsmodels,
+  which,
+}:
+
+buildPythonPackage rec {
+  pname = "gluonts";
+  version = "0.16.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "awslabs";
+    repo = "gluonts";
+    tag = "v${version}";
+    hash = "sha256-i4yCNe8C9BZw6AZUDOZC1E9PQOOOoUovSZnOF1yzycM=";
+  };
+
+  build-system = [
+    setuptools
+  ];
+
+  dependencies = [
+    numpy
+    pandas
+    pydantic
+    tqdm
+    toolz
+  ];
+
+  optional-dependencies = {
+    torch = [
+      torch
+      lightning
+      scipy
+    ];
+  };
+
+  pythonRelaxDeps = [
+    "numpy"
+    "toolz"
+  ];
+
+  pythonImportsCheck = [
+    "gluonts"
+    "gluonts.core"
+    "gluonts.dataset"
+    "gluonts.ev"
+    "gluonts.evaluation"
+    "gluonts.ext"
+    "gluonts.model"
+    "gluonts.shell"
+    "gluonts.time_feature"
+    "gluonts.torch"
+    "gluonts.transform"
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    distutils
+    matplotlib
+    pyarrow
+    statsmodels
+    which
+  ] ++ optional-dependencies.torch;
+
+  preCheck = ''export HOME=$(mktemp -d)'';
+
+  disabledTestPaths = [
+    # requires `cpflows`, not in Nixpkgs
+    "test/torch/model"
+  ];
+
+  disabledTests =
+    [
+      # tries to access network
+      "test_against_former_evaluator"
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [
+      # RuntimeError: *** -[__NSPlaceholderArray initWithObjects:count:]: attempt to insert nil object from objects[1]
+      "test_forecast"
+    ];
+
+  meta = {
+    description = "Probabilistic time series modeling in Python";
+    homepage = "https://ts.gluon.ai";
+    changelog = "https://github.com/awslabs/gluonts/releases/tag/${src.tag}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ bcdarwin ];
+  };
+}

--- a/pkgs/development/python-modules/lightning/default.nix
+++ b/pkgs/development/python-modules/lightning/default.nix
@@ -1,0 +1,43 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  # build-system
+  setuptools,
+
+  # dependencies
+  pytorch-lightning,
+
+  # tests
+  psutil,
+  pytestCheckHook,
+}:
+
+buildPythonPackage {
+  pname = "lightning";
+  pyproject = true;
+
+  inherit (pytorch-lightning)
+    version
+    src
+    build-system
+    meta
+    ;
+
+  dependencies = pytorch-lightning.dependencies ++ [ pytorch-lightning ];
+
+  nativeCheckInputs = [
+    psutil
+    pytestCheckHook
+  ];
+
+  # Some packages are not in NixPkgs; other tests try to build distributed
+  # models, which doesn't work in the sandbox.
+  doCheck = false;
+
+  pythonImportsCheck = [
+    "lightning"
+    "lightning.pytorch"
+  ];
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5584,6 +5584,8 @@ self: super: with self; {
 
   glueviz = callPackage ../development/python-modules/glueviz { };
 
+  gluonts = callPackage ../development/python-modules/gluonts { };
+
   glymur = callPackage ../development/python-modules/glymur { };
 
   glyphsets = callPackage ../development/python-modules/glyphsets { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7869,6 +7869,8 @@ self: super: with self; {
 
   lightify = callPackage ../development/python-modules/lightify { };
 
+  lightning = callPackage ../development/python-modules/lightning { };
+
   lightning-utilities = callPackage ../development/python-modules/lightning-utilities { };
 
   lightparam = callPackage ../development/python-modules/lightparam { };


### PR DESCRIPTION
python313Packages.lightning: init at 2.5.1post0 (${pytorch-lightning.version})

Init [gluonts](https://ts.gluon.ai/stable/), a Python package for probabilistic time series modelling in Python.

In terms of optional dependencies I only added `torch`-specific ones, not e.g. MXNet, Prophet, etc., etc., for now.

@GaetanLepage of possible interest due to addition of `lightning` wrapper for pytorch-lightning.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).