### PR TITLE
skytemple: disable new version check

### DIFF
--- a/pkgs/by-name/sk/skytemple/disable-update-check.patch
+++ b/pkgs/by-name/sk/skytemple/disable-update-check.patch
@@ -1,0 +1,19 @@
+diff --git a/skytemple/controller/main.py b/skytemple/controller/main.py
+index f3ed6ef4..524acb90 100644
+--- a/skytemple/controller/main.py
++++ b/skytemple/controller/main.py
+@@ -976,14 +976,6 @@ class MainController:
+         # TODO Update recent files store too!
+ 
+     def _check_for_updates(self):
+-        try:
+-            new_version = check_newest_release(ReleaseType.SKYTEMPLE)
+-            if packaging.version.parse(version()) < packaging.version.parse(new_version):
+-                builder_get_assert(self.builder, Gtk.Label, "update_new_version").set_text(new_version)
+-                return
+-        except Exception:
+-            pass
+-        # else/except:
+         builder_get_assert(self.builder, Gtk.Box, "update_info").hide()
+ 
+     def _check_for_banner(self):

--- a/pkgs/by-name/sk/skytemple/package.nix
+++ b/pkgs/by-name/sk/skytemple/package.nix
@@ -21,6 +21,10 @@ python3Packages.buildPythonApplication rec {
     hash = "sha256-RFLxDV/L6Qbz14KqIEcMX/EnirNUrHL0MW8v5Z8ByK0=";
   };
 
+  patches = [
+    ./disable-update-check.patch
+  ];
+
   build-system = with python3Packages; [ setuptools ];
 
   buildInputs = [


### PR DESCRIPTION
Disable the request made on each startup to the Skytemple website, which prompts the user to download a newer version if it is available. Leave only the bit that hides the "new version of Skytemple is available" label.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
