### PR TITLE
libslirp, darwin.linux-builder: fix DNS resolution using libslirp on MacOS

### DIFF
--- a/nixos/modules/profiles/nix-builder-vm.nix
+++ b/nixos/modules/profiles/nix-builder-vm.nix
@@ -111,14 +111,6 @@ in
       };
     };
 
-    # DNS fails for QEMU user networking (SLiRP) on macOS.  See:
-    #
-    # https://github.com/utmapp/UTM/issues/2353
-    #
-    # This works around that by using a public DNS server other than the DNS
-    # server that QEMU provides (normally 10.0.2.3)
-    networking.nameservers = [ "8.8.8.8" ];
-
     # The linux builder is a lightweight VM for remote building; not evaluation.
     nix.channel.enable = false;
 

--- a/pkgs/by-name/li/libslirp/fix-dns-for-darwin.patch
+++ b/pkgs/by-name/li/libslirp/fix-dns-for-darwin.patch
@@ -1,0 +1,46 @@
+From 735904142f95d0500c0eae6bf763e4ad24b6b9fd Mon Sep 17 00:00:00 2001
+From: Samuel Thibault <samuel.thibault@ens-lyon.org>
+Date: Wed, 26 Mar 2025 08:42:35 +0100
+Subject: [PATCH] apple: Fix getting IPv4 DNS server address when IPv4 and IPv4
+ are interleaved
+
+When getting an IPv4 DNS server address, if libresolv returns
+
+IPv4
+IPv6
+IPv4
+IPv6
+
+(or just IPv4 and IPv6)
+
+we would still have found == 1 on the second iteration and thus take the
+IPv6 even if it's not the proper af. We can as well just completely ignore
+the non-matching af entries.
+
+Fixes #85
+---
+ src/slirp.c | 7 +++++--
+ 1 file changed, 5 insertions(+), 2 deletions(-)
+
+diff --git a/src/slirp.c b/src/slirp.c
+index bccee53..62a018a 100644
+--- a/src/slirp.c
++++ b/src/slirp.c
+@@ -289,9 +289,12 @@ static int get_dns_addr_libresolv(int af, void *pdns_addr, void *cached_addr,
+     found = 0;
+     DEBUG_MISC("IP address of your DNS(s):");
+     for (int i = 0; i < count; i++) {
+-        if (af == servers[i].sin.sin_family) {
+-            found++;
++        if (af != servers[i].sin.sin_family) {
++            continue;
+         }
++
++        found++;
++
+         if (af == AF_INET) {
+             addr = &servers[i].sin.sin_addr;
+         } else { // af == AF_INET6
+-- 
+GitLab
+

--- a/pkgs/by-name/li/libslirp/package.nix
+++ b/pkgs/by-name/li/libslirp/package.nix
@@ -20,6 +20,12 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-Eqdw6epFkLv4Dnw/s1pcKW0P70ApZwx/J2VkCwn50Ew=";
   };
 
+  patches = [
+    # https://gitlab.freedesktop.org/slirp/libslirp/-/commit/735904142f95d0500c0eae6bf763e4ad24b6b9fd
+    # Vendorized due to frequent instability of the upstream repository.
+    ./fix-dns-for-darwin.patch
+  ];
+
   separateDebugInfo = true;
 
   nativeBuildInputs = [


### PR DESCRIPTION
- **libslirp: fix DNS resolution on MacOS**
- **linux-builder: remove DNS hack for libslirp**


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
