### PR TITLE
dprint-plugins: getPluginList helper

### DIFF
--- a/pkgs/by-name/dp/dprint/plugins/default.nix
+++ b/pkgs/by-name/dp/dprint/plugins/default.nix
@@ -1,4 +1,8 @@
-{ lib, fetchurl }:
+{
+  lib,
+  fetchurl,
+  stdenv,
+}:
 let
   mkDprintPlugin =
     {
@@ -12,28 +16,32 @@ let
       license ? lib.licenses.mit,
       maintainers ? [ lib.maintainers.phanirithvij ],
     }:
-    fetchurl {
-      inherit
-        hash
-        url
-        pname
-        version
-        ;
-      name = "${pname}-${version}.wasm";
+    stdenv.mkDerivation (finalAttrs: {
+      inherit pname version;
+      src = fetchurl { inherit url hash; };
+      dontUnpack = true;
       meta = {
-        inherit
-          description
-          license
-          maintainers
-          ;
+        inherit description license maintainers;
       };
+      /*
+        in the dprint configuration
+        dprint expects a plugin path to end with .wasm extension
+
+        for auto update with nixpkgs-update to work
+        we cannot have .wasm extension at the end in the nix store path
+      */
+      buildPhase = ''
+        mkdir -p $out
+        cp $src $out/plugin.wasm
+      '';
       passthru = {
         updateScript = ./update-plugins.py;
         inherit initConfig updateUrl;
       };
-    };
+    });
   inherit (lib)
     filterAttrs
+    isDerivation
     mapAttrs'
     nameValuePair
     removeSuffix
@@ -45,5 +53,13 @@ let
     name: _:
     nameValuePair (removeSuffix ".nix" name) (import (./. + "/${name}") { inherit mkDprintPlugin; })
   ) files;
+  # Expects a function that receives the dprint plugin set as an input
+  # and returns a list of plugins
+  # Example:
+  # pkgs.dprint-plugins.getPluginList (plugins: [
+  #   plugins.dprint-plugin-toml
+  #   (pkgs.callPackage ./dprint/plugins/sample.nix {})
+  # ]
+  getPluginList = cb: map (p: "${p}/plugin.wasm") (cb plugins);
 in
-plugins // { inherit mkDprintPlugin; }
+plugins // { inherit mkDprintPlugin getPluginList; }

--- a/pkgs/by-name/dp/dprint/plugins/update-plugins.py
+++ b/pkgs/by-name/dp/dprint/plugins/update-plugins.py
@@ -29,11 +29,9 @@ else:
 
 
 # get sri hash for a url, no unpack
-def nix_prefetch_url(url, name, algo="sha256"):
+def nix_prefetch_url(url, algo="sha256"):
     hash = (
-        subprocess.check_output(
-            ["nix-prefetch-url", "--type", algo, "--name", name, url]
-        )
+        subprocess.check_output(["nix-prefetch-url", "--type", algo, url])
         .decode("utf-8")
         .rstrip()
     )
@@ -119,7 +117,7 @@ def update_plugin_by_name(name):
     data = requests.get(p["updateUrl"]).json()
     p["url"] = data["url"]
     p["version"] = data["version"]
-    p["hash"] = nix_prefetch_url(data["url"], f"{name}-{data["version"]}.wasm")
+    p["hash"] = nix_prefetch_url(data["url"])
 
     write_plugin_derivation(p)
 
@@ -136,7 +134,7 @@ def update_plugins():
             pname = pname.replace("/", "-")
         drv_attrs = {
             "url": e["url"],
-            "hash": nix_prefetch_url(e["url"], f"{pname}-{e["version"]}.wasm"),
+            "hash": nix_prefetch_url(e["url"]),
             "updateUrl": update_url,
             "pname": pname,
             "version": e["version"],


### PR DESCRIPTION
Follow up to #395998

- `dprint-plugins.getPluginList` is a helper function which allows outside consumers to easily use the official plugins
- [x] tests
  - [x] nixpkgs-update works
  - [x] dprint-plugins.getPluginList works
- [x] how to make the users aware of these functions? document this where?
   - [x] documenting in treefmt-nix's dprint plugins example. see https://github.com/numtide/treefmt-nix/pull/341

### To test manually

<details open><summary>treefmt.nix</summary>

```nix
{ pkgs }: {
  projectRootFile = "shell.nix";
  programs.dprint = {
    enable = true;
    settings = {
      plugins = pkgs.dprint-plugins.getPluginList (
        dps: with dps; [
          dprint-plugin-json
          dprint-plugin-markdown
          dprint-plugin-toml
          g-plane-pretty_yaml
        ]
      );
    };
  };
}
```
</details>

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---
cc @kachick @zimbatm 

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
