### PR TITLE
resticprofile: 0.29.1 -> 0.30.1

### DIFF
--- a/pkgs/by-name/re/resticprofile/package.nix
+++ b/pkgs/by-name/re/resticprofile/package.nix
@@ -1,6 +1,6 @@
 {
   lib,
-  buildGo123Module,
+  buildGoModule,
   fetchFromGitHub,
   installShellFiles,
   restic,
@@ -9,15 +9,15 @@
   resticprofile,
 }:
 
-buildGo123Module rec {
+buildGoModule rec {
   pname = "resticprofile";
-  version = "0.29.1";
+  version = "0.30.1";
 
   src = fetchFromGitHub {
     owner = "creativeprojects";
     repo = "resticprofile";
     tag = "v${version}";
-    hash = "sha256-6s58rI+YMu6sCV8UsG9GOdF46Br3cMWIUqciVd2d4dY=";
+    hash = "sha256-Pg7rqllNRc/pN5VSgy7KiHQ7V7xOxiGM5fk5Y6+OBjw=";
   };
 
   postPatch = ''
@@ -32,7 +32,7 @@ buildGo123Module rec {
 
   '';
 
-  vendorHash = "sha256-N39zPGos5EYRXGylsHFSjJ4EcQ9jahBOGV8xn7fF7gc=";
+  vendorHash = "sha256-M9S6F/Csz7HnOq8PSWjpENKm1704kVx9zDts1ieraTE=";
 
   ldflags = [
     "-X main.version=${version}"
@@ -44,14 +44,16 @@ buildGo123Module rec {
   nativeBuildInputs = [ installShellFiles ];
 
   preCheck = ''
-    rm battery_test.go # tries to get battery data
-    rm update_test.go # tries to use network
+    rm batt/battery_test.go # tries to get battery data
+    rm commands_test.go # tries to use systemctl
+    rm config/path_test.go # expects normal environment
     rm lock/lock_test.go # needs ping
     rm preventsleep/caffeinate_test.go # tries to communicate with dbus
     rm priority/ioprio_test.go # tries to set nice(2) IO priority
     rm restic/downloader_test.go # tries to use network
-    rm schedule/schedule_test.go # tries to use systemctl
-    rm config/path_test.go # expects normal environment
+    rm schedule/*_test.go # tries to use systemctl
+    rm update_test.go # tries to use network
+    rm user/user_test.go # expects normal environment
     rm util/tempdir_test.go # expects normal environment
   '';
 


### PR DESCRIPTION
https://github.com/creativeprojects/resticprofile/releases/tag/v0.30.0

There are apparently some breaking changes.

CC: @bbigras @jloh for testing (if you have the time)

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
