### PR TITLE
doxide: init at version 0.9.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -21234,6 +21234,12 @@
     name = "Robert Helgesson";
     keys = [ { fingerprint = "36CA CF52 D098 CC0E 78FB  0CB1 3573 356C 25C4 24D4"; } ];
   };
+  ryex = {
+    email = "powers.e.rachel@gmail.com";
+    github = "Ryex";
+    githubId = 508861;
+    name = "Rachel Powers";
+  };
   ryneeverett = {
     email = "ryneeverett@gmail.com";
     github = "ryneeverett";

--- a/pkgs/by-name/do/doxide/package.nix
+++ b/pkgs/by-name/do/doxide/package.nix
@@ -1,0 +1,91 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  libyaml,
+  icu,
+}:
+
+let
+  cli11 = fetchFromGitHub {
+    owner = "CLIUtils";
+    repo = "CLI11";
+    rev = "291c58789c031208f08f4f261a858b5b7083e8e2";
+    hash = "sha256-x3/kBlf5LdzkTO4NYOKanZBfcU4oK+fJw9L7cf88LsY=";
+  };
+  glob = fetchFromGitHub {
+    owner = "p-ranav";
+    repo = "glob";
+    rev = "8cd16218ae648addf166977d7e41b914768bcb05";
+    hash = "sha256-Zkgjon61Z/mmVa+TGmChfv6cvZNsCrRpqr2IDFztSFw=";
+  };
+  tree_sitter = fetchFromGitHub {
+    owner = "tree-sitter";
+    repo = "tree-sitter";
+    rev = "bdfe32402e85673bbc693216f0a6ef72c98bb665";
+    hash = "sha256-2Pg4D1Pf1Ex6ykXouAJvD1NVfg5CH4rCQcSTAJmYwd4=";
+  };
+  tree_sitter_cpp = fetchFromGitHub {
+    owner = "tree-sitter";
+    repo = "tree-sitter-cpp";
+    rev = "30d2fa385735378388a55917e2910965fce19748";
+    hash = "sha256-O7EVmGvkMCLTzoxNc+Qod6eCTWs6y8DYVpQqw+ziqGo=";
+  };
+  tree_sitter_cuda = fetchFromGitHub {
+    owner = "tree-sitter-grammars";
+    repo = "tree-sitter-cuda";
+    rev = "cbce8aedc6fa35313a4cecd206196011a08a85c4";
+    hash = "sha256-Ini+K3Ez6fXhcwbPHb0T8tbKzIASz86YF8ciSt39Aos=";
+  };
+
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "doxide";
+  version = "0.9.0";
+
+  src = fetchFromGitHub {
+    owner = "lawmurray";
+    repo = "doxide";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-s/kRMbS2j/CXuv6zJlOE+KMJDpem001PsuRtf/DuCkM=";
+  };
+
+  postUnpack = ''
+    mkdir -p contrib
+    rm -rf contrib/glob
+    ln -s ${glob} contrib/glob
+    rm -rf contrib/CLI11
+    ln -s ${cli11} contrib/CLI11
+    rm -rf contrib/tree-sitter
+    ln -s ${tree_sitter} contrib/tree-sitter
+    rm -rf contrib/tree-sitter-cpp
+    ln -s ${tree_sitter_cpp} contrib/tree-sitter-cpp
+    rm -rf contrib/tree-sitter-cuda
+    ln -s ${tree_sitter_cuda} contrib/tree-sitter-cuda
+  '';
+
+  nativeBuildInputs = [ cmake ];
+
+  buildInputs = [
+    icu
+    libyaml
+  ];
+
+  doCheck = true;
+
+  meta = {
+    description = "Modern documentation for modern C++";
+    longDescription = ''
+      Doxide is a documentation generator for C++. By generating Markdown,
+      Doxide opens C++ documentation to the whole wide world of static site
+      generation tools and themes.
+    '';
+    homepage = "https://doxide.org";
+    changelog = "https://github.com/lawmurray/doxide/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ ryex ];
+    mainProgram = "doxide";
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
+  };
+})


### PR DESCRIPTION
C++ documentation generation tool using markdown

Doxide does some interesting things with it's vendoring by directly including source files from tree-sitter and it's cpp and cuda grammar. but aside form libyaml all others are header only libraries. as such to avoid pulling sub-modules some symlins are used.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
