### PR TITLE
bitcoind: 28.1 -> 29.0

### DIFF
--- a/pkgs/applications/blockchains/bitcoin/default.nix
+++ b/pkgs/applications/blockchains/bitcoin/default.nix
@@ -2,16 +2,13 @@
   lib,
   stdenv,
   fetchurl,
-  autoreconfHook,
+  cmake,
   pkg-config,
   installShellFiles,
-  util-linux,
-  hexdump,
   autoSignDarwinBinariesHook,
   wrapQtAppsHook ? null,
   boost,
   libevent,
-  miniupnpc,
   zeromq,
   zlib,
   db48,
@@ -35,24 +32,22 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = if withGui then "bitcoin" else "bitcoind";
-  version = "28.1";
+  version = "29.0";
 
   src = fetchurl {
     urls = [
       "https://bitcoincore.org/bin/bitcoin-core-${finalAttrs.version}/bitcoin-${finalAttrs.version}.tar.gz"
     ];
     # hash retrieved from signed SHA256SUMS
-    sha256 = "c5ae2dd041c7f9d9b7c722490ba5a9d624f7e9a089c67090615e1ba4ad0883ba";
+    sha256 = "882c782c34a3bf2eacd1fae5cdc58b35b869883512f197f7d6dc8f195decfdaa";
   };
 
   nativeBuildInputs =
     [
-      autoreconfHook
+      cmake
       pkg-config
       installShellFiles
     ]
-    ++ lib.optionals stdenv.hostPlatform.isLinux [ util-linux ]
-    ++ lib.optionals stdenv.hostPlatform.isDarwin [ hexdump ]
     ++ lib.optionals (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isAarch64) [
       autoSignDarwinBinariesHook
     ]
@@ -62,7 +57,6 @@ stdenv.mkDerivation (finalAttrs: {
     [
       boost
       libevent
-      miniupnpc
       zeromq
       zlib
     ]
@@ -77,6 +71,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   postInstall =
     ''
+      cd ..
       installShellCompletion --bash contrib/completions/bash/bitcoin-cli.bash
       installShellCompletion --bash contrib/completions/bash/bitcoind.bash
       installShellCompletion --bash contrib/completions/bash/bitcoin-tx.bash
@@ -95,21 +90,20 @@ stdenv.mkDerivation (finalAttrs: {
       install -Dm644 share/pixmaps/bitcoin256.png $out/share/pixmaps/bitcoin.png
     '';
 
-  configureFlags =
+  cmakeFlags =
     [
-      "--with-boost-libdir=${boost.out}/lib"
-      "--disable-bench"
+      (lib.cmakeBool "BUILD_BENCH" false)
     ]
     ++ lib.optionals (!finalAttrs.doCheck) [
-      "--disable-tests"
-      "--disable-gui-tests"
+      (lib.cmakeBool "BUILD_TESTS" false)
+      (lib.cmakeBool "BUILD_FUZZ_BINARY" false)
+      (lib.cmakeBool "BUILD_GUI_TESTS" false)
     ]
     ++ lib.optionals (!withWallet) [
-      "--disable-wallet"
+      (lib.cmakeBool "ENABLE_WALLET" false)
     ]
     ++ lib.optionals withGui [
-      "--with-gui=qt5"
-      "--with-qt-bindir=${qtbase.dev}/bin:${qttools.dev}/bin"
+      (lib.cmakeBool "BUILD_GUI" true)
     ];
 
   nativeCheckInputs = [ python3 ];


### PR DESCRIPTION
Bitcoin Core switched the build system from autotools to cmake.

The cmake flags were mapped from the autotools configure flags as per https://github.com/bitcoin-core/bitcoin-devwiki/wiki/Autotools-to-CMake-Options-Mapping

With cmake, $PWD ends up being the "build" directory and to access the source dir (e.g. to access the shell completions), we need to use the parent dir.

The `miniupnpc` dependency has been dropped in Bitcoin Core v29.0. See https://github.com/bitcoin-core/bitcoin-devwiki/wiki/29.0-Release-Notes-draft#p2p-and-network-changes


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
