### PR TITLE
maintainers/scripts/update: default to nix-update-script

### DIFF
--- a/maintainers/scripts/update.nix
+++ b/maintainers/scripts/update.nix
@@ -9,7 +9,6 @@
   package ? null,
   maintainer ? null,
   predicate ? null,
-  get-script ? pkg: pkg.updateScript or null,
   path ? null,
   max-workers ? null,
   include-overlays ? false,
@@ -35,6 +34,8 @@ let
   );
 
   inherit (pkgs) lib;
+
+  get-script = pkg: pkg.updateScript or (pkgs.nix-update-script { });
 
   # Remove duplicate elements from the list based on some extracted value. O(n^2) complexity.
   nubOn =
@@ -110,11 +111,11 @@ let
   # Recursively find all packages (derivations) in `pkgs` matching `cond` predicate.
   packagesWith = packagesWithPath [ ];
 
-  # Recursively find all packages in `pkgs` with updateScript matching given predicate.
+  # Recursively find all packages in `pkgs` matching given predicate.
   packagesWithUpdateScriptMatchingPredicate =
     cond: packagesWith (path: pkg: (get-script pkg != null) && cond path pkg);
 
-  # Recursively find all packages in `pkgs` with updateScript by given maintainer.
+  # Recursively find all packages in `pkgs` by given maintainer.
   packagesWithUpdateScriptAndMaintainer =
     maintainer':
     let
@@ -185,8 +186,7 @@ let
 
         % nix-shell maintainers/scripts/update.nix --argstr maintainer garbas
 
-    to run all update scripts for all packages that lists \`garbas\` as a maintainer
-    and have \`updateScript\` defined, or:
+    to run all update scripts for all packages that lists \`garbas\` as a maintainer, or:
 
         % nix-shell maintainers/scripts/update.nix --argstr package nautilus
 

--- a/pkgs/by-name/ke/keen4/package.nix
+++ b/pkgs/by-name/ke/keen4/package.nix
@@ -30,6 +30,9 @@ writeShellApplication {
     dosbox ./KEEN4E.EXE -fullscreen -exit
   '';
 
+  # no .version attribute makes update script trip
+  passthru.updateScript = null;
+
   meta = {
     description = "Commander Keen Episode 4: Secret of the Oracle";
     homepage = "https://web.archive.org/web/20141013080934/http://www.3drealms.com/keen4/index.html";


### PR DESCRIPTION
I've seen plenty of additions of `passthru.updateScript = nix-update-script { }` in the past, where the only reason seemed to be, to make the maintainer-update-script work with it.

How about we default to that instead?

This means you'd need to opt-out for some packages explicitly, as shown in the second commit for example. Breakage would be restricted to those running the update scripts, though.

Upside: We don't need to add those updateScripts in packages manually anymore...

Recent examples:
- https://github.com/NixOS/nixpkgs/pull/397517#discussion_r2039948993 @FliegendeWurst 
- https://github.com/NixOS/nixpkgs/pull/393419#discussion_r2031622424 @JohnRTitor @Mic92 