### PR TITLE
cockpit: fix sudo login

### DIFF
--- a/nixos/modules/services/monitoring/cockpit.nix
+++ b/nixos/modules/services/monitoring/cockpit.nix
@@ -12,7 +12,6 @@ let
     mkEnableOption
     mkOption
     mkIf
-    literalMD
     mkPackageOption
     ;
   settingsFormat = pkgs.formats.ini { };
@@ -24,6 +23,18 @@ in
 
       package = mkPackageOption pkgs "Cockpit" {
         default = [ "cockpit" ];
+      };
+
+      allowed-origins = lib.mkOption {
+        type = types.listOf types.str;
+
+        default = [];
+
+        description = ''
+          List of allowed origins.
+
+          Maps to the WebService.Origins setting and allows merging from multiple modules.
+        '';
       };
 
       settings = lib.mkOption {
@@ -62,14 +73,16 @@ in
     # generate cockpit settings
     environment.etc."cockpit/cockpit.conf".source = settingsFormat.generate "cockpit.conf" cfg.settings;
 
-    security.pam.services.cockpit = { };
+    security.pam.services.cockpit = {
+      startSession = true;
+    };
 
     networking.firewall.allowedTCPPorts = mkIf cfg.openFirewall [ cfg.port ];
 
     systemd.packages = [ cfg.package ];
     systemd.sockets.cockpit.wantedBy = [ "multi-user.target" ];
     systemd.sockets.cockpit.listenStreams = [
-      ""
+      "" # workaround so it doesn't listen on both ports caused by the runtime merging
       (toString cfg.port)
     ];
 
@@ -80,6 +93,12 @@ in
       "L+ /run/cockpit/motd - - - - inactive.motd"
       "d /etc/cockpit/ws-certs.d 0600 root root 0"
     ];
+
+    services.cockpit.allowed-origins = [
+      "https://localhost:${toString config.services.cockpit.port}"
+    ];
+
+    services.cockpit.settings.WebService.Origins = builtins.concatStringsSep " " config.services.cockpit.allowed-origins;
   };
 
   meta.maintainers = pkgs.cockpit.meta.maintainers;

--- a/nixos/modules/services/monitoring/cockpit.nix
+++ b/nixos/modules/services/monitoring/cockpit.nix
@@ -28,7 +28,7 @@ in
       allowed-origins = lib.mkOption {
         type = types.listOf types.str;
 
-        default = [];
+        default = [ ];
 
         description = ''
           List of allowed origins.
@@ -98,7 +98,8 @@ in
       "https://localhost:${toString config.services.cockpit.port}"
     ];
 
-    services.cockpit.settings.WebService.Origins = builtins.concatStringsSep " " config.services.cockpit.allowed-origins;
+    services.cockpit.settings.WebService.Origins =
+      builtins.concatStringsSep " " config.services.cockpit.allowed-origins;
   };
 
   meta.maintainers = pkgs.cockpit.meta.maintainers;

--- a/nixos/tests/cockpit.nix
+++ b/nixos/tests/cockpit.nix
@@ -23,11 +23,9 @@ import ./make-test-python.nix (
             enable = true;
             port = 7890;
             openFirewall = true;
-            settings = {
-              WebService = {
-                Origins = "https://server:7890";
-              };
-            };
+            allowed-origins = [
+              "https://server:${toString config.services.cockpit.port}"
+            ];
           };
         };
       client =
