### PR TITLE
judy: revert Darwin reproducibility fixes

### DIFF
--- a/pkgs/by-name/ju/judy/package.nix
+++ b/pkgs/by-name/ju/judy/package.nix
@@ -23,11 +23,6 @@ stdenv.mkDerivation rec {
     ./fix-source-date.patch
   ];
 
-  # fixes non-determinism between builds on macos
-  preConfigure = lib.optional stdenv.hostPlatform.isDarwin ''
-    export LDFLAGS="$LDFLAGS -Wl,-no_uuid -Wl,-install_name,@rpath/libJudy.1.dylib"
-  '';
-
   # Disable parallel builds as manpages lack some dependencies:
   #    ../tool/jhton ext/JudyHS_funcs_3.htm | grep -v '^[   ]*$' | sed -e 's/\.C//' > man/man3/JudyHS_funcs
   #    make[2]: *** No rule to make target 'man/man3/JSLD', needed by 'all-am'.  Stop.


### PR DESCRIPTION
It was already reproducible: the only reason it seemed not to be was due to a quirk of how `--rebuild` works on macOS. Since the implementation of the Nix sandbox on macOS is unable to change the meaning of paths, when rebuilding a derivation, it can't be done at the same path as the original. Instead, the rebuild occurs with a different output path, and the output is scanned for instances of that path so that they can be replaced with the correct one afterwards (ala ca-derivations).

Unfortunately, macOS's codesigning system seems to include the hash of the signed binary as part of its signature, including any incorrect paths it contains. This results in the binaries still being different after the path replacement step has occured.

The reason to go out of our way to revert this is that the workaround to avoid including the output path in any binaries includes replacing the install name of judy with `@rpath/*` rather than its absolute path, which breaks at least one dependency that doesn't add it to RPATH (gtkwave), and possibly others.

To confirm that it's reproducible:

```
drv=$(nix eval .#judy --apply "pkg: (pkg.overrideAttrs { __REBUILD = true; }).drvPath" --raw)
out=$(nix derivation show "$drv" | jq -r ".[].outputs.out.path")

nix build "$drv^*" --no-link
cp -r "$out" rebuild-1

nix store delete "$out" --option keep-outputs false
nix build "$drv^*" --no-link
cp -r "$out" rebuild-2

diff -r rebuild-1 rebuild-2
```

See also: #394620 #396823

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
