### PR TITLE
openssh: 9.9p2 -> 10.0p2

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2505.section.md
+++ b/nixos/doc/manual/release-notes/rl-2505.section.md
@@ -22,6 +22,8 @@
   - the global Mesa version can now be managed without a mass rebuild by setting `hardware.graphics.package`
   - packages that used to depend on Mesa for libgbm or libdri should use `libgbm` or `dri-pkgconfig-stub` as inputs, respectively
 
+- OpenSSH has been updated from 9.9p2 to 10.0p2, dropping support for DSA keys and adding a new `ssh-auth` binary to handle user authentication in a different address space from unauthenticated sessions. Additionally, we now enable a configure option by default that attempts to lock sshd into RAM to prevent it from being swapped out, which may improve performance if the system is under memory pressure. See the [full changelog](https://www.openwall.com/lists/oss-security/2025/04/09/1) for more details.
+
 - The `intel` video driver for X.org (from the xf86-video-intel package) which was previously removed because it was non-functional has been fixed and the driver has been re-introduced.
 
 - The Mattermost module ({option}`services.mattermost`) and packages (`mattermost` and `mmctl`) have been substantially updated:

--- a/pkgs/by-name/pa/pam_rssh/package.nix
+++ b/pkgs/by-name/pa/pam_rssh/package.nix
@@ -40,9 +40,11 @@ rustPlatform.buildRustPackage rec {
   checkFlags = [
     # Fails because it tries finding authorized_keys in /home/$USER.
     "--skip=tests::parse_user_authorized_keys"
+    # Skip unsupported DSA keys since OpenSSH v10.
+    "--skip=sign_verify::test_dsa_sign_verify"
   ];
 
-  nativeCheckInputs = [ (openssh.override { dsaKeysSupport = true; }) ];
+  nativeCheckInputs = [ openssh ];
 
   env.USER = "nixbld";
 
@@ -55,7 +57,6 @@ rustPlatform.buildRustPackage rec {
     ssh-keygen -q -N "" -t ecdsa -b 256 -f $HOME/.ssh/id_ecdsa256
     ssh-keygen -q -N "" -t ed25519 -f $HOME/.ssh/id_ed25519
     ssh-keygen -q -N "" -t rsa -f $HOME/.ssh/id_rsa
-    ssh-keygen -q -N "" -t dsa -f $HOME/.ssh/id_dsa
     export SSH_AUTH_SOCK=$HOME/ssh-agent.sock
     eval $(ssh-agent -a $SSH_AUTH_SOCK)
     ssh-add $HOME/.ssh/id_ecdsa521
@@ -63,7 +64,6 @@ rustPlatform.buildRustPackage rec {
     ssh-add $HOME/.ssh/id_ecdsa256
     ssh-add $HOME/.ssh/id_ed25519
     ssh-add $HOME/.ssh/id_rsa
-    ssh-add $HOME/.ssh/id_dsa
   '';
 
   meta = with lib; {

--- a/pkgs/tools/networking/openssh/common.nix
+++ b/pkgs/tools/networking/openssh/common.nix
@@ -38,7 +38,6 @@
   withPAM ? stdenv.hostPlatform.isLinux,
   # Attempts to mlock the entire sshd process on startup to prevent swapping.
   withLinuxMemlock ? stdenv.hostPlatform.isLinux,
-  dsaKeysSupport ? false,
   linkOpenssl ? true,
   isNixos ? stdenv.hostPlatform.isLinux,
 }:
@@ -108,7 +107,6 @@ stdenv.mkDerivation (finalAttrs: {
       "--with-libedit=yes"
       "--disable-strip"
       (lib.withFeature withPAM "pam")
-      (lib.enableFeature dsaKeysSupport "dsa-keys")
     ]
     ++ lib.optional (etcDir != null) "--sysconfdir=${etcDir}"
     ++ lib.optional (!withSecurityKey) "--disable-security-key"

--- a/pkgs/tools/networking/openssh/common.nix
+++ b/pkgs/tools/networking/openssh/common.nix
@@ -36,6 +36,8 @@
   withSecurityKey ? !stdenv.hostPlatform.isStatic,
   withFIDO ? stdenv.hostPlatform.isUnix && !stdenv.hostPlatform.isMusl && withSecurityKey,
   withPAM ? stdenv.hostPlatform.isLinux,
+  # Attempts to mlock the entire sshd process on startup to prevent swapping.
+  withLinuxMemlock ? stdenv.hostPlatform.isLinux,
   dsaKeysSupport ? false,
   linkOpenssl ? true,
   isNixos ? stdenv.hostPlatform.isLinux,
@@ -119,6 +121,7 @@ stdenv.mkDerivation (finalAttrs: {
     ++ lib.optional (!linkOpenssl) "--without-openssl"
     ++ lib.optional withLdns "--with-ldns"
     ++ lib.optional stdenv.hostPlatform.isOpenBSD "--with-bsd-auth"
+    ++ lib.optional withLinuxMemlock "--with-linux-memlock-onfault"
     ++ extraConfigureFlags;
 
   ${if stdenv.hostPlatform.isStatic then "NIX_LDFLAGS" else null} =

--- a/pkgs/tools/networking/openssh/common.nix
+++ b/pkgs/tools/networking/openssh/common.nix
@@ -202,6 +202,13 @@ stdenv.mkDerivation (finalAttrs: {
     "sysconfdir=\${out}/etc/ssh"
   ];
 
+  doInstallCheck = true;
+  installCheckPhase = ''
+    for binary in ssh sshd; do
+      $out/bin/$binary -V 2>&1 | grep -P "$(printf '^OpenSSH_\\Q%s\\E,' "$version")"
+    done
+  '';
+
   passthru = {
     inherit withKerberos;
     tests = {

--- a/pkgs/tools/networking/openssh/default.nix
+++ b/pkgs/tools/networking/openssh/default.nix
@@ -24,17 +24,17 @@ in
 
   openssh_hpn = common rec {
     pname = "openssh-with-hpn";
-    version = "9.9p2";
+    version = "10.0p1";
     extraDesc = " with high performance networking patches";
 
     src = fetchurl {
       url = "mirror://openbsd/OpenSSH/portable/openssh-${version}.tar.gz";
-      hash = "sha256-karbYD4IzChe3fll4RmdAlhfqU2ZTWyuW0Hhch4hVnM=";
+      hash = "sha256-AhoucJoO30JQsSVr1anlAEEakN3avqgw7VnO+Q652Fw=";
     };
 
     extraPatches =
       let
-        url = "https://raw.githubusercontent.com/freebsd/freebsd-ports/7ba88c964b6e5724eec462021d984da3989e6a08/security/openssh-portable/files/extra-patch-hpn";
+        url = "https://raw.githubusercontent.com/freebsd/freebsd-ports/dde9561b3ff73639aeebe8ec33ad52ecca0bf58d/security/openssh-portable/files/extra-patch-hpn";
       in
       [
         ./ssh-keysign-8.5.patch
@@ -45,7 +45,7 @@ in
           inherit url;
           stripLen = 1;
           excludes = [ "channels.c" ];
-          hash = "sha256-zk7t6FNzTE+8aDU4QuteR1x0W3O2gjIQmeCkTNbaUfA=";
+          hash = "sha256-0HQAacNdvqX+7CTDhkbgAyb0WbqnnH6iAYQBFh8XenA=";
         })
 
         (fetchpatch {

--- a/pkgs/tools/networking/openssh/default.nix
+++ b/pkgs/tools/networking/openssh/default.nix
@@ -11,11 +11,11 @@ in
 {
   openssh = common rec {
     pname = "openssh";
-    version = "9.9p2";
+    version = "10.0p1";
 
     src = fetchurl {
       url = "mirror://openbsd/OpenSSH/portable/openssh-${version}.tar.gz";
-      hash = "sha256-karbYD4IzChe3fll4RmdAlhfqU2ZTWyuW0Hhch4hVnM=";
+      hash = "sha256-AhoucJoO30JQsSVr1anlAEEakN3avqgw7VnO+Q652Fw=";
     };
 
     extraPatches = [ ./ssh-keysign-8.5.patch ];

--- a/pkgs/tools/networking/openssh/default.nix
+++ b/pkgs/tools/networking/openssh/default.nix
@@ -7,14 +7,28 @@
 }:
 let
   common = opts: callPackage (import ./common.nix opts) { };
+
+  # Gets the correct OpenSSH URL for a given version.
+  urlFor =
+    version:
+    let
+      urlVersion =
+        {
+          # 10.0p1 was accidentally released as 10.0p2:
+          # https://www.openwall.com/lists/oss-security/2025/04/09/6
+          "10.0p2" = "10.0p1";
+        }
+        .${version} or version;
+    in
+    "mirror://openbsd/OpenSSH/portable/openssh-${urlVersion}.tar.gz";
 in
 {
   openssh = common rec {
     pname = "openssh";
-    version = "10.0p1";
+    version = "10.0p2";
 
     src = fetchurl {
-      url = "mirror://openbsd/OpenSSH/portable/openssh-${version}.tar.gz";
+      url = urlFor version;
       hash = "sha256-AhoucJoO30JQsSVr1anlAEEakN3avqgw7VnO+Q652Fw=";
     };
 
@@ -24,11 +38,11 @@ in
 
   openssh_hpn = common rec {
     pname = "openssh-with-hpn";
-    version = "10.0p1";
+    version = "10.0p2";
     extraDesc = " with high performance networking patches";
 
     src = fetchurl {
-      url = "mirror://openbsd/OpenSSH/portable/openssh-${version}.tar.gz";
+      url = urlFor version;
       hash = "sha256-AhoucJoO30JQsSVr1anlAEEakN3avqgw7VnO+Q652Fw=";
     };
 
@@ -67,11 +81,11 @@ in
 
   openssh_gssapi = common rec {
     pname = "openssh-with-gssapi";
-    version = "10.0p1";
+    version = "10.0p2";
     extraDesc = " with GSSAPI support";
 
     src = fetchurl {
-      url = "mirror://openbsd/OpenSSH/portable/openssh-${version}.tar.gz";
+      url = urlFor version;
       hash = "sha256-AhoucJoO30JQsSVr1anlAEEakN3avqgw7VnO+Q652Fw=";
     };
 

--- a/pkgs/tools/networking/openssh/default.nix
+++ b/pkgs/tools/networking/openssh/default.nix
@@ -67,12 +67,12 @@ in
 
   openssh_gssapi = common rec {
     pname = "openssh-with-gssapi";
-    version = "9.9p2";
+    version = "10.0p1";
     extraDesc = " with GSSAPI support";
 
     src = fetchurl {
       url = "mirror://openbsd/OpenSSH/portable/openssh-${version}.tar.gz";
-      hash = "sha256-karbYD4IzChe3fll4RmdAlhfqU2ZTWyuW0Hhch4hVnM=";
+      hash = "sha256-AhoucJoO30JQsSVr1anlAEEakN3avqgw7VnO+Q652Fw=";
     };
 
     extraPatches = [
@@ -81,7 +81,7 @@ in
       (fetchpatch {
         name = "openssh-gssapi.patch";
         url = "https://salsa.debian.org/ssh-team/openssh/raw/debian/1%25${version}-1/debian/patches/gssapi.patch";
-        hash = "sha256-JyOXA8Al8IFLdndJQ1LO+r4hJqtXjz1NHwOPiSAQkE8=";
+        hash = "sha256-7Q27tvtCY3b9evC3lbqEz4u7v5DcerjWZfhh8azIAQo=";
       })
     ];
 

--- a/pkgs/tools/networking/openssh/default.nix
+++ b/pkgs/tools/networking/openssh/default.nix
@@ -33,7 +33,12 @@ in
     };
 
     extraPatches = [ ./ssh-keysign-8.5.patch ];
-    extraMeta.maintainers = lib.teams.helsinki-systems.members ++ [ lib.maintainers.philiptaron ];
+    extraMeta.maintainers =
+      lib.teams.helsinki-systems.members
+      ++ (with lib.maintainers; [
+        numinit
+        philiptaron
+      ]);
   };
 
   openssh_hpn = common rec {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

https://www.openwall.com/lists/oss-security/2025/04/09/1

Goodbye, DSA keys! :tada: 

`nix-build -A nixosTests.openssh` works :smile: 

(Notably, I had to disable jemalloc's checkPhase since it's segfaulting right now. ~~Also, the hpn and gssapi patches failed to apply on 10.0, so those are not being updated just yet.)~~

~Draft for now until we decide that it's OK to update one and not the others, or otherwise wait. Undrafting since they are working even though they're on 9.9, since freebsd ports haven't updated.~

cc @philiptaron 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
