### PR TITLE
huion-switcher: init at 0.5.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6469,6 +6469,12 @@
     githubId = 472846;
     name = "Sebastian Krohn";
   };
+  dramforever = {
+    name = "Vivian Wang";
+    email = "dramforever@live.com";
+    github = "dramforever";
+    githubId = 2818072;
+  };
   drawbu = {
     email = "nixpkgs@drawbu.dev";
     github = "drawbu";

--- a/pkgs/by-name/hu/huion-switcher/package.nix
+++ b/pkgs/by-name/hu/huion-switcher/package.nix
@@ -1,0 +1,60 @@
+{
+  lib,
+  nix-update-script,
+  fetchFromGitHub,
+  rustPlatform,
+  udev,
+  pkg-config,
+  installShellFiles,
+  versionCheckHook,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "huion-switcher";
+  version = "0.5.0";
+
+  src = fetchFromGitHub {
+    owner = "whot";
+    repo = "huion-switcher";
+    tag = finalAttrs.version;
+    hash = "sha256-+cMvBVtJPbsJhEmOh3SEXZrVwp9Uuvx6QmUCcpenS20=";
+  };
+
+  buildInputs = [ udev ];
+  nativeBuildInputs = [
+    pkg-config
+    installShellFiles
+  ];
+
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-yj55FMdf91ZG95yuMt3dQFhUjYM0/sUfFKB+W+5xEfo=";
+
+  postInstall = ''
+    mv huion-switcher.{man,1}
+    installManPage huion-switcher.1
+
+    # Install 80-huion-switcher.rules
+
+    # Mind the trailing space! We leave the args to huion-switcher in place
+    substituteInPlace "80-huion-switcher.rules" --replace-fail \
+      "IMPORT{program}=\"huion-switcher " \
+      "IMPORT{program}=\"$out/bin/huion-switcher "
+
+    install -Dm 0644 -t "$out/lib/udev/rules.d" "80-huion-switcher.rules"
+  '';
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Utility to switch Huion devices into raw tablet mode";
+    homepage = "https://github.com/whot/huion-switcher";
+    changelog = "https://github.com/whot/huion-switcher/releases/tag/${finalAttrs.version}";
+    license = lib.licenses.gpl2Only;
+    platforms = lib.platforms.linux;
+    mainProgram = "huion-switcher";
+    maintainers = with lib.maintainers; [ dramforever ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

> A small utility to switch Huion (Vendor ID 0x256C) devices into raw tablet mode.

https://github.com/whot/huion-switcher

Some Huion (and other VID 256c) tablets require some host magic to become fully functional. Some magic is provided by hid-uclogic in the kernel. For those that aren't in hid-uclogic, you can use huion-switcher.

However, without an HID-BPF program, and udev-hid-bpf to load it, Linux cannot understand the raw tablet mode events. See the README on huion-switcher for more details. So this is just for testing for now, until I figure out udev-hid-bpf packaging. For NixOS, to use the udev rules:

```nix
services.udev.packages = [ pkgs.huion-switcher ];
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [X] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
