### PR TITLE
lixPackageSets.{lix_2_93,git}: init

### DIFF
--- a/maintainers/team-list.nix
+++ b/maintainers/team-list.nix
@@ -869,6 +869,7 @@ with lib.maintainers;
       qyriad
       _9999years
       lf-
+      alois31
     ];
     scope = "Maintain the Lix package manager inside of Nixpkgs.";
     shortName = "Lix ecosystem";

--- a/nixos/tests/installer.nix
+++ b/nixos/tests/installer.nix
@@ -632,6 +632,7 @@ let
       grubUseEfi ? false,
       enableOCR ? false,
       meta ? { },
+      passthru ? { },
       testSpecialisationConfig ? false,
       testFlakeSwitch ? false,
       testByAttrSwitch ? false,
@@ -644,7 +645,7 @@ let
       isEfi = bootLoader == "systemd-boot" || (bootLoader == "grub" && grubUseEfi);
     in
     makeTest {
-      inherit enableOCR;
+      inherit enableOCR passthru;
       name = "installer-" + name;
       meta = {
         # put global maintainers here, individuals go into makeInstallerTest fkt call
@@ -1109,10 +1110,12 @@ in
 
   # The (almost) simplest partitioning scheme: a swap partition and
   # one big filesystem partition.
-  simple = makeInstallerTest "simple" simple-test-config;
-  lix-simple = makeInstallerTest "simple" simple-test-config // {
-    selectNixPackage = pkgs: pkgs.lix;
-  };
+  simple = makeInstallerTest "simple" (
+    simple-test-config
+    // {
+      passthru.override = args: makeInstallerTest "simple" simple-test-config // args;
+    }
+  );
 
   switchToFlake = makeInstallerTest "switch-to-flake" simple-test-config-flake;
 

--- a/nixos/tests/nix/misc.nix
+++ b/nixos/tests/nix/misc.nix
@@ -3,20 +3,16 @@
 
 let
   inherit (pkgs) lib;
-  tests = {
-    default = testsForPackage { nixPackage = pkgs.nix; };
-    lix = testsForPackage { nixPackage = pkgs.lix; };
-  };
+  tests.default = testsForPackage { nixPackage = pkgs.nix; };
 
-  testsForPackage =
-    args:
-    lib.recurseIntoAttrs {
-      # If the attribute is not named 'test'
-      # You will break all the universe on the release-*.nix side of things.
-      # `discoverTests` relies on `test` existence to perform a `callTest`.
-      test = testMiscFeatures args;
-      passthru.override = args': testsForPackage (args // args');
+  testsForPackage = args: {
+    # If the attribute is not named 'test'
+    # You will break all the universe on the release-*.nix side of things.
+    # `discoverTests` relies on `test` existence to perform a `callTest`.
+    test = testMiscFeatures args // {
+      passthru.override = args': (testsForPackage (args // args')).test;
     };
+  };
 
   testMiscFeatures =
     { nixPackage, ... }:

