### PR TITLE
darwin.libcxx: (╯°□°）╯︵ ┻━┻

### DIFF
--- a/doc/redirects.json
+++ b/doc/redirects.json
@@ -216,6 +216,12 @@
   "sec-building-packages-with-llvm-using-clang-stdenv": [
     "index.html#sec-building-packages-with-llvm-using-clang-stdenv"
   ],
+  "sec-darwin-libcxx-deployment-targets": [
+    "index.html#sec-darwin-libcxx-deployment-targets"
+  ],
+  "sec-darwin-libcxx-versions": [
+    "index.html#sec-darwin-libcxx-versions"
+  ],
   "sec-functions-library-treefmt": [
     "index.html#sec-functions-library-treefmt"
   ],

--- a/doc/release-notes/rl-2511.section.md
+++ b/doc/release-notes/rl-2511.section.md
@@ -10,6 +10,10 @@
   supported. `pkgsCross.loongarch64-linux-embedded` can be used to build software and systems for these platforms.
 - The official Nix formatter `nixfmt` is now stable and available as `pkgs.nixfmt`, deprecating the temporary `pkgs.nixfmt-rfc-style` attribute. The classic `nixfmt` will stay available for some more time as `pkgs.nixfmt-classic`.
 
+- Darwin has switched to using the system libc++. This was done for improved compatibility and to avoid ODR violations.
+  If a newer C++ library feature is not available on the default deployment target, you will need to increase the deployment target.
+  See the Darwin platform documentation for more details.
+
 ## Backward Incompatibilities {#sec-nixpkgs-release-25.11-incompatibilities}
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->

--- a/doc/stdenv/platform-notes.chapter.md
+++ b/doc/stdenv/platform-notes.chapter.md
@@ -12,6 +12,9 @@ If it does, you’re done; skip the rest of this.
 - Darwin uses Clang by default instead of GCC. Packages that refer to `$CC` or `cc` should just work in most cases.
   Some packages may hardcode `gcc` or `g++`. You can usually fix that by setting `makeFlags = [ "CC=cc" "CXX=C++" ]`.
   If that does not work, you will have to patch the build scripts yourself to use the correct compiler for Darwin.
+- Darwin uses the system libc++ by default to avoid ODR violations and potential compatibility issues from mixing LLVM libc++ with the system libc++.
+  While mixing the two usually worked, the two implementations are not guaranteed to be ABI compatible and are considered distinct by upstream.
+  See the troubleshooting guide below if you need to use newer C++ library features than those supported by the default deployment target.
 - Darwin needs an SDK to build software.
   The SDK provides a default set of frameworks and libraries to build software, most of which are specific to Darwin.
   There are multiple versions of the SDK packages in Nixpkgs, but one is included by default in the `stdenv`.
@@ -29,6 +32,20 @@ Start with writing your derivation as if everything is already set up for you (b
 If you run into issues or failures, continue reading below for how to deal with the most common issues you may encounter.
 
 ### Darwin Issue Troubleshooting {#sec-darwin-troubleshooting}
+
+#### Building a C++ package or library says that certain APIs are unavailable {#sec-darwin-libcxx-versions}
+
+While some newer APIs may be available via headers only, some require using a system libc++ with the required API support.
+When that happens, your build will fail because libc++ makes failure to use the correct deployment target an error.
+To make the newer API available, increase the deployment target to the required version.
+Note that it is possible to use libc++ from LLVM instead of increasing the deployment target, but it is not recommended.
+Doing so can cause problems when multiple libc++ implementations are linked into a binary (e.g., from dependencies).
+
+##### Using a newer deployment target {#sec-darwin-libcxx-deployment-targets}
+
+See below for how to use a newer deployment target.
+For example, `std::print` depends on features that are only available on macOS 13.3 or newer.
+To make them available, set the deployment target to 13.3 using `darwinMinVersionHook`.
 
 #### Package requires a non-default SDK or fails to build due to missing frameworks or symbols {#sec-darwin-troubleshooting-using-sdks}
 

--- a/pkgs/by-name/ap/apple-sdk/common/process-stubs.nix
+++ b/pkgs/by-name/ap/apple-sdk/common/process-stubs.nix
@@ -36,21 +36,5 @@ self: super: {
       llvm-readtapi --filetype=tbd-v4 usr/lib/$libSystem~ -o usr/lib/$libSystem
       rm usr/lib/$libSystem~
     done
-
-    # Strip weak C++ symbols to work around `libc++` leakage in system
-    # frameworks for now. These are only present on `x86_64-darwin`, so
-    # it should hopefully be harmless.
-    #
-    # TODO FIXME: This is kind of horrible.
-    while read -r -d "" stub; do
-      printf 'Stripping weak C++ symbols from %s\n' "$stub"
-      llvm-readtapi --filetype=tbd-v5 "$stub" \
-      | jq '
-        (.main_library, .libraries[]?).exported_symbols[]?.data.weak[]? |=
-          select(startswith("__Z") | not)
-      ' > $stub~
-      llvm-readtapi --filetype=tbd-v4 $stub~ -o $stub
-      rm $stub~
-    done < <(find . -name '*.tbd' -print0)
   '';
 }

--- a/pkgs/by-name/ap/apple-sdk/metadata/apple-oss-lockfile.json
+++ b/pkgs/by-name/ap/apple-sdk/metadata/apple-oss-lockfile.json
@@ -711,14 +711,14 @@
       "version": "10063.101.15"
     }
   },
