### PR TITLE
mrtrix: 3.0.4 -> 3.0.4-unstable-2025-04-09

### DIFF
--- a/pkgs/applications/science/biology/mrtrix/default.nix
+++ b/pkgs/applications/science/biology/mrtrix/default.nix
@@ -18,28 +18,63 @@
   libXext,
   less,
   withGui ? true,
+  fetchFromGitLab,
+  fetchpatch,
 }:
+
+let
+  # reverts 'eigen: 3.4.0 -> 3.4.0-unstable-2022-05-19'
+  # https://github.com/NixOS/nixpkgs/commit/d298f046edabc84b56bd788e11eaf7ed72f8171c
+  eigen' = (
+    eigen.overrideAttrs (old: rec {
+      version = "3.4.0";
+      src = fetchFromGitLab {
+        owner = "libeigen";
+        repo = "eigen";
+        tag = version;
+        hash = "sha256-1/4xMetKMDOgZgzz3WMxfHUEpmdAm52RqZvz6i0mLEw=";
+      };
+      patches = (old.patches or [ ]) ++ [
+        # Fixes e.g. onnxruntime on aarch64-darwin:
+        # https://hydra.nixos.org/build/248915128/nixlog/1,
+        # originally suggested in https://github.com/NixOS/nixpkgs/pull/258392.
+        #
+        # The patch is from
+        # ["Fix vectorized reductions for Eigen::half"](https://gitlab.com/libeigen/eigen/-/merge_requests/699)
+        # which is two years old,
+        # but Eigen hasn't had a release in two years either:
+        # https://gitlab.com/libeigen/eigen/-/issues/2699.
+        (fetchpatch {
+          url = "https://gitlab.com/libeigen/eigen/-/commit/d0e3791b1a0e2db9edd5f1d1befdb2ac5a40efe0.patch";
+          hash = "sha256-8qiNpuYehnoiGiqy0c3Mcb45pwrmc6W4rzCxoLDSvj0=";
+        })
+      ];
+    })
+  );
+in
 
 stdenv.mkDerivation rec {
   pname = "mrtrix";
-  version = "3.0.4";
+  version = "3.0.4-unstable-2025-04-09";
 
   src = fetchFromGitHub {
     owner = "MRtrix3";
     repo = "mrtrix3";
-    tag = version;
-    hash = "sha256-87zBAoBLWQPccGS37XyQ8H0GhL01k8GQFgcLL6IwbcM=";
+    rev = "7843bfc53a75f465901804ccf3fd6797d77531dd";
+    hash = "sha256-C4Io3VkX10eWia4djrYvN12fWmwm0j1G60I8lmFH49w=";
     fetchSubmodules = true;
   };
 
   nativeBuildInputs = [
-    eigen
     makeWrapper
+    less
+    python
   ] ++ lib.optional withGui qt5.wrapQtAppsHook;
 
   buildInputs =
     [
       ants
+      eigen'
       python
       fftw
       libtiff
@@ -58,36 +93,47 @@ stdenv.mkDerivation rec {
   nativeInstallCheckInputs = [ bc ];
 
   postPatch = ''
-    patchShebangs ./build ./configure ./run_tests ./bin/*
+    patchShebangs --build ./build ./configure ./run_tests
+    patchShebangs --host ./bin/*
 
     # patching interpreters before fixup is needed for tests:
-    patchShebangs ./bin/*
     patchShebangs testing/binaries/data/vectorstats/*py
 
     substituteInPlace ./run_tests  \
-      --replace 'git submodule update --init $datadir >> $LOGFILE 2>&1' ""
+      --replace-fail 'git submodule update --init $datadir >> $LOGFILE 2>&1' ""
 
+    # reduce build noise
+    substituteInPlace ./configure \
+      --replace-fail "[ '-Wall' ]" "[]"
+
+    # fix error output (cuts off after a few lines otherwise)
     substituteInPlace ./build  \
-      --replace '"less -RX "' '"${less}/bin/less -RX "'
+      --replace-fail 'stderr=subprocess.PIPE' 'stderr=None'
   '';
 
   configurePhase = ''
-    export EIGEN_CFLAGS="-isystem ${eigen}/include/eigen3"
+    runHook preConfigure
+    export EIGEN_CFLAGS="-isystem ${eigen'}/include/eigen3"
     unset LD  # similar to https://github.com/MRtrix3/mrtrix3/issues/1519
     ./configure ${lib.optionalString (!withGui) "-nogui"};
+    runHook postConfigure
   '';
 
   buildPhase = ''
+    runHook preBuild
     ./build
     (cd testing && ../build)
+    runHook postBuild
   '';
 
   installCheckPhase = ''
+    runHook preInstallCheck
     ./run_tests units
     ./run_tests binaries
 
     # can also `./run_tests scripts`, but this fails due to lack of FSL package
     # (and there's no convenient way to disable individual tests)
+    runHook postInstallCheck
   '';
   doInstallCheck = true;
 
@@ -99,13 +145,19 @@ stdenv.mkDerivation rec {
     runHook postInstall
   '';
 
-  postInstall = ''
-    for prog in $out/bin/*; do
-      if [[ -x "$prog" ]]; then
-        wrapProgram $prog --prefix PATH : ${lib.makeBinPath [ ants ]}
-      fi
-    done
-  '';
+  preFixup =
+    if withGui then
+      ''
+        qtWrapperArgs+=(--prefix PATH : ${lib.makeBinPath [ ants ]})
+      ''
+    else
+      ''
+        for prog in $out/bin/*; do
+          if [[ -x "$prog" ]]; then
+            wrapProgram $prog --prefix PATH : ${lib.makeBinPath [ ants ]}
+          fi
+        done
+      '';
 
   meta = with lib; {
     broken = (stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isAarch64);


### PR DESCRIPTION
mrtrix plans to release an official release shortly https://github.com/MRtrix3/mrtrix3/issues/1871

In addition to the update do some general cleanup.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).