### PR TITLE
git: update documentation patch

### DIFF
--- a/pkgs/applications/version-management/git/git-send-email-honor-PATH.patch
+++ b/pkgs/applications/version-management/git/git-send-email-honor-PATH.patch
@@ -1,8 +1,17 @@
-diff --git a/Documentation/git-send-email.txt b/Documentation/git-send-email.txt
-index 3db4eab4ba..39bc0e77c9 100644
+diff --git a/Documentation/git-send-email.adoc b/Documentation/git-send-email.adoc
+index 7f223db42d..7e46a07d31 100644
 --- a/Documentation/git-send-email.adoc
 +++ b/Documentation/git-send-email.adoc
-@@ -220,9 +220,9 @@ a password is obtained using 'git-credential'.
+@@ -177,7 +177,7 @@ Sending
+ 	The command will be executed in the shell if necessary.  Default
+ 	is the value of `sendemail.sendmailCmd`.  If unspecified, and if
+ 	--smtp-server is also unspecified, git-send-email will search
+-	for `sendmail` in `/usr/sbin`, `/usr/lib` and $PATH.
++	for `sendmail` in $PATH.
+ 
+ --smtp-encryption=<encryption>::
+ 	Specify in what way encrypting begins for the SMTP connection.
+@@ -233,9 +233,9 @@ a password is obtained using 'git-credential'.
  --smtp-server=<host>::
  	If set, specifies the outgoing SMTP server to use (e.g.
  	`smtp.example.com` or a raw IP address).  If unspecified, and if
@@ -16,10 +25,10 @@ index 3db4eab4ba..39bc0e77c9 100644
  For backward compatibility, this option can also specify a full pathname
  of a sendmail-like program instead; the program must support the `-i`
 diff --git a/git-send-email.perl b/git-send-email.perl
-index e65d969d0b..508d49483d 100755
+index 798d59b84f..69c9cc2a7d 100755
 --- a/git-send-email.perl
 +++ b/git-send-email.perl
-@@ -1066,8 +1066,7 @@ sub expand_one_alias {
+@@ -1091,8 +1091,7 @@ sub expand_one_alias {
  }
  
  if (!defined $sendmail_cmd && !defined $smtp_server) {


### PR DESCRIPTION
The patch was missing another option in `git-send-email` that needs updating. This PR adds that and regenerates the patch from the Git 2.49.0 source.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
