### PR TITLE
deluge: Add option for web listening interface

### DIFF
--- a/nixos/modules/services/torrent/deluge.nix
+++ b/nixos/modules/services/torrent/deluge.nix
@@ -166,11 +166,19 @@ in
       deluge.web = {
         enable = lib.mkEnableOption "Deluge Web daemon";
 
+        interface = lib.mkOption {
+          type = lib.types.str;
+          default = "0.0.0.0";
+          description = ''
+            IP address for Deluge web server to listen on.
+          '';
+        };
+
         port = lib.mkOption {
           type = lib.types.port;
           default = 8112;
           description = ''
-            Deluge web UI port.
+            Port for Deluge web server to listen on.
           '';
         };
 
@@ -267,6 +275,7 @@ in
           ${cfg.package}/bin/deluge-web \
             ${lib.optionalString (!isDeluge1) "--do-not-daemonize"} \
             --config ${configDir} \
+            --interface ${cfg.web.interface} \
             --port ${toString cfg.web.port}
         '';
         User = cfg.user;


### PR DESCRIPTION
Add support for the `--interface` parameter for deluge-web.

(By default, it will always listen on the public interface 😱)

For reference, here's `deluge-web --help`:

```
# deluge-web --help
usage: .deluge-web-wrapped [-h] [-V] [-c <config>] [-l <logfile>] [-L <level>]
                           [--logrotate [<max-size>]] [-q] [--profile [<profile-file>]]
                           [-i <ip_address>] [-p <port>] [-b <path>] [--ssl] [--no-ssl]
                           [-P <pidfile>] [-d] [-U <user>] [-g <group>]

Starts the Deluge Web interface

Common Options:
  -h, --help                    Print this help message
  -V, --version                 Print version information
  -c, --config <config>         Set the config directory path
  -l, --logfile <logfile>       Output to specified logfile instead of stdout
  -L, --loglevel <level>        Set the log level (none, error, warning, info, debug)
  --logrotate [<max-size>]      Enable logfile rotation, with optional maximum logfile
                                  size, default: 2M (Logfile rotation count is 5)
  -q, --quiet                   Quieten logging output (Same as `--loglevel none`)
  --profile [<profile-file>]    Profile .deluge-web-wrapped with cProfile. Outputs to
                                  stdout unless a filename is specified

Web Server Options:
  -i, --interface <ip_address>  IP address for web server to listen on
  -p, --port <port>             Port for web server to listen on
  -b, --base <path>             Set the base path that the ui is running on
  --ssl                         Force the web server to use SSL
  --no-ssl                      Force the web server to disable SSL

Process Control Options:
  -P, --pidfile <pidfile>       Pidfile to store the process id
  -d, --do-not-daemonize        Do not daemonize (fork) this process
  -U, --user <user>             Change to this user on startup (Requires root)
  -g, --group <group>           Change to this group on startup (Requires root)
```

## Things done

I don't have that much NixOS experience, so I found this hard to test. I ended up building a qemu VM with NixOS and enabled the module for manual testing. This worked as intended, the service started listening on the configured interface.

The change is backwards compatible thanks to the default value.

The branch targets `release-24.11` because that's what I tested with. The same change should work on `master` as well (but I did not test it, when I tried some other packages failed to build).

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [x] (Module updates) Added a release notes entry if the change is significant
    -> Not a significant change, so no release notes needed
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
