### PR TITLE
gtkdialog: 0.8.3 -> 0.8.6-pre

### DIFF
--- a/pkgs/by-name/gt/gtkdialog/package.nix
+++ b/pkgs/by-name/gt/gtkdialog/package.nix
@@ -1,34 +1,35 @@
 {
   lib,
   stdenv,
-  fetchurl,
-  fetchpatch,
-  gtk2,
+  meson,
+  ninja,
+  cmake,
+  gtk-layer-shell,
+  bison,
+  flex,
+  vte,
+  fetchFromGitHub,
+  gtk3,
   pkg-config,
 }:
 
 stdenv.mkDerivation rec {
   pname = "gtkdialog";
-  version = "0.8.3";
+  version = "0.8.6-pre";
 
-  src = fetchurl {
-    url = "https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/${pname}/${pname}-${version}.tar.gz";
-    sha256 = "ff89d2d7f1e6488e5df5f895716ac1d4198c2467a2a5dc1f51ab408a2faec38e";
+  src = fetchFromGitHub {
+    owner = "puppylinux-woof-CE";
+    repo = "gtkdialog";
+    # master branch commit that includes the fix for GCC 14
+    rev = "db9b3347d2e001c7530f471e7e89c1b34011e7cf";
+    hash = "sha256-VaKyR7KJOAHzZ3YrTVDN7DssRNQeWhZExiY79eEZNP4=";
   };
-  patches = [
-    # Pull Gentoo patch for -fno-common toolchain fix.
-    (fetchpatch {
-      name = "fno-common.patch";
-      url = "https://gitweb.gentoo.org/repo/gentoo.git/plain/x11-misc/gtkdialog/files/gtkdialog-0.8.3-fno-common.patch?id=98692e4c4ad494b88c4902ca1ab3e6541190bbe8";
-      sha256 = "1mh01krzpfy7lbbqx3xm71xsiqqgg67w4snv794wspfqkk2hicvz";
-    })
-  ];
 
-  nativeBuildInputs = [ pkg-config ];
-  buildInputs = [ gtk2 ];
+  nativeBuildInputs = [ pkg-config meson ninja cmake bison flex ];
+  buildInputs = [ gtk3 gtk-layer-shell vte ];
 
   meta = {
-    homepage = "https://code.google.com/archive/p/gtkdialog/";
+    homepage = "https://github.com/puppylinux-woof-CE/gtkdialog";
     # community links: http://murga-linux.com/puppy/viewtopic.php?t=111923 -> https://github.com/01micko/gtkdialog
     description = "Small utility for fast and easy GUI building from many scripted and compiled languages";
     mainProgram = "gtkdialog";


### PR DESCRIPTION
The puppylinux people took over development of gtkdialog a while ago. This fork contains fixes for GCC 14 as well, so we push all the way to master to get it to build again. Last official release would have been from 2022, but backporting the patch is too much work I think.

They also switched the build system over to meson and cmake, easy enough.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
