### PR TITLE
fishnet: 2.9.4 -> 2.9.5 with added update script

### DIFF
--- a/pkgs/by-name/fi/fishnet/package.nix
+++ b/pkgs/by-name/fi/fishnet/package.nix
@@ -19,14 +19,14 @@ let
     sha256 = "sha256-N/GPYtdy8xB+HWqso4mMEww8hvKrY+ZVX7vKIGNaiZ0=";
   };
 in
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "fishnet";
   version = "2.9.4";
 
   src = fetchFromGitHub {
     owner = "lichess-org";
     repo = "fishnet";
-    rev = "v${version}";
+    rev = "v${finalAttrs.version}";
     hash = "sha256-JhllThFiHeC/5AAFwwZQ0mgbENIWP1cA7aD01DeDVL8=";
     fetchSubmodules = true;
   };
@@ -45,7 +45,7 @@ rustPlatform.buildRustPackage rec {
     versionCheckHook
   ];
   doInstallCheck = true;
-  versionCheckProgram = "${placeholder "out"}/bin/${meta.mainProgram}";
+  versionCheckProgram = "${placeholder "out"}/bin/${finalAttrs.meta.mainProgram}";
   versionCheckProgramArg = "--version";
 
   meta = with lib; {
@@ -62,4 +62,4 @@ rustPlatform.buildRustPackage rec {
     ];
     mainProgram = "fishnet";
   };
-}
+})

--- a/pkgs/by-name/fi/fishnet/package.nix
+++ b/pkgs/by-name/fi/fishnet/package.nix
@@ -26,7 +26,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   src = fetchFromGitHub {
     owner = "lichess-org";
     repo = "fishnet";
-    rev = "v${finalAttrs.version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-JhllThFiHeC/5AAFwwZQ0mgbENIWP1cA7aD01DeDVL8=";
     fetchSubmodules = true;
   };

