### PR TITLE
nix-prefetch-git: add `--name` parameter

### DIFF
--- a/pkgs/build-support/fetchgit/builder.sh
+++ b/pkgs/build-support/fetchgit/builder.sh
@@ -6,7 +6,7 @@
 
 echo "exporting $url (rev $rev) into $out"
 
-$SHELL $fetcher --builder --url "$url" --out "$out" --rev "$rev" \
+$SHELL $fetcher --builder --url "$url" --out "$out" --rev "$rev" --name "$name" \
   ${leaveDotGit:+--leave-dotGit} \
   ${fetchLFS:+--fetch-lfs} \
   ${deepClone:+--deepClone} \

--- a/pkgs/build-support/fetchgit/nix-prefetch-git
+++ b/pkgs/build-support/fetchgit/nix-prefetch-git
@@ -47,6 +47,7 @@ Options:
       --url url       Any url understood by 'git clone'.
       --rev ref       Any sha1 or references (such as refs/heads/master)
       --hash h        Expected hash.
+      --name n        Symbolic store path name to use for the result (default: based on URL)
       --branch-name   Branch name to check out into
       --sparse-checkout Only fetch and checkout part of the repository.
       --non-cone-mode Use non-cone mode for sparse checkouts.
@@ -75,6 +76,7 @@ for arg; do
             --url) argfun=set_url;;
             --rev) argfun=set_rev;;
             --hash) argfun=set_hashType;;
+            --name) argfun=set_symbolicName;;
             --branch-name) argfun=set_branchName;;
             --deepClone) deepClone=true;;
             --sparse-checkout) argfun=set_sparseCheckout;;
@@ -424,6 +426,12 @@ if test -z "$branchName"; then
     branchName=fetchgit
 fi
 
+if [ -v symbolicName ]; then
+    storePathName="$symbolicName"
+else
+    storePathName="$(url_to_name "$url" "$rev")"
+fi
+
 tmpHomePath="$(mktemp -d "${TMPDIR:-/tmp}/nix-prefetch-git-tmp-home-XXXXXXXXXX")"
 exit_handlers+=(remove_tmpHomePath)
 ln -s "${NETRC:-$HOME/.netrc}" "$tmpHomePath/.netrc"
@@ -443,7 +451,7 @@ else
     # If the hash was given, a file with that hash may already be in the
     # store.
     if test -n "$expHash"; then
-        finalPath=$(nix-store --print-fixed-path --recursive "$hashType" "$expHash" "$(url_to_name "$url" "$rev")")
+        finalPath=$(nix-store --print-fixed-path --recursive "$hashType" "$expHash" "$storePathName")
         if ! nix-store --check-validity "$finalPath" 2> /dev/null; then
             finalPath=
         fi
@@ -458,7 +466,7 @@ else
         tmpPath="$(realpath "$(mktemp -d --tmpdir git-checkout-tmp-XXXXXXXX)")"
         exit_handlers+=(remove_tmpPath)
 
-        tmpFile="$tmpPath/$(url_to_name "$url" "$rev")"
+        tmpFile="$tmpPath/$storePathName"
         mkdir -p "$tmpFile"
 
         # Perform the checkout.


### PR DESCRIPTION
This allows tools like `npins` to avoid re-downloading pre-fetched sources at evaluation time, by setting the same symbolic store path name as `builtins.fetchGit` does, and would make hacks such as [0] obsolete.

Historical note: `builtins.fetchGit` was introduced in 2016 [1] and released in 2018 [2]. Before that, there was only the Nixpkgs `fetchgit`, and the convention for using constant store path names [3] was not established yet [4].

While arguably in retrospect store path names were a mistake, we cannot undo it here even partially by setting them to a constant, as it would invalidate countless fixed-output derivations and thus incur an increase in resource consumption and potentially a large number of build failures.

[0]: https://github.com/andir/npins/commit/f0449d090cd4cbf17849d29821a53ead9a88c42a
[1]: https://github.com/nixos/nix/commit/38539b943a060d9cdfc24d6e5d997c0885b8aa2f
[2]: https://github.com/NixOS/nix/releases/tag/2.0
[3]: https://github.com/NixOS/nix.dev/blob/db00265e810b3729a1077a0e5f8f4112f49019af/source/guides/best-practices.md#L263-L264
[4]: https://github.com/NixOS/nixpkgs/commit/a8603605aaaf780aa45edd0f16c8c9588455ccf2


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
