### PR TITLE
gamja: 1.0.0-beta.10 -> 1.0.0-beta.11

### DIFF
--- a/pkgs/by-name/ga/gamja/package.nix
+++ b/pkgs/by-name/ga/gamja/package.nix
@@ -8,17 +8,17 @@
 }:
 buildNpmPackage rec {
   pname = "gamja";
-  version = "1.0.0-beta.10";
+  version = "1.0.0-beta.11";
 
   src = fetchFromGitea {
     domain = "codeberg.org";
     owner = "emersion";
     repo = "gamja";
     rev = "v${version}";
-    hash = "sha256-JqnEiPnYRGSeIZm34Guu7MgMfwcySc42aTXweMqL8BQ=";
+    hash = "sha256-amwJ6PWS0In7ERcvZr5XbJyHedSwJGAUUS2vWIqktNE=";
   };
 
-  npmDepsHash = "sha256-dAfbluNNBF1e9oagej+SRxO/YffCdLLAUUgt8krnWvg=";
+  npmDepsHash = "sha256-5YU9H3XHwZADdIvKmS99cAFFg69GPJzD9u0LOuJmKXE=";
 
   installPhase = ''
     runHook preInstall
@@ -33,7 +33,7 @@ buildNpmPackage rec {
 
   meta = with lib; {
     description = "Simple IRC web client";
-    homepage = "https://git.sr.ht/~emersion/gamja";
+    homepage = "https://codeberg.org/emersion/gamja";
     license = licenses.agpl3Only;
     maintainers = with maintainers; [
       motiejus


### PR DESCRIPTION
## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - Updated myself, works as expected: https://git.jakstys.lt/motiejus/config/commit/ed60715544bc3261f08d493fabb27805a4328230
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