--- a/pkgs/by-name/fi/fishnet/package.nix
+++ b/pkgs/by-name/fi/fishnet/package.nix
@@ -11,12 +11,12 @@ let
   nnueBigFile = "nn-1111cefa1111.nnue";
   nnueBig = fetchurl {
     url = "https://tests.stockfishchess.org/api/nn/${nnueBigFile}";
-    sha256 = "sha256-ERHO+hERa3cWG9SxTatMUPJuWSDHVvSGFZK+Pc1t4XQ=";
+    hash = "sha256-ERHO+hERa3cWG9SxTatMUPJuWSDHVvSGFZK+Pc1t4XQ=";
   };
   nnueSmallFile = "nn-37f18f62d772.nnue";
   nnueSmall = fetchurl {
     url = "https://tests.stockfishchess.org/api/nn/${nnueSmallFile}";
-    sha256 = "sha256-N/GPYtdy8xB+HWqso4mMEww8hvKrY+ZVX7vKIGNaiZ0=";
+    hash = "sha256-N/GPYtdy8xB+HWqso4mMEww8hvKrY+ZVX7vKIGNaiZ0=";
   };
 in
 rustPlatform.buildRustPackage (finalAttrs: {

--- a/pkgs/by-name/fi/fishnet/package.nix
+++ b/pkgs/by-name/fi/fishnet/package.nix
@@ -3,8 +3,7 @@
   rustPlatform,
   fetchFromGitHub,
   fetchurl,
-  testers,
-  fishnet,
+  versionCheckHook,
 }:
 
 let
@@ -42,9 +41,12 @@ rustPlatform.buildRustPackage rec {
   useFetchCargoVendor = true;
   cargoHash = "sha256-aUSppXw0UDqCDX7YX+sYNEcmiABXDn0nrow0H9UjpaA=";
 
-  passthru.tests.version = testers.testVersion {
-    package = fishnet;
-  };
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+  doInstallCheck = true;
+  versionCheckProgram = "${placeholder "out"}/bin/${meta.mainProgram}";
+  versionCheckProgramArg = "--version";
 
   meta = with lib; {
     description = "Distributed Stockfish analysis for lichess.org";

--- a/pkgs/by-name/fi/fishnet/package.nix
+++ b/pkgs/by-name/fi/fishnet/package.nix
@@ -13,8 +13,8 @@
 
 let
   # These files can be found in Stockfish/src/evaluate.h
-  nnueBigFile = "nn-1111cefa1111.nnue";
-  nnueBigHash = "sha256-ERHO+hERa3cWG9SxTatMUPJuWSDHVvSGFZK+Pc1t4XQ=";
+  nnueBigFile = "nn-1c0000000000.nnue";
+  nnueBigHash = "sha256-HAAAAAAApn1imZnZMtDDc/dFDOQ80S0FYoaPTq+a4q0=";
   nnueBig = fetchurl {
     url = "https://tests.stockfishchess.org/api/nn/${nnueBigFile}";
     hash = nnueBigHash;
@@ -28,13 +28,13 @@ let
 in
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "fishnet";
-  version = "2.9.4";
+  version = "2.9.5";
 
   src = fetchFromGitHub {
     owner = "lichess-org";
     repo = "fishnet";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-JhllThFiHeC/5AAFwwZQ0mgbENIWP1cA7aD01DeDVL8=";
+    hash = "sha256-+JkqxO7wwYZHwWRMboKGe8uo/F223efR+9pIsAIoFpU=";
     fetchSubmodules = true;
   };
 
@@ -46,7 +46,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   '';
 
   useFetchCargoVendor = true;
-  cargoHash = "sha256-aUSppXw0UDqCDX7YX+sYNEcmiABXDn0nrow0H9UjpaA=";
+  cargoHash = "sha256-WjBrv4GApT7LTnexLDhY7Zni5kLtvUzaGs2YuA3UiHE=";
 
   nativeInstallCheckInputs = [
     versionCheckHook

--- a/pkgs/by-name/fi/fishnet/update.bash
+++ b/pkgs/by-name/fi/fishnet/update.bash
@@ -1,0 +1,43 @@
+new_version="$(
+    curl --fail --silent ${GITHUB_TOKEN:+-u ":$GITHUB_TOKEN"} "https://api.github.com/repos/$GITHUB_REPOSITORY/releases/latest" |
+        jq '.tag_name | ltrimstr("v")' --raw-output
+)"
+stockfish_revision="$(
+    curl --fail --silent ${GITHUB_TOKEN:+-u ":$GITHUB_TOKEN"} "https://api.github.com/repos/$GITHUB_REPOSITORY/contents/Stockfish?ref=v$new_version" |
+        jq .sha --raw-output
+)"
+stockfish_header="$(
+    curl --fail --silent "https://raw.githubusercontent.com/official-stockfish/Stockfish/$stockfish_revision/src/evaluate.h"
+)"
+new_nnue_big_file="$(
+    echo "$stockfish_header" |
+        grep --perl-regexp --only-matching 'EvalFileDefaultNameBig "\Knn-(\w+).nnue'
+)"
+new_nnue_big_hash="$(
+    nix hash to-sri --type sha256 "$(
+        nix-prefetch-url --type sha256 "https://tests.stockfishchess.org/api/nn/${new_nnue_big_file}"
+    )"
+)"
+new_nnue_small_file="$(
+    echo "$stockfish_header" |
+        grep --perl-regexp --only-matching 'EvalFileDefaultNameSmall "\Knn-(\w+).nnue'
+)"
+new_nnue_small_hash="$(
+    nix hash to-sri --type sha256 "$(
+        nix-prefetch-url --type sha256 "https://tests.stockfishchess.org/api/nn/${new_nnue_small_file}"
+    )"
+)"
+
+# Update NNUE
+pkg_body="$(<"$PKG_FILE")"
+pkg_body="${pkg_body//"$NNUE_BIG_FILE"/"$new_nnue_big_file"}"
+pkg_body="${pkg_body//"$NNUE_BIG_HASH"/"$new_nnue_big_hash"}"
+pkg_body="${pkg_body//"$NNUE_SMALL_FILE"/"$new_nnue_small_file"}"
+pkg_body="${pkg_body//"$NNUE_SMALL_HASH"/"$new_nnue_small_hash"}"
+echo "$pkg_body" >"$PKG_FILE"
+
+# Update version, src
+update-source-version "$PNAME" "$new_version" --ignore-same-version --print-changes
+
+# Update cargoHash
+nix-update --version=skip "$PNAME"


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

- Fixes the [failing automatic update](https://nixpkgs-update-logs.nix-community.org/fishnet/2025-04-10.log).
- Adds an update script that also detects and updates the NNUE file.
- Bump version with the added update script. https://github.com/lichess-org/fishnet/compare/v2.9.4...v2.9.5
- Includes minor refactoring within the package.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

cc: @tu-maurice @ornicar

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
