### PR TITLE
tests.haskell.documentationTarball: switch to random

### DIFF
--- a/pkgs/test/haskell/documentationTarball/default.nix
+++ b/pkgs/test/haskell/documentationTarball/default.nix
@@ -1,7 +1,7 @@
 { pkgs, haskellPackages }:
 
 let
-  drv = haskellPackages.vector;
+  drv = haskellPackages.random;
   docs = pkgs.haskell.lib.compose.documentationTarball drv;
 
 in
@@ -15,10 +15,10 @@ pkgs.runCommand "test haskell.lib.compose.documentationTarball"
     tar xvzf "${docs}/${drv.name}-docs.tar.gz"
 
     # Check for Haddock html
-    find "${drv.name}-docs" | grep -q "Data-Vector.html"
+    find "${drv.name}-docs" | grep -q "System-Random.html"
 
     # Check for source html
-    find "${drv.name}-docs" | grep -q  "src/Data.Vector.html"
+    find "${drv.name}-docs" | grep -q  "src/System.Random.html"
 
     touch "$out"
   ''


### PR DESCRIPTION
We only need *a* package, to test the "documentationTarball" function, not specifically vector. I guess we should use a package that is rarely broken itself... for which a *dependency* of vector should be a good choice. I took a random one... "random"!

The error for vector-docs before was something like this:

```
benchlib/Bench/Vector/TestData/ParenTree.hs:3:1: error: [GHC-22211]
    Could not load module ‘Data.Vector.Unboxed’.
    There are files missing in the ‘vector-0.13.2.0’ package,
    try running 'ghc-pkg check'.
    Use -v to see a list of the files searched for.
  |
3 | import qualified Data.Vector.Unboxed as V
```

This indicates a packaging problem for `vector`, so nothing we should worry about here.


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
