### PR TITLE
nixosTests.gitlab: fix

### DIFF
--- a/nixos/tests/gitlab.nix
+++ b/nixos/tests/gitlab.nix
@@ -249,7 +249,7 @@ in
           with subtest("Setup Git and SSH for Alice"):
               gitlab.succeed("git config --global user.name Alice")
               gitlab.succeed("git config --global user.email alice@nixos.invalid")
-              gitlab.succeed("mkdir -m 700 /root/.ssh")
+              gitlab.succeed("mkdir -p -m 700 /root/.ssh")
               gitlab.succeed("cat ${snakeOilPrivateKey} > /root/.ssh/id_ecdsa")
               gitlab.succeed("chmod 600 /root/.ssh/id_ecdsa")
               gitlab.succeed(


### PR DESCRIPTION
Not sure why the .ssh folder already exists by now, but this fixes it for now and makes sure it won't regress if the folder does not exist anymore.



## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
