### PR TITLE
_1password-gui: update to 8.10.72 and myself as a maintainer

### DIFF
--- a/pkgs/applications/misc/1password-gui/default.nix
+++ b/pkgs/applications/misc/1password-gui/default.nix
@@ -37,6 +37,7 @@ let
       timstott
       savannidgerinel
       sebtm
+      bdd
     ];
     platforms = builtins.attrNames sources.${channel};
     mainProgram = "1password";

--- a/pkgs/applications/misc/1password-gui/sources.json
+++ b/pkgs/applications/misc/1password-gui/sources.json
@@ -1,20 +1,20 @@
 {
   "stable": {
     "x86_64-linux": {
-      "url": "https://downloads.1password.com/linux/tar/stable/x86_64/1password-8.10.70.x64.tar.gz",
-      "hash": "sha256-QGKeKX7qxu7heJ6T0I8aayI1P2M3KOmU9faS929BCjI="
+      "url": "https://downloads.1password.com/linux/tar/stable/x86_64/1password-8.10.72.x64.tar.gz",
+      "hash": "sha256-vJJ5Dh3K3B0DAEVMifiITNJmOtkCyn0XYS4tdYxoKjM="
     },
     "aarch64-linux": {
-      "url": "https://downloads.1password.com/linux/tar/stable/aarch64/1password-8.10.70.arm64.tar.gz",
-      "hash": "sha256-Uz8YKlIa6zibRv3ObnVVlyEk3sZP5wX+0E/nX02m6SA="
+      "url": "https://downloads.1password.com/linux/tar/stable/aarch64/1password-8.10.72.arm64.tar.gz",
+      "hash": "sha256-GLDmBiIXGRQVy7wjW/52gIx97E6Q+A3wJwOGQvW29p8="
     },
     "x86_64-darwin": {
-      "url": "https://downloads.1password.com/mac/1Password-8.10.70-x86_64.zip",
-      "hash": "sha256-s6+LUSHZwCH5PgREt2bkCCR3JeGBj9llQ6rGrOhEPlQ="
+      "url": "https://downloads.1password.com/mac/1Password-8.10.72-x86_64.zip",
+      "hash": "sha256-SijXMG33quuxip2JOkjyB9ITSm9livqXzBPbqMmLVns="
     },
     "aarch64-darwin": {
-      "url": "https://downloads.1password.com/mac/1Password-8.10.70-aarch64.zip",
-      "hash": "sha256-f9b8L4S6CToMukeqrW3EKXAov0rqEMsIpZEGrvDQmg8="
+      "url": "https://downloads.1password.com/mac/1Password-8.10.72-aarch64.zip",
+      "hash": "sha256-y4kK4tL9NjvUT/C6q7WxaX/7LOCr3xkRJTBhqw2jjtQ="
     }
   },
   "beta": {

--- a/pkgs/applications/misc/1password-gui/versions.json
+++ b/pkgs/applications/misc/1password-gui/versions.json
@@ -1,6 +1,6 @@
 {
-  "stable-linux": "8.10.70",
-  "stable-darwin": "8.10.70",
+  "stable-linux": "8.10.72",
+  "stable-darwin": "8.10.72",
   "beta-linux":"8.10.70-24.BETA",
   "beta-darwin": "8.10.70-24.BETA"
 }


### PR DESCRIPTION
- 8.10.68 -> 8.10.72
- Add myself as a maintainer

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
