### PR TITLE
gpgme: mark cross as broken

### DIFF
--- a/pkgs/development/libraries/gpgme/default.nix
+++ b/pkgs/development/libraries/gpgme/default.nix
@@ -105,7 +105,10 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     # fatal error: 'QtCore/qcompare.h' file not found
-    broken = qtbase != null && stdenv.hostPlatform.isDarwin;
+    # Cross is broken because libgpg-error.dev is not built for the build platform.
+    broken =
+      qtbase != null && stdenv.hostPlatform.isDarwin
+      || !stdenv.buildPlatform.canExecute stdenv.hostPlatform;
     homepage = "https://gnupg.org/software/gpgme/index.html";
     changelog = "https://git.gnupg.org/cgi-bin/gitweb.cgi?p=gpgme.git;f=NEWS;hb=gpgme-${version}";
     description = "Library for making GnuPG easier to use";


### PR DESCRIPTION
See code comments for reasoning. Some scripts in libgpg-error.dev do work, which is why I did not mark that one as broken

## Things done

- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).