### PR TITLE
[Backport release-24.11] patchelfUnstable: 0.18.0-unstable-2024-06-15 -> 0.18.0-unstable-2025-…

### DIFF
--- a/pkgs/development/tools/misc/patchelf/unstable.nix
+++ b/pkgs/development/tools/misc/patchelf/unstable.nix
@@ -8,13 +8,13 @@
 
 stdenv.mkDerivation {
   pname = "patchelf";
-  version = "0.18.0-unstable-2024-06-15";
+  version = "0.18.0-unstable-2025-01-07";
 
   src = fetchFromGitHub {
     owner = "NixOS";
     repo = "patchelf";
-    rev = "a0f54334df36770b335c051e540ba40afcbf8378";
-    sha256 = "sha256-FSoxTcRZMGHNJh8dNtKOkcUtjhmhU6yQXcZZfUPLhQM=";
+    rev = "43b75fbc9ffbc1190fee7c8693ad74cb8286cfd4";
+    sha256 = "sha256-rqFH9xUu36Hky763cQ9D1V7iuWteItAFDM2jIQGP5Us=";
   };
 
   # Drop test that fails on musl (?)


### PR DESCRIPTION
Backport of https://github.com/NixOS/nixpkgs/pull/371776, prerequisite for https://github.com/NixOS/nixpkgs/pull/397744.

Auto-backport failed, because the base version of patchelfUnstable on 24.11 happened to be older than when https://github.com/NixOS/nixpkgs/pull/371776 was created.

