### PR TITLE
python313Packages.django-extensions: 3.2.3 -> 4.0

### DIFF
--- a/pkgs/development/python-modules/django-extensions/default.nix
+++ b/pkgs/development/python-modules/django-extensions/default.nix
@@ -2,7 +2,6 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  fetchpatch2,
 
   # build-system
   setuptools,
@@ -10,14 +9,16 @@
   # dependencies
   aiosmtpd,
   django,
-  looseversion,
 
   # tests
   factory-boy,
   mock,
   pip,
+  postgresql,
+  postgresqlTestHook,
   pygments,
   pytestCheckHook,
+  pytest-cov-stub,
   pytest-django,
   shortuuid,
   vobject,
@@ -26,39 +27,21 @@
 
 buildPythonPackage rec {
   pname = "django-extensions";
-  version = "3.2.3";
+  version = "4.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = pname;
     repo = pname;
     tag = version;
-    hash = "sha256-A2+5FBv0IhTJPkwgd7je+B9Ac64UHJEa3HRBbWr2FxM=";
+    hash = "sha256-VosMPkwzqmEieB85k7qX5yfefHNn+RwAsoR1ezYJHC4=";
   };
-
-  patches = [
-    (fetchpatch2 {
-      # Replace dead asyncore, smtp implementation with aiosmtpd
-      name = "django-extensions-aiosmtpd.patch";
-      url = "https://github.com/django-extensions/django-extensions/commit/37d56c4a4704c823ac6a4ef7c3de4c0232ceee64.patch";
-      hash = "sha256-49UeJQKO0epwY/7tqoiHgOXdgPcB/JBIZaCn3ulaHTg=";
-    })
-  ];
-
-  postPatch = ''
-    substituteInPlace setup.cfg \
-      --replace-fail "--cov=django_extensions --cov-report html --cov-report term" ""
-
-    substituteInPlace django_extensions/management/commands/pipchecker.py \
-      --replace-fail "from distutils.version" "from looseversion"
-  '';
 
   build-system = [ setuptools ];
 
   dependencies = [
     aiosmtpd
     django
-    looseversion
   ];
 
   __darwinAllowLocalNetworking = true;
@@ -67,7 +50,10 @@ buildPythonPackage rec {
     factory-boy
     mock
     pip
+    postgresql
+    postgresqlTestHook
     pygments # not explicitly declared in setup.py, but some tests require it
+    pytest-cov-stub
     pytest-django
     pytestCheckHook
     shortuuid
@@ -75,21 +61,20 @@ buildPythonPackage rec {
     werkzeug
   ];
 
-  disabledTests = [
-    # Mismatch in expectation of exception message
-    "test_installed_apps_no_resolve_conflicts_function"
-    # pygments compat issue
-    "test_should_highlight_python_syntax_with_name"
-  ];
+  env = {
+    postgresqlEnableTCP = 1;
+    PGUSER = "postgres";
+    PGPASSWORD = "postgres";
+    PGDATABASE = "django_extensions_test";
+  };
 
   disabledTestPaths = [
-    # requires network access
-    "tests/management/commands/test_pipchecker.py"
-    # django.db.utils.OperationalError: no such table: django_extensions_permmodel
+    # https://github.com/django-extensions/django-extensions/issues/1871
     "tests/test_dumpscript.py"
   ];
 
   meta = with lib; {
+    changelog = "https://github.com/django-extensions/django-extensions/releases/tag/${src.tag}";
     description = "Collection of custom extensions for the Django Framework";
     homepage = "https://github.com/django-extensions/django-extensions";
     license = licenses.mit;


### PR DESCRIPTION
https://github.com/django-extensions/django-extensions/releases/tag/4.0

Targeting staging-next for newer setuptools version compat.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
