### PR TITLE
xfce.xfce4-pulseaudio-plugin: 0.4.9 -> 0.5.0

### DIFF
--- a/pkgs/desktops/xfce/panel-plugins/xfce4-pulseaudio-plugin/default.nix
+++ b/pkgs/desktops/xfce/panel-plugins/xfce4-pulseaudio-plugin/default.nix
@@ -1,6 +1,7 @@
 {
+  stdenv,
   lib,
-  mkXfceDerivation,
+  fetchFromGitLab,
   exo,
   gtk3,
   libcanberra,
@@ -9,17 +10,36 @@
   libxfce4ui,
   libxfce4util,
   libxfce4windowing,
+  meson,
+  ninja,
+  pkg-config,
   xfce4-panel,
   xfconf,
   keybinder3,
   glib,
+  gitUpdater,
 }:
 
-mkXfceDerivation {
-  category = "panel-plugins";
+stdenv.mkDerivation (finalAttrs: {
   pname = "xfce4-pulseaudio-plugin";
-  version = "0.4.9";
-  sha256 = "sha256-bJp4HicAFPuRATDHus0DfJFy1c6gw6Tkpd2UN7SXqsI=";
+  version = "0.5.0";
+
+  src = fetchFromGitLab {
+    domain = "gitlab.xfce.org";
+    owner = "panel-plugins";
+    repo = "xfce4-pulseaudio-plugin";
+    tag = "xfce4-pulseaudio-plugin-${finalAttrs.version}";
+    hash = "sha256-FIEV99AV5UiGLTXi9rU4DKK//SolkrOQfpENXQcy64E=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    glib # glib-compile-resources
+    meson
+    ninja
+    pkg-config
+  ];
 
   buildInputs = [
     exo
@@ -36,8 +56,13 @@ mkXfceDerivation {
     xfconf
   ];
 
-  meta = with lib; {
+  passthru.updateScript = gitUpdater { rev-prefix = "xfce4-pulseaudio-plugin-"; };
+
+  meta = {
     description = "Adjust the audio volume of the PulseAudio sound system";
-    maintainers = with maintainers; [ ] ++ teams.xfce.members;
+    homepage = "https://gitlab.xfce.org/panel-plugins/xfce4-pulseaudio-plugin";
+    license = lib.licenses.gpl2Plus;
+    maintainers = lib.teams.xfce.members;
+    platforms = lib.platforms.linux;
   };
-}
+})


### PR DESCRIPTION
https://gitlab.xfce.org/panel-plugins/xfce4-pulseaudio-plugin/-/compare/xfce4-pulseaudio-plugin-0.4.9...xfce4-pulseaudio-plugin-0.5.0




## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->
