### PR TITLE
cd2netmd-gui: init at 2.1.4

### DIFF
--- a/pkgs/by-name/at/atracdenc/package.nix
+++ b/pkgs/by-name/at/atracdenc/package.nix
@@ -1,0 +1,35 @@
+{
+  cmake,
+  fetchFromGitHub,
+  lib,
+  libsndfile,
+  stdenv,
+}:
+stdenv.mkDerivation {
+  pname = "atracdenc";
+  version = "0-unstable-2025-01-04";
+
+  src = fetchFromGitHub {
+    owner = "dcherednik";
+    repo = "atracdenc";
+    rev = "0fe8e1a0d1a495e41a281f54af31d6713c0de01d";
+    hash = "sha256-Tpg9YOE+UUhNMX2sWZiuM6w4IulYuiwFJFUR9HIMoNU=";
+  };
+
+  buildInputs = [
+    libsndfile
+  ];
+
+  nativeBuildInputs = [
+    cmake
+  ];
+
+  meta = {
+    description = "ATRAC decoder/encoder";
+    license = lib.licenses.lgpl21Plus;
+    homepage = "https://github.com/dcherednik/atracdenc";
+    maintainers = with lib.maintainers; [ ddelabru ];
+    mainProgram = "atracdenc";
+    platforms = lib.platforms.all;
+  };
+}

--- a/pkgs/by-name/cd/cd2netmd-gui/package.nix
+++ b/pkgs/by-name/cd/cd2netmd-gui/package.nix
@@ -1,0 +1,143 @@
+{
+  atracdenc,
+  bash,
+  cmake,
+  copyDesktopItems,
+  fetchFromGitHub,
+  ffmpeg,
+  lib,
+  libcdio,
+  libcdio-paranoia,
+  libgcrypt,
+  libgpg-error,
+  libusb1,
+  makeDesktopItem,
+  netmdplusplus,
+  nlohmann_json,
+  pkg-config,
+  qt5,
+  stdenv,
+  taglib,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "cd2netmd-gui";
+  version = "2.1.4";
+
+  src = fetchFromGitHub {
+    owner = "Jo2003";
+    repo = "cd2netmd_gui";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-WPcs96xA3FGo62pIKC+xwqm4s3Gxo0l9HMx8vmH+9xg=";
+  };
+
+  buildInputs = [
+    libcdio
+    libcdio-paranoia
+    libgcrypt
+    libgpg-error
+    libusb1
+    netmdplusplus
+    nlohmann_json
+    qt5.qtbase
+    taglib
+  ];
+
+  cmakeFlags = lib.optionals stdenv.hostPlatform.isDarwin [
+    "-DQ_OS_MAC=1"
+  ];
+
+  postPatch = ''
+    # Source uses git tags to determine version. We replace that here to avoid
+    # a build dependency on the .git directory
+    echo "#define GIT_VERSION \"v${finalAttrs.version}\"" > git_version.h
+    substituteInPlace CMakeLists.txt \
+      --replace-fail \
+        'add_custom_target(git_version_h COMMAND cd ${"$"}{CMAKE_SOURCE_DIR} && ./upd_git_version.sh)' \
+        "" \
+      --replace-fail \
+        'add_dependencies(netmd_wizard git_version_h)' \
+        ""
+
+    # Fix CLI invocation of atracdenc to use absolute path
+    substituteInPlace cxenc.h \
+      --replace-fail \
+        'static constexpr const char* XENC_CLI = "toolchain/atracdenc.exe";' \
+        'static constexpr const char* XENC_CLI = "${lib.getExe atracdenc}";' \
+      --replace-fail \
+        'static constexpr const char* XENC_CLI = "atracdenc";' \
+        'static constexpr const char* XENC_CLI = "${lib.getExe atracdenc}";'
+
+    # Fix CLI invocation of ffmpeg to use absolute path
+    substituteInPlace cffmpeg.h \
+      --replace-fail \
+        'static constexpr const char* FFMPEG_CLI = "toolchain/ffmpeg.exe";' \
+        'static constexpr const char* FFMPEG_CLI = "${lib.getExe ffmpeg}";' \
+      --replace-fail \
+        'static constexpr const char* FFMPEG_CLI = "ffmpeg";' \
+        'static constexpr const char* FFMPEG_CLI = "${lib.getExe ffmpeg}";' \
+      --replace-fail \
+        'static constexpr const char* FFMPEG_CLI = "c2nffmpeg";' \
+        'static constexpr const char* FFMPEG_CLI = "${lib.getExe ffmpeg}";'
+    substituteInPlace cffmpeg.cpp \
+      --replace-fail \
+        'QString encTool = QString("%1/%2").arg(sAppDir).arg(FFMPEG_CLI);' \
+        'QString encTool = FFMPEG_CLI;' \
+      --replace-fail \
+        'QString ffmpeg = QFile::exists(QString("/usr/bin/%1").arg(FFMPEG_CLI)) ? FFMPEG_CLI : "ffmpeg";' \
+        'QString ffmpeg = FFMPEG_CLI;'
+
+    # Let cmake handle the install phase
+    echo "install(TARGETS netmd_wizard)" >> CMakeLists.txt
+  '';
+
+  postInstall = ''
+    # Install application icon
+    mkdir -p $out/share/icons/hicolor/256x256/apps
+    install -Dm 444 ${finalAttrs.src}/res/netmd_wizard.png $out/share/icons/hicolor/256x256/apps/
+  '';
+
+  nativeBuildInputs = [
+    cmake
+    copyDesktopItems
+    pkg-config
+    qt5.wrapQtAppsHook
+  ];
+
+  propagatedBuildInputs = [
+    atracdenc
+    ffmpeg
+  ];
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "NetMD Wizard";
+      genericName = "NetMD MiniDisc burner";
+      desktopName = "NetMD Wizard";
+      exec = "netmd_wizard";
+      icon = "netmd_wizard";
+      comment = "Transfer audio from CD to NetMD";
+      keywords = [
+        "audio"
+        "minidisc"
+        "netmd"
+      ];
+      categories = [
+        "Audio"
+        "AudioVideo"
+        "DiscBurning"
+        "Qt"
+      ];
+      terminal = false;
+    })
+  ];
+
+  meta = {
+    description = "Transfer audio from CD to NetMD";
+    license = lib.licenses.gpl3Plus;
+    homepage = "https://github.com/Jo2003/cd2netmd_gui";
+    changelog = "https://github.com/Jo2003/cd2netmd_gui/releases/tag/v${finalAttrs.version}";
+    maintainers = with lib.maintainers; [ ddelabru ];
+    mainProgram = "netmd_wizard";
+    platforms = lib.platforms.all;
+  };
+})