@@ -130,7 +128,7 @@ import ./make-test-python.nix (
                     
                     log("Checking that /nonexistent is not a thing")
                     assert '/nonexistent' not in driver.page_source
-                    assert driver.find_element(By.CSS_SELECTOR, '#machine-reconnect') is not None
+                    assert len(driver.find_elements(By.CSS_SELECTOR, '#machine-reconnect')) == 0
 
                     driver.close()
                   '';

--- a/nixos/tests/cockpit.nix
+++ b/nixos/tests/cockpit.nix
@@ -123,10 +123,14 @@ import ./make-test-python.nix (
                     assert "Web console is running in limited access mode" in driver.page_source
 
                     log("Clicking the sudo button")
+                    for button in driver.find_elements(By.TAG_NAME, "button"):
+                        if 'admin' in button.text:
+                            button.click()
                     driver.switch_to.default_content()
-                    driver.find_element(By.CSS_SELECTOR, 'button.ct-locked').click()
+                    
                     log("Checking that /nonexistent is not a thing")
                     assert '/nonexistent' not in driver.page_source
+                    assert driver.find_element(By.CSS_SELECTOR, '#machine-reconnect') is not None
 
                     driver.close()
                   '';

--- a/nixos/tests/cockpit.nix
+++ b/nixos/tests/cockpit.nix
@@ -125,7 +125,7 @@ import ./make-test-python.nix (
                         if 'admin' in button.text:
                             button.click()
                     driver.switch_to.default_content()
-                    
+
                     log("Checking that /nonexistent is not a thing")
                     assert '/nonexistent' not in driver.page_source
                     assert len(driver.find_elements(By.CSS_SELECTOR, '#machine-reconnect')) == 0

--- a/pkgs/by-name/co/cockpit/package.nix
+++ b/pkgs/by-name/co/cockpit/package.nix
@@ -165,8 +165,11 @@ stdenv.mkDerivation (finalAttrs: {
       } \
       --run 'cd $(mktemp -d)'
 
-    wrapProgram $out/bin/cockpit-bridge \
-      --prefix PYTHONPATH : $out/${python3Packages.python.sitePackages}
+    for binary in $out/bin/cockpit-bridge $out/libexec/cockpit-askpass; do
+      chmod +x $binary
+      wrapProgram $binary \
+        --prefix PYTHONPATH : $out/${python3Packages.python.sitePackages}
+    done
 
     substituteInPlace $out/${python3Packages.python.sitePackages}/cockpit/_vendor/systemd_ctypes/libsystemd.py \
       --replace-warn libsystemd.so.0 ${systemd}/lib/libsystemd.so.0

--- a/pkgs/by-name/co/cockpit/package.nix
+++ b/pkgs/by-name/co/cockpit/package.nix
@@ -14,7 +14,9 @@
   git,
   glib,
   glib-networking,
+  gnused,
   gnutls,
+  iproute2,
   json-glib,
   krb5,
   libssh,
@@ -33,6 +35,7 @@
   systemd,
   udev,
   xmlto,
+  which,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -63,6 +66,7 @@ stdenv.mkDerivation (finalAttrs: {
     python3Packages.setuptools
     systemd
     xmlto
+    which
   ];
 
   buildInputs = [
@@ -92,6 +96,9 @@ stdenv.mkDerivation (finalAttrs: {
 
     substituteInPlace src/common/cockpitconf.c \
       --replace-fail 'const char *cockpit_config_dirs[] = { PACKAGE_SYSCONF_DIR' 'const char *cockpit_config_dirs[] = { "/etc"'
+
+    substituteInPlace src/**/*.c \
+      --replace '"/bin/sh"' "\"$(which sh)\""
 
     # instruct users with problems to create a nixpkgs issue instead of nagging upstream directly
     substituteInPlace configure.ac \
@@ -170,6 +177,14 @@ stdenv.mkDerivation (finalAttrs: {
       wrapProgram $binary \
         --prefix PYTHONPATH : $out/${python3Packages.python.sitePackages}
     done
+
+    patchShebangs $out/share/cockpit/issue/update-issue
+    wrapProgram $out/share/cockpit/issue/update-issue \
+      --prefix PATH : ${lib.makeBinPath [
+        iproute2
+        gnused
+      ]}
+
 
     substituteInPlace $out/${python3Packages.python.sitePackages}/cockpit/_vendor/systemd_ctypes/libsystemd.py \
       --replace-warn libsystemd.so.0 ${systemd}/lib/libsystemd.so.0

--- a/pkgs/by-name/co/cockpit/package.nix
+++ b/pkgs/by-name/co/cockpit/package.nix
@@ -180,10 +180,12 @@ stdenv.mkDerivation (finalAttrs: {
 
     patchShebangs $out/share/cockpit/issue/update-issue
     wrapProgram $out/share/cockpit/issue/update-issue \
-      --prefix PATH : ${lib.makeBinPath [
-        iproute2
-        gnused
-      ]}
+      --prefix PATH : ${
+        lib.makeBinPath [
+          iproute2
+          gnused
+        ]
+      }
 
 
     substituteInPlace $out/${python3Packages.python.sitePackages}/cockpit/_vendor/systemd_ctypes/libsystemd.py \


### PR DESCRIPTION
- **nixosTests.cockpit: tests more complete**
- **cockpit: properly wrap libexec/cockpit-askpass**
- **cockpit: fix sudo login, patch tweaking, option for allowed origins**

Also tested it using the interactive test driver, the test uses a different port to test
if a different port works so make sure the port 7890 is exposed instead of 9090.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
