### PR TITLE
gowall: 0.2.0 > 0.2.1

### DIFF
--- a/pkgs/by-name/go/gowall/package.nix
+++ b/pkgs/by-name/go/gowall/package.nix
@@ -4,6 +4,7 @@
   buildGoModule,
   fetchFromGitHub,
   installShellFiles,
+  nix-update-script,
 }:
 
 buildGoModule rec {
@@ -29,6 +30,8 @@ buildGoModule rec {
       --fish <($out/bin/gowall completion fish) \
       --zsh <($out/bin/gowall completion zsh)
   '';
+
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     changelog = "https://github.com/Achno/gowall/releases/tag/v${version}";

--- a/pkgs/by-name/go/gowall/package.nix
+++ b/pkgs/by-name/go/gowall/package.nix
@@ -21,6 +21,9 @@ buildGoModule rec {
 
   nativeBuildInputs = [ installShellFiles ];
   postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+    export HOME=$TMPDIR
+    mkdir -p $HOME/.config
+
     installShellCompletion --cmd gowall \
       --bash <($out/bin/gowall completion bash) \
       --fish <($out/bin/gowall completion fish) \

--- a/pkgs/by-name/go/gowall/package.nix
+++ b/pkgs/by-name/go/gowall/package.nix
@@ -8,16 +8,16 @@
 
 buildGoModule rec {
   pname = "gowall";
-  version = "0.2.0";
+  version = "0.2.1";
 
   src = fetchFromGitHub {
     owner = "Achno";
     repo = "gowall";
     rev = "v${version}";
-    hash = "sha256-QKukWA8TB0FoNHu0Wyco55x4oBY+E33qdoT/SaXW6DE=";
+    hash = "sha256-fgO4AoyHR51zD86h75b06BXV0ONlFfHdBvxfJvcD7J8=";
   };
 
-  vendorHash = "sha256-H2Io1K2LEFmEPJYVcEaVAK2ieBrkV6u+uX82XOvNXj4=";
+  vendorHash = "sha256-V/VkbJZIzy4KlEPtlTTqdUIPG6lKD+XidNM0NWpATbk=";
 
   nativeBuildInputs = [ installShellFiles ];
   postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''


### PR DESCRIPTION
Updated gowall from 0.2.0 to 0.2.1, added update-script & fixed issue when build:

Issue related to this:

```bash
2025/04/15 04:48:10 Error: Could not create config directory: mkdir /homeless-shelter: permission denied
2025/04/15 04:48:10 Error: Could not create config directory: mkdir /homeless-shelter: permission denied
2025/04/15 04:48:10 Error: Could not create config directory: mkdir /homeless-shelter: permission denied
ERROR: installShellCompletion: installShellCompletion: installed shell completion file `/nix/store/b3ncxdb2g0627kch93vh805531j24fqc-gowall-0.2.1/share/bash-completion/completions/gowall.bash' does not exist or has zero size
```

Key changes:

Build Inputs:
* Added `nix-update-script` to the list of build inputs.

Post-Installation Script:
* Added commands to set up the HOME directory and create a `.config` directory during the post-installation.

Additional Metadata:
* Added `passthru.updateScript` to include the `nix-update-script` function.

## Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).