### PR TITLE
ferrishot: init at 0.1.0

### DIFF
--- a/pkgs/by-name/fe/ferrishot/package.nix
+++ b/pkgs/by-name/fe/ferrishot/package.nix
@@ -1,0 +1,72 @@
+{
+  lib,
+  stdenv,
+  rustPlatform,
+  fetchFromGitHub,
+  makeBinaryWrapper,
+  writableTmpDirAsHomeHook,
+  libGL,
+  libX11,
+  libxkbcommon,
+  libxcb,
+  wayland,
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "ferrishot";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "nik-rev";
+    repo = "ferrishot";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-1jKwbhn85KcIQrSakWTIfxPso7VZuuvPrUbTCF1NerM=";
+  };
+
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-NPReNHKOS4PQIt2lmY5w19lVHPDjznR9gv5vHDXyqaI=";
+
+  nativeBuildInputs =
+    [
+      makeBinaryWrapper
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [
+      # error: unable to open output file '/homeless-shelter/.cache/clang/ModuleCache/354UBE8EJRBZ3/Cocoa-31YYBL2V1XGQP.pcm': 'No such file or directory'
+      writableTmpDirAsHomeHook
+    ];
+
+  buildInputs = lib.optionals stdenv.hostPlatform.isLinux [
+    libxcb
+  ];
+
+  postInstall =
+    let
+      runtimeDeps =
+        [
+          libGL
+        ]
+        ++ lib.optionals stdenv.hostPlatform.isLinux [
+          libX11
+          libxkbcommon
+          wayland
+        ];
+    in
+    ''
+      wrapProgram $out/bin/ferrishot \
+        --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath runtimeDeps}"
+    '';
+
+  passthru = {
+    updateScript = nix-update-script { };
+  };
+
+  meta = {
+    description = "Screenshot app written in Rust";
+    homepage = "https://github.com/nik-rev/ferrishot";
+    changelog = "https://github.com/nik-rev/ferrishot/blob/v${finalAttrs.version}/CHANGELOG.md";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ GaetanLepage ];
+    mainProgram = "ferrishot";
+  };
+})


### PR DESCRIPTION
## Things done

Add [ferrishot](https://github.com/nik-rev/ferrishot), a screenshot app written in Rust.

I used https://github.com/nik-rev/ferrishot/blob/main/flake.nix as a reference.

cc @nik-rev

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
