### PR TITLE
kubectl-rook-ceph: init at 0.9.3

### DIFF
--- a/pkgs/by-name/ku/kubectl-rook-ceph/package.nix
+++ b/pkgs/by-name/ku/kubectl-rook-ceph/package.nix
@@ -1,0 +1,52 @@
+{
+  buildGoModule,
+  fetchFromGitHub,
+  lib,
+  nix-update-script,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "kubectl-rook-ceph";
+  version = "0.9.3";
+
+  src = fetchFromGitHub {
+    owner = "rook";
+    repo = "kubectl-rook-ceph";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-stWuRej3ogGETLzVabMRfakoK358lJbK56/hjBh2k2M=";
+  };
+
+  vendorHash = "sha256-fB3S946nv1uH9blek6w2EmmYYcdnBcEbmYELfPH9A04=";
+
+  postInstall = ''
+    mv $out/bin/cmd $out/bin/kubectl-rook-ceph
+  '';
+  # FIXME: uncomment once https://github.com/rook/kubectl-rook-ceph/issues/353 has been resolved
+  # nativeBuildInputs = [ installShellFiles ];
+  # postInstall =
+  #   ''
+  #     ln -s $out/bin/cmd $out/bin/kubectl-rook-ceph
+  #   ''
+  #   + lib.optionalString (stdenv.hostPlatform.emulatorAvailable buildPackages) (
+  #     let
+  #       emulator = stdenv.hostPlatform.emulator buildPackages;
+  #     in
+  #     ''
+  #       installShellCompletion --cmd kubectl-rook-ceph \
+  #       --bash <(${emulator} $out/bin/kubectl-rook-ceph completion bash) \
+  #       --fish <(${emulator} $out/bin/kubectl-rook-ceph completion fish) \
+  #       --zsh <(${emulator} $out/bin/kubectl-rook-ceph completion zsh)
+  #     ''
+  #   );
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Krew plugin to run kubectl commands with rook-ceph";
+    mainProgram = "kubectl-rook-ceph";
+    homepage = "https://github.com/rook/kubectl-rook-ceph";
+    changelog = "https://github.com/rook/kubectl-rook-ceph/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ vinylen ];
+  };
+})


### PR DESCRIPTION
Add krew plugin kubectl-rook-ceph at version 0.9.3

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
