### PR TITLE
dalphaball: init at 0-unstable-2023-06-15

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2129,6 +2129,11 @@
     githubId = 11493130;
     name = "Asbjørn Olling";
   };
+  aschleck = {
+    name = "April Schleck";
+    github = "aschleck";
+    githubId = 115766;
+  };
   ascii17 = {
     name = "Allen Conlon";
     email = "software@conlon.dev";

--- a/pkgs/by-name/da/dalphaball/package.nix
+++ b/pkgs/by-name/da/dalphaball/package.nix
@@ -1,0 +1,46 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  gfortran,
+  gmp,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "dalphaball";
+  version = "0-unstable-2023-06-15";
+
+  src = fetchFromGitHub {
+    owner = "outpace-bio";
+    repo = "DAlphaBall";
+    rev = "7b9dc05fa2a40f7ea36c6d89973d150eaed459d9";
+    hash = "sha256-mUxEL9b67z/mG+0pcM5uQ/jPAfEUpJlXOXPmqDea+U4=";
+  };
+
+  sourceRoot = "${src.name}/src";
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    gfortran
+  ];
+
+  buildInputs = [
+    gfortran.cc.lib
+    gmp
+  ];
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm755 DAlphaBall.gcc $out/bin/DAlphaBall
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Computes the surface area and volume of unions of many balls";
+    mainProgram = "DAlphaBall";
+    homepage = "https://github.com/outpace-bio/DAlphaBall";
+    license = lib.licenses.lgpl21Only;
+    maintainers = with lib.maintainers; [ aschleck ];
+    platforms = lib.platforms.unix;
+  };
+}


### PR DESCRIPTION
DAlphaBall computes the surface area of unions of many small balls, which is useful for software that does protein design. For example https://github.com/martinpacesa/BindCraft and https://github.com/RosettaCommons/RFDesign both depend on it. There are no proper releases of this package so I just took the latest commit.

Homepage/repository: https://github.com/outpace-bio/DAlphaBall

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
