### PR TITLE
compiler-rt: enable build of libatomic

### DIFF
--- a/pkgs/development/compilers/llvm/common/compiler-rt/default.nix
+++ b/pkgs/development/compilers/llvm/common/compiler-rt/default.nix
@@ -23,6 +23,29 @@
   # are, so long as it provides some builtins.
   doFakeLibgcc ? stdenv.hostPlatform.isFreeBSD,
 
+  # Whether to build the set of __atomic_* routines that would typically
+  # be provided by libatomic in gcc environments. Although this has
+  # always been available, we only enable this by default on LLVM >= 13
+  # since that's when the standalone build became available; GCC's
+  # libatomic should be used in other cases.
+  withAtomics ?
+    (stdenv.hostPlatform.useLLVM or false)
+    && (
+      (lib.versionAtLeast release_version "13" && stdenv.cc.libc != null)
+      || !stdenv.hostPlatform.hasSharedLibraries
+    ),
+  # If withAtomics is enabled, setting this to true ships those routines
+  # in a separate DSO (aliased as libatomic to match gcc's) rather than
+  # making them part of builtins.a. Unless no dynamic linking is used at
+  # all, this is the correct setup as it ensures the locks are unique in
+  # memory.
+  withAtomicsLib ? lib.versionAtLeast release_version "13" && stdenv.hostPlatform.hasSharedLibraries,
+  # If withAtomics is enabled, this selects the pthreads-based
+  # implementation of the routines instead of the implementation
+  # using ad-hoc mutexes (which doesn't depend on libc at all).
+  # Use of pthreads helps code play better with sanitizers.
+  withAtomicsPthread ? lib.versionAtLeast release_version "19" && stdenv.cc.libc != null,
+
   # In recent releases, the compiler-rt build seems to produce
   # many `libclang_rt*` libraries, but not a single unified
   # `libcompiler_rt` library, at least under certain configurations. Some
@@ -256,6 +279,11 @@ stdenv.mkDerivation {
     ++ lib.optionals (noSanitizers && lib.versionAtLeast release_version "19") [
       "-DCOMPILER_RT_BUILD_CTX_PROFILE=OFF"
     ]
+    ++ lib.optionals withAtomics (
+      [ (lib.cmakeBool "COMPILER_RT_EXCLUDE_ATOMIC_BUILTIN" (!withAtomicsLib)) ]
+      ++ lib.optional withAtomicsLib (lib.cmakeBool "COMPILER_RT_BUILD_STANDALONE_LIBATOMIC" true)
+      ++ lib.optional withAtomicsPthread (lib.cmakeBool "COMPILER_RT_LIBATOMIC_USE_PTHREAD" true)
+    )
     ++ devExtraCmakeFlags;
 
   outputs = [
@@ -342,6 +370,11 @@ stdenv.mkDerivation {
     ''
     + lib.optionalString forceLinkCompilerRt ''
       ln -s $out/lib/*/libclang_rt.builtins-*.a $out/lib/libcompiler_rt.a
+    ''
+    + lib.optionalString (withAtomics && withAtomicsLib) ''
+      ln -s $out/lib/*/libclang_rt.atomic-*.so $out/lib/libatomic.so
+      # create a link with the original soname as well, so it's found at runtime
+      ln -s $out/lib/*/libclang_rt.atomic-*.so $out/lib/
     '';
 
   meta = llvm_meta // {


### PR DESCRIPTION
LLVM stdenvs lack a set of `__atomic_*` routines that compilers sometimes rely on, making it impossible to build certain C programs in them. The reason we lack these routines is that we're using neither compiler-rt's implementation of them (which was [disabled by default](https://reviews.llvm.org/D47606) a long time ago) nor gcc's implementation (libatomic). See #391740 for a more detailed explanation and an example of program that cannot be built.

Since no particular preference was expressed as to which approach should be used to solve this, this PR goes with LLVM's implementation and recommended setup, which seems to be used also in AIX, Fuchsia and Apple platforms. This consists of enabling a CMake flag, `COMPILER_RT_BUILD_STANDALONE_LIBATOMIC`, which causes the routines to be [built and shipped in a separate DSO](https://reviews.llvm.org/D102155) (placing them in a DSO instead of `builtins.a` is needed for correctness, as it ensures the lock section is unique in memory).

As with other builtins, I'm symlinking this DSO to `libatomic.so` so that downstream packages don't need specific/complicated logic for LLVM.

Other details:
- For static platforms, since no dynamic linking is expected at all, it should be correct to ship the symbols in `builtins.a`. So, that's what I'm doing in those cases.
- Since v19, compiler-rt allows [using pthread locks rather than ad-hoc ones](https://github.com/llvm/llvm-project/pull/95326) for the atomic routines. Since this plays better with instrumentation, I'm enabling this whenever libc is available.
- It would be nice to put the DSO in a separate output / derivation, so that the rest of compiler-rt isn't pulled into the runtime closure, but it isn't high prio since compiler-rt doesn't pull in dependencies other than libc, libc++ and unwinder.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
