### PR TITLE
code-cursor: mark aarch64-linux as broken, disable corresponding update

### DIFF
--- a/chroium-snap.worksheet
+++ b/chroium-snap.worksheet
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CurrentWorkingDirectory</key>
+	<string>/Users/seclark/Library/Application Support/BBEdit/Stationery</string>
+	<key>WorksheetContents</key>
+	<string>releases=$(curl --header 'Snap-Device-Series: 16' http://api.snapcraft.io/v2/snaps/info/chromium)
+# echo $releases | yq -p=json
+echo $releases | jq '."channel-map"|.[]|select(.channel.risk=="stable")'
+echo $releases | jq '."channel-map"|.[]|select(.channel.risk=="stable") | {arch: .channel.architecture, url: .download.url, version}'
+{
+  "arch": "amd64",
+  "url": "https://api.snapcraft.io/api/v1/snaps/download/XKEcBqPM06H1Z7zGOdG5fbICuf8NWK5R_3099.snap",
+  "version": "135.0.7049.52"
+}
+{
+  "arch": "arm64",
+  "url": "https://api.snapcraft.io/api/v1/snaps/download/XKEcBqPM06H1Z7zGOdG5fbICuf8NWK5R_3092.snap",
+  "version": "135.0.7049.52"
+}
+{
+  "arch": "armhf",
+  "url": "https://api.snapcraft.io/api/v1/snaps/download/XKEcBqPM06H1Z7zGOdG5fbICuf8NWK5R_3091.snap",
+  "version": "135.0.7049.52"
+}
+{
+  "arch": "i386",
+  "url": "https://api.snapcraft.io/api/v1/snaps/download/XKEcBqPM06H1Z7zGOdG5fbICuf8NWK5R_1862.snap",
+  "version": "98.0.4758.9"
+}
+
+</string>
+</dict>
+</plist>

--- a/pkgs/by-name/co/code-cursor/package.nix
+++ b/pkgs/by-name/co/code-cursor/package.nix
@@ -57,10 +57,11 @@ let
       url = "https://downloads.cursor.com/production/1d623c4cc1d3bb6e0fe4f1d5434b47b958b05876/linux/x64/Cursor-0.48.7-x86_64.AppImage";
       hash = "sha256-LxAUhmEM02qCaeUUsHgjv0upAF7eerX+/QiGeKzRY4M=";
     };
-    aarch64-linux = fetchurl {
-      url = "https://downloads.cursor.com/production/1d623c4cc1d3bb6e0fe4f1d5434b47b958b05876/linux/arm64/Cursor-0.48.7-aarch64.AppImage";
-      hash = "sha256-l1T0jLX7oWjq4KzxO4QniUAjzVbBu4SWA1r5aXGpDS4=";
-    };
+    # Broken: see https://github.com/NixOS/nixpkgs/issues/304751 (blocked by https://github.com/NixOS/nixpkgs/issues/304751)
+    # aarch64-linux = fetchurl {
+    #   url = "https://downloads.cursor.com/production/1d623c4cc1d3bb6e0fe4f1d5434b47b958b05876/linux/arm64/Cursor-0.48.7-aarch64.AppImage";
+    #   hash = "sha256-l1T0jLX7oWjq4KzxO4QniUAjzVbBu4SWA1r5aXGpDS4=";
+    # };
     x86_64-darwin = fetchurl {
       url = "https://downloads.cursor.com/production/1d623c4cc1d3bb6e0fe4f1d5434b47b958b05876/darwin/x64/Cursor-darwin-x64.dmg";
       hash = "sha256-h9zcmZRpOcfBRK5Xw/AdY/rwlINEHYiUgpCoGXg6hSY=";
@@ -197,6 +198,7 @@ stdenvNoCC.mkDerivation {
       aspauldingcode
     ];
     platforms = lib.platforms.linux ++ lib.platforms.darwin;
+    badPlatforms = [ "aarch64-linux" ]; # Blocked by https://github.com/NixOS/nixpkgs/issues/304751
     mainProgram = "cursor";
   };
 }

--- a/pkgs/by-name/co/code-cursor/update.sh
+++ b/pkgs/by-name/co/code-cursor/update.sh
@@ -4,7 +4,9 @@ set -eu -o pipefail
 
 currentVersion=$(nix-instantiate --eval -E "with import ./. {}; code-cursor.version or (lib.getVersion code-cursor)" | tr -d '"')
 
-declare -A platforms=( [x86_64-linux]='linux-x64' [aarch64-linux]='linux-arm64' [x86_64-darwin]='darwin-x64' [aarch64-darwin]='darwin-arm64' )
+# declare -A platforms=( [x86_64-linux]='linux-x64' [aarch64-linux]='linux-arm64' [x86_64-darwin]='darwin-x64' [aarch64-darwin]='darwin-arm64' )
+# Ignoring aarch64-linux for now, as it depends on an unavailable package
+declare -A platforms=( [x86_64-linux]='linux-x64' [x86_64-darwin]='darwin-x64' [aarch64-darwin]='darwin-arm64' )
 declare -A updates=( )
 first_version=""
 


### PR DESCRIPTION
#397277 is a build bug for code-cursor on aarch64-linux: it's missing an appropriate build of `vivaldi-ffmpeg-codecs`.

#304751 -- open for a year -- is a packaging request for the missing codecs; it's a non-trivial issue.

Not to be a [BOFH](http://catb.org/jargon/html/B/BOFH.html), but I'm disabling code-cursor on aarch64-linux so nobody else stumbles into this bug. I'm investigating fixes, but it's just a mess.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
