### PR TITLE
feat(node-packages): verdaccio

### DIFF
--- a/nixos/modules/services/web-apps/verdaccio.nix
+++ b/nixos/modules/services/web-apps/verdaccio.nix
@@ -1,0 +1,85 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+with lib;
+
+let
+  cfg = config.services.verdaccio;
+  format = pkgs.formats.yaml { };
+  configFileName = "config.yaml";
+  configFile = format.generate configFileName cfg.settings;
+in
+{
+  options.services.verdaccio = {
+    enable = mkEnableOption "Verdaccio npm registry";
+
+    settings = mkOption {
+      type = types.attrs;
+      default = { };
+      description = ''
+        Verdaccio configuration options as a Nix attribute set.
+        These will be rendered to YAML and used as the Verdaccio configuration.
+
+        Check here https://verdaccio.org/docs/configuration for all available
+        configuration options.
+      '';
+    };
+
+    package = mkOption {
+      type = types.package;
+      default = pkgs.nodePackages.verdaccio;
+      description = "The Verdaccio package to use.";
+    };
+
+    user = mkOption {
+      type = types.str;
+      default = "verdaccio";
+      description = "User under which Verdaccio runs.";
+    };
+
+    group = mkOption {
+      type = types.str;
+      default = "verdaccio";
+      description = "Group under which Verdaccio runs.";
+    };
+
+    dataDir = mkOption {
+      type = types.path;
+      default = "/var/lib/verdaccio";
+      description = "Directory where Verdaccio stores data.";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    users.users.verdaccio = {
+      isSystemUser = true;
+      group = cfg.group;
+      home = cfg.dataDir;
+    };
+
+    users.groups.verdaccio = { };
+
+    systemd.tmpfiles.rules = [
+      "d '${cfg.dataDir}' 0700 ${cfg.user} ${cfg.group} - -"
+    ];
+
+    systemd.services.verdaccio = {
+      description = "Verdaccio lightweight npm proxy registry";
+      wantedBy = [ "multi-user.target" ];
+      restartTriggers = [ configFile ];
+      serviceConfig = {
+        ExecStart = "${cfg.package}/bin/verdaccio --config /etc/verdaccio/${configFileName}";
+        User = cfg.user;
+        Group = cfg.group;
+        WorkingDirectory = cfg.dataDir;
+        Restart = "on-failure";
+      };
+    };
+
+    environment.etc."verdaccio/${configFileName}".source = configFile;
+  };
+}

--- a/pkgs/by-name/ve/verdaccio/package.nix
+++ b/pkgs/by-name/ve/verdaccio/package.nix
@@ -1,0 +1,65 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  yarn-berry_3,
+  makeWrapper,
+}:
+let
+  yarn-berry = yarn-berry_3;
+in
+
+stdenv.mkDerivation (finalAttrs: rec {
+  pname = "verdaccio";
+  version = "6.1.2";
+
+  src = fetchFromGitHub {
+    owner = "verdaccio";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-EssvN5HtGI5Hmw4EXetj5nzrkBZAAJGgOx09dlYJzhI=";
+  };
+
+  nativeBuildInputs = [
+    makeWrapper
+    yarn-berry
+    yarn-berry.yarnBerryConfigHook
+  ];
+
+  offlineCache = yarn-berry.fetchYarnBerryDeps {
+    inherit (finalAttrs) src;
+    hash = "sha256-jzkmDxQtIFMa1LIPcvKKsXIItPntgXTavoWhd5eZWyQ=";
+  };
+
+  buildPhase = ''
+    runHook preBuild
+
+    yarn install
+    yarn run build
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/share
+    cp -r . $out/share/verdaccio
+
+     # PnP based packages need `yarn node` instead of `node` to run binaries
+    makeWrapper ${lib.getExe yarn-berry} "$out/bin/verdaccio" \
+      --chdir "$out/share/verdaccio" \
+      --add-flags "node ./bin/verdaccio"
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "A simple, zero-config-required local private npm registry";
+    longDescription = ''
+      Verdaccio is a simple, zero-config-required local private npm registry. No need for an entire database just to get started! Verdaccio comes out of the box with its own tiny database, and the ability to proxy other registries (eg. npmjs.org), caching the downloaded modules along the way. For those looking to extend their storage capabilities, Verdaccio supports various community-made plugins to hook into services such as Amazon's s3, Google Cloud Storage or create your own plugin.
+    '';
+    homepage = "https://verdaccio.org";
+    license = licenses.mit;
+  };
+})


### PR DESCRIPTION
Packaging Verdaccio https://github.com/verdaccio/verdaccio

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

I've followed this https://github.com/NixOS/nixpkgs/blob/master/doc/languages-frameworks/javascript.section.md#adding-and-updating-javascript-packages-in-nixpkgs-javascript-adding-or-updating-packages

~and the package seems to run (at least) but I'm not sure if what I did is correct because generate.sh script also updated all the others node packages and apart from that I also expected it to generate the deps using `pnpm.fetchDeps`.~

~![image](https://github.com/user-attachments/assets/e61c5ead-ec54-4f30-b0bd-6ea1e188c146)~

~Also after running the package I'm getting this error even if I'm not using `npm`, if someone could help me test the package it would be great.~

~The login seems to work even if this it shows this error, but it doesn't seem to cache the modules I required in the project.~

EDIT:

In the end I figured it was my local user's `.npmrc` permission issue, so I just deleted it and now it works 

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
