### PR TITLE
makeBinaryWrapper: --add-flags arguments now properly escaped

### DIFF
--- a/pkgs/test/make-binary-wrapper/add-flags/add-flags.c
+++ b/pkgs/test/make-binary-wrapper/add-flags/add-flags.c
@@ -3,7 +3,7 @@
 #include <assert.h>
 
 int main(int argc, char **argv) {
-    char **argv_tmp = calloc(6 + argc + 2 + 1, sizeof(*argv_tmp));
+    char **argv_tmp = calloc(27 + argc + 2 + 1, sizeof(*argv_tmp));
     assert(argv_tmp != NULL);
     argv_tmp[0] = argv[0];
     argv_tmp[1] = "-x";
@@ -12,12 +12,33 @@ int main(int argc, char **argv) {
     argv_tmp[4] = "-abc";
     argv_tmp[5] = "-g";
     argv_tmp[6] = "*.txt";
+    argv_tmp[7] = "some word";
+    argv_tmp[8] = "some word";
+    argv_tmp[9] = "-g";
+    argv_tmp[10] = "*.txt *.lua $HOME";
+    argv_tmp[11] = "$HOME";
+    argv_tmp[12] = "--cmd";
+    argv_tmp[13] = "lua testvar = true";
+    argv_tmp[14] = "--cmd";
+    argv_tmp[15] = "lua print(true)";
+    argv_tmp[16] = "--cmd";
+    argv_tmp[17] = "lua print(\"hello\")";
+    argv_tmp[18] = "--cmd";
+    argv_tmp[19] = "lua print('hello')";
+    argv_tmp[20] = "--cmd";
+    argv_tmp[21] = "lua print('$HOME')";
+    argv_tmp[22] = "-g";
+    argv_tmp[23] = "*.txt\n    *.lua $HOME";
+    argv_tmp[24] = "$HOME";
+    argv_tmp[25] = "$word";
+    argv_tmp[26] = "$word";
+    argv_tmp[27] = "\\$word";
     for (int i = 1; i < argc; ++i) {
-        argv_tmp[6 + i] = argv[i];
+        argv_tmp[27 + i] = argv[i];
     }
-    argv_tmp[6 + argc + 0] = "-foo";
-    argv_tmp[6 + argc + 1] = "-bar";
-    argv_tmp[6 + argc + 2] = NULL;
+    argv_tmp[27 + argc + 0] = "-foo";
+    argv_tmp[27 + argc + 1] = "-bar";
+    argv_tmp[27 + argc + 2] = NULL;
     argv = argv_tmp;
 
     argv[0] = "/send/me/flags";

--- a/pkgs/test/make-binary-wrapper/add-flags/add-flags.cmdline
+++ b/pkgs/test/make-binary-wrapper/add-flags/add-flags.cmdline
@@ -1,4 +1,18 @@
     --append-flags "-foo -bar" \
     --add-flags "-x -y -z" \
     --add-flags -abc \
-    --add-flags "-g *.txt"
+    --add-flags "-g *.txt" \
+    --add-flags 'some\ word' \
+    --add-flags some\\\ word \
+    --add-flags '-g "*.txt *.lua $HOME"
+    \$HOME' \
+    --add-flags "--cmd 'lua testvar = true'" \
+    --add-flags "--cmd 'lua print(true)'" \
+    --add-flags "--cmd 'lua print(\"hello\")'" \
+    --add-flags '--cmd "lua print('\''hello'\'')"' \
+    --add-flags '--cmd "lua print('\''$HOME'\'')"' \
+    --add-flags '-g "*.txt
+    *.lua $HOME"
+    $HOME' \
+    --add-flags '\$word "\$word"' \
+    --add-flags ''\''\$word'\'''

--- a/pkgs/test/make-binary-wrapper/add-flags/add-flags.env
+++ b/pkgs/test/make-binary-wrapper/add-flags/add-flags.env
@@ -6,5 +6,27 @@ SUBST_ARGV0
 -abc
 -g
 *.txt
+some word
+some word
+-g
+*.txt *.lua $HOME
+$HOME
+--cmd
+lua testvar = true
+--cmd
+lua print(true)
+--cmd
+lua print("hello")
+--cmd
+lua print('hello')
+--cmd
+lua print('$HOME')
+-g
+*.txt
+    *.lua $HOME
+$HOME
+$word
+$word
+\$word
 -foo
 -bar


### PR DESCRIPTION
arguments passed to --add-flags were ALWAYS split by spaces regardless of how you passed them. This PR also applies to --append-flags as well

This splits them correctly as if they were shell arguments.

Addresses https://github.com/NixOS/nixpkgs/issues/330471

--add-flags is useless for makeBinaryWrapper for a ton of programs because of the inability to accept arguments with spaces regardless of escaping.

I also hope to introduce a --run in a future PR (Edit: although, unsure if I will be able to in a way that makes sense to add) such that makeBinaryWrapper becomes truly a drop in replacement for makeWrapper, but for now, this should be fixed.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
