### PR TITLE
{ayatana-indicator*,lomiri.lomiri-indicator-network}: Add corresponding Lomiri indicator test to passthru.tests

### DIFF
--- a/pkgs/by-name/ay/ayatana-indicator-bluetooth/package.nix
+++ b/pkgs/by-name/ay/ayatana-indicator-bluetooth/package.nix
@@ -65,8 +65,11 @@ stdenv.mkDerivation (finalAttrs: {
         "lomiri"
       ];
     };
+    tests = {
+      startup = nixosTests.ayatana-indicators;
+      lomiri = nixosTests.lomiri.desktop-ayatana-indicator-bluetooth;
+    };
     updateScript = gitUpdater { };
-    tests.vm = nixosTests.ayatana-indicators;
   };
 
   meta = {

--- a/pkgs/by-name/ay/ayatana-indicator-datetime/package.nix
+++ b/pkgs/by-name/ay/ayatana-indicator-datetime/package.nix
@@ -137,7 +137,8 @@ stdenv.mkDerivation (finalAttrs: {
       ];
     };
     tests = {
-      inherit (nixosTests) ayatana-indicators;
+      startup = nixosTests.ayatana-indicators;
+      lomiri = nixosTests.lomiri.desktop-ayatana-indicator-datetime;
     };
     updateScript = gitUpdater { };
   };

--- a/pkgs/by-name/ay/ayatana-indicator-display/package.nix
+++ b/pkgs/by-name/ay/ayatana-indicator-display/package.nix
@@ -114,7 +114,10 @@ stdenv.mkDerivation (finalAttrs: {
         "lomiri"
       ];
     };
-    tests.vm = nixosTests.ayatana-indicators;
+    tests = {
+      startup = nixosTests.ayatana-indicators;
+      lomiri = nixosTests.lomiri.desktop-ayatana-indicator-display;
+    };
     updateScript = gitUpdater { };
   };
 

--- a/pkgs/by-name/ay/ayatana-indicator-power/package.nix
+++ b/pkgs/by-name/ay/ayatana-indicator-power/package.nix
@@ -94,7 +94,10 @@ stdenv.mkDerivation (finalAttrs: {
         "lomiri"
       ];
     };
-    tests.vm = nixosTests.ayatana-indicators;
+    tests = {
+      startup = nixosTests.ayatana-indicators;
+      lomiri = nixosTests.lomiri.desktop-ayatana-indicator-power;
+    };
     updateScript = gitUpdater { };
   };
 

--- a/pkgs/by-name/ay/ayatana-indicator-session/package.nix
+++ b/pkgs/by-name/ay/ayatana-indicator-session/package.nix
@@ -84,7 +84,10 @@ stdenv.mkDerivation (finalAttrs: {
         "lomiri"
       ];
     };
-    tests.vm = nixosTests.ayatana-indicators;
+    tests = {
+      startup = nixosTests.ayatana-indicators;
+      lomiri = nixosTests.lomiri.desktop-ayatana-indicator-session;
+    };
     updateScript = gitUpdater { };
   };
 

--- a/pkgs/by-name/ay/ayatana-indicator-sound/package.nix
+++ b/pkgs/by-name/ay/ayatana-indicator-sound/package.nix
@@ -115,7 +115,10 @@ stdenv.mkDerivation (finalAttrs: {
         "lomiri"
       ];
     };
-    tests.vm = nixosTests.ayatana-indicators;
+    tests = {
+      startup = nixosTests.ayatana-indicators;
+      lomiri = nixosTests.lomiri.desktop-ayatana-indicator-sound;
+    };
     updateScript = gitUpdater { };
   };
 

--- a/pkgs/desktops/lomiri/services/lomiri-indicator-network/default.nix
+++ b/pkgs/desktops/lomiri/services/lomiri-indicator-network/default.nix
@@ -125,7 +125,8 @@ stdenv.mkDerivation (finalAttrs: {
     };
     tests = {
       pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-      vm = nixosTests.ayatana-indicators;
+      startup = nixosTests.ayatana-indicators;
+      lomiri = nixosTests.lomiri.desktop-ayatana-indicator-network;
     };
     updateScript = gitUpdater { };
   };


### PR DESCRIPTION
The Lomiri indicator VM test has been split up into per-indicator ones awhile ago, to cope with the weaker OfBorg CI hardware.

A side effect of this is that we can now hook up these very specific graphical VM tests as `<indicator>.passthru.tests` entries for the corresponding indicator packages. So let's do that, and have CI test that indicator updates don't break under Lomiri.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
