### PR TITLE
nixos/direnv: fix silent option

### DIFF
--- a/nixos/modules/programs/direnv.nix
+++ b/nixos/modules/programs/direnv.nix
@@ -13,6 +13,7 @@ let
       default = true;
       example = false;
     };
+  format = pkgs.formats.toml { };
 in
 {
   options.programs.direnv = {
@@ -72,11 +73,34 @@ in
         '';
       };
     };
+
+    settings = lib.mkOption {
+      inherit (format) type;
+      default = { };
+      example = lib.literalExpression ''
+        {
+          global = {
+            log_format = "-";
+            log_filter = "^$";
+          };
+        }
+      '';
+      description = ''
+        Direnv configuration. Refer to {manpage}`direnv.toml(1)`.
+      '';
+    };
   };
 
   config = lib.mkIf cfg.enable {
 
     programs = {
+      direnv.settings = lib.mkIf cfg.silent {
+        global = {
+          log_format = lib.mkDefault "-";
+          log_filter = lib.mkDefault "^$";
+        };
+      };
+
       zsh.interactiveShellInit = lib.mkIf cfg.enableZshIntegration ''
         if ${lib.boolToString cfg.loadInNixShell} || printenv PATH | grep -vqc '/nix/store'; then
          eval "$(${lib.getExe cfg.package} hook zsh)"
@@ -119,18 +143,19 @@ in
         (pkgs.symlinkJoin {
           inherit (cfg.package) name;
           paths = [ cfg.package ];
+          nativeBuildInputs = [ pkgs.makeBinaryWrapper ];
           postBuild = ''
-            rm -rf $out/share/fish
+            wrapProgram "$out/bin/direnv" \
+              --set-default 'DIRENV_CONFIG' '/etc/direnv'
+            rm -rf "$out/share/fish"
           '';
         })
       ];
 
-      variables = {
-        DIRENV_CONFIG = "/etc/direnv";
-        DIRENV_LOG_FORMAT = lib.mkIf cfg.silent "";
-      };
-
       etc = {
+        "direnv/direnv.toml".source = lib.mkIf (cfg.settings != { }) (
+          format.generate "direnv.toml" cfg.settings
+        );
         "direnv/direnvrc".text = ''
           ${lib.optionalString cfg.nix-direnv.enable ''
             #Load nix-direnv


### PR DESCRIPTION
`$DIRENV_LOG_FORMAT` is currently broken see: <https://github.com/direnv/direnv/issues/1418>

this PR fixes the `silent` option and adds the `settings` option
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
