### PR TITLE
soularr: init at 0-unstable-2025-04-14

### DIFF
--- a/pkgs/by-name/so/soularr/package.nix
+++ b/pkgs/by-name/so/soularr/package.nix
@@ -1,0 +1,47 @@
+{
+  lib,
+  fetchFromGitHub,
+  installShellFiles,
+  python3Packages,
+}:
+
+python3Packages.buildPythonApplication {
+  pname = "soularr";
+  version = "0-unstable-2025-04-14";
+  pyproject = false;
+
+  src = fetchFromGitHub {
+    owner = "mrusse";
+    repo = "soularr";
+    rev = "df9945dcf224096a21edabfc7e98b638f3ce1191";
+    hash = "sha256-HVv6Nz59M6YtdiAb30Xwv1pmZPNs0ByfozMyf5/Xhq8=";
+  };
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  dependencies = with python3Packages; [
+    music-tag
+    pyarr
+    slskd-api
+  ];
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mv soularr{.py,}
+    installBin soularr
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Python script that connects Lidarr with Soulseek";
+    homepage = "https://soularr.net/";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ getchoo ];
+    mainProgram = "soularr";
+  };
+}

--- a/pkgs/development/python-modules/slskd-api/default.nix
+++ b/pkgs/development/python-modules/slskd-api/default.nix
@@ -1,0 +1,34 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  requests,
+  setuptools-git-versioning,
+}:
+
+buildPythonPackage rec {
+  pname = "slskd-api";
+  version = "0.1.5";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "bigoulours";
+    repo = "slskd-python-api";
+    tag = "v${version}";
+    hash = "sha256-Kyzbd8y92VFzjIp9xVbhkK9rHA/6KCCJh7kNS/MtixI=";
+  };
+
+  nativeBuildInputs = [ setuptools-git-versioning ];
+
+  dependencies = [ requests ];
+
+  pythonImportsCheck = [ "slskd_api" ];
+
+  meta = {
+    description = "API Wrapper to interact with slskd";
+    homepage = "https://slskd-api.readthedocs.io/";
+    changelog = "https://github.com/bigoulours/slskd-python-api/releases/tag/${src.tag}";
+    license = lib.licenses.agpl3Only;
+    maintainers = with lib.maintainers; [ getchoo ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -15912,6 +15912,8 @@ self: super: with self; {
 
   slpp = callPackage ../development/python-modules/slpp { };
 
+  slskd-api = callPackage ../development/python-modules/slskd-api { };
+
   slugid = callPackage ../development/python-modules/slugid { };
 
   sly = callPackage ../development/python-modules/sly { };


### PR DESCRIPTION
[Soularr](https://soularr.net) is a Python script that connects Lidarr with Soulseek

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
