### PR TITLE
zig: drop 0.11, use ninja

### DIFF
--- a/pkgs/by-name/ba/backlight-auto/package.nix
+++ b/pkgs/by-name/ba/backlight-auto/package.nix
@@ -25,6 +25,8 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   meta = with lib; {
+    # Does not support zig 0.12 or newer, hasn't been updated in 2 years.
+    broken = lib.versionAtLeast zig.version "0.12";
     description = "Automatically set screen brightness with a webcam";
     mainProgram = "backlight-auto";
     homepage = "https://len.falken.directory/backlight-auto.html";

--- a/pkgs/by-name/bl/blackshades/package.nix
+++ b/pkgs/by-name/bl/blackshades/package.nix
@@ -7,22 +7,47 @@
   libGLU,
   libsndfile,
   openal,
-  zig_0_11,
+  zig_0_14,
+  runCommand,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "blackshades";
-  version = "2.5.1";
+  version = "2.5.2-unstable-2025-03-12";
 
   src = fetchFromSourcehut {
     owner = "~cnx";
     repo = "blackshades";
-    rev = finalAttrs.version;
+    rev = "a2fbe0e08bedbbbb1089dbb8f3e3cb4d76917bd0";
     fetchSubmodules = true;
-    hash = "sha256-qdpXpuXHr9w2XMfgOVveWv3JoqdJHVB8TCqZdyaw/DM=";
+    hash = "sha256-W6ltmWCw7jfiTiNlh60YVF7mz//8s+bgu4F9gy5cDgw=";
   };
 
-  nativeBuildInputs = [ zig_0_11.hook ];
+  postUnpack = ''
+    ln -s ${
+      runCommand "${finalAttrs.finalPackage.name}-zig-deps"
+        {
+          inherit (finalAttrs) src;
+
+          nativeBuildInputs = [ zig_0_14 ];
+
+          outputHashAlgo = null;
+          outputHashMode = "recursive";
+          outputHash = "sha256-wBIfLeaKtTow2Z7gjEgIFmqcTGWgpRWI+k0t294BslM=";
+        }
+        ''
+          export ZIG_GLOBAL_CACHE_DIR=$(mktemp -d)
+
+          runHook unpackPhase
+          cd $sourceRoot
+
+          zig build --fetch
+          mv $ZIG_GLOBAL_CACHE_DIR/p $out
+        ''
+    } $ZIG_GLOBAL_CACHE_DIR/p
+  '';
+
+  nativeBuildInputs = [ zig_0_14.hook ];
 
   buildInputs = [
     glfw

--- a/pkgs/by-name/cy/cyber/package.nix
+++ b/pkgs/by-name/cy/cyber/package.nix
@@ -2,22 +2,22 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  zig_0_11,
+  zig_0_12,
 }:
 
 stdenv.mkDerivation rec {
   pname = "cyber";
-  version = "unstable-2023-09-19";
+  version = "0-unstable-2025-12-10";
 
   src = fetchFromGitHub {
     owner = "fubark";
     repo = "cyber";
-    rev = "f95cd189cf090d26542a87b1d2ced461e75fa1a7";
-    hash = "sha256-ctEd8doXMKq3L9/T+jOcWqlBQN0pVhsu9DjBXsg/u/4=";
+    rev = "2a2298d6aa12f9136b18cd85965f4a58e484f506";
+    hash = "sha256-d81z+wUIQ/KUVa+GyXbT+E8dsG8Mdt1hZW1Qe1mmAiw=";
   };
 
   nativeBuildInputs = [
-    zig_0_11.hook
+    zig_0_12.hook
   ];
 
   zigBuildFlags = [
@@ -34,7 +34,7 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/fubark/cyber";
     license = licenses.mit;
     maintainers = with maintainers; [ figsoda ];
-    inherit (zig_0_11.meta) platforms;
+    inherit (zig_0_12.meta) platforms;
     broken = stdenv.hostPlatform.isDarwin;
   };
 }

--- a/pkgs/by-name/dt/dt/package.nix
+++ b/pkgs/by-name/dt/dt/package.nix
@@ -3,21 +3,21 @@
   stdenv,
   fetchFromGitHub,
   testers,
-  zig_0_11,
+  zig_0_12,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "dt";
-  version = "1.3.1";
+  version = "1.3.1-unstable-2024-07-16";
 
   src = fetchFromGitHub {
     owner = "so-dang-cool";
     repo = "dt";
-    rev = "v${finalAttrs.version}";
-    hash = "sha256-qHfvHf4T0wWnzqp5FfLg7n7te24xc2aMEdTK3Iia8Q0=";
+    rev = "0d16ca2867131e99a93a412231465cf68f2e594f";
+    hash = "sha256-pfTlOMJpOPbXZaJJvOKDUyCZxFHNLRRUteJFWT9IKOU=";
   };
 
-  nativeBuildInputs = [ zig_0_11.hook ];
+  nativeBuildInputs = [ zig_0_12.hook ];
 
   passthru.tests.version = testers.testVersion { package = finalAttrs.finalPackage; };
 
@@ -37,7 +37,8 @@ stdenv.mkDerivation (finalAttrs: {
       In short, dt is intended to be generally useful, with zero pretense of
       elegance.
     '';
-    changelog = "https://github.com/so-dang-cool/dt/releases/tag/v${finalAttrs.version}";
+    # TODO: uncomment when dt pushes a new release
+    # changelog = "https://github.com/so-dang-cool/dt/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [ booniepepper ];
     platforms = lib.platforms.unix;

--- a/pkgs/by-name/fi/findup/package.nix
+++ b/pkgs/by-name/fi/findup/package.nix
@@ -3,11 +3,8 @@
   stdenv,
   fetchFromGitHub,
   testers,
-  zig_0_11,
+  zig,
 }:
-let
-  zig = zig_0_11;
-in
 stdenv.mkDerivation (finalAttrs: {
   pname = "findup";
   version = "1.1.2";
@@ -24,6 +21,8 @@ stdenv.mkDerivation (finalAttrs: {
   passthru.tests.version = testers.testVersion { package = finalAttrs.finalPackage; };
 
   meta = {
+    # Doesn't support zig 0.12 or newer, last commit was 2 years ago.
+    broken = lib.versionAtLeast zig.version "0.12";
     homepage = "https://github.com/booniepepper/findup";
     description = "Search parent directories for sentinel files";
     license = lib.licenses.mit;

--- a/pkgs/by-name/zo/zon2nix/package.nix
+++ b/pkgs/by-name/zo/zon2nix/package.nix
@@ -2,23 +2,23 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  zig_0_11,
+  zig_0_14,
   nix,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "zon2nix";
-  version = "0.1.2";
+  version = "0.1.3-unstable-2025-03-20";
 
   src = fetchFromGitHub {
     owner = "nix-community";
     repo = "zon2nix";
-    rev = "v${version}";
-    hash = "sha256-pS0D+wdebtpNaGpDee9aBwEKTDvNU56VXer9uzULXcM=";
+    rev = "2360e358c2107860dadd340f88b25d260b538188";
+    hash = "sha256-89hYzrzQokQ+HUOd3g4epP9jdajaIoaMG81SrCNCqqU=";
   };
 
   nativeBuildInputs = [
-    zig_0_11.hook
+    zig_0_14.hook
   ];
 
   zigBuildFlags = [
@@ -29,13 +29,16 @@ stdenv.mkDerivation rec {
     "-Dnix=${lib.getExe nix}"
   ];
 
-  meta = with lib; {
+  meta = {
     description = "Convert the dependencies in `build.zig.zon` to a Nix expression";
     mainProgram = "zon2nix";
     homepage = "https://github.com/nix-community/zon2nix";
-    changelog = "https://github.com/nix-community/zon2nix/blob/${src.rev}/CHANGELOG.md";
-    license = licenses.mpl20;
-    maintainers = with maintainers; [ figsoda ];
-    inherit (zig_0_11.meta) platforms;
+    changelog = "https://github.com/nix-community/zon2nix/blob/${finalAttrs.src.rev}/CHANGELOG.md";
+    license = lib.licenses.mpl20;
+    maintainers = with lib.maintainers; [
+      figsoda
+      RossComputerGuy
+    ];
+    inherit (zig_0_14.meta) platforms;
   };
-}
+})

--- a/pkgs/development/compilers/zig/default.nix
+++ b/pkgs/development/compilers/zig/default.nix
@@ -9,10 +9,6 @@
 }:
 let
   versions = {
-    "0.11.0" = {
-      llvmPackages = llvmPackages_16;
-      hash = "sha256-iuU1fzkbJxI+0N1PiLQM013Pd1bzrgqkbIyTxo5gB2I=";
-    };
     "0.12.1" = {
       llvmPackages = llvmPackages_17;
       hash = "sha256-C56jyVf16Co/XCloMLSRsbG9r/gBc8mzCdeEMHV2T2s=";

--- a/pkgs/development/compilers/zig/generic.nix
+++ b/pkgs/development/compilers/zig/generic.nix
@@ -7,6 +7,7 @@
   xcbuild,
   targetPackages,
   libxml2,
+  ninja,
   zlib,
   coreutils,
   callPackage,
@@ -35,6 +36,7 @@ stdenv.mkDerivation (finalAttrs: {
     [
       cmake
       (lib.getDev llvmPackages.llvm.dev)
+      ninja
     ]
     ++ lib.optionals stdenv.hostPlatform.isDarwin [
       # provides xcode-select, which is required for SDK detection

--- a/pkgs/development/compilers/zig/generic.nix
+++ b/pkgs/development/compilers/zig/generic.nix
@@ -175,8 +175,6 @@ stdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ andrewrk ] ++ lib.teams.zig.members;
     mainProgram = "zig";
-    # docgen fails to build
-    broken = version == "0.11.0";
     platforms = lib.platforms.unix;
   };
 })

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -1895,6 +1895,7 @@ mapAliases {
   zfs_2_1 = throw "zfs 2.1 has been removed as it is EOL. Please upgrade to a newer version"; # Added 2024-12-25
   zig_0_9 = throw "zig 0.9 has been removed, upgrade to a newer version instead"; # Added 2025-01-24
   zig_0_10 = throw "zig 0.10 has been removed, upgrade to a newer version instead"; # Added 2025-01-24
+  zig_0_11 = throw "zig 0.11 has been removed, upgrade to a newer version instead"; # Added 2025-04-09
   zimlib = throw "'zimlib' has been removed because it was an outdated and unused version of 'libzim'"; # Added 2025-03-07
   zinc = zincsearch; # Added 2023-05-28
   zk-shell = throw "zk-shell has been removed as it was broken and unmaintained"; # Added 2024-08-10

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11541,13 +11541,11 @@ with pkgs;
     (rec {
       zigPackages = recurseIntoAttrs (callPackage ../development/compilers/zig { });
 
-      zig_0_11 = zigPackages."0.11";
       zig_0_12 = zigPackages."0.12";
       zig_0_13 = zigPackages."0.13";
       zig_0_14 = zigPackages."0.14";
     })
     zigPackages
-    zig_0_11
     zig_0_12
     zig_0_13
     zig_0_14

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9026,10 +9026,6 @@ with pkgs;
 
   aws-spend-summary = haskellPackages.aws-spend-summary.bin;
 
-  backlight-auto = callPackage ../by-name/ba/backlight-auto/package.nix {
-    zig = buildPackages.zig_0_11;
-  };
-
   inherit (callPackages ../development/libraries/bashup-events { }) bashup-events32 bashup-events44;
 
   bc-soci = callPackage ../development/libraries/soci/bc-soci.nix { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Uses ninja instead of make for a more optimal build experience. Drops Zig 0.11 as it's ancient by now and broken. Bumps anything we can off Zig 0.11 or mark it as broken. Some of these packages haven't been updated upstream in years.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
