### PR TITLE
Provide `key` attribute for anonymous modules created with mkRemovedOptionModule and mkRenamedOptionModule

### DIFF
--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -1488,6 +1488,7 @@ let
     optionName: replacementInstructions:
     { options, ... }:
     {
+      key = "removedOptionModule#" + concatStringsSep "_" optionName;
       options = setAttrByPath optionName (mkOption {
         visible = false;
         apply =

--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -1830,6 +1830,7 @@ let
         opt.type or (types.submodule { });
     in
     {
+      key = "renamedOptionModule#" + concatStringsSep "_" from + "->" + concatStringsSep "_" to;
       options = setAttrByPath from (
         mkOption {
           inherit visible;


### PR DESCRIPTION
## Problem

Anonymous modules, introduced by `mkRemovedOptionModule` and `mkRenamedOptionModule` are impossible to disable using `disabledModules`.

### Detailed description
Option modules renames and removals are generally defined in `modules/rename.nix` using functions `mkRemovedOptionModule` and `mkRenamedOptionModule`.
Both of them introduce anonymous modules, which are impossible to disable using `disabledModules`.

The current implementation also doesn't provide `key` attribute, whose intended purpose is to be able to disable the module by its key, and not path.

The above makes it impossible to use the option namespaces already free and unused (!) in the flakes consuming `nixpkgs`.
Even though certain functionality may be removed in nixpkgs doesn't mean these namespaces couldn't be used in 3rd party configurations elsewhere.

For example, an attempt to use `boot.loader.raspberryPi` (which has been deprecated and removed from `nixpkgs` a long time ago) namespace in a custom flake results in the following errors:
```
 The option `boot.loader.raspberryPi' in module `/nix/store/1dwky0bis4bkl3qngsc6pmq902swa9b6-source/nixos/modules/rename.nix' would be a parent of the following options, but its type `<no description>' does not support nested options.
        - option(s) with prefix `boot.loader.raspberryPi.bootPath' in module `/nix/store/ls7n42f4rxh5fzd9cd334h9z4w58zbhb-source/modules/system/boot/loader/raspberrypi'
        - option(s) with prefix `boot.loader.raspberryPi.bootPopulateCmd' in module `/nix/store/ls7n42f4rxh5fzd9cd334h9z4w58zbhb-source/modules/system/boot/loader/raspberrypi'
...
```

## Proposed solution

Provide `key` attribute to the anonymous modules created with `mkRemovedOptionModule` and `mkRenamedOptionModule`.

This makes it possible to disable modules producing "removed options" assertion with the desired functionality, reusing free module namespace:
```nix
disabledModules = [
    # the module has been removed in nixpkgs, but that shouldn't prevent us
    # from using the now free (!) name for our module
    # mkRemovedOptionModule in `"modulesPath + rename.nix"`, unfortunately,
    # prevents us from doing so in upstream nixpkgs
    { key = "removedOptionModule#boot_loader_raspberryPi"; }
  ];
```

## Related issues and prior work in `nixpkgs`
- Documentation section mentioning `key` functionality: https://github.com/NixOS/nixpkgs/blob/2e0a6706c1c1a9bcd49ab0c994f4969cb01cfc68/nixos/doc/manual/development/replace-modules.section.md
- PR #211855 introducing possibility to disable anonymous modules using `key`
- Issue #343792 about the shortcoming of the documentation regarding `key`

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
