### PR TITLE
python3Packages.ctranslate2: respect cudaSupport

### DIFF
--- a/pkgs/by-name/ct/ctranslate2/package.nix
+++ b/pkgs/by-name/ct/ctranslate2/package.nix
@@ -7,7 +7,8 @@
   llvmPackages, # openmp
   withMkl ? false,
   mkl,
-  withCUDA ? config.cudaSupport,
+  cudaSupport ? config.cudaSupport,
+  withCUDA ? cudaSupport,
   withCuDNN ? withCUDA && (cudaPackages ? cudnn),
   cudaPackages,
   # Enabling both withOneDNN and withOpenblas is broken
@@ -30,7 +31,7 @@ stdenv'.mkDerivation (finalAttrs: {
   pname = "ctranslate2";
   version = "4.8.1";
 
-  __strutcturedAttrs = true;
+  __structuredAttrs = true;
   strictDeps = true;
 
   src = fetchFromGitHub {

--- a/pkgs/development/python-modules/ctranslate2/default.nix
+++ b/pkgs/development/python-modules/ctranslate2/default.nix
@@ -18,14 +18,22 @@
   transformers,
   writableTmpDirAsHomeHook,
   wurlitzer,
+
+  config,
+  cudaSupport ? config.cudaSupport,
 }:
 
-buildPythonPackage rec {
-  inherit (ctranslate2-cpp) pname version src;
+let
+  ctranslate2-cpp' = ctranslate2-cpp.override { inherit cudaSupport; };
+in
+
+buildPythonPackage (finalAttrs: {
+  inherit (ctranslate2-cpp') pname version src;
   pyproject = true;
+  __structuredAttrs = true;
 
   # https://github.com/OpenNMT/CTranslate2/tree/master/python
-  sourceRoot = "${src.name}/python";
+  sourceRoot = "${finalAttrs.src.name}/python";
 
   postPatch = ''
     substituteInPlace pyproject.toml \
@@ -37,14 +45,18 @@ buildPythonPackage rec {
     setuptools
   ];
 
-  buildInputs = [ ctranslate2-cpp ];
+  buildInputs = [
+    ctranslate2-cpp'
+  ];
 
   dependencies = [
     numpy
     pyyaml
   ];
 
-  cmakeFlags = [ "-DCMAKE_POLICY_VERSION_MINIMUM=3.5" ];
+  cmakeFlags = [
+    # "-DCMAKE_POLICY_VERSION_MINIMUM=3.5"
+  ];
 
   pythonImportsCheck = [
     # https://opennmt.net/CTranslate2/python/overview.html
@@ -62,8 +74,8 @@ buildPythonPackage rec {
     wurlitzer
   ];
 
+  # run tests against build result, not sources
   preCheck = ''
-    # run tests against build result, not sources
     rm -rf ctranslate2
   '';
 
@@ -80,6 +92,7 @@ buildPythonPackage rec {
   disabledTestPaths = [
     # TODO: ModuleNotFoundError: No module named 'opennmt'
     "tests/test_opennmt_tf.py"
+
     # OSError: We couldn't connect to 'https://huggingface.co' to load this file
     "tests/test_transformers.py"
   ];
@@ -87,8 +100,8 @@ buildPythonPackage rec {
   meta = {
     description = "Fast inference engine for Transformer models";
     homepage = "https://github.com/OpenNMT/CTranslate2";
-    changelog = "https://github.com/OpenNMT/CTranslate2/blob/${src.rev}/CHANGELOG.md";
+    changelog = "https://github.com/OpenNMT/CTranslate2/blob/${finalAttrs.src.tag}/CHANGELOG.md";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ hexa ];
   };
-}
+})


### PR DESCRIPTION
- **python3Packages.ctranslate2: respect cudaSupport**
- **ctranslate2: remove with lib**

Test script using `python3Packages.faster-whisper`:

```python
from argparse import ArgumentParser
from pathlib import Path
from faster_whisper import WhisperModel

def main():
    parser = ArgumentParser(description="Roda modelo em arquivo")
    parser.add_argument('input', type=Path)
    args = parser.parse_args()
    assert args.input.is_file() and args.input.exists()

    model = WhisperModel('large-v3', device='cuda')
    segments, info = model.transcribe(args.input)
    print(info)
    print(segments)
    for segment in segments:
        print('[%.2fs -> %.2fs] %s' %(segment.start, segment.end, segment.text))

if __name__ == '__main__':
    main()
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
