### PR TITLE
charmcraft: 3.4.3 -> 3.4.4

### DIFF
--- a/pkgs/by-name/ch/charmcraft/package.nix
+++ b/pkgs/by-name/ch/charmcraft/package.nix
@@ -8,7 +8,7 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "charmcraft";
-  version = "3.4.3";
+  version = "3.4.4";
 
   pyproject = true;
 
@@ -16,7 +16,7 @@ python3Packages.buildPythonApplication rec {
     owner = "canonical";
     repo = "charmcraft";
     tag = version;
-    hash = "sha256-TCr6iZHUIJ/dZhj8pWsCYKAfqv9LXD3fGP432UQh/Lo=";
+    hash = "sha256-EdpnTKbSDo2ZF4J/bWlcBYWuPSkxW3dmrQYjBeIyTzo=";
   };
 
   postPatch = ''

--- a/pkgs/development/python-modules/craft-parts/default.nix
+++ b/pkgs/development/python-modules/craft-parts/default.nix
@@ -9,6 +9,7 @@
   pyyaml,
   requests,
   requests-unixsocket,
+  pyfakefs,
   pytestCheckHook,
   pytest-check,
   pytest-mock,
@@ -28,7 +29,7 @@
 
 buildPythonPackage rec {
   pname = "craft-parts";
-  version = "2.7.0";
+  version = "2.8.0";
 
   pyproject = true;
 
@@ -36,7 +37,7 @@ buildPythonPackage rec {
     owner = "canonical";
     repo = "craft-parts";
     tag = version;
-    hash = "sha256-Diu8cHy3tRWsyI7mPsAcYREK9nUG7tzasmZYAARzpXU=";
+    hash = "sha256-1SnT/yB6vJm82yhszBRjeph13B91KYap8/KR4L9VcjM=";
   };
 
   patches = [ ./bash-path.patch ];
@@ -67,6 +68,7 @@ buildPythonPackage rec {
     jdk
     jsonschema
     maven
+    pyfakefs
     pytest-check
     pytest-mock
     pytest-subprocess

--- a/pkgs/development/python-modules/craft-platforms/default.nix
+++ b/pkgs/development/python-modules/craft-platforms/default.nix
@@ -14,7 +14,7 @@
 
 buildPythonPackage rec {
   pname = "craft-platforms";
-  version = "0.7.0";
+  version = "0.7.1";
   pyproject = true;
 
   disabled = pythonOlder "3.10";
@@ -23,7 +23,7 @@ buildPythonPackage rec {
     owner = "canonical";
     repo = "craft-platforms";
     tag = version;
-    hash = "sha256-BFs+LqcJWqKMgEr7IzyP5qME+zaV6EFc79ustOB1Cno=";
+    hash = "sha256-+7uaN+ePu+88goPCj9KM3dKhTwV2erP0/Fg05LqOWPg=";
   };
 
   postPatch = ''
@@ -46,6 +46,12 @@ buildPythonPackage rec {
   pythonImportsCheck = [ "craft_platforms" ];
 
   pytestFlagsArray = [ "tests/unit" ];
+
+  disabledTests = [
+    # Attempts to get distro information, and expects "ubuntu-ish"
+    # information to be returned, which doesn't work under NixOS
+    "test_fuzz_get_platforms_build_plan_single_base"
+  ];
 
   passthru.updateScript = nix-update-script { };
 


### PR DESCRIPTION


## Things done

Bump to latest upstream release: https://github.com/canonical/charmcraft/compare/3.4.3...3.4.4

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
