### PR TITLE
breseq: init at 0.39.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5065,7 +5065,6 @@
   };
   croots = {
     name = "Cameron Roots";
-    email = "38054423+croots@users.noreply.github.com";
     github = "croots";
     githubId = 38054423;
     keys = [ { fingerprint = "8496 ECF3 0961 115C A6DE 919F A01D C430 0605 1618"; } ];

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5063,6 +5063,13 @@
     githubId = 4162215;
     keys = [ { fingerprint = "CE97 9DEE 904C 26AA 3716  78C2 96A4 38F9 EE72 572F"; } ];
   };
+  croots = {
+    name = "Cameron Roots";
+    email = "38054423+croots@users.noreply.github.com";
+    github = "croots";
+    githubId = 38054423;
+    keys = [ { fingerprint = "8496 ECF3 0961 115C A6DE 919F A01D C430 0605 1618"; } ];
+  };
   crschnick = {
     email = "crschnick@xpipe.io";
     name = "Christopher Schnick";

--- a/nixos/doc/manual/release-notes/rl-2505.section.md
+++ b/nixos/doc/manual/release-notes/rl-2505.section.md
@@ -49,6 +49,8 @@
 
 - [Bazecor](https://github.com/Dygmalab/Bazecor), the graphical configurator for Dygma Products.
 
+- [breseq](https://github.com/barricklab/breseq), a pipeline for analyzing mutations in microbes from short-read DNA sequencing data.
+
 - [Bonsai](https://git.sr.ht/~stacyharper/bonsai), a general-purpose event mapper/state machine primarily used to create complex key shortcuts, and as part of the [SXMO](https://sxmo.org/) desktop environment. Available as [services.bonsaid](#opt-services.bonsaid.enable).
 
 - [archtika](https://github.com/archtika/archtika), a FLOSS, modern, performant, lightweight and self‑hosted CMS. Available as [services.archtika](#opt-services.archtika.enable).

--- a/nixos/doc/manual/release-notes/rl-2505.section.md
+++ b/nixos/doc/manual/release-notes/rl-2505.section.md
@@ -49,7 +49,7 @@
 
 - [Bazecor](https://github.com/Dygmalab/Bazecor), the graphical configurator for Dygma Products.
 
-- [breseq](https://github.com/barricklab/breseq), a pipeline for analyzing mutations in microbes from short-read DNA sequencing data.
+- [breseq](https://github.com/barricklab/breseq), a pipeline for analyzing short-read DNA sequencing data for mutations in microbes.
 
 - [Bonsai](https://git.sr.ht/~stacyharper/bonsai), a general-purpose event mapper/state machine primarily used to create complex key shortcuts, and as part of the [SXMO](https://sxmo.org/) desktop environment. Available as [services.bonsaid](#opt-services.bonsaid.enable).
 

--- a/pkgs/by-name/br/breseq/package.nix
+++ b/pkgs/by-name/br/breseq/package.nix
@@ -1,33 +1,35 @@
-{ stdenv, lib, fetchFromGitHub, callPackage,
-libz,
-autoconf,
-automake,
-libtool,
-perl,
-R,
-bowtie2}:
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  callPackage,
+  libz,
+  autoconf,
+  automake,
+  libtool,
+  perl,
+  R,
+  bowtie2,
+}:
 
 stdenv.mkDerivation rec {
-    name = "breseq-${version}";
-    version = "0.39.0";
+  name = "breseq-${version}";
+  version = "0.39.0";
 
-    src = fetchFromGitHub {
-        owner = "barricklab";
-        repo = "breseq";
-        rev = "v${version}";
-        sha256 = "DsDX2oGn7Ex50Wnp1phJjCziCzZIeeZOHriUGJbejsk=";
-    };
+  src = fetchFromGitHub {
+    owner = "barricklab";
+    repo = "breseq";
+    rev = "v${version}";
+    sha256 = "DsDX2oGn7Ex50Wnp1phJjCziCzZIeeZOHriUGJbejsk=";
+  };
 
-    buildInputs = [
-        perl
-        libz
-        autoconf
-        automake
-        libtool
-    ];
-
-  REQUIRED_R = R.outPath;
-  REQUIRED_BOWTIE = bowtie2.outPath;
+  buildInputs = [
+    perl
+    libz
+    autoconf
+    automake
+    libtool
+  ];
 
   buildPhase = ''
     ./bootstrap.sh
@@ -42,13 +44,13 @@ stdenv.mkDerivation rec {
     mkdir $out/bin
     touch $out/bin/breseq
     touch $out/bin/gdtools
-    echo -e "#! /usr/bin/bash\n\nexport PATH=$REQUIRED_R/bin:$REQUIRED_BOWTIE/bin:\$PATH\n\nexec $out/unwrapped/bin/breseq \$@" >> $out/bin/breseq
-    echo -e "#! /usr/bin/bash\n\nexport PATH=$REQUIRED_R/bin:$REQUIRED_BOWTIE/bin:\$PATH\n\nexec $out/unwrapped/bin/gdtools \$@" >> $out/bin/gdtools
+    echo -e "#! /usr/bin/bash\n\nexport PATH=${R.outPath}/bin:${bowtie2.outPath}/bin:\$PATH\n\nexec $out/unwrapped/bin/breseq \$@" >> $out/bin/breseq
+    echo -e "#! /usr/bin/bash\n\nexport PATH=${R.outPath}/bin:${bowtie2.outPath}/bin:\$PATH\n\nexec $out/unwrapped/bin/gdtools \$@" >> $out/bin/gdtools
     chmod +x $out/bin/breseq
     chmod +x $out/bin/gdtools
     # Clean up dependency tree
     find $out -type f -exec patchelf --shrink-rpath '{}' \; -exec strip '{}' \; 2>/dev/null
-    # Copy over tests and license
+    # Copy over tests (incl necessary datasets) and license
     cp LICENSE $out/license
     mkdir $out/tests
     mkdir $out/tests/data
@@ -67,8 +69,11 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "A computational pipeline for finding mutations relative to a reference sequence in short-read DNA re-sequencing data.";
     homepage = "https://github.com/barricklab/breseq";
-    license = with lib.licenses; [ gpl2 gpl3 ];
+    license = with lib.licenses; [
+      gpl2
+      gpl3
+    ];
     maintainers = with maintainers; [ croots ];
     platforms = platforms.all;
-    };
+  };
 }

--- a/pkgs/by-name/br/breseq/package.nix
+++ b/pkgs/by-name/br/breseq/package.nix
@@ -1,0 +1,57 @@
+{ stdenv, lib, fetchFromGitHub,
+libz,
+autoconf,
+automake,
+libtool,
+perl,
+R,
+bowtie2}:
+
+stdenv.mkDerivation rec {
+    name = "breseq-${version}";
+    version = "0.39.0";
+
+    src = fetchFromGitHub {
+        owner = "barricklab";
+        repo = "breseq";
+        rev = "v${version}";
+        sha256 = "DsDX2oGn7Ex50Wnp1phJjCziCzZIeeZOHriUGJbejsk=";
+    };
+
+    buildInputs = [
+        perl
+        libz
+        autoconf
+        automake
+        libtool
+    ];
+
+  REQUIRED_R = R.outPath;
+  REQUIRED_BOWTIE = bowtie2.outPath;
+
+  buildPhase = ''
+    ./bootstrap.sh
+    ./configure --prefix=$out/unwrapped
+    make -s
+  '';
+
+  installPhase = ''
+    make install
+    mkdir $out/bin
+    touch $out/bin/breseq
+    touch $out/bin/gdtools
+    echo -e "#! /usr/bin/bash\n\nexport PATH=$REQUIRED_R/bin:$REQUIRED_BOWTIE/bin:\$PATH\n\nexec $out/unwrapped/bin/breseq \$@" >> $out/bin/breseq
+    echo -e "#! /usr/bin/bash\n\nexport PATH=$REQUIRED_R/bin:$REQUIRED_BOWTIE/bin:\$PATH\n\nexec $out/unwrapped/bin/gdtools \$@" >> $out/bin/gdtools
+    chmod +x $out/bin/breseq
+    chmod +x $out/bin/gdtools
+    find $out -type f -exec patchelf --shrink-rpath '{}' \; -exec strip '{}' \; 2>/dev/null
+  '';
+
+  meta = with lib; {
+    description = "A computational pipeline for finding mutations relative to a reference sequence in short-read DNA re-sequencing data.";
+    homepage = "https://github.com/barricklab/breseq";
+    license = with lib.licenses; [ gpl2 gpl3 ];
+    maintainers = with maintainers; [ croots ];
+    platforms = platforms.all;
+    };
+}

--- a/pkgs/by-name/br/breseq/tests/breseq.nix
+++ b/pkgs/by-name/br/breseq/tests/breseq.nix
@@ -1,27 +1,30 @@
-{ runCommand, phoronix-test-suite, breseq}:
+{
+  runCommand,
+  phoronix-test-suite,
+  breseq,
+}:
 
 let
   inherit (phoronix-test-suite) pname version;
 in
 
-runCommand "${pname}-tests" { meta.timeout = 60; }
-  ''
-    ${phoronix-test-suite}/bin/phoronix-test-suite enterprise-setup >/dev/null
-    if [[ `${phoronix-test-suite}/bin/phoronix-test-suite version` != *"${version}"*  ]]; then
-      echo "Error: program version does not match package version"
-      exit 1
-    fi
+runCommand "${pname}-tests" { meta.timeout = 60; } ''
+  ${phoronix-test-suite}/bin/phoronix-test-suite enterprise-setup >/dev/null
+  if [[ `${phoronix-test-suite}/bin/phoronix-test-suite version` != *"${version}"*  ]]; then
+    echo "Error: program version does not match package version"
+    exit 1
+  fi
 
-    export TESTBINPREFIX=${breseq}/bin
-    export TESTDIR=$(mktemp -d)
-    trap "rm -rf \"$TESTDIR\"" EXIT
-    cp ${breseq}/tests $TESTDIR/breseqtests -r
-    chmod -R +w $TESTDIR/breseqtests
-    echo "Testing breseq - breseq executable"
-    output=$($TESTDIR/breseqtests/tmv_plasmid_circular_deletion/testcmd.sh 2>&1) || {
-      echo "$output"
-      echo "Error testing breseq - breseq executable"
-      exit 1
-    }
-    touch $out
-  ''
+  export TESTBINPREFIX=${breseq}/bin
+  export TESTDIR=$(mktemp -d)
+  trap "rm -rf \"$TESTDIR\"" EXIT
+  cp ${breseq}/tests $TESTDIR/breseqtests -r
+  chmod -R +w $TESTDIR/breseqtests
+  echo "Testing breseq - breseq executable"
+  output=$($TESTDIR/breseqtests/tmv_plasmid_circular_deletion/testcmd.sh 2>&1) || {
+    echo "$output"
+    echo "Error testing breseq - breseq executable"
+    exit 1
+  }
+  touch $out
+''

--- a/pkgs/by-name/br/breseq/tests/breseq.nix
+++ b/pkgs/by-name/br/breseq/tests/breseq.nix
@@ -1,0 +1,27 @@
+{ runCommand, phoronix-test-suite, breseq}:
+
+let
+  inherit (phoronix-test-suite) pname version;
+in
+
+runCommand "${pname}-tests" { meta.timeout = 60; }
+  ''
+    ${phoronix-test-suite}/bin/phoronix-test-suite enterprise-setup >/dev/null
+    if [[ `${phoronix-test-suite}/bin/phoronix-test-suite version` != *"${version}"*  ]]; then
+      echo "Error: program version does not match package version"
+      exit 1
+    fi
+
+    export TESTBINPREFIX=${breseq}/bin
+    export TESTDIR=$(mktemp -d)
+    trap "rm -rf \"$TESTDIR\"" EXIT
+    cp ${breseq}/tests $TESTDIR/breseqtests -r
+    chmod -R +w $TESTDIR/breseqtests
+    echo "Testing breseq - breseq executable"
+    output=$($TESTDIR/breseqtests/tmv_plasmid_circular_deletion/testcmd.sh 2>&1) || {
+      echo "$output"
+      echo "Error testing breseq - breseq executable"
+      exit 1
+    }
+    touch $out
+  ''

--- a/pkgs/by-name/br/breseq/tests/gdtools.nix
+++ b/pkgs/by-name/br/breseq/tests/gdtools.nix
@@ -1,0 +1,27 @@
+{ runCommand, phoronix-test-suite, breseq}:
+
+let
+  inherit (phoronix-test-suite) pname version;
+in
+
+runCommand "${pname}-tests" { meta.timeout = 60; }
+  ''
+    ${phoronix-test-suite}/bin/phoronix-test-suite enterprise-setup >/dev/null
+    if [[ `${phoronix-test-suite}/bin/phoronix-test-suite version` != *"${version}"*  ]]; then
+      echo "Error: program version does not match package version"
+      exit 1
+    fi
+
+    export TESTBINPREFIX=${breseq}/bin
+    export TESTDIR=$(mktemp -d)
+    trap "rm -rf \"$TESTDIR\"" EXIT
+    cp ${breseq}/tests $TESTDIR/breseqtests -r
+    chmod -R +w $TESTDIR/breseqtests
+    echo "Testing breseq - gdtools executable"
+    output=$($TESTDIR/breseqtests/gdtools_compare_1/testcmd.sh 2>&1) || {
+      echo "$output"
+      echo "Error testing breseq - gdtools executable"
+      exit 1
+    }
+    touch $out
+  ''

--- a/pkgs/by-name/br/breseq/tests/gdtools.nix
+++ b/pkgs/by-name/br/breseq/tests/gdtools.nix
@@ -1,27 +1,30 @@
-{ runCommand, phoronix-test-suite, breseq}:
+{
+  runCommand,
+  phoronix-test-suite,
+  breseq,
+}:
 
 let
   inherit (phoronix-test-suite) pname version;
 in
 
-runCommand "${pname}-tests" { meta.timeout = 60; }
-  ''
-    ${phoronix-test-suite}/bin/phoronix-test-suite enterprise-setup >/dev/null
-    if [[ `${phoronix-test-suite}/bin/phoronix-test-suite version` != *"${version}"*  ]]; then
-      echo "Error: program version does not match package version"
-      exit 1
-    fi
+runCommand "${pname}-tests" { meta.timeout = 60; } ''
+  ${phoronix-test-suite}/bin/phoronix-test-suite enterprise-setup >/dev/null
+  if [[ `${phoronix-test-suite}/bin/phoronix-test-suite version` != *"${version}"*  ]]; then
+    echo "Error: program version does not match package version"
+    exit 1
+  fi
 
-    export TESTBINPREFIX=${breseq}/bin
-    export TESTDIR=$(mktemp -d)
-    trap "rm -rf \"$TESTDIR\"" EXIT
-    cp ${breseq}/tests $TESTDIR/breseqtests -r
-    chmod -R +w $TESTDIR/breseqtests
-    echo "Testing breseq - gdtools executable"
-    output=$($TESTDIR/breseqtests/gdtools_compare_1/testcmd.sh 2>&1) || {
-      echo "$output"
-      echo "Error testing breseq - gdtools executable"
-      exit 1
-    }
-    touch $out
-  ''
+  export TESTBINPREFIX=${breseq}/bin
+  export TESTDIR=$(mktemp -d)
+  trap "rm -rf \"$TESTDIR\"" EXIT
+  cp ${breseq}/tests $TESTDIR/breseqtests -r
+  chmod -R +w $TESTDIR/breseqtests
+  echo "Testing breseq - gdtools executable"
+  output=$($TESTDIR/breseqtests/gdtools_compare_1/testcmd.sh 2>&1) || {
+    echo "$output"
+    echo "Error testing breseq - gdtools executable"
+    exit 1
+  }
+  touch $out
+''


### PR DESCRIPTION
This PR adds _[breseq](https://github.com/barricklab/breseq)_ a popular (>9500 academic citations) pipeline for analyzing microbial sequencing data.

I am experimenting with NixOS as I run multiple machines (see: easy distribution of configurations), some of which I use for bioinformatics data analysis (see: one of the few ways of R version control). A tool I use frequently (from my lab) is breseq. This tool is highly convenient for the analysis of microbial sequencing data. Adding this to nixpkgs would be a step forward in the adoption of Nix as a package manager for bioinformatics analysis.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
