### PR TITLE
pdfpc: 4.6.0 -> 4.7.0, add update script

### DIFF
--- a/pkgs/applications/misc/pdfpc/default.nix
+++ b/pkgs/applications/misc/pdfpc/default.nix
@@ -19,7 +19,7 @@
   webkitgtk_4_1,
   discount,
   json-glib,
-  fetchpatch,
+  nix-update-script,
 }:
 
 stdenv.mkDerivation rec {
@@ -58,6 +58,8 @@ stdenv.mkDerivation rec {
   ];
 
   cmakeFlags = lib.optional stdenv.hostPlatform.isDarwin (lib.cmakeBool "MOVIES" false);
+
+  passthru.updateScript = nix-update-script { };
 
   meta = with lib; {
     description = "Presenter console with multi-monitor support for PDF files";

--- a/pkgs/applications/misc/pdfpc/default.nix
+++ b/pkgs/applications/misc/pdfpc/default.nix
@@ -16,7 +16,7 @@
   gobject-introspection,
   wrapGAppsHook3,
   qrencode,
-  webkitgtk_4_0,
+  webkitgtk_4_1,
   discount,
   json-glib,
   fetchpatch,
@@ -24,13 +24,13 @@
 
 stdenv.mkDerivation rec {
   pname = "pdfpc";
-  version = "4.6.0";
+  version = "4.7.0";
 
   src = fetchFromGitHub {
     repo = "pdfpc";
     owner = "pdfpc";
     rev = "v${version}";
-    hash = "sha256-5HFmbVsNajMwo+lBe9kJcJyQGe61N6Oy2CI/WJwmSE4=";
+    hash = "sha256-fPhCrn1ELC03/II+e021BUNJr1OKCBIcFCM7z+2Oo+s=";
   };
 
   nativeBuildInputs = [
@@ -52,25 +52,9 @@ stdenv.mkDerivation rec {
     (gst-plugins-good.override { gtkSupport = true; })
     gst-libav
     qrencode
-    webkitgtk_4_0
+    webkitgtk_4_1
     discount
     json-glib
-  ];
-
-  patches = [
-    # needed for compiling pdfpc 4.6.0 with vala 0.56.7, see
-    # https://github.com/pdfpc/pdfpc/issues/686
-    # https://github.com/pdfpc/pdfpc/pull/687
-    (fetchpatch {
-      url = "https://github.com/pdfpc/pdfpc/commit/d38edfac63bec54173b4b31eae5c7fb46cd8f714.diff";
-      hash = "sha256-KC2oyzcwU2fUmxaed8qAsKcePwR5KcXgpVdstJg8KmU=";
-    })
-    # Allow compiling with markdown3
-    # https://github.com/pdfpc/pdfpc/pull/716
-    (fetchpatch {
-      url = "https://github.com/pdfpc/pdfpc/commit/08e66b9d432e9598c1ee9a78b2355728036ae1a1.patch";
-      hash = "sha256-SKH2GQ5/6Is36xOFmSs89Yw/w7Fnma3FrNqwjOlUQKM=";
-    })
   ];
 
   cmakeFlags = lib.optional stdenv.hostPlatform.isDarwin (lib.cmakeBool "MOVIES" false);


### PR DESCRIPTION
pdfpc: 4.6.0 -> 4.7.0
Diff: https://github.com/pdfpc/pdfpc/compare/v4.6.0...v4.7.0

Since https://github.com/pdfpc/pdfpc/pull/728,
libsoup3 (and thus webkitgtk_4_1) is supported.

The two previously applied patches are included in the release, see:
https://github.com/pdfpc/pdfpc/commit/d38edfac63bec54173b4b31eae5c7fb46cd8f714
https://github.com/pdfpc/pdfpc/commit/29a5d226f62ae081de5ee779baef827b51e3841c

This is mainly motivated by https://github.com/NixOS/nixpkgs/issues/360897. The newer version of pdfpc supports libsoup_3, and therefore it should be updated.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
