### PR TITLE
postgresqlPackages: refactor finalAttrs support

### DIFF
--- a/pkgs/servers/sql/postgresql/ext/age.nix
+++ b/pkgs/servers/sql/postgresql/ext/age.nix
@@ -19,7 +19,7 @@ let
     "13" = "sha256-HR6nnWt/V2a0rD5eHHUsFIZ1y7lmvLz36URt9pPJnCw=";
   };
 in
-postgresqlBuildExtension rec {
+postgresqlBuildExtension (finalAttrs: {
   pname = "age";
   version = "1.5.0-rc0";
 
@@ -27,7 +27,7 @@ postgresqlBuildExtension rec {
     owner = "apache";
     repo = "age";
     tag = "PG${lib.versions.major postgresql.version}/v${
-      builtins.replaceStrings [ "." ] [ "_" ] version
+      builtins.replaceStrings [ "." ] [ "_" ] finalAttrs.version
     }";
     hash =
       hashes.${lib.versions.major postgresql.version}
@@ -42,7 +42,7 @@ postgresqlBuildExtension rec {
 
   enableUpdateScript = false;
   passthru.tests = stdenv.mkDerivation {
-    inherit version src;
+    inherit (finalAttrs) version src;
 
     pname = "age-regression";
 
@@ -50,7 +50,7 @@ postgresqlBuildExtension rec {
 
     buildPhase =
       let
-        postgresqlAge = postgresql.withPackages (ps: [ ps.age ]);
+        postgresqlAge = postgresql.withPackages (_: [ finalAttrs.finalPackage ]);
       in
       ''
         # The regression tests need to be run in the order specified in the Makefile.
@@ -76,9 +76,9 @@ postgresqlBuildExtension rec {
     broken = !builtins.elem (lib.versions.major postgresql.version) (builtins.attrNames hashes);
     description = "Graph database extension for PostgreSQL";
     homepage = "https://age.apache.org/";
-    changelog = "https://github.com/apache/age/raw/v${src.rev}/RELEASE";
+    changelog = "https://github.com/apache/age/raw/v${finalAttrs.src.rev}/RELEASE";
     maintainers = [ ];
     platforms = postgresql.meta.platforms;
     license = lib.licenses.asl20;
   };
-}
+})

--- a/pkgs/servers/sql/postgresql/ext/citus.nix
+++ b/pkgs/servers/sql/postgresql/ext/citus.nix
@@ -9,14 +9,14 @@
   stdenv,
 }:
 
-postgresqlBuildExtension rec {
+postgresqlBuildExtension (finalAttrs: {
   pname = "citus";
   version = "13.0.3";
 
   src = fetchFromGitHub {
     owner = "citusdata";
     repo = "citus";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-tQ2YkMUeziz+dhfXtfuK0x8PWH3vfoJiVbE+YvQ/Gzc=";
   };
 
@@ -42,9 +42,9 @@ postgresqlBuildExtension rec {
     broken = lib.versionOlder postgresql.version "15";
     description = "Distributed PostgreSQL as an extension";
     homepage = "https://www.citusdata.com/";
-    changelog = "https://github.com/citusdata/citus/blob/${src.rev}/CHANGELOG.md";
+    changelog = "https://github.com/citusdata/citus/blob/${finalAttrs.src.rev}/CHANGELOG.md";
     license = lib.licenses.agpl3Only;
     maintainers = [ ];
     inherit (postgresql.meta) platforms;
   };
-}
+})

--- a/pkgs/servers/sql/postgresql/ext/hypopg.nix
+++ b/pkgs/servers/sql/postgresql/ext/hypopg.nix
@@ -7,14 +7,14 @@
   stdenv,
 }:
 
-postgresqlBuildExtension rec {
+postgresqlBuildExtension (finalAttrs: {
   pname = "hypopg";
   version = "1.4.1";
 
   src = fetchFromGitHub {
     owner = "HypoPG";
     repo = "hypopg";
-    tag = version;
+    tag = finalAttrs.version;
     hash = "sha256-88uKPSnITRZ2VkelI56jZ9GWazG/Rn39QlyHKJKSKMM=";
   };
 
@@ -31,4 +31,4 @@ postgresqlBuildExtension rec {
     platforms = postgresql.meta.platforms;
     maintainers = with lib.maintainers; [ bbigras ];
   };
-}
+})

--- a/pkgs/servers/sql/postgresql/ext/periods.nix
+++ b/pkgs/servers/sql/postgresql/ext/periods.nix
@@ -6,14 +6,14 @@
   stdenv,
 }:
 