--- a/pkgs/by-name/ne/netmdplusplus/package.nix
+++ b/pkgs/by-name/ne/netmdplusplus/package.nix
@@ -1,0 +1,52 @@
+{
+  cmake,
+  fetchFromGitHub,
+  lib,
+  libgpg-error,
+  libgcrypt,
+  libusb1,
+  stdenv,
+  testers,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "netmdplusplus";
+  version = "1.0.3";
+
+  src = fetchFromGitHub {
+    owner = "Jo2003";
+    repo = "netmd_plusplus";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-niDt7q6NOhiPTGYkiOfVxPZeHJ5ErDBlgJO+HKsZ+Dk=";
+  };
+
+  buildInputs = [
+    libgcrypt
+    libgpg-error
+    libusb1
+  ];
+
+  nativeBuildInputs = [
+    cmake
+  ];
+
+  cmakeFlags = [
+    # https://github.com/NixOS/nixpkgs/issues/144170
+    "-DCMAKE_INSTALL_INCLUDEDIR=include"
+    "-DCMAKE_INSTALL_LIBDIR=lib"
+  ];
+
+  passthru.tests.pkg-config = testers.hasPkgConfigModules {
+    package = finalAttrs.finalPackage;
+  };
+
+  meta = {
+    description = "C++ library for transferring audio to NetMD";
+    license = lib.licenses.gpl3Plus;
+    homepage = "https://github.com/Jo2003/netmd_plusplus";
+    maintainers = with lib.maintainers; [ ddelabru ];
+    pkgConfigModules = [
+      "libnetmd++"
+    ];
+    platforms = lib.platforms.all;
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Here I have packaged the NetMD Wizard Qt-based application that writes audio files to MiniDisc via a NetMD MiniDisc device connected over USB. I have also separately packaged two of the application's dependencies: atracdenc, a standalone CLI encoder/decoder for the ATRAC audio format used on MiniDiscs, and netmd++, a C++ library for NetMD operations that originated within the NetMD Wizard application code.

For the application itself, I packaged v2.1.4. To compile atracdenc I had to use a more recent git commit than the latest git tag, hence the "unstable" version on this dependency.

The binary release of the application is packaged with precompiled binaries for atracdenc and ffmpeg. Here I have done some small source patches to instead invoke these programs from the nix store in the hope of making the package more platform-agnostic. However, I have only tested the output on x86_64-linux.

Due to Qt5 version discrepancies, in order to test this on NixOS 24.11 I had to copy the three `package.nix` files into the `nixos-24.11` branch and build the application there. It works as expected there, including the invocation of ffmpeg to decode audio to PCM and the invocation of atracdenc to encode tracks in LP2 mode before writing them to MiniDisc. (atracdenc is not invoked in the default SP mode because the NetMD device itself handles encoding in this case.)

There is a popular web application that can control both NetMD and Hi-MD devices using WebUSB in Chromium-based browsers, but NetMD Wizard has the advantage of a unique SP "Disc At Once" mode capable of producing gapless MiniDiscs.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
