### PR TITLE
html2pdf: init at 0.8.2

### DIFF
--- a/pkgs/by-name/ht/html2pdf/package.nix
+++ b/pkgs/by-name/ht/html2pdf/package.nix
@@ -1,0 +1,59 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  rustPlatform,
+  makeWrapper,
+  chromium,
+  withChromium ? (lib.meta.availableOn stdenv.hostPlatform chromium),
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "html2pdf";
+  version = "0.8.2";
+
+  src = fetchFromGitHub {
+    owner = "ilaborie";
+    repo = "html2pdf";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-Z1fb7pDjawMIhJgl4ao2VoV6zpfcGy/48Dt7JtIxgJo=";
+  };
+
+  cargoHash = "sha256-T5A2b7Qcg8dQKndaD8P5RAutBZeINOqIBUHR2VDOeo0=";
+
+  # Avoiding "rustfmt not found" error in auto_generate_cdp.
+  # ref: https://github.com/mdrokz/auto_generate_cdp/pull/8
+  env.DO_NOT_FORMAT = "true";
+
+  nativeBuildInputs = [
+    makeWrapper
+  ];
+
+  postInstall = lib.optionalString withChromium (
+    let
+      runtimeInputs = [
+        chromium
+      ];
+    in
+    ''
+      wrapProgram "$out/bin/html2pdf" --prefix PATH : '${lib.makeBinPath runtimeInputs}'
+    ''
+  );
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "CLI tool to convert local HTML files to PDF";
+    homepage = "https://github.com/ilaborie/html2pdf";
+    changelog = "https://github.com/ilaborie/html2pdf/blob/v${finalAttrs.version}/CHANGELOG.md";
+    license = with lib.licenses; [
+      mit
+      asl20
+    ];
+    maintainers = with lib.maintainers; [
+      kachick
+    ];
+    mainProgram = "html2pdf";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This PR introduces https://github.com/ilaborie/html2pdf, it converts local HTML files to a PDF powered by headless chrome(chromium).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [x] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable: # Sending [a PR](https://github.com/ilaborie/html2pdf/pull/49) to prepare for adding a version check.
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
