### PR TITLE
xkeyboard-config, xtrans, xorg-{cf-files,docs,sgml-doctools}: refactor and move to pkgs/by-name from xorg namespace

### DIFF
--- a/lib/licenses.nix
+++ b/lib/licenses.nix
@@ -232,6 +232,17 @@ lib.mapAttrs mkLicense (
       fullName = "Lawrence Berkeley National Labs BSD variant license";
     };
 
+    bsd3TheodoreTso = {
+      fullName = "BSD 3 Clause Theodore Tso Variant";
+      # TODO: if the license gets accepted to spdx then
+      #   add spdxId
+      # else
+      #   remove license
+      #   && replace all references with bsd3
+      # https://tools.spdx.org/app/license_requests/442/
+      # https://github.com/spdx/license-list-XML/issues/2702
+    };
+
     bsdAxisNoDisclaimerUnmodified = {
       fullName = "BSD-Axis without Warranty Disclaimer with Unmodified requirement";
       url = "https://scancode-licensedb.aboutcode.org/bsd-no-disclaimer-unmodified.html";

--- a/pkgs/by-name/xk/xkeyboard-config/package.nix
+++ b/pkgs/by-name/xk/xkeyboard-config/package.nix
@@ -1,0 +1,80 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  pkg-config,
+  meson,
+  ninja,
+  python3,
+  perl,
+  libxslt,
+  gettext,
+  writeScript,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "xkeyboard-config";
+  version = "2.44";
+
+  src = fetchurl {
+    url = "mirror://xorg/individual/data/xkeyboard-config/xkeyboard-config-${finalAttrs.version}.tar.xz";
+    hash = "sha256-VNLDPu67Ax1I+lkMVD5Uyby9DwA4brxkibL0eg2kNCo=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    pkg-config
+    meson
+    ninja
+    python3
+    perl
+    libxslt # xsltproc
+    gettext # msgfmt
+  ];
+
+  mesonFlags = [
+    (lib.mesonBool "xorg-rules-symlinks" true)
+  ];
+
+  prePatch = ''
+    patchShebangs rules/merge.py rules/compat/map-variants.py rules/generate-options-symbols.py rules/xml2lst.pl
+  '';
+
+  # 1: compatibility for X11/xkb location
+  # 2: I think pkg-config/ is supposed to be in /lib/
+  postInstall = ''
+    ln -s share "$out/etc"
+    mkdir -p "$out/lib" && ln -s ../share/pkgconfig "$out/lib/"
+  '';
+
+  passthru = {
+    updateScript = writeScript "update-${finalAttrs.pname}" ''
+      #!/usr/bin/env nix-shell
+      #!nix-shell -i bash -p common-updater-scripts
+
+      version="$(list-directory-versions --pname ${finalAttrs.pname} \
+        --url https://xorg.freedesktop.org/releases/individual/data/xkeyboard-config/ \
+        | sort -V | tail -n1)"
+
+      update-source-version ${finalAttrs.pname} "$version"
+    '';
+  };
+
+  meta = {
+    description = "Provides a consistent, well-structured, database of keyboard configuration data";
+    homepage = "https://gitlab.freedesktop.org/xkeyboard-config/xkeyboard-config";
+    license = with lib.licenses; [
+      hpndSellVariant
+      x11
+      mitOpenGroup
+      mit
+      hpnd
+      cronyx
+      # there is another unknown license at the end but it seems free
+      # also see this issue https://gitlab.freedesktop.org/xkeyboard-config/xkeyboard-config/-/issues/527
+      free
+    ];
+    maintainers = [ ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/by-name/xo/xorg-cf-files/package.nix
+++ b/pkgs/by-name/xo/xorg-cf-files/package.nix
@@ -1,0 +1,46 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  pkg-config,
+  writeScript,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "xorg-cf-files";
+  version = "1.0.8";
+
+  src = fetchurl {
+    url = "mirror://xorg/individual/util/xorg-cf-files-${finalAttrs.version}.tar.xz";
+    hash = "sha256-dAiVXe/Pqw9E0b7dTsDCDbYZFJF60Xv8Hxyb9WrMF7k=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [ pkg-config ];
+
+  postInstall = lib.optionalString stdenv.hostPlatform.isDarwin ''
+    substituteInPlace $out/lib/X11/config/darwin.cf --replace "/usr/bin/" ""
+  '';
+
+  passthru = {
+    updateScript = writeScript "update-${finalAttrs.pname}" ''
+      #!/usr/bin/env nix-shell
+      #!nix-shell -i bash -p common-updater-scripts
+      version="$(list-directory-versions --pname ${finalAttrs.pname} \
+        --url https://xorg.freedesktop.org/releases/individual/util/ \
+        | sort -V | tail -n1)"
+      update-source-version ${finalAttrs.pname} "$version"
+    '';
+  };
+
+  meta = {
+    description = "Xorg imake configuration files";
+    homepage = "https://gitlab.freedesktop.org/xorg/util/cf";
+    license = with lib.licenses; [
+      icu
+      x11
+    ];
+    maintainers = [ ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/by-name/xo/xorg-docs/package.nix
+++ b/pkgs/by-name/xo/xorg-docs/package.nix
@@ -1,0 +1,65 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  pkg-config,
+  writeScript,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "xorg-docs";
+  version = "1.7.3";
+
+  src = fetchurl {
+    url = "mirror://xorg/individual/doc/xorg-docs-${finalAttrs.version}.tar.xz";
+    hash = "sha256-KKLy7rXZ/1i4WWH/Pte6qvH/oTLiqB+LK7l8tJm83e8=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [ pkg-config ];
+
+  # This makes the man pages discoverable by the default man,
+  # since it looks for packages in $PATH
+  postInstall = "mkdir $out/bin";
+
+  passthru = {
+    updateScript = writeScript "update-${finalAttrs.pname}" ''
+      #!/usr/bin/env nix-shell
+      #!nix-shell -i bash -p common-updater-scripts
+      version="$(list-directory-versions --pname ${finalAttrs.pname} \
+        --url https://xorg.freedesktop.org/releases/individual/doc/ \
+        | sort -V | tail -n1)"
+      update-source-version ${finalAttrs.pname} "$version"
+    '';
+  };
+
+  meta = {
+    description = "Documentation for the X Window System";
+    homepage = "https://gitlab.freedesktop.org/xorg/doc/xorg-docs";
+    license = with lib.licenses; [
+      # The project does not provide a top-level license or copying file, so I scoured the whole
+      # codebase (which is quite small, fortunately) to find all licenses.
+      # There is a licensing file at general/Licenses.xml.
+      mit
+      icu
+      x11
+      hpndSellVariant
+      hpnd
+      bsd3
+      bsdOriginalUC
+      bsd3TheodoreTso
+      bsd2
+      isc
+      sgi-b-20
+      # Luxi fonts license is listed in general/Licenses.xml.
+      # However, since there is no font is in the repo, this license is not added here.
+      # There is a high chance that some of the other licenses are not used in xorg-docs either
+      # but there is no way to find out.
+
+      # repo contains the X logo, which was converted from Xmu/DrawLogo.c, licensed under:
+      mitOpenGroup
+    ];
+    maintainers = [ ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/by-name/xo/xorg-sgml-doctools/package.nix
+++ b/pkgs/by-name/xo/xorg-sgml-doctools/package.nix
@@ -1,0 +1,45 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  pkg-config,
+  writeScript,
+  testers,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "xorg-sgml-doctools";
+  version = "1.12.1";
+
+  src = fetchurl {
+    url = "mirror://xorg/individual/doc/xorg-sgml-doctools-${finalAttrs.version}.tar.xz";
+    hash = "sha256-Cl1UwHBrTonVrNTUVds3RatK0mvmJ8zgFbkK1AO1bW8=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [ pkg-config ];
+
+  passthru = {
+    updateScript = writeScript "update-${finalAttrs.pname}" ''
+      #!/usr/bin/env nix-shell
+      #!nix-shell -i bash -p common-updater-scripts
+      version="$(list-directory-versions --pname ${finalAttrs.pname} \
+        --url https://xorg.freedesktop.org/releases/individual/doc \
+        | sort -V | tail -n1)"
+      update-source-version ${finalAttrs.pname} "$version"
+    '';
+    tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+  };
+
+  meta = {
+    description = "SGML entities and XML/CSS stylesheets used in X.Org docs";
+    homepage = "https://gitlab.freedesktop.org/xorg/doc/xorg-sgml-doctools";
+    license = with lib.licenses; [
+      mit
+      hpndSellVariant
+    ];
+    maintainers = [ ];
+    pkgConfigModules = [ "xorg-sgml-doctools" ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/by-name/xt/xtrans/package.nix
+++ b/pkgs/by-name/xt/xtrans/package.nix
@@ -1,0 +1,48 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  pkg-config,
+  writeScript,
+  testers,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "xtrans";
+  version = "1.6.0";
+
+  src = fetchurl {
+    url = "mirror://xorg/individual/lib/xtrans-${finalAttrs.version}.tar.xz";
+    hash = "sha256-+q/qFmvyRRoXPZ1ZM1KUDsZAQUXF0dpcITQjzk01npI=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [ pkg-config ];
+
+  passthru = {
+    updateScript = writeScript "update-${finalAttrs.pname}" ''
+      #!/usr/bin/env nix-shell
+      #!nix-shell -i bash -p common-updater-scripts
+      version="$(list-directory-versions --pname ${finalAttrs.pname} \
+        --url https://xorg.freedesktop.org/releases/individual/lib/ \
+        | sort -V | tail -n1)"
+      update-source-version ${finalAttrs.pname} "$version"
+    '';
+    tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+  };
+
+  meta = {
+    description = "X Window System Protocols Transport layer shared code";
+    homepage = "https://gitlab.freedesktop.org/xorg/lib/libxtrans";
+    license = with lib.licenses; [
+      mitOpenGroup
+      hpnd
+      mit
+      x11
+      hpndSellVariant
+    ];
+    maintainers = [ ];
+    pkgConfigModules = [ "xtrans" ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -17,6 +17,7 @@
   xorg-cf-files,
   xorg-docs,
   xorg-sgml-doctools,
+  xtrans,
 }:
 
 self: with self; {
@@ -29,6 +30,7 @@ self: with self; {
     makedepend
     pixman
     xbitmaps
+    xtrans
     ;
   fontalias = font-alias;
   fontutil = font-util;
@@ -8098,37 +8100,6 @@ self: with self; {
       passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
       meta = {
         pkgConfigModules = [ ];
-        platforms = lib.platforms.unix;
-      };
-    })
-  ) { };
-
-  # THIS IS A GENERATED FILE.  DO NOT EDIT!
-  xtrans = callPackage (
-    {
-      stdenv,
-      pkg-config,
-      fetchurl,
-      testers,
-    }:
-    stdenv.mkDerivation (finalAttrs: {
-      pname = "xtrans";
-      version = "1.6.0";
-      builder = ./builder.sh;
-      src = fetchurl {
-        url = "mirror://xorg/individual/lib/xtrans-1.6.0.tar.xz";
-        sha256 = "14ly6m6ww8rl45fdmlf58m0l1ihfji936ncx7lbiligjdcbfmbzs";
-      };
-      hardeningDisable = [
-        "bindnow"
-        "relro"
-      ];
-      strictDeps = true;
-      nativeBuildInputs = [ pkg-config ];
-      buildInputs = [ ];
-      passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-      meta = {
-        pkgConfigModules = [ "xtrans" ];
         platforms = lib.platforms.unix;
       };
     })

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -14,6 +14,7 @@
   xbitmaps,
   xcb-proto,
   xkeyboard-config,
+  xorg-cf-files,
 }:
 
 self: with self; {
@@ -33,6 +34,7 @@ self: with self; {
   utilmacros = util-macros;
   xcbproto = xcb-proto;
   xkeyboardconfig = xkeyboard-config;
+  xorgcffiles = xorg-cf-files;
 
   # THIS IS A GENERATED FILE.  DO NOT EDIT!
   appres = callPackage (
@@ -7597,37 +7599,6 @@ self: with self; {
         xorgproto
         libXt
       ];
-      passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-      meta = {
-        pkgConfigModules = [ ];
-        platforms = lib.platforms.unix;
-      };
-    })
-  ) { };
-
-  # THIS IS A GENERATED FILE.  DO NOT EDIT!
-  xorgcffiles = callPackage (
-    {
-      stdenv,
-      pkg-config,
-      fetchurl,
-      testers,
-    }:
-    stdenv.mkDerivation (finalAttrs: {
-      pname = "xorg-cf-files";
-      version = "1.0.8";
-      builder = ./builder.sh;
-      src = fetchurl {
-        url = "mirror://xorg/individual/util/xorg-cf-files-1.0.8.tar.xz";
-        sha256 = "1f8primgb6qw3zy7plbsj4a1kdhdqb04xpdys520zaygxxfra23l";
-      };
-      hardeningDisable = [
-        "bindnow"
-        "relro"
-      ];
-      strictDeps = true;
-      nativeBuildInputs = [ pkg-config ];
-      buildInputs = [ ];
       passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
       meta = {
         pkgConfigModules = [ ];

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -13,6 +13,7 @@
   util-macros,
   xbitmaps,
   xcb-proto,
+  xkeyboard-config,
 }:
 
 self: with self; {
@@ -31,6 +32,7 @@ self: with self; {
   libpthreadstubs = libpthread-stubs;
   utilmacros = util-macros;
   xcbproto = xcb-proto;
+  xkeyboardconfig = xkeyboard-config;
 
   # THIS IS A GENERATED FILE.  DO NOT EDIT!
   appres = callPackage (
@@ -7245,37 +7247,6 @@ self: with self; {
         libXaw
         libXt
       ];
-      passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-      meta = {
-        pkgConfigModules = [ ];
-        platforms = lib.platforms.unix;
-      };
-    })
-  ) { };
-
-  # THIS IS A GENERATED FILE.  DO NOT EDIT!
-  xkeyboardconfig = callPackage (
-    {
-      stdenv,
-      pkg-config,
-      fetchurl,
-      testers,
-    }:
-    stdenv.mkDerivation (finalAttrs: {
-      pname = "xkeyboard-config";
-      version = "2.44";
-      builder = ./builder.sh;
-      src = fetchurl {
-        url = "mirror://xorg/individual/data/xkeyboard-config/xkeyboard-config-2.44.tar.xz";
-        sha256 = "0aillh6pmx5ji5jbqviq007vvg69ahz5832rz941s0xvxqzc7ljl";
-      };
-      hardeningDisable = [
-        "bindnow"
-        "relro"
-      ];
-      strictDeps = true;
-      nativeBuildInputs = [ pkg-config ];
-      buildInputs = [ ];
       passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
       meta = {
         pkgConfigModules = [ ];

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -16,6 +16,7 @@
   xkeyboard-config,
   xorg-cf-files,
   xorg-docs,
+  xorg-sgml-doctools,
 }:
 
 self: with self; {
@@ -37,6 +38,7 @@ self: with self; {
   xkeyboardconfig = xkeyboard-config;
   xorgcffiles = xorg-cf-files;
   xorgdocs = xorg-docs;
+  xorgsgmldoctools = xorg-sgml-doctools;
 
   # THIS IS A GENERATED FILE.  DO NOT EDIT!
   appres = callPackage (
@@ -7738,37 +7740,6 @@ self: with self; {
       passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
       meta = {
         pkgConfigModules = [ "xorg-server" ];
-        platforms = lib.platforms.unix;
-      };
-    })
-  ) { };
-
-  # THIS IS A GENERATED FILE.  DO NOT EDIT!
-  xorgsgmldoctools = callPackage (
-    {
-      stdenv,
-      pkg-config,
-      fetchurl,
-      testers,
-    }:
-    stdenv.mkDerivation (finalAttrs: {
-      pname = "xorg-sgml-doctools";
-      version = "1.12.1";
-      builder = ./builder.sh;
-      src = fetchurl {
-        url = "mirror://xorg/individual/doc/xorg-sgml-doctools-1.12.1.tar.xz";
-        sha256 = "0vvdnl1x82mr2phcq9z6dg94mas56zdmbm6lmkaqjkkbf3058p8a";
-      };
-      hardeningDisable = [
-        "bindnow"
-        "relro"
-      ];
-      strictDeps = true;
-      nativeBuildInputs = [ pkg-config ];
-      buildInputs = [ ];
-      passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-      meta = {
-        pkgConfigModules = [ "xorg-sgml-doctools" ];
         platforms = lib.platforms.unix;
       };
     })

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -15,6 +15,7 @@
   xcb-proto,
   xkeyboard-config,
   xorg-cf-files,
+  xorg-docs,
 }:
 
 self: with self; {
@@ -35,6 +36,7 @@ self: with self; {
   xcbproto = xcb-proto;
   xkeyboardconfig = xkeyboard-config;
   xorgcffiles = xorg-cf-files;
+  xorgdocs = xorg-docs;
 
   # THIS IS A GENERATED FILE.  DO NOT EDIT!
   appres = callPackage (
@@ -7599,37 +7601,6 @@ self: with self; {
         xorgproto
         libXt
       ];
-      passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-      meta = {
-        pkgConfigModules = [ ];
-        platforms = lib.platforms.unix;
-      };
-    })
-  ) { };
-
-  # THIS IS A GENERATED FILE.  DO NOT EDIT!
-  xorgdocs = callPackage (
-    {
-      stdenv,
-      pkg-config,
-      fetchurl,
-      testers,
-    }:
-    stdenv.mkDerivation (finalAttrs: {
-      pname = "xorg-docs";
-      version = "1.7.3";
-      builder = ./builder.sh;
-      src = fetchurl {
-        url = "mirror://xorg/individual/doc/xorg-docs-1.7.3.tar.xz";
-        sha256 = "1vyxpjcv8z5r5f5iza726ahzzwdapbbkxzv1b6w5izyrnppg58i8";
-      };
-      hardeningDisable = [
-        "bindnow"
-        "relro"
-      ];
-      strictDeps = true;
-      nativeBuildInputs = [ pkg-config ];
-      buildInputs = [ ];
       passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
       meta = {
         pkgConfigModules = [ ];

--- a/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
+++ b/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
@@ -41,6 +41,7 @@ $pcMap{"pciaccess"} = "libpciaccess";
 $pcMap{"pthread-stubs"} = "libpthreadstubs";
 $pcMap{"xbitmaps"} = "xbitmaps";
 $pcMap{"xcb-proto"} = "xcbproto";
+$pcMap{"xtrans"} = "xtrans";
 $pcMap{"\$PIXMAN"} = "pixman";
 $pcMap{"\$RENDERPROTO"} = "xorgproto";
 $pcMap{"\$DRI3PROTO"} = "xorgproto";
@@ -281,6 +282,7 @@ print OUT <<EOF;
   xorg-cf-files,
   xorg-docs,
   xorg-sgml-doctools,
+  xtrans,
 }:
 
 self: with self; {
@@ -293,6 +295,7 @@ self: with self; {
     makedepend
     pixman
     xbitmaps
+    xtrans
     ;
   fontalias = font-alias;
   fontutil = font-util;

--- a/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
+++ b/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
@@ -279,6 +279,7 @@ print OUT <<EOF;
   xcb-proto,
   xkeyboard-config,
   xorg-cf-files,
+  xorg-docs,
 }:
 
 self: with self; {
@@ -299,6 +300,7 @@ self: with self; {
   xcbproto = xcb-proto;
   xkeyboardconfig = xkeyboard-config;
   xorgcffiles = xorg-cf-files;
+  xorgdocs = xorg-docs;
 
 EOF
 

--- a/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
+++ b/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
@@ -278,6 +278,7 @@ print OUT <<EOF;
   xbitmaps,
   xcb-proto,
   xkeyboard-config,
+  xorg-cf-files,
 }:
 
 self: with self; {
@@ -297,6 +298,7 @@ self: with self; {
   utilmacros = util-macros;
   xcbproto = xcb-proto;
   xkeyboardconfig = xkeyboard-config;
+  xorgcffiles = xorg-cf-files;
 
 EOF
 

--- a/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
+++ b/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
@@ -280,6 +280,7 @@ print OUT <<EOF;
   xkeyboard-config,
   xorg-cf-files,
   xorg-docs,
+  xorg-sgml-doctools,
 }:
 
 self: with self; {
@@ -301,6 +302,7 @@ self: with self; {
   xkeyboardconfig = xkeyboard-config;
   xorgcffiles = xorg-cf-files;
   xorgdocs = xorg-docs;
+  xorgsgmldoctools = xorg-sgml-doctools;
 
 EOF
 

--- a/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
+++ b/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
@@ -277,6 +277,7 @@ print OUT <<EOF;
   util-macros,
   xbitmaps,
   xcb-proto,
+  xkeyboard-config,
 }:
 
 self: with self; {
@@ -295,6 +296,7 @@ self: with self; {
   libpthreadstubs = libpthread-stubs;
   utilmacros = util-macros;
   xcbproto = xcb-proto;
+  xkeyboardconfig = xkeyboard-config;
 
 EOF
 

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -1414,12 +1414,6 @@ self: super:
   xmodmap = addMainProgram super.xmodmap { };
   xmore = addMainProgram super.xmore { };
 
-  xorgdocs = super.xorgdocs.overrideAttrs (attrs: {
-    # This makes the man pages discoverable by the default man,
-    # since it looks for packages in $PATH
-    postInstall = "mkdir $out/bin";
-  });
-
   xpr = addMainProgram super.xpr { };
   xprop = addMainProgram super.xprop { };
 

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -1414,12 +1414,6 @@ self: super:
   xmodmap = addMainProgram super.xmodmap { };
   xmore = addMainProgram super.xmore { };
 
-  xorgcffiles = super.xorgcffiles.overrideAttrs (attrs: {
-    postInstall = lib.optionalString stdenv.hostPlatform.isDarwin ''
-      substituteInPlace $out/lib/X11/config/darwin.cf --replace "/usr/bin/" ""
-    '';
-  });
-
   xorgdocs = super.xorgdocs.overrideAttrs (attrs: {
     # This makes the man pages discoverable by the default man,
     # since it looks for packages in $PATH

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -903,29 +903,6 @@ self: super:
     };
   });
 
-  xkeyboardconfig = super.xkeyboardconfig.overrideAttrs (attrs: {
-    prePatch = ''
-      patchShebangs rules/merge.py rules/compat/map-variants.py rules/generate-options-symbols.py rules/xml2lst.pl
-    '';
-    nativeBuildInputs = attrs.nativeBuildInputs ++ [
-      meson
-      ninja
-      python3
-      perl
-      libxslt # xsltproc
-      gettext # msgfmt
-    ];
-    mesonFlags = [
-      (lib.mesonBool "xorg-rules-symlinks" true)
-    ];
-    # 1: compatibility for X11/xkb location
-    # 2: I think pkg-config/ is supposed to be in /lib/
-    postInstall = ''
-      ln -s share "$out/etc"
-      mkdir -p "$out/lib" && ln -s ../share/pkgconfig "$out/lib/"
-    '';
-  });
-
   # xkeyboardconfig variant extensible with custom layouts.
   # See nixos/modules/services/x11/extra-layouts.nix
   xkeyboardconfig_custom =

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -70,7 +70,6 @@ mirror://xorg/individual/app/xwd-1.0.9.tar.xz
 mirror://xorg/individual/app/xwininfo-1.1.6.tar.xz
 mirror://xorg/individual/app/xwud-1.0.7.tar.xz
 mirror://xorg/individual/data/xcursor-themes-1.0.7.tar.xz
-mirror://xorg/individual/doc/xorg-docs-1.7.3.tar.xz
 mirror://xorg/individual/doc/xorg-sgml-doctools-1.12.1.tar.xz
 mirror://xorg/individual/driver/xf86-input-evdev-2.11.0.tar.xz
 mirror://xorg/individual/driver/xf86-input-joystick-1.6.4.tar.xz

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -70,7 +70,6 @@ mirror://xorg/individual/app/xwd-1.0.9.tar.xz
 mirror://xorg/individual/app/xwininfo-1.1.6.tar.xz
 mirror://xorg/individual/app/xwud-1.0.7.tar.xz
 mirror://xorg/individual/data/xcursor-themes-1.0.7.tar.xz
-mirror://xorg/individual/data/xkeyboard-config/xkeyboard-config-2.44.tar.xz
 mirror://xorg/individual/doc/xorg-docs-1.7.3.tar.xz
 mirror://xorg/individual/doc/xorg-sgml-doctools-1.12.1.tar.xz
 mirror://xorg/individual/driver/xf86-input-evdev-2.11.0.tar.xz

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -70,7 +70,6 @@ mirror://xorg/individual/app/xwd-1.0.9.tar.xz
 mirror://xorg/individual/app/xwininfo-1.1.6.tar.xz
 mirror://xorg/individual/app/xwud-1.0.7.tar.xz
 mirror://xorg/individual/data/xcursor-themes-1.0.7.tar.xz
-mirror://xorg/individual/doc/xorg-sgml-doctools-1.12.1.tar.xz
 mirror://xorg/individual/driver/xf86-input-evdev-2.11.0.tar.xz
 mirror://xorg/individual/driver/xf86-input-joystick-1.6.4.tar.xz
 mirror://xorg/individual/driver/xf86-input-keyboard-2.0.0.tar.xz

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -198,7 +198,6 @@ mirror://xorg/individual/lib/libXxf86dga-1.1.6.tar.xz
 mirror://xorg/individual/lib/libXxf86misc-1.0.4.tar.bz2
 mirror://xorg/individual/lib/libXxf86vm-1.1.6.tar.xz
 mirror://xorg/individual/lib/xcb-util-cursor-0.1.5.tar.xz
-mirror://xorg/individual/lib/xtrans-1.6.0.tar.xz
 mirror://xorg/individual/proto/xorgproto-2024.1.tar.xz
 mirror://xorg/individual/util/bdftopcf-1.1.2.tar.xz
 mirror://xorg/individual/util/imake-1.0.10.tar.xz

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -205,5 +205,4 @@ mirror://xorg/individual/proto/xorgproto-2024.1.tar.xz
 mirror://xorg/individual/util/bdftopcf-1.1.2.tar.xz
 mirror://xorg/individual/util/imake-1.0.10.tar.xz
 mirror://xorg/individual/util/lndir-1.0.5.tar.xz
-mirror://xorg/individual/util/xorg-cf-files-1.0.8.tar.xz
 mirror://xorg/individual/xserver/xorg-server-21.1.16.tar.xz

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12504,7 +12504,7 @@ with pkgs;
 
   whitesur-kde = kdePackages.callPackage ../data/themes/whitesur-kde { };
 
-  xkeyboard_config = xorg.xkeyboardconfig;
+  xkeyboard_config = xkeyboard-config;
 
   xlsx2csv = with python3Packages; toPythonApplication xlsx2csv;
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

plan is to migrate all packages from xorg to pkgs/by-name
it looks like chunks of 5 packages seem ok small chunks

this is the script i use to get the packages that don't depend on other xorg packages:
```nix
let
  inherit (import <nixpkgs> { }) lib;

  done = import ./pkgs/servers/x11/xorg/default.nix |> lib.functionArgs |> lib.attrNames;

  pkgs =
    (import ./default.nix { }).xorg
    |> lib.filterAttrs (
      n: v:
      lib.isAttrs v
      && v ? pname
      && !lib.elem n done
      && !lib.elem n (map (lib.replaceStrings [ "-" ] [ "" ]) done)
      && !lib.elem v.pname done
      && !lib.elem v.pname (map (lib.replaceStrings [ "-" ] [ "" ]) done)
      && !lib.elem (lib.toLower n) done
      && !lib.elem (lib.toLower n) (map (lib.replaceStrings [ "-" ] [ "" ]) done)
      && !v.meta.unfree
      && !v.meta.broken
      && !v.meta.unsupported
    );

  pnames = lib.mapAttrsToList (_: v: v.pname) pkgs;
in
pkgs
# get deps
|> lib.mapAttrs (
  _: v:
  v.buildInputs ++ v.nativeBuildInputs ++ v.propagatedBuildInputs ++ v.propagatedNativeBuildInputs
)
# filter deps for xorg packages
|> lib.mapAttrs (_: v: lib.filter (x: x ? pname && lib.elem x.pname pnames) v)
# map deps to list and count
|> lib.mapAttrsToList (
  name: value: {
    inherit name;
    deps = map (x: x.pname or "error") value |> lib.unique;
    count = lib.length value;
  }
)
# sort
|> lib.sort (x: y: x.count > y.count)
# represent as string
|> map (x: "${toString x.count} - ${toString x.name}: ${lib.concatStringsSep " " x.deps}")
```

you can call it like this to get a nice output:
```sh
nix eval --json --file ./xorg-nodepends.nix | jq .[] --raw-output
```

## Things done

- Built on platform(s)
  - [x] x86_64-linux (commits cherry picked on nixos-unstable)
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
