### PR TITLE
python3Packages.dj-rest-auth: fix build

### DIFF
--- a/pkgs/development/python-modules/dj-rest-auth/default.nix
+++ b/pkgs/development/python-modules/dj-rest-auth/default.nix
@@ -6,6 +6,7 @@
   djangorestframework,
   djangorestframework-simplejwt,
   fetchFromGitHub,
+  fetchpatch,
   python,
   responses,
   setuptools,
@@ -23,6 +24,15 @@ buildPythonPackage rec {
     tag = version;
     hash = "sha256-bus7Sf5H4PA5YFrkX7hbALOq04koDz3KTO42hHFJPhw=";
   };
+
+  patches = [
+    # See https://github.com/iMerica/dj-rest-auth/pull/683
+    (fetchpatch {
+      name = "djangorestframework-simplejwt_5.5_compatibility.patch";
+      url = "https://github.com/iMerica/dj-rest-auth/commit/cc5587e4e3f327697709f3f0d491650bff5464e7.diff";
+      hash = "sha256-2LahibxuNECAfjqsbNs2ezaWt1VH0ZBNwSNWCZwIe8I=";
+    })
+  ];
 
   postPatch = ''
     substituteInPlace setup.py \


### PR DESCRIPTION
Add a patch to make the build compatible with `djangorestframework-simplejwt-5.5` (introduced by #395156).


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)

- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

## `nixpkgs-review` result

### `x86_64-linux`
<details>
  <summary>:x: 27 packages failed to build:</summary>
  <ul>
    <li>netbox</li>
    <li>netbox_4_1</li>
    <li>peering-manager</li>
    <li>python312Packages.netbox-attachments</li>
    <li>python312Packages.netbox-bgp</li>
    <li>python312Packages.netbox-contract</li>
    <li>python312Packages.netbox-documents</li>
    <li>python312Packages.netbox-floorplan-plugin</li>
    <li>python312Packages.netbox-interface-synchronization</li>
    <li>python312Packages.netbox-napalm-plugin</li>
    <li>python312Packages.netbox-plugin-prometheus-sd</li>
    <li>python312Packages.netbox-qrcode</li>
    <li>python312Packages.netbox-reorder-rack</li>
    <li>python312Packages.netbox-routing</li>
    <li>python312Packages.netbox-topology-views</li>
    <li>python313Packages.netbox-bgp</li>
    <li>python313Packages.netbox-documents</li>
    <li>python313Packages.netbox-interface-synchronization</li>
    <li>python313Packages.netbox-qrcode</li>
    <li>python313Packages.netbox-reorder-rack</li>
    <li>python313Packages.netbox-routing</li>
    <li>weblate</li>
    <li>python313Packages.netbox-plugin-prometheus-sd</li>
    <li>peering-manager.passthru.tests.peering-manager</li>
    <li>netbox.passthru.tests.netbox</li>
    <li>netbox_4_1.passthru.tests.netbox</li>
    <li>weblate.passthru.tests.weblate</li>
  </ul>
</details>
<details>
  <summary>:white_check_mark: 7 packages built:</summary>
  <ul>
    <li>python312Packages.dj-rest-auth</li>
    <li>python312Packages.drf-spectacular</li>
    <li>python312Packages.drf-standardized-errors</li>
    <li>python313Packages.dj-rest-auth</li>
    <li>python313Packages.drf-spectacular</li>
    <li>python313Packages.drf-standardized-errors</li>
    <li>authentik</li>
  </ul>
</details>