-  "15.2": {
+  "15.5": {
     "CarbonHeaders": {
       "hash": "sha256-nIPXnLr21yVnpBhx9K5q3l/nPARA6JL/dED08MeyhP8=",
       "version": "18.1"
     },
     "CommonCrypto": {
       "hash": "sha256-+qAwL6+s7di9cX/qXtapLkjCFoDuZaSYltRJEG4qekM=",
-      "version": "600033.60.1"
+      "version": "600035"
     },
     "IOAudioFamily": {
       "hash": "sha256-VSk3jvsITJugtL67Qt0m4qJ879i7Fj6B/NGBFVCwpiU=",
@@ -757,16 +757,16 @@
       "version": "261"
     },
     "IOGraphics": {
-      "hash": "sha256-Ag37fd3tZJLXLVq1yzHOCWGOYYfwwTkC8hnvNaTEaWg=",
-      "version": "598"
+      "hash": "sha256-iysZE42mOKZbFxSZBNspaBTCRKEKK38DFGBxZWQxZxI=",
+      "version": "599"
     },
     "IOHIDFamily": {
-      "hash": "sha256-utWAwmn9jss/6fc4flDHXeJR5ZBymO0ZFbDFIFVBnt4=",
-      "version": "2104.61.1"
+      "hash": "sha256-gEYPyjXgQ2ABGufCKPjmzMdNRLxhELkCvOURCokyTO4=",
+      "version": "2115.100.21"
     },
     "IOKitUser": {
-      "hash": "sha256-vfz/kLZlVyoHKOlrNdNrf2HcUOB6bY+mpbCvEEg2sus=",
-      "version": "100140.60.14"
+      "hash": "sha256-p32U+jHfwA/tqnjF4p1BmojghEXK8KxiflW3IHs2iIY=",
+      "version": "100150.120.2"
     },
     "IONetworkingFamily": {
       "hash": "sha256-gZ7Dkk4Iu7AV9K2ioqSeJ1W7bTNxv77bmT18iv3ljLg=",
@@ -777,28 +777,28 @@
       "version": "93"
     },
     "IOStorageFamily": {
-      "hash": "sha256-tjzvlJYVjSTG7oF3AhHgCASKax1fYjOBAxcsrKh/urY=",
-      "version": "317.40.2"
+      "hash": "sha256-/0H0tqWUWkgYigYypucbc7lOCFYDuukwF9fvLEOhwOk=",
+      "version": "323"
     },
     "IOUSBFamily": {
       "hash": "sha256-Z0E3TfKP49toYo1Fo9kElRap8CZ+mVDHy5RIexgJTpA=",
       "version": "630.4.5"
     },
     "Libc": {
-      "hash": "sha256-/J1Oawa+cMbcAlMlpr6ce32KQQp2lMGnfbRi/2Oc1cY=",
-      "version": "1669.60.4"
+      "hash": "sha256-nWDokN0Vr5pUyNGculnDOah9RNgHiWr3S13RSQLmZrc=",
+      "version": "1698.100.8"
     },
     "Libinfo": {
-      "hash": "sha256-D7JMCakQVCQ9j2zUHQSGB8zZcHD6azwYY3bsJU0JfEE=",
-      "version": "592"
+      "hash": "sha256-UI5mGvzZ6BPafGYD6CrNAJAKjeJLB6urAS2lpB6X/Ec=",
+      "version": "597"
     },
     "Libm": {
       "hash": "sha256-p4BndAag9d0XSMYWQ+c4myGv5qXbKx5E1VghudSbpTk=",
       "version": "2026"
     },
     "Libnotify": {
-      "hash": "sha256-XwVB4sYXPLAHDuLv8mxAWlC1ia17V4cf73DEJDDm4ck=",
-      "version": "327.60.1"
+      "hash": "sha256-GDYMVi1034f9empq0YOuumQp/BDJ7phTb0Zl4KTY9xg=",
+      "version": "342"
     },
     "Librpcsvc": {
       "hash": "sha256-UWYdCQ9QsBqwM01bWr+igINAHSdSluB/FrOclC5AjTI=",
@@ -813,80 +813,80 @@
       "version": "146"
     },
     "Security": {
-      "hash": "sha256-sRpFQyMk3x4kRthXpqeAnfQ9dE5RMxiSFUiUKRCneck=",
-      "version": "61439.60.117"
+      "hash": "sha256-ZOrOOCk+hZbzDilzkihpQfsDpzV3Ul4zy6fpFRWUQHw=",
+      "version": "61439.120.27"
     },
     "architecture": {
       "hash": "sha256-PRNUrhzSOrwmxSPkKmV0LV7yEIik65sdkfKdBqcwFhU=",
       "version": "282"
     },
     "configd": {
-      "hash": "sha256-xRaEzq/OOMBi7lvi2bV2/ObN5JJJ5vcFy8DGHLItUWM=",
-      "version": "1351"
+      "hash": "sha256-ZdUq1SrOwB88Lx68ekrA4zeVsLDZz4TAJywNnF+uAzY=",
+      "version": "1351.120.3"
     },
     "copyfile": {
-      "hash": "sha256-Vz1fo4p2b6S8xfyDPu1FNgMkH1aX0tkpXCZkdzkRdq0=",
-      "version": "213.40.2"
+      "hash": "sha256-rLqT6e44W2ohgwUXREmiOyJBYCrV3gRLbtVnbUq60xc=",
+      "version": "221.121.1"
     },
     "dtrace": {
       "hash": "sha256-iNEZyxK3DmEwO3gzrfvCaVZSEuuOMQm5IG/6FodPNdI=",
       "version": "411"
     },
     "dyld": {
-      "hash": "sha256-DDhV7X81nhd3oeJuICEvF8FU43yE/afQ/LYgDNtXswA=",
-      "version": "1241.17"
+      "hash": "sha256-4OOghgUYyMJbsTe96fiWCndTJ1BS94rK9v6Kqn/ooYs=",
+      "version": "1285.19"
     },
     "eap8021x": {
-      "hash": "sha256-2FdEb76KBbCAl2iwly4c1Xstar53O8qgGdN/3WXO23U=",
-      "version": "364"
+      "hash": "sha256-Kx/wwnt108hDm0qQPyTNbZ8KoHkD5m7L4yb5qjSuQjI=",
+      "version": "365.120.2"
     },
     "hfs": {
-      "hash": "sha256-isTLSBDxh12W10I5KY6O6SsygqnOvqJ0TfdWIKSK3pM=",
-      "version": "677.60.1"
+      "hash": "sha256-5/3Ycp3cKqlgAl1kjBmbF5tFlfJYQS5rbrbk4SS66b8=",
+      "version": "683.120.3"
     },
     "launchd": {
       "hash": "sha256-8mW9bnuHmRXCx9py8Wy28C5b2QPICW0rlAps5njYa00=",
       "version": "842.1.4"
     },
     "libclosure": {
-      "hash": "sha256-I0PKQFnoJVRMA7H3yT+inHS0454/FXHhQB6nwmHFvFs=",
-      "version": "95"
+      "hash": "sha256-pvwfcbeEJmTEPdt6/lgVswiabLRG+sMN6VT5FwG7C4Q=",
+      "version": "96"
     },
     "libdispatch": {
-      "hash": "sha256-f2ex/53OFeSR5A0nMapxC6AocqBSweecNtEhp4bWjhE=",
-      "version": "1504.60.7"
+      "hash": "sha256-jTp2DolOOCQPBt1HRotkmPnKgQ2LGgniEqeHoM+vlKg=",
+      "version": "1521.120.4"
     },
     "libmalloc": {
-      "hash": "sha256-Rw/9s7yY3qPtKfDhP+p+0z+aaCsxgwvdUyRG2V1N6D8=",
-      "version": "657.60.21"
+      "hash": "sha256-d9AVHSYTqHDlgctv8Hh4HAYW53MJelj4F8LWPsjrsws=",
+      "version": "715.120.13"
     },
     "libplatform": {
-      "hash": "sha256-o/W1pQ9yGTE8HQlGcggM+XiJbEyqgc/s0uiY3+yBtnA=",
-      "version": "340.60.2"
+      "hash": "sha256-gpijoTMvdkM0PdG8gyIllOJlh/MtTc4ro9ODDAhN6gM=",
+      "version": "349"
     },
     "libpthread": {
-      "hash": "sha256-eYHDAt2wNk7hJZJxsC7Y9w4ASKdexidu613kPo7TAKs=",
-      "version": "535"
+      "hash": "sha256-N+MMXdbthsxauTTfZ5ElUs39dVH+Chn1yyU6pObZpkU=",
+      "version": "536"
     },
     "mDNSResponder": {
-      "hash": "sha256-mDyY/2S4EHbGh02J6VWZVxhNXXZmWGX+NjUjPfMZgZA=",
-      "version": "2559.60.39.0.1"
+      "hash": "sha256-ILx12PRxj/+VqfpCCErJFEJXFI9yzTh4g+FK0UCenIE=",
+      "version": "2600.120.12"
     },
     "objc4": {
-      "hash": "sha256-uBFS5extMQkXAXJfPtPlBYAQpz+zsRHQnEaLpDOcYGM=",
-      "version": "928.3"
+      "hash": "sha256-DMxa25gXjKCkiDnVJ/8SyJUjaBlmBGABg8EfCHcmTj0=",
+      "version": "940.4"
     },
     "ppp": {
       "hash": "sha256-8+QUA79sHf85yvGSPE9qCmGsrZDT3NZnbgZVroJw/Hg=",
       "version": "1016"
     },
     "removefile": {
-      "hash": "sha256-h1jb4DcgDHwi9eiUguc2e5OLP8ZHxCN3B4Myp/DFDBg=",
-      "version": "75"
+      "hash": "sha256-Z5UD0mk/s80CQB0PZWDzSl2JWXmnVmwUvlNb28+hR3k=",
+      "version": "81"
     },
     "xnu": {
-      "hash": "sha256-o8CxHvM2OXiAWJmnFe5ERQYnrNyJ+Bpdb9H0sjd6L10=",
-      "version": "11215.61.5"
+      "hash": "sha256-o4tCuCAIgAYg/Li3wTs12mVWr5C/4vbwu1zi+kJ9d6w=",
+      "version": "11417.121.6"
     }
   }
 }