-postgresqlBuildExtension rec {
+postgresqlBuildExtension (finalAttrs: {
   pname = "periods";
   version = "1.2.3";
 
   src = fetchFromGitHub {
     owner = "xocolatl";
     repo = "periods";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-97v6+WNDcYb/KivlE/JBlRIZ3gYHj68AlK0fylp1cPo=";
   };
 
@@ -24,4 +24,4 @@ postgresqlBuildExtension rec {
     platforms = postgresql.meta.platforms;
     license = lib.licenses.postgresql;
   };
-}
+})

--- a/pkgs/servers/sql/postgresql/ext/pg_auto_failover.nix
+++ b/pkgs/servers/sql/postgresql/ext/pg_auto_failover.nix
@@ -6,14 +6,14 @@
   stdenv,
 }:
 
-postgresqlBuildExtension rec {
+postgresqlBuildExtension (finalAttrs: {
   pname = "pg_auto_failover";
   version = "2.2";
 
   src = fetchFromGitHub {
     owner = "citusdata";
     repo = "pg_auto_failover";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-lsnVry+5n08kLOun8u0B7XFvI5ijTKJtFJ84fixMHe4=";
   };
 
@@ -23,9 +23,9 @@ postgresqlBuildExtension rec {
     description = "PostgreSQL extension and service for automated failover and high-availability";
     mainProgram = "pg_autoctl";
     homepage = "https://github.com/citusdata/pg_auto_failover";
-    changelog = "https://github.com/citusdata/pg_auto_failover/blob/v${version}/CHANGELOG.md";
+    changelog = "https://github.com/citusdata/pg_auto_failover/blob/v${finalAttrs.version}/CHANGELOG.md";
     maintainers = [ ];
     platforms = postgresql.meta.platforms;
     license = lib.licenses.postgresql;
   };
-}
+})

--- a/pkgs/servers/sql/postgresql/ext/pg_bigm.nix
+++ b/pkgs/servers/sql/postgresql/ext/pg_bigm.nix
@@ -5,14 +5,14 @@
   postgresqlBuildExtension,
 }:
 
-postgresqlBuildExtension rec {
+postgresqlBuildExtension (finalAttrs: {
   pname = "pg_bigm";
   version = "1.2-20240606";
 
   src = fetchFromGitHub {
     owner = "pgbigm";
     repo = "pg_bigm";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-5Uy1DmGZR4WdtRUvNdZ5b9zBHJUb9idcEzW20rkreBs=";
   };
 
@@ -25,4 +25,4 @@ postgresqlBuildExtension rec {
     platforms = postgresql.meta.platforms;
     license = lib.licenses.postgresql;
   };
-}
+})

--- a/pkgs/servers/sql/postgresql/ext/pg_cron.nix
+++ b/pkgs/servers/sql/postgresql/ext/pg_cron.nix
@@ -6,23 +6,23 @@
   stdenv,
 }:
 
-postgresqlBuildExtension rec {
+postgresqlBuildExtension (finalAttrs: {
   pname = "pg_cron";
   version = "1.6.5";
 
   src = fetchFromGitHub {
     owner = "citusdata";
     repo = "pg_cron";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-Llksil7Fk7jvJJmCpfCN0Qm2b2I4J1VOA7/ibytO+KM=";
   };
 
   meta = {
     description = "Run Cron jobs through PostgreSQL";
     homepage = "https://github.com/citusdata/pg_cron";
-    changelog = "https://github.com/citusdata/pg_cron/releases/tag/v${version}";
+    changelog = "https://github.com/citusdata/pg_cron/releases/tag/v${finalAttrs.version}";
     maintainers = with lib.maintainers; [ thoughtpolice ];
     platforms = postgresql.meta.platforms;
     license = lib.licenses.postgresql;
   };
-}
+})

--- a/pkgs/servers/sql/postgresql/ext/pg_ed25519.nix
+++ b/pkgs/servers/sql/postgresql/ext/pg_ed25519.nix
@@ -6,14 +6,14 @@
   stdenv,
 }:
 
