### PR TITLE
nm-file-secret-agent: v1.0.1 -> v1.1.0

### DIFF
--- a/pkgs/by-name/nm/nm-file-secret-agent/package.nix
+++ b/pkgs/by-name/nm/nm-file-secret-agent/package.nix
@@ -1,6 +1,6 @@
 {
   lib,
-  fetchFromGitHub,
+  fetchFromGitea,
   rustPlatform,
   dbus,
   networkmanager,
@@ -11,8 +11,9 @@ rustPlatform.buildRustPackage rec {
   name = "nm-file-secret-agent";
   version = "1.1.0";
 
-  src = fetchFromGitHub {
-    owner = "lilioid";
+  src = fetchFromGitea {
+    domain = "codeberg.org";
+    owner = "lilly";
     repo = "nm-file-secret-agent";
     rev = "v${version}";
     hash = "sha256-FZef9qMJeQkoLvCHcsGMqr0riC98WVXntQtbt76Iev4=";
@@ -27,7 +28,7 @@ rustPlatform.buildRustPackage rec {
   meta = {
     description = "NetworkManager secret agent that responds with the content of preconfigured files";
     mainProgram = "nm-file-secret-agent";
-    homepage = "https://github.com/lilioid/nm-file-secret-agent/";
+    homepage = "https://codeberg.org/lilly/nm-file-secret-agent";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ lilioid ];
     platforms = lib.lists.intersectLists dbus.meta.platforms networkmanager.meta.platforms;

--- a/pkgs/by-name/nm/nm-file-secret-agent/package.nix
+++ b/pkgs/by-name/nm/nm-file-secret-agent/package.nix
@@ -9,16 +9,16 @@
 }:
 rustPlatform.buildRustPackage rec {
   name = "nm-file-secret-agent";
-  version = "1.0.1";
+  version = "1.1.0";
 
   src = fetchFromGitHub {
     owner = "lilioid";
     repo = "nm-file-secret-agent";
     rev = "v${version}";
-    hash = "sha256-xQWgNxrbpHOfnKXa57cV1F3JmtJcvQsqUfgwfWg5Ni4=";
+    hash = "sha256-FZef9qMJeQkoLvCHcsGMqr0riC98WVXntQtbt76Iev4=";
   };
   useFetchCargoVendor = true;
-  cargoHash = "sha256-Q2RQ6pWYKOr/6nD7PLpTonVldOfyUu2lvwNRAc8zkLg=";
+  cargoHash = "sha256-HYyL0r9YrDL22uQdypJQ7Xep9Uqt4b16bhl0D9kRByU=";
   buildInputs = [ dbus ];
   nativeBuildInputs = [ pkg-config ];
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Update software [nm-file-secret-agent](https://codeberg.org/lilly/nm-file-secret-agent) to its newest version [v1.1.0](https://codeberg.org/lilly/nm-file-secret-agent/releases/tag/v1.1.0) which includes some improvements and bug fixes.

The canonical repository has also been moved to codeberg.org and the derivation source has been updated accordingly.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
