### PR TITLE
spicetify-cli: rework

### DIFF
--- a/pkgs/by-name/sp/spicetify-cli/package.nix
+++ b/pkgs/by-name/sp/spicetify-cli/package.nix
@@ -3,17 +3,20 @@
   buildGoModule,
   fetchFromGitHub,
   testers,
+  replaceVars,
   spicetify-cli,
 }:
-
-buildGoModule rec {
-  pname = "spicetify-cli";
+let
   version = "2.39.6";
+in
+buildGoModule {
+  pname = "spicetify-cli";
+  inherit version;
 
   src = fetchFromGitHub {
     owner = "spicetify";
     repo = "cli";
-    rev = "v${version}";
+    tag = "v${version}";
     hash = "sha256-rdyHVHKVgl9fOviFYQuXY8Ko+/XwpKlKDfriQAgkusE=";
   };
 
@@ -24,28 +27,41 @@ buildGoModule rec {
     "-X 'main.version=${version}'"
   ];
 
-  # used at runtime, but not installed by default
-  postInstall = ''
-    mv $out/bin/cli $out/bin/spicetify
-    ln -s $out/bin/spicetify $out/bin/spicetify-cli
-    cp -r ${src}/jsHelper $out/bin/jsHelper
-    cp -r ${src}/CustomApps $out/bin/CustomApps
-    cp -r ${src}/Extensions $out/bin/Extensions
-    cp -r ${src}/Themes $out/bin/Themes
-  '';
+  patches = [
+    # Stops spicetify from attempting to fetch a newer css-map.json
+    (replaceVars ./version.patch {
+      inherit version;
+    })
+  ];
 
-  doInstallCheck = true;
-  installCheckPhase = ''
-    $out/bin/spicetify --help > /dev/null
-  '';
+  postInstall =
+    /*
+      jsHelper and css-map.json are required at runtime
+      and are looked for in the directory of the spicetify binary
+      so here we move spicetify to /share/spicetify
+      so that css-map.json and jsHelper don't pollute PATH
+    */
+    ''
+      mkdir -p $out/share/spicetify
+
+      cp -r $src/jsHelper $out/share/spicetify/jsHelper
+      cp $src/css-map.json $out/share/spicetify/css-map.json
+
+      mv $out/bin/cli $out/share/spicetify/spicetify
+
+      ln -s $out/share/spicetify/spicetify $out/bin/spicetify
+    '';
 
   passthru.tests.version = testers.testVersion { package = spicetify-cli; };
 
-  meta = with lib; {
+  meta = {
     description = "Command-line tool to customize Spotify client";
     homepage = "https://github.com/spicetify/cli";
-    license = licenses.gpl3Plus;
-    maintainers = [ maintainers.mdarocha ];
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [
+      mdarocha
+      gerg-l
+    ];
     mainProgram = "spicetify";
   };
 }

--- a/pkgs/by-name/sp/spicetify-cli/version.patch
+++ b/pkgs/by-name/sp/spicetify-cli/version.patch
@@ -1,0 +1,14 @@
+diff --git a/src/preprocess/preprocess.go b/src/preprocess/preprocess.go
+index ac0f084..f38ece2 100644
+--- a/src/preprocess/preprocess.go
++++ b/src/preprocess/preprocess.go
+@@ -66,7 +66,7 @@ func Start(version string, extractedAppsPath string, flags Flag) {
+ 	var cssTranslationMap = make(map[string]string)
+ 	// readSourceMapAndGenerateCSSMap(appPath)
+ 
+-	if version != "Dev" {
++	if version != "@version@" {
+ 		tag, err := FetchLatestTagMatchingOrMain(version)
+ 		if err != nil {
+ 			utils.PrintWarning("Cannot fetch version tag for CSS mappings")
+


### PR DESCRIPTION
Slight rework
removes the `spicetify-cli` symlink
stops the pollution of `PATH`
patches the error of "attempting to fetch css-map.json"
adds myself as a maintainer
removes the copying of CustomApps, Extensions, and Themes which causes `SPICETIFY_CONFIG` to not work as those folders in the same directory as the binary they take precedence over that env var

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