-postgresqlBuildExtension rec {
+postgresqlBuildExtension (finalAttrs: {
   pname = "pg_ed25519";
   version = "0.2";
 
   src = fetchFromGitLab {
     owner = "dwagin";
     repo = "pg_ed25519";
-    tag = version;
+    tag = finalAttrs.version;
     hash = "sha256-IOL3ogbPCMNmwDwpeaCZSoaFLJRX0Oah+ysgyUfHg5s=";
   };
 
@@ -26,4 +26,4 @@ postgresqlBuildExtension rec {
     # Broken with no upstream fix available.
     broken = lib.versionAtLeast postgresql.version "16";
   };
-}
+})

--- a/pkgs/servers/sql/postgresql/ext/pg_hll.nix
+++ b/pkgs/servers/sql/postgresql/ext/pg_hll.nix
@@ -6,23 +6,23 @@
   stdenv,
 }:
 
-postgresqlBuildExtension rec {
+postgresqlBuildExtension (finalAttrs: {
   pname = "pg_hll";
   version = "2.18";
 
   src = fetchFromGitHub {
     owner = "citusdata";
     repo = "postgresql-hll";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-Latdxph1Ura8yKEokEjalJ+/GY+pAKOT3GXjuLprj6c=";
   };
 
   meta = {
     description = "HyperLogLog for PostgreSQL";
     homepage = "https://github.com/citusdata/postgresql-hll";
-    changelog = "https://github.com/citusdata/postgresql-hll/blob/v${version}/CHANGELOG.md";
+    changelog = "https://github.com/citusdata/postgresql-hll/blob/v${finalAttrs.version}/CHANGELOG.md";
     maintainers = with lib.maintainers; [ thoughtpolice ];
     platforms = postgresql.meta.platforms;
     license = lib.licenses.asl20;
   };
-}
+})

--- a/pkgs/servers/sql/postgresql/ext/pg_ivm.nix
+++ b/pkgs/servers/sql/postgresql/ext/pg_ivm.nix
@@ -6,24 +6,24 @@
   stdenv,
 }:
 
-postgresqlBuildExtension rec {
+postgresqlBuildExtension (finalAttrs: {
   pname = "pg_ivm";
   version = "1.10";
 
   src = fetchFromGitHub {
     owner = "sraoss";
     repo = "pg_ivm";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-4/ftJkm2ZInm9lkjJG7y4ZULwlyVC19lP0wGXu56SGw=";
   };
 
   meta = {
     description = "Materialized views with IVM (Incremental View Maintenance) for PostgreSQL";
     homepage = "https://github.com/sraoss/pg_ivm";
-    changelog = "https://github.com/sraoss/pg_ivm/releases/tag/v${version}";
+    changelog = "https://github.com/sraoss/pg_ivm/releases/tag/v${finalAttrs.version}";
     maintainers = with lib.maintainers; [ ivan ];
     platforms = postgresql.meta.platforms;
     license = lib.licenses.postgresql;
     broken = lib.versionOlder postgresql.version "13";
   };
-}
+})

--- a/pkgs/servers/sql/postgresql/ext/pg_net.nix
+++ b/pkgs/servers/sql/postgresql/ext/pg_net.nix
@@ -7,14 +7,14 @@
   stdenv,
 }:
 
-postgresqlBuildExtension rec {
+postgresqlBuildExtension (finalAttrs: {
   pname = "pg_net";
   version = "0.14.0";
 
   src = fetchFromGitHub {
     owner = "supabase";
     repo = "pg_net";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-c1pxhTyrE5j6dY+M5eKAboQNofIORS+Dccz+7HKEKQI=";
   };
 
@@ -25,9 +25,9 @@ postgresqlBuildExtension rec {
   meta = {
     description = "Async networking for Postgres";
     homepage = "https://github.com/supabase/pg_net";
-    changelog = "https://github.com/supabase/pg_net/releases/tag/v${version}";
+    changelog = "https://github.com/supabase/pg_net/releases/tag/v${finalAttrs.version}";
     maintainers = with lib.maintainers; [ thoughtpolice ];
     platforms = postgresql.meta.platforms;
     license = lib.licenses.postgresql;
   };
-}
+})

--- a/pkgs/servers/sql/postgresql/ext/pg_partman.nix
+++ b/pkgs/servers/sql/postgresql/ext/pg_partman.nix
@@ -6,24 +6,24 @@
   stdenv,
 }:
 
