### PR TITLE
nixos-rebuild: Fix quoting in build-image output, improve docs

### DIFF
--- a/nixos/doc/manual/installation/building-images-via-nixos-rebuild-build-image.chapter.md
+++ b/nixos/doc/manual/installation/building-images-via-nixos-rebuild-build-image.chapter.md
@@ -2,23 +2,27 @@
 
 Nixpkgs contains a variety of modules to build custom images for different virtualization platforms and cloud providers, such as e.g. `amazon-image.nix` and `proxmox-lxc.nix`.
 
-While those can be imported individually, `system.build.images` provides an attribute set mapping variant names to image derivations. Available variants are defined - end extendable - in `image.modules`, an attribute set mapping variant names to a list of NixOS modules.
+While those can be imported directly, `system.build.images` provides an attribute set mapping variant names to image derivations. Available variants are defined - end extendable - in `image.modules`, an attribute set mapping variant names to NixOS modules.
 
-All of those images can be built via both, their `system.build.image` attribute, and the CLI `nixos-rebuild build-image`. To build i.e. an Amazon image from your existing NixOS configuration:
+All of those images can be built via both, their `system.build.image` attribute and the `nixos-rebuild build-image` command.
+
+For example, to build an Amazon image from your existing NixOS configuration, run:
 
 ```ShellSession
 $ nixos-rebuild build-image --image-variant amazon
-$ ls result
-nixos-image-amazon-25.05pre-git-x86_64-linux.vhd  nix-support
+[...]
+Done. The disk image can be found in /nix/store/[hash]-nixos-image-amazon-25.05pre-git-x86_64-linux/nixos-image-amazon-25.05pre-git-x86_64-linux.vpc
 ```
 
 To get a list of all variants available, run `nixos-rebuild build-image` without arguments.
 
+::: {.example #ex-nixos-rebuild-build-image-customize}
+
 ## Customize specific image variants {#sec-image-nixos-rebuild-build-image-customize}
 
-The `image.modules` option can be used to set specific options per image variant, in a similar fashion as [specialisations](options.html#opt-specialisation) for generic nixos configurations.
+The `image.modules` option can be used to set specific options per image variant, in a similar fashion as [specialisations](options.html#opt-specialisation) for generic NixOS configurations.
 
-E.g. images for the cloud provider Linode use `grub2` as a bootloader by default. If you are using `systemd-boot` on other platforms and want to disable it for Linode onlz, you could use the following options:
+E.g. images for the cloud provider Linode use `grub2` as a bootloader by default. If you are using `systemd-boot` on other platforms and want to disable it for Linode only, you could use the following options:
 
 ``` nix
   image.modules.linode = {

--- a/nixos/doc/manual/installation/building-images-via-nixos-rebuild-build-image.chapter.md
+++ b/nixos/doc/manual/installation/building-images-via-nixos-rebuild-build-image.chapter.md
@@ -14,3 +14,14 @@ nixos-image-amazon-25.05pre-git-x86_64-linux.vhd  nix-support
 
 To get a list of all variants available, run `nixos-rebuild build-image` without arguments.
 
+## Customize specific image variants {#sec-image-nixos-rebuild-build-image-customize}
+
+The `image.modules` option can be used to set specific options per image variant, in a similar fashion as [specialisations](options.html#opt-specialisation) for generic nixos configurations.
+
+E.g. images for the cloud provider Linode use `grub2` as a bootloader by default. If you are using `systemd-boot` on other platforms and want to disable it for Linode onlz, you could use the following options:
+
+``` nix
+  image.modules.linode = {
+    boot.loader.systemd-boot.enable = lib.mkForce false;
+  };
+```

--- a/nixos/doc/manual/redirects.json
+++ b/nixos/doc/manual/redirects.json
@@ -146,6 +146,9 @@
   "ex-config": [
     "index.html#ex-config"
   ],
+  "ex-nixos-rebuild-build-image-customize": [
+    "index.html#ex-nixos-rebuild-build-image-customize"
+  ],
   "sec-installation-additional-notes": [
     "index.html#sec-installation-additional-notes"
   ],

--- a/nixos/doc/manual/redirects.json
+++ b/nixos/doc/manual/redirects.json
@@ -200,6 +200,9 @@
   "sec-image-nixos-rebuild-build-image": [
     "index.html#sec-image-nixos-rebuild-build-image"
   ],
+  "sec-image-nixos-rebuild-build-image-customize": [
+    "index.html#sec-image-nixos-rebuild-build-image-customize"
+  ],
   "sec-image-repart": [
     "index.html#sec-image-repart"
   ],

--- a/pkgs/os-specific/linux/nixos-rebuild/nixos-rebuild.sh
+++ b/pkgs/os-specific/linux/nixos-rebuild/nixos-rebuild.sh
@@ -865,16 +865,18 @@ if [ -z "$rollback" ]; then
                     set = if builtins.isFunction value then value {} else value;
                 in set.${attr:+$attr.}config.system.build.images.$imageVariant.v.passthru.filePath" \
                 "${extraBuildFlags[@]}"
+                | jq -r .
             )"
         elif [[ -z $flake ]]; then
             imageName="$(
                 runCmd nix-instantiate --eval --strict --json --expr \
                 "with import <nixpkgs/nixos> {}; config.system.build.images.$imageVariant.passthru.filePath" \
                 "${extraBuildFlags[@]}"
+                | jq -r .
             )"
         else
             imageName="$(
-                runCmd nix "${flakeFlags[@]}" eval --json \
+                runCmd nix "${flakeFlags[@]}" eval --raw \
                 "$flake#$flakeAttr.config.system.build.images.$imageVariant.passthru.filePath" \
                 "${evalArgs[@]}" "${extraBuildFlags[@]}"
             )"


### PR DESCRIPTION
Don't quote `imageName` in `nixos-rebuild build-image`. It's just a string, not actual json. This mixup - which I authored - leads to extra quoting when printing the image name, e.g.:

```
Done.  The disk image can be found in /nix/store/rynka0dxk4n6c29mggijf8cmbqzf47zh-nixos-image-amazon-25.0
5pre-git-x86_64-linux/"nixos-image-amazon-25.05pre-git-x86_64-linux.vpc"
```

The rest is just documentation updates