### PR TITLE
xfce.xfce4-weather-plugin: Backport support for libsoup3

### DIFF
--- a/pkgs/desktops/xfce/panel-plugins/xfce4-weather-plugin/default.nix
+++ b/pkgs/desktops/xfce/panel-plugins/xfce4-weather-plugin/default.nix
@@ -2,19 +2,20 @@
   lib,
   stdenv,
   fetchurl,
+  fetchpatch,
   gettext,
   pkg-config,
+  xfce4-dev-tools,
   glib,
   gtk3,
   json_c,
   libxml2,
-  libsoup_2_4,
+  libsoup_3,
   upower,
   libxfce4ui,
   libxfce4util,
   xfce4-panel,
   xfconf,
-  hicolor-icon-theme,
   gitUpdater,
 }:
 
@@ -31,9 +32,23 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-AC0f5jkG0vOgEvPLWMzv8d+8xGZ1njbHbTsD3QHA3Fc=";
   };
 
+  patches = [
+    # Port to libsoup-3.0
+    # https://gitlab.xfce.org/panel-plugins/xfce4-weather-plugin/-/merge_requests/28
+    (fetchpatch {
+      url = "https://gitlab.xfce.org/panel-plugins/xfce4-weather-plugin/-/commit/c0653a903c6f2cecdf41ac9eaeba4f4617656ffe.patch";
+      hash = "sha256-wAowm4ppBSKvYwOowZbbs5pnTh9EQ9XX05lA81wtsRM=";
+    })
+    (fetchpatch {
+      url = "https://gitlab.xfce.org/panel-plugins/xfce4-weather-plugin/-/commit/279c975dc1f95bd1ce9152eee1d19122e7deb9a8.patch";
+      hash = "sha256-gVfyXkE0bjBfvcQU9fDp+Gm59bD3VbAam04Jak8i31k=";
+    })
+  ];
+
   nativeBuildInputs = [
     gettext
     pkg-config
+    xfce4-dev-tools
   ];
 
   buildInputs = [
@@ -41,14 +56,15 @@ stdenv.mkDerivation rec {
     gtk3
     json_c
     libxml2
-    libsoup_2_4
+    libsoup_3
     upower
     libxfce4ui
     libxfce4util
     xfce4-panel
     xfconf
-    hicolor-icon-theme
   ];
+
+  configureFlags = [ "--enable-maintainer-mode" ];
 
   enableParallelBuilding = true;
 


### PR DESCRIPTION
These are the patches [backported by Void](https://github.com/void-linux/void-packages/tree/4775f80cb4c35b3374a0258ca269fd83f2ba390e/srcpkgs/xfce4-weather-plugin/patches) and I recently [convinced](https://gitlab.xfce.org/panel-plugins/xfce4-weather-plugin/-/issues/94#note_105338) Fedora doing that too :upside_down_face: 

(mkXfceDerivation will eventually be deprecated with the meson switch so not using that...) 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