-postgresqlBuildExtension rec {
+postgresqlBuildExtension (finalAttrs: {
   pname = "pg_partman";
   version = "5.2.4";
 
   src = fetchFromGitHub {
     owner = "pgpartman";
     repo = "pg_partman";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-i/o+JZEXnJRO17kfdTw87aca28+I8pvuFZsPMA/kf+w=";
   };
 
   meta = {
     description = "Partition management extension for PostgreSQL";
     homepage = "https://github.com/pgpartman/pg_partman";
-    changelog = "https://github.com/pgpartman/pg_partman/blob/v${version}/CHANGELOG.md";
+    changelog = "https://github.com/pgpartman/pg_partman/blob/v${finalAttrs.version}/CHANGELOG.md";
     maintainers = with lib.maintainers; [ ggpeti ];
     platforms = postgresql.meta.platforms;
     license = lib.licenses.postgresql;
     broken = lib.versionOlder postgresql.version "14";
   };
-}
+})

--- a/pkgs/servers/sql/postgresql/ext/pg_rational.nix
+++ b/pkgs/servers/sql/postgresql/ext/pg_rational.nix
@@ -5,14 +5,14 @@
   postgresqlBuildExtension,
 }:
 
-postgresqlBuildExtension rec {
+postgresqlBuildExtension (finalAttrs: {
   pname = "pg_rational";
   version = "0.0.2";
 
   src = fetchFromGitHub {
     owner = "begriffs";
     repo = "pg_rational";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-Sp5wuX2nP3KGyWw7MFa11rI1CPIKIWBt8nvBSsASIEw=";
   };
 
@@ -23,4 +23,4 @@ postgresqlBuildExtension rec {
     platforms = postgresql.meta.platforms;
     license = lib.licenses.mit;
   };
-}
+})

--- a/pkgs/servers/sql/postgresql/ext/pg_relusage.nix
+++ b/pkgs/servers/sql/postgresql/ext/pg_relusage.nix
@@ -6,14 +6,14 @@
   stdenv,
 }:
 
-postgresqlBuildExtension rec {
+postgresqlBuildExtension (finalAttrs: {
   pname = "pg_relusage";
   version = "0.0.1";
 
   src = fetchFromGitHub {
     owner = "adept";
     repo = "pg_relusage";
-    tag = "${version}";
+    tag = "${finalAttrs.version}";
     hash = "sha256-8hJNjQ9MaBk3J9a73l+yQMwMW/F2N8vr5PO2o+5GvYs=";
   };
 
@@ -24,4 +24,4 @@ postgresqlBuildExtension rec {
     platforms = postgresql.meta.platforms;
     license = lib.licenses.postgresql;
   };
-}
+})

--- a/pkgs/servers/sql/postgresql/ext/pg_uuidv7.nix
+++ b/pkgs/servers/sql/postgresql/ext/pg_uuidv7.nix
@@ -6,14 +6,14 @@
   stdenv,
 }:
 
-postgresqlBuildExtension rec {
+postgresqlBuildExtension (finalAttrs: {
   pname = "pg_uuidv7";
   version = "1.6.0";
 
   src = fetchFromGitHub {
     owner = "fboulnois";
     repo = "pg_uuidv7";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-lG6dCnbLALnfQc4uclqXXXfYjK/WXLV0lo5I8l1E5p4=";
   };
 
@@ -26,4 +26,4 @@ postgresqlBuildExtension rec {
     license = lib.licenses.mpl20;
     broken = lib.versionOlder postgresql.version "13";
   };
-}
+})

--- a/pkgs/servers/sql/postgresql/ext/pgmq.nix
+++ b/pkgs/servers/sql/postgresql/ext/pgmq.nix
@@ -6,27 +6,27 @@
   stdenv,
 }:
 
