### PR TITLE
perl: apply patch for CVE-2024-56406

### DIFF
--- a/pkgs/development/interpreters/perl/CVE-2024-56406.patch
+++ b/pkgs/development/interpreters/perl/CVE-2024-56406.patch
@@ -1,0 +1,26 @@
+commit 385e8759c3ff1e7f7f996bd4ea391074d61d48c1
+Author:     Karl Williamson <khw@cpan.org>
+AuthorDate: 2024-12-18 18:25:29 -0700
+Commit:     Steve Hay <steve.m.hay@googlemail.com>
+CommitDate: 2025-03-30 11:59:51 +0100
+
+    CVE-2024-56406: Heap-buffer-overflow with tr//
+
+    This was due to underallocating needed space.  If the translation forces
+    something to become UTF-8 that is initially bytes, that UTF-8 could
+    now require two bytes where previously a single one would do.
+
+    (cherry picked from commit f93109c8a6950aafbd7488d98e112552033a3686)
+
+diff --git a/op.c b/op.c
+index 3fc23eca49a..aeee88e0335 100644
+--- a/op.c
++++ b/op.c
+@@ -6649,6 +6649,7 @@ S_pmtrans(pTHX_ OP *o, OP *expr, OP *repl)
+                  * same time.  But otherwise one crosses before the other */
+                 if (t_cp < 256 && r_cp_end > 255 && r_cp != t_cp) {
+                     can_force_utf8 = TRUE;
++                    max_expansion = MAX(2, max_expansion);
+                 }
+             }
+

--- a/pkgs/development/interpreters/perl/interpreter.nix
+++ b/pkgs/development/interpreters/perl/interpreter.nix
@@ -71,7 +71,9 @@ stdenv.mkDerivation (
     disallowedReferences = [ stdenv.cc ];
 
     patches =
-      [ ]
+      [
+        ./CVE-2024-56406.patch
+      ]
       # Do not look in /usr etc. for dependencies.
       ++ lib.optional ((lib.versions.majorMinor version) == "5.38") ./no-sys-dirs-5.38.0.patch
       ++ lib.optional ((lib.versions.majorMinor version) == "5.40") ./no-sys-dirs-5.40.0.patch


### PR DESCRIPTION

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
