### PR TITLE
yosys: mark as broken on darwin

### DIFF
--- a/pkgs/development/compilers/yosys/default.nix
+++ b/pkgs/development/compilers/yosys/default.nix
@@ -177,6 +177,11 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://yosyshq.net/yosys/";
     license = licenses.isc;
     platforms = platforms.all;
+    badPlatforms = [
+      # Tests fail
+      # https://github.com/NixOS/nixpkgs/issues/398121
+      lib.systems.inspect.patterns.isDarwin
+    ];
     maintainers = with maintainers; [
       shell
       thoughtpolice


### PR DESCRIPTION
## Things done


The following failures appear during tests:
```
ERROR: FF myDFFP.$auto$ff.cc:266:slice$814 (type $_DFF_PP1_) cannot be legalized: unsupported initial value and async reset value combination
Expected error pattern 'unsupported initial value and async reset value combination' found !!!
...
ERROR: Signal difference
Expected error pattern 'Signal difference' found !!!
...
make -C tests/sim -f run-test.mk
make[1]: Entering directory '/private/tmp/nix-build-yosys-0.51.drv-1/source/tests/sim'
dyld[64511]: Library not loaded: @rpath/libJudy.1.dylib
  Referenced from: <9DDACBAD-0218-3996-8431-48572F6EABDF> /nix/store/pglbyz3zdwigkcmjpdc15ff7d577372l-gtkwave-3.3.121/bin/.vcd2fst-wrapped
  Reason: tried: '/usr/local/lib/libJudy.1.dylib' (no such file), '/usr/lib/libJudy.1.dylib' (no such file, not in dyld cache)
ERROR: Shell command failed!
```

I opened https://github.com/NixOS/nixpkgs/issues/398121.

cc @VShell @thoughtpolice @Luflosi

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
