### PR TITLE
setup-hooks: add fix-darwin-duplicate-lc-rpaths

### DIFF
--- a/pkgs/applications/editors/emacs/make-emacs.nix
+++ b/pkgs/applications/editors/emacs/make-emacs.nix
@@ -194,18 +194,18 @@ mkDerivation (finalAttrs: {
               builtins.map (x: ''"-B${x}"'') (
                 [
                   # Paths necessary so the JIT compiler finds its libraries:
-                  "${lib.getLib libgccjit}/lib"
+                  # "${lib.getLib libgccjit}"
                 ]
-                ++ libGccJitLibraryPaths
+                # libGccJitLibraryPaths
                 ++ [
                   # Executable paths necessary for compilation (ld, as):
-                  "${lib.getBin stdenv.cc.cc}/bin"
-                  "${lib.getBin stdenv.cc.bintools}/bin"
-                  "${lib.getBin stdenv.cc.bintools.bintools}/bin"
+                  # "${lib.getBin stdenv.cc.cc}/bin"
+                  # "${lib.getBin stdenv.cc.bintools}/bin"
+                  # "${lib.getBin stdenv.cc.bintools.bintools}/bin"
                 ]
                 ++ lib.optionals stdenv.hostPlatform.isDarwin [
                   # The linker needs to know where to find libSystem on Darwin.
-                  "${apple-sdk.sdkroot}/usr/lib"
+                  # "${apple-sdk.sdkroot}/usr/lib"
                 ]
               )
             )
@@ -369,6 +369,7 @@ mkDerivation (finalAttrs: {
     ]
     ++ lib.optionals stdenv.hostPlatform.isDarwin [
       sigtool
+      apple-sdk
     ]
     ++ lib.optionals withNS [
       librsvg
@@ -458,7 +459,9 @@ mkDerivation (finalAttrs: {
   env =
     lib.optionalAttrs withNativeCompilation {
       NATIVE_FULL_AOT = "1";
-      LIBRARY_PATH = lib.concatStringsSep ":" libGccJitLibraryPaths;
+      # dummy variable for now
+      LIBRARY_PATH = "";
+      # LIBRARY_PATH = lib.concatStringsSep ":" libGccJitLibraryPaths;
     }
     // lib.optionalAttrs (variant == "macport") {
       # Fixes intermittent segfaults when compiled with LLVM >= 7.0.

--- a/pkgs/build-support/setup-hooks/fix-darwin-dylib-duplicate-lc-rpath.sh
+++ b/pkgs/build-support/setup-hooks/fix-darwin-dylib-duplicate-lc-rpath.sh
@@ -1,0 +1,29 @@
+# maxOS Sequoia 15.4 updated their link-loader to refuse to evaluate
+# dylibs that include duplciate LC_RPATH instructions. Some libraries
+# haven't properly fixed this yet, and some internal NixOS builds seem
+# to cause this type of issue to occur. This hook simply cleans up any
+# duplicates detected inside dylib files.
+
+fixupOutputHooks+=('fixDarwinDuplicateRpathsIn $prefix')
+
+removeDarwinDuplicateRpaths() {
+    dylib_path=$1
+    duplicates=$(@targetPrefix@otool -l "$dylib_path" | awk '/cmd LC_RPATH/{getline; getline; paths[$2]+=1} END { for (p in paths) if (paths[p]>1) print p }')
+    if [ -n "$duplicates" ]; then
+        echo "$dylib_path: removing duplicates"
+        echo "$duplicates"
+        while IFS= read -r dup; do
+            @targetPrefix@install_name_tool $dylib_path -delete_rpath "$dup"
+        done <<< "$duplicates"
+    fi
+}
+
+fixDarwinDuplicateRpathsIn() {
+    local dir="$1"
+    dirs=$(find $dir -name "*.dylib")
+    if [ -n "$dirs" ]; then
+        while IFS= read -r dylib_path; do
+            removeDarwinDuplicateRpaths $dylib_path
+        done <<< "$dirs"
+    fi
+}

--- a/pkgs/development/compilers/gcc/common/dependencies.nix
+++ b/pkgs/development/compilers/gcc/common/dependencies.nix
@@ -6,6 +6,7 @@
   targetPackages,
   texinfo,
   which,
+  fixDarwinDylibDuplicateLcRpaths,
   gettext,
   gnused,
   patchelf,
@@ -50,7 +51,10 @@ in
     ++ optionals langRust [ cargo ]
     # The builder relies on GNU sed (for instance, Darwin's `sed' fails with
     # "-i may not be used with stdin"), and `stdenvNative' doesn't provide it.
-    ++ optionals buildPlatform.isDarwin [ gnused ];
+    ++ optionals buildPlatform.isDarwin [
+      gnused
+      fixDarwinDylibDuplicateLcRpaths
+    ];
 
   # For building runtime libs
   # same for all gcc's

--- a/pkgs/development/compilers/gcc/default.nix
+++ b/pkgs/development/compilers/gcc/default.nix
@@ -54,6 +54,7 @@
   apple-sdk,
   cctools,
   darwin,
+  fixDarwinDylibDuplicateLcRpaths,
 }:
 
 let
@@ -150,6 +151,7 @@ let
       fetchpatch
       fetchurl
       flex
+      fixDarwinDylibDuplicateLcRpaths
       gettext
       gmp
       gnat-bootstrap

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -914,6 +914,12 @@ with pkgs;
     meta.platforms = lib.platforms.darwin;
   } ../build-support/setup-hooks/fix-darwin-dylib-names.sh;
 
+  fixDarwinDylibDuplicateLcRpaths = makeSetupHook {
+    name = "fix-darwin-dylib-duplicate-lc-rpath-hook";
+    substitutions = { inherit (darwin.binutils) targetPrefix; };
+    meta.platforms = lib.platforms.darwin;
+  } ../build-support/setup-hooks/fix-darwin-dylib-duplicate-lc-rpath.sh;
+
   writeDarwinBundle = callPackage ../build-support/make-darwin-bundle/write-darwin-bundle.nix { };
 
   desktopToDarwinBundle = makeSetupHook {


### PR DESCRIPTION
* resolves: issue with some libraries in Sequoia 15.4 where the link-loader fails to evaluate dylibs containing duplicate LC_RPATH instructions
* add hook so that this fixes an issue with libgccjit

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
