### PR TITLE
ruxguitar: init at 0.5.8

### DIFF
--- a/pkgs/by-name/ru/ruxguitar/package.nix
+++ b/pkgs/by-name/ru/ruxguitar/package.nix
@@ -1,0 +1,57 @@
+{
+  fetchFromGitHub,
+  rustPlatform,
+  lib,
+  versionCheckHook,
+  pkg-config,
+  alsa-lib,
+  wayland,
+  libGL,
+  libxkbcommon,
+  libgcc,
+  nix-update-script,
+  autoPatchelfHook,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "ruxguitar";
+  version = "0.6.2";
+
+  src = fetchFromGitHub {
+    owner = "agourlay";
+    repo = "ruxguitar";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-HQin+2dA9RP92PFUZsmsXCIufnbmnxjbmk3pLFaZwtk=";
+  };
+
+  cargoHash = "sha256-3w1HXNAxI81cZiGsG9L+rSIKb5liJvKjggpPY5KVhmM=";
+
+  nativeBuildInputs = [
+    pkg-config
+    autoPatchelfHook
+  ];
+  buildInputs = [
+    alsa-lib
+    libgcc
+  ];
+  runtimeDependencies = [
+    wayland
+    libGL
+    libxkbcommon
+  ];
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    mainProgram = "ruxguitar";
+    description = "Guitar Pro tablature player";
+    homepage = "https://github.com/agourlay/ruxguitar";
+    changelog = "https://github.com/agourlay/ruxguitar/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.asl20;
+    platforms = lib.platforms.unix;
+    maintainers = with lib.maintainers; [ cilki ];
+  };
+})


### PR DESCRIPTION
Add `ruxguitar` which is a graphical player for guitar pro files.

Note: waiting on https://github.com/NixOS/nixpkgs/pull/387127 for my `maintainers-list.nix` entry to be added.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
