### PR TITLE
lib/tests: Fix eval for Nix >= 2.28

### DIFF
--- a/lib/tests/nix-for-tests.nix
+++ b/lib/tests/nix-for-tests.nix
@@ -14,7 +14,7 @@
 
 builtins.mapAttrs (
   attr: pkg:
-  if lib.versionAtLeast pkg.version "2.29pre" then
+  if lib.versionAtLeast pkg.version "2.28" then
     pkg.overrideScope (finalScope: prevScope: { aws-sdk-cpp = null; })
   else
     pkg.override { withAWS = false; }


### PR DESCRIPTION
The componentised build is already in 2.28, not 2.29 as introduced in https://github.com/NixOS/nixpkgs/pull/393509. This was detected after updating the CI Nixpkgs in https://github.com/NixOS/nixpkgs/pull/397453.

Ping @Mic92

Done:
- `nix-instantiate --arg pkgs '(import ./ci/. {}).pkgs' lib/tests/release.nix`

---

This work is funded by [Antithesis](https://antithesis.com/) and [Tweag](https://tweag.io) :sparkles:

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
