### PR TITLE
keycloak: add extra build args for smoother overriding

### DIFF
--- a/pkgs/by-name/ke/keycloak/package.nix
+++ b/pkgs/by-name/ke/keycloak/package.nix
@@ -6,10 +6,17 @@
   jre_headless,
   nixosTests,
   callPackage,
+
+  # Keycloak config file to use for the build.
   confFile ? null,
+  # Extra plugins to add to the keycloak build.
   plugins ? [ ],
+  # Extra features to add in the keycloak build.
   extraFeatures ? [ ],
+  # Extra features to disable in the keycloak build.
   disabledFeatures ? [ ],
+  # Extra build arguments to the keycloak build.
+  extraBuildArgs ? [ ],
 }:
 
 let
@@ -21,6 +28,8 @@ let
       disabledFeatures != [ ]
     ) "--features-disabled=${lib.concatStringsSep "," disabledFeatures}"}
   '';
+
+  buildFlags = lib.concatStringsSep " " (map (s: "\'${s}\'") extraBuildArgs);
 in
 stdenv.mkDerivation rec {
   pname = "keycloak";
@@ -63,7 +72,7 @@ stdenv.mkDerivation rec {
       patchShebangs bin/kc.sh
       export KC_HOME_DIR=$(pwd)
       export KC_CONF_DIR=$(pwd)/conf
-      bin/kc.sh build ${featuresSubcommand}
+      bin/kc.sh build ${buildFlags} ${featuresSubcommand}
 
       runHook postBuild
     '';


### PR DESCRIPTION
- Add `extraBuildFlags` to keycloak's build command to be able to better control how to build keycloak when overriding it. This is forexample used in https://github.com/cachix/devenv/pull/1806.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