-postgresqlBuildExtension rec {
+postgresqlBuildExtension (finalAttrs: {
   pname = "pgmq";
   version = "1.5.1";
 
   src = fetchFromGitHub {
     owner = "tembo-io";
     repo = "pgmq";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-IU+i6ONPwtgsFKdzya6E+222ualR66gkbb0lDr+7Rb8=";
   };
 
-  sourceRoot = "${src.name}/pgmq-extension";
+  sourceRoot = "${finalAttrs.src.name}/pgmq-extension";
 
   dontConfigure = true;
 
   meta = {
     description = "Lightweight message queue like AWS SQS and RSMQ but on Postgres";
     homepage = "https://tembo.io/pgmq";
-    changelog = "https://github.com/tembo-io/pgmq/releases/tag/v${version}";
+    changelog = "https://github.com/tembo-io/pgmq/releases/tag/v${finalAttrs.version}";
     maintainers = with lib.maintainers; [ takeda ];
     platforms = postgresql.meta.platforms;
     license = lib.licenses.postgresql;
   };
-}
+})

--- a/pkgs/servers/sql/postgresql/ext/pgroonga.nix
+++ b/pkgs/servers/sql/postgresql/ext/pgroonga.nix
@@ -10,14 +10,14 @@
   xxHash,
 }:
 
-postgresqlBuildExtension rec {
+postgresqlBuildExtension (finalAttrs: {
   pname = "pgroonga";
   version = "4.0.1";
 
   src = fetchFromGitHub {
     owner = "pgroonga";
     repo = "pgroonga";
-    tag = "${version}";
+    tag = "${finalAttrs.version}";
     hash = "sha256-a5nNtlUiFBuuqWAjIN0gU/FaoV3VpJh+/fab8R/77dw=";
   };
 
@@ -43,9 +43,9 @@ postgresqlBuildExtension rec {
       You can use super fast full text search feature against all languages by installing PGroonga into your PostgreSQL.
     '';
     homepage = "https://pgroonga.github.io/";
-    changelog = "https://github.com/pgroonga/pgroonga/releases/tag/${version}";
+    changelog = "https://github.com/pgroonga/pgroonga/releases/tag/${finalAttrs.version}";
     license = lib.licenses.postgresql;
     platforms = postgresql.meta.platforms;
     maintainers = with lib.maintainers; [ DerTim1 ];
   };
-}
+})

--- a/pkgs/servers/sql/postgresql/ext/pgrouting.nix
+++ b/pkgs/servers/sql/postgresql/ext/pgrouting.nix
@@ -9,7 +9,7 @@
   stdenv,
 }:
 
-postgresqlBuildExtension rec {
+postgresqlBuildExtension (finalAttrs: {
   pname = "pgrouting";
   version = "3.7.3";
 
@@ -22,16 +22,16 @@ postgresqlBuildExtension rec {
   src = fetchFromGitHub {
     owner = "pgRouting";
     repo = "pgrouting";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-jaevnDCJ6hRQeDhdAkvMTvnnFWElMNvo9gZRW53proQ=";
   };
 
   meta = {
     description = "PostgreSQL/PostGIS extension that provides geospatial routing functionality";
     homepage = "https://pgrouting.org/";
-    changelog = "https://github.com/pgRouting/pgrouting/releases/tag/v${version}";
+    changelog = "https://github.com/pgRouting/pgrouting/releases/tag/v${finalAttrs.version}";
     maintainers = with lib.maintainers; lib.teams.geospatial.members ++ [ steve-chavez ];
     platforms = postgresql.meta.platforms;
     license = lib.licenses.gpl2Plus;
   };
-}
+})

--- a/pkgs/servers/sql/postgresql/ext/pgsql-http.nix
+++ b/pkgs/servers/sql/postgresql/ext/pgsql-http.nix
@@ -7,14 +7,14 @@
   stdenv,
 }:
 
