### PR TITLE
Add `nixpkgsFlake.lib.lib`

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -18,8 +18,7 @@
           inherit system;
         }
       );
-    in
-    {
+
       /**
         `nixpkgs.lib` is a combination of the [Nixpkgs library](https://nixos.org/manual/nixpkgs/unstable/#id-1.4), and other attributes
         that are _not_ part of the Nixpkgs library, but part of the Nixpkgs flake:
@@ -30,7 +29,7 @@
       */
       # DON'T USE lib.extend TO ADD NEW FUNCTIONALITY.
       # THIS WAS A MISTAKE. See the warning in lib/default.nix.
-      lib = lib.extend (
+      legacyFlakeLib = lib.extend (
         final: prev: {
 
           /**
@@ -95,6 +94,26 @@
             );
         }
       );
+
+      # The `lib` flake output attribute which isn't an unsound merger of the flake `lib` and the Nixpkgs standard library.
+      newFlakeLib = {
+        inherit lib;
+      };
+
+    in
+    {
+
+      /**
+        `lib` is the standard flake attribute for libraries. The nixpkgs flake
+        includes libraries for
+        - The Nixpkgs standard library, also known as `lib` or (here) `nixpkgsFlake.lib.lib`
+        - NixOS: `nixpkgsFlake.lib.nixos` and `nixpkgsFlake.lib.nixosSystem`
+
+        Before Nixpkgs 25.05, `lib` was a combination of the Nixpkgs standard library *and* the NixOS library.
+        In Nixpkgs 25.05, this continues to be the case, while making available `nixpkgsFlake.lib.lib` to clear the way
+        for an ecosystem-wide migration.
+      */
+      lib = legacyFlakeLib // newFlakeLib;
 
       checks = forAllSystems (
         system:

--- a/flake.nix
+++ b/flake.nix
@@ -29,71 +29,72 @@
       */
       # DON'T USE lib.extend TO ADD NEW FUNCTIONALITY.
       # THIS WAS A MISTAKE. See the warning in lib/default.nix.
-      legacyFlakeLib = lib.extend (
-        final: prev: {
+      legacyFlakeLib = lib.extend (final: prev: makeFlakeLib final);
 
-          /**
-            Other NixOS-provided functionality, such as [`runTest`](https://nixos.org/manual/nixos/unstable/#sec-call-nixos-test-outside-nixos).
-            See also `lib.nixosSystem`.
-          */
-          nixos = import ./nixos/lib { lib = final; };
+      # TODO (@roberth): After 25.05, start deprecation of `makeFlakeLib final` behaviors, favoring `makeFlakeLib lib` behaviors.
+      makeFlakeLib = final: {
 
-          /**
-            Create a NixOS system configuration.
+        /**
+          Other NixOS-provided functionality, such as [`runTest`](https://nixos.org/manual/nixos/unstable/#sec-call-nixos-test-outside-nixos).
+          See also `lib.nixosSystem`.
+        */
+        nixos = import ./nixos/lib { lib = final; };
 
-            Example:
+        /**
+          Create a NixOS system configuration.
 
-                lib.nixosSystem {
-                  modules = [ ./configuration.nix ];
-                }
+          Example:
 
-            Inputs:
-
-            - `modules` (list of paths or inline modules): The NixOS modules to include in the system configuration.
-
-            - `specialArgs` (attribute set): Extra arguments to pass to all modules, that are available in `imports` but can not be extended or overridden by the `modules`.
-
-            - `modulesLocation` (path): A default location for modules that aren't passed by path, used for error messages.
-
-            Legacy inputs:
-
-            - `system`: Legacy alias for `nixpkgs.hostPlatform`, but this is already set in the generated `hardware-configuration.nix`, included by `configuration.nix`.
-            - `pkgs`: Legacy alias for `nixpkgs.pkgs`; use `nixpkgs.pkgs` and `nixosModules.readOnlyPkgs` instead.
-          */
-          nixosSystem =
-            args:
-            import ./nixos/lib/eval-config.nix (
-              {
-                lib = final;
-                # Allow system to be set modularly in nixpkgs.system.
-                # We set it to null, to remove the "legacy" entrypoint's
-                # non-hermetic default.
-                system = null;
-
-                modules = args.modules ++ [
-                  # This module is injected here since it exposes the nixpkgs self-path in as
-                  # constrained of contexts as possible to avoid more things depending on it and
-                  # introducing unnecessary potential fragility to changes in flakes itself.
-                  #
-                  # See: failed attempt to make pkgs.path not copy when using flakes:
-                  # https://github.com/NixOS/nixpkgs/pull/153594#issuecomment-1023287913
-                  (
-                    {
-                      config,
-                      pkgs,
-                      lib,
-                      ...
-                    }:
-                    {
-                      config.nixpkgs.flake.source = self.outPath;
-                    }
-                  )
-                ];
+              lib.nixosSystem {
+                modules = [ ./configuration.nix ];
               }
-              // builtins.removeAttrs args [ "modules" ]
-            );
-        }
-      );
+
+          Inputs:
+
+          - `modules` (list of paths or inline modules): The NixOS modules to include in the system configuration.
+
+          - `specialArgs` (attribute set): Extra arguments to pass to all modules, that are available in `imports` but can not be extended or overridden by the `modules`.
+
+          - `modulesLocation` (path): A default location for modules that aren't passed by path, used for error messages.
+
+          Legacy inputs:
+
+          - `system`: Legacy alias for `nixpkgs.hostPlatform`, but this is already set in the generated `hardware-configuration.nix`, included by `configuration.nix`.
+          - `pkgs`: Legacy alias for `nixpkgs.pkgs`; use `nixpkgs.pkgs` and `nixosModules.readOnlyPkgs` instead.
+        */
+        nixosSystem =
+          args:
+          import ./nixos/lib/eval-config.nix (
+            {
+              lib = final;
+              # Allow system to be set modularly in nixpkgs.system.
+              # We set it to null, to remove the "legacy" entrypoint's
+              # non-hermetic default.
+              system = null;
+
+              modules = args.modules ++ [
+                # This module is injected here since it exposes the nixpkgs self-path in as
+                # constrained of contexts as possible to avoid more things depending on it and
+                # introducing unnecessary potential fragility to changes in flakes itself.
+                #
+                # See: failed attempt to make pkgs.path not copy when using flakes:
+                # https://github.com/NixOS/nixpkgs/pull/153594#issuecomment-1023287913
+                (
+                  {
+                    config,
+                    pkgs,
+                    lib,
+                    ...
+                  }:
+                  {
+                    config.nixpkgs.flake.source = self.outPath;
+                  }
+                )
+              ];
+            }
+            // builtins.removeAttrs args [ "modules" ]
+          );
+      };
 
       # The `lib` flake output attribute which isn't an unsound merger of the flake `lib` and the Nixpkgs standard library.
       newFlakeLib = {


### PR DESCRIPTION
Best reviewed commit-by-commit due to reformatting.

A simple preparation for plans discussed in
- https://github.com/NixOS/nixpkgs/pull/376033

Crucially, without these changes, the identifier `lib` has too many
meanings and therefore doesn't mean anything, making it unmaintainable.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