--- a/pkgs/tools/package-management/lix/common-lix.nix
+++ b/pkgs/tools/package-management/lix/common-lix.nix
@@ -42,6 +42,7 @@ assert lib.assertMsg (
   libarchive,
   libcpuid,
   libsodium,
+  libsystemtap,
   llvmPackages,
   lowdown,
   lowdown-unsandboxed,
@@ -59,9 +60,11 @@ assert lib.assertMsg (
   pkg-config,
   rapidcheck,
   sqlite,
+  systemtap-sdt,
   util-linuxMinimal,
   removeReferencesTo,
   xz,
+  yq,
   nixosTests,
   rustPlatform,
   # Only used for versions before 2.92.
@@ -76,6 +79,10 @@ assert lib.assertMsg (
   enableStrictLLVMChecks ? true,
   withAWS ? !enableStatic && (stdenv.hostPlatform.isLinux || stdenv.hostPlatform.isDarwin),
   aws-sdk-cpp,
+  # FIXME support Darwin once https://github.com/NixOS/nixpkgs/pull/392918 lands
+  withDtrace ?
+    lib.meta.availableOn stdenv.hostPlatform libsystemtap
+    && lib.meta.availableOn stdenv.buildPlatform systemtap-sdt,
   # RISC-V support in progress https://github.com/seccomp/libseccomp/pull/50
   withLibseccomp ? lib.meta.availableOn stdenv.hostPlatform libseccomp,
   libseccomp,
@@ -88,6 +95,8 @@ let
   isLLVMOnly = lib.versionAtLeast version "2.92";
   hasExternalLixDoc = lib.versionOlder version "2.92";
   isLegacyParser = lib.versionOlder version "2.91";
+  hasDtraceSupport = lib.versionAtLeast version "2.93";
+  parseToYAML = lib.versionAtLeast version "2.93";
 in
 # gcc miscompiles coroutines at least until 13.2, possibly longer
 # do not remove this check unless you are sure you (or your users) will not report bugs to Lix upstream about GCC miscompilations.
@@ -159,6 +168,8 @@ stdenv.mkDerivation (finalAttrs: {
       mdbook-linkcheck
       doxygen
     ]
+    ++ lib.optionals (hasDtraceSupport && withDtrace) [ systemtap-sdt ]
+    ++ lib.optionals parseToYAML [ yq ]
     ++ lib.optionals stdenv.hostPlatform.isLinux [ util-linuxMinimal ];
 
   buildInputs =
@@ -187,7 +198,8 @@ stdenv.mkDerivation (finalAttrs: {
     ++ lib.optionals stdenv.hostPlatform.isStatic [ llvmPackages.libunwind ]
     ++ lib.optionals (stdenv.hostPlatform.isx86_64) [ libcpuid ]
     ++ lib.optionals withLibseccomp [ libseccomp ]
-    ++ lib.optionals withAWS [ aws-sdk-cpp ];
+    ++ lib.optionals withAWS [ aws-sdk-cpp ]
+    ++ lib.optionals (hasDtraceSupport && withDtrace) [ libsystemtap ];
 
   inherit cargoDeps;
 
@@ -255,6 +267,9 @@ stdenv.mkDerivation (finalAttrs: {
       (lib.mesonOption "store-dir" storeDir)
       (lib.mesonOption "state-dir" stateDir)
       (lib.mesonOption "sysconfdir" confDir)
+    ]
+    ++ lib.optionals hasDtraceSupport [
+      (lib.mesonEnable "dtrace-probes" withDtrace)
     ]
     ++ lib.optionals stdenv.hostPlatform.isLinux [
       (lib.mesonOption "sandbox-shell" "${busybox-sandbox-shell}/bin/busybox")

--- a/pkgs/tools/package-management/lix/common-lix.nix
+++ b/pkgs/tools/package-management/lix/common-lix.nix
@@ -347,8 +347,8 @@ stdenv.mkDerivation (finalAttrs: {
   passthru = {
     inherit aws-sdk-cpp boehmgc;
     tests = {
-      misc = nixosTests.nix-misc.lix;
-      installer = nixosTests.installer.lix-simple;
+      misc = nixosTests.nix-misc.default.passthru.override { nixPackage = finalAttrs.finalPackage; };
+      installer = nixosTests.installer.simple.override { selectNixPackage = _: finalAttrs.finalPackage; };
     };
   };
 

--- a/pkgs/tools/package-management/lix/common-nix-eval-jobs.nix
+++ b/pkgs/tools/package-management/lix/common-nix-eval-jobs.nix
@@ -11,6 +11,7 @@
   lib,
   lix,
   boost,
+  capnproto,
   nlohmann_json,
   meson,
   pkg-config,
@@ -23,11 +24,16 @@ stdenv.mkDerivation {
   pname = "nix-eval-jobs";
   version = "${version}${suffix}";
   inherit src patches;
-  buildInputs = [
-    nlohmann_json
-    lix
-    boost
-  ];
+  sourceRoot = if lib.versionAtLeast version "2.93" then "source/subprojects/nix-eval-jobs" else null;
+  buildInputs =
+    [
+      nlohmann_json
+      lix
+      boost
+    ]
+    ++ lib.optionals (lib.versionAtLeast version "2.93") [
+      capnproto
+    ];
   nativeBuildInputs = [
     meson
     pkg-config

--- a/pkgs/tools/package-management/lix/default.nix
+++ b/pkgs/tools/package-management/lix/default.nix
@@ -1,13 +1,14 @@
 {
   lib,
   stdenv,
+  makeScopeWithSplicing',
+  generateSplicesForMkScope,
   aws-sdk-cpp,
   boehmgc,
   callPackage,
   fetchgit,
   fetchFromGitHub,
   rustPlatform,
-  newScope,
   editline,
   ncurses,
   clangStdenv,
@@ -22,6 +23,7 @@
 let
   makeLixScope =
     {
+      attrName,
       lix-args,
       nix-eval-jobs-args,
     }:
@@ -29,83 +31,90 @@ let
       # GCC 13.2 is known to miscompile Lix coroutines (introduced in 2.92).
       lixStdenv = if lib.versionAtLeast lix-args.version "2.92" then clangStdenv else stdenv;
     in
-    lib.makeScope newScope (
-      self:
-      lib.recurseIntoAttrs {
-        inherit
-          storeDir
-          stateDir
-          confDir
-          ;
+    makeScopeWithSplicing' {
+      otherSplices = generateSplicesForMkScope [
+        "lixPackageSets"
+        attrName
+      ];
+      f =
+        self:
+        lib.recurseIntoAttrs {
+          inherit
+            storeDir
+            stateDir
+            confDir
+            ;
 
-        boehmgc =
-          # TODO: Why is this called `boehmgc-nix_2_3`?
-          let
-            boehmgc-nix_2_3 = boehmgc.override { enableLargeConfig = true; };
-          in
-          # Since Lix 2.91 does not use boost coroutines, it does not need boehmgc patches either.
-          if lib.versionOlder lix-args.version "2.91" then
-            boehmgc-nix_2_3.overrideAttrs (drv: {
-              patches = (drv.patches or [ ]) ++ [
-                # Part of the GC solution in https://github.com/NixOS/nix/pull/4944
-                ../nix/patches/boehmgc-coroutine-sp-fallback.patch
+          boehmgc =
+            # TODO: Why is this called `boehmgc-nix_2_3`?
+            let
+              boehmgc-nix_2_3 = boehmgc.override { enableLargeConfig = true; };
+            in
+            # Since Lix 2.91 does not use boost coroutines, it does not need boehmgc patches either.
+            if lib.versionOlder lix-args.version "2.91" then
+              boehmgc-nix_2_3.overrideAttrs (drv: {
+                patches = (drv.patches or [ ]) ++ [
+                  # Part of the GC solution in https://github.com/NixOS/nix/pull/4944
+                  ../nix/patches/boehmgc-coroutine-sp-fallback.patch
+                ];
+              })
+            else
+              boehmgc-nix_2_3;
+
+          aws-sdk-cpp =
+            (aws-sdk-cpp.override {
+              apis = [
+                "s3"
+                "transfer"
               ];
-            })
-          else
-            boehmgc-nix_2_3;
+              customMemoryManagement = false;
+            }).overrideAttrs
+              {
+                # only a stripped down version is build which takes a lot less resources to build
+                requiredSystemFeatures = [ ];
+              };
 
-        aws-sdk-cpp =
-          (aws-sdk-cpp.override {
-            apis = [
-              "s3"
-              "transfer"
-            ];
-            customMemoryManagement = false;
-          }).overrideAttrs
-            {
-              # only a stripped down version is build which takes a lot less resources to build
-              requiredSystemFeatures = [ ];
-            };
+          editline = editline.override {
+            inherit ncurses;
+            enableTermcap = true;
+          };
 
-        editline = editline.override {
-          inherit ncurses;
-          enableTermcap = true;
+          # NOTE: The `common-*.nix` helpers contain a top-level function which
+          # takes the Lix source to build and version information. We use the
+          # outer `callPackage` for that.
+          #
+          # That *returns* another function which takes the actual build
+          # dependencies, and that uses the new scope's `self.callPackage` so
+          # that `nix-eval-jobs` can be built against the correct `lix` version.
+          lix = self.callPackage (callPackage ./common-lix.nix lix-args) {
+            stdenv = lixStdenv;
+          };
+
+          nix-direnv = nix-direnv.override {
+            nix = self.lix;
+          };
+
+          nix-eval-jobs = self.callPackage (callPackage ./common-nix-eval-jobs.nix nix-eval-jobs-args) {
+            stdenv = lixStdenv;
+          };
+
+          nix-fast-build = nix-fast-build.override {
+            inherit (self) nix-eval-jobs;
+          };
+
+          colmena = colmena.override {
+            nix = self.lix;
+            inherit (self) nix-eval-jobs;
+          };
         };
-
-        # NOTE: The `common-*.nix` helpers contain a top-level function which
-        # takes the Lix source to build and version information. We use the
-        # outer `callPackage` for that.
-        #
-        # That *returns* another function which takes the actual build
-        # dependencies, and that uses the new scope's `self.callPackage` so
-        # that `nix-eval-jobs` can be built against the correct `lix` version.
-        lix = self.callPackage (callPackage ./common-lix.nix lix-args) {
-          stdenv = lixStdenv;
-        };
-
-        nix-direnv = nix-direnv.override {
-          nix = self.lix;
-        };
-
-        nix-eval-jobs = self.callPackage (callPackage ./common-nix-eval-jobs.nix nix-eval-jobs-args) {
-          stdenv = lixStdenv;
-        };
-
-        nix-fast-build = nix-fast-build.override {
-          inherit (self) nix-eval-jobs;
-        };
-
-        colmena = colmena.override {
-          nix = self.lix;
-          inherit (self) nix-eval-jobs;
-        };
-      }
-    );
+    };
 in
 lib.makeExtensible (self: {
   inherit makeLixScope;
 
   lix_2_90 = self.makeLixScope {
+    attrName = "lix_2_90";
+
     lix-args = rec {
       version = "2.90.0";
 
@@ -136,6 +145,8 @@ lib.makeExtensible (self: {
   };
 
   lix_2_91 = self.makeLixScope {
+    attrName = "lix_2_91";
+
     lix-args = rec {
       version = "2.91.1";
 
@@ -166,6 +177,8 @@ lib.makeExtensible (self: {
   };
 
   lix_2_92 = self.makeLixScope {
+    attrName = "lix_2_92";
+
     lix-args = rec {
       version = "2.92.0";
 

--- a/pkgs/tools/package-management/lix/default.nix
+++ b/pkgs/tools/package-management/lix/default.nix
@@ -230,6 +230,28 @@ lib.makeExtensible (self: {
     };
   };
 
+  git = self.makeLixScope {
+    attrName = "git";
+
+    lix-args = rec {
+      version = "2.94.0-pre-20250509_${builtins.substring 0 12 src.rev}";
+
+      src = fetchFromGitea {
+        domain = "git.lix.systems";
+        owner = "lix-project";
+        repo = "lix";
+        rev = "dcb0a97000d50b2868ed4f8d9fd465c5a5b8eb3a";
+        hash = "sha256-qCRBy8Bbh5XhPalPkhonxNgfsbw3lP0UIXBLSrhxAvI=";
+      };
+
+      cargoDeps = rustPlatform.fetchCargoVendor {
+        name = "lix-${version}";
+        inherit src;
+        hash = "sha256-YMyNOXdlx0I30SkcmdW/6DU0BYc3ZOa2FMJSKMkr7I8=";
+      };
+    };
+  };
+
   latest = self.lix_2_93;
 
   # Note: This is not yet 2.92 because of a non-deterministic `curl` error.

--- a/pkgs/tools/package-management/lix/default.nix
+++ b/pkgs/tools/package-management/lix/default.nix
@@ -8,6 +8,7 @@
   callPackage,
   fetchgit,
   fetchFromGitHub,
+  fetchFromGitea,
   rustPlatform,
   editline,
   ncurses,
@@ -25,7 +26,8 @@ let
     {
       attrName,
       lix-args,
-      nix-eval-jobs-args,
+      # Starting with 2.93, `nix-eval-jobs` lives in the `lix` repository.
+      nix-eval-jobs-args ? { inherit (lix-args) version src; },
     }:
     let
       # GCC 13.2 is known to miscompile Lix coroutines (introduced in 2.92).
@@ -192,7 +194,6 @@ lib.makeExtensible (self: {
       cargoDeps = rustPlatform.fetchCargoVendor {
         name = "lix-${version}";
         inherit src;
-        allowGitDependencies = false;
         hash = "sha256-YMyNOXdlx0I30SkcmdW/6DU0BYc3ZOa2FMJSKMkr7I8=";
       };
     };
@@ -207,7 +208,29 @@ lib.makeExtensible (self: {
     };
   };
 
-  latest = self.lix_2_92;
+  lix_2_93 = self.makeLixScope {
+    attrName = "lix_2_93";
+
+    lix-args = rec {
+      version = "2.93.0";
+
+      src = fetchFromGitea {
+        domain = "git.lix.systems";
+        owner = "lix-project";
+        repo = "lix";
+        rev = version;
+        hash = "sha256-hsFe4Tsqqg4l+FfQWphDtjC79WzNCZbEFhHI8j2KJzw=";
+      };
+
+      cargoDeps = rustPlatform.fetchCargoVendor {
+        name = "lix-${version}";
+        inherit src;
+        hash = "sha256-YMyNOXdlx0I30SkcmdW/6DU0BYc3ZOa2FMJSKMkr7I8=";
+      };
+    };
+  };
+
+  latest = self.lix_2_93;
 
   # Note: This is not yet 2.92 because of a non-deterministic `curl` error.
   # See: https://git.lix.systems/lix-project/lix/issues/662


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
