### PR TITLE
seasonpackarr: add package and module

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -889,6 +889,7 @@
   ./services/misc/rshim.nix
   ./services/misc/safeeyes.nix
   ./services/misc/sdrplay.nix
+  ./services/misc/seasonpackarr.nix
   ./services/misc/servarr/lidarr.nix
   ./services/misc/servarr/prowlarr.nix
   ./services/misc/servarr/radarr.nix

--- a/nixos/modules/services/misc/seasonpackarr.nix
+++ b/nixos/modules/services/misc/seasonpackarr.nix
@@ -1,0 +1,165 @@
+{
+  config,
+  lib,
+  pkgs,
+  utils,
+  ...
+}:
+
+let
+  cfg = config.services.seasonpackarr;
+  settingsFormat = pkgs.formats.yaml { };
+  stateDir = "/var/lib/seasonpackarr";
+in
+{
+  meta.maintainers = with lib.maintainers; [ ambroisie ];
+
+  options.services.seasonpackarr = {
+    enable = lib.mkEnableOption "seasonpackarr service";
+
+    package = lib.mkPackageOption pkgs "seasonpackarr" { };
+
+    settings = lib.mkOption {
+      default = { };
+      type = lib.types.submodule {
+        freeformType = settingsFormat.type;
+        options = {
+          port = lib.mkOption {
+            type = lib.types.port;
+            default = 42069;
+            example = 8000;
+            description = "Port the seasonpackarr daemon listens on.";
+          };
+        };
+      };
+
+      example = {
+        apiToken = {
+          _secret = "/run/credentials/seasonpackarr.service/apiToken";
+        };
+
+        clients = {
+          default = {
+            host = "127.0.0.1";
+            port = 8080;
+            username = "admin";
+            password = {
+              _secret = "/run/credentials/seasonpackarr.service/qbittorentPassword";
+            };
+            preImportPath = "/data/torrents/tv-hd";
+          };
+        };
+      };
+      description = ''
+        Configuration options for seasonpackarr.
+
+        The configuration is processed using [utils.genJqSecretsReplacementSnippet](https://github.com/NixOS/nixpkgs/blob/master/nixos/lib/utils.nix#L232-L331) to handle secret substitution.
+
+        To avoid permission issues, secrets should be provided via systemd's credential mechanism:
+
+        ```nix
+        systemd.services.seasonpackarr.serviceConfig.LoadCredential = [
+          "apiToken:''${config.sops.secrets.apiToken.path}"
+          "qbittorentPassword:''${config.sops.secrets.qbittorentPassword.path}"
+        ];
+        ```
+      '';
+    };
+
+    user = lib.mkOption {
+      type = lib.types.str;
+      default = "seasonpackarr";
+      description = "User account under which seasonpackarr runs.";
+    };
+
+    group = lib.mkOption {
+      type = lib.types.str;
+      default = "seasonpackarr";
+      description = "Group under which seasonpackarr runs.";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    systemd.services.seasonpackarr = {
+      description = "seasonpackarr";
+      wantedBy = [ "multi-user.target" ];
+
+      # YAML is a JSON super-set
+      preStart = utils.genJqSecretsReplacementSnippet cfg.settings "${stateDir}/config.yaml";
+
+      serviceConfig = {
+        Type = "simple";
+        # `--config` expects a directory which contains `config.yaml`...
+        ExecStart = "${lib.getExe cfg.package} start --config ${stateDir}";
+        User = cfg.user;
+        Group = cfg.group;
+        Restart = "on-failure";
+
+        StateDirectory = "seasonpackarr";
+
+        # Only allow binding to the specified port.
+        SocketBindDeny = "any";
+        SocketBindAllow = cfg.settings.port;
+
+        # Security options:
+        LockPersonality = true;
+        MemoryDenyWriteExecute = true;
+        NoNewPrivileges = true;
+        PrivateDevices = true;
+        PrivateMounts = true;
+        PrivateNetwork = false;
+        PrivateTmp = true;
+        PrivateUsers = true;
+        ProtectClock = true;
+        ProtectControlGroups = true;
+        ProtectHome = true;
+        ProtectHostname = true;
+        ProtectKernelLogs = true;
+        ProtectKernelModules = true;
+        ProtectKernelTunables = true;
+        ProtectProc = true;
+        ProtectSystem = "strict";
+        RemoveIPC = true;
+        RestrictRealtime = true;
+        RestrictSUIDSGID = true;
+        RestrictAddressFamilies = [
+          "AF_INET"
+          "AF_INET6"
+        ];
+        RestrictNamespaces = true;
+        SystemCallArchitectures = "native";
+        SystemCallFilter = [
+          "@system-service"
+          "~@clock"
+          "~@aio"
+          "~@cpu-emulation"
+          "~@debug"
+          "~@keyring"
+          "~@memlock"
+          "~@module"
+          "~@mount"
+          "~@obsolete"
+          "~@privileged"
+          "~@raw-io"
+          "~@reboot"
+          "~@setuid"
+          "~@swap"
+        ];
+        SystemCallErrorNumber = "EPERM";
+      };
+    };
+
+    users.users = lib.mkIf (cfg.user == "seasonpackarr") {
+      seasonpackarr = {
+        isSystemUser = true;
+        description = "seasonpackarr user";
+        home = stateDir;
+        group = cfg.group;
+      };
+    };
+
+    users.groups = lib.mkIf (cfg.group == "seasonpackarr") {
+      ${cfg.group} = { };
+    };
+  };
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1188,6 +1188,7 @@ in
   sdl3 = handleTest ./sdl3.nix { };
   seafile = handleTest ./seafile.nix { };
   searx = runTest ./searx.nix;
+  seasonpackarr = runTest ./seasonpackarr.nix;
   seatd = handleTest ./seatd.nix { };
   send = runTest ./send.nix;
   service-runner = handleTest ./service-runner.nix { };

--- a/nixos/tests/seasonpackarr.nix
+++ b/nixos/tests/seasonpackarr.nix
@@ -1,0 +1,31 @@
+{ lib, ... }:
+{
+  name = "seasonpackarr";
+  meta.maintainers = with lib.maintainers; [ ambroisie ];
+
+  nodes.machine =
+    { pkgs, ... }:
+    {
+      services.seasonpackarr = {
+        enable = true;
+        settings = {
+          apiToken = {
+            # Use an actual secret manager in production
+            _secret = pkgs.writeText "apiToken" "someSecretTokenValue";
+          };
+        };
+      };
+    };
+
+  testScript = # python
+    ''
+      start_all()
+      machine.wait_for_unit("seasonpackarr.service")
+      machine.wait_for_open_port(42069)
+
+      with subtest("Test security"):
+          output = machine.succeed("systemd-analyze security seasonpackarr.service")
+          machine.log(output)
+          assert output[-7:-1] == "OK :-)"
+    '';
+}

--- a/pkgs/by-name/se/seasonpackarr/package.nix
+++ b/pkgs/by-name/se/seasonpackarr/package.nix
@@ -3,6 +3,7 @@
   buildGoModule,
   fetchFromGitHub,
   nix-update-script,
+  nixosTests,
 }:
 
 buildGoModule (finalAttrs: {
@@ -33,6 +34,9 @@ buildGoModule (finalAttrs: {
 
   passthru = {
     updateScript = nix-update-script;
+    tests = {
+      inherit (nixosTests) seasonpackarr;
+    };
   };
 
   meta = with lib; {

--- a/pkgs/by-name/se/seasonpackarr/package.nix
+++ b/pkgs/by-name/se/seasonpackarr/package.nix
@@ -1,0 +1,45 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  nix-update-script,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "seasonpackarr";
+  version = "0.12.0";
+
+  src = fetchFromGitHub {
+    owner = "nuxencs";
+    repo = "seasonpackarr";
+    rev = "v${finalAttrs.version}";
+    sha256 = "sha256-l9cnjXCONz3w85ffXJSuraqGmKoC2kEGS1utz5MoZvc=";
+  };
+
+  vendorHash = "sha256-zwGBsORzO8SvxoHU3Cry99vUraM9ZERyRhtjPwGq4GY=";
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X github.com/nuxencs/seasonpackarr/internal/buildinfo.Version=v${finalAttrs.version}"
+    "-X github.com/nuxencs/seasonpackarr/internal/buildinfo.Commit=v${finalAttrs.version}"
+    "-X github.com/nuxencs/seasonpackarr/internal/buildinfo.Date=unknown"
+  ];
+
+  checkFlags = [
+    # Tries to make API calls
+    "-skip=^Test_TVMaze"
+  ];
+
+  passthru = {
+    updateScript = nix-update-script;
+  };
+
+  meta = with lib; {
+    description = "Automagically hardlink downloaded episodes into a season folder";
+    homepage = "https://github.com/nuxencs/seasonpackarr";
+    maintainers = with maintainers; [ ambroisie ];
+    license = licenses.gpl2Plus;
+    mainProgram = "seasonpackarr";
+  };
+})


### PR DESCRIPTION
## Things done

I don't have qBittorent (waiting for upstream to add support for alternative clients), if any passer-by with qBittorrent could test it out in production, that'd help.

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
