### PR TITLE
pythonPackages.python-coinmarketcap: init at 0.6

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6330,6 +6330,12 @@
     githubId = 131907205;
     name = "David Thievon";
   };
+  dolphindalt = {
+    email = "dolphindalt@gmail.com";
+    github = "dolphindalt";
+    githubId = 13937320;
+    name = "Dalton Caron";
+  };
   domenkozar = {
     email = "domen@dev.si";
     github = "domenkozar";

--- a/pkgs/development/python-modules/python-coinmarketcap/default.nix
+++ b/pkgs/development/python-modules/python-coinmarketcap/default.nix
@@ -29,6 +29,8 @@ buildPythonPackage rec {
     "coinmarketcapapi"
   ];
 
+  doCheck = false; # Tests use the CoinMarketCap API
+
   meta = {
     description = "Python package to wrap the CoinMarketCap API";
     homepage = "https://github.com/rsz44/python-coinmarketcap";

--- a/pkgs/development/python-modules/python-coinmarketcap/default.nix
+++ b/pkgs/development/python-modules/python-coinmarketcap/default.nix
@@ -15,7 +15,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "rsz44";
     repo = "python-coinmarketcap";
-    rev = "de069d55d7cc5eea9cd194b47d4609c4846d59d1";
+    rev = "de069d55d7cc5eea9cd194b47d4609c4846d59d1"; # No tags
     hash = "sha256-FQIfDV7O3z5S2HGKi2k8NPsvkAS66rsueggoSAGvbVU=";
   };
 

--- a/pkgs/development/python-modules/python-coinmarketcap/default.nix
+++ b/pkgs/development/python-modules/python-coinmarketcap/default.nix
@@ -1,0 +1,35 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  pytestCheckHook,
+  requests,
+}:
+
+buildPythonPackage rec {
+  pname = "python-coinmarketcap";
+  version = "0.6";
+  format = "setuptools";
+
+  src = fetchFromGitHub {
+    owner = "rsz44";
+    repo = "python-coinmarketcap";
+    rev = "de069d55d7cc5eea9cd194b47d4609c4846d59d1";
+    hash = "sha256-FQIfDV7O3z5S2HGKi2k8NPsvkAS66rsueggoSAGvbVU=";
+  };
+
+  dependencies = [
+    requests
+  ];
+
+  pythonImportsCheck = [
+    "coinmarketcapapi"
+  ];
+
+  meta = with lib; {
+    description = "Python package to wrap the CoinMarketCap API";
+    homepage = "https://github.com/rsz44/python-coinmarketcap";
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ dolphindalt ];
+  };
+}

--- a/pkgs/development/python-modules/python-coinmarketcap/default.nix
+++ b/pkgs/development/python-modules/python-coinmarketcap/default.nix
@@ -4,6 +4,7 @@
   fetchFromGitHub,
   pytestCheckHook,
   requests,
+  setuptools,
 }:
 
 buildPythonPackage rec {

--- a/pkgs/development/python-modules/python-coinmarketcap/default.nix
+++ b/pkgs/development/python-modules/python-coinmarketcap/default.nix
@@ -9,7 +9,7 @@
 buildPythonPackage rec {
   pname = "python-coinmarketcap";
   version = "0.6";
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "rsz44";

--- a/pkgs/development/python-modules/python-coinmarketcap/default.nix
+++ b/pkgs/development/python-modules/python-coinmarketcap/default.nix
@@ -17,7 +17,8 @@ buildPythonPackage rec {
     rev = "de069d55d7cc5eea9cd194b47d4609c4846d59d1";
     hash = "sha256-FQIfDV7O3z5S2HGKi2k8NPsvkAS66rsueggoSAGvbVU=";
   };
-build-system = [ setuptools ];
+
+  build-system = [ setuptools ];
 
   dependencies = [
     requests

--- a/pkgs/development/python-modules/python-coinmarketcap/default.nix
+++ b/pkgs/development/python-modules/python-coinmarketcap/default.nix
@@ -17,6 +17,7 @@ buildPythonPackage rec {
     rev = "de069d55d7cc5eea9cd194b47d4609c4846d59d1";
     hash = "sha256-FQIfDV7O3z5S2HGKi2k8NPsvkAS66rsueggoSAGvbVU=";
   };
+build-system = [ setuptools ];
 
   dependencies = [
     requests

--- a/pkgs/development/python-modules/python-coinmarketcap/default.nix
+++ b/pkgs/development/python-modules/python-coinmarketcap/default.nix
@@ -26,10 +26,10 @@ buildPythonPackage rec {
     "coinmarketcapapi"
   ];
 
-  meta = with lib; {
+  meta = {
     description = "Python package to wrap the CoinMarketCap API";
     homepage = "https://github.com/rsz44/python-coinmarketcap";
-    license = with licenses; [ mit ];
-    maintainers = with maintainers; [ dolphindalt ];
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ dolphindalt ];
   };
 }

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -13817,6 +13817,8 @@ self: super: with self; {
 
   python-codon-tables = callPackage ../development/python-modules/python-codon-tables { };
 
+  python-coinmarketcap = callPackage ../development/python-modules/python-coinmarketcap { };
+
   python-constraint = callPackage ../development/python-modules/python-constraint { };
 
   python-creole = callPackage ../development/python-modules/python-creole { };


### PR DESCRIPTION
This PR introduces [https://github.com/rsz44/python-coinmarketcap](https://github.com/rsz44/python-coinmarketcap), which is used to monitor and watch the cryto market. 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