--- a/pkgs/by-name/ap/apple-sdk/metadata/versions.json
+++ b/pkgs/by-name/ap/apple-sdk/metadata/versions.json
@@ -33,10 +33,10 @@
   },
   "15": {
     "urls": [
-      "https://swcdn.apple.com/content/downloads/36/33/072-44426-A_G1AII30AST/ddbss9h6gse6a32rg6luosbrm6vgniu033/CLTools_macOSNMOS_SDK.pkg",
-      "https://web.archive.org/web/20250210234739/https://swcdn.apple.com/content/downloads/36/33/072-44426-A_G1AII30AST/ddbss9h6gse6a32rg6luosbrm6vgniu033/CLTools_macOSNMOS_SDK.pkg"
+      "https://swcdn.apple.com/content/downloads/52/01/082-41241-A_0747ZN8FHV/dectd075r63pppkkzsb75qk61s0lfee22j/CLTools_macOSNMOS_SDK.pkg",
+      "https://web.archive.org/web/20250530132510/https://swcdn.apple.com/content/downloads/52/01/082-41241-A_0747ZN8FHV/dectd075r63pppkkzsb75qk61s0lfee22j/CLTools_macOSNMOS_SDK.pkg"
     ],
-    "version": "15.2",
-    "hash": "sha256-OP5Ah/JnSZ6sD42BD5vGDmikgFzjsfFBmz1hvQD1dOI="
+    "version": "15.5",
+    "hash": "sha256-HBiSJuw1XBUK5R/8Sj65c3rftSEvQl/O9ZZVp/g1Amo="
   }
 }

