### PR TITLE
gcc14: fix internal compiler error on aarch64

### DIFF
--- a/pkgs/development/compilers/gcc/patches/14/aarch64-fix-ice-subreg.patch
+++ b/pkgs/development/compilers/gcc/patches/14/aarch64-fix-ice-subreg.patch
@@ -1,0 +1,87 @@
+diff --git a/gcc/config/aarch64/aarch64.md b/gcc/config/aarch64/aarch64.md
+index d3c381e82ce..6a481059bf0 100644
+--- a/gcc/config/aarch64/aarch64.md
++++ b/gcc/config/aarch64/aarch64.md
+@@ -6161,8 +6161,8 @@
+ 			  (match_dup 1))
+ 	(match_dup 2))]
+   {
+-    operands[2] = lowpart_subreg (<GPI:MODE>mode, operands[2],
+-				  <ALLX:MODE>mode);
++    operands[2] = force_lowpart_subreg (<GPI:MODE>mode, operands[2],
++					<ALLX:MODE>mode);
+   }
+   [(set_attr "type" "bfm,neon_ins_q,neon_ins_q")
+    (set_attr "arch" "*,simd,simd")]
+@@ -7210,7 +7210,7 @@
+ 
+       emit_insn (gen_iorv2<v_int_equiv>3 (
+ 	lowpart_subreg (V2<V_INT_EQUIV>mode, operands[0], <MODE>mode),
+-	lowpart_subreg (V2<V_INT_EQUIV>mode, operands[1], <MODE>mode),
++	force_lowpart_subreg (V2<V_INT_EQUIV>mode, operands[1], <MODE>mode),
+ 	v_bitmask));
+       DONE;
+     }
+@@ -7255,8 +7255,8 @@
+   "TARGET_SIMD"
+ {
+   rtx tmp = gen_reg_rtx (<VCONQ>mode);
+-  rtx op1 = lowpart_subreg (<VCONQ>mode, operands[1], <MODE>mode);
+-  rtx op2 = lowpart_subreg (<VCONQ>mode, operands[2], <MODE>mode);
++  rtx op1 = force_lowpart_subreg (<VCONQ>mode, operands[1], <MODE>mode);
++  rtx op2 = force_lowpart_subreg (<VCONQ>mode, operands[2], <MODE>mode);
+   emit_insn (gen_xorsign3 (<VCONQ>mode, tmp, op1, op2));
+   emit_move_insn (operands[0],
+ 		  lowpart_subreg (<MODE>mode, tmp, <VCONQ>mode));
+diff --git a/gcc/explow.cc b/gcc/explow.cc
+index f6843398c4b..80f59418bca 100644
+--- a/gcc/explow.cc
++++ b/gcc/explow.cc
+@@ -760,6 +760,34 @@ force_subreg (machine_mode outermode, rtx op,
+   return simplify_gen_subreg (outermode, op, innermode, byte);
+ }
+ 
++/* Try to return an rvalue expression for the OUTERMODE lowpart of OP,
++   which has mode INNERMODE.  Allow OP to be forced into a new register
++   if necessary.
++
++   Return null on failure.  */
++
++rtx
++force_lowpart_subreg (machine_mode outermode, rtx op,
++		      machine_mode innermode)
++{
++  auto byte = subreg_lowpart_offset (outermode, innermode);
++  return force_subreg (outermode, op, innermode, byte);
++}
++
++/* Try to return an rvalue expression for the OUTERMODE highpart of OP,
++   which has mode INNERMODE.  Allow OP to be forced into a new register
++   if necessary.
++
++   Return null on failure.  */
++
++rtx
++force_highpart_subreg (machine_mode outermode, rtx op,
++		       machine_mode innermode)
++{
++  auto byte = subreg_highpart_offset (outermode, innermode);
++  return force_subreg (outermode, op, innermode, byte);
++}
++
+ /* If X is a memory ref, copy its contents to a new temp reg and return
+    that reg.  Otherwise, return X.  */
+ 
+diff --git a/gcc/explow.h b/gcc/explow.h
+index cbd1fcb7eb3..de89e9e2933 100644
+--- a/gcc/explow.h
++++ b/gcc/explow.h
+@@ -43,6 +43,8 @@ extern rtx copy_to_suggested_reg (rtx, rtx, machine_mode);
+ extern rtx force_reg (machine_mode, rtx);
+ 
+ extern rtx force_subreg (machine_mode, rtx, machine_mode, poly_uint64);
++extern rtx force_lowpart_subreg (machine_mode, rtx, machine_mode);
++extern rtx force_highpart_subreg (machine_mode, rtx, machine_mode);
+ 
+ /* Return given rtx, copied into a new temp reg if it was in memory.  */
+ extern rtx force_not_mem (rtx);

--- a/pkgs/development/compilers/gcc/patches/default.nix
+++ b/pkgs/development/compilers/gcc/patches/default.nix
@@ -94,6 +94,11 @@ in
 ++ optional langD ./libphobos.patch
 ++ optional (!atLeast14) ./cfi_startproc-reorder-label-09-1.diff
 ++ optional (atLeast14 && !canApplyIainsDarwinPatches) ./cfi_startproc-reorder-label-14-1.diff
+# backports of https://gcc.gnu.org/bugzilla/show_bug.cgi?id=118501
+#          and https://gcc.gnu.org/bugzilla/show_bug.cgi?id=118892
+#          and https://gcc.gnu.org/bugzilla/show_bug.cgi?id=119133
+# (hopefully all three will be included in the upcoming 14.3.0 release)
+++ optional is14 ./14/aarch64-fix-ice-subreg.patch
 
 ## 2. Patches relevant to gcc>=12 on specific platforms ####################################
 


### PR DESCRIPTION
This PR combines fixes of these 3 upstream issues:
- https://gcc.gnu.org/bugzilla/show_bug.cgi?id=118501
- https://gcc.gnu.org/bugzilla/show_bug.cgi?id=118892
- https://gcc.gnu.org/bugzilla/show_bug.cgi?id=119133

All 3 are related to segfault (internal compiler error) caused by the `force_subreg` function and are fixed by using the new `force_lowpart_subreg` function

Hopefully all 3 fixes will become part of the 14.3.0 release but until then we should patch them locally since the ICE can be triggered by compiling torch 2.6.0 on aarch64 and thus this blocks torch update in https://github.com/NixOS/nixpkgs/pull/377785.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
