### PR TITLE
go-task: 3.41.0 -> 3.42.1

### DIFF
--- a/pkgs/by-name/go/go-task/package.nix
+++ b/pkgs/by-name/go/go-task/package.nix
@@ -6,20 +6,21 @@
   installShellFiles,
   nix-update-script,
   versionCheckHook,
+  fetchpatch2,
 }:
 
 buildGoModule rec {
   pname = "go-task";
-  version = "3.41.0";
+  version = "3.42.1";
 
   src = fetchFromGitHub {
     owner = "go-task";
     repo = "task";
     tag = "v${version}";
-    hash = "sha256-yJ9XTCS0BK+pcQvcbGR2ixwPODJKdfQnHgB1QoTFhzA=";
+    hash = "sha256-oA/vW4TWLePOW26xOguiAOcVxx6J2PiJFelOM0mDYBA=";
   };
 
-  vendorHash = "sha256-DR9G+I6PYk8jrR0CZiPqtuULTMekATNSLjyHACOmlbk=";
+  vendorHash = "sha256-BmpyPWCgVpx5KWET/VUYkxKE7Rni9Rnsqk5skxlxrqA=";
 
   nativeBuildInputs = [ installShellFiles ];
 
@@ -29,6 +30,17 @@ buildGoModule rec {
     "-s"
     "-w"
     "-X=github.com/go-task/task/v3/internal/version.version=${version}"
+  ];
+
+  patches = [
+    # Workaround to avoid empty version number. Consider removing after release 3.42.2 or later.
+    # This patch was suggested in https://github.com/go-task/task/pull/2105 and is still used in the Homebrew formula.
+    # Although that PR was closed by merging https://github.com/go-task/task/pull/2131 upstream,
+    # the commit depends on other unreleased changes.
+    (fetchpatch2 {
+      url = "https://github.com/go-task/task/commit/44cb98cb0620ea98c43d0f11ce92f5692ad57212.patch?full_index=1";
+      hash = "sha256-LCaDarCeKs7fZ70DjlKdGAjRZpE5mASbhAxCbhtc5nI=";
+    })
   ];
 
   env.CGO_ENABLED = 0;


### PR DESCRIPTION
Diff: https://github.com/go-task/task/compare/v3.41.0...v3.42.1

Changelog: https://github.com/go-task/task/blob/v3.42.1/CHANGELOG.md

This release does not fill version number even if using ldflags, so added a temporal patch as same as homebrew.
https://github.com/Homebrew/homebrew-core/blob/bcc078ce47bbaa3abca3ff96c9905053dea07e7d/Formula/g/go-task.rb#L22-L26

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

This PR aims to fix [failing automatic update](https://nixpkgs-update-logs.nix-community.org/go-task/2025-04-08.log).
The auto-updater may be fixed in the next release, but I'm not sure about their release schedule.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [x] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

cc: @Parasrah

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
