### PR TITLE
haskell.packages.ghc92.haskell-language-server: remove at 2.10.0.0

### DIFF
--- a/pkgs/development/haskell-modules/configuration-ghc-9.2.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.2.x.nix
@@ -74,20 +74,7 @@ self: super: {
     }
   );
 
-  haskell-language-server = lib.pipe super.haskell-language-server [
-    (disableCabalFlag "fourmolu")
-    (disableCabalFlag "ormolu")
-    (disableCabalFlag "cabal")
-    (disableCabalFlag "stylishHaskell")
-    (
-      d:
-      d.override {
-        ormolu = null;
-        fourmolu = null;
-        stan = null;
-      }
-    )
-  ];
+  haskell-language-server = throw "haskell-language-server has dropped support for ghc 9.2 in version 2.10.0.0, please use a newer ghc version or an older nixpkgs version";
 
   # For GHC < 9.4, some packages need data-array-byte as an extra dependency
   hashable = addBuildDepends [ self.data-array-byte ] super.hashable;

--- a/pkgs/development/haskell-modules/configuration-ghc-9.2.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.2.x.nix
@@ -97,8 +97,8 @@ self: super: {
   # Needs to match ghc version
   ghc-tags = doDistribute self.ghc-tags_1_5;
 
-  # For "ghc-lib" flag see https://github.com/haskell/haskell-language-server/issues/3185#issuecomment-1250264515
-  hlint = enableCabalFlag "ghc-lib" super.hlint;
+  # Needs to match ghc-lib
+  hlint = doDistribute self.hlint_3_6_1;
 
   # ghc-lib >= 9.8 and friends no longer build with GHC 9.2 since they require semaphore-compat
   ghc-lib-parser = doDistribute (

--- a/pkgs/development/haskell-modules/configuration-hackage2nix/main.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/main.yaml
@@ -52,7 +52,6 @@ extra-packages:
   - ansi-terminal-types == 0.11.5       # 2025-02-27: required for ghcjs
   - ansi-wl-pprint >= 0.6 && < 0.7      # 2024-03-23: required for ghcjs
   - apply-refact == 0.9.*               # 2022-12-12: needed for GHC < 9.2
-  - apply-refact == 0.11.*              # 2023-02-02: needed for hls-hlint-plugin on GHC 9.2
   - attoparsec == 0.13.*                # 2022-02-23: Needed to compile elm for now
   - commonmark-pandoc < 0.2.3           # 2025-04-06: Needed for pandoc 3.6
   - extensions == 0.1.0.2               # 2024-10-20: for GHC 9.10/Cabal 3.12

--- a/pkgs/development/haskell-modules/configuration-hackage2nix/main.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/main.yaml
@@ -88,13 +88,13 @@ extra-packages:
   - hasql-notifications < 0.2.3         # 2025-01-19: Needed for building postgrest
   - hasql-pool < 1.1                    # 2025-01-19: Needed for building postgrest
   - hasql-transaction < 1.1.1           # 2025-01-19: Needed for building postgrest
-  - hlint == 3.4.1                      # 2022-09-21: needed for hls with ghc-lib-parser 9.2
+  - hlint == 3.4.1                      # 2022-09-21: preserve for ghc 8.10
   - hlint == 3.6.*                      # 2025-04-14: needed for hls with ghc-lib-parser 9.6
   - hnix-store-core < 0.7               # 2023-12-11: required by hnix-store-remote 0.6
   - hspec < 2.8                         # 2022-04-07: Needed for tasty-hspec 1.1.6
   - hspec-core < 2.8                    # 2022-04-07: Needed for tasty-hspec 1.1.6
   - hspec-discover < 2.8                # 2022-04-07: Needed for tasty-hspec 1.1.6
-  - hspec-megaparsec == 2.2.0           # 2023-11-18: Latest version compatible with ghc 9.0, needed for HLS
+  - hspec-megaparsec == 2.2.0           # 2023-11-18: Latest version compatible with ghc 9.0
   - hspec-meta < 2.8                    # 2022-12-07: Needed for elmPackages.elm / hspec-discover
   - language-javascript == 0.7.0.0      # required by purescript
   - lsp < 2.5                           # 2024-07-08: need for koka
@@ -102,16 +102,16 @@ extra-packages:
   - lsp-types == 2.1.*                  # 2024-02-28: need for dhall-lsp-server and koka
   - network-run == 0.4.0                # 2024-10-20: for GHC 9.10/network == 3.1.*
   - optparse-applicative < 0.16         # needed for niv-0.2.19
-  - ormolu == 0.5.2.0                   # 2023-08-08: for hls on ghc 9.0 and 9.2
+  - ormolu == 0.5.2.0                   # 2023-08-08: preserve for ghc 9.0
   - ormolu == 0.7.2.0                   # 2023-11-13: for ghc-lib-parser 9.6 compat
   - ormolu == 0.7.7.0                   # 2025-01-27: for ghc 9.10 compat
   - postgresql-binary < 0.14            # 2025-01-19: Needed for building postgrest
-  - primitive-unlifted == 0.1.3.1       # 2024-03-16: Needed for hls on ghc 9.2
-  - retrie < 1.2.0.0                    # 2022-12-30: required for hls on ghc < 9.2
+  - primitive-unlifted == 0.1.3.1       # 2024-03-16: preserve for ghc 9.2
+  - retrie < 1.2.0.0                    # 2022-12-30: preserve for ghc < 9.2
   - shake-cabal < 0.2.2.3               # 2023-07-01: last version to support Cabal 3.6.*
-  - stylish-haskell == 0.14.4.0         # 2022-09-19: needed for hls on ghc 9.2
+  - stylish-haskell == 0.14.4.0         # 2022-09-19: preserve for ghc 9.0
   - stylish-haskell == 0.14.5.0         # 2025-04-14: needed for hls with ghc-lib 9.6
-  - tar == 0.6.0.0                      # 2025-02-08: last version to not require os-string (which can't be buil with GHC < 9.2)
+  - tar == 0.6.0.0                      # 2025-02-08: last version to not require os-string (which can't be built with GHC < 9.2)
   - text == 2.0.2                       # 2023-09-14: Needed for elm (which is currently on ghc-8.10)
   - text-metrics < 0.3.3                # 2025-02-08: >= 0.3.3 uses GHC2021
   - versions < 6                        # 2024-04-22: required by spago-0.21

--- a/pkgs/top-level/release-haskell.nix
+++ b/pkgs/top-level/release-haskell.nix
@@ -579,6 +579,8 @@ let
         compilerNames.ghc8107
         # Support ceased as of 2.5.0.0
         compilerNames.ghc902
+        # Support ceased as of 2.10.0.0
+        compilerNames.ghc928
       ] released;
       hoogle = released;
       hlint = lib.subtractLists [


### PR DESCRIPTION
~~First 6 commits are from #398668.~~

HLS 2.10.0.0 dropped support for GHC 9.2, so let's remove that. I kept hlint, though, because it's just a quick downgrade to the same version we use for GHC 9.4.

I rewrote the comments in main.yaml. We could think about removing some of those things, because they are not needed anymore for HLS on GHC 9.2 - although, why break packages that build there this way? So I just remove the references to HLS, which were outdated.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
