### PR TITLE
cagebreak: 2.3.1 -> 2.4.0

### DIFF
--- a/pkgs/applications/window-managers/cagebreak/default.nix
+++ b/pkgs/applications/window-managers/cagebreak/default.nix
@@ -28,13 +28,13 @@
 
 stdenv.mkDerivation rec {
   pname = "cagebreak";
-  version = "2.3.1";
+  version = "2.4.0";
 
   src = fetchFromGitHub {
     owner = "project-repo";
     repo = pname;
     rev = version;
-    hash = "sha256-GAANZIEUtuONPBpk0E3fErgOZtm3wB+gWJNwfO6VOTo=";
+    hash = "sha256-eJLYv9CalBTOQEOMRg/5ctHByrkA44pfS7K3H4XTdSc=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/ca/cagebreak/package.nix
+++ b/pkgs/by-name/ca/cagebreak/package.nix
@@ -23,7 +23,7 @@
   wayland-scanner,
   withXwayland ? true,
   xwayland,
-  wlroots,
+  wlroots_0_18,
 }:
 
 stdenv.mkDerivation rec {
@@ -59,7 +59,7 @@ stdenv.mkDerivation rec {
     systemd
     wayland
     wayland-protocols
-    wlroots
+    wlroots_0_18
   ];
 
   mesonFlags = [

--- a/pkgs/by-name/ca/cagebreak/package.nix
+++ b/pkgs/by-name/ca/cagebreak/package.nix
@@ -83,12 +83,12 @@ stdenv.mkDerivation (finalAttrs: {
       --prefix PATH : "${lib.makeBinPath [ xwayland ]}"
   '';
 
-  meta = with lib; {
+  meta = {
     homepage = "https://github.com/project-repo/cagebreak";
     description = "Wayland tiling compositor inspired by ratpoison";
-    license = licenses.mit;
-    maintainers = with maintainers; [ berbiche ];
-    platforms = platforms.linux;
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ berbiche ];
+    platforms = lib.platforms.linux;
     changelog = "https://github.com/project-repo/cagebreak/blob/${finalAttrs.version}/Changelog.md";
     mainProgram = "cagebreak";
   };

--- a/pkgs/by-name/ca/cagebreak/package.nix
+++ b/pkgs/by-name/ca/cagebreak/package.nix
@@ -87,7 +87,7 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/project-repo/cagebreak";
     description = "Wayland tiling compositor inspired by ratpoison";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ berbiche ];
+    maintainers = with lib.maintainers; [ ];
     platforms = lib.platforms.linux;
     changelog = "https://github.com/project-repo/cagebreak/blob/${finalAttrs.version}/Changelog.md";
     mainProgram = "cagebreak";

--- a/pkgs/by-name/ca/cagebreak/package.nix
+++ b/pkgs/by-name/ca/cagebreak/package.nix
@@ -26,14 +26,14 @@
   wlroots_0_18,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "cagebreak";
   version = "2.4.0";
 
   src = fetchFromGitHub {
     owner = "project-repo";
-    repo = pname;
-    rev = version;
+    repo = "cagebreak";
+    tag = finalAttrs.version;
     hash = "sha256-eJLYv9CalBTOQEOMRg/5ctHByrkA44pfS7K3H4XTdSc=";
   };
 
@@ -64,7 +64,7 @@ stdenv.mkDerivation rec {
 
   mesonFlags = [
     "-Dman-pages=true"
-    "-Dversion_override=${version}"
+    "-Dversion_override=${finalAttrs.version}"
     "-Dxwayland=${lib.boolToString withXwayland}"
   ];
 
@@ -89,9 +89,9 @@ stdenv.mkDerivation rec {
     license = licenses.mit;
     maintainers = with maintainers; [ berbiche ];
     platforms = platforms.linux;
-    changelog = "https://github.com/project-repo/cagebreak/blob/${version}/Changelog.md";
+    changelog = "https://github.com/project-repo/cagebreak/blob/${finalAttrs.version}/Changelog.md";
     mainProgram = "cagebreak";
   };
 
   passthru.tests.basic = nixosTests.cagebreak;
-}
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19519,7 +19519,7 @@ with pkgs;
   };
 
   cagebreak = callPackage ../applications/window-managers/cagebreak {
-    wlroots = wlroots_0_17;
+    wlroots = wlroots_0_18;
   };
 
   zrythm = callPackage ../applications/audio/zrythm {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19518,10 +19518,6 @@ with pkgs;
     inherit (darwin.apple_sdk.frameworks) CoreServices;
   };
 
-  cagebreak = callPackage ../applications/window-managers/cagebreak {
-    wlroots = wlroots_0_18;
-  };
-
   zrythm = callPackage ../applications/audio/zrythm {
     inherit (plasma5Packages) breeze-icons;
   };


### PR DESCRIPTION
- Changelog: https://github.com/project-repo/cagebreak/releases/tag/2.4.0
- Move to `pkgs/by-name`
- Use finalAttrs pattern
- Remove `with lib;`
- Remove berbiche from maintainers

Closes #397720

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
