### PR TITLE
nixos/firewalld: init

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2511.section.md
+++ b/nixos/doc/manual/release-notes/rl-2511.section.md
@@ -32,6 +32,10 @@
 
   Refer to the [GNOME release notes](https://release.gnome.org/49/) for more details.
 
+- FirewallD support has been added. It can be configured both as a standalone service (through `services.firewalld`), and as a backend to the existing `networking.firewall` options.
+
+- `networking.firewall` now has a `backend` option for choosing which backend to use.
+
 ## New Modules {#sec-release-25.11-new-modules}
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
@@ -52,6 +56,8 @@
 - [Fediwall](https://fediwall.social), a web application for live displaying toots from mastodon, inspired by mastowall. Available as [services.fediwall](#opt-services.fediwall.enable).
 
 - [umami](https://github.com/umami-software/umami), a simple, fast, privacy-focused alternative to Google Analytics. Available with [services.umami](#opt-services.umami.enable).
+
+- [FirewallD](https://firewalld.org/), a firewall daemon with D-Bus interface providing a dynamic firewall. Available as [services.firewalld](#opt-services.firewalld.enable) and a [networking.firewall.backend](#opt-networking.firewall.backend).
 
 - [FileBrowser](https://filebrowser.org/), a web application for managing and sharing files. Available as [services.filebrowser](#opt-services.filebrowser.enable).
 

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1165,6 +1165,7 @@
   ./services/networking/firewall-iptables.nix
   ./services/networking/firewall-nftables.nix
   ./services/networking/firewall.nix
+  ./services/networking/firewalld
   ./services/networking/firezone/gateway.nix
   ./services/networking/firezone/gui-client.nix
   ./services/networking/firezone/headless-client.nix

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1162,6 +1162,7 @@
   ./services/networking/ferm.nix
   ./services/networking/firefox-syncserver.nix
   ./services/networking/fireqos.nix
+  ./services/networking/firewall-firewalld.nix
   ./services/networking/firewall-iptables.nix
   ./services/networking/firewall-nftables.nix
   ./services/networking/firewall.nix

--- a/nixos/modules/services/networking/firewall-firewalld.nix
+++ b/nixos/modules/services/networking/firewall-firewalld.nix
@@ -1,0 +1,61 @@
+{ config, lib, ... }:
+
+let
+  cfg = config.networking.firewall;
+in
+{
+  config = lib.mkIf (cfg.enable && cfg.backend == "firewalld") {
+    assertions = [
+      {
+        assertion = cfg.interfaces == { };
+        message = ''
+          Per interface configurations is not supported with the firewalld based firewall.
+          Create zones with `services.firewalld.zones` instead.
+        '';
+      }
+    ];
+
+    boot.kernel.sysctl."net.ipv4.conf.all.rp_filter" =
+      if cfg.checkReversePath == false then
+        0
+      else if cfg.checkReversePath == "loose" then
+        1
+      else
+        2;
+
+    services.firewalld = {
+      settings = {
+        DefaultZone = lib.mkDefault "nixos-fw-default";
+        LogDenied =
+          if cfg.logRefusedConnections then
+            (if cfg.logRefusedUnicastsOnly then "unicast" else "all")
+          else
+            "off";
+        IPv6_rpfilter =
+          if cfg.checkReversePath == false then
+            "no"
+          else
+            let
+              mode = if cfg.checkReversePath == true then "strict" else cfg.checkReversePath;
+              suffix = if cfg.filterForward then "" else "-forward";
+            in
+            "${mode}${suffix}";
+      };
+      zones = {
+        nixos-fw-default = {
+          target = if cfg.rejectPackets then "%%REJECT%%" else "DROP";
+          icmpBlockInversion = true;
+          icmpBlocks = lib.mkIf cfg.allowPing [ "echo-request" ];
+          ports =
+            let
+              f = protocol: port: { inherit protocol port; };
+              tcpPorts = map (f "tcp") (cfg.allowedTCPPorts ++ cfg.allowedTCPPortRanges);
+              udpPorts = map (f "udp") (cfg.allowedUDPPorts ++ cfg.allowedUDPPortRanges);
+            in
+            tcpPorts ++ udpPorts;
+        };
+        trusted.interfaces = cfg.trustedInterfaces;
+      };
+    };
+  };
+}

--- a/nixos/modules/services/networking/firewall-iptables.nix
+++ b/nixos/modules/services/networking/firewall-iptables.nix
@@ -285,9 +285,7 @@ let
 in
 
 {
-
   options = {
-
     networking.firewall = {
       extraCommands = lib.mkOption {
         type = lib.types.lines;
@@ -317,13 +315,11 @@ in
         '';
       };
     };
-
   };
 
   # FIXME: Maybe if `enable' is false, the firewall should still be
   # built but not started by default?
-  config = lib.mkIf (cfg.enable && config.networking.nftables.enable == false) {
-
+  config = lib.mkIf (cfg.enable && cfg.backend == "iptables") {
     assertions = [
       # This is approximately "checkReversePath -> kernelHasRPFilter",
       # but the checkReversePath option can include non-boolean
@@ -335,6 +331,8 @@ in
     ];
 
     networking.firewall.checkReversePath = lib.mkIf (!kernelHasRPFilter) (lib.mkDefault false);
+
+    environment.systemPackages = [ pkgs.nixos-firewall-tool ];
 
     systemd.services.firewall = {
       description = "Firewall";
@@ -365,7 +363,5 @@ in
         ExecStop = "@${stopScript} firewall-stop";
       };
     };
-
   };
-
 }

--- a/nixos/modules/services/networking/firewall-nftables.nix
+++ b/nixos/modules/services/networking/firewall-nftables.nix
@@ -19,9 +19,7 @@ let
 in
 
 {
-
   options = {
-
     networking.firewall = {
       extraInputRules = lib.mkOption {
         type = lib.types.lines;
@@ -59,11 +57,9 @@ in
         '';
       };
     };
-
   };
 
-  config = lib.mkIf (cfg.enable && config.networking.nftables.enable) {
-
+  config = lib.mkIf (cfg.enable && cfg.backend == "nftables") {
     assertions = [
       {
         assertion = cfg.extraCommands == "";
@@ -82,6 +78,8 @@ in
         message = "networking.nftables.rulesetFile conflicts with the firewall";
       }
     ];
+
+    environment.systemPackages = [ pkgs.nixos-firewall-tool ];
 
     networking.nftables.tables."nixos-fw".family = "inet";
     networking.nftables.tables."nixos-fw".content = ''
@@ -203,7 +201,5 @@ in
         }
       ''}
     '';
-
   };
-
 }

--- a/nixos/modules/services/networking/firewall.nix
+++ b/nixos/modules/services/networking/firewall.nix
@@ -68,9 +68,7 @@ let
 in
 
 {
-
   options = {
-
     networking.firewall = {
       enable = lib.mkOption {
         type = lib.types.bool;
@@ -79,6 +77,32 @@ in
           Whether to enable the firewall.  This is a simple stateful
           firewall that blocks connection attempts to unauthorised TCP
           or UDP ports on this machine.
+        '';
+      };
+
+      backend = lib.mkOption {
+        type = lib.types.enum [
+          "iptables"
+          "nftables"
+          "firewalld"
+        ];
+        default =
+          if config.services.firewalld.enable then
+            "firewalld"
+          else if config.networking.nftables.enable then
+            "nftables"
+          else
+            "iptables";
+        defaultText = lib.literalExpression ''
+          if config.services.firewalld.enable then
+            "firewalld"
+          else if config.networking.nftables.enable then
+            "nftables"
+          else
+            "iptables"
+        '';
+        description = ''
+          Underlying implementation for the firewall service.
         '';
       };
 
@@ -292,11 +316,9 @@ in
       };
     }
     // commonOptions;
-
   };
 
   config = lib.mkIf cfg.enable {
-
     assertions = [
       {
         assertion = cfg.filterForward -> config.networking.nftables.enable;
@@ -311,11 +333,7 @@ in
 
     networking.firewall.trustedInterfaces = [ "lo" ];
 
-    environment.systemPackages = [
-      cfg.package
-      pkgs.nixos-firewall-tool
-    ]
-    ++ cfg.extraPackages;
+    environment.systemPackages = [ cfg.package ] ++ cfg.extraPackages;
 
     boot.kernelModules =
       (lib.optional cfg.autoLoadConntrackHelpers "nf_conntrack")
@@ -323,7 +341,5 @@ in
     boot.extraModprobeConfig = lib.optionalString cfg.autoLoadConntrackHelpers ''
       options nf_conntrack nf_conntrack_helper=1
     '';
-
   };
-
 }

--- a/nixos/modules/services/networking/firewalld/default.nix
+++ b/nixos/modules/services/networking/firewalld/default.nix
@@ -1,0 +1,66 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.services.firewalld;
+  paths = pkgs.buildEnv {
+    name = "firewalld-paths";
+    paths = cfg.packages;
+    pathsToLink = [ "/lib/firewalld" ];
+  };
+in
+{
+  imports = [
+    ./service.nix
+    ./settings.nix
+    ./zone.nix
+  ];
+
+  options.services.firewalld = {
+    enable = lib.mkEnableOption "FirewallD";
+    package = lib.mkPackageOption pkgs "firewalld" { };
+    packages = lib.mkOption {
+      type = lib.types.listOf lib.types.package;
+      default = [ ];
+      description = ''
+        Packages providing firewalld zones and other files.
+        Files found in `/lib/firewalld` will be included.
+      '';
+    };
+    extraArgs = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [ ];
+      example = [ "--debug" ];
+      description = "Extra arguments to pass to FirewallD.";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    environment.systemPackages = [ cfg.package ];
+    services.dbus.packages = [ cfg.package ];
+    services.firewalld.packages = [ cfg.package ];
+
+    services.logrotate.settings."/var/log/firewalld" = {
+      copytruncate = true;
+      minsize = "1M";
+    };
+
+    environment.etc."sysconfig/firewalld".text = ''
+      FIREWALLD_ARGS=${lib.concatStringsSep " " cfg.extraArgs}
+    '';
+
+    systemd.packages = [ cfg.package ];
+    systemd.services.firewalld = {
+      aliases = [ "dbus-org.fedoraproject.FirewallD1.service" ];
+      wantedBy = [ "multi-user.target" ];
+      serviceConfig.ExecReload = "${lib.getExe' pkgs.coreutils "kill"} -HUP $MAINPID";
+      environment.NIX_FIREWALLD_CONFIG_PATH = "${paths}/lib/firewalld";
+    };
+  };
+
+  meta.maintainers = with lib.maintainers; [ prince213 ];
+}

--- a/nixos/modules/services/networking/firewalld/lib.nix
+++ b/nixos/modules/services/networking/firewalld/lib.nix
@@ -1,0 +1,55 @@
+{ lib }:
+
+let
+  inherit (lib) mkOption;
+  inherit (lib.types)
+    either
+    enum
+    nullOr
+    port
+    submodule
+    ;
+  mkPortOption =
+    {
+      optional ? false,
+    }:
+    mkOption {
+      type =
+        let
+          type = either port (submodule {
+            options = {
+              from = mkOption { type = port; };
+              to = mkOption { type = port; };
+            };
+          });
+        in
+        if optional then (nullOr type) else type;
+      description = "";
+      apply =
+        value: if builtins.isAttrs value then "${toString value.from}-${toString value.to}" else value;
+    };
+  protocolOption = mkOption {
+    type = enum [
+      "tcp"
+      "udp"
+      "sctp"
+      "dccp"
+    ];
+    description = "";
+  };
+in
+{
+  inherit mkPortOption;
+  inherit protocolOption;
+
+  toXmlAttrs = lib.mapAttrs' (name: lib.nameValuePair ("@" + name));
+  mkXmlAttr = name: value: { "@${name}" = value; };
+  filterNullAttrs = lib.filterAttrsRecursive (_: value: value != null);
+
+  portProtocolOptions = {
+    options = {
+      port = mkPortOption { };
+      protocol = protocolOption;
+    };
+  };
+}

--- a/nixos/modules/services/networking/firewalld/service.nix
+++ b/nixos/modules/services/networking/firewalld/service.nix
@@ -1,0 +1,121 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.services.firewalld;
+  format = pkgs.formats.xml { };
+  lib' = import ./lib.nix { inherit lib; };
+  inherit (lib')
+    filterNullAttrs
+    mkXmlAttr
+    portProtocolOptions
+    toXmlAttrs
+    ;
+  inherit (lib) mkOption;
+  inherit (lib.types)
+    attrsOf
+    listOf
+    nonEmptyStr
+    nullOr
+    strMatching
+    submodule
+    ;
+in
+{
+  options.services.firewalld.services = mkOption {
+    description = ''
+      firewalld service configuration files. See {manpage}`firewalld.service(5)`.
+    '';
+    default = { };
+    type = attrsOf (submodule {
+      options = {
+        version = mkOption {
+          type = nullOr nonEmptyStr;
+          description = "Version of the service.";
+          default = null;
+        };
+        short = mkOption {
+          type = nullOr nonEmptyStr;
+          description = "Short description for the service.";
+          default = null;
+        };
+        description = mkOption {
+          type = nullOr nonEmptyStr;
+          description = "Description for the service.";
+          default = null;
+        };
+        ports = mkOption {
+          type = listOf (submodule portProtocolOptions);
+          description = "Ports of the service.";
+          default = [ ];
+        };
+        protocols = mkOption {
+          type = listOf nonEmptyStr;
+          description = "Protocols for the service.";
+          default = [ ];
+        };
+        sourcePorts = mkOption {
+          type = listOf (submodule portProtocolOptions);
+          description = "Source ports for the service.";
+          default = [ ];
+        };
+        destination = mkOption {
+          type = submodule {
+            options = {
+              ipv4 = mkOption {
+                type = nullOr (strMatching "([0-9]{1,3}\\.){3}[0-9]{1,3}(/[0-9]{1,2})?");
+                description = "IPv4 destination.";
+                default = null;
+              };
+              ipv6 = mkOption {
+                type = nullOr (strMatching "[0-9A-Fa-f:]{3,39}(/[0-9]{1,3})?");
+                description = "IPv6 destination.";
+                default = null;
+              };
+            };
+          };
+          description = "Destinations for the service.";
+          default = { };
+        };
+        includes = mkOption {
+          type = listOf nonEmptyStr;
+          description = "Services to include for the service.";
+          default = [ ];
+        };
+        helpers = mkOption {
+          type = listOf nonEmptyStr;
+          description = "Helpers for the service.";
+          default = [ ];
+        };
+      };
+    });
+  };
+
+  config = lib.mkIf cfg.enable {
+    environment.etc = lib.mapAttrs' (
+      name: value:
+      lib.nameValuePair "firewalld/services/${name}.xml" {
+        source = format.generate "firewalld-service-${name}.xml" {
+          service = filterNullAttrs (
+            lib.mergeAttrsList [
+              (toXmlAttrs { inherit (value) version; })
+              {
+                inherit (value) short description;
+                port = builtins.map toXmlAttrs value.ports;
+                protocol = builtins.map (mkXmlAttr "value") value.protocols;
+                source-port = builtins.map toXmlAttrs value.sourcePorts;
+                destination = toXmlAttrs value.destination;
+                include = builtins.map (mkXmlAttr "service") value.includes;
+                helper = builtins.map (mkXmlAttr "name") value.helpers;
+              }
+            ]
+          );
+        };
+      }
+    ) cfg.services;
+  };
+}

--- a/nixos/modules/services/networking/firewalld/settings.nix
+++ b/nixos/modules/services/networking/firewalld/settings.nix
@@ -1,0 +1,198 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.services.firewalld;
+  format = pkgs.formats.keyValue { };
+  inherit (lib) mkOption;
+  inherit (lib.types)
+    bool
+    commas
+    either
+    enum
+    nonEmptyStr
+    separatedString
+    submodule
+    ;
+in
+{
+  options.services.firewalld.settings = mkOption {
+    description = ''
+      FirewallD config file.
+      See {manpage}`firewalld.conf(5)`.
+    '';
+    default = { };
+    type = submodule {
+      freeformType = format.type;
+      options = {
+        DefaultZone = mkOption {
+          type = nonEmptyStr;
+          description = "Default zone for connections.";
+          default = "public";
+        };
+        CleanupOnExit = mkOption {
+          type = bool;
+          description = "Whether to clean up firewall rules when firewalld stops.";
+          default = true;
+        };
+        CleanupModulesOnExit = mkOption {
+          type = bool;
+          description = "Whether to unload all firewall-related kernel modules when firewalld stops.";
+          default = false;
+        };
+        IPv6_rpfilter = mkOption {
+          type = enum [
+            "strict"
+            "loose"
+            "strict-forward"
+            "loose-forward"
+            "no"
+          ];
+          description = ''
+            Performs reverse path filtering (RPF) on IPv6 packets as per RFC 3704.
+
+            Possible values:
+
+            `"strict"`
+            : Performs "strict" filtering as per RFC 3704.
+              This check verifies that the in ingress interface is the same interface that would be used to send a packet reply to the source.
+              That is, `ingress == egress`.
+
+            `"loose"`
+            : Performs "loose" filtering as per RFC 3704.
+              This check only verifies that there is a route back to the source through any interface; even if it's not the same one on which the packet arrived.
+
+            `"strict-forward"`
+            : This is almost identical to "strict", but does not perform RPF for packets targeted to the host (INPUT).
+
+            `"loose-forward"`
+            : This is almost identical to "loose", but does not perform RPF for packets targeted to the host (INPUT).
+
+            `"no"`
+            : RPF is completely disabled.
+
+            The rp_filter for IPv4 is controlled using sysctl.
+          '';
+          default = "strict";
+        };
+        IndividualCalls = mkOption {
+          type = bool;
+          description = ''
+            Whether to use individual -restore calls to apply changes to the firewall.
+            The use of individual calls increases the time that is needed to apply changes and to start the daemon, but is good for debugging as error messages are more specific.
+          '';
+          default = false;
+        };
+        LogDenied = mkOption {
+          type = enum [
+            "all"
+            "unicast"
+            "broadcast"
+            "multicast"
+            "off"
+          ];
+          description = ''
+            Add logging rules right before reject and drop rules in the INPUT, FORWARD and OUTPUT chains for the default rules and also final reject and drop rules in zones for the configured link-layer packet type.
+          '';
+          default = "off";
+        };
+        FirewallBackend = mkOption {
+          type = enum [
+            "nftables"
+            "iptables"
+          ];
+          description = ''
+            The firewall backend implementation.
+            This applies to all firewalld primitives.
+            The only exception is direct and passthrough rules which always use the traditional iptables, ip6tables, and ebtables backends.
+
+            ::: {.caution}
+            The iptables backend is deprecated.
+            It will be removed in a future release.
+            :::
+          '';
+          default = "nftables";
+        };
+        FlushAllOnReload = mkOption {
+          type = bool;
+          description = "Whether to flush all runtime rules on a reload.";
+          default = true;
+        };
+        ReloadPolicy = mkOption {
+          type =
+            let
+              policy = enum [
+                "DROP"
+                "REJECT"
+                "ACCEPT"
+              ];
+            in
+            either policy commas;
+          description = "The policy during reload.";
+          default = "INPUT:DROP,FORWARD:DROP,OUTPUT:DROP";
+        };
+        RFC3964_IPv4 = mkOption {
+          type = bool;
+          description = ''
+            Whether to filter IPv6 traffic with 6to4 destination addresses that correspond to IPv4 addresses that should not be routed over the public internet.
+          '';
+          default = true;
+        };
+        StrictForwardPorts = mkOption {
+          type = bool;
+          description = ''
+            If enabled, the generated destination NAT (DNAT) rules will NOT accept traffic that was DNAT'd by other entities, e.g. docker.
+            Firewalld will be strict and not allow published container ports until they're explicitly allowed via firewalld.
+            If set to `false`, then docker (and podman) integrates seamlessly with firewalld.
+            Published container ports are implicitly allowed.
+          '';
+          default = false;
+        };
+        NftablesFlowtable = mkOption {
+          type = separatedString " ";
+          description = ''
+            This may improve forwarded traffic throughput by enabling nftables flowtable.
+            It is a software fastpath and avoids calling nftables rule evaluation for data packets.
+            Its value is a space separate list of interfaces.
+          '';
+          default = "off";
+        };
+        NftablesCounters = mkOption {
+          type = bool;
+          description = "Whether to add a counter to every nftables rule.";
+          default = false;
+        };
+        NftablesTableOwner = mkOption {
+          type = bool;
+          description = ''
+            If enabled, the generated nftables rule set will be owned exclusively by firewalld.
+            This prevents other entities from mistakenly (or maliciously) modifying firewalld's rule set.
+            If you intend to modify firewalld's rules, set this to `false`.
+          '';
+          default = true;
+        };
+      };
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = cfg.settings.FirewallBackend == "nftables" -> config.networking.nftables.enable;
+        message = ''
+          FirewallD uses nftables as the firewall backend (by default), but nftables support isn't enabled.
+          Please read the description of networking.nftables.enable for possible problems.
+          If using nftables is not desired, set services.firewalld.settings.FirewallBackend to "iptables", but be aware that FirewallD has deprecated support for it, and will override firewall rule set by other services, if any.
+        '';
+      }
+    ];
+
+    environment.etc."firewalld/firewalld.conf" = {
+      source = format.generate "firewalld.conf" cfg.settings;
+    };
+  };
+}

--- a/nixos/modules/services/networking/firewalld/zone.nix
+++ b/nixos/modules/services/networking/firewalld/zone.nix
@@ -1,0 +1,281 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.services.firewalld;
+  format = pkgs.formats.xml { };
+  lib' = import ./lib.nix { inherit lib; };
+  inherit (lib')
+    filterNullAttrs
+    mkPortOption
+    mkXmlAttr
+    portProtocolOptions
+    protocolOption
+    toXmlAttrs
+    ;
+  inherit (lib) mkOption;
+  inherit (lib.types)
+    attrTag
+    attrsOf
+    bool
+    enum
+    ints
+    listOf
+    nonEmptyStr
+    nullOr
+    strMatching
+    submodule
+    ;
+in
+{
+  options.services.firewalld.zones = mkOption {
+    description = ''
+      firewalld zone configuration files.
+      See {manpage}`firewalld.zone(5)`.
+    '';
+    default = { };
+    example = {
+      public = {
+        forward = true;
+        services = [
+          "ssh"
+          "dhcpv6-client"
+        ];
+      };
+      external = {
+        forward = true;
+        services = [
+          "ssh"
+        ];
+        masquerade = true;
+      };
+      dmz = {
+        forward = true;
+        services = [
+          "ssh"
+        ];
+      };
+      work = {
+        forward = true;
+        services = [
+          "ssh"
+          "dhcpv6-client"
+        ];
+      };
+      home = {
+        forward = true;
+        services = [
+          "ssh"
+          "mdns"
+          "samba-client"
+          "dhcpv6-client"
+        ];
+      };
+      internal = {
+        forward = true;
+        services = [
+          "ssh"
+          "mdns"
+          "samba-client"
+          "dhcpv6-client"
+        ];
+      };
+    };
+    type = attrsOf (submodule {
+      options = {
+        version = mkOption {
+          type = nullOr nonEmptyStr;
+          description = "Version of the zone.";
+          default = null;
+        };
+        target = mkOption {
+          type = enum [
+            "ACCEPT"
+            "%%REJECT%%"
+            "DROP"
+          ];
+          description = "Action for packets that doesn't match any rules.";
+          default = "%%REJECT%%";
+        };
+        ingressPriority = mkOption {
+          type = nullOr ints.s16;
+          description = ''
+            Priority for inbound traffic.
+            Lower values have higher priority.
+          '';
+          default = null;
+        };
+        egressPriority = mkOption {
+          type = nullOr ints.s16;
+          description = ''
+            Priority for outbound traffic.
+            Lower values have higher priority.
+          '';
+          default = null;
+        };
+        interfaces = mkOption {
+          type = listOf nonEmptyStr;
+          description = "Interfaces to bind.";
+          default = [ ];
+        };
+        sources = mkOption {
+          type = listOf (attrTag {
+            address = mkOption {
+              type = nonEmptyStr;
+              description = ''
+                An IP address or a network IP address with a mask for IPv4 or IPv6.
+                For IPv4, the mask can be a network mask or a plain number.
+                For IPv6 the mask is a plain number.
+                The use of host names is not supported.
+              '';
+            };
+            mac = mkOption {
+              type = strMatching "([[:xdigit:]]{2}:){5}[[:xdigit:]]{2}";
+              description = "A MAC address.";
+            };
+            ipset = mkOption {
+              type = nonEmptyStr;
+              description = "An ipset.";
+            };
+          });
+          description = "Source addresses, address ranges, MAC addresses or ipsets to bind.";
+          default = [ ];
+        };
+        icmpBlockInversion = mkOption {
+          type = bool;
+          description = ''
+            Whether to invert the icmp block handling.
+            Only enabled ICMP types are accepted and all others are rejected in the zone.
+          '';
+          default = false;
+        };
+        forward = mkOption {
+          type = bool;
+          description = ''
+            Whether to enable intra-zone forwarding.
+            When enabled, packets will be forwarded between interfaces or sources within a zone, even if the zone's target is not set to ACCEPT.
+          '';
+          default = false;
+        };
+        short = mkOption {
+          type = nullOr nonEmptyStr;
+          description = "Short description for the zone.";
+          default = null;
+        };
+        description = mkOption {
+          type = nullOr nonEmptyStr;
+          description = "Description for the zone.";
+          default = null;
+        };
+        services = mkOption {
+          type = listOf nonEmptyStr;
+          description = "Services to allow in the zone.";
+          default = [ ];
+        };
+        ports = mkOption {
+          type = listOf (submodule portProtocolOptions);
+          description = "Ports to allow in the zone.";
+          default = [ ];
+        };
+        protocols = mkOption {
+          type = listOf nonEmptyStr;
+          description = "Protocols to allow in the zone.";
+          default = [ ];
+        };
+        icmpBlocks = mkOption {
+          type = listOf nonEmptyStr;
+          description = "ICMP types to block in the zone.";
+          default = [ ];
+        };
+        masquerade = mkOption {
+          type = bool;
+          description = "Whether to enable masquerading in the zone.";
+          default = false;
+        };
+        forwardPorts = mkOption {
+          type = listOf (submodule {
+            options = {
+              port = mkPortOption { };
+              protocol = protocolOption;
+              to-port = (mkPortOption { optional = true; }) // {
+                default = null;
+              };
+              to-addr = mkOption {
+                type = nullOr nonEmptyStr;
+                description = "Destination IP address.";
+                default = null;
+              };
+            };
+          });
+          description = "Ports to forward in the zone.";
+          default = [ ];
+        };
+        sourcePorts = mkOption {
+          type = listOf (submodule portProtocolOptions);
+          description = "Source ports to allow in the zone.";
+          default = [ ];
+        };
+        rules = mkOption {
+          type = listOf (format.type);
+          description = "Rich rules for the zone.";
+          default = [ ];
+        };
+      };
+    });
+  };
+
+  config = lib.mkIf cfg.enable {
+    services.firewalld.zones = {
+      drop = {
+        target = "DROP";
+        forward = true;
+      };
+      block = {
+        forward = true;
+      };
+      trusted = {
+        target = "ACCEPT";
+        forward = true;
+      };
+    };
+
+    environment.etc = lib.mapAttrs' (
+      name: value:
+      lib.nameValuePair "firewalld/zones/${name}.xml" {
+        source = format.generate "firewalld-zone-${name}.xml" {
+          zone =
+            let
+              mkXmlAttrList = name: builtins.map (mkXmlAttr name);
+              mkXmlTag = value: if value then "" else null;
+            in
+            filterNullAttrs (
+              lib.mergeAttrsList [
+                (toXmlAttrs { inherit (value) version target; })
+                (mkXmlAttr "ingress-priority" value.ingressPriority)
+                (mkXmlAttr "egress-priority" value.egressPriority)
+                {
+                  interface = mkXmlAttrList "name" value.interfaces;
+                  source = builtins.map toXmlAttrs value.sources;
+                  icmp-block-inversion = mkXmlTag value.icmpBlockInversion;
+                  forward = mkXmlTag value.forward;
+                  inherit (value) short description;
+                  service = mkXmlAttrList "name" value.services;
+                  port = builtins.map toXmlAttrs value.ports;
+                  protocol = mkXmlAttrList "value" value.protocols;
+                  icmp-block = mkXmlAttrList "name" value.icmpBlocks;
+                  masquerade = mkXmlTag value.masquerade;
+                  forward-port = builtins.map toXmlAttrs (builtins.map filterNullAttrs value.forwardPorts);
+                  source-port = builtins.map toXmlAttrs value.sourcePorts;
+                  rule = value.rules;
+                }
+              ]
+            );
+        };
+      }
+    ) cfg.zones;
+  };
+}

--- a/nixos/modules/services/video/wivrn.nix
+++ b/nixos/modules/services/video/wivrn.nix
@@ -231,6 +231,8 @@ in
       allowedUDPPorts = [ 9757 ];
     };
 
+    services.firewalld.packages = [ cfg.package ];
+
     environment = {
       systemPackages = [
         cfg.package

--- a/nixos/modules/services/x11/desktop-managers/kodi.nix
+++ b/nixos/modules/services/x11/desktop-managers/kodi.nix
@@ -38,5 +38,7 @@ in
     ];
 
     environment.systemPackages = [ cfg.package ];
+
+    services.firewalld.packages = [ cfg.package ];
   };
 }

--- a/nixos/modules/virtualisation/libvirtd.nix
+++ b/nixos/modules/virtualisation/libvirtd.nix
@@ -447,6 +447,8 @@ in
       Include ${cfg.package}/etc/ssh/ssh_config.d/30-libvirt-ssh-proxy.conf
     '';
 
+    services.firewalld.packages = [ cfg.package ];
+
     systemd.packages = [ cfg.package ];
 
     systemd.services.libvirtd-config = {

--- a/nixos/modules/virtualisation/podman/default.nix
+++ b/nixos/modules/virtualisation/podman/default.nix
@@ -249,7 +249,9 @@ in
       };
 
       # containers cannot reach aardvark-dns otherwise
-      networking.firewall.interfaces.${network_interface}.allowedUDPPorts = lib.mkIf dns_enabled [ 53 ];
+      networking.firewall = lib.mkIf (config.networking.firewall.backend != "firewalld") {
+        interfaces.${network_interface}.allowedUDPPorts = lib.mkIf dns_enabled [ 53 ];
+      };
 
       virtualisation.containers = {
         enable = true; # Enable common /etc/containers configuration

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -579,6 +579,7 @@ in
     imports = [ ./firewall.nix ];
     _module.args.backend = "nftables";
   };
+  firewalld = runTest ./firewalld.nix;
   firezone = runTest ./firezone/firezone.nix;
   fish = runTest ./fish.nix;
   flannel = runTestOn [ "x86_64-linux" ] ./flannel.nix;

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -569,11 +569,15 @@ in
   firejail = runTest ./firejail.nix;
   firewall = runTest {
     imports = [ ./firewall.nix ];
-    _module.args.nftables = false;
+    _module.args.backend = "iptables";
+  };
+  firewall-firewalld = runTest {
+    imports = [ ./firewall.nix ];
+    _module.args.backend = "firewalld";
   };
   firewall-nftables = runTest {
     imports = [ ./firewall.nix ];
-    _module.args.nftables = true;
+    _module.args.backend = "nftables";
   };
   firezone = runTest ./firezone/firezone.nix;
   fish = runTest ./fish.nix;

--- a/nixos/tests/firewall.nix
+++ b/nixos/tests/firewall.nix
@@ -12,10 +12,11 @@
 
   nodes = {
     walled =
-      { ... }:
+      { lib, ... }:
       {
         networking.firewall = {
           enable = true;
+          inherit backend;
           logRefusedPackets = true;
           # Syntax smoke test, not actually verified otherwise
           allowedTCPPorts = [
@@ -37,23 +38,25 @@
               to = 8010;
             }
           ];
-          interfaces.eth0 = {
-            allowedTCPPorts = [ 10003 ];
-            allowedTCPPortRanges = [
-              {
-                from = 10000;
-                to = 10005;
-              }
-            ];
-          };
-          interfaces.eth3 = {
-            allowedUDPPorts = [ 10003 ];
-            allowedUDPPortRanges = [
-              {
-                from = 10000;
-                to = 10005;
-              }
-            ];
+          interfaces = lib.mkIf (backend != "firewalld") {
+            eth0 = {
+              allowedTCPPorts = [ 10003 ];
+              allowedTCPPortRanges = [
+                {
+                  from = 10000;
+                  to = 10005;
+                }
+              ];
+            };
+            eth3 = {
+              allowedUDPPorts = [ 10003 ];
+              allowedUDPPortRanges = [
+                {
+                  from = 10000;
+                  to = 10005;
+                }
+              ];
+            };
           };
         };
         networking.nftables.enable = nftables;

--- a/nixos/tests/firewalld.nix
+++ b/nixos/tests/firewalld.nix
@@ -1,0 +1,52 @@
+{ lib, pkgs, ... }:
+{
+  name = "firewalld";
+  meta.maintainers = with pkgs.lib.maintainers; [
+    prince213
+  ];
+
+  nodes = {
+    walled = {
+      networking.nftables.enable = true;
+      services.firewalld.enable = true;
+      services.httpd.enable = true;
+      services.httpd.adminAddr = "foo@example.org";
+    };
+
+    open = {
+      networking.nftables.enable = true;
+      services.firewalld = {
+        enable = true;
+        settings.DefaultZone = "trusted";
+      };
+      services.httpd.enable = true;
+      services.httpd.adminAddr = "foo@example.org";
+    };
+  };
+
+  testScript = ''
+    start_all()
+
+    walled.wait_for_unit("firewalld")
+    walled.wait_for_unit("httpd")
+
+    open.wait_for_unit("network.target")
+
+    with subtest("walled local httpd works"):
+      walled.succeed("curl -v http://localhost/ >&2")
+
+    with subtest("incoming connections are blocked"):
+      open.fail("curl --fail --connect-timeout 2 http://walled/ >&2")
+
+    with subtest("outgoing connections are allowed"):
+      walled.succeed("curl -v http://open/ >&2")
+
+    with subtest("runtime configuration can be changed"):
+      walled.succeed("firewall-cmd --add-service=http")
+      open.succeed("curl -v http://walled/ >&2")
+
+    with subtest("runtime configuration are not permanent"):
+      walled.succeed("firewall-cmd --complete-reload")
+      open.fail("curl --fail --connect-timeout 2 http://walled/ >&2")
+  '';
+}

--- a/pkgs/by-name/fi/firewalld/package.nix
+++ b/pkgs/by-name/fi/firewalld/package.nix
@@ -155,6 +155,7 @@ stdenv.mkDerivation rec {
   '';
 
   passthru.tests = {
+    firewalld = nixosTests.firewalld;
     firewall-firewalld = nixosTests.firewall-firewalld;
   };
 

--- a/pkgs/by-name/fi/firewalld/package.nix
+++ b/pkgs/by-name/fi/firewalld/package.nix
@@ -26,6 +26,7 @@
   sysctl,
   wrapGAppsNoGuiHook,
   withGui ? false,
+  nixosTests,
 }:
 
 let
@@ -152,6 +153,10 @@ stdenv.mkDerivation rec {
     patchShebangs --host $out/share/firewalld/*.py
     wrapPythonProgramsIn "$out/bin" "$out ${pythonPath}"
   '';
+
+  passthru.tests = {
+    firewall-firewalld = nixosTests.firewall-firewalld;
+  };
 
   meta = {
     description = "Firewall daemon with D-Bus interface";


### PR DESCRIPTION
This PR introduces NixOS modules for FirewallD.
There are 3 main parts:

- `services.firewalld`, which allows for declarative configuration of firewalld; and
- `networking.firewall.firewalld`, which will create a default zone name `nixos` with many existing configurations from `networking.firewall`.
- (https://github.com/NixOS/nixpkgs/pull/463498) NetworkManager now installs firewalld zone `nm-shared`.

What's not done:

- [ ] Configuration for files other than zones and services
- [ ] `/etc/firewall/applet.conf`
- [x] `networking.firewall.backend` as a enum, current approach is complicated
- [x] NetworkManager integration https://github.com/NixOS/nixpkgs/blob/2631b0b7abcea6e640ce31cd78ea58910d31e650/pkgs/tools/networking/networkmanager/default.nix#L121-L122

Related to https://git.sr.ht/~prince213/firewalld-nix.
Related to #389437.
Closes #165882.
Supersedes #205380.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [X] (Module updates) Added a release notes entry if the change is significant
  - [X] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
