### PR TITLE
lib/minver: bump to nix 2.18.0

### DIFF
--- a/lib/minver.nix
+++ b/lib/minver.nix
@@ -1,2 +1,2 @@
 # Expose the minimum required version for evaluating Nixpkgs
-"2.3.17"
+"2.18.0"


### PR DESCRIPTION
Improved sentence:

**This version was released in September 2023**, which should provide **users with sufficient time to upgrade**.

Bumping to this version allows us to use unsafeDiscardReferences for NixOS images. Additionally, the current minimum version (2.3.17) contains **several unpatched security vulnerabilities** as documented in the Nix security advisories. While not all vulnerabilities apply to version 2.3, maintaining an older version requirement would force us to run that same version for regression testing, which is problematic from a security perspective.