-postgresqlBuildExtension rec {
+postgresqlBuildExtension (finalAttrs: {
   pname = "pgsql-http";
   version = "1.6.3";
 
   src = fetchFromGitHub {
     owner = "pramsey";
     repo = "pgsql-http";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-Ij8BaNj2SOwDfjgLxrpLFvvPCzSahXyyckRPGmcqKtE=";
   };
 
@@ -24,9 +24,9 @@ postgresqlBuildExtension rec {
   meta = {
     description = "HTTP client for PostgreSQL, retrieve a web page from inside the database";
     homepage = "https://github.com/pramsey/pgsql-http";
-    changelog = "https://github.com/pramsey/pgsql-http/releases/tag/v${version}";
+    changelog = "https://github.com/pramsey/pgsql-http/releases/tag/v${finalAttrs.version}";
     maintainers = [ ];
     platforms = postgresql.meta.platforms;
     license = lib.licenses.mit;
   };
-}
+})

--- a/pkgs/servers/sql/postgresql/ext/pgvector.nix
+++ b/pkgs/servers/sql/postgresql/ext/pgvector.nix
@@ -6,23 +6,23 @@
   stdenv,
 }:
 
-postgresqlBuildExtension rec {
+postgresqlBuildExtension (finalAttrs: {
   pname = "pgvector";
   version = "0.8.0";
 
   src = fetchFromGitHub {
     owner = "pgvector";
     repo = "pgvector";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-JsZV+I4eRMypXTjGmjCtMBXDVpqTIPHQa28ogXncE/Q=";
   };
 
   meta = {
     description = "Open-source vector similarity search for PostgreSQL";
     homepage = "https://github.com/pgvector/pgvector";
-    changelog = "https://github.com/pgvector/pgvector/raw/v${version}/CHANGELOG.md";
+    changelog = "https://github.com/pgvector/pgvector/raw/v${finalAttrs.version}/CHANGELOG.md";
     license = lib.licenses.postgresql;
     platforms = postgresql.meta.platforms;
     maintainers = [ ];
   };
-}
+})

--- a/pkgs/servers/sql/postgresql/ext/plr.nix
+++ b/pkgs/servers/sql/postgresql/ext/plr.nix
@@ -8,9 +8,11 @@
   stdenv,
 }:
 
-postgresqlBuildExtension rec {
+postgresqlBuildExtension (finalAttrs: {
   pname = "plr";
-  version = "${builtins.replaceStrings [ "_" ] [ "." ] (lib.strings.removePrefix "REL" src.rev)}";
+  version = "${builtins.replaceStrings [ "_" ] [ "." ] (
+    lib.strings.removePrefix "REL" finalAttrs.src.rev
+  )}";
 
   src = fetchFromGitHub {
     owner = "postgres-plr";
@@ -27,9 +29,9 @@ postgresqlBuildExtension rec {
   meta = {
     description = "PL/R - R Procedural Language for PostgreSQL";
     homepage = "https://github.com/postgres-plr/plr";
-    changelog = "https://github.com/postgres-plr/plr/blob/${src.rev}/changelog.md";
+    changelog = "https://github.com/postgres-plr/plr/blob/${finalAttrs.src.rev}/changelog.md";
     maintainers = with lib.maintainers; [ qoelet ];
     platforms = postgresql.meta.platforms;
     license = lib.licenses.gpl2Only;
   };
-}
+})

--- a/pkgs/servers/sql/postgresql/ext/repmgr.nix
+++ b/pkgs/servers/sql/postgresql/ext/repmgr.nix
@@ -9,14 +9,14 @@
   stdenv,
 }:
 
-postgresqlBuildExtension rec {
+postgresqlBuildExtension (finalAttrs: {
   pname = "repmgr";
   version = "5.5.0";
 
   src = fetchFromGitHub {
     owner = "EnterpriseDB";
     repo = "repmgr";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-8G2CzzkWTKEglpUt1Gr7d/DuHJvCIEjsbYDMl3Zt3cs=";
   };
 
@@ -34,4 +34,4 @@ postgresqlBuildExtension rec {
     platforms = postgresql.meta.platforms;
     maintainers = with lib.maintainers; [ zimbatm ];
   };
-}
+})

--- a/pkgs/servers/sql/postgresql/ext/sqlite_fdw.nix
+++ b/pkgs/servers/sql/postgresql/ext/sqlite_fdw.nix
@@ -6,14 +6,14 @@
   sqlite,
 }:
 
