### PR TITLE
fedimint: 0.5.1 -> 0.7.1

### DIFF
--- a/nixos/modules/services/networking/fedimintd.nix
+++ b/nixos/modules/services/networking/fedimintd.nix
@@ -49,36 +49,36 @@ let
           openFirewall = mkOption {
             type = types.bool;
             default = true;
-            description = "Opens port in firewall for fedimintd's p2p port";
+            description = "Opens port in firewall for fedimintd's p2p port (both TCP and UDP)";
           };
           port = mkOption {
             type = types.port;
             default = 8173;
-            description = "Port to bind on for p2p connections from peers";
+            description = "Port to bind on for p2p connections from peers (both TCP and UDP)";
           };
           bind = mkOption {
             type = types.str;
             default = "0.0.0.0";
-            description = "Address to bind on for p2p connections from peers";
+            description = "Address to bind on for p2p connections from peers (both TCP and UDP)";
           };
           url = mkOption {
-            type = types.str;
+            type = types.nullOr types.str;
             example = "fedimint://p2p.myfedimint.com:8173";
             description = ''
-              Public address for p2p connections from peers
+              Public address for p2p connections from peers (if TCP is used)
             '';
           };
         };
-        api = {
+        api_ws = {
           openFirewall = mkOption {
             type = types.bool;
             default = false;
-            description = "Opens port in firewall for fedimintd's api port";
+            description = "Opens TCP port in firewall for fedimintd's Websocket API";
           };
           port = mkOption {
             type = types.port;
             default = 8174;
-            description = "Port to bind on for API connections relied by the reverse proxy/tls terminator.";
+            description = "TCP Port to bind on for API connections relayed by the reverse proxy/tls terminator.";
           };
           bind = mkOption {
             type = types.str;
@@ -86,10 +86,44 @@ let
             description = "Address to bind on for API connections relied by the reverse proxy/tls terminator.";
           };
           url = mkOption {
-            type = types.str;
+            type = types.nullOr types.str;
             description = ''
               Public URL of the API address of the reverse proxy/tls terminator. Usually starting with `wss://`.
             '';
+          };
+        };
+        api_iroh = {
+          openFirewall = mkOption {
+            type = types.bool;
+            default = true;
+            description = "Opens UDP port in firewall for fedimintd's API Iroh endpoint";
+          };
+          port = mkOption {
+            type = types.port;
+            default = 8174;
+            description = "UDP Port to bind Iroh endpoint for API connections";
+          };
+          bind = mkOption {
+            type = types.str;
+            default = "0.0.0.0";
+            description = "Address to bind on for Iroh endpoint for API connections";
+          };
+        };
+        ui = {
+          openFirewall = mkOption {
+            type = types.bool;
+            default = false;
+            description = "Opens TCP port in firewall for built-in UI";
+          };
+          port = mkOption {
+            type = types.port;
+            default = 8175;
+            description = "TCP Port to bind on for UI connections";
+          };
+          bind = mkOption {
+            type = types.str;
+            default = "127.0.0.1";
+            description = "Address to bind on for UI connections";
           };
         };
         bitcoin = {
@@ -159,7 +193,13 @@ let
             example = "api.myfedimint.com";
             description = "Public domain of the API address of the reverse proxy/tls terminator.";
           };
-          path = mkOption {
+          path_ui = mkOption {
+            type = types.str;
+            example = "/";
+            default = "/";
+            description = "Path to host the built-in UI on and forward to the daemon's api port";
+          };
+          path_ws = mkOption {
             type = types.str;
             example = "/";
             default = "/ws/";
@@ -197,7 +237,21 @@ in
       networking.firewall.allowedTCPPorts = concatLists (
         mapAttrsToList (
           fedimintdName: cfg:
-          (lib.optional cfg.api.openFirewall cfg.api.port ++ lib.optional cfg.p2p.openFirewall cfg.p2p.port)
+          (
+            lib.optional cfg.api_ws.openFirewall cfg.api_ws.port
+            ++ lib.optional cfg.p2p.openFirewall cfg.p2p.port
+            ++ lib.optional cfg.ui.openFirewall cfg.ui.port
+          )
+        ) eachFedimintd
+      );
+
+      networking.firewall.allowedUDPPorts = concatLists (
+        mapAttrsToList (
+          fedimintdName: cfg:
+          (
+            lib.optional cfg.api_iroh.openFirewall cfg.api_iroh.port
+            ++ lib.optional cfg.p2p.openFirewall cfg.p2p.port
+          )
         ) eachFedimintd
       );
 
@@ -205,14 +259,13 @@ in
         fedimintdName: cfg:
         (nameValuePair "fedimintd-${fedimintdName}" (
           let
-            startScript = pkgs.writeShellScript "fedimintd-start" (
+            startScript = pkgs.writeShellScriptBin "fedimintd" (
               (
                 if cfg.bitcoin.rpc.secretFile != null then
                   ''
-                    secret=$(${pkgs.coreutils}/bin/head -n 1 "${cfg.bitcoin.rpc.secretFile}")
-                    prefix="''${FM_BITCOIN_RPC_URL%*@*}"  # Everything before the last '@'
-                    suffix="''${FM_BITCOIN_RPC_URL##*@}"  # Everything after the last '@'
-                    FM_BITCOIN_RPC_URL="''${prefix}:''${secret}@''${suffix}"
+                    >&2 echo "Setting FM_FORCE_BITCOIN_RPC_URL using password from ${cfg.bitcoin.rpc.secretFile}"
+                    secret=$(${pkgs.coreutils}/bin/head -n 1 "${cfg.bitcoin.rpc.secretFile}" || exit 1)
+                    export FM_FORCE_BITCOIN_RPC_URL=$(echo "$FM_BITCOIN_RPC_URL" | sed "s|^\(\w\+://[^@]\+\)\(@.*\)|\1:''${secret}\2|")
                   ''
                 else
                   ""
@@ -229,14 +282,23 @@ in
             environment = lib.mkMerge [
               {
                 FM_BIND_P2P = "${cfg.p2p.bind}:${toString cfg.p2p.port}";
-                FM_BIND_API = "${cfg.api.bind}:${toString cfg.api.port}";
-                FM_P2P_URL = cfg.p2p.url;
-                FM_API_URL = cfg.api.url;
+                FM_BIND_API_WS = "${cfg.api_ws.bind}:${toString cfg.api_ws.port}";
+                FM_BIND_API_IROH = "${cfg.api_iroh.bind}:${toString cfg.api_iroh.port}";
+                FM_BIND_UI = "${cfg.ui.bind}:${toString cfg.ui.port}";
                 FM_DATA_DIR = cfg.dataDir;
                 FM_BITCOIN_NETWORK = cfg.bitcoin.network;
                 FM_BITCOIN_RPC_URL = cfg.bitcoin.rpc.url;
                 FM_BITCOIN_RPC_KIND = cfg.bitcoin.rpc.kind;
               }
+
+              (lib.optionalAttrs (cfg.p2p.url != null) {
+                FM_P2P_URL = cfg.p2p.url;
+              })
+
+              (lib.optionalAttrs (cfg.api_ws.url != null) {
+                FM_API_URL = cfg.api_ws.url;
+              })
+
               cfg.environment
             ];
             serviceConfig = {
@@ -244,7 +306,7 @@ in
 
               StateDirectory = "fedimintd-${fedimintdName}";
               StateDirectoryMode = "0700";
-              ExecStart = startScript;
+              ExecStart = "${startScript}/bin/fedimintd";
 
               Restart = "always";
               RestartSec = 10;
@@ -268,9 +330,11 @@ in
               RestrictAddressFamilies = [
                 "AF_INET"
                 "AF_INET6"
+                "AF_NETLINK"
               ];
               RestrictNamespaces = true;
               RestrictRealtime = true;
+              SocketBindAllow = "udp:${builtins.toString cfg.api_iroh.port}";
               SystemCallArchitectures = "native";
               SystemCallFilter = [
                 "@system-service"
@@ -289,12 +353,18 @@ in
 
             {
               # Note: we want by default to enable OpenSSL, but it seems anything 100 and above is
-              # overriden by default value from vhost-options.nix
+              # overridden by default value from vhost-options.nix
               enableACME = mkOverride 99 true;
               forceSSL = mkOverride 99 true;
-              locations.${cfg.nginx.path} = {
-                proxyPass = "http://127.0.0.1:${toString cfg.api.port}/";
+              locations.${cfg.nginx.path_ws} = {
+                proxyPass = "http://127.0.0.1:${builtins.toString cfg.api_ws.port}/";
                 proxyWebsockets = true;
+                extraConfig = ''
+                  proxy_pass_header Authorization;
+                '';
+              };
+              locations.${cfg.nginx.path_ui} = {
+                proxyPass = "http://127.0.0.1:${builtins.toString cfg.ui.port}/";
                 extraConfig = ''
                   proxy_pass_header Authorization;
                 '';

--- a/nixos/tests/fedimintd.nix
+++ b/nixos/tests/fedimintd.nix
@@ -17,12 +17,10 @@
         p2p = {
           url = "fedimint://example.com";
         };
-        api = {
+        api_ws = {
           url = "wss://example.com";
         };
-        environment = {
-          "FM_REL_NOTES_ACK" = "0_4_xyz";
-        };
+        environment = { };
       };
     };
 
@@ -32,6 +30,6 @@
       start_all()
 
       machine.wait_for_unit("fedimintd-mainnet.service")
-      machine.wait_for_open_port(${toString nodes.machine.services.fedimintd.mainnet.api.port})
+      machine.wait_for_open_port(${toString nodes.machine.services.fedimintd.mainnet.api_ws.port})
     '';
 }

--- a/pkgs/by-name/fe/fedimint/package.nix
+++ b/pkgs/by-name/fe/fedimint/package.nix
@@ -6,21 +6,24 @@
   pkg-config,
   protobuf,
   rustPlatform,
+  version ? "0.7.1",
+  hash ? "sha256-7meBYUN7sG1OAtMEm6I66+ptf4EfsbA+dm5/4P3IRV4=",
+  cargoHash ? "sha256-4cFuasH2hvrnzTBTFifHEMtXZKsBv7OVpuwPlV19GGw=",
 }:
 
 rustPlatform.buildRustPackage rec {
   pname = "fedimint";
-  version = "0.5.1";
+  inherit version;
 
   src = fetchFromGitHub {
     owner = "fedimint";
     repo = "fedimint";
     rev = "v${version}";
-    hash = "sha256-dhZYOfXepOnt1lQEgrM/y++5V58weiiTMAyMKl2t37Q=";
+    inherit hash;
   };
 
   useFetchCargoVendor = true;
-  cargoHash = "sha256-WElH4AdLlF/BuxRrURUv6xNGUVBZ6hhSFg1p+T3jG54=";
+  inherit cargoHash;
 
   nativeBuildInputs = [
     protobuf
@@ -45,7 +48,7 @@ rustPlatform.buildRustPackage rec {
     mkdir -p $fedimint/bin $fedimintCli/bin $gateway/bin $gatewayCli/bin $devimint/bin
 
     # delete fuzzing targets and other binaries no one cares about
-    binsToKeep=(fedimint-cli fedimint-dbtool recoverytool fedimintd gatewayd gateway-cli gateway-cln-extension devimint)
+    binsToKeep=(fedimint-cli fedimint-dbtool recoverytool fedimintd gatewayd gateway-cli devimint)
     keepPattern=$(printf "|%s" "''${binsToKeep[@]}")
     keepPattern=''${keepPattern:1}
     find "$out/bin" -maxdepth 1 -type f | grep -Ev "(''${keepPattern})" | xargs rm -f
@@ -59,7 +62,6 @@ rustPlatform.buildRustPackage rec {
     cp -a $releaseDir/gateway-cli $gatewayCli/bin/
 
     cp -a $releaseDir/gatewayd $gateway/bin/
-    cp -a $releaseDir/gateway-cln-extension $gateway/bin/
 
     cp -a $releaseDir/devimint $devimint/bin/
   '';


### PR DESCRIPTION
0.7 release of Fedimint includes deployment changes. Notably:

* Experimental Iroh p2p connectivity support (uses UDP)
* built-in admin UI

This introduces some changes to the service config.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
