### PR TITLE
python313Packages.certbot: 3.1.0 -> 4.0.0

### DIFF
--- a/pkgs/by-name/ce/certbot/package.nix
+++ b/pkgs/by-name/ce/certbot/package.nix
@@ -7,19 +7,6 @@ let
   python = python3.override {
     self = python;
     packageOverrides = self: super: {
-      josepy = super.josepy.overridePythonAttrs (old: rec {
-        version = "1.15.0";
-        src = fetchFromGitHub {
-          owner = "certbot";
-          repo = "josepy";
-          tag = "v${version}";
-          hash = "sha256-fK4JHDP9eKZf2WO+CqRdEjGwJg/WNLvoxiVrb5xQxRc=";
-        };
-        dependencies = with self; [
-          pyopenssl
-          cryptography
-        ];
-      });
     };
   };
 in

--- a/pkgs/by-name/si/simp_le/package.nix
+++ b/pkgs/by-name/si/simp_le/package.nix
@@ -10,7 +10,15 @@ let
   python = python3.override {
     self = python;
     packageOverrides = self: super: {
-      # acme doesn't support josepy v2
+      certbot = super.certbot.overridePythonAttrs rec {
+        version = "3.1.0";
+        src = fetchFromGitHub {
+          owner = "certbot";
+          repo = "certbot";
+          tag = "v${version}";
+          hash = "sha256-lYGJgUNDzX+bE64GJ+djdKR+DXmhpcNbFJrAEnP86yQ=";
+        };
+      };
       josepy = super.josepy.overridePythonAttrs (old: rec {
         version = "1.15.0";
         src = fetchFromGitHub {

--- a/pkgs/development/python-modules/certbot/default.nix
+++ b/pkgs/development/python-modules/certbot/default.nix
@@ -23,14 +23,14 @@
 
 buildPythonPackage rec {
   pname = "certbot";
-  version = "3.1.0";
+  version = "4.0.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "certbot";
     repo = "certbot";
     tag = "v${version}";
-    hash = "sha256-lYGJgUNDzX+bE64GJ+djdKR+DXmhpcNbFJrAEnP86yQ=";
+    hash = "sha256-GS4JLLXrX4+BQ4S6ySbOHUaUthCFYTCHWnOaMpfnIj8=";
   };
 
   postPatch = "cd certbot"; # using sourceRoot would interfere with patches
@@ -84,8 +84,6 @@ buildPythonPackage rec {
     '';
 
   meta = with lib; {
-    # AttributeError: module 'josepy' has no attribute 'ComparableX509'
-    broken = lib.versionAtLeast josepy.version "2";
     homepage = "https://github.com/certbot/certbot";
     changelog = "https://github.com/certbot/certbot/blob/${src.tag}/certbot/CHANGELOG.md";
     description = "ACME client that can obtain certs and extensibly update server configurations";

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -163,22 +163,6 @@ let
         };
       });
 
-      # acme and thus hass-nabucasa doesn't support josepy v2
-      # https://github.com/certbot/certbot/issues/10185
-      josepy = super.josepy.overridePythonAttrs (old: rec {
-        version = "1.15.0";
-        src = fetchFromGitHub {
-          owner = "certbot";
-          repo = "josepy";
-          tag = "v${version}";
-          hash = "sha256-fK4JHDP9eKZf2WO+CqRdEjGwJg/WNLvoxiVrb5xQxRc=";
-        };
-        dependencies = with self; [
-          pyopenssl
-          cryptography
-        ];
-      });
-
       openhomedevice = super.openhomedevice.overridePythonAttrs (oldAttrs: rec {
         version = "2.2";
         src = fetchFromGitHub {


### PR DESCRIPTION
Diff: https://github.com/certbot/certbot/compare/refs/tags/v3.1.0...v4.0.0

Changelog: https://github.com/certbot/certbot/blob/v4.0.0/certbot/CHANGELOG.md


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