-postgresqlBuildExtension rec {
+postgresqlBuildExtension (finalAttrs: {
   pname = "sqlite_fdw";
   version = "2.5.0";
 
   src = fetchFromGitHub {
     owner = "pgspider";
     repo = "sqlite_fdw";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-zPVIFzUv6UFFHq0Zi5MeQOcvgsfZAKGkkNIGxkTJ+oo=";
   };
 
@@ -24,9 +24,9 @@ postgresqlBuildExtension rec {
   meta = {
     description = "SQLite Foreign Data Wrapper for PostgreSQL";
     homepage = "https://github.com/pgspider/sqlite_fdw";
-    changelog = "https://github.com/pgspider/sqlite_fdw/releases/tag/v${version}";
+    changelog = "https://github.com/pgspider/sqlite_fdw/releases/tag/v${finalAttrs.version}";
     maintainers = with lib.maintainers; [ apfelkuchen6 ];
     platforms = lib.platforms.unix;
     license = lib.licenses.postgresql;
   };
-}
+})

--- a/pkgs/servers/sql/postgresql/ext/system_stats.nix
+++ b/pkgs/servers/sql/postgresql/ext/system_stats.nix
@@ -5,14 +5,14 @@
   postgresqlBuildExtension,
   stdenv,
 }:
-postgresqlBuildExtension rec {
+postgresqlBuildExtension (finalAttrs: {
   pname = "system_stats";
   version = "3.2";
 
   src = fetchFromGitHub {
     owner = "EnterpriseDB";
     repo = "system_stats";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-/xXnui0S0ZjRw7P8kMAgttHVv8T41aOhM3pM8P0OTig=";
   };
 
@@ -21,9 +21,9 @@ postgresqlBuildExtension rec {
   meta = {
     description = "Postgres extension for exposing system metrics such as CPU, memory and disk information";
     homepage = "https://github.com/EnterpriseDB/system_stats";
-    changelog = "https://github.com/EnterpriseDB/system_stats/raw/v${version}/CHANGELOG.md";
+    changelog = "https://github.com/EnterpriseDB/system_stats/raw/v${finalAttrs.version}/CHANGELOG.md";
     maintainers = with lib.maintainers; [ shivaraj-bh ];
     platforms = postgresql.meta.platforms;
     license = lib.licenses.postgresql;
   };
-}
+})

--- a/pkgs/servers/sql/postgresql/ext/tds_fdw.nix
+++ b/pkgs/servers/sql/postgresql/ext/tds_fdw.nix
@@ -8,7 +8,7 @@
   unstableGitUpdater,
 }:
 
-postgresqlBuildExtension rec {
+postgresqlBuildExtension (finalAttrs: {
   pname = "tds_fdw";
   version = "2.0.4";
 
@@ -17,16 +17,16 @@ postgresqlBuildExtension rec {
   src = fetchFromGitHub {
     owner = "tds-fdw";
     repo = "tds_fdw";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-ruelOHueaHx1royLPvDM8Abd1rQD62R4KXgtHY9qqTw=";
   };
 
   meta = {
     description = "PostgreSQL foreign data wrapper to connect to TDS databases (Sybase and Microsoft SQL Server)";
     homepage = "https://github.com/tds-fdw/tds_fdw";
-    changelog = "https://github.com/tds-fdw/tds_fdw/releases/tag/v${version}";
+    changelog = "https://github.com/tds-fdw/tds_fdw/releases/tag/v${finalAttrs.version}";
     maintainers = with lib.maintainers; [ steve-chavez ];
     platforms = postgresql.meta.platforms;
     license = lib.licenses.postgresql;
   };
-}
+})

--- a/pkgs/servers/sql/postgresql/ext/temporal_tables.nix
+++ b/pkgs/servers/sql/postgresql/ext/temporal_tables.nix
@@ -6,14 +6,14 @@
   stdenv,
 }:
 
-postgresqlBuildExtension rec {
+postgresqlBuildExtension (finalAttrs: {
   pname = "temporal_tables";
   version = "1.2.2";
 
   src = fetchFromGitHub {
     owner = "arkhipov";
     repo = "temporal_tables";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-7+DCSPAPhsokWDq/5IXNhd7jY6FfzxxUjlsg/VJeD3k=";
   };
 
@@ -24,4 +24,4 @@ postgresqlBuildExtension rec {
     platforms = postgresql.meta.platforms;
     license = lib.licenses.bsd2;
   };
-}
+})

--- a/pkgs/servers/sql/postgresql/ext/timescaledb.nix
+++ b/pkgs/servers/sql/postgresql/ext/timescaledb.nix
@@ -12,14 +12,14 @@
   enableUnfree ? true,
 }:
 
