### PR TITLE
Python supabase

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -23300,6 +23300,12 @@
     githubId = 4294323;
     name = "Langston Barrett";
   };
+  siegema = {
+    email = "bee@sharpbeedevelopment.com";
+    name = "Martin";
+    github = "Siegema";
+    githubId = 15473103;
+  };
   sielicki = {
     name = "Nicholas Sielicki";
     email = "nix@opensource.nslick.com";

--- a/pkgs/development/python-modules/gotrue/default.nix
+++ b/pkgs/development/python-modules/gotrue/default.nix
@@ -1,0 +1,44 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  poetry-core,
+  httpx,
+  h2,
+  pydantic,
+  pyjwt,
+  pytest-mock,
+}:
+
+buildPythonPackage rec {
+  pname = "gotrue";
+  version = "2.12.0";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-ueoWTuUpZNg2TFUM3hbdDpV2JBpM/+qlLsozn2HR0Us=";
+  };
+
+  build-system = [ poetry-core ];
+
+  dependencies = [
+    httpx
+    h2
+    pydantic
+    pyjwt
+    pytest-mock
+  ];
+
+  pythonImportsCheck = [ "gotrue" ];
+
+  # test aren't in pypi package
+  doCheck = false;
+
+  meta = {
+    homepage = "https://github.com/supabase/auth-py";
+    license = lib.licenses.mit;
+    description = "Python Client Library for Supabase Auth";
+    maintainers = with lib.maintainers; [ siegema ];
+  };
+}

--- a/pkgs/development/python-modules/realtime/default.nix
+++ b/pkgs/development/python-modules/realtime/default.nix
@@ -1,0 +1,57 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  poetry-core,
+  python-dateutil,
+  typing-extensions,
+  websockets,
+  aiohttp,
+  pytestCheckHook,
+  python-dotenv,
+}:
+
+buildPythonPackage rec {
+  pname = "realtime-py";
+  version = "2.5.2";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "supabase";
+    repo = "realtime-py";
+    rev = "v${version}";
+    hash = "sha256-NFxWcnt/zpgDehacqK7QlXhmjrh6JoA6xh+sFjD/tt0=";
+  };
+
+  dependencies = [
+    python-dateutil
+    typing-extensions
+    websockets
+    aiohttp
+  ];
+
+  pythonRelaxDeps = [
+    "websockets"
+    "aiohttp"
+    "typing-extensions"
+  ];
+
+  # Can't run all the tests due to infinite loop in pytest-asyncio
+  nativeBuildInputs = [
+    pytestCheckHook
+    python-dotenv
+  ];
+
+  pythonImportsCheck = [ "realtime" ];
+
+  build-system = [ poetry-core ];
+
+  doCheck = false;
+
+  meta = {
+    homepage = "https://github.com/supabase/realtime-py";
+    license = lib.licenses.mit;
+    description = "Python Realtime Client for Supabase";
+    maintainers = with lib.maintainers; [ siegema ];
+  };
+}

--- a/pkgs/development/python-modules/storage3/default.nix
+++ b/pkgs/development/python-modules/storage3/default.nix
@@ -1,0 +1,43 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  poetry-core,
+  python-dateutil,
+  httpx,
+  h2,
+  deprecation,
+}:
+
+buildPythonPackage rec {
+  pname = "storage3";
+  version = "0.12.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "supabase";
+    repo = "storage-py";
+    rev = "v${version}";
+    hash = "sha256-3Z+j9n/seL1ZuB1djOVpA6Qci/Ygi9g8g2lLQGKRUHM=";
+  };
+
+  dependencies = [
+    python-dateutil
+    httpx
+    h2
+    deprecation
+  ];
+
+  build-system = [ poetry-core ];
+
+  pythonImportCheck = [ "storage3" ];
+
+  # tests fail due to mock server not starting
+
+  meta = {
+    homepage = "https://github.com/supabase/storage-py";
+    license = lib.licenses.mit;
+    description = "Supabase Storage client for Python.";
+    maintainers = with lib.maintainers; [ siegema ];
+  };
+}

