### PR TITLE
birdfont: 2.33.3 -> 2.33.6 

### DIFF
--- a/pkgs/tools/misc/birdfont/default.nix
+++ b/pkgs/tools/misc/birdfont/default.nix
@@ -18,6 +18,7 @@
   gsettings-desktop-schemas,
   wrapGAppsHook3,
   autoPatchelfHook,
+  nix-update-script,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -62,6 +63,8 @@ stdenv.mkDerivation (finalAttrs: {
   buildPhase = "./build.py";
 
   installPhase = "./install.py";
+
+  passthru.updateScript = nix-update-script { };
 
   meta = with lib; {
     description = "Font editor which can generate fonts in TTF, EOT, SVG and BIRDFONT format";

--- a/pkgs/tools/misc/birdfont/default.nix
+++ b/pkgs/tools/misc/birdfont/default.nix
@@ -1,7 +1,7 @@
 {
   lib,
   stdenv,
-  fetchurl,
+  fetchFromGitHub,
   pkg-config,
   python3,
   xmlbird,
@@ -10,7 +10,7 @@
   libgee,
   glib,
   gtk3,
-  webkitgtk_4_0,
+  webkitgtk_4_1,
   libnotify,
   sqlite,
   vala,
@@ -20,13 +20,15 @@
   autoPatchelfHook,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "birdfont";
-  version = "2.33.3";
+  version = "2.33.6";
 
-  src = fetchurl {
-    url = "https://birdfont.org/releases/birdfont-${version}.tar.xz";
-    sha256 = "sha256-NNw7203BtHhNyyQezb3/EP98cTsu7ABDFBnM5Ms2ePY=";
+  src = fetchFromGitHub {
+    owner = "johanmattssonm";
+    repo = "birdfont";
+    tag = "v${finalAttrs.version}";
+    sha256 = "sha256-7xVjY/yH7pMlUBpQc5Gb4t4My24Mx5KkARVp2KSr+Iw=";
   };
 
   nativeBuildInputs = [
@@ -44,7 +46,7 @@ stdenv.mkDerivation rec {
     gdk-pixbuf
     glib
     gtk3
-    webkitgtk_4_0
+    webkitgtk_4_1
     libnotify
     sqlite
     gsettings-desktop-schemas
@@ -67,4 +69,4 @@ stdenv.mkDerivation rec {
     license = licenses.gpl3;
     maintainers = with maintainers; [ dtzWill ];
   };
-}
+})


### PR DESCRIPTION
Birdfont didn't upload their more recent releases as tarball. However, github has the tags and allows easier automatic updating.

Since https://github.com/johanmattssonm/birdfont/commit/62cba5304ca4a4f27a80911c8387c68f3b83a299 [first included in 2.33.4], birdfont now builds against webkitgtk_4_1. This allows us to drop yet another libsoup_2_4 dependency. Related to https://github.com/NixOS/nixpkgs/issues/360897.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
