### PR TITLE
traceshark: init at unstable-2025-04-13

### DIFF
--- a/pkgs/by-name/tr/traceshark/package.nix
+++ b/pkgs/by-name/tr/traceshark/package.nix
@@ -1,0 +1,34 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  qt6Packages,
+}:
+
+stdenv.mkDerivation {
+  pname = "traceshark";
+  version = "unstable-2025-04-13";
+
+  src = fetchFromGitHub {
+    owner = "cunctator";
+    repo = "traceshark";
+    rev = "d4c52bbafe9e3ae3c856a1f7922a75a4af95d88c";
+    sha256 = "sha256-qR4uBT2qURYuWrMVbVq2rBmuDrsRArvo/JW++NHS3l4=";
+  };
+
+  buildInputs = [ qt6Packages.qtbase ];
+  nativeBuildInputs = [
+    qt6Packages.wrapQtAppsHook
+    qt6Packages.qmake
+  ];
+  qmakeFlags = [ "CUSTOM_INSTALL_PREFIX=${placeholder "out"}" ];
+
+  meta = with lib; {
+    description = "A tool for Linux kernel ftrace and perf events visualization";
+    homepage = "https://github.com/cunctator/traceshark";
+    license = licenses.gpl3;
+    mainProgram = "traceshark";
+    maintainers = with maintainers; [ jjjollyjim ];
+    platforms = platforms.linux;
+  };
+}


### PR DESCRIPTION
> A tool for Linux kernel ftrace and perf events visualization

Latest git tag FTBFS, so picked the latest commit instead.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