--- a/pkgs/development/python-modules/supabase/default.nix
+++ b/pkgs/development/python-modules/supabase/default.nix
@@ -1,0 +1,58 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  poetry-core,
+  gotrue,
+  postgrest-py,
+  realtime,
+  storage3,
+  supafunc,
+  httpx,
+  pytestCheckHook,
+  python-dotenv,
+  pytest-asyncio,
+  pydantic,
+}:
+
+buildPythonPackage rec {
+  pname = "supabase-py";
+  version = "2.16.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "supabase";
+    repo = "supabase-py";
+    rev = "v${version}";
+    hash = "sha256-n+LVC4R9m/BKID9wLEMw/y/2I589TUXTygSIPfTZwB8=";
+  };
+
+  build-system = [ poetry-core ];
+
+  propagatedBuildInputs = [
+    postgrest-py
+    realtime
+    gotrue
+    httpx
+    storage3
+    supafunc
+    pydantic
+  ];
+
+  nativeBuildInputs = [
+    pytestCheckHook
+    python-dotenv
+    pytest-asyncio
+  ];
+
+  pythonImportsCheck = [ "supabase" ];
+
+  doCheck = true;
+
+  meta = {
+    homepage = "https://github.com/supabase/supabase-py";
+    license = lib.licenses.mit;
+    description = "Supabas client for Python";
+    maintainers = with lib.maintainers; [ siegema ];
+  };
+}

--- a/pkgs/development/python-modules/supafunc/default.nix
+++ b/pkgs/development/python-modules/supafunc/default.nix
@@ -1,0 +1,40 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  poetry-core,
+  strenum,
+  httpx,
+  h2,
+}:
+
+buildPythonPackage rec {
+  pname = "supafunc";
+  version = "0.10.1";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-pbM8i67La1KX0l2imiUD4uxn7mmG89RME35lG4pZoX0=";
+  };
+
+  dependencies = [
+    strenum
+    httpx
+    h2
+  ];
+
+  build-system = [ poetry-core ];
+
+  pythonImportsCheck = [ "supafunc" ];
+
+  # tests are not in pypi package
+  doCheck = false;
+
+  meta = {
+    homepage = "https://github.com/supabase/functions-py";
+    license = lib.licenses.mit;
+    description = "Library for Supabase Functions";
+    maintainers = with lib.maintainers; [ siegema ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -17452,6 +17452,8 @@ self: super: with self; {
 
   sunweg = callPackage ../development/python-modules/sunweg { };
 
+  supabase = callPackage ../development/python-modules/supabase { };
+
   supabase-functions = self.supafunc;
 
   supafunc = callPackage ../development/python-modules/supafunc { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -17450,6 +17450,10 @@ self: super: with self; {
 
   sunweg = callPackage ../development/python-modules/sunweg { };
 
+  supabase-functions = self.supafunc;
+
+  supafunc = callPackage ../development/python-modules/supafunc { };
+
   superqt = callPackage ../development/python-modules/superqt { };
 
   supervise-api = callPackage ../development/python-modules/supervise-api { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -17328,6 +17328,8 @@ self: super: with self; {
 
   stopit = callPackage ../development/python-modules/stopit { };
 
+  storage3 = callPackage ../development/python-modules/storage3 { };
+
   stp = toPythonModule (pkgs.stp.override { python3 = self.python; });
 
   stransi = callPackage ../development/python-modules/stransi { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -15423,6 +15423,8 @@ self: super: with self; {
 
   readthedocs-sphinx-ext = callPackage ../development/python-modules/readthedocs-sphinx-ext { };
 
+  realtime = callPackage ../development/python-modules/realtime { };
+
   rebulk = callPackage ../development/python-modules/rebulk { };
 
   recipe-scrapers = callPackage ../development/python-modules/recipe-scrapers { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6113,6 +6113,8 @@ self: super: with self; {
 
   gotify = callPackage ../development/python-modules/gotify { };
 
+  gotrue = callPackage ../development/python-modules/gotrue { };
+
   govee-ble = callPackage ../development/python-modules/govee-ble { };
 
   govee-led-wez = callPackage ../development/python-modules/govee-led-wez { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
adding the [supabase-py](https://github.com/supabase/supabase-py) client with dependencies

[realtime](https://github.com/supabase/realtime-py)
[storage3](https://github.com/supabase/storage-py)
[supafunc](https://github.com/supabase/functions-py)
[postgrest](https://github.com/supabase/postgrest-py)
[supabase-auth](https://github.com/supabase/auth-py)
[gotrue](https://github.com/supabase/auth-py)

gotrue and supabase-auth point to the same repo because their builds result in 2 pypi packages where the import names are different

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
