### PR TITLE
rquickshare: 0.11.4 -> 0.11.5

### DIFF
--- a/pkgs/by-name/rq/rquickshare/fix-pnpm-outdated-lockfile.patch
+++ b/pkgs/by-name/rq/rquickshare/fix-pnpm-outdated-lockfile.patch
@@ -1,0 +1,35 @@
+diff --git a/app/legacy/pnpm-lock.yaml b/app/legacy/pnpm-lock.yaml
+index ce6a292..76ba03e 100644
+--- a/app/legacy/pnpm-lock.yaml
++++ b/app/legacy/pnpm-lock.yaml
+@@ -12,8 +12,8 @@ importers:
+         specifier: link:../../core_lib
+         version: link:../../core_lib
+       '@tauri-apps/api':
+-        specifier: 1.5.6
+-        version: 1.5.6
++        specifier: 1.6.0
++        version: 1.6.0
+       pinia:
+         specifier: ^2.2.1
+         version: 2.2.1(typescript@5.6.0-dev.20240811)(vue@3.4.27(typescript@5.6.0-dev.20240811))
+@@ -500,10 +500,6 @@ packages:
+     peerDependencies:
+       tailwindcss: '>=3.0.0 || insiders'
+ 
+-  '@tauri-apps/api@1.5.6':
+-    resolution: {integrity: sha512-LH5ToovAHnDVe5Qa9f/+jW28I6DeMhos8bNDtBOmmnaDpPmJmYLyHdeDblAWWWYc7KKRDg9/66vMuKyq0WIeFA==}
+-    engines: {node: '>= 14.6.0', npm: '>= 6.6.0', yarn: '>= 1.19.1'}
+-
+   '@tauri-apps/api@1.6.0':
+     resolution: {integrity: sha512-rqI++FWClU5I2UBp4HXFvl+sBWkdigBkxnpJDQUWttNyG7IZP4FwQGhTNL5EOw0vI8i6eSAJ5frLqO7n7jbJdg==}
+     engines: {node: '>= 14.6.0', npm: '>= 6.6.0', yarn: '>= 1.19.1'}
+@@ -2707,8 +2703,6 @@ snapshots:
+       postcss-selector-parser: 6.0.10
+       tailwindcss: 3.4.9
+ 
+-  '@tauri-apps/api@1.5.6': {}
+-
+   '@tauri-apps/api@1.6.0': {}
+ 
+   '@tauri-apps/cli-darwin-arm64@1.5.14':

--- a/pkgs/by-name/rq/rquickshare/package.nix
+++ b/pkgs/by-name/rq/rquickshare/package.nix
@@ -3,6 +3,7 @@
   cargo-tauri,
   cargo-tauri_1,
   fetchFromGitHub,
+  applyPatches,
   glib-networking,
   libayatana-appindicator,
   libsoup_2_4,
