### PR TITLE
modules: Add `_prefix` module argument, improve error, add docs

### DIFF
--- a/doc/module-system/module-system.chapter.md
+++ b/doc/module-system/module-system.chapter.md
@@ -122,43 +122,39 @@ Module arguments are the attribute values passed to modules when they are evalua
 
 They originate from these sources:
 1. Built-in arguments
-  - `lib`,
-  - `config`,
-  - `options`,
-  - `_class`,
-  - `_prefix`,
+    - `lib`,
+    - `config`,
+    - `options`,
+    - `_class`,
+    - `_prefix`,
 2. Attributes from the [`specialArgs`] argument passed to [`evalModules`] or `submoduleWith`. These are application-specific.
 3. Attributes from the `_module.args` option value. These are application-specific and can be provided by any module.
 
 The prior two categories are available while evaluating the `imports`, whereas
 the last category is only available after the `imports` have been resolved.
 
-### `lib` {#module-system-module-argument-lib}
+[`lib`]{#module-system-module-argument-lib} [🔗](#module-system-module-argument-lib)
+: A reference to the Nixpkgs library.
 
-A reference to the Nixpkgs library.
+[`config`]{#module-system-module-argument-config} [🔗](#module-system-module-argument-config)
+: All option values.
+  Unlike the `evalModules` [`config` return attribute](#module-system-lib-evalModules-return-value-config), this includes `_module`.
 
-### `config` {#module-system-module-argument-config}
+[`options`]{#module-system-module-argument-options} [🔗](#module-system-module-argument-options)
+: All evaluated option declarations.
 
-All option values.
-Unlike the `evalModules` [`config` return attribute](#module-system-lib-evalModules-return-value-config), this includes `_module`.
+[`_class`]{#module-system-module-argument-_class} [🔗](#module-system-module-argument-_class)
+: The [expected class](#module-system-lib-evalModules-param-class) of the loaded modules.
 
-### `options` {#module-system-module-argument-options}
+[`_prefix`]{#module-system-module-argument-_prefix} [🔗](#module-system-module-argument-_prefix)
+: The location under which the module is evaluated.
+  This is used to improve error reporting and to find the implicit `name` module argument in submodules.
+  It is exposed as a module argument due to how the module system is implemented, which cannot be avoided without breaking compatibility.
 
-All evaluated option declarations.
+  It is a good practice not to rely on `_prefix`. A module should not make assumptions about its location in the configuration tree.
+  For example, the root of a NixOS configuration may have a non-empty prefix, for example when it is a specialisation, or when it is part of a larger, multi-host configuration such as a [NixOS test](https://nixos.org/manual/nixos/unstable/#sec-nixos-tests).
+  Instead of depending on `_prefix` use explicit options, whose default definitions can be provided by the module that imports them.
 
-### `_class` {#module-system-module-argument-_class}
-
-The [expected class](#module-system-lib-evalModules-param-class) of the loaded modules.
-
-### `_prefix` {#module-system-module-argument-_prefix}
-
-The location under which the module is evaluated.
-This is used to improve error reporting and to find the implicit `name` module argument in submodules.
-It is exposed as a module argument due to how the module system is implemented, which cannot be avoided without breaking compatibility.
-
-It is a good practice not to rely on `_prefix`. A module should not make assumptions about its location in the configuration tree.
-For example, the root of a NixOS configuration may have a non-empty prefix, for example when it is a specialisation, or when it is part of a larger, multi-host configuration such as a [NixOS test](https://nixos.org/manual/nixos/unstable/#sec-nixos-tests).
-Instead of depending on `_prefix` use explicit options, whose default definitions can be provided by the module that imports them.
-
+<!-- markdown link aliases -->
 [`evalModules`]: #module-system-lib-evalModules
 [`specialArgs`]: #module-system-lib-evalModules-param-specialArgs

--- a/doc/module-system/module-system.chapter.md
+++ b/doc/module-system/module-system.chapter.md
@@ -127,7 +127,7 @@ They originate from these sources:
   - `options`,
   - `_class`,
   - `_prefix`,
-2. Attributes from the [`specialArgs`] which were passed to [`evalModules`] or `submoduleWith`. These are application-specific.
+2. Attributes from the [`specialArgs`] argument passed to [`evalModules`] or `submoduleWith`. These are application-specific.
 3. Attributes from the `_module.args` option value. These are application-specific and can be provided by any module.
 
 The prior two categories are available while evaluating the `imports`, whereas
@@ -152,11 +152,13 @@ The [expected class](#module-system-lib-evalModules-param-class) of the loaded m
 
 ### `_prefix` {#module-system-module-argument-_prefix}
 
-The location under which the module is evaluated. This is used to improve error reporting and find the implicit `name` module argument in submodules.
+The location under which the module is evaluated.
+This is used to improve error reporting and to find the implicit `name` module argument in submodules.
+It is exposed as a module argument due to how the module system is implemented, which cannot be avoided without breaking compatibility.
 
 It is a good practice not to rely on `_prefix`. A module should not make assumptions about its location in the configuration tree.
 For example, the root of a NixOS configuration may have a non-empty prefix, for example when it is a specialisation, or when it is part of a larger, multi-host configuration such as a [NixOS test](https://nixos.org/manual/nixos/unstable/#sec-nixos-tests).
-Any dependencies on `_prefix` should be replaced with explicit options, whose default definitions can be provided by the module that imports them.
+Instead of depending on `_prefix` use explicit options, whose default definitions can be provided by the module that imports them.
 
 [`evalModules`]: #module-system-lib-evalModules
 [`specialArgs`]: #module-system-lib-evalModules-param-specialArgs

--- a/doc/module-system/module-system.chapter.md
+++ b/doc/module-system/module-system.chapter.md
@@ -115,3 +115,48 @@ A nominal type marker, always `"configuration"`.
 #### `class` {#module-system-lib-evalModules-return-value-_configurationClass}
 
 The [`class` argument](#module-system-lib-evalModules-param-class).
+
+## Module arguments {#module-system-module-arguments}
+
+Module arguments are the attribute values passed to modules when they are evaluated.
+
+They originate from these sources:
+1. Built-in arguments
+  - `lib`,
+  - `config`,
+  - `options`,
+  - `_class`,
+  - `_prefix`,
+2. Attributes from the [`specialArgs`] which were passed to [`evalModules`] or `submoduleWith`. These are application-specific.
+3. Attributes from the `_module.args` option value. These are application-specific and can be provided by any module.
+
+The prior two categories are available while evaluating the `imports`, whereas
+the last category is only available after the `imports` have been resolved.
+
+### `lib` {#module-system-module-argument-lib}
+
+A reference to the Nixpkgs library.
+
+### `config` {#module-system-module-argument-config}
+
+All option values.
+Unlike the `evalModules` [`config` return attribute](#module-system-lib-evalModules-return-value-config), this includes `_module`.
+
+### `options` {#module-system-module-argument-options}
+
+All evaluated option declarations.
+
+### `_class` {#module-system-module-argument-_class}
+
+The [expected class](#module-system-lib-evalModules-param-class) of the loaded modules.
+
+### `_prefix` {#module-system-module-argument-_prefix}
+
+The location under which the module is evaluated. This is used to improve error reporting and find the implicit `name` module argument in submodules.
+
+It is a good practice not to rely on `_prefix`. A module should not make assumptions about its location in the configuration tree.
+For example, the root of a NixOS configuration may have a non-empty prefix, for example when it is a specialisation, or when it is part of a larger, multi-host configuration such as a [NixOS test](https://nixos.org/manual/nixos/unstable/#sec-nixos-tests).
+Any dependencies on `_prefix` should be replaced with explicit options, whose default definitions can be provided by the module that imports them.
+
+[`evalModules`]: #module-system-lib-evalModules
+[`specialArgs`]: #module-system-lib-evalModules-param-specialArgs

--- a/doc/redirects.json
+++ b/doc/redirects.json
@@ -4363,5 +4363,23 @@
   ],
   "sec-interop.cylonedx-fod": [
     "index.html#sec-interop.cylonedx-fod"
+  ],
+  "module-system-module-argument-_prefix": [
+    "index.html#module-system-module-argument-_prefix"
+  ],
+  "module-system-module-argument-lib": [
+    "index.html#module-system-module-argument-lib"
+  ],
+  "module-system-module-argument-config": [
+    "index.html#module-system-module-argument-config"
+  ],
+  "module-system-module-arguments": [
+    "index.html#module-system-module-arguments"
+  ],
+  "module-system-module-argument-_class": [
+    "index.html#module-system-module-argument-_class"
+  ],
+  "module-system-module-argument-options": [
+    "index.html#module-system-module-argument-options"
   ]
 }

--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -258,6 +258,7 @@ let
                     specialArgs
                     ;
                   _class = class;
+                  _prefix = prefix;
                 }
                 // specialArgs
               );

--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -2024,12 +2024,13 @@ let
           value,
           _type,
           expectedClass ? null,
+          prefix,
         }:
         paragraphs (
           [
             ''
               Expected a module, but found a value of type ${warn (escapeNixString _type)}${into_fallback_file_maybe fallbackFile}.
-              A module is typically loaded by adding it the ${code "imports = [ ... ];"} attribute of an existing module, or in the ${code "modules = [ ... ];"} argument of various functions.
+              A module is typically loaded by adding it to the ${code "imports = [ ... ];"} attribute of an existing module, or in the ${code "modules = [ ... ];"} argument of various functions.
               Please make sure that each of the list items is a module, and not a different kind of value.
             ''
           ]
@@ -2058,7 +2059,7 @@ let
                 '')
               ]
               ++ optionalMatch {
-                # We'll no more than 5 custom suggestions here.
+                # We'll add no more than 5 custom suggestions here.
                 # Please switch to `.modules.${class}` in your Module System application.
                 "nixos" = trim ''
                   or

--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -389,6 +389,7 @@ let
                 value = m;
                 _type = m._type;
                 expectedClass = class;
+                prefix = args._prefix;
               }
             )
         else if isList m then
@@ -1977,6 +1978,10 @@ let
           file != null && file != unknownModule
         ) ", while trying to load a module into ${toString file}";
 
+      into_prefix_maybe =
+        prefix:
+        optionalString (prefix != [ ]) ", while trying to load a module into ${code (showOption prefix)}";
+
       /**
         Format text with one line break between each list item.
       */
@@ -2029,7 +2034,7 @@ let
         paragraphs (
           [
             ''
-              Expected a module, but found a value of type ${warn (escapeNixString _type)}${into_fallback_file_maybe fallbackFile}.
+              Expected a module, but found a value of type ${warn (escapeNixString _type)}${into_fallback_file_maybe fallbackFile}${into_prefix_maybe prefix}.
               A module is typically loaded by adding it to the ${code "imports = [ ... ];"} attribute of an existing module, or in the ${code "modules = [ ... ];"} argument of various functions.
               Please make sure that each of the list items is a module, and not a different kind of value.
             ''

--- a/lib/tests/modules.sh
+++ b/lib/tests/modules.sh
@@ -606,6 +606,7 @@ checkConfigError 'Expected a module, but found a value of type .*"flake".*, whil
 checkConfigOutput '^true$' config.enable ./declare-enable.nix ./define-enable-with-top-level-mkIf.nix
 checkConfigError 'Expected a module, but found a value of type .*"configuration".*, while trying to load a module into .*/import-configuration.nix.' config ./import-configuration.nix
 checkConfigError 'please only import the modules that make up the configuration' config ./import-configuration.nix
+checkConfigError 'Expected a module, but found a value of type "configuration", while trying to load a module into .*/import-error-submodule.nix, while trying to load a module into .*foo.*\.' config.foo ./import-error-submodule.nix
 
 # doRename works when `warnings` does not exist.
 checkConfigOutput '^1234$' config.c.d.e ./doRename-basic.nix

--- a/lib/tests/modules.sh
+++ b/lib/tests/modules.sh
@@ -352,6 +352,9 @@ checkConfigOutput '^"submodule"$' options.submodule.type.description ./declare-s
 ## Paths should be allowed as values and work as expected
 checkConfigOutput '^true$' config.submodule.enable ./declare-submoduleWith-path.nix
 
+## _prefix module argument is available at import time and contains the prefix
+checkConfigOutput '^true$' config.foo.ok ./prefix-module-argument.nix
+
 ## deferredModule
 # default module is merged into nodes.foo
 checkConfigOutput '"beta"' config.nodes.foo.settingsDict.c ./deferred-module.nix

--- a/lib/tests/modules/import-error-submodule.nix
+++ b/lib/tests/modules/import-error-submodule.nix
@@ -1,0 +1,18 @@
+{ lib, ... }:
+let
+  myconf = lib.evalModules { modules = [ { } ]; };
+in
+{
+  options.foo = lib.mkOption {
+    type = lib.types.submodule { };
+    default = { };
+  };
+  config.foo =
+    { ... }:
+    {
+      imports = [
+        # error, like `import-configuration.nix`, but in a submodule this time
+        myconf
+      ];
+    };
+}

--- a/lib/tests/modules/prefix-module-argument.nix
+++ b/lib/tests/modules/prefix-module-argument.nix
@@ -1,0 +1,17 @@
+{ lib, ... }:
+{
+  options.foo = lib.mkOption {
+    type = lib.types.submodule { };
+    default = { };
+  };
+
+  config = {
+    foo =
+      { _prefix, ... }:
+      assert _prefix == [ "foo" ];
+      {
+        options.ok = lib.mkOption { };
+        config.ok = true;
+      };
+  };
+}


### PR DESCRIPTION
My main goal is to improve the error message, roughly:

```diff
 error: Expected a module, but found a value of type "nixops4ResourceType", while trying to load a module into /nix/store/bwhrd98iy2k10km9b7m7h2w6dwgslf66-source/example/flake.nix.
+, while trying to load a module into nixops4Deployments.default.resources.foo.
```

and of course it needs to include tests and documentation.

The `_prefix` module argument is somewhat of a consequence of having to bring this info to `collectModules` in a compatible way. I have documented why it's not a favored solution for modules.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