--- a/pkgs/by-name/ov/ovftool/package.nix
+++ b/pkgs/by-name/ov/ovftool/package.nix
@@ -240,7 +240,6 @@ stdenv.mkDerivation (final: {
       done
 
       # Patches for ovftool binary
-      change_args+=(-change /usr/lib/libc++.1.dylib ${stdenv.cc.libcxx}/lib/libc++.1.dylib)
       change_args+=(-change /usr/lib/libiconv.2.dylib ${libiconv}/lib/libiconv.2.dylib)
       change_args+=(-change /usr/lib/libxml2.2.dylib ${libxml2}/lib/libxml2.2.dylib)
       change_args+=(-change /usr/lib/libz.1.dylib ${zlib}/lib/libz.1.dylib)

--- a/pkgs/development/compilers/llvm/common/default.nix
+++ b/pkgs/development/compilers/llvm/common/default.nix
@@ -200,6 +200,8 @@ let
       clang =
         if stdenv.targetPlatform.libc == null then
           tools.clangNoLibc
+        else if stdenv.targetPlatform.isDarwin then
+          tools.systemLibcxxClang
         else if stdenv.targetPlatform.useLLVM or false then
           tools.clangUseLLVM
         else if (pkgs.targetPackages.stdenv or args.stdenv).cc.isGNU then
@@ -299,7 +301,8 @@ let
 
       clangWithLibcAndBasicRtAndLibcxx = wrapCCWith rec {
         cc = tools.clang-unwrapped;
-        libcxx = targetLlvmLibraries.libcxx;
+        # This is used to build compiler-rt. Make sure to use the system libc++ on Darwin.
+        libcxx = if stdenv.hostPlatform.isDarwin then darwin.libcxx else targetLlvmLibraries.libcxx;
         bintools = bintools';
         extraPackages = [
           targetLlvmLibraries.compiler-rt-no-libc

--- a/pkgs/development/compilers/llvm/common/default.nix
+++ b/pkgs/development/compilers/llvm/common/default.nix
@@ -222,6 +222,15 @@ let
         extraBuildCommands = mkExtraBuildCommands cc;
       };
 
+      # Darwin uses the system libc++ by default. It is set up as its own clang definition so that `libcxxClang`
+      # continues to use the libc++ from LLVM.
+      systemLibcxxClang = wrapCCWith rec {
+        cc = tools.clang-unwrapped;
+        libcxx = darwin.libcxx;
+        extraPackages = [ targetLlvmLibraries.compiler-rt ];
+        extraBuildCommands = mkExtraBuildCommands cc;
+      };
+
       lld = callPackage ./lld {
       };
 

--- a/pkgs/development/libraries/science/math/libtorch/bin.nix
+++ b/pkgs/development/libraries/science/math/libtorch/bin.nix
@@ -24,7 +24,6 @@ let
   device = if cudaSupport then "cuda" else "cpu";
   srcs = import ./binary-hashes.nix version;
   unavailable = throw "libtorch is not available for this platform";
-  libcxx-for-libtorch = if stdenv.hostPlatform.isDarwin then libcxx else (lib.getLib stdenv.cc.cc);
 in
 stdenv.mkDerivation {
   inherit version;
@@ -87,9 +86,6 @@ stdenv.mkDerivation {
         for rpath in $(otool -L $f | grep rpath | awk '{print $1}');do
           install_name_tool -change $rpath $out/lib/$(basename $rpath) $f
         done
-        if otool -L $f | grep /usr/lib/libc++ >& /dev/null; then
-          install_name_tool -change /usr/lib/libc++.1.dylib ${libcxx-for-libtorch.outPath}/lib/libc++.1.0.dylib $f
-        fi
       done
       for f in $out/lib/*.dylib; do
           otool -L $f

--- a/pkgs/os-specific/darwin/libcxx/default.nix
+++ b/pkgs/os-specific/darwin/libcxx/default.nix
@@ -1,0 +1,28 @@
+{
+  # Use the text-based stubs and headers from the latest SDK (currently 15.x). This is safe because
+  # using features that are not available on an older deployment target is a hard error.
+  apple-sdk_15,
+  stdenvNoCC,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "libcxx";
+  # Keep this in sync with the corresponding LLVM libc++ version
+  # defined as `_LIBCPP_VERSION` in `usr/include/c++/v1/__config`.
+  version = "19.1.2+apple-sdk-${apple-sdk_15.version}";
+  inherit (apple-sdk_15) src;
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p "$out/include" "$out/lib"
+    cp -v usr/lib/libc++abi.tbd usr/lib/libc++.1.tbd "$out/lib"
+    ln -s libc++.1.tbd "$out/lib/libc++.tbd"
+    cp -rv usr/include/c++ "$out/include"
+    runHook postInstall
+  '';
+
+  passthru.isLLVM = true;
+})

--- a/pkgs/stdenv/adapters.nix
+++ b/pkgs/stdenv/adapters.nix
@@ -67,50 +67,6 @@ rec {
       extraBuildInputs = (prev.extraBuildInputs or [ ]) ++ pkgs;
     });
 
-  # Override the libc++ dynamic library used in the stdenv to use the one from the platform’s
-  # default stdenv. This allows building packages and linking dependencies with different
-  # compiler versions while still using the same libc++ implementation for compatibility.
-  #
-  # Note that this adapter still uses the headers from the new stdenv’s libc++. This is necessary
-  # because older compilers may not be able to parse the headers from the default stdenv’s libc++.
-  overrideLibcxx =
-    stdenv:
-    assert stdenv.cc.libcxx != null;
-    assert pkgs.stdenv.cc.libcxx != null;
-    # only unified libcxx / libcxxabi stdenv's are supported
-    assert lib.versionAtLeast pkgs.stdenv.cc.libcxx.version "12";
-    assert lib.versionAtLeast stdenv.cc.libcxx.version "12";
-    let
-      llvmLibcxxVersion = lib.getVersion llvmLibcxx;
-
-      stdenvLibcxx = pkgs.stdenv.cc.libcxx;
-      llvmLibcxx = stdenv.cc.libcxx;
-
-      libcxx =
-        pkgs.runCommand "${stdenvLibcxx.name}-${llvmLibcxxVersion}"
-          {
-            outputs = [
-              "out"
-              "dev"
-            ];
-            isLLVM = true;
-          }
-          ''
-            mkdir -p "$dev/nix-support"
-            ln -s '${stdenvLibcxx}' "$out"
-            echo '${stdenvLibcxx}' > "$dev/nix-support/propagated-build-inputs"
-            ln -s '${lib.getDev llvmLibcxx}/include' "$dev/include"
-          '';
-    in
-    overrideCC stdenv (
-      stdenv.cc.override {
-        inherit libcxx;
-        extraPackages = [
-          pkgs.buildPackages.targetPackages."llvmPackages_${lib.versions.major llvmLibcxxVersion}".compiler-rt
-        ];
-      }
-    );
-
   # Override the setup script of stdenv.  Useful for testing new
   # versions of the setup script without causing a rebuild of
   # everything.

--- a/pkgs/stdenv/cross/default.nix
+++ b/pkgs/stdenv/cross/default.nix
@@ -117,7 +117,7 @@ lib.init bootStages
               then
                 throw "no C compiler provided for this platform"
               else if crossSystem.isDarwin then
-                buildPackages.llvmPackages.libcxxClang
+                buildPackages.llvmPackages.systemLibcxxClang
               else if crossSystem.useLLVM or false then
                 buildPackages.llvmPackages.clang
               else if crossSystem.useZig or false then

--- a/pkgs/stdenv/darwin/default.nix
+++ b/pkgs/stdenv/darwin/default.nix
@@ -133,7 +133,14 @@ let
 
             isClang = true;
             inherit (prevStage) libc;
-            inherit (prevStage.llvmPackages) libcxx;
+            # TODO: replace with `darwin.libcxx` once the bootstrap tools no longer have libc++.
+            libcxx =
+              if
+                prevStage.darwin.libcxx == null || name == "bootstrap-stage1" || name == "bootstrap-stage-xclang"
+              then
+                prevStage.llvmPackages.libcxx
+              else
+                prevStage.darwin.libcxx;
 
             inherit lib;
             inherit (prevStage) coreutils gnugrep;
@@ -298,6 +305,7 @@ let
 
   # LLVM tools packages are staged separately (xclang, stage3) from LLVM libs (xclang).
   llvmLibrariesPackages = prevStage: { inherit (prevStage.llvmPackages) compiler-rt libcxx; };
+  llvmLibrariesDarwinDepsNoCC = prevStage: { inherit (prevStage.darwin) libcxx; };
   llvmLibrariesDeps = _: { };
 
   llvmToolsPackages = prevStage: {
@@ -365,6 +373,7 @@ assert bootstrapTools.passthru.isFromBootstrapFiles or false; # sanity check
       darwin = {
         binutils = null;
         binutils-unwrapped = null;
+        libcxx = null;
         libSystem = null;
         sigtool = null;
       };
@@ -986,7 +995,7 @@ assert bootstrapTools.passthru.isFromBootstrapFiles or false; # sanity check
                   _: _:
                   llvmToolsPackages prevStage
                   // {
-                    libcxxClang = super.wrapCCWith rec {
+                    systemLibcxxClang = super.wrapCCWith rec {
                       nativeTools = false;
                       nativeLibc = false;
 
@@ -1008,7 +1017,7 @@ assert bootstrapTools.passthru.isFromBootstrapFiles or false; # sanity check
 
                       isClang = true;
                       libc = self.darwin.libSystem;
-                      inherit (self.llvmPackages) libcxx;
+                      inherit (self.darwin) libcxx;
 
                       inherit lib;
                       inherit (self)
@@ -1160,6 +1169,7 @@ assert bootstrapTools.passthru.isFromBootstrapFiles or false; # sanity check
           ]
           ++ lib.optionals localSystem.isx86_64 [ prevStage.darwin.Csu ]
           ++ (with prevStage.darwin; [
+            libcxx
             libiconv.out
             libresolv.out
             libsbuf.out
@@ -1172,8 +1182,6 @@ assert bootstrapTools.passthru.isFromBootstrapFiles or false; # sanity check
             (lib.getLib clang-unwrapped)
             compiler-rt
             compiler-rt.dev
-            libcxx
-            libcxx.dev
             lld
             llvm
             llvm.lib
@@ -1268,7 +1276,6 @@ assert bootstrapTools.passthru.isFromBootstrapFiles or false; # sanity check
 
     assert isBuiltByNixpkgsCompiler prevStage.llvmPackages.clang-unwrapped;
     assert isBuiltByNixpkgsCompiler prevStage.llvmPackages.libllvm;
-    assert isBuiltByNixpkgsCompiler prevStage.llvmPackages.libcxx;
     assert isBuiltByNixpkgsCompiler prevStage.llvmPackages.compiler-rt;
 
     # Make sure these evaluate since they were disabled explicitly in the bootstrap.

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -1911,6 +1911,7 @@ mapAliases {
   oraclejdk11 = throw "All Oracle JDKs and JREs were dropped due to being unmaintained and heavily insecure. OpenJDK provides compatible replacements for JDKs and JREs."; # Added 2024-11-01
   OSCAR = oscar; # Added 2024-06-12
   osxfuse = throw "'osxfuse' has been renamed to/replaced by 'macfuse-stubs'"; # Converted to throw 2024-10-17
+  overrideLibcxx = "overrideLibcxx has beeen removed, as it was no longer used and Darwin now uses libc++ from the latest SDK; see the Nixpkgs 25.11 release notes for details"; # Added 2025-09-15
   overrideSDK = "overrideSDK has been removed as it was a legacy compatibility stub. See <https://nixos.org/manual/nixpkgs/stable/#sec-darwin-legacy-frameworks-overrides> for migration instructions"; # Added 2025-08-04
   ovn-lts = throw "ovn-lts has been removed. Please use the latest version available under ovn"; # Added 2024-08-24
   oxygen-icons5 = throw ''

--- a/pkgs/top-level/darwin-packages.nix
+++ b/pkgs/top-level/darwin-packages.nix
@@ -101,6 +101,8 @@ makeScopeWithSplicing' {
 
         libunwind = callPackage ../os-specific/darwin/libunwind { };
 
+        libcxx = callPackage ../os-specific/darwin/libcxx { };
+
         sigtool = callPackage ../os-specific/darwin/sigtool { };
 
         signingUtils = callPackage ../os-specific/darwin/signing-utils { };


### PR DESCRIPTION
Darwin currently uses libc++ from nixpkgs, but it probably shouldn’t (at least not by default). The libc++ that is built in nixpkgs comes from LLVM. [According][1] to Louis Dionne (of Apple and a member of the C++ committee), the libc++ shipped by Apple should be considered distinct from the libc++ in LLVM. We’ve been lucky that we have not had problems with ODR violations. This PR was prompted by leakage of symbols from the system libc++ that started happening with the release of macOS 15.4. It changes a number of things to improve the compatibility of C++ on Darwin.

* It makes the system libc++ the default C++. The Darwin bootstrap is built against it. The default stdenv uses it. This is done by making the libc++ headers and text-based stubs available from the 15.2 SDK. This is safe to do because using symbols that are not available on your deployment target results in a compile-time error.

### Testing

I also confirmed that all of the packages updated in this PR built (except for servo, which is broken due to Darwin having a case-insensitive build location), that Qt 5 and opencv4 built on x86_64-darwin, and that my [configs](https://github.com/reckenrode/nixos-configs) built (except for util-linux, which appears broken again on Darwin).

## Breaking Change

The primary points of breakage are as follows:

* Packages (such as Bazel and MoltenVK) that work around [#150655](https://github.com/NixOS/nixpkgs/issues/150655) by referencing `libcxx` should instead reference `stdenv.cc.libcxx`. (Those are also fixed in this PR.)
* The system libc++ expects Clang 16 or newer (due to libc++ support policies). To build with an older Clang, you need to override the SDK used by libc++ to make it use older libc++ headers.
* `overrideLibcxx` doesn’t work with the system libc++. If you really need to use it, you should use it with `llvmPackages.libcxxStdenv`.

# Notes about fixed packages

* Several packages depend on qt6.qtdeclarative, but it doesn’t build. Fixed in [#398849](https://github.com/NixOS/nixpkgs/pull/398849).
* python3Packages.py3exid2 looks for Boost in `/usr/local/lib`. Fixed in [#399005](https://github.com/NixOS/nixpkgs/pull/399005).

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
[1]: https://discourse.llvm.org/t/apples-libc-now-provides-std-type-descriptor-t-functionality-not-found-in-upstream-libc/73881/3