### PR TITLE
teams-for-linux: 1.13.1 -> 2.0.7

### DIFF
--- a/pkgs/by-name/te/teams-for-linux/package.nix
+++ b/pkgs/by-name/te/teams-for-linux/package.nix
@@ -5,26 +5,27 @@
   fetchFromGitHub,
   alsa-utils,
   copyDesktopItems,
-  electron_34,
+  electron_35,
   makeDesktopItem,
   makeWrapper,
   nix-update-script,
   versionCheckHook,
+  vulkan-loader,
   which,
 }:
 
 buildNpmPackage rec {
   pname = "teams-for-linux";
-  version = "1.13.1";
+  version = "2.0.7";
 
   src = fetchFromGitHub {
     owner = "IsmaelMartinez";
     repo = "teams-for-linux";
     tag = "v${version}";
-    hash = "sha256-0u5UyhRSa4gsLVQLctWMZe/oE8l9jrwCzkPtLWv2xlo=";
+    hash = "sha256-w7KY7qxsK512YuLw0Ms+kIsuDTou+ZvJ9wPGJx4fbt0=";
   };
 
-  npmDepsHash = "sha256-BHz1+pd88TDfTXtG0gl5kYiDeG/M94pYdpPtwBrBYzQ=";
+  npmDepsHash = "sha256-oTS+ylkTf3a0B0pP1aEyxdTR4KL5gk8u+scEWZwyrwg=";
 
   nativeBuildInputs = [
     makeWrapper
@@ -39,21 +40,31 @@ buildNpmPackage rec {
     ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
   };
 
-  buildPhase = ''
-    runHook preBuild
+  makeCacheWritable = true;
 
-    cp -r ${electron_34.dist} electron-dist
-    chmod -R u+w electron-dist
+  buildPhase =
+    ''
+      runHook preBuild
 
-    npm exec electron-builder -- \
-        --dir \
-        -c.npmRebuild=true \
-        -c.asarUnpack="**/*.node" \
-        -c.electronDist=electron-dist \
-        -c.electronVersion=${electron_34.version}
+      cp -r ${electron_35.dist} electron-dist
+      chmod -R u+w electron-dist
+    ''
+    # Electron builder complains about symlink in electron-dist
+    + lib.optionalString stdenv.hostPlatform.isLinux ''
+      rm electron-dist/libvulkan.so.1
+      cp ${lib.getLib vulkan-loader}/lib/libvulkan.so.1 electron-dist
+    ''
+    + ''
 
-    runHook postBuild
-  '';
+      npm exec electron-builder -- \
+          --dir \
+          -c.npmRebuild=true \
+          -c.asarUnpack="**/*.node" \
+          -c.electronDist=electron-dist \
+          -c.electronVersion=${electron_35.version}
+
+      runHook postBuild
+    '';
 
   installPhase =
     ''
@@ -72,7 +83,7 @@ buildNpmPackage rec {
       popd
 
       # Linux needs 'aplay' for notification sounds
-      makeWrapper '${lib.getExe electron_34}' "$out/bin/teams-for-linux" \
+      makeWrapper '${lib.getExe electron_35}' "$out/bin/teams-for-linux" \
         --prefix PATH : ${
           lib.makeBinPath [
             alsa-utils


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
https://github.com/IsmaelMartinez/teams-for-linux/compare/v1.13.2...v2.0.7

Bumped electron version
Requires `makeCacheWritable`
Electron builder complaining about vulkan symlink inside electron-dist couldn't be copied. Just remove the offending file and copy it over. 

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
