### PR TITLE
mimir: Fix Darwin builds.

### DIFF
--- a/pkgs/by-name/mi/mimir/package.nix
+++ b/pkgs/by-name/mi/mimir/package.nix
@@ -30,7 +30,7 @@ buildGoModule rec {
       "delete-objects"
       "list-deduplicated-blocks"
       "listblocks"
-      "markblocks"
+      "mark-blocks"
       "undelete-blocks"
     ]);
 
@@ -51,7 +51,6 @@ buildGoModule rec {
       t = "github.com/grafana/mimir/pkg/util/version";
     in
     [
-      ''-extldflags "-static"''
       "-s"
       "-w"
       "-X ${t}.Version=${version}"


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Fixes https://github.com/NixOS/nixpkgs/issues/398744.

Disable static linking to fix Darwin builds. Also switching `tools/markblocks` to `tools/mark-blocks` since it was migrated upstream ([ref](https://github.com/grafana/mimir/tree/00db0fb4b22ed009493b66e16ce74b3088c76bc3/tools/markblocks)).

2.15.1 was working fine on Darwin with the `-static` flag, but 2.16.0 caused Darwin builds to break for some reason.

Tested on an `aarch64-darwin` system.

`nix-build -A nesting`

```console
this derivation will be built:
  /nix/store/fvv04gbv3najw10pw571p7jndbysf4zg-mimir-2.16.0.drv
building '/nix/store/fvv04gbv3najw10pw571p7jndbysf4zg-mimir-2.16.0.drv'...
Running phase: unpackPhase
unpacking source archive /nix/store/7kr5dcyxj7z423rfm4cqvmzlaqm3abf7-source
source root is source
unpackPhase completed in 45 seconds
Running phase: patchPhase
Running phase: updateAutotoolsGnuConfigScriptsPhase
Running phase: configurePhase
Running phase: buildPhase
Building subPackage ./cmd/mimir
Building subPackage ./cmd/mimirtool
Building subPackage ./tools/compaction-planner
Building subPackage ./tools/copyblocks
Building subPackage ./tools/copyprefix
Building subPackage ./tools/delete-objects
Building subPackage ./tools/list-deduplicated-blocks
Building subPackage ./tools/listblocks
Building subPackage ./tools/mark-blocks
Building subPackage ./tools/undelete-blocks
buildPhase completed in 56 seconds
Running phase: checkPhase
ok      github.com/grafana/mimir/cmd/mimir      1.019s
?       github.com/grafana/mimir/cmd/mimirtool  [no test files]
?       github.com/grafana/mimir/tools/compaction-planner       [no test files]
?       github.com/grafana/mimir/tools/copyblocks       [no test files]
?       github.com/grafana/mimir/tools/copyprefix       [no test files]
?       github.com/grafana/mimir/tools/delete-objects   [no test files]
?       github.com/grafana/mimir/tools/list-deduplicated-blocks [no test files]
?       github.com/grafana/mimir/tools/listblocks       [no test files]
ok      github.com/grafana/mimir/tools/mark-blocks      0.388s
ok      github.com/grafana/mimir/tools/undelete-blocks  0.390s
checkPhase completed in 43 seconds
Running phase: installPhase
Running phase: fixupPhase
checking for references to /private/tmp/nix-build-mimir-2.16.0.drv-0/ in /nix/store/bcsp9dic7fx70n7fp2fzgg5bzq0hcy3d-mimir-2.16.0...
patching script interpreter paths in /nix/store/bcsp9dic7fx70n7fp2fzgg5bzq0hcy3d-mimir-2.16.0
stripping (with command strip and flags -S) in  /nix/store/bcsp9dic7fx70n7fp2fzgg5bzq0hcy3d-mimir-2.16.0/bin
/nix/store/bcsp9dic7fx70n7fp2fzgg5bzq0hcy3d-mimir-2.16.0
```

`tree /nix/store/bcsp9dic7fx70n7fp2fzgg5bzq0hcy3d-mimir-2.16.0`

```console
/nix/store/bcsp9dic7fx70n7fp2fzgg5bzq0hcy3d-mimir-2.16.0
└── bin
    ├── compaction-planner
    ├── copyblocks
    ├── copyprefix
    ├── delete-objects
    ├── list-deduplicated-blocks
    ├── listblocks
    ├── mark-blocks
    ├── mimir
    ├── mimirtool
    └── undelete-blocks
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
