### PR TITLE
lib: re-export missing builtins in lib

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -105,12 +105,23 @@ let
       # network
       network = callLibs ./network;
 
-      # TODO: For consistency, all builtins should also be available from a sub-library;
-      # these are the only ones that are currently not
       inherit (builtins)
         addErrorContext
-        isPath
+        getContext
+        hasContext
+        convertHash
+        hashString
+        hasFile
+        parseDrvName
+        placeholder
+        fromJSON
+        fromTOML
+        toFile
+        toJSON
+        toString
+        toXML
         trace
+        tryEval
         typeOf
         unsafeGetAttrPos
         ;
@@ -121,6 +132,8 @@ let
         concat
         or
         and
+        mul
+        div
         xor
         bitAnd
         bitOr
@@ -171,6 +184,8 @@ let
         pathExists
         genericClosure
         readFile
+        ceil
+        floor
         ;
       inherit (self.fixedPoints)
         fix
@@ -414,10 +429,13 @@ let
         getExe'
         ;
       inherit (self.filesystem)
-        pathType
+        baseNameOf
+        dirOf
+        isPath
+        packagesFromDirectoryRecursive
         pathIsDirectory
         pathIsRegularFile
-        packagesFromDirectoryRecursive
+        pathType
         ;
       inherit (self.sources)
         cleanSourceFilter
@@ -429,6 +447,7 @@ let
         pathHasContext
         canCleanSource
         pathIsGitRepo
+        filterSource
         ;
       inherit (self.modules)
         evalModules
@@ -559,6 +578,7 @@ let
         imap
         ;
       inherit (self.versions)
+        compareVersions
         splitVersion
         ;
     }

--- a/lib/filesystem.nix
+++ b/lib/filesystem.nix
@@ -25,6 +25,11 @@ let
 in
 
 {
+  inherit (builtins)
+    baseNameOf
+    dirOf
+    isPath
+    ;
 
   /**
     The type of a path. The path needs to exist and be accessible.

--- a/lib/sources.nix
+++ b/lib/sources.nix
@@ -436,4 +436,6 @@ in
 
     trace
     ;
+
+  inherit (builtins) filterSource;
 }

--- a/lib/trivial.nix
+++ b/lib/trivial.nix
@@ -373,6 +373,8 @@ in
     isFloat
     add
     sub
+    mul
+    div
     lessThan
     seq
     deepSeq
@@ -380,6 +382,8 @@ in
     bitAnd
     bitOr
     bitXor
+    ceil
+    floor
     ;
 
   ## nixpkgs version strings

--- a/lib/versions.nix
+++ b/lib/versions.nix
@@ -3,6 +3,8 @@
 
 rec {
 
+  inherit (builtins) compareVersions;
+
   /**
     Break a version string into its component parts.
 


### PR DESCRIPTION
Closes #369215

CC @infinisil @stepbrobd 
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
