### PR TITLE
workflows: make requested permissions explicit for create-github-app-token

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -24,6 +24,8 @@ jobs:
         with:
           app-id: ${{ vars.NIXPKGS_CI_APP_ID }}
           private-key: ${{ secrets.NIXPKGS_CI_APP_PRIVATE_KEY }}
+          permission-contents: write
+          permission-pull-requests: write
 
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:

--- a/.github/workflows/codeowners-v2.yml
+++ b/.github/workflows/codeowners-v2.yml
@@ -68,6 +68,8 @@ jobs:
         with:
           app-id: ${{ vars.OWNER_RO_APP_ID }}
           private-key: ${{ secrets.OWNER_RO_APP_PRIVATE_KEY }}
+          permission-administration: read
+          permission-members: read
 
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
@@ -101,6 +103,9 @@ jobs:
         with:
           app-id: ${{ vars.OWNER_APP_ID }}
           private-key: ${{ secrets.OWNER_APP_PRIVATE_KEY }}
+          permission-administration: read
+          permission-members: read
+          permission-pull-requests: write
 
       - name: Build review request package
         run: nix-build ci -A requestReviews

--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -249,6 +249,9 @@ jobs:
         with:
           app-id: ${{ vars.OWNER_APP_ID }}
           private-key: ${{ secrets.OWNER_APP_PRIVATE_KEY }}
+          permission-administration: read
+          permission-members: read
+          permission-pull-requests: write
 
       - name: Download process result
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8

--- a/.github/workflows/periodic-merge.yml
+++ b/.github/workflows/periodic-merge.yml
@@ -24,6 +24,8 @@ jobs:
         with:
           app-id: ${{ vars.NIXPKGS_CI_APP_ID }}
           private-key: ${{ secrets.NIXPKGS_CI_APP_PRIVATE_KEY }}
+          permission-contents: write
+          permission-pull-requests: write
 
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 


### PR DESCRIPTION
Resolves #396875

This is essentially only best-practice, because each token that is created already uses a separate GitHub App with specifically scoped privileges only.

Still, being even more explicit here is not wrong, I think.

## Things done

Not tested manually, because I don't have a repo with all those apps set up. The action input names are taken from https://github.com/actions/create-github-app-token/blob/main/action.yml - and which privileges we are using is already described in comments.

- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
