### PR TITLE
ugreen-leds-cli: init at 0.3

### DIFF
--- a/pkgs/by-name/ug/ugreen-leds-cli/package.nix
+++ b/pkgs/by-name/ug/ugreen-leds-cli/package.nix
@@ -1,0 +1,40 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  nix-update-script,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "ugreen-leds-cli";
+  version = "0.3";
+
+  src = fetchFromGitHub {
+    owner = "miskcoo";
+    repo = "ugreen_leds_controller";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-eSTOUHs4y6n4cacpjQAp4JIfyu40aBJEMsvuCN6RFZc=";
+  };
+  sourceRoot = "${finalAttrs.src.name}/cli";
+
+  passthru.updateScript = nix-update-script { };
+
+  postPatch = ''
+    substituteInPlace Makefile --replace-warn "-static" ""
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm755 ugreen_leds_cli $out/bin/ugreen_leds_cli
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "CLI tool to control UGREEN NAS LEDs";
+    homepage = "https://github.com/miskcoo/ugreen_leds_controller";
+    license = lib.licenses.mit;
+    mainProgram = "ugreen_leds_cli";
+    maintainers = with lib.maintainers; [ michaelvanstraten ];
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
This adds a LED Command-line Tool for UGREEN's DX/DXP NAS Series.

It might be that only `platforms = [ "x86_64-linux" ]` might be valid here, since it's currently the only platform the NAS Series has, let me know if I should change that.

There is currently no license included in the metadata, since the upstream repo does not provide one. I've created an [issue]( https://github.com/miskcoo/ugreen_leds_controller/issues/54) upstream for a license request.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
