### PR TITLE
cloud-provider-kind: init at 0.6.0

### DIFF
--- a/pkgs/by-name/cl/cloud-provider-kind/package.nix
+++ b/pkgs/by-name/cl/cloud-provider-kind/package.nix
@@ -1,0 +1,28 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  gitUpdater,
+}:
+buildGoModule rec {
+  pname = "cloud-provider-kind";
+  version = "0.6.0";
+
+  src = fetchFromGitHub {
+    owner = "kubernetes-sigs";
+    repo = "cloud-provider-kind";
+    tag = "v${version}";
+    hash = "sha256-6HdP6/uUCtLyZ7vjFGB2NLqe73v/yolRTUE5s/KyIIk=";
+  };
+  passthru.updateScript = gitUpdater { rev-prefix = "v"; };
+
+  vendorHash = null;
+
+  meta = {
+    description = "Load Balancer implementation for Kubernetes-in-Docker";
+    homepage = "https://github.com/kubernetes-sigs/cloud-provider-kind";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ nicoo ];
+    mainProgram = "cloud-provider-kind";
+  };
+}

--- a/pkgs/by-name/cl/cloud-provider-kind/package.nix
+++ b/pkgs/by-name/cl/cloud-provider-kind/package.nix
@@ -19,9 +19,7 @@ buildGoModule rec {
 
   vendorHash = null;
 
-  checkFlags = lib.optional
-    stdenv.isDarwin
-    "-skip=^Test_firstSuccessfulProbe$";
+  checkFlags = lib.optional stdenv.isDarwin "-skip=^Test_firstSuccessfulProbe$";
 
   meta = {
     description = "Load Balancer implementation for Kubernetes-in-Docker";

--- a/pkgs/by-name/cl/cloud-provider-kind/package.nix
+++ b/pkgs/by-name/cl/cloud-provider-kind/package.nix
@@ -3,6 +3,7 @@
   buildGoModule,
   fetchFromGitHub,
   gitUpdater,
+  stdenv,
 }:
 buildGoModule rec {
   pname = "cloud-provider-kind";
@@ -17,6 +18,10 @@ buildGoModule rec {
   passthru.updateScript = gitUpdater { rev-prefix = "v"; };
 
   vendorHash = null;
+
+  checkFlags = lib.optional
+    stdenv.isDarwin
+    "-skip=^Test_firstSuccessfulProbe$"
 
   meta = {
     description = "Load Balancer implementation for Kubernetes-in-Docker";

--- a/pkgs/by-name/cl/cloud-provider-kind/package.nix
+++ b/pkgs/by-name/cl/cloud-provider-kind/package.nix
@@ -21,7 +21,7 @@ buildGoModule rec {
 
   checkFlags = lib.optional
     stdenv.isDarwin
-    "-skip=^Test_firstSuccessfulProbe$"
+    "-skip=^Test_firstSuccessfulProbe$";
 
   meta = {
     description = "Load Balancer implementation for Kubernetes-in-Docker";


### PR DESCRIPTION
Package [cloud-provider-kind], a load-balancer implementation for Kubernetes-in-Docker

It is necessary for testing setups under KinD, which depend on LB objects to expose various services.

[cloud-provider-kind]: https://github.com/kubernetes-sigs/cloud-provider-kind

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