-postgresqlBuildExtension rec {
+postgresqlBuildExtension (finalAttrs: {
   pname = "timescaledb${lib.optionalString (!enableUnfree) "-apache"}";
   version = "2.19.2";
 
   src = fetchFromGitHub {
     owner = "timescale";
     repo = "timescaledb";
-    tag = version;
+    tag = finalAttrs.version;
     hash = "sha256-H46lhvM6rA9J4nLRLeFArCc7tqmVmpWztsGFAboSM0k=";
   };
 
@@ -55,10 +55,10 @@ postgresqlBuildExtension rec {
   meta = {
     description = "Scales PostgreSQL for time-series data via automatic partitioning across time and space";
     homepage = "https://www.timescale.com/";
-    changelog = "https://github.com/timescale/timescaledb/blob/${version}/CHANGELOG.md";
+    changelog = "https://github.com/timescale/timescaledb/blob/${finalAttrs.version}/CHANGELOG.md";
     maintainers = with lib.maintainers; [ kirillrdy ];
     platforms = postgresql.meta.platforms;
     license = with lib.licenses; if enableUnfree then tsl else asl20;
     broken = lib.versionOlder postgresql.version "14";
   };
-}
+})

--- a/pkgs/servers/sql/postgresql/ext/tsja.nix
+++ b/pkgs/servers/sql/postgresql/ext/tsja.nix
@@ -7,12 +7,12 @@
   stdenv,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "tsja";
   version = "0.5.0";
 
   src = fetchzip {
-    url = "https://www.amris.jp/tsja/tsja-${version}.tar.xz";
+    url = "https://www.amris.jp/tsja/tsja-${finalAttrs.version}.tar.xz";
     hash = "sha256-h59UhUG/7biN8NaDiGK6kXDqfhR9uMzt8CpwbJ+PpEM=";
   };
 
@@ -45,4 +45,4 @@ stdenv.mkDerivation rec {
     platforms = lib.platforms.gnu;
     license = lib.licenses.gpl2Only;
   };
-}
+})

--- a/pkgs/servers/sql/postgresql/ext/wal2json.nix
+++ b/pkgs/servers/sql/postgresql/ext/wal2json.nix
@@ -6,10 +6,10 @@
   postgresqlBuildExtension,
 }:
 
-postgresqlBuildExtension rec {
+postgresqlBuildExtension (finalAttrs: {
   pname = "wal2json";
   version = "${builtins.replaceStrings [ "_" ] [ "." ] (
-    lib.strings.removePrefix "wal2json_" src.rev
+    lib.strings.removePrefix "wal2json_" finalAttrs.src.rev
   )}";
 
   src = fetchFromGitHub {
@@ -26,9 +26,9 @@ postgresqlBuildExtension rec {
   meta = {
     description = "PostgreSQL JSON output plugin for changeset extraction";
     homepage = "https://github.com/eulerto/wal2json";
-    changelog = "https://github.com/eulerto/wal2json/releases/tag/${src.rev}";
+    changelog = "https://github.com/eulerto/wal2json/releases/tag/${finalAttrs.src.rev}";
     maintainers = with lib.maintainers; [ euank ];
     platforms = postgresql.meta.platforms;
     license = lib.licenses.bsd3;
   };
-}
+})

--- a/pkgs/servers/sql/postgresql/postgresqlBuildExtension.nix
+++ b/pkgs/servers/sql/postgresql/postgresqlBuildExtension.nix
@@ -63,10 +63,14 @@
   nix-update-script,
 }:
 
-args:
+lib.extendMkDerivation {
+  constructDrv = stdenv.mkDerivation;
 
-let
-  postgresqlBuildExtension =
+  excludeDrvArgNames = [
+    "enableUpdateScript"
+  ];
+
+  extendDrvArgs =
     finalAttrs:
     {
       enableUpdateScript ? true,
@@ -145,5 +149,4 @@ let
         ''
         + prevAttrs.postInstall or "";
     };
-in
-stdenv.mkDerivation (lib.extends postgresqlBuildExtension (lib.toFunction args))
+}


### PR DESCRIPTION
Rebuilds are caused by not passing `enableUpdateScript` through, anymore.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
