### PR TITLE
music-assistant: 2.5.0 -> 2.5.1

### DIFF
--- a/nixos/modules/services/audio/music-assistant.nix
+++ b/nixos/modules/services/audio/music-assistant.nix
@@ -70,6 +70,8 @@ in
       documentation = [ "https://music-assistant.io" ];
 
       wantedBy = [ "multi-user.target" ];
+      wants = [ "network-online.target" ];
+      after = [ "network-online.target" ];
 
       environment = {
         HOME = "/var/lib/music-assistant";

--- a/pkgs/by-name/mu/music-assistant/frontend.nix
+++ b/pkgs/by-name/mu/music-assistant/frontend.nix
@@ -7,12 +7,12 @@
 
 buildPythonPackage rec {
   pname = "music-assistant-frontend";
-  version = "2.14.8";
+  version = "2.14.9";
   pyproject = true;
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-YUir/YBBbggsQUh5b6qSG5fpAa25jJmgcSsf0EZ8rhw=";
+    hash = "sha256-UEGRZBegoAnls5xAyVgjisD0B8nu8kXp1XHI4A114lw=";
   };
 
   postPatch = ''

--- a/pkgs/by-name/mu/music-assistant/package.nix
+++ b/pkgs/by-name/mu/music-assistant/package.nix
@@ -48,14 +48,14 @@ assert
 
 python.pkgs.buildPythonApplication rec {
   pname = "music-assistant";
-  version = "2.5.0";
+  version = "2.5.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "music-assistant";
     repo = "server";
     tag = version;
-    hash = "sha256-yugtL3dCuGb2OSTy49V4mil9EnfACcGrYCA1rW/lo+4=";
+    hash = "sha256-d/Pj6WVNCC5FGcZ0m+gBkd8BS0nYFTXXeznxRsauJrU=";
   };
 
   patches = [

--- a/pkgs/by-name/mu/music-assistant/providers.nix
+++ b/pkgs/by-name/mu/music-assistant/providers.nix
@@ -1,7 +1,7 @@
 # Do not edit manually, run ./update-providers.py
 
 {
-  version = "2.5.0";
+  version = "2.5.1";
   providers = {
     airplay = ps: [
     ];


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Changelog: https://github.com/music-assistant/server/releases/tag/2.5.1

~Marking this as draft, because the NixOS test broke. Probably related to https://github.com/music-assistant/server/pull/2100~
NixOS test is now fixed.

```
machine # curl: (7) Failed to connect to localhost port 8095 after 20 ms: Could not connect to server
machine # [    9.601227] mass[696]: 2025-04-11 08:51:54.674 ERROR (MainThread) [music_assistant] Error doing task: Task exception was never retrieved
machine # [    9.603200] mass[696]: Traceback (most recent call last):
machine # [    9.603943] mass[696]:   File "/nix/store/5qhn8garnkwprrv80hql9l59amqikfxf-python3.12-aiorun-2025.1.1/lib/python3.12/site-packages/aiorun/__init__.py", line 223, in new_coro
machine # [    9.606325] mass[696]:     await coro
machine # [    9.606905] mass[696]:   File "/nix/store/623yh2lx5y8255fhaj6i4vnanhdkmzc7-music-assistant-2.5.1/lib/python3.12/site-packages/music_assistant/__main__.py", line 214, in start_mass
machine # [    9.609174] mass[696]:     await mass.start()
machine # [    9.609994] mass[696]:   File "/nix/store/623yh2lx5y8255fhaj6i4vnanhdkmzc7-music-assistant-2.5.1/lib/python3.12/site-packages/music_assistant/mass.py", line 138, in start
machine # [    9.611972] mass[696]:     self.aiozc = AsyncZeroconf(ip_version=IPVersion.V4Only, interfaces=InterfaceChoice.Default)
machine # [    9.613432] mass[696]:                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
machine # [    9.614843] mass[696]:   File "/nix/store/yv2wywvmyrs5xx3lk54p999g1j3w1iyi-python3.12-zeroconf-0.145.1/lib/python3.12/site-packages/zeroconf/asyncio.py", line 171, in __init__
machine # [    9.617516] mass[696]:     self.zeroconf = zc or Zeroconf(
machine # [    9.619147] mass[696]:                           ^^^^^^^^^
machine # [    9.619961] mass[696]:   File "/nix/store/yv2wywvmyrs5xx3lk54p999g1j3w1iyi-python3.12-zeroconf-0.145.1/lib/python3.12/site-packages/zeroconf/_core.py", line 181, in __init__
machine # [    9.622096] mass[696]:     listen_socket, respond_sockets = create_sockets(interfaces, unicast, ip_version, apple_p2p=apple_p2p)
machine # [    9.623521] mass[696]:                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
machine # [    9.624931] mass[696]:   File "/nix/store/yv2wywvmyrs5xx3lk54p999g1j3w1iyi-python3.12-zeroconf-0.145.1/lib/python3.12/site-packages/zeroconf/_utils/net.py", line 412, in create_sockets
machine # [    9.626808] mass[696]:     add_multicast_member(cast(socket.socket, listen_socket), i)
machine # [    9.627835] mass[696]:   File "/nix/store/yv2wywvmyrs5xx3lk54p999g1j3w1iyi-python3.12-zeroconf-0.145.1/lib/python3.12/site-packages/zeroconf/_utils/net.py", line 316, in add_multicast_member
machine # [    9.629805] mass[696]:     listen_socket.setsockopt(socket.IPPROTO_IP, socket.IP_ADD_MEMBERSHIP, _value)
machine # [    9.631528] mass[696]: OSError: [Errno 19] No such device
machine # [    9.632409] mass[696]: 2025-04-11 08:51:54.682 INFO (MainThread) [aiorun] Entering shutdown phase.
machine # [    9.633933] mass[696]: 2025-04-11 08:51:54.682 INFO (MainThread) [aiorun] Executing provided shutdown_callback.
machine # [    9.635385] mass[696]: 2025-04-11 08:51:54.682 INFO (MainThread) [root] shutdown requested!
machine # [    9.636826] mass[696]: 2025-04-11 08:51:54.688 INFO (MainThread) [music_assistant] Stop called, cleaning up...
machine # [    9.638663] mass[696]: 2025-04-11 08:51:54.688 INFO (MainThread) [aiorun] Waiting for executor shutdown.
machine # [    9.640212] mass[696]: 2025-04-11 08:51:54.697 INFO (MainThread) [aiorun] Shutting down async generators
machine # [    9.641594] mass[696]: 2025-04-11 08:51:54.697 INFO (MainThread) [aiorun] Closing the loop.
machine # [    9.642758] mass[696]: 2025-04-11 08:51:54.697 INFO (MainThread) [aiorun] Leaving. Bye!
machine # [    9.644589] mass[696]: 2025-04-11 08:51:54.697 INFO (MainThread) [aiorun] Reraising unhandled exception
machine # [    9.648327] mass[696]: 2025-04-11 08:51:54.697 ERROR (MainThread) [root] Uncaught exception
machine # [    9.649716] mass[696]: Traceback (most recent call last):
machine # [    9.651227] mass[696]:   File "/nix/store/623yh2lx5y8255fhaj6i4vnanhdkmzc7-music-assistant-2.5.1/bin/.mass-wrapped", line 9, in <module>
machine # [    9.652914] mass[696]:     sys.exit(main())
machine # [    9.653536] mass[696]:              ^^^^^^
machine # [    9.654161] mass[696]:   File "/nix/store/623yh2lx5y8255fhaj6i4vnanhdkmzc7-music-assistant-2.5.1/lib/python3.12/site-packages/music_assistant/__main__.py", line 220, in main
machine # [    9.657149] mass[696]:     run(
machine # [    9.657673] mass[696]:   File "/nix/store/5qhn8garnkwprrv80hql9l59amqikfxf-python3.12-aiorun-2025.1.1/lib/python3.12/site-packages/aiorun/__init__.py", line 374, in run
machine # [    9.659601] mass[696]:     raise pending_exception_to_raise
machine # [    9.660407] mass[696]:   File "/nix/store/5qhn8garnkwprrv80hql9l59amqikfxf-python3.12-aiorun-2025.1.1/lib/python3.12/site-packages/aiorun/__init__.py", line 276, in run
machine # [    9.662384] mass[696]:     shutdown_callback(loop)
machine # [    9.663222] mass[696]:   File "/nix/store/623yh2lx5y8255fhaj6i4vnanhdkmzc7-music-assistant-2.5.1/lib/python3.12/site-packages/music_assistant/__main__.py", line 205, in on_shutdown
machine # [    9.665276] mass[696]:     loop.run_until_complete(mass.stop())
machine # [    9.666254] mass[696]:   File "/nix/store/f2krmq3iv5nibcvn4rw7nrnrciqprdkh-python3-3.12.9/lib/python3.12/asyncio/base_events.py", line 691, in run_until_complete
machine # [    9.669224] mass[696]:     return future.result()
machine # [    9.670042] mass[696]:            ^^^^^^^^^^^^^^^
machine # [    9.670804] mass[696]:   File "/nix/store/623yh2lx5y8255fhaj6i4vnanhdkmzc7-music-assistant-2.5.1/lib/python3.12/site-packages/music_assistant/mass.py", line 205, in stop
machine # [    9.672601] mass[696]:     await self.streams.close()
machine # [    9.673283] mass[696]:           ^^^^^^^^^^^^
machine # [    9.674028] mass[696]: AttributeError: 'MusicAssistant' object has no attribute 'streams'
machine # [    9.767094] systemd[1]: music-assistant.service: Main process exited, code=exited, status=1/FAILURE
machine # [    9.769198] systemd[1]: music-assistant.service: Failed with result 'exit-code'.
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
