### PR TITLE
industrializer: enable Pulse backend, fix and enable strictDeps

### DIFF
--- a/pkgs/by-name/in/industrializer/package.nix
+++ b/pkgs/by-name/in/industrializer/package.nix
@@ -6,10 +6,12 @@
   audiofile,
   autoconf,
   automake,
+  gettext,
   gnome2,
   gtk2,
   libGL,
   libjack2,
+  libpulseaudio,
   libtool,
   libxml2,
   pkg-config,
@@ -27,6 +29,10 @@ stdenv.mkDerivation rec {
     pkg-config
     autoconf
     automake
+    gettext # autopoint
+    libxml2 # AM_PATH_XML2
+    alsa-lib # AM_PATH_ALSA
+    libtool
   ];
 
   buildInputs = [
@@ -36,9 +42,11 @@ stdenv.mkDerivation rec {
     gtk2
     libGL
     libjack2
-    libtool
     libxml2
+    libpulseaudio
   ];
+
+  strictDeps = true;
 
   preConfigure = "./autogen.sh";
 


### PR DESCRIPTION
## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux (cross)
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).