### PR TITLE
Add basic x32 support

### DIFF
--- a/lib/systems/default.nix
+++ b/lib/systems/default.nix
@@ -96,6 +96,7 @@ let
           canExecute =
             platform:
             final.isAndroid == platform.isAndroid
+            && final.isX32 == platform.isX32 # Not default enabled
             && parse.isCompatible final.parsed.cpu platform.parsed.cpu
             && final.parsed.kernel == platform.parsed.kernel;
           isCompatible =
@@ -162,7 +163,12 @@ let
           # for this platform normally assume.
           libDir =
             if final.isLinux then
-              if final.isx86_64 || final.isMips64 || final.isPower64 then "lib64" else "lib"
+              if final.isX32 then
+                "libx32"
+              else if final.isx86_64 || final.isMips64 || final.isPower64 then
+                "lib64"
+              else
+                "lib"
             else
               null;
           extensions =

--- a/lib/systems/doubles.nix
+++ b/lib/systems/doubles.nix
@@ -180,6 +180,10 @@ in
     ++ filterDoubles (matchAttrs {
       kernel = parse.kernels.linux;
       abi = parse.abis.gnuabielfv2;
+    })
+    ++ filterDoubles (matchAttrs {
+      kernel = parse.kernels.linux;
+      abi = parse.abis.gnux32;
     });
   illumos = filterDoubles predicates.isSunOS;
   linux = filterDoubles predicates.isLinux;

--- a/lib/systems/inspect.nix
+++ b/lib/systems/inspect.nix
@@ -53,6 +53,11 @@ rec {
         bits = 64;
       };
     };
+    isX32 = {
+      abi = {
+        abi = "x32";
+      };
+    };
     isPower = {
       cpu = {
         family = "power";
@@ -369,6 +374,7 @@ rec {
         gnueabihf
         gnuabielfv1
         gnuabielfv2
+        gnux32
       ];
     isMusl =
       with abis;
@@ -378,6 +384,7 @@ rec {
         musleabihf
         muslabin32
         muslabi64
+        muslx32
       ];
     isUClibc =
       with abis;

--- a/lib/systems/parse.nix
+++ b/lib/systems/parse.nix
@@ -711,6 +711,13 @@ rec {
       abi = "n32";
     };
 
+    gnux32 = {
+      abi = "x32";
+    };
+    muslx32 = {
+      abi = "x32";
+    };
+
     gnuabielfv2 = {
       abi = "elfv2";
     };

--- a/pkgs/build-support/bintools-wrapper/default.nix
+++ b/pkgs/build-support/bintools-wrapper/default.nix
@@ -141,6 +141,8 @@ let
       "${sharedLibraryLoader}/libexec/ld.elf_so"
     else if targetPlatform.system == "i686-linux" then
       "${sharedLibraryLoader}/lib/ld-linux.so.2"
+    else if targetPlatform.isX32 then
+      "${sharedLibraryLoader}/lib/ld-linux-x32.so.2"
     else if targetPlatform.system == "x86_64-linux" then
       "${sharedLibraryLoader}/lib/ld-linux-x86-64.so.2"
     else if targetPlatform.system == "s390x-linux" then

--- a/pkgs/build-support/setup-hooks/move-libx32.sh
+++ b/pkgs/build-support/setup-hooks/move-libx32.sh
@@ -1,0 +1,17 @@
+# This setup hook is like _moveLib64 but it's for libx32
+
+fixupOutputHooks+=(_moveLibx32)
+
+_moveLibx32() {
+    if [ "${dontMoveLibx32-}" = 1 ]; then return; fi
+    if [ ! -e "$prefix/libx32" -o -L "$prefix/libx32" ]; then return; fi
+    echo "moving $prefix/libx32/* to $prefix/lib"
+    mkdir -p $prefix/lib
+    shopt -s dotglob
+    for i in $prefix/libx32/*; do
+        mv --no-clobber "$i" $prefix/lib
+    done
+    shopt -u dotglob
+    rmdir $prefix/libx32
+    ln -s lib $prefix/libx32
+}

--- a/pkgs/development/compilers/gcc/common/builder.nix
+++ b/pkgs/development/compilers/gcc/common/builder.nix
@@ -259,12 +259,18 @@ originalAttrs:
           makeCompatibilitySymlink lib lib32
           makeCompatibilitySymlink lib lib64
         ''
+      + lib.optionalString stdenv.targetPlatform.isX32 ''
+        makeCompatibilitySymlink lib libx32
+      ''
       +
         # This will redirect $output/$targetConfig/lib{,32,64} to $output/$targetConfig/lib.
         lib.optionalString isCross ''
           makeCompatibilitySymlink lib $targetConfig/lib32
           makeCompatibilitySymlink lib $targetConfig/lib64
-        '';
+        ''
+      + lib.optionalString stdenv.targetPlatform.isX32 ''
+        makeCompatibilitySymlink lib $targetConfig/libx32
+      '';
 
     postInstall =
       ''

--- a/pkgs/stdenv/generic/default.nix
+++ b/pkgs/stdenv/generic/default.nix
@@ -84,6 +84,9 @@ let
           ../../build-support/setup-hooks/set-source-date-epoch-to-latest.sh
           ../../build-support/setup-hooks/strip.sh
         ]
+        ++ lib.optionals hostPlatform.isX32 [
+          ../../build-support/setup-hooks/move-libx32.sh
+        ]
         ++ lib.optionals hasCC [ cc ];
 
       defaultBuildInputs = extraBuildInputs;

--- a/pkgs/top-level/stage.nix
+++ b/pkgs/top-level/stage.nix
@@ -100,11 +100,13 @@ let
             gnuabi64 = lib.systems.parse.abis.muslabi64;
             gnuabielfv2 = lib.systems.parse.abis.musl;
             gnuabielfv1 = lib.systems.parse.abis.musl;
+            gnux32 = lib.systems.parse.abis.muslx32;
             # The following two entries ensure that this function is idempotent.
             musleabi = lib.systems.parse.abis.musleabi;
             musleabihf = lib.systems.parse.abis.musleabihf;
             muslabin32 = lib.systems.parse.abis.muslabin32;
             muslabi64 = lib.systems.parse.abis.muslabi64;
+            muslx32 = lib.systems.parse.abis.muslx32;
           }
           .${parsed.abi.name} or lib.systems.parse.abis.musl;
       }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Add enough support for `gnux32` and `muslx32` so that hello crosses at least for `x86_64-unknown-linux-gnux32`. (**edit**: `x86_64-unknown-linux-{gnu,musl}x32` both work)

To run the built program, get a x86_64 machine and rebuild your Linux with `CONFIG_X86_X32_ABI=y`. On NixOS that would be:

```
{ lib, ... }:

{
  boot.kernelPatches = [
    {
      patch = null;
      extraStructuredConfig = with lib.kernel; {
        X86_X32_ABI = yes;
      };
    }
  ];
}
```

## Decisions and bikesheds:

- What do we do with `libx32`? Add `move-libx32.sh`?
- What do we do with `canExecute`? `CONFIG_X86_X32_ABI` is disabled by default
- `isX32`? `isx32`? `isx32Abi`?

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux (`hello` on `(build = x86_64-unknown-linux-gnu, host = x86_64-unknown-linux-{gnu,musl}x32)`)
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [X] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
