### PR TITLE
treewide: remove env-vars from build outputs

### DIFF
--- a/pkgs/applications/networking/davmail/default.nix
+++ b/pkgs/applications/networking/davmail/default.nix
@@ -1,6 +1,6 @@
 {
   stdenv,
-  fetchurl,
+  fetchzip,
   lib,
   makeWrapper,
   unzip,
@@ -25,16 +25,15 @@ stdenv.mkDerivation rec {
   pname = "davmail";
   version = "6.3.0";
 
-  src = fetchurl {
+  src = fetchzip {
     url = "mirror://sourceforge/${pname}/${version}/${pname}-${version}-${toString rev}.zip";
-    hash = "sha256-Yh61ZHsEMF6SchLEyBV3rRI7pJ/bvR2K4G8U6jrPa3A=";
+    hash = "sha256-zJMwCFX/uJnLeThj6/t2usBRM+LIuamZt0EFLG3N+8k=";
+    stripRoot = false;
   };
 
   postPatch = ''
     sed -i -e '/^JAVA_OPTS/d' davmail
   '';
-
-  sourceRoot = ".";
 
   nativeBuildInputs = [
     makeWrapper

--- a/pkgs/by-name/ge/geoserver/package.nix
+++ b/pkgs/by-name/ge/geoserver/package.nix
@@ -17,12 +17,19 @@ stdenv.mkDerivation (finalAttrs: rec {
     hash = "sha256-bhL+u+BoKgW2cwOXEzaq0h07dKFz9u9WB2jW8nAF0vI=";
   };
 
+  sourceRoot = "source";
+
+  unpackPhase = ''
+    runHook preUnpack
+    unzip $src -d "$sourceRoot"
+    runHook postUnpack
+  '';
+
   patches = [
     # set GEOSERVER_DATA_DIR to current working directory if not provided
     ./data-dir.patch
   ];
 
-  sourceRoot = ".";
   nativeBuildInputs = [
     unzip
     makeWrapper

--- a/pkgs/by-name/po/powershell/package.nix
+++ b/pkgs/by-name/po/powershell/package.nix
@@ -38,7 +38,14 @@ stdenv.mkDerivation rec {
     passthru.sources.${stdenv.hostPlatform.system}
       or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
 
-  sourceRoot = ".";
+  sourceRoot = "source";
+
+  unpackPhase = ''
+    runHook preUnpack
+    mkdir -p "$sourceRoot"
+    tar xf $src --directory="$sourceRoot"
+    runHook postUnpack
+  '';
 
   strictDeps = true;
 

--- a/pkgs/by-name/un/unihan-database/package.nix
+++ b/pkgs/by-name/un/unihan-database/package.nix
@@ -18,7 +18,13 @@ stdenv.mkDerivation rec {
     unzip
   ];
 
-  sourceRoot = ".";
+  sourceRoot = "source";
+
+  unpackPhase = ''
+    runHook preUnpack
+    unzip $src -d $sourceRoot
+    runHook postUnpack
+  '';
 
   installPhase = ''
     runHook preInstall

--- a/pkgs/by-name/xm/xmage/package.nix
+++ b/pkgs/by-name/xm/xmage/package.nix
@@ -17,8 +17,14 @@ stdenv.mkDerivation (finalAttrs: {
 
   preferLocalBuild = true;
 
+  nativeBuildInputs = [ unzrip ];
+
+  sourceRoot = "source";
+
   unpackPhase = ''
-    ${unzrip}/bin/unzrip $src
+    runHook preUnpack
+    unzrip $src -d "$sourceRoot"
+    runHook postUnpack
   '';
 
   installPhase =

--- a/pkgs/servers/ombi/default.nix
+++ b/pkgs/servers/ombi/default.nix
@@ -35,12 +35,19 @@ stdenv.mkDerivation rec {
   pname = "ombi";
   version = "4.47.1";
 
-  sourceRoot = ".";
-
   src = fetchurl {
     url = "https://github.com/Ombi-app/Ombi/releases/download/v${version}/${os}-${arch}.tar.gz";
     sha256 = hash;
   };
+
+  sourceRoot = "source";
+
+  unpackPhase = ''
+    runHook preUnpack
+    mkdir -p "$sourceRoot"
+    tar xf $src --directory="$sourceRoot"
+    runHook postUnpack
+  '';
 
   nativeBuildInputs =
     [ makeWrapper ]

--- a/pkgs/top-level/dotnet-packages.nix
+++ b/pkgs/top-level/dotnet-packages.nix
@@ -175,6 +175,7 @@ let
       version = "11.0.2";
       sha256 = "07na27n4mlw77f3hg5jpayzxll7f4gyna6x7k9cybmxpbs6l77k7";
       outputFiles = [ "*" ];
+      postInstall = "rm $target/env-vars"; # fetchNuGet already sets preInstall
     };
 
     Paket = fetchNuGet {
@@ -182,6 +183,7 @@ let
       version = "5.179.1";
       sha256 = "11rzna03i145qj08hwrynya548fwk8xzxmg65swyaf19jd7gzg82";
       outputFiles = [ "*" ];
+      postInstall = "rm $target/env-vars"; # fetchNuGet already sets preInstall
     };
 
   };


### PR DESCRIPTION
This reduces runtime closures. Found with `nix-locate --top-level --regex '/env-vars$'`. I also found https://github.com/NixOS/nixpkgs/pull/397740 while authoring this PR

- **davmail: remove env-vars from output**
- **geoserver: remove env-vars from output**
- **ombi: remove env-vars from output**
- **powershell: remove env-vars from output**
- **unihan-database: remove env-vars from output**
- **xmage: remove env-vars from output**
- **dotnetPackages.{NewtonsoftJson,Paket}: remove env-vars from output**



<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
