### PR TITLE
Add onelogin and onelogin-aws-assume-role python libraries

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8900,6 +8900,12 @@
     githubId = 19275558;
     name = "Julien Girard-Satabin";
   };
+  gjhenrique = {
+    email = "me@gjhenrique.com";
+    github = "gjhenrique";
+    githubId = 2664596;
+    name = "Guilherme Henrique";
+  };
   GKasparov = {
     email = "mizozahr@gmail.com";
     github = "GKasparov";

--- a/pkgs/development/python-modules/onelogin-aws-assume-role/default.nix
+++ b/pkgs/development/python-modules/onelogin-aws-assume-role/default.nix
@@ -1,0 +1,42 @@
+{
+  boto3,
+  buildPythonPackage,
+  fetchFromGitHub,
+  lib,
+  lxml,
+  onelogin_2,
+  pyyaml,
+  setuptools,
+}:
+
+buildPythonPackage rec {
+  pname = "onelogin-aws-assume-role";
+  version = "1.10.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "onelogin";
+    repo = "onelogin-python-aws-assume-role";
+    rev = "v${version}";
+    hash = "sha256-cHaelV6Mkgpv5XaJFRzqJLWfdZ9ctG7GPAMkGnvIpT0=";
+  };
+
+  build-system = [
+    setuptools
+  ];
+
+  dependencies = [
+    boto3
+    lxml
+    onelogin_2
+    pyyaml
+  ];
+
+  meta = with lib; {
+    description = "Assume an AWS Role and get temporary credentials using OneLogin";
+    homepage = "https://github.com/onelogin/onelogin-python-aws-assume-role";
+    changelog = "https://github.com/onelogin/onelogin-python-aws-assume-role/tag/${src.rev}";
+    maintainers = with maintainers; [ gjhenrique ];
+    mainProgram = "onelogin-aws-assume-role";
+  };
+}

--- a/pkgs/development/python-modules/onelogin/2.nix
+++ b/pkgs/development/python-modules/onelogin/2.nix
@@ -1,0 +1,48 @@
+{
+  buildPythonPackage,
+  defusedxml,
+  fetchFromGitHub,
+  lib,
+  python-dateutil,
+  requests,
+  setuptools,
+}:
+
+buildPythonPackage rec {
+  pname = "onelogin";
+  version = "2.0.4";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "onelogin";
+    repo = "onelogin-python-sdk";
+    rev = version;
+    hash = "sha256-KfrYvsNr+RZOTmhJHYcLhxvKy00vUmejvcX9d1e6Rqo=";
+  };
+
+  nativeBuildInputs = [ setuptools ];
+
+  build-system = [
+    setuptools
+  ];
+
+  dependencies = [
+    requests
+    defusedxml
+    python-dateutil
+  ];
+
+  postConfigure = ''
+    substituteInPlace setup.py \
+      --replace-fail "defusedxml>=0.6.0" "defusedxml"
+  '';
+
+  pythonImportsCheck = [ "onelogin" ];
+
+  meta = with lib; {
+    description = "OpenAPI Specification for OneLogin";
+    homepage = "https://github.com/onelogin/onelogin-python-sdk";
+    license = licenses.mit;
+    maintainers = with maintainers; [ gjhenrique ];
+  };
+}

--- a/pkgs/development/python-modules/onelogin/default.nix
+++ b/pkgs/development/python-modules/onelogin/default.nix
@@ -1,0 +1,50 @@
+{
+  aenum,
+  buildPythonPackage,
+  fetchFromGitHub,
+  frozendict,
+  lib,
+  pydantic_1,
+  pytestCheckHook,
+  python-dateutil,
+  setuptools,
+  urllib3,
+}:
+
+buildPythonPackage rec {
+  pname = "onelogin";
+  version = "3.1.5";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "onelogin";
+    repo = "onelogin-python-sdk";
+    rev = version;
+    hash = "sha256-4REMLFMVDTEu0BpxhlF8nfXGLW8/UwoejXVT4P7jTuo=";
+  };
+
+  nativeBuildInputs = [ setuptools ];
+
+  build-system = [
+    setuptools
+  ];
+
+  dependencies = [
+    aenum
+    frozendict
+    python-dateutil
+    pydantic_1
+    urllib3
+  ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  pythonImportsCheck = [ "onelogin" ];
+
+  meta = with lib; {
+    description = "OpenAPI Specification for OneLogin";
+    homepage = "https://github.com/onelogin/onelogin-python-sdk";
+    license = licenses.mit;
+    maintainers = with maintainers; [ gjhenrique ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10145,6 +10145,8 @@ self: super: with self; {
 
   onedrive-personal-sdk = callPackage ../development/python-modules/onedrive-personal-sdk { };
 
+  onelogin = callPackage ../development/python-modules/onelogin { };
+
   onetimepad = callPackage ../development/python-modules/onetimepad { };
 
   onetimepass = callPackage ../development/python-modules/onetimepass { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10149,6 +10149,8 @@ self: super: with self; {
 
   onelogin_2 = callPackage ../development/python-modules/onelogin/2.nix { };
 
+  onelogin-aws-assume-role = callPackage ../development/python-modules/onelogin-aws-assume-role { };
+
   onetimepad = callPackage ../development/python-modules/onetimepad { };
 
   onetimepass = callPackage ../development/python-modules/onetimepass { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10147,6 +10147,8 @@ self: super: with self; {
 
   onelogin = callPackage ../development/python-modules/onelogin { };
 
+  onelogin_2 = callPackage ../development/python-modules/onelogin/2.nix { };
+
   onetimepad = callPackage ../development/python-modules/onetimepad { };
 
   onetimepass = callPackage ../development/python-modules/onetimepass { };


### PR DESCRIPTION
My company uses [onelogin](https://www.onelogin.com/) to store the AWS accounts and roles. We have an internal tool that wraps the python-based [aws-login-aws-assume-role](https://github.com/onelogin/onelogin-python-aws-assume-role)

The plan is to add this package to nixpkgs together with its dependency `onelogin` (version bigger than 3) and `onelogin_2`. This tool is only compatible with 2.x.x, so `onelogin` wasn't needed, but it's a nice to have.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

