### PR TITLE
creek: add update script

### DIFF
--- a/pkgs/by-name/cr/creek/package.nix
+++ b/pkgs/by-name/cr/creek/package.nix
@@ -38,17 +38,18 @@ stdenv.mkDerivation (finalAttrs: {
     wayland-protocols
   ];
 
-  deps = callPackage ./build.zig.zon.nix {
-    inherit zig;
-  };
+  deps = callPackage ./build.zig.zon.nix { };
 
   zigBuildFlags = [
     "--system"
     "${finalAttrs.deps}"
   ];
 
+  passthru.updateScript = ./update.sh;
+
   meta = {
-    homepage = "https://git.8pit.net/creek";
+    homepage = "https://github.com/nmeum/creek";
+    changelog = "https://github.com/nmeum/creek/releases/tag/v${finalAttrs.version}";
     description = "Malleable and minimalist status bar for the River compositor";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ alexandrutocar ];

--- a/pkgs/by-name/cr/creek/update.sh
+++ b/pkgs/by-name/cr/creek/update.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p bash common-updater-scripts gnused nixfmt-rfc-style
+
+latest_tag=$(list-git-tags --url=https://github.com/nmeum/creek | sed 's/^v//' | tail -n 1)
+
+update-source-version creek "$latest_tag"
+
+wget "https://raw.githubusercontent.com/nmeum/creek/v${latest_tag}/build.zig.zon"
+nix --extra-experimental-features 'nix-command flakes' run github:nix-community/zon2nix# -- build.zig.zon >pkgs/by-name/cr/creek/build.zig.zon.nix
+
+nixfmt pkgs/by-name/cr/creek/build.zig.zon.nix
+
+rm -rf build.zig.zon


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

- Provides an `update.sh` script. 
  - Migrates from [zig2nix](https://github.com/Cloudef/zig2nix) to the community-maintained [zon2nix](https://github.com/nix-community/zon2nix). The reason for this change is that zon2nix generates code without unnecessary boilerplate and follows best practices (e.g., avoiding the `with; ...` syntax where feasible).
- Provides a `meta.changelog`. 
  - Corrects `meta.homepage`. The motivation for this change is that the previous homepage URL pointed to a repository that is neither a proper homepage nor the source of the package. The GitHub repository, in contrast, offers more relevant information such as releases and pull requests.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
