### PR TITLE
ci: Update pinned Nixpkgs

### DIFF
--- a/ci/pinned-nixpkgs.json
+++ b/ci/pinned-nixpkgs.json
@@ -1,4 +1,4 @@
 {
-  "rev": "573c650e8a14b2faa0041645ab18aed7e60f0c9a",
-  "sha256": "0qg99zj0gb0pc6sjlkmwhk1c1xz14qxmk6gamgfmcxpsfdp5vn72"
+  "rev": "b2b0718004cc9a5bca610326de0a82e6ea75920b",
+  "sha256": "0aqrxx1w40aqicjhg2057bpyrrbsx6mnii5dp5klpm4labfg2iwi"
 }


### PR DESCRIPTION
Same as https://github.com/NixOS/nixpkgs/pull/389635, but now including the nixfmt update from https://github.com/NixOS/nixpkgs/pull/396013.

Ran `ci/update-pinned-nixpkgs.sh`, which updated it to the version from this nixpkgs-unstable Hydra eval: https://hydra.nixos.org/eval/1814458#tabs-inputs

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
