### PR TITLE
nixos/nix-store-veritysetup: init

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2511.section.md
+++ b/nixos/doc/manual/release-notes/rl-2511.section.md
@@ -34,6 +34,8 @@
 
 - [Szurubooru](https://github.com/rr-/szurubooru), an image board engine inspired by services such as Danbooru, dedicated for small and medium communities. Available as [services.szurubooru](#opt-services.szurubooru.enable).
 
+- [nix-store-veritysetup](https://github.com/nikstur/nix-store-veritysetup-generator), a systemd generator to unlock the Nix Store as a dm-verity protected block device. Available as [boot.initrd.nix-store-veritysetup](options.html#opt-boot.initrd.nix-store-veritysetup.enable).
+
 - [SuiteNumérique Docs](https://github.com/suitenumerique/docs), a collaborative note taking, wiki and documentation web platform and alternative to Notion or Outline. Available as [services.lasuite-docs](#opt-services.lasuite-docs.enable).
 
 [dwl](https://codeberg.org/dwl/dwl), a compact, hackable compositor for Wayland based on wlroots. Available as [programs.dwl](#opt-programs.dwl.enable).

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1786,6 +1786,7 @@
   ./system/boot/luksroot.nix
   ./system/boot/modprobe.nix
   ./system/boot/networkd.nix
+  ./system/boot/nix-store-veritysetup.nix
   ./system/boot/plymouth.nix
   ./system/boot/resolved.nix
   ./system/boot/shutdown.nix

--- a/nixos/modules/system/boot/nix-store-veritysetup.nix
+++ b/nixos/modules/system/boot/nix-store-veritysetup.nix
@@ -1,0 +1,38 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.boot.initrd.nix-store-veritysetup;
+in
+{
+  meta.maintainers = with lib.maintainers; [ nikstur ];
+
+  options.boot.initrd.nix-store-veritysetup = {
+    enable = lib.mkEnableOption "nix-store-veritysetup";
+  };
+
+  config = lib.mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = config.boot.initrd.systemd.dmVerity.enable;
+        message = "nix-store-veritysetup requires dm-verity in the systemd initrd.";
+      }
+    ];
+
+    boot.initrd.systemd = {
+      contents = {
+        "/etc/systemd/system-generators/nix-store-veritysetup-generator".source =
+          "${lib.getExe pkgs.nix-store-veritysetup-generator}";
+      };
+
+      storePaths = [
+        "${config.boot.initrd.systemd.package}/bin/systemd-escape"
+      ];
+    };
+
+  };
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -938,6 +938,7 @@ in
   nix-required-mounts = runTest ./nix-required-mounts;
   nix-serve = runTest ./nix-serve.nix;
   nix-serve-ssh = runTest ./nix-serve-ssh.nix;
+  nix-store-veritysetup = runTest ./nix-store-veritysetup.nix;
   nixops = handleTest ./nixops/default.nix { };
   nixos-generate-config = runTest ./nixos-generate-config.nix;
   nixos-rebuild-install-bootloader = handleTestOn [

--- a/nixos/tests/nix-store-veritysetup.nix
+++ b/nixos/tests/nix-store-veritysetup.nix
@@ -1,0 +1,108 @@
+{ lib, ... }:
+{
+
+  name = "nix-store-veritysetup";
+
+  meta.maintainers = with lib.maintainers; [ nikstur ];
+
+  nodes.machine =
+    { config, modulesPath, ... }:
+    {
+
+      imports = [
+        "${modulesPath}/image/repart.nix"
+      ];
+
+      image.repart = {
+        name = "nix-store";
+        partitions = {
+          "nix-store" = {
+            storePaths = [ config.system.build.toplevel ];
+            stripNixStorePrefix = true;
+            repartConfig = {
+              Type = "linux-generic";
+              Label = "nix-store";
+              Format = "erofs";
+              Minimize = "best";
+              Verity = "data";
+              VerityMatchKey = "nix-store";
+            };
+          };
+          "nix-store-verity" = {
+            repartConfig = {
+              Type = "linux-generic";
+              Label = "nix-store-verity";
+              Verity = "hash";
+              VerityMatchKey = "nix-store";
+              Minimize = "best";
+            };
+          };
+        };
+      };
+
+      boot.initrd = {
+        systemd = {
+          enable = true;
+          dmVerity.enable = true;
+        };
+        nix-store-veritysetup.enable = true;
+      };
+
+      virtualisation = {
+        mountHostNixStore = false;
+        qemu.drives = [
+          {
+            name = "nix-store";
+            file = ''"$NIX_STORE"'';
+          }
+        ];
+        fileSystems = {
+          "/nix/store" = {
+            fsType = "erofs";
+            device = "/dev/mapper/nix-store";
+          };
+        };
+      };
+
+    };
+
+  testScript =
+    { nodes, ... }:
+    ''
+      import os
+      import json
+      import subprocess
+      import tempfile
+
+      with open("${nodes.machine.system.build.image}/repart-output.json") as f:
+        data = json.load(f)
+
+      storehash = data[0]["roothash"]
+
+      os.environ["QEMU_KERNEL_PARAMS"] = f"storehash={storehash}"
+
+      tmp_disk_image = tempfile.NamedTemporaryFile()
+
+      subprocess.run([
+        "${nodes.machine.virtualisation.qemu.package}/bin/qemu-img",
+        "create",
+        "-f",
+        "qcow2",
+        "-b",
+        "${nodes.machine.system.build.image}/${nodes.machine.image.repart.imageFile}",
+        "-F",
+        "raw",
+        tmp_disk_image.name,
+      ])
+
+      os.environ["NIX_STORE"] = tmp_disk_image.name
+
+      machine.start()
+
+      print(machine.succeed("findmnt"))
+      print(machine.succeed("dmsetup info nix-store"))
+
+      machine.wait_for_unit("multi-user.target")
+    '';
+
+}

--- a/pkgs/by-name/ni/nix-store-veritysetup-generator/package.nix
+++ b/pkgs/by-name/ni/nix-store-veritysetup-generator/package.nix
@@ -40,5 +40,6 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/nikstur/nix-store-veritysetup-generator";
     license = licenses.mit;
     maintainers = with lib.maintainers; [ nikstur ];
+    mainProgram = "nix-store-veritysetup-generator";
   };
 }


### PR DESCRIPTION
Adds a module for [nix-store-veritysetup-generator](https://github.com/nikstur/nix-store-veritysetup-generator). This makes it possible to use the generator without another dependency. Everything is available in Nixpkgs now!

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
