### PR TITLE
fuse3: 3.16.2 -> 3.17.2

### DIFF
--- a/pkgs/os-specific/linux/fuse/default.nix
+++ b/pkgs/os-specific/linux/fuse/default.nix
@@ -14,7 +14,7 @@ in
   };
 
   fuse_3 = mkFuse {
-    version = "3.16.2";
-    hash = "sha256-QO9s+IkR0rkqIYNqt2IYST6AVBkCr56jcuuz5nKJuA4=";
+    version = "3.17.2";
+    hash = "sha256-rpWA97ZnoYWEQoUCGtITpx9w1J4qy6LGSxomFNOnKBc=";
   };
 }

--- a/pkgs/os-specific/linux/fuse/fuse3-Do-not-set-FUSERMOUNT_DIR.patch
+++ b/pkgs/os-specific/linux/fuse/fuse3-Do-not-set-FUSERMOUNT_DIR.patch
@@ -1,13 +1,13 @@
-diff --git a/lib/meson.build b/lib/meson.build
 --- a/lib/meson.build
 +++ b/lib/meson.build
 @@ -37,8 +37,7 @@ libfuse = library('fuse3', libfuse_sources, version: meson.project_version(),
-                   soversion: '3', include_directories: include_dirs,
-                   dependencies: deps, install: true,
+                   include_directories: include_dirs,
+                   dependencies: deps,
+                   install: true,
                    link_depends: 'fuse_versionscript',
--                  c_args: [ '-DFUSE_USE_VERSION=312',
+-                  c_args: [ '-DFUSE_USE_VERSION=317',
 -                            '-DFUSERMOUNT_DIR="@0@"'.format(fusermount_path) ],
-+                  c_args: [ '-DFUSE_USE_VERSION=312' ],
++                  c_args: [ '-DFUSE_USE_VERSION=317' ],
                    link_args: ['-Wl,--version-script,' + meson.current_source_dir()
                                + '/fuse_versionscript' ])
  


### PR DESCRIPTION
Changes:
- https://github.com/libfuse/libfuse/releases/tag/fuse-3.17.1
- https://github.com/libfuse/libfuse/releases/tag/fuse-3.17.2


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
