### PR TITLE
pnpm.configHook: improve error message when install fails due to hash

### DIFF
--- a/pkgs/development/tools/pnpm/fetch-deps/pnpm-config-hook.sh
+++ b/pkgs/development/tools/pnpm/fetch-deps/pnpm-config-hook.sh
@@ -44,11 +44,23 @@ pnpmConfigHook() {
 
     runHook prePnpmInstall
 
-    pnpm install \
+    if ! pnpm install \
         --offline \
         --ignore-scripts \
         "${pnpmInstallFlags[@]}" \
         --frozen-lockfile
+    then
+        echo
+        echo "ERROR: pnpm failed to install dependencies"
+        echo
+        echo "If you see ERR_PNPM_NO_OFFLINE_TARBALL above this, follow these to fix the issue:"
+        echo '1. Set pnpmDeps.hash to "" (empty string)'
+        echo "2. Build the derivation and wait for it to fail with a hash mismatch"
+        echo "3. Copy the 'got: sha256-' value back into the pnpmDeps.hash field"
+        echo
+
+        exit 1
+    fi
 
 
     echo "Patching scripts"


### PR DESCRIPTION
Helps with https://github.com/NixOS/nixpkgs/issues/397412

This PR adds a hint for the user when they try to use an outdated `pnpmDeps`, similarly to [`npmConfigHook`](https://github.com/NixOS/nixpkgs/blob/477b7a4ae7e2371b6ac459fbb905eaab70036100/pkgs/build-support/node/build-npm-package/hooks/npm-config-hook.sh#L54-L63), but with some limitations because the lockfile is not in `pnpmDeps` (and we shouldn't add it yet as it would break all hashes):
- we can't give information about which packages are missing, but pnpm outputs the name of the first one
- unlike with a lockfile comparison, not getting this error message doesn't guarantee that `pnpmDeps` is up to date (eg. if upstream only removed a package and we updated the `src` but not `pnpmDeps`, this check wouldn't be triggered)
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Testing

Before the PR it may not be clear to the user how to fix it: `nix build github:gepbird/pnpm-fetch-deps-issue-repro/single-package`
```console
       > Executing pnpmConfigHook
       > Configuring pnpm store
       > /build /build/y7rwrcb76zx6pbkz0bqkbzyamxd494la-source
       > /build/y7rwrcb76zx6pbkz0bqkbzyamxd494la-source
       > Installing dependencies
       > Lockfile is up to date, resolution step is skipped
       > Packages: +1
       > 
       >  ERR_PNPM_NO_OFFLINE_TARBALL  A package is missing from the store but cannot download it in offline mode. The missing package may be downloaded from https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz.
       > Progress: resolved 1, reused 0, downloaded 0, added 0
```

After the PR: `nix build github:gepbird/pnpm-fetch-deps-issue-repro/single-package --override-input nixpkgs github:gepbird/nixpkgs/pnpm-config-hook-install-error-better-message`
```console
       > Executing pnpmConfigHook
       > Configuring pnpm store
       > /build /build/y7rwrcb76zx6pbkz0bqkbzyamxd494la-source
       > /build/y7rwrcb76zx6pbkz0bqkbzyamxd494la-source
       > Installing dependencies
       > Lockfile is up to date, resolution step is skipped
       > Packages: +1
       > 
       >  ERR_PNPM_NO_OFFLINE_TARBALL  A package is missing from the store but cannot download it in offline mode. The missing package may be downloaded from https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz.
       > Progress: resolved 1, reused 0, downloaded 0, added 0
       >
       > ERROR: pnpm failed to install dependencies
       >
       > If you see ERR_PNPM_NO_OFFLINE_TARBALL above this, follow these to fix the issue:
       > 1. Set pnpmDeps.hash to "" (empty string)
       > 2. Build the derivation and wait for it to fail with a hash mismatch
       > 3. Copy the 'got: sha256-' value back into the pnpmDeps.hash field
       >
```


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
