### PR TITLE
python3Packages.inline-snapshot: disable test with hardcoded formatting

### DIFF
--- a/pkgs/development/python-modules/inline-snapshot/default.nix
+++ b/pkgs/development/python-modules/inline-snapshot/default.nix
@@ -75,6 +75,11 @@ buildPythonPackage rec {
     "tests/test_formating.py"
   ];
 
+  disabledTests = [
+    # Tests for precise formatting
+    "test_empty_sub_snapshot"
+  ];
+
   meta = with lib; {
     description = "Create and update inline snapshots in Python tests";
     homepage = "https://github.com/15r10nk/inline-snapshot/";


### PR DESCRIPTION
```
=========================== short test summary info ============================
FAILED tests/test_pytest_plugin.py::test_empty_sub_snapshot - AssertionError: assert '============...===========\n' == '============...===========\n'
  
  Skipping 658 identical leading characters in diff, use -v to show
  - =========== 1 passed, 1 error in <time> ==================================================================
  ?           -
  + ========== 1 passed, 1 error in <time> ==================================================================
== 1 failed, 524 passed, 1 xfailed, 974 subtests passed in 566.95s (0:09:26) ===
```
[full log](https://paste.fliegendewurst.eu/1wRrsa.log)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).