### PR TITLE
xmonad: fix xmonad --recompile when cross-compiled

### DIFF
--- a/nixos/modules/services/x11/window-managers/xmonad.nix
+++ b/nixos/modules/services/x11/window-managers/xmonad.nix
@@ -50,7 +50,7 @@ let
           makeWrapper ${configured}/bin/xmonad $out/bin/xmonad \
         ''
         + optionalString cfg.enableConfiguredRecompile ''
-          --set XMONAD_GHC "${xmonadEnv}/bin/ghc" \
+          --set XMONAD_GHC "${xmonadEnv}/bin/${xmonadEnv.passthru.targetPrefix}ghc" \
         ''
         + ''
           --set XMONAD_XMESSAGE "${pkgs.xorg.xmessage}/bin/xmessage"

--- a/pkgs/applications/window-managers/xmonad/wrapper.nix
+++ b/pkgs/applications/window-managers/xmonad/wrapper.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation {
   buildCommand = ''
     install -D ${xmonadEnv}/share/man/man1/xmonad.1.gz $out/share/man/man1/xmonad.1.gz
     makeWrapper ${xmonadEnv}/bin/xmonad $out/bin/xmonad \
-      --set XMONAD_GHC "${xmonadEnv}/bin/ghc" \
+      --set XMONAD_GHC "${xmonadEnv}/bin/${xmonadEnv.passthru.targetPrefix}ghc" \
       --set XMONAD_XMESSAGE "${xmessage}/bin/xmessage"
   '';
 

--- a/pkgs/development/haskell-modules/with-packages-wrapper.nix
+++ b/pkgs/development/haskell-modules/with-packages-wrapper.nix
@@ -200,7 +200,7 @@ else
       + postBuild;
     preferLocalBuild = true;
     passthru = {
-      inherit (ghc) version meta;
+      inherit (ghc) version meta targetPrefix;
 
       # Inform users about backwards incompatibilities with <= 21.05
       override =


### PR DESCRIPTION
by using `targetPrefix` in front of `ghc` binary.

The contents of the `bin` directory look like this
```shell
armv7l-unknown-linux-gnueabihf-ghc            armv7l-unknown-linux-gnueabihf-hp2ps
armv7l-unknown-linux-gnueabihf-ghc-9.6.6      armv7l-unknown-linux-gnueabihf-hp2ps-ghc-9.6.6
armv7l-unknown-linux-gnueabihf-ghci           armv7l-unknown-linux-gnueabihf-hsc2hs
armv7l-unknown-linux-gnueabihf-ghci-9.6.6     armv7l-unknown-linux-gnueabihf-hsc2hs-ghc-9.6.6
armv7l-unknown-linux-gnueabihf-ghc-pkg        hsc2hs-ghc-9.6.6
armv7l-unknown-linux-gnueabihf-ghc-pkg-9.6.6  xmonad
```
and before this patch `XMONAD_GHC` points to just `.../bin/ghc`.

This is also propagates `targetPrefix` via `ghcWithPackages.passthru` set, to make it consistent with
 `(pkgs.haskellPackages.ghcWithPackages (ps: [])).passthru.targetPrefix`
which is equal to `pkgs.haskellPackages.ghc.passthru.targetPrefix`, but missing when any package is added to the list.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
