### PR TITLE
breseq: init at 0.39.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5735,6 +5735,12 @@
     githubId = 4162215;
     keys = [ { fingerprint = "CE97 9DEE 904C 26AA 3716  78C2 96A4 38F9 EE72 572F"; } ];
   };
+  croots = {
+    name = "Cameron Roots";
+    github = "croots";
+    githubId = 38054423;
+    keys = [ { fingerprint = "8496 ECF3 0961 115C A6DE 919F A01D C430 0605 1618"; } ];
+  };
   crop = {
     email = "crop_tech@proton.me";
     name = "crop";

--- a/pkgs/by-name/br/breseq/package.nix
+++ b/pkgs/by-name/br/breseq/package.nix
@@ -1,0 +1,94 @@
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  callPackage,
+  nix-update-script,
+  libz,
+  libtool,
+  perl,
+  R,
+  bowtie2,
+  which,
+  ghostscript,
+  makeWrapper,
+  autoreconfHook,
+  versionCheckHook,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "breseq";
+  version = "0.39.0";
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "barricklab";
+    repo = "breseq";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-DsDX2oGn7Ex50Wnp1phJjCziCzZIeeZOHriUGJbejsk=";
+  };
+
+  buildInputs = [
+    perl
+    libz
+    libtool
+  ];
+
+  nativeBuildInputs = [
+    makeWrapper
+    autoreconfHook
+  ];
+
+  postInstall = ''
+    # Make wrappers
+    wrapProgram $out/bin/breseq --prefix PATH : ${
+      lib.makeBinPath [
+        which
+        ghostscript
+        bowtie2
+        R
+      ]
+    }
+    wrapProgram $out/bin/gdtools --prefix PATH :  ${
+      lib.makeBinPath [
+        which
+        ghostscript
+        bowtie2
+        R
+      ]
+    }
+    # Copy over tests (incl necessary datasets) and license
+    cp LICENSE $out/license
+    mkdir $out/tests
+    mkdir $out/tests/data
+    cp tests/data/tmv_plasmid $out/tests/data/tmv_plasmid -r
+    cp tests/data/lambda $out/tests/data/lambda -r
+    cp tests/common.sh $out/tests/common.sh
+    cp tests/tmv_plasmid_circular_deletion $out/tests/tmv_plasmid_circular_deletion -r
+    cp tests/gdtools_compare_1 $out/tests/gdtools_compare_1 -r
+  '';
+
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+  doInstallCheck = true;
+
+  passthru.tests = {
+    breseq_works = callPackage ./tests/breseq.nix { };
+    gdtools_works = callPackage ./tests/gdtools.nix { };
+  };
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Computational pipeline for finding mutations relative to a reference sequence in short-read DNA re-sequencing data";
+    mainProgram = "breseq";
+    homepage = "https://github.com/barricklab/breseq";
+    license = with lib.licenses; [
+      gpl2Plus # See barricklab/breseq#398
+    ];
+    maintainers = with lib.maintainers; [ croots ];
+    platforms = lib.platforms.all;
+  };
+})

--- a/pkgs/by-name/br/breseq/tests/breseq.nix
+++ b/pkgs/by-name/br/breseq/tests/breseq.nix
@@ -1,0 +1,21 @@
+{
+  runCommand,
+  breseq,
+}:
+
+let
+  inherit (breseq) pname version;
+in
+
+runCommand "breseq-tests" { meta.timeout = 60; } ''
+  echo "Testing breseq - breseq executable"
+  export TESTBINPREFIX=${breseq}/bin
+  cp ${breseq}/tests $PWD/breseqtests -r
+  chmod -R +w $PWD/breseqtests
+  output=$($PWD/breseqtests/tmv_plasmid_circular_deletion/testcmd.sh 2>&1) || {
+    echo "$output"
+    echo "Error testing breseq - breseq executable"
+    exit 1
+  }
+  touch $out
+''

--- a/pkgs/by-name/br/breseq/tests/gdtools.nix
+++ b/pkgs/by-name/br/breseq/tests/gdtools.nix
@@ -1,0 +1,21 @@
+{
+  runCommand,
+  breseq,
+}:
+
+let
+  inherit (breseq) pname version;
+in
+
+runCommand "breseq-tests" { meta.timeout = 60; } ''
+  echo "Testing breseq - gdtools executable"
+  export TESTBINPREFIX=${breseq}/bin
+  cp ${breseq}/tests $PWD/breseqtests -r
+  chmod -R +w $PWD/breseqtests
+  output=$($PWD/breseqtests/gdtools_compare_1/testcmd.sh 2>&1) || {
+    echo "$output"
+    echo "Error testing breseq - gdtools executable"
+    exit 1
+  }
+  touch $out
+''


### PR DESCRIPTION
This PR adds _[breseq](https://github.com/barricklab/breseq)_ a popular (>9500 academic citations) pipeline for analyzing microbial sequencing data.

I am experimenting with Nix as I run multiple machines (see: easy distribution of configurations), some of which I use for bioinformatics data analysis (see: one of the few ways of R version control). A tool I use frequently (from my lab) is breseq. This tool is highly convenient for the analysis of microbial sequencing data. Adding this to nixpkgs would be a step forward in the adoption of Nix as a package manager for bioinformatics analysis.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
