### PR TITLE
chatterino2: 2.5.2 -> 2.5.3; chatterino7: 7.5.2 -> 7.5.3

### DIFF
--- a/pkgs/by-name/ch/chatterino2/common.nix
+++ b/pkgs/by-name/ch/chatterino2/common.nix
@@ -7,6 +7,7 @@
   boost,
   openssl,
   libsecret,
+  libnotify,
   libavif,
   kdePackages,
 }:
@@ -24,13 +25,17 @@ stdenv.mkDerivation {
       qtsvg
       qt5compat
       qtkeychain
+      qtimageformats
     ])
     ++ [
       boost
       openssl
       libsecret
     ]
-    ++ lib.optional stdenv.hostPlatform.isLinux kdePackages.qtwayland
+    ++ lib.optionals stdenv.hostPlatform.isLinux [
+      kdePackages.qtwayland
+      libnotify
+    ]
     ++ lib.optional enableAvifSupport libavif;
 
   cmakeFlags = [

--- a/pkgs/by-name/ch/chatterino2/package.nix
+++ b/pkgs/by-name/ch/chatterino2/package.nix
@@ -12,13 +12,13 @@
   (
     finalAttrs: _: {
       pname = "chatterino2";
-      version = "2.5.2";
+      version = "2.5.3";
 
       src = fetchFromGitHub {
         owner = "Chatterino";
         repo = "chatterino2";
         tag = "v${finalAttrs.version}";
-        hash = "sha256-nrw4dQ7QjPPMbZXMC+p3VgUQKwc1ih6qS13D9+9oNuw=";
+        hash = "sha256-W2sqlqL6aa68aQ3nE161G64x7K7p8iByX03g1dseQbs=";
         fetchSubmodules = true;
       };
 

--- a/pkgs/by-name/ch/chatterino7/package.nix
+++ b/pkgs/by-name/ch/chatterino7/package.nix
@@ -13,13 +13,13 @@
   (
     finalAttrs: _: {
       pname = "chatterino7";
-      version = "7.5.2";
+      version = "7.5.3";
 
       src = fetchFromGitHub {
         owner = "SevenTV";
         repo = "chatterino7";
         tag = "v${finalAttrs.version}";
-        hash = "sha256-kQeW9Qa8NPs47xUlqggS4Df4fxIoknG8O5IBdOeIo+4=";
+        hash = "sha256-KrAr3DcQDjb+LP+vIf0qLSSgII0m5rNwhncLNHlLaC8=";
         fetchSubmodules = true;
       };
 


### PR DESCRIPTION
- fixed webps used in some link previews and for 7TV animated paints and/or emotes from not loading by adding `qtimageformats` back (removed in 909dc0158a9366e01321319fa7ac064ceb39fc7f)
- updated to the latest releases
- added new required build input `libnotify` for [feat: add Linux support for Live Notifications toasts w/ libnotify](https://github.com/Chatterino/chatterino2/pull/5881)

closes #399779

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
