### PR TITLE
cc-wrapper: enable frame pointers by default.

### DIFF
--- a/pkgs/build-support/cc-wrapper/default.nix
+++ b/pkgs/build-support/cc-wrapper/default.nix
@@ -767,8 +767,15 @@ stdenvNoCC.mkDerivation {
       export hardening_unsupported_flags="${concatStringsSep " " ccHardeningUnsupportedFlags}"
     ''
 
+    # Do not prevent omission of framepointers on x86 32bit due to the small
+    # number of general purpose registers. Keeping EBP available provides
+    # non-trivial performance benefits.
+    + optionalString (!targetPlatform.isx86_32) ''
+      echo " -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer " >> $out/nix-support/cc-cflags-before
+    ''
+
     # For clang, this is handled in add-clang-cc-cflags-before.sh
-    + lib.optionalString (!isClang && machineFlags != [ ]) ''
+    + optionalString (!isClang && machineFlags != [ ]) ''
       printf "%s\n" ${lib.escapeShellArgs machineFlags} >> $out/nix-support/cc-cflags-before
     ''
 


### PR DESCRIPTION
Allow easy system-level profiling with e.g. Linux perf or bpf(trace).

Frame pointers are enabled by default in Fedora, Ubuntu, and Arch Linux.

---

Profiling applications in NixOS is quite expensive due to the size of closures of basic but widely-used libraries. Full-system profiling is even harder as it effectively requires re-compiling the world with ~0 caching.

By enabling it by default, we make this trivially possible (except for the packages that explicitly specify `-fomit-frame-pointers`, of course).

Due to these hurdles NixOS itself is hard to profile. I wouldn't be surprised if we find some low-hanging fruit once the infra is in place.

The change as such is not terribly controversial based on 
* https://discourse.nixos.org/t/nixos-frame-pointer-enable/39554 or
* https://github.com/NixOS/nixpkgs/pull/216341

... though there isn't a whole lot of discussion.

On the outside world part, from the big distributions, Fedora had it enabled the longest, and it survived re-evaluation. Ubuntu decided to add it to their LTS build so there's some commitment there. Arch still has it after >1y.

---

This PR is my best guess at how to actually accomplish this. Certainly looking for feedback here.

My rather simple test was to compare `find path/to/nixpkgs` built from this PR against the one on master, using `perf record -F 9999 -ag find ...`. It compiled and the perf reports looked as intended. Naturally the impact of this PR is much larger ... too large to test myself on my system.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
