### PR TITLE
python312Packages.jsonrpclib-pelix: 0.4.3.3 -> 0.4.3.4

### DIFF
--- a/pkgs/development/python-modules/jsonrpclib-pelix/default.nix
+++ b/pkgs/development/python-modules/jsonrpclib-pelix/default.nix
@@ -6,12 +6,13 @@
 
 buildPythonPackage rec {
   pname = "jsonrpclib-pelix";
-  version = "0.4.3.3";
+  version = "0.4.3.4";
   format = "setuptools";
 
   src = fetchPypi {
-    inherit pname version;
-    hash = "sha256-xJT+cQCxE5sTEUacKLwy0cuS5P8fRRH7cdaAcgXcN3M=";
+    pname = "jsonrpclib_pelix";
+    inherit version;
+    hash = "sha256-6C1vTakHp9ER75P9I2HIwgt50ki+T+mWeOCGJqqPy+8=";
   };
 
   doCheck = false; # test_suite="tests" in setup.py but no tests in pypi.

--- a/pkgs/development/python-modules/jsonrpclib-pelix/default.nix
+++ b/pkgs/development/python-modules/jsonrpclib-pelix/default.nix
@@ -1,5 +1,6 @@
 {
   buildPythonPackage,
+  hatchling,
   fetchPypi,
   lib,
 }:
@@ -7,7 +8,8 @@
 buildPythonPackage rec {
   pname = "jsonrpclib-pelix";
   version = "0.4.3.4";
-  format = "setuptools";
+  pyproject = true;
+  build-system = [ hatchling ];
 
   src = fetchPypi {
     pname = "jsonrpclib_pelix";

--- a/pkgs/development/python-modules/jsonrpclib-pelix/default.nix
+++ b/pkgs/development/python-modules/jsonrpclib-pelix/default.nix
@@ -19,7 +19,7 @@ buildPythonPackage rec {
 
   doCheck = false; # test_suite="tests" in setup.py but no tests in pypi.
 
-  meta = with lib; {
+  meta = {
     description = "JSON RPC client library - Pelix compatible fork";
     homepage = "https://pypi.python.org/pypi/jsonrpclib-pelix/";
     license = lib.licenses.asl20;


### PR DESCRIPTION
Fix `python3Packages.jsonrpclib-pelix` ([broken](https://hydra.nixos.org/build/294234272) on `staging-next` by https://github.com/NixOS/nixpkgs/pull/395156) by switching the build system from `setuptools` to `pyproject.toml`/`hatchling`.  (Also remove an unused `with lib;`.)

Edit: This re-updates the package, after the update [got reverted](https://github.com/NixOS/nixpkgs/pull/395862/commits/32eaf7a4fce2a589df943590cf1543c4295247bf).

Edit: Now that [`staging-next` got merged](https://github.com/NixOS/nixpkgs/pull/395862#event-17238739010), this can go straight to `master`.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

More:

- [x] `electrum` (dependee of `jsonrpclib-pelix`) builds fine.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc