### PR TITLE
hidapitester: init at 0.5

### DIFF
--- a/pkgs/by-name/hi/hidapitester/package.nix
+++ b/pkgs/by-name/hi/hidapitester/package.nix
@@ -1,0 +1,58 @@
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  hidapi,
+  udev,
+  pkg-config,
+  nix-update-script,
+  versionCheckHook,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "hidapitester";
+  version = "0.5";
+
+  src = fetchFromGitHub {
+    owner = "todbot";
+    repo = "hidapitester";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-OpLeKTouCB3efsXWJO0lZxUHxtDKeBY7OYk0HwC2NF4=";
+  };
+
+  postUnpack = ''
+    cp --no-preserve=mode -r ${hidapi.src} hidapi
+    export HIDAPI_DIR=$PWD/hidapi
+  '';
+
+  env.HIDAPITESTER_VERSION = finalAttrs.version;
+
+  buildInputs = [
+    udev
+    hidapi
+  ];
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm755 hidapitester $out/bin/hidapitester
+    runHook postInstall
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  meta = {
+    description = "Simple command-line program to test HIDAPI";
+    homepage = "https://github.com/todbot/hidapitester";
+    changelog = "https://github.com/todbot/hidapitester/releases/tag/v${finalAttrs.version}";
+    maintainers = with lib.maintainers; [ lykos153 ];
+    license = lib.licenses.gpl3Only;
+    mainProgram = "hidapitester";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

add hidapitester, a simple command-line program to test HIDAPI 

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
