### PR TITLE
home-assistant: 2025.4.1 -> 2025.4.2

### DIFF
--- a/pkgs/development/python-modules/aioairzone/default.nix
+++ b/pkgs/development/python-modules/aioairzone/default.nix
@@ -9,7 +9,7 @@
 
 buildPythonPackage rec {
   pname = "aioairzone";
-  version = "0.9.9";
+  version = "1.0.0";
   pyproject = true;
 
   disabled = pythonOlder "3.11";
@@ -18,7 +18,7 @@ buildPythonPackage rec {
     owner = "Noltari";
     repo = "aioairzone";
     tag = version;
-    hash = "sha256-K/QzoN08keaD5+o5HrKOwrNfIugg1GONdwT7RycOM18=";
+    hash = "sha256-/ZzswdGGA4IGc7djTuSIzLtBLA9oRhJBQHMBUlPci7o=";
   };
 
   build-system = [ setuptools ];

--- a/pkgs/development/python-modules/aioesphomeapi/default.nix
+++ b/pkgs/development/python-modules/aioesphomeapi/default.nix
@@ -26,7 +26,7 @@
 
 buildPythonPackage rec {
   pname = "aioesphomeapi";
-  version = "29.8.0";
+  version = "29.9.0";
   pyproject = true;
 
   disabled = pythonOlder "3.9";
@@ -35,7 +35,7 @@ buildPythonPackage rec {
     owner = "esphome";
     repo = "aioesphomeapi";
     tag = "v${version}";
-    hash = "sha256-hX0OOgLnaZOreBfb8ptNkNLzUn+S38/84DfJD423RAM=";
+    hash = "sha256-Wk2WxyyU8SUsBu99sj1LNNzQYspC3eLy1tPXSjk2UxQ=";
   };
 
   build-system = [

--- a/pkgs/development/python-modules/aioshelly/default.nix
+++ b/pkgs/development/python-modules/aioshelly/default.nix
@@ -16,7 +16,7 @@
 
 buildPythonPackage rec {
   pname = "aioshelly";
-  version = "13.4.0";
+  version = "13.4.1";
   pyproject = true;
 
   disabled = pythonOlder "3.11";
@@ -25,7 +25,7 @@ buildPythonPackage rec {
     owner = "home-assistant-libs";
     repo = "aioshelly";
     tag = version;
-    hash = "sha256-sGcI8+y/l8meYmlerWC2cEhW+LMKnZpoCw4ZWG26c6g=";
+    hash = "sha256-1QefCtEjbcvH+VIIoTBbyuMbkPj7z5YtYROFpj2VtH0=";
   };
 
   build-system = [ setuptools ];

--- a/pkgs/development/python-modules/gcal-sync/default.nix
+++ b/pkgs/development/python-modules/gcal-sync/default.nix
@@ -3,6 +3,7 @@
   aiohttp,
   buildPythonPackage,
   fetchFromGitHub,
+  fetchpatch,
   freezegun,
   ical,
   pydantic,
@@ -26,6 +27,15 @@ buildPythonPackage rec {
     tag = version;
     hash = "sha256-8VUXW6tIX43TV7UIxeforZIxAUqGY9uqpz6WGyH4d8E=";
   };
+
+  patches = [
+    (fetchpatch {
+      name = "ical-v9-compat.patch";
+      url = "https://github.com/allenporter/gcal_sync/commit/7ce4b4214568764c234bff179cf05f7e03e21c1b.patch";
+      hash = "sha256-OKFOl1uSCFECbZJe5/J+9oD3fpX/sRM1zPgJ+fmBqPg=";
+      excludes = [ "requirements_dev.txt" ];
+    })
+  ];
 
   build-system = [ setuptools ];
 

--- a/pkgs/development/python-modules/ical/default.nix
+++ b/pkgs/development/python-modules/ical/default.nix
@@ -17,7 +17,7 @@
 
 buildPythonPackage rec {
   pname = "ical";
-  version = "9.0.3";
+  version = "9.1.0";
   pyproject = true;
 
   disabled = pythonOlder "3.11";
@@ -26,7 +26,7 @@ buildPythonPackage rec {
     owner = "allenporter";
     repo = "ical";
     tag = version;
-    hash = "sha256-f2MGG+E6YxziEK4eGoyPBfp/HVVF7qV3yU8N2uw4Lnc=";
+    hash = "sha256-E5CIvjWi18E8PYuOsXhsQempa2pPw1frSWK+/R3UqmQ=";
   };
 
   build-system = [ setuptools ];

--- a/pkgs/development/python-modules/livisi/default.nix
+++ b/pkgs/development/python-modules/livisi/default.nix
@@ -10,14 +10,14 @@
 
 buildPythonPackage rec {
   pname = "livisi";
-  version = "0.0.24";
+  version = "0.0.25";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "planbnet";
     repo = "livisi";
     tag = "v${version}";
-    hash = "sha256-ggEbzN9FfqT968hgOblIh5dfVibzgUEc4SoZfBGOCwo=";
+    hash = "sha256-kEkbuZmYzxhrbTdo7eZJYu2N2uJtfspgqepplXvSXFg=";
   };
 
   pythonRelaxDeps = [ "colorlog" ];

--- a/pkgs/development/python-modules/opower/default.nix
+++ b/pkgs/development/python-modules/opower/default.nix
@@ -15,7 +15,7 @@
 
 buildPythonPackage rec {
   pname = "opower";
-  version = "0.10.1";
+  version = "0.11.1";
   pyproject = true;
 
   disabled = pythonOlder "3.9";
@@ -24,7 +24,7 @@ buildPythonPackage rec {
     owner = "tronikos";
     repo = "opower";
     tag = "v${version}";
-    hash = "sha256-egkXrTKqUz6AiOr55QRUTkz/3CnhTO2GeBDcd40QGvQ=";
+    hash = "sha256-8wUzv5iUKunWu2wR8abw28vQxqrhPVxsIsFhpI1uBbM=";
   };
 
   build-system = [ setuptools ];

--- a/pkgs/development/python-modules/pyvicare/default.nix
+++ b/pkgs/development/python-modules/pyvicare/default.nix
@@ -12,14 +12,14 @@
 
 buildPythonPackage rec {
   pname = "pyvicare";
-  version = "2.43.1";
+  version = "2.44.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "openviess";
     repo = "PyViCare";
     tag = version;
-    hash = "sha256-dVUb3v8r+1Kkh6BCWtny1F2vzynSRijT62OnrQCTTao=";
+    hash = "sha256-R7GhMiE4gXCTQkew7meSkMBGSdZlTKd9X2A1zEgC8ng=";
   };
 
   postPatch = ''

--- a/pkgs/development/python-modules/reolink-aio/default.nix
+++ b/pkgs/development/python-modules/reolink-aio/default.nix
@@ -13,7 +13,7 @@
 
 buildPythonPackage rec {
   pname = "reolink-aio";
-  version = "0.13.0";
+  version = "0.13.1";
   pyproject = true;
 
   disabled = pythonOlder "3.11";
@@ -22,7 +22,7 @@ buildPythonPackage rec {
     owner = "starkillerOG";
     repo = "reolink_aio";
     tag = version;
-    hash = "sha256-sDTC+tjgEc6SQ4G+MWILYXHcJAPIoRo7GttmGAnp4R8=";
+    hash = "sha256-yEv04y8mkXRmxGmK0UXBRcFdmyAg2xEXYYB0X+0zkao=";
   };
 
   build-system = [ setuptools ];

--- a/pkgs/development/python-modules/sharkiq/default.nix
+++ b/pkgs/development/python-modules/sharkiq/default.nix
@@ -8,14 +8,14 @@
 
 buildPythonPackage rec {
   pname = "sharkiq";
-  version = "1.0.2";
+  version = "1.1.0";
   format = "setuptools";
 
   src = fetchFromGitHub {
     owner = "JeffResc";
     repo = pname;
     tag = "v${version}";
-    hash = "sha256-UG460uEv1U/KTuVEcXMZlVbK/7REFpotkUk4U7z7KpA=";
+    hash = "sha256-adSBFH5nGVPo7OBMak6rN5HA5uMKZCqnIVXBnR7REgQ=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -2,7 +2,7 @@
 # Do not edit!
 
 {
-  version = "2025.4.1";
+  version = "2025.4.2";
   components = {
     "3_day_blinds" =
       ps: with ps; [

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -393,7 +393,7 @@ let
   extraBuildInputs = extraPackages python.pkgs;
 
   # Don't forget to run update-component-packages.py after updating
-  hassVersion = "2025.4.1";
+  hassVersion = "2025.4.2";
 
 in
 python.pkgs.buildPythonApplication rec {
@@ -414,13 +414,13 @@ python.pkgs.buildPythonApplication rec {
     owner = "home-assistant";
     repo = "core";
     tag = version;
-    hash = "sha256-h+PqVBEWBZu56opMxtAhQyIwLafyQP6uilqojuDJ/k0=";
+    hash = "sha256-7OwkZ2KF1IxSNCXvr7Ex0nIKWWr78Zvma2WGaKM5cJE=";
   };
 
   # Secondary source is pypi sdist for translations
   sdist = fetchPypi {
     inherit pname version;
-    hash = "sha256-7HHL2fkAOw7cgJT6oy7ICjltiBop37dyMCTA+WNypQ8=";
+    hash = "sha256-IBJxyPZgFrCiARgOzYEcC6Eu/hwoOFTH87lkb+6UYJ4=";
   };
 
   build-system = with python.pkgs; [

--- a/pkgs/servers/home-assistant/frontend.nix
+++ b/pkgs/servers/home-assistant/frontend.nix
@@ -8,7 +8,7 @@ buildPythonPackage rec {
   # the frontend version corresponding to a specific home-assistant version can be found here
   # https://github.com/home-assistant/home-assistant/blob/master/homeassistant/components/frontend/manifest.json
   pname = "home-assistant-frontend";
-  version = "20250404.0";
+  version = "20250411.0";
   format = "wheel";
 
   src = fetchPypi {
@@ -16,7 +16,7 @@ buildPythonPackage rec {
     pname = "home_assistant_frontend";
     dist = "py3";
     python = "py3";
-    hash = "sha256-og/8P3wh5ztjpQJhI+pF/YHKeNjz/AOoCzxGQRl0Aac=";
+    hash = "sha256-oVvYSEvkJ2bvmoC4DHEUi4EE9iOBn3dJyUnyObWSx1k=";
   };
 
   # there is nothing to strip in this package

--- a/pkgs/servers/home-assistant/pytest-homeassistant-custom-component.nix
+++ b/pkgs/servers/home-assistant/pytest-homeassistant-custom-component.nix
@@ -18,7 +18,7 @@
 
 buildPythonPackage rec {
   pname = "pytest-homeassistant-custom-component";
-  version = "0.13.232";
+  version = "0.13.233";
   pyproject = true;
 
   disabled = pythonOlder "3.12";
@@ -27,7 +27,7 @@ buildPythonPackage rec {
     owner = "MatthewFlamm";
     repo = "pytest-homeassistant-custom-component";
     rev = "refs/tags/${version}";
-    hash = "sha256-LHdkU89YzILPZFf/EgnCdPCG4tk1s5V7tpDsNtEaAak=";
+    hash = "sha256-Yi865ZCK1Rr9Nto0HpqRqwCE6t/UPLR8lqfPv0P+bcs=";
   };
 
   build-system = [ setuptools ];

--- a/pkgs/servers/home-assistant/stubs.nix
+++ b/pkgs/servers/home-assistant/stubs.nix
@@ -10,7 +10,7 @@
 
 buildPythonPackage rec {
   pname = "homeassistant-stubs";
-  version = "2025.3.4";
+  version = "2025.4.2";
   pyproject = true;
 
   disabled = python.version != home-assistant.python.version;
@@ -19,7 +19,7 @@ buildPythonPackage rec {
     owner = "KapJI";
     repo = "homeassistant-stubs";
     tag = version;
-    hash = "sha256-HO1A1uLGNnFdigmoZVL+T28f1Oh+6t1pDUa+nh84MLA=";
+    hash = "sha256-SFMGBPVjgoLkPlYHuTKZLbhTMbKGEeE1wYsFJ0ssbgg=";
   };
 
   build-system = [


### PR DESCRIPTION
    https://github.com/home-assistant/core/releases/tag/2025.4.2
    https://github.com/JeffResc/sharkiq/compare/refs/tags/v1.0.2...refs/tags/v1.1.0
    https://github.com/starkillerOG/reolink_aio/releases/tag/0.13.1
    https://github.com/openviess/PyViCare/releases/tag/2.44.0
    https://github.com/andrewsayre/pysmartthings/releases/tag/v3.0.4
    https://github.com/tronikos/opower/releases/tag/v0.11.1
    https://github.com/planbnet/livisi/compare/refs/tags/v0.0.24...refs/tags/v0.0.25
    https://github.com/allenporter/ical/releases/tag/9.1.0
    https://github.com/home-assistant-libs/aioshelly/releases/tag/13.4.1
    https://github.com/esphome/aioesphomeapi/releases/tag/v29.9.0
    https://github.com/Noltari/aioairzone/releases/tag/1.0.0

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