@@ -39,13 +40,16 @@ let
 in
 rustPlatform.buildRustPackage rec {
   pname = "rquickshare" + (app-type-either "" "-legacy");
-  version = "0.11.4";
+  version = "0.11.5";
 
-  src = fetchFromGitHub {
-    owner = "Martichou";
-    repo = "rquickshare";
-    tag = "v${version}";
-    hash = "sha256-Gq78vxM9hJ+dAHM3RAKHtkFIsoV0XQN4vNbOO3amvTs=";
+  src = applyPatches {
+    src = fetchFromGitHub {
+      owner = "Martichou";
+      repo = "rquickshare";
+      tag = "v${version}";
+      hash = "sha256-DZdzk0wqKhVa51PgQf8UsAY6EbGKvRIGru71Z8rvrwA=";
+    };
+    patches = [ ./fix-pnpm-outdated-lockfile.patch ];
   };
 
   # from https://github.com/NixOS/nixpkgs/blob/04e40bca2a68d7ca85f1c47f00598abb062a8b12/pkgs/by-name/ca/cargo-tauri/test-app.nix#L23-L26
@@ -59,14 +63,14 @@ rustPlatform.buildRustPackage rec {
     inherit pname version src;
 
     sourceRoot = "${src.name}/app/${app-type}";
-    hash = app-type-either "sha256-V46V/VPwCKEe3sAp8zK0UUU5YigqgYh1GIOorqIAiNE=" "sha256-sDHysaKMdNcbL1szww7/wg0bGHOnEKsKoySZJJCcPik=";
+    hash = app-type-either "sha256-V46V/VPwCKEe3sAp8zK0UUU5YigqgYh1GIOorqIAiNE=" "sha256-8QRigYNtxirXidFFnTzA6rP0+L64M/iakPqe2lZKegs=";
   };
 
   useFetchCargoVendor = true;
   cargoRoot = "app/${app-type}/src-tauri";
   buildAndTestSubdir = cargoRoot;
   cargoPatches = [ ./remove-duplicate-versions-of-sys-metrics.patch ];
-  cargoHash = app-type-either "sha256-wraCzzC7YVCXEXBTd8c1cbtCdBunENpUMQ1vZGwfGMs=" "sha256-TBsHlFwbWWa2LEZdmDyz/9vWiFOXKX39PCsjW6OqEGY=";
+  cargoHash = app-type-either "sha256-XfN+/oC3lttDquLfoyJWBaFfdjW/wyODCIiZZksypLM=" "sha256-4vBHxuKg4P9H0FZYYNUT+AVj4Qvz99q7Bhd7x47UC2w=";
 
   nativeBuildInputs = [
     proper-cargo-tauri.hook

--- a/pkgs/by-name/rq/rquickshare/remove-duplicate-versions-of-sys-metrics.patch
+++ b/pkgs/by-name/rq/rquickshare/remove-duplicate-versions-of-sys-metrics.patch
@@ -1,9 +1,9 @@
 diff --git a/app/legacy/src-tauri/Cargo.lock b/app/legacy/src-tauri/Cargo.lock
-index 1bba0ae..af24986 100644
+index 14872dc..341fcc8 100644
 --- a/app/legacy/src-tauri/Cargo.lock
 +++ b/app/legacy/src-tauri/Cargo.lock
-@@ -4138,7 +4138,7 @@ dependencies = [
-  "rand 0.8.5",
+@@ -4296,7 +4296,7 @@ dependencies = [
+  "rand 0.9.0",
   "serde",
   "sha2",
 - "sys_metrics 0.2.7 (git+https://github.com/Martichou/sys_metrics)",
@@ -11,7 +11,7 @@ index 1bba0ae..af24986 100644
   "tokio",
   "tokio-util",
   "tracing-subscriber",
-@@ -4158,7 +4158,7 @@ dependencies = [
+@@ -4316,7 +4316,7 @@ dependencies = [
   "rqs_lib",
   "serde",
   "serde_json",
@@ -20,10 +20,13 @@ index 1bba0ae..af24986 100644
   "tauri",
   "tauri-build",
   "tauri-plugin-autostart",
-@@ -4759,22 +4759,7 @@ dependencies = [
- [[package]]
- name = "sys_metrics"
- version = "0.2.7"
+@@ -4920,21 +4920,6 @@ dependencies = [
+  "libc",
+ ]
+ 
+-[[package]]
+-name = "sys_metrics"
+-version = "0.2.7"
 -source = "registry+https://github.com/rust-lang/crates.io-index"
 -checksum = "c9b266b80f59f86e2e1e0a4938e316e32c3730d94a749f236305152279f77484"
 -dependencies = [
@@ -36,16 +39,11 @@ index 1bba0ae..af24986 100644
 - "serde",
 -]
 -
--[[package]]
--name = "sys_metrics"
--version = "0.2.7"
--source = "git+https://github.com/Martichou/sys_metrics#c0f4ec7b9156d3ab83ee61276984c7fd4e632098"
-+source = "git+https://github.com/Martichou/sys_metrics#e5b324a17d1724bd97923a173c3535cc06a44b0c"
- dependencies = [
-  "core-foundation-sys",
-  "glob",
+ [[package]]
+ name = "sys_metrics"
+ version = "0.2.7"
 diff --git a/app/legacy/src-tauri/Cargo.toml b/app/legacy/src-tauri/Cargo.toml
-index b971c3d..44abf29 100644
+index fb735b2..cfd1349 100644
 --- a/app/legacy/src-tauri/Cargo.toml
 +++ b/app/legacy/src-tauri/Cargo.toml
 @@ -20,7 +20,7 @@ notify-rust = "4.10"
@@ -54,15 +52,15 @@ index b971c3d..44abf29 100644
  serde_json = "1.0"
 -sys_metrics = "0.2"
 +sys_metrics = { git = "https://github.com/Martichou/sys_metrics" }
- tauri = { version = "1.5", features = ["api-all", "reqwest-native-tls-vendored", "system-tray", "devtools"] }
+ tauri = { version = "1.8", features = ["api-all", "reqwest-native-tls-vendored", "devtools", "system-tray"] }
  tauri-plugin-autostart = { git = "https://github.com/tauri-apps/plugins-workspace", branch = "v1" }
  tauri-plugin-single-instance = { git = "https://github.com/tauri-apps/plugins-workspace", branch = "v1" }
 diff --git a/app/main/src-tauri/Cargo.lock b/app/main/src-tauri/Cargo.lock
-index bc4753a..ed4c7e8 100644
+index 5580ef5..4327d4c 100644
 --- a/app/main/src-tauri/Cargo.lock
 +++ b/app/main/src-tauri/Cargo.lock
-@@ -4182,7 +4182,7 @@ dependencies = [
-  "rand 0.8.5",
+@@ -4247,7 +4247,7 @@ dependencies = [
+  "rand 0.9.0",
   "serde",
   "sha2",
 - "sys_metrics 0.2.7 (git+https://github.com/Martichou/sys_metrics)",
@@ -70,7 +68,7 @@ index bc4753a..ed4c7e8 100644
   "tokio",
   "tokio-util",
   "tracing-subscriber",
-@@ -4202,7 +4202,7 @@ dependencies = [
+@@ -4267,7 +4267,7 @@ dependencies = [
   "rqs_lib",
   "serde",
   "serde_json",
@@ -79,7 +77,7 @@ index bc4753a..ed4c7e8 100644
   "tauri",
   "tauri-build",
   "tauri-plugin-autostart",
-@@ -4867,21 +4867,6 @@ dependencies = [
+@@ -4932,21 +4932,6 @@ dependencies = [
   "syn 2.0.95",
  ]
  
@@ -102,7 +100,7 @@ index bc4753a..ed4c7e8 100644
  name = "sys_metrics"
  version = "0.2.7"
 diff --git a/app/main/src-tauri/Cargo.toml b/app/main/src-tauri/Cargo.toml
-index 5653700..5120513 100644
+index 8864112..7707922 100644
 --- a/app/main/src-tauri/Cargo.toml
 +++ b/app/main/src-tauri/Cargo.toml
 @@ -20,7 +20,7 @@ notify-rust = "4.10"


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
https://github.com/Martichou/rquickshare: Rust implementation of NearbyShare/QuickShare from Android for Linux and macOS

The latest update had a disparity between the `package.json` and `pnpm-lock.yaml` files in the legacy version of the app and needed to be patched.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
