### PR TITLE
ghidra, ghidra-bin: 11.3.1 -> 11.3.2

### DIFF
--- a/pkgs/tools/security/ghidra/build.nix
+++ b/pkgs/tools/security/ghidra/build.nix
@@ -20,7 +20,7 @@
 let
   pkg_path = "$out/lib/ghidra";
   pname = "ghidra";
-  version = "11.3.1";
+  version = "11.3.2";
 
   releaseName = "NIX";
   distroPrefix = "ghidra_${version}_${releaseName}";
@@ -28,7 +28,7 @@ let
     owner = "NationalSecurityAgency";
     repo = "Ghidra";
     rev = "Ghidra_${version}_build";
-    hash = "sha256-2VOuEOLFDHMuN/xqhSofeCMVvCvLI7CGFq21qdwQetA=";
+    hash = "sha256-EvIOC/VIUaEl7eneVzgEt2fhLSP9DaawMAutk4ouFp8=";
     # populate values that require us to use git. By doing this in postFetch we
     # can delete .git afterwards and maintain better reproducibility of the src.
     leaveDotGit = true;

--- a/pkgs/tools/security/ghidra/default.nix
+++ b/pkgs/tools/security/ghidra/default.nix
@@ -28,12 +28,12 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "ghidra";
-  version = "11.3.1";
-  versiondate = "20250219";
+  version = "11.3.2";
+  versiondate = "20250415";
 
   src = fetchzip {
     url = "https://github.com/NationalSecurityAgency/ghidra/releases/download/Ghidra_${version}_build/ghidra_${version}_PUBLIC_${versiondate}.zip";
-    hash = "sha256-9vGxHE4Z6J3Vkz9bo8BfgnZsN3sARFxB1CHBXDB02a8=";
+    hash = "sha256-97L3BueekbZfFAdiLX1DHlVSzNyspu4exafpFVraMWE=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/tools/security/ghidra/deps.json
+++ b/pkgs/tools/security/ghidra/deps.json
@@ -103,7 +103,7 @@
    "tar.gz": "sha256-FzNmYFJZqD3BicQyf/TDclSv7WW0+GbL2KXvLqRJ6PM="
   }
  },
- "https://github.com/NationalSecurityAgency/ghidra-data/raw/Ghidra_11.3.1": {
+ "https://github.com/NationalSecurityAgency/ghidra-data/raw/Ghidra_11.3.2": {
   "FunctionID/vs2012_x64": {
    "fidb": "sha256-1OmKs/eQuDF5MhhDC7oNiySl+/TaZbDB/6jLDPvrDNw="
   },
@@ -246,9 +246,6 @@
    "jar": "sha256-8CqV+hpele2z7YWf0Pt99wnRIaNSkO/4t03OKrf01u0=",
    "pom": "sha256-N/h3mLGDhRE8kYv6nhJ2/lBzXvj6hJtYAMUZ1U2/Efg="
   },
-  "com/google/protobuf#protobuf-bom/3.17.3": {
-   "pom": "sha256-bf431vImF9VqQUzNrf+NmFhaH3kXEr6HbCYWZxDR2N0="
-  },
   "com/google/protobuf#protobuf-bom/3.21.8": {
    "pom": "sha256-+7Ds/DyjGFddtifjOuRUwT1qTcp68UXRTT9m4IY8PPo="
   },
@@ -256,16 +253,9 @@
    "jar": "sha256-RP2JrzepsvHdQcCUqbtzPAe/f8eg4jhooQuvbjUfpeA=",
    "pom": "sha256-Gwqekab09LYqWmB4wibudwqo3FdnueRzwvwY8KOImAQ="
   },
-  "com/google/protobuf#protobuf-java/3.17.3": {
-   "jar": "sha256-SsVJsZJpQUGVgEnwYKHIJqMzQvYZ4QjO2MF9mHf14+0=",
-   "pom": "sha256-Km8izVJli4uxTBANs+F5NT+MNR0ENzo79voKOzlGStw="
-  },
   "com/google/protobuf#protobuf-java/3.21.8": {
    "jar": "sha256-C4WBrYENLfrv0Nz78VabFFBEhlAjjX4v1rF2yTLQjJU=",
    "pom": "sha256-OJBUBuApx6MYaW8O4RnFXM7HizN+oR5MMZWfDgardAg="
-  },
-  "com/google/protobuf#protobuf-parent/3.17.3": {
-   "pom": "sha256-T09Q5moqvM/o7SCbU/q3C4k+NfQ77FqB98GESbY+hrE="
   },
   "com/google/protobuf#protobuf-parent/3.21.8": {
    "pom": "sha256-bHKyrDl1sAnR5FdQlVnp+onyV4vShD3LTWo+XPgRFws="


### PR DESCRIPTION
Updates Ghidra from 11.3.1 to 11.3.2. No changes needed to patches/etc. Basic functionality is working on Linux, but my Darwin builder is not currently working due to an issue that has cropped up recently and seems to be breaking basically all builds, so can't test at the moment. It is expected to not compile due to #370662, which I am still a bit confused by (though if I can get my Darwin builder working I would like to try to apply a workaround based on what is suggested in that issue; not in this PR, though.)

All extensions seem to still be building at the moment.

- [Release Page](https://github.com/NationalSecurityAgency/ghidra/releases/tag/Ghidra_11.3.2_build)
- [What's New](https://github.com/NationalSecurityAgency/ghidra/blob/Ghidra_11.3.2_build/Ghidra/Configurations/Public_Release/src/global/docs/WhatsNew.md)
- [Change History](https://github.com/NationalSecurityAgency/ghidra/blob/Ghidra_11.3.2_build/Ghidra/Configurations/Public_Release/src/global/docs/ChangeHistory.md)
- [Installation Guide](https://github.com/NationalSecurityAgency/ghidra/blob/Ghidra_11.3.2_build/GhidraDocs/InstallationGuide.md)
- https://github.com/NationalSecurityAgency/ghidra/compare/Ghidra_11.3.1_build...Ghidra_11.3.2_build

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
