### PR TITLE
btcpayserver: 2.0.8 -> 2.1.0

### DIFF
--- a/pkgs/by-name/bt/btcpayserver/package.nix
+++ b/pkgs/by-name/bt/btcpayserver/package.nix
@@ -8,13 +8,13 @@
 
 buildDotnetModule rec {
   pname = "btcpayserver";
-  version = "2.0.8";
+  version = "2.1.0";
 
   src = fetchFromGitHub {
     owner = "btcpayserver";
     repo = "btcpayserver";
     tag = "v${version}";
-    sha256 = "sha256-OK2OqI4h2SLtnGM2Oen5IgmFKqCkd1ZPuXgCOx6Gixs=";
+    sha256 = "sha256-vojRe64STkCKNn/es5+TyBAXvSBXkjjGLbykuKTEa5k=";
   };
 
   projectFile = "BTCPayServer/BTCPayServer.csproj";

--- a/pkgs/by-name/nb/nbxplorer/deps.json
+++ b/pkgs/by-name/nb/nbxplorer/deps.json
@@ -166,13 +166,13 @@
   },
   {
     "pname": "NBitcoin",
-    "version": "7.0.50",
-    "hash": "sha256-l3H70u5OAbd2hevX/yeVBdQyee/dUn5mp4iGvTnTcjk="
+    "version": "8.0.4",
+    "hash": "sha256-9GxJVcByg3zHl9uR01KpTkFkwKuFyr2hm0uZWWlDGeE="
   },
   {
     "pname": "NBitcoin.Altcoins",
-    "version": "3.0.34",
-    "hash": "sha256-eh5Yft+UQqlLREJJ3kKAKLYYjAHOuMxhBI+tr3Ciya8="
+    "version": "4.0.4",
+    "hash": "sha256-fHG/dlTbEu9DjFnHpEVI6/LbVz0BSJdqkPOo6tQW0fg="
   },
   {
     "pname": "NETStandard.Library",

--- a/pkgs/by-name/nb/nbxplorer/package.nix
+++ b/pkgs/by-name/nb/nbxplorer/package.nix
@@ -7,13 +7,13 @@
 
 buildDotnetModule rec {
   pname = "nbxplorer";
-  version = "2.5.23";
+  version = "2.5.25";
 
   src = fetchFromGitHub {
     owner = "dgarage";
     repo = "NBXplorer";
     rev = "v${version}";
-    sha256 = "sha256-T7pKIj7e4ZOX0JRawLc53eqjMrAV2CV8m6BRjukJ+t4=";
+    sha256 = "sha256-RTkKyckdAv6+wJSlDlR+Q8fw0aZEbi4AwB+OPHI7TR4=";
   };
 
   projectFile = "NBXplorer/NBXplorer.csproj";

--- a/pkgs/by-name/nb/nbxplorer/util/update-common.sh
+++ b/pkgs/by-name/nb/nbxplorer/util/update-common.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env nix-shell
-#!nix-shell -i bash -p coreutils curl jq common-updater-scripts dotnet-sdk_6 git gnupg nixFlakes
+#!nix-shell -i bash -p coreutils curl jq common-updater-scripts dotnet-sdk_8 git gnupg
 set -euo pipefail
 
 # This script uses the following env vars:


### PR DESCRIPTION
- [x] The [nix-bitcoin VM test](https://gist.github.com/erikarvstedt/f654472df9d975599f8584ed50269c31) succeeds on `x86_64-linux`.

Notes for reviewers:
You can verify GPG signatures with `refetch=1 pkgs/by-name/bt/btcpayserver/update.sh`.

cc @prusnak