### PR TITLE
fnirsi: init at unstable-2025-07-01

### DIFF
--- a/pkgs/development/python-modules/fnirsi/default.nix
+++ b/pkgs/development/python-modules/fnirsi/default.nix
@@ -1,0 +1,64 @@
+{
+  lib,
+  fetchFromGitHub,
+  stdenv,
+  buildPythonPackage,
+  python3Packages,
+}:
+
+buildPythonPackage rec {
+  pname = "fnirsi-usb-power-data-logger";
+  # https://github.com/baryluk/fnirsi-usb-power-data-logger/pull/26
+  version = "unstable-2025-07-01";
+
+  src = fetchFromGitHub {
+    owner = "baryluk";
+    repo = "fnirsi-usb-power-data-logger";
+    rev = "5aaecf514d92fe1ce1bfcc4051ab37c38798d264";
+    hash = "sha256-Kiq7sLh5FM6FxVDO/j7cm+nYe4ZwyNjWMHTFr78jo5Q=";
+  };
+
+  propagatedBuildInputs = with python3Packages; [
+    pyusb
+    crc
+  ];
+
+  format = "pyproject";
+
+  # Custom install phase if there's no setup.py
+  installPhase = ''
+    mkdir -p $out/bin
+    mkdir -p $out/${python3Packages.python.sitePackages}
+
+    # Copy Python files to site-packages
+    cp -r *.py $out/${python3Packages.python.sitePackages}/
+
+    # Create executable scripts
+    for script in fnirsi_logger.py; do
+      if [ -f $script ]; then
+        makeWrapper ${python3Packages.python.interpreter} $out/bin/''${script%.py} \
+          --add-flags "$out/${python3Packages.python.sitePackages}/$script" \
+          --set PYTHONPATH "$PYTHONPATH:$out/${python3Packages.python.sitePackages}"
+      fi
+    done
+  '';
+
+  postInstall = lib.optionalString stdenv.hostPlatform.isLinux ''
+    mkdir -p $out/etc/udev/rules.d
+    cp udev/90-usb-power-meter.rules $out/etc/udev/rules.d
+  '';
+
+  nativeBuildInputs = [
+    python3Packages.wrapPython
+    python3Packages.setuptools
+  ];
+
+  meta = {
+    description = "USB power data logger for FNIRSI devices";
+    homepage = "https://github.com/baryluk/fnirsi-usb-power-data-logger";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ phodina ];
+    platforms = lib.platforms.all;
+    mainProgram = "fnirsi_logger";
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5208,6 +5208,8 @@ self: super: with self; {
 
   fritzconnection = callPackage ../development/python-modules/fritzconnection { };
 
+  fnirsi = callPackage ../development/python-modules/fnirsi { };
+
   froide = toPythonModule (pkgs.froide.override { python3Packages = self; });
 
   frozendict = callPackage ../development/python-modules/frozendict { };


### PR DESCRIPTION
Small Python module for FNIRSI FNB58 USB power meter.

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
