### PR TITLE
python313Packages.uvloop: patch for broken tests

### DIFF
--- a/pkgs/development/python-modules/uvloop/default.nix
+++ b/pkgs/development/python-modules/uvloop/default.nix
@@ -4,6 +4,7 @@
   buildPythonPackage,
   pythonOlder,
   fetchPypi,
+  fetchpatch,
 
   # build-system
   cython,
@@ -31,6 +32,20 @@ buildPythonPackage rec {
     inherit pname version;
     hash = "sha256-O/ErD9poRHgGp62Ee/pZFhMXcnXTW2ckse5XP6o3BOM=";
   };
+
+  patches = [
+    # fix test failures on Python 3.13
+    # (remove on next update)
+    (fetchpatch {
+      url = "https://github.com/MagicStack/uvloop/commit/96b7ed31afaf02800d779a395591da6a2c8c50e1.patch";
+      hash = "sha256-Nbe3BuIuwlylll5fIYij+OiP90ZeFNI0GKHK9SwWRk8=";
+      excludes = [ ".github/workflows/tests.yml" ];
+    })
+    (fetchpatch {
+      url = "https://github.com/MagicStack/uvloop/commit/56807922f847ddac231a53d5b03eef70092b987c.patch";
+      hash = "sha256-X5Ob1t/CRy9csw2JrWvwS55G6qTqZhIuGLTy83O03GU=";
+    })
+  ];
 
   postPatch = ''
     rm -rf vendor


### PR DESCRIPTION
Probably broke in a Python patch update? ([full log](https://paste.fliegendewurst.eu/R6LyWb.log))
The upstream report used Python 3.14 https://github.com/MagicStack/uvloop/issues/637#issuecomment-2717966778

https://github.com/MagicStack/uvloop/pull/662
https://github.com/MagicStack/uvloop/pull/663

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).