### PR TITLE
xdg-desktop-portal-cosmic: substitute fallback background path

### DIFF
--- a/pkgs/by-name/xd/xdg-desktop-portal-cosmic/package.nix
+++ b/pkgs/by-name/xd/xdg-desktop-portal-cosmic/package.nix
@@ -10,6 +10,7 @@
   libgbm,
   pipewire,
   gst_all_1,
+  cosmic-wallpapers,
   coreutils,
   nix-update-script,
   nixosTests,
@@ -59,8 +60,22 @@ rustPlatform.buildRustPackage (finalAttrs: {
     })
   ];
 
-  # Also modifies the functionality by replacing 'false' with 'true' to enable the portal to start properly.
   postPatch = ''
+    # While the `kate-hazen-COSMIC-desktop-wallpaper.png` image is present
+    # in the `pop-wallpapers` package, we're using the Orion Nebula image
+    # from NASA available in the `cosmic-wallpapers` package. Mainly because
+    # the previous image was used in the GNOME shell extension and the
+    # Orion Nebula image is widely used in the Rust-based COSMIC DE's
+    # marketing materials. Another reason to use the Orion Nebula image
+    # is that it's actually the default wallpaper as configured by the
+    # `cosmic-bg` package's configuration in upstream [1] [2].
+    #
+    # [1]: https://github.com/pop-os/cosmic-bg/blob/epoch-1.0.0-alpha.6/config/src/lib.rs#L142
+    # [2]: https://github.com/pop-os/cosmic-bg/blob/epoch-1.0.0-alpha.6/data/v1/all#L3
+    substituteInPlace src/screenshot.rs src/widget/screenshot.rs \
+      --replace-fail '/usr/share/backgrounds/pop/kate-hazen-COSMIC-desktop-wallpaper.png' '${cosmic-wallpapers}/share/backgrounds/cosmic/orion_nebula_nasa_heic0601a.jpg'
+
+    # Also modifies the functionality by replacing 'false' with 'true' to enable the portal to start properly.
     substituteInPlace data/org.freedesktop.impl.portal.desktop.cosmic.service \
       --replace-fail 'Exec=/bin/false' 'Exec=${lib.getExe' coreutils "true"}'
   '';


### PR DESCRIPTION
The directory `/usr/share/backgrounds/pop/` is not accessible on NixOS because the directory `/usr` does not exist on NixOS. The package `cosmic-wallpapers` exists in nixpkgs that provides the background image that is used in the COSMIC DE's screenshots on the first-party website[0]. Substitute the unreachable, FHS path with a valid path of the background image from the Nix store.

Note: We are putting in a different fallback background path alltogether but I believe that this is okay because that is used by upstream in their marketing materials. Meaning, after substitution, we match marketing screenshots from upstream.

[0]: https://system76.com/cosmic/

---

This PR is similar to #397783 and a part of #397209.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

cc: @NixOS/cosmic

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
