### PR TITLE
inxi: 3.3.37-1 -> 3.3.38-1

### DIFF
--- a/pkgs/by-name/in/inxi/package.nix
+++ b/pkgs/by-name/in/inxi/package.nix
@@ -62,16 +62,16 @@ let
     ++ recommendedSystemPrograms
     ++ recommendedDisplayInformationPrograms;
 in
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "inxi";
-  version = "3.3.37-1";
+  version = "3.3.38-1";
 
   src = fetchFromGitea {
     domain = "codeberg.org";
     owner = "smxi";
     repo = "inxi";
-    rev = version;
-    hash = "sha256-LyIKjXdfE2sK81zFpXPneaFyfKqa4tU4GfXtt89TZOg=";
+    tag = finalAttrs.version;
+    hash = "sha256-+2NPQUn2A8Xy5ByKYS3MOcad6xXvkqcusWEMr7mkEwA=";
   };
 
   nativeBuildInputs = [ makeWrapper ];
@@ -87,7 +87,7 @@ stdenv.mkDerivation rec {
     cp inxi.1 $out/share/man/man1/
   '';
 
-  meta = with lib; {
+  meta = {
     description = "Full featured CLI system information tool";
     longDescription = ''
       inxi is a command line system information script built for console and
@@ -97,10 +97,10 @@ stdenv.mkDerivation rec {
       Processes, RAM usage, and a wide variety of other useful information.
     '';
     homepage = "https://smxi.org/docs/inxi.htm";
-    changelog = "https://github.com/smxi/inxi/blob/${version}/inxi.changelog";
-    license = licenses.gpl3Plus;
-    platforms = platforms.unix;
+    changelog = "https://codeberg.org/smxi/inxi/src/tag/${finalAttrs.version}/inxi.changelog";
+    license = lib.licenses.gpl3Plus;
+    platforms = lib.platforms.unix;
     maintainers = [ ];
     mainProgram = "inxi";
   };
-}
+})


### PR DESCRIPTION
https://codeberg.org/smxi/inxi/src/tag/3.3.38-1/inxi.changelog
https://codeberg.org/smxi/inxi/compare/3.3.37-1...3.3.38-1

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review`

---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 31 packages built:</summary>
  <ul>
    <li>blueberry</li>
    <li>cinnamon-common</li>
    <li>cinnamon-gsettings-overrides</li>
    <li>cinnamon-screensaver</li>
    <li>cinnamon-session</li>
    <li>hw-probe</li>
    <li>hypnotix</li>
    <li>inxi</li>
    <li>lightdm-slick-greeter</li>
    <li>nemo</li>
    <li>nemo-fileroller</li>
    <li>nemo-preview</li>
    <li>nemo-python</li>
    <li>nemo-seahorse</li>
    <li>nemo-with-extensions</li>
    <li>nemo.dev</li>
    <li>pix</li>
    <li>python312Packages.python-xapp</li>
    <li>python313Packages.python-xapp</li>
    <li>sticky</li>
    <li>themechanger</li>
    <li>timeshift</li>
    <li>timeshift-minimal</li>
    <li>timeshift-unwrapped</li>
    <li>warpinator</li>
    <li>xapp</li>
    <li>xapp.dev</li>
    <li>xdg-desktop-portal-xapp</li>
    <li>xed-editor</li>
    <li>xreader</li>
    <li>xviewer</li>
  </ul>
</details>

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc