### PR TITLE
python312Packages.textual: 2.1.2 -> 3.1.0

### DIFF
--- a/pkgs/by-name/me/memray/package.nix
+++ b/pkgs/by-name/me/memray/package.nix
@@ -63,6 +63,11 @@ python3Packages.buildPythonApplication rec {
   disabledTestPaths = [
     # Very time-consuming and some tests fails (performance-related?)
     "tests/integration/test_main.py"
+
+    # AssertionError since textual was updated to 3.1.0
+    # https://github.com/bloomberg/memray/issues/750
+    "tests/unit/test_tree_reporter.py"
+    "tests/unit/test_tui_reporter.py"
   ];
 
   meta = with lib; {

--- a/pkgs/development/python-modules/textual-textarea/default.nix
+++ b/pkgs/development/python-modules/textual-textarea/default.nix
@@ -13,6 +13,7 @@
   # tests
   pytestCheckHook,
   pytest-asyncio,
+  tree-sitter-python,
 }:
 
 buildPythonPackage rec {
@@ -46,17 +47,27 @@ buildPythonPackage rec {
   nativeCheckInputs = [
     pytestCheckHook
     pytest-asyncio
+    tree-sitter-python
   ];
 
   pythonImportsCheck = [ "textual_textarea" ];
 
-  disabledTestPaths = [
+  pytestFlagsArray = [
+    # "--deselect=tests/functional_tests/test_comments.py::test_comments[sql--- ]"
+  ];
+
+  disabledTests = [
+    # Requires unpackaged tree-sitter-sql
+    #  textual.widgets._text_area.LanguageDoesNotExist
+    "test_comments"
+
+    # AssertionError: assert Selection(sta...), end=(0, 6)) == Selection(sta...), end=(1, 0))
     # https://github.com/tconbeer/textual-textarea/issues/296
-    "tests/functional_tests/test_textarea.py"
+    "test_keys"
   ];
 
   meta = {
-    description = "A text area (multi-line input) with syntax highlighting for Textual";
+    description = "Text area (multi-line input) with syntax highlighting for Textual";
     homepage = "https://github.com/tconbeer/textual-textarea";
     changelog = "https://github.com/tconbeer/textual-textarea/releases/tag/v${version}";
     license = lib.licenses.mit;

--- a/pkgs/development/python-modules/textual/default.nix
+++ b/pkgs/development/python-modules/textual/default.nix
@@ -23,18 +23,20 @@
   pytestCheckHook,
   syrupy,
   time-machine,
+  tree-sitter-markdown,
+  tree-sitter-python,
 }:
 
 buildPythonPackage rec {
   pname = "textual";
-  version = "2.1.2";
+  version = "3.1.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "Textualize";
     repo = "textual";
     tag = "v${version}";
-    hash = "sha256-VKo1idLu5sYGtuK8yZzVE6QrrMOciYIesbGVlqzNjfk=";
+    hash = "sha256-JBqzaSsLSCzUYdIjlPZdPJlRKrqtWWPqJPp85uMcMLc=";
   };
 
   build-system = [ poetry-core ];
@@ -63,33 +65,25 @@ buildPythonPackage rec {
     syrupy
     time-machine
     tree-sitter
+    tree-sitter-markdown
+    tree-sitter-python
   ];
 
   disabledTestPaths = [
     # Snapshot tests require syrupy<4
     "tests/snapshot_tests/test_snapshots.py"
-
-    # Flaky: https://github.com/Textualize/textual/issues/5511
-    # RuntimeError: There is no current event loop in thread 'MainThread'.
-    "tests/test_focus.py"
   ];
 
   disabledTests = [
     # Assertion issues
     "test_textual_env_var"
-
-    # Requirements for tests are not quite ready
-    "test_register_language"
-
-    # Requires python bindings for tree-sitter languages
-    # https://github.com/Textualize/textual/issues/5449
-    "test_setting_unknown_language"
-    "test_update_highlight_query"
   ];
 
-  # Some tests in groups require state from previous tests
-  # See https://github.com/Textualize/textual/issues/4924#issuecomment-2304889067
-  pytestFlagsArray = [ "--dist=loadgroup" ];
+  pytestFlagsArray = [
+    # Some tests in groups require state from previous tests
+    # See https://github.com/Textualize/textual/issues/4924#issuecomment-2304889067
+    "--dist=loadgroup"
+  ];
 
   pythonImportsCheck = [ "textual" ];
 

--- a/pkgs/development/python-modules/tree-sitter-markdown/default.nix
+++ b/pkgs/development/python-modules/tree-sitter-markdown/default.nix
@@ -1,0 +1,46 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  tree-sitter,
+  pytestCheckHook,
+}:
+
+buildPythonPackage rec {
+  pname = "tree-sitter-markdown";
+  version = "0.4.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "tree-sitter-grammars";
+    repo = "tree-sitter-markdown";
+    tag = "v${version}";
+    hash = "sha256-Oe2iL5b1Cyv+dK0nQYFNLCCOCe+93nojxt6ukH2lEmU=";
+  };
+
+  build-system = [
+    setuptools
+  ];
+
+  optional-dependencies = {
+    core = [
+      tree-sitter
+    ];
+  };
+
+  pythonImportsCheck = [ "tree_sitter_markdown" ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    tree-sitter
+  ];
+
+  meta = {
+    description = "Markdown grammar for tree-sitter";
+    homepage = "https://github.com/tree-sitter-grammars/tree-sitter-markdown";
+    changelog = "https://github.com/tree-sitter-grammars/tree-sitter-markdown/releases/tag/v${version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ GaetanLepage ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -17499,6 +17499,8 @@ self: super: with self; {
 
   tree-sitter-make = callPackage ../development/python-modules/tree-sitter-make { };
 
+  tree-sitter-markdown = callPackage ../development/python-modules/tree-sitter-markdown { };
+
   tree-sitter-python = callPackage ../development/python-modules/tree-sitter-python { };
 
   tree-sitter-rust = callPackage ../development/python-modules/tree-sitter-rust { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->
- **python312Packages.tree-sitter-markdown: init at 0.4.1**
- **python312Packages.textual: 2.1.2 -> 3.1.0**

Diff: https://github.com/Textualize/textual/compare/refs/tags/v2.1.2...refs/tags/v3.1.0
Changelog: https://github.com/Textualize/textual/blob/v3.1.0/CHANGELOG.md

cc @gepbird

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
