### PR TITLE
nixos/gowitness: init module

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2505.section.md
+++ b/nixos/doc/manual/release-notes/rl-2505.section.md
@@ -244,6 +244,8 @@ Alongside many enhancements to NixOS modules and general system improvements, th
   Prometheus exporter for custom eBPF metrics. Available as
   [services.prometheus.exporters.ebpf](#opt-services.prometheus.exporters.ebpf.enable).
 
+- [gowitness](https://github.com/sensepost/gowitness), a web screenshot service. Available as [services.gowitness](option.html#opt-services.gowitness.enable)
+
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
 
 ## Backward Incompatibilities {#sec-release-25.05-incompatibilities}

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1420,6 +1420,7 @@
   ./services/security/esdm.nix
   ./services/security/fail2ban.nix
   ./services/security/fprintd.nix
+  ./services/security/gowitness.nix
   ./services/security/haveged.nix
   ./services/security/hockeypuck.nix
   ./services/security/hologram-agent.nix

--- a/nixos/modules/services/security/gowitness.nix
+++ b/nixos/modules/services/security/gowitness.nix
@@ -1,0 +1,142 @@
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}:
+let
+  cfg = config.services.gowitness;
+in
+{
+
+  options.services.gowitness = {
+    enable = lib.mkEnableOption "Wether to enable gowitness.";
+
+    package = lib.mkPackageOption pkgs "gowitness" { };
+
+    debug = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = ''
+        Enable debug logging.
+      '';
+    };
+
+    quiet = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = ''
+        Silence (almost all) logging.
+      '';
+    };
+
+    dataPath = lib.mkOption {
+      type = lib.types.path;
+      default = "/var/lib/gowitness";
+      description = ''
+        The directory where gowitness stores its data files.
+      '';
+    };
+
+    screenshotPath = lib.mkOption {
+      type = lib.types.path;
+      default = "/var/lib/gowitness/screenshots";
+      description = ''
+        The path where screenshots are stored.
+      '';
+    };
+
+    dbUri = lib.mkOption {
+      type = lib.types.str;
+      default = "sqlite:///var/lib/gowitness/db.sqlite3";
+      example = "postgres://user:pass@host:port/db";
+      description = ''
+        The database URI to use. Supports SQLite, Postgres, and MySQL.
+      '';
+    };
+
+    host = lib.mkOption {
+      type = lib.types.str;
+      default = "127.0.0.1";
+      description = ''
+        The host address to bind the webserver.
+      '';
+    };
+
+    port = lib.mkOption {
+      type = lib.types.port;
+      default = 7171;
+      description = ''
+        The host address to bind the webserver.
+      '';
+    };
+
+    openFirewall = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = ''
+        Open port in the firewall for the gowitness webserver.
+      '';
+    };
+
+    user = lib.mkOption {
+      type = lib.types.nonEmptyStr;
+      default = "gowitness";
+      description = ''
+        The gowitness service user.
+      '';
+    };
+
+    group = lib.mkOption {
+      type = lib.types.nonEmptyStr;
+      default = "gowitness";
+      description = ''
+        The gowitness service group.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    systemd.packages = [ cfg.package ];
+    systemd.services.gowitness = {
+      description = "gowitness";
+
+      wantedBy = [ "multi-user.target" ];
+      after = [ "network.target" ];
+
+      serviceConfig = {
+        User = cfg.user;
+        Group = cfg.group;
+        StateDirectory = "gowitness";
+        WorkingDirectory = cfg.dataPath;
+        Restart = "on-failure";
+      };
+
+      script = ''
+        ${lib.getExe cfg.package} report server \
+        --db-uri ${cfg.dbUri} \
+        --host ${cfg.host} \
+        --port ${toString cfg.port} \
+        --screenshot-path ${cfg.screenshotPath} \
+        ${if cfg.debug then "--debug-log \\" else ""}
+        ${if cfg.quiet then "--quiet" else ""}
+      '';
+    };
+
+    networking.firewall = lib.mkIf cfg.openFirewall {
+      allowedTCPPorts = [ cfg.port ];
+    };
+
+    users.users = lib.mkIf (cfg.user == "gowitness") {
+      gowitness = {
+        isSystemUser = true;
+        group = cfg.group;
+        home = cfg.dataPath;
+      };
+    };
+
+    users.groups = lib.mkIf (cfg.group == "gowitness") { gowitness = { }; };
+  };
+
+  meta.maintainers = with lib.maintainers; [ codexlynx ];
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -568,6 +568,7 @@ in
   gotenberg = handleTest ./gotenberg.nix { };
   gotify-server = handleTest ./gotify-server.nix { };
   gotosocial = runTest ./web-apps/gotosocial.nix;
+  gowitness = runTest ./gowitness.nix;
   grafana = handleTest ./grafana { };
   graphite = handleTest ./graphite.nix { };
   grav = runTest ./web-apps/grav.nix;

--- a/nixos/tests/gowitness.nix
+++ b/nixos/tests/gowitness.nix
@@ -1,0 +1,20 @@
+{ lib, ... }:
+{
+  name = "gowitness";
+
+  nodes.machine = {
+    services.gowitness.enable = true;
+  };
+
+  testScript = ''
+    machine.wait_for_unit("gowitness.service")
+    machine.wait_for_open_port(7171)
+    machine.fail("journalctl -u gowitness.service | grep debug")
+    machine.succeed("journalctl -u gowitness.service | grep 127.0.0.1")
+    machine.succeed("journalctl -u gowitness.service | grep 7171")
+    machine.succeed("cat /etc/systemd/system/gowitness.service | grep User=gowitness")
+    machine.succeed("cat /etc/systemd/system/gowitness.service | grep Group=gowitness")
+  '';
+
+  meta.maintainers = with lib.maintainers; [ codexlynx ];
+}


### PR DESCRIPTION
This adds a module for [gowitness](https://github.com/sensepost/gowitness).

## Things done

- Built on platform(s)
  - [x] x86_64-linux
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
