### PR TITLE
wire-desktop: Add passthru.updateScript

### DIFF
--- a/pkgs/by-name/wi/wire-desktop/package.nix
+++ b/pkgs/by-name/wi/wire-desktop/package.nix
@@ -26,25 +26,21 @@ let
 
   pname = "wire-desktop";
 
+  versions = builtins.fromJSON (builtins.readFile ./versions.json);
+
   version =
-    let
-      x86_64-darwin = "3.39.5211";
-    in
     {
-      inherit x86_64-darwin;
-      aarch64-darwin = x86_64-darwin;
-      x86_64-linux = "3.39.3653";
+      x86_64-darwin = versions.macos.version;
+      aarch64-darwin = versions.macos.version;
+      x86_64-linux = versions.linux.version;
     }
     .${system} or throwSystem;
 
   hash =
-    let
-      x86_64-darwin = "sha256-k6CIqHt67AFL70zdK0/91aQcpbb00OIggk5TF7y1IOY=";
-    in
     {
-      inherit x86_64-darwin;
-      aarch64-darwin = x86_64-darwin;
-      x86_64-linux = "sha256-BbY+7fGAWW5CR/z4GeoBl5aOewCRuWzQjpQX4x1rzls=";
+      x86_64-darwin = versions.macos.hash;
+      aarch64-darwin = versions.macos.hash;
+      x86_64-linux = versions.linux.hash;
     }
     .${system} or throwSystem;
 

--- a/pkgs/by-name/wi/wire-desktop/package.nix
+++ b/pkgs/by-name/wi/wire-desktop/package.nix
@@ -71,8 +71,21 @@ let
     hydraPlatforms = [ ];
   };
 
+  passthru.updateScript = {
+    command = [
+      ./update.sh
+      ./.
+    ];
+    supportedFeatures = [ "commit" ];
+  };
+
   linux = stdenv.mkDerivation rec {
-    inherit pname version meta;
+    inherit
+      pname
+      version
+      meta
+      passthru
+      ;
 
     src = fetchurl {
       url = "https://wire-app.wire.com/linux/debian/pool/main/Wire-${version}_amd64.deb";
@@ -147,7 +160,12 @@ let
   };
 
   darwin = stdenv.mkDerivation {
-    inherit pname version meta;
+    inherit
+      pname
+      version
+      meta
+      passthru
+      ;
 
     src = fetchurl {
       url = "https://github.com/wireapp/wire-desktop/releases/download/macos%2F${version}/Wire.pkg";

--- a/pkgs/by-name/wi/wire-desktop/update.sh
+++ b/pkgs/by-name/wi/wire-desktop/update.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p curl jq
+
+set -e
+
+cd $1
+
+releases=$(curl -L \
+  -H "Accept: application/vnd.github+json" \
+  -H "X-GitHub-Api-Version: 2022-11-28" \
+  "https://api.github.com/repos/wireapp/wire-desktop/releases" \
+)
+
+latest=$(jq --argjson suffix '{ "linux": ".deb", "macos": ".pkg" }' \
+  --slurpfile versions versions.json '
+  def platform_latest(platform):
+    map(select(.tag_name | startswith(platform)))
+    | max_by(.tag_name)
+    | { version: .tag_name | ltrimstr(platform + "/")
+      , url: .assets.[]
+             | .browser_download_url
+             | select(endswith($suffix.[platform]))
+      };
+
+  . as $releases
+  | $versions.[] as $old
+  | $old
+  | with_entries( .key as $key
+                  | { key: $key, value: $releases | platform_latest($key) }
+                  | select(.value.version != $old.[$key].version)
+                )
+' <<< "$releases"
+)
+
+urlHashes=$(
+  printf '{ '
+  function entries () {
+    local sep=''
+    for url in $(jq --raw-output '.[].url' <<< "$latest"); do
+      printf '%s"%s": "%s"\n' "$sep" "$url" \
+        "$(nix-hash --to-sri --type sha256 $(nix-prefetch-url $url))"
+      sep=', '
+    done
+  }
+  entries
+  printf '}'
+)
+
+commit=$(jq --arg versionJSON "$(printf '%s/versions.json' "$1")" \
+  --slurpfile versions versions.json '
+  $versions.[] as $old
+  | to_entries
+  | map("\(.key) \($old.[.key].version) -> \(.value.version)")
+  | join(", ")
+  | [ if . == ""
+      then empty
+      else { attrPath: "wire-desktop"
+           , oldVersion: "A"
+           , newVersion: "B"
+           , files: [ $versionJSON ]
+           , commitMessage: "wire-desktop: \(.)"
+           }
+      end
+    ]
+' <<< "$latest"
+)
+
+tempfile=$(mktemp)
+
+updated=$(jq --argjson hashes "$urlHashes" --slurpfile versions versions.json '
+  $versions.[] as $old
+  | $old + map_values(with_entries(if .key == "url"
+                                   then { key: "hash"
+                                        , value: $hashes.[.value]
+                                        }
+                                   else .
+                                   end
+                                  )
+                     )
+' <<< "$latest" > $tempfile
+)
+
+mv $tempfile versions.json
+
+printf '%s' "$commit"
+exit 0

--- a/pkgs/by-name/wi/wire-desktop/update.sh
+++ b/pkgs/by-name/wi/wire-desktop/update.sh
@@ -37,8 +37,11 @@ urlHashes=$(
   function entries () {
     local sep=''
     for url in $(jq --raw-output '.[].url' <<< "$latest"); do
-      printf '%s"%s": "%s"\n' "$sep" "$url" \
-        "$(nix-hash --to-sri --type sha256 $(nix-prefetch-url $url))"
+      hash=$(nix-hash --to-sri --type sha256 $(nix-prefetch-url $url))
+      if [ -z "$hash" ]; then
+        printf 'Failed to retrieve hash for %s\n' "$url" 2>&1
+      fi
+      printf '%s"%s": "%s"\n' "$sep" "$url" "$hash"
       sep=', '
     done
   }

--- a/pkgs/by-name/wi/wire-desktop/versions.json
+++ b/pkgs/by-name/wi/wire-desktop/versions.json
@@ -1,10 +1,10 @@
 {
   "linux": {
-    "version": "3.39.3653",
-    "hash": "sha256-BbY+7fGAWW5CR/z4GeoBl5aOewCRuWzQjpQX4x1rzls="
+    "version": "3.40.3718",
+    "hash": "sha256-1jBhF+Rnys8C3DaVbCKHDiylox2WG1qRvwnDbQrp1Mk="
   },
   "macos": {
-    "version": "3.39.5211",
-    "hash": "sha256-k6CIqHt67AFL70zdK0/91aQcpbb00OIggk5TF7y1IOY="
+    "version": "3.40.5285",
+    "hash": "sha256-pcWB3irdPyDj55dWmNyc+oThVGgHtIu//EAk1k/56is="
   }
 }

--- a/pkgs/by-name/wi/wire-desktop/versions.json
+++ b/pkgs/by-name/wi/wire-desktop/versions.json
@@ -1,0 +1,10 @@
+{
+  "linux": {
+    "version": "3.39.3653",
+    "hash": "sha256-BbY+7fGAWW5CR/z4GeoBl5aOewCRuWzQjpQX4x1rzls="
+  },
+  "macos": {
+    "version": "3.39.5211",
+    "hash": "sha256-k6CIqHt67AFL70zdK0/91aQcpbb00OIggk5TF7y1IOY="
+  }
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Updates are very mechanical, since it's a binary package it's pretty much just always a version number and hash bump. This is my stab at automating it.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
