### PR TITLE
nixos/ax25/{axports,axlisten}: init

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1055,6 +1055,7 @@
   ./services/networking/atticd.nix
   ./services/networking/autossh.nix
   ./services/networking/avahi-daemon.nix
+  ./services/networking/ax25/axlisten.nix
   ./services/networking/ax25/axports.nix
   ./services/networking/babeld.nix
   ./services/networking/bee.nix

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1055,6 +1055,7 @@
   ./services/networking/atticd.nix
   ./services/networking/autossh.nix
   ./services/networking/avahi-daemon.nix
+  ./services/networking/ax25/axports.nix
   ./services/networking/babeld.nix
   ./services/networking/bee.nix
   ./services/networking/biboumi.nix

--- a/nixos/modules/services/networking/ax25/axlisten.nix
+++ b/nixos/modules/services/networking/ax25/axlisten.nix
@@ -1,0 +1,62 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  inherit (lib)
+    types
+    ;
+
+  inherit (lib.modules)
+    mkIf
+    ;
+
+  inherit (lib.options)
+    mkEnableOption
+    mkOption
+    literalExpression
+    ;
+
+  cfg = config.services.ax25.axlisten;
+in
+{
+  options = {
+
+    services.ax25.axlisten = {
+
+      enable = mkEnableOption "AX.25 axlisten daemon";
+
+      package = mkOption {
+        type = types.package;
+        default = pkgs.ax25-apps;
+        defaultText = literalExpression "pkgs.ax25-apps";
+        description = "The ax25-apps package to use.";
+      };
+
+      config = mkOption {
+        type = types.str;
+        default = "-art";
+        description = ''
+          Options that will be passed to the axlisten daemon.
+        '';
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+
+    systemd.services.axlisten = {
+      description = "AX.25 traffic monitor";
+      wantedBy = [ "multi-user.target" ];
+      after = [ "ax25-axports.target" ];
+      requires = [ "ax25-axports.target" ];
+      serviceConfig = {
+        Type = "exec";
+        ExecStart = "${cfg.package}/bin/axlisten ${cfg.config}";
+      };
+    };
+  };
+}

--- a/nixos/modules/services/networking/ax25/axports.nix
+++ b/nixos/modules/services/networking/ax25/axports.nix
@@ -1,0 +1,149 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  inherit (lib)
+    types
+    ;
+
+  inherit (lib.strings)
+    concatStringsSep
+    optionalString
+    ;
+
+  inherit (lib.attrsets)
+    filterAttrs
+    mapAttrsToList
+    mapAttrs'
+    ;
+
+  inherit (lib.modules)
+    mkIf
+    ;
+
+  inherit (lib.options)
+    mkEnableOption
+    mkOption
+    mkPackageOption
+    ;
+
+  cfg = config.services.ax25.axports;
+
+  enabledAxports = filterAttrs (ax25Name: cfg: cfg.enable) cfg;
+
+  axportsOpts = {
+
+    options = {
+      enable = mkEnableOption "Enables the axport interface";
+
+      package = mkPackageOption pkgs "ax25-tools" { };
+
+      tty = mkOption {
+        type = types.str;
+        example = "/dev/ttyACM0";
+        description = ''
+          Location of hardware kiss tnc for this interface.
+        '';
+      };
+
+      callsign = mkOption {
+        type = types.str;
+        example = "WB6WLV-7";
+        description = ''
+          The callsign of the physical interface to bind to.
+        '';
+      };
+
+      description = mkOption {
+        type = types.str;
+        # This cannot be empty since some ax25 tools cant parse /etc/ax25/axports without it
+        default = "NixOS managed tnc";
+        description = ''
+          Free format description of this interface.
+        '';
+      };
+
+      baud = mkOption {
+        type = types.int;
+        example = 57600;
+        description = ''
+          The serial port speed of this interface.
+        '';
+      };
+
+      paclen = mkOption {
+        type = types.int;
+        default = 255;
+        description = ''
+          Default maximum packet size for this interface.
+        '';
+      };
+
+      window = mkOption {
+        type = types.int;
+        default = 7;
+        description = ''
+          Default window size for this interface.
+        '';
+      };
+
+      kissParams = mkOption {
+        type = types.nullOr types.str;
+        default = null;
+        example = "-t 300 -l 10 -s 12 -r 80 -f n";
+        description = ''
+          Kissattach parameters for this interface.
+        '';
+      };
+    };
+  };
+in
+{
+
+  options = {
+
+    services.ax25.axports = mkOption {
+      type = types.attrsOf (types.submodule axportsOpts);
+      default = { };
+      description = "Specification of one or more AX.25 ports.";
+    };
+  };
+
+  config = mkIf (enabledAxports != { }) {
+
+    environment.etc."ax25/axports" = {
+      text = concatStringsSep "\n" (
+        mapAttrsToList (
+          portName: portCfg:
+          "${portName} ${portCfg.callsign} ${toString portCfg.baud} ${toString portCfg.paclen} ${toString portCfg.window} ${portCfg.description}"
+        ) enabledAxports
+      );
+      mode = "0644";
+    };
+
+    systemd.targets.ax25-axports = {
+      description = "AX.25 axports group target";
+    };
+
+    systemd.services = mapAttrs' (portName: portCfg: {
+      name = "ax25-kissattach-${portName}";
+      value = {
+        description = "AX.25 KISS attached interface for ${portName}";
+        wantedBy = [ "multi-user.target" ];
+        before = [ "ax25-axports.target" ];
+        partOf = [ "ax25-axports.target" ];
+        serviceConfig = {
+          Type = "exec";
+          ExecStart = "${portCfg.package}/bin/kissattach ${portCfg.tty} ${portName}";
+        };
+        postStart = optionalString (portCfg.kissParams != null) ''
+          ${portCfg.package}/bin/kissparms -p ${portName} ${portCfg.kissParams}
+        '';
+      };
+    }) enabledAxports;
+  };
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -213,6 +213,7 @@ in
   atop = import ./atop.nix { inherit pkgs runTest; };
   atticd = runTest ./atticd.nix;
   atuin = runTest ./atuin.nix;
+  ax25 = handleTest ./ax25.nix { };
   audiobookshelf = runTest ./audiobookshelf.nix;
   auth-mysql = runTest ./auth-mysql.nix;
   authelia = runTest ./authelia.nix;

--- a/nixos/tests/ax25.nix
+++ b/nixos/tests/ax25.nix
@@ -1,0 +1,131 @@
+import ./make-test-python.nix (
+  { pkgs, lib, ... }:
+  let
+
+    baud = 57600;
+    tty = "/dev/ttyACM0";
+    port = "tnc0";
+    socatPort = 1234;
+
+    createAX25Node = nodeId: {
+
+      boot.kernelPackages = pkgs.linuxPackages_ham;
+      boot.kernelModules = [ "ax25" ];
+
+      networking.firewall.allowedTCPPorts = [ socatPort ];
+
+      environment.systemPackages = with pkgs; [
+        libax25
+        ax25-tools
+        ax25-apps
+        socat
+      ];
+
+      services.ax25.axports."${port}" = {
+        inherit baud tty;
+        enable = true;
+        callsign = "NOCALL-${toString nodeId}";
+        description = "mocked tnc";
+      };
+
+      services.ax25.axlisten = {
+        enable = true;
+      };
+
+      # All mocks radios will connect back to socat-broker on node 1 in order to get
+      # all messages that are "broadcasted over the ether"
+      systemd.services.ax25-mock-hardware = {
+        description = "mock AX.25 TNC and Radio";
+        wantedBy = [ "default.target" ];
+        before = [
+          "ax25-kissattach-${port}.service"
+          "axlisten.service"
+        ];
+        after = [ "network.target" ];
+        serviceConfig = {
+          Type = "exec";
+          ExecStart = "${pkgs.socat}/bin/socat -d -d tcp:192.168.1.1:${toString socatPort} pty,link=${tty},b${toString baud},raw";
+        };
+      };
+    };
+  in
+  {
+    name = "ax25Simple";
+    nodes = {
+      node1 = lib.mkMerge [
+        (createAX25Node 1)
+        # mimicking radios on the same frequency
+        {
+          systemd.services.ax25-mock-ether = {
+            description = "mock radio ether";
+            wantedBy = [ "default.target" ];
+            requires = [ "network.target" ];
+            before = [ "ax25-mock-hardware.service" ];
+            # broken needs access to "ss" or "netstat"
+            path = [ pkgs.iproute2 ];
+            serviceConfig = {
+              Type = "exec";
+              ExecStart = "${pkgs.socat}/bin/socat-broker.sh tcp4-listen:${toString socatPort}";
+            };
+            postStart = "${pkgs.coreutils}/bin/sleep 2";
+          };
+        }
+      ];
+      node2 = createAX25Node 2;
+      node3 = createAX25Node 3;
+    };
+    testScript =
+      { ... }:
+      ''
+        def wait_for_machine(m):
+          m.succeed("lsmod | grep ax25")
+          m.wait_for_unit("ax25-axports.target")
+          m.wait_for_unit("axlisten.service")
+          m.fail("journalctl -o cat -u axlisten.service | grep -i \"no AX.25 port data configured\"")
+
+        # start the first node since the socat-broker needs to be running
+        node1.start()
+        node1.wait_for_unit("ax25-mock-ether.service")
+        wait_for_machine(node1)
+
+        node2.start()
+        node3.start()
+        wait_for_machine(node2)
+        wait_for_machine(node3)
+
+        # Node 1 -> Node 2
+        node1.succeed("echo hello | ax25_call ${port} NOCALL-1 NOCALL-2")
+        node2.sleep(1)
+        node2.succeed("journalctl -o cat -u axlisten.service | grep -A1 \"NOCALL-1 to NOCALL-2 ctl I00\" | grep hello")
+
+        # Node 1 -> Node 3
+        node1.succeed("echo hello | ax25_call ${port} NOCALL-1 NOCALL-3")
+        node3.sleep(1)
+        node3.succeed("journalctl -o cat -u axlisten.service | grep -A1 \"NOCALL-1 to NOCALL-3 ctl I00\" | grep hello")
+
+        # Node 2 -> Node 1
+        # must sleep due to previous ax25_call lingering
+        node2.sleep(5)
+        node2.succeed("echo hello | ax25_call ${port} NOCALL-2 NOCALL-1")
+        node1.sleep(1)
+        node1.succeed("journalctl -o cat -u axlisten.service | grep -A1 \"NOCALL-2 to NOCALL-1 ctl I00\" | grep hello")
+
+        # Node 2 -> Node 3
+        node2.succeed("echo hello | ax25_call ${port} NOCALL-2 NOCALL-3")
+        node3.sleep(1)
+        node3.succeed("journalctl -o cat -u axlisten.service | grep -A1 \"NOCALL-2 to NOCALL-3 ctl I00\" | grep hello")
+
+        # Node 3 -> Node 1
+        # must sleep due to previous ax25_call lingering
+        node3.sleep(5)
+        node3.succeed("echo hello | ax25_call ${port} NOCALL-3 NOCALL-1")
+        node1.sleep(1)
+        node1.succeed("journalctl -o cat -u axlisten.service | grep -A1 \"NOCALL-3 to NOCALL-1 ctl I00\" | grep hello")
+
+        # Node 3 -> Node 2
+        node3.succeed("echo hello | ax25_call ${port} NOCALL-3 NOCALL-2")
+        node2.sleep(1)
+        node2.succeed("journalctl -o cat -u axlisten.service | grep -A1 \"NOCALL-3 to NOCALL-2 ctl I00\" | grep hello")
+      '';
+  }
+)


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

This adds support for configuring `/etc/ax25/axports` and `axlisten` via NixOS modules 

To test `ax25/axports` and `ax25/axlisten` with its corresponding nixos test: `nix build .#nixosTests.ax25` This will spin up 3 VMs and use `socat-broker` and `socat` to mock out radios and terminal node controllers (tncs) to communicate across the nodes.The result is the ability to test AX.25 without needing any of the physical hardware.

The nixos tests were enabled by the recent addition of a ham radio enabled kernel in nixpkgs: https://github.com/NixOS/nixpkgs/pull/389291 

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
