### PR TITLE
wxGTK32, python3Packages.wxpython: update to libsoup_3

### DIFF
--- a/pkgs/applications/misc/prusa-slicer/default.nix
+++ b/pkgs/applications/misc/prusa-slicer/default.nix
@@ -36,27 +36,14 @@
   libbgcode,
   heatshrink,
   catch2,
-  webkitgtk_4_0,
+  webkitgtk_4_1,
   withSystemd ? lib.meta.availableOn stdenv.hostPlatform systemd,
   systemd,
   wxGTK-override ? null,
   opencascade-override ? null,
 }:
 let
-  wxGTK-prusa = wxGTK32.overrideAttrs (old: {
-    pname = "wxwidgets-prusa3d-patched";
-    version = "3.2.0";
-    configureFlags = old.configureFlags ++ [ "--disable-glcanvasegl" ];
-    patches = [ ./wxWidgets-Makefile.in-fix.patch ];
-    src = fetchFromGitHub {
-      owner = "prusa3d";
-      repo = "wxWidgets";
-      rev = "78aa2dc0ea7ce99dc19adc1140f74c3e2e3f3a26";
-      hash = "sha256-rYvmNmvv48JSKVT4ph9AS+JdstnLSRmcpWz1IdgBzQo=";
-      fetchSubmodules = true;
-    };
-  });
-  nanosvg-fltk = nanosvg.overrideAttrs (old: rec {
+  nanosvg-fltk = nanosvg.overrideAttrs (old: {
     pname = "nanosvg-fltk";
     version = "unstable-2022-12-22";
 
@@ -68,7 +55,7 @@ let
     };
   });
   openvdb_tbb_2021_8 = openvdb.override { tbb = tbb_2021_11; };
-  wxGTK-override' = if wxGTK-override == null then wxGTK-prusa else wxGTK-override;
+  wxGTK-override' = if wxGTK-override == null then wxGTK32 else wxGTK-override;
   opencascade-override' =
     if opencascade-override == null then opencascade-occt_7_6_1 else opencascade-override;
 in
@@ -89,6 +76,8 @@ stdenv.mkDerivation (finalAttrs: {
       url = "https://github.com/prusa3d/PrusaSlicer/commit/cdc3db58f9002778a0ca74517865527f50ade4c3.patch";
       hash = "sha256-zgpGg1jtdnCBaWjR6oUcHo5sGuZx5oEzpux3dpRdMAM=";
     })
+    # https://github.com/prusa3d/PrusaSlicer/pull/11769
+    ./fix-ambiguous-constructors.patch
   ];
 
   # required for GCC 14
@@ -138,7 +127,7 @@ stdenv.mkDerivation (finalAttrs: {
       libbgcode
       heatshrink
       catch2
-      webkitgtk_4_0
+      webkitgtk_4_1
     ]
     ++ lib.optionals withSystemd [
       systemd

--- a/pkgs/applications/misc/prusa-slicer/fix-ambiguous-constructors.patch
+++ b/pkgs/applications/misc/prusa-slicer/fix-ambiguous-constructors.patch
@@ -1,0 +1,37 @@
+From 910328f3131e24e330808f5d4cb814454dbe201d Mon Sep 17 00:00:00 2001
+From: Gregor Riepl <onitake@gmail.com>
+Date: Mon, 27 Nov 2023 13:01:55 +0100
+Subject: [PATCH] Make initializers explicit to avoid ambiguous wxArrayString
+ overloads
+
+---
+ src/slic3r/GUI/PhysicalPrinterDialog.cpp | 2 +-
+ src/slic3r/GUI/Plater.cpp                | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/slic3r/GUI/PhysicalPrinterDialog.cpp b/src/slic3r/GUI/PhysicalPrinterDialog.cpp
+index 849e987c731..7d0c628c23f 100644
+--- a/src/slic3r/GUI/PhysicalPrinterDialog.cpp
++++ b/src/slic3r/GUI/PhysicalPrinterDialog.cpp
+@@ -607,7 +607,7 @@ void PhysicalPrinterDialog::build_printhost_settings(ConfigOptionsGroup* m_optgr
+     // Always fill in the "printhost_port" combo box from the config and select it.
+     {
+         Choice* choice = dynamic_cast<Choice*>(m_optgroup->get_field("printhost_port"));
+-        choice->set_values({ m_config->opt_string("printhost_port") });
++        choice->set_values(std::vector<std::string>({ m_config->opt_string("printhost_port") }));
+         choice->set_selection();
+     }
+ 
+diff --git a/src/slic3r/GUI/Plater.cpp b/src/slic3r/GUI/Plater.cpp
+index debfe625fd4..4d61e29a2dc 100644
+--- a/src/slic3r/GUI/Plater.cpp
++++ b/src/slic3r/GUI/Plater.cpp
+@@ -4420,7 +4420,7 @@ void Plater::load_project(const wxString& filename)
+     s_multiple_beds.set_loading_project_flag(true);
+     ScopeGuard guard([](){ s_multiple_beds.set_loading_project_flag(false);});
+ 
+-    if (! load_files({ into_path(filename) }).empty()) {
++    if (! load_files(std::vector<boost::filesystem::path>({ into_path(filename) })).empty()) {
+         // At least one file was loaded.
+         p->set_project_filename(filename);
+         // Save the names of active presets and project specific config into ProjectDirtyStateManager.

--- a/pkgs/by-name/wx/wxGTK32/package.nix
+++ b/pkgs/by-name/wx/wxGTK32/package.nix
@@ -28,7 +28,7 @@
   unicode ? true,
   withMesa ? !stdenv.hostPlatform.isDarwin,
   withWebKit ? true,
-  webkitgtk_4_0,
+  webkitgtk_4_1,
 }:
 let
   catch = fetchFromGitHub {
@@ -82,7 +82,7 @@ stdenv.mkDerivation rec {
       xorgproto
     ]
     ++ lib.optional withMesa libGLU
-    ++ lib.optional (withWebKit && stdenv.hostPlatform.isLinux) webkitgtk_4_0
+    ++ lib.optional (withWebKit && stdenv.hostPlatform.isLinux) webkitgtk_4_1
     ++ lib.optionals stdenv.hostPlatform.isDarwin [
       expat
     ];

--- a/pkgs/development/python-modules/wxpython/4.2.nix
+++ b/pkgs/development/python-modules/wxpython/4.2.nix
@@ -30,7 +30,7 @@
   libglvnd,
   libgbm,
   pango,
-  webkitgtk_4_0,
+  webkitgtk_4_1,
   wxGTK,
   xorgproto,
 
@@ -92,7 +92,7 @@ buildPythonPackage rec {
       libXxf86vm
       libglvnd
       libgbm
-      webkitgtk_4_0
+      webkitgtk_4_1
       xorgproto
     ];
 


### PR DESCRIPTION
This change is part of the effort to replace libsoup_3, see https://github.com/NixOS/nixpkgs/issues/360897

Previously, this change was impossible to implement as colliding versions of libsoup would cause breaks at runtime. The goal of the `libsoup-updates` branch is to bundle all the libsoup related updates in one place so the switch can be done cleanly, while each individual update is still one PR.

Pings:
@jtojnar (familiar with libsoup)
@alyssais (helped set up the branch)
@mweinelt (maintainer wxpython)
@tfmoraes @FliegendeWurst (maintainers wxwidgets)

Closes #369710

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
