### PR TITLE
soapysdr: 0.8.1 -> 0.8.1-unstable-2025-03-30

### DIFF
--- a/pkgs/applications/radio/soapysdr/default.nix
+++ b/pkgs/applications/radio/soapysdr/default.nix
@@ -18,7 +18,7 @@
 stdenv.mkDerivation (finalAttrs: {
   pname = "soapysdr";
   # Don't forget to change passthru.abiVersion
-  version = "0.8.1-unstable-2024-12-22";
+  version = "0.8.1-unstable-2025-03-30-03";
 
   src = fetchFromGitHub {
     owner = "pothosware";
@@ -26,8 +26,8 @@ stdenv.mkDerivation (finalAttrs: {
 
     # Instead of applying several patches for Python 3.12 compat, just take the latest, from:
     # use old get python lib for v2 (#437)
-    rev = "309335ec6a52eb712387ed025d705a3c0f7a1e24";
-    hash = "sha256-a9414gX4fUAPQaKKqrWgSlFHZH0BWqbgHzhVCKnIn2M=";
+    rev = "fbf9f3c328868f46029284716df49095ab7b99a6";
+    hash = "sha256-W4915c6hV/GR5PZRRXZJW3ERsZmQQQ08EA9wYp2tAVk=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/so/soapyremote/package.nix
+++ b/pkgs/by-name/so/soapyremote/package.nix
@@ -8,7 +8,7 @@
 }:
 
 let
-  version = "0.5.2";
+  version = "0.5.2-unstable-2024-01-24";
 
 in
 stdenv.mkDerivation {
@@ -18,8 +18,8 @@ stdenv.mkDerivation {
   src = fetchFromGitHub {
     owner = "pothosware";
     repo = "SoapyRemote";
-    rev = "soapy-remote-${version}";
-    sha256 = "124sy9v08fm51ds1yzrxspychn34y0rl6y48mzariianazvzmfax";
+    rev = "54caa5b2af348906607c5516a112057650d0873d";
+    sha256 = "sha256-uekElbcbX2P5TEufWEoP6tgUM/4vxgSQZu8qaBCSo18=";
   };
 
   nativeBuildInputs = [ cmake ];


### PR DESCRIPTION
Update soapysdr to 0.8.1-unstable-2025-03-30 and also update soapyremote to unstable-2024-12-22.
The client/server feature of soapysdr does not work for the prior combination of soapysdr and soapyremote.
I checked that the remote feature works for the combination of soapysdr and soapyremote in this PR. 

## Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [X] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
-  [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
