### PR TITLE
python3Packages.pygsl: 2.5.1 -> 2.6.2

### DIFF
--- a/pkgs/development/python-modules/pygsl/default.nix
+++ b/pkgs/development/python-modules/pygsl/default.nix
@@ -2,42 +2,41 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+  pkg-config,
   gsl,
   swig,
+  meson-python,
   numpy,
   pytestCheckHook,
 }:
 
 buildPythonPackage rec {
   pname = "pygsl";
-  version = "2.5.1";
-  format = "setuptools";
+  version = "2.6.2";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "pygsl";
     repo = "pygsl";
     tag = "v${version}";
-    hash = "sha256-Xgb37uY8CV0gkBZ7Rgg8d5uD+bIBsPfi1ss8PT1LMAY=";
+    hash = "sha256-1aAc2qGVlClnsw70D1QqPbSsyij0JNgfIXsLzelYx3E=";
   };
 
-  # error: no member named 'n' in 'gsl_bspline_workspace'
-  postPatch = lib.optionalString (lib.versionAtLeast gsl.version "2.8") ''
-    substituteInPlace src/bspline/bspline.ic \
-      --replace-fail "self->w->n" "self->w->ncontrol"
-    substituteInPlace swig_src/bspline_wrap.c \
-      --replace-fail "self->w->n;" "self->w->ncontrol;"
-  '';
-
   nativeBuildInputs = [
-    gsl.dev
+    pkg-config
     swig
   ];
-  buildInputs = [ gsl ];
-  dependencies = [ numpy ];
+  buildInputs = [
+    gsl
+  ];
 
-  preBuild = ''
-    python setup.py build_ext --inplace
-  '';
+  build-system = [
+    meson-python
+    numpy
+  ];
+  dependencies = [
+    numpy
+  ];
 
   preCheck = ''
     cd tests


### PR DESCRIPTION
https://github.com/pygsl/pygsl/releases/tag/v2.6.2

This also fixes the current build failure: https://hydra.nixos.org/build/293086312

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
