### PR TITLE
encrypted-dns-server: init at 0.9.16

### DIFF
--- a/pkgs/by-name/en/encrypted-dns-server/package.nix
+++ b/pkgs/by-name/en/encrypted-dns-server/package.nix
@@ -1,0 +1,46 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  pkg-config,
+  libsodium,
+  nix-update-script,
+  versionCheckHook,
+}:
+rustPlatform.buildRustPackage rec {
+  pname = "encrypted-dns-server";
+  version = "0.9.16";
+
+  src = fetchFromGitHub {
+    owner = "DNSCrypt";
+    repo = "encrypted-dns-server";
+    tag = version;
+    hash = "sha256-llBMOqmxEcysoBsRg5s1uqCyR6+ilTgBI7BaeSDVoEw=";
+  };
+
+  cargoHash = "sha256-33XcfiktgDG34aamw8X3y0QkybVENUJxLhx47WZUpFc=";
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [ libsodium ];
+
+  env = {
+    SODIUM_USE_PKG_CONFIG = true;
+  };
+
+  passthru.updateScript = nix-update-script { };
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+  versionCheckProgram = "${placeholder "out"}/bin/encrypted-dns";
+  versionCheckProgramArg = "--version";
+
+  meta = {
+    changelog = "https://github.com/DNSCrypt/encrypted-dns-server/releases/tag/${version}";
+    description = "An easy to install, high-performance, zero maintenance proxy to run an encrypted DNS server";
+    homepage = "https://github.com/DNSCrypt/encrypted-dns-server";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ paepcke ];
+    mainProgram = "encrypted-dns";
+  };
+}


### PR DESCRIPTION
https://github.com/DNSCrypt/encrypted-dns-server 

The (rust) server allows to (self-) host following protocols:
 - DNSCrypt v2
 - Anonymized DNSCrypt
 - DNS-over-HTTP (DoH) forwarding

Package 
 - [X] has build/version check hooks
 - [X] has auto update hooks
 - [X] produces one static (runtime) dependency free package 
 
Next step, after approval: services.encrypted-dns-server.[*] systemd integration
Upstream Project has >1k gh stars, well established since 2019, rust, toml config => perfect fit for nixos.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [X] `sandbox = true`
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
