### PR TITLE
treewide: Remove use of apple_sdk framework stub paths

### DIFF
--- a/pkgs/by-name/gi/gildas/package.nix
+++ b/pkgs/by-name/gi/gildas/package.nix
@@ -12,7 +12,6 @@
   perl,
   groff,
   which,
-  darwin,
   ncurses,
 }:
 
@@ -49,17 +48,13 @@ stdenv.mkDerivation rec {
     which
   ];
 
-  buildInputs =
-    [
-      gtk2-x11
-      lesstif
-      cfitsio
-      python3Env
-      ncurses
-    ]
-    ++ lib.optionals stdenv.hostPlatform.isDarwin (
-      with darwin.apple_sdk.frameworks; [ CoreFoundation ]
-    );
+  buildInputs = [
+    gtk2-x11
+    lesstif
+    cfitsio
+    python3Env
+    ncurses
+  ];
 
   patches =
     [ ./wrapper.patch ]
@@ -72,10 +67,6 @@ stdenv.mkDerivation rec {
 
   # Workaround for https://github.com/NixOS/nixpkgs/issues/304528
   env.GAG_CPP = lib.optionalString stdenv.hostPlatform.isDarwin "${gfortran.outPath}/bin/cpp";
-
-  NIX_LDFLAGS = lib.optionalString stdenv.hostPlatform.isDarwin (
-    with darwin.apple_sdk.frameworks; "-F${CoreFoundation}/Library/Frameworks"
-  );
 
   configurePhase = ''
     substituteInPlace admin/wrapper.sh --replace '%%OUT%%' $out

--- a/pkgs/by-name/od/odin/darwin-remove-impure-links.patch
+++ b/pkgs/by-name/od/odin/darwin-remove-impure-links.patch
@@ -1,0 +1,23 @@
+diff --git a/src/linker.cpp b/src/linker.cpp
+index ec165ef7d..91a28b8fc 100644
+--- a/src/linker.cpp
++++ b/src/linker.cpp
+@@ -769,18 +769,6 @@ try_cross_linking:;
+ 			gbString platform_lib_str = gb_string_make(heap_allocator(), "");
+ 			defer (gb_string_free(platform_lib_str));
+ 			if (build_context.metrics.os == TargetOs_darwin) {
+-				platform_lib_str = gb_string_appendc(platform_lib_str, "-Wl,-syslibroot /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk -L/usr/local/lib ");
+-
+-				// Homebrew's default library path, checking if it exists to avoid linking warnings.
+-				if (gb_file_exists("/opt/homebrew/lib")) {
+-					platform_lib_str = gb_string_appendc(platform_lib_str, "-L/opt/homebrew/lib ");
+-				}
+-
+-				// MacPort's default library path, checking if it exists to avoid linking warnings.
+-				if (gb_file_exists("/opt/local/lib")) {
+-					platform_lib_str = gb_string_appendc(platform_lib_str, "-L/opt/local/lib ");
+-				}
+-
+ 				// Only specify this flag if the user has given a minimum version to target.
+ 				// This will cause warnings to show up for mismatched libraries.
+ 				if (build_context.minimum_os_version_string_given) {

--- a/pkgs/by-name/od/odin/package.nix
+++ b/pkgs/by-name/od/odin/package.nix
@@ -1,12 +1,9 @@
 {
   fetchFromGitHub,
   lib,
-  libiconv,
   llvmPackages,
-  MacOSX-SDK,
   makeBinaryWrapper,
   nix-update-script,
-  Security,
   which,
 }:
 
@@ -24,16 +21,9 @@ stdenv.mkDerivation {
     hash = "sha256-GXea4+OIFyAhTqmDh2q+ewTUqI92ikOsa2s83UH2r58=";
   };
 
-  postPatch =
-    lib.optionalString stdenv.hostPlatform.isDarwin ''
-      substituteInPlace src/linker.cpp \
-          --replace-fail '/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk' ${MacOSX-SDK}
-    ''
-    + ''
-      substituteInPlace build_odin.sh \
-          --replace-fail '-framework System' '-lSystem'
-      patchShebangs build_odin.sh
-    '';
+  patches = [
+    ./darwin-remove-impure-links.patch
+  ];
 
   LLVM_CONFIG = "${llvmPackages.llvm.dev}/bin/llvm-config";
 
@@ -44,11 +34,6 @@ stdenv.mkDerivation {
   nativeBuildInputs = [
     makeBinaryWrapper
     which
-  ];
-
-  buildInputs = lib.optionals stdenv.hostPlatform.isDarwin [
-    libiconv
-    Security
   ];
 
   installPhase = ''

--- a/pkgs/development/libraries/bullet/default.nix
+++ b/pkgs/development/libraries/bullet/default.nix
@@ -6,8 +6,6 @@
   libGLU,
   libGL,
   libglut,
-  Cocoa,
-  OpenGL,
 }:
 
 stdenv.mkDerivation rec {
@@ -22,26 +20,16 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ cmake ];
-  buildInputs =
-    lib.optionals stdenv.hostPlatform.isLinux [
-      libGLU
-      libGL
-      libglut
-    ]
-    ++ lib.optionals stdenv.hostPlatform.isDarwin [
-      Cocoa
-      OpenGL
-    ];
+  buildInputs = [
+    libGLU
+    libGL
+    libglut
+  ];
 
-  postPatch =
-    ''
-      substituteInPlace examples/ThirdPartyLibs/Gwen/CMakeLists.txt \
-        --replace "-DGLEW_STATIC" "-DGLEW_STATIC -Wno-narrowing"
-    ''
-    + lib.optionalString stdenv.hostPlatform.isDarwin ''
-      sed -i 's/FIND_PACKAGE(OpenGL)//' CMakeLists.txt
-      sed -i 's/FIND_LIBRARY(COCOA_LIBRARY Cocoa)//' CMakeLists.txt
-    '';
+  postPatch = ''
+    substituteInPlace examples/ThirdPartyLibs/Gwen/CMakeLists.txt \
+      --replace "-DGLEW_STATIC" "-DGLEW_STATIC -Wno-narrowing"
+  '';
 
   cmakeFlags =
     [
@@ -50,11 +38,6 @@ stdenv.mkDerivation rec {
       "-DINSTALL_EXTRA_LIBS=ON"
     ]
     ++ lib.optionals stdenv.hostPlatform.isDarwin [
-      "-DOPENGL_FOUND=true"
-      "-DOPENGL_LIBRARIES=${OpenGL}/Library/Frameworks/OpenGL.framework"
-      "-DOPENGL_INCLUDE_DIR=${OpenGL}/Library/Frameworks/OpenGL.framework"
-      "-DOPENGL_gl_LIBRARY=${OpenGL}/Library/Frameworks/OpenGL.framework"
-      "-DCOCOA_LIBRARY=${Cocoa}/Library/Frameworks/Cocoa.framework"
       "-DBUILD_BULLET2_DEMOS=OFF"
       "-DBUILD_UNIT_TESTS=OFF"
       "-DBUILD_BULLET_ROBOTICS_GUI_EXTRA=OFF"

--- a/pkgs/development/libraries/bullet/roboschool-fork.nix
+++ b/pkgs/development/libraries/bullet/roboschool-fork.nix
@@ -6,8 +6,6 @@
   libGLU,
   libGL,
   libglut,
-  Cocoa,
-  OpenGL,
 }:
 
 stdenv.mkDerivation {
@@ -26,23 +24,13 @@ stdenv.mkDerivation {
   };
 
   nativeBuildInputs = [ cmake ];
-  buildInputs =
-    lib.optionals stdenv.hostPlatform.isLinux [
-      libGLU
-      libGL
-      libglut
-    ]
-    ++ lib.optionals stdenv.hostPlatform.isDarwin [
-      Cocoa
-      OpenGL
-    ];
+  buildInputs = [
+    libGLU
+    libGL
+    libglut
+  ];
 
   patches = [ ./gwen-narrowing.patch ];
-
-  postPatch = lib.optionalString stdenv.hostPlatform.isDarwin ''
-    sed -i 's/FIND_PACKAGE(OpenGL)//' CMakeLists.txt
-    sed -i 's/FIND_LIBRARY(COCOA_LIBRARY Cocoa)//' CMakeLists.txt
-  '';
 
   cmakeFlags =
     [
@@ -51,11 +39,6 @@ stdenv.mkDerivation {
       "-DINSTALL_EXTRA_LIBS=ON"
     ]
     ++ lib.optionals stdenv.hostPlatform.isDarwin [
-      "-DOPENGL_FOUND=true"
-      "-DOPENGL_LIBRARIES=${OpenGL}/Library/Frameworks/OpenGL.framework"
-      "-DOPENGL_INCLUDE_DIR=${OpenGL}/Library/Frameworks/OpenGL.framework"
-      "-DOPENGL_gl_LIBRARY=${OpenGL}/Library/Frameworks/OpenGL.framework"
-      "-DCOCOA_LIBRARY=${Cocoa}/Library/Frameworks/Cocoa.framework"
       "-DBUILD_BULLET2_DEMOS=OFF"
       "-DBUILD_UNIT_TESTS=OFF"
     ];

--- a/pkgs/development/libraries/libsamplerate/default.nix
+++ b/pkgs/development/libraries/libsamplerate/default.nix
@@ -4,15 +4,8 @@
   fetchurl,
   pkg-config,
   libsndfile,
-  ApplicationServices,
-  Carbon,
-  CoreServices,
 }:
 
-let
-  inherit (lib) optionals optionalString;
-
-in
 stdenv.mkDerivation rec {
   pname = "libsamplerate";
   version = "0.2.2";
@@ -23,12 +16,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ pkg-config ];
-  buildInputs =
-    [ libsndfile ]
-    ++ optionals stdenv.hostPlatform.isDarwin [
-      ApplicationServices
-      CoreServices
-    ];
+  buildInputs = [ libsndfile ];
 
   configureFlags = [ "--disable-fftw" ];
 
@@ -36,12 +24,6 @@ stdenv.mkDerivation rec {
     "dev"
     "out"
   ];
-
-  postConfigure = optionalString stdenv.hostPlatform.isDarwin ''
-    # need headers from the Carbon.framework in /System/Library/Frameworks to
-    # compile this on darwin -- not sure how to handle
-    NIX_CFLAGS_COMPILE+=" -I${Carbon}/Library/Frameworks/Carbon.framework/Headers"
-  '';
 
   meta = with lib; {
     description = "Sample Rate Converter for audio";

--- a/pkgs/development/libraries/netcdf-fortran/default.nix
+++ b/pkgs/development/libraries/netcdf-fortran/default.nix
@@ -6,9 +6,6 @@
   hdf5,
   curl,
   gfortran,
-  CoreFoundation,
-  CoreServices,
-  SystemConfiguration,
 }:
 stdenv.mkDerivation rec {
   pname = "netcdf-fortran";
@@ -22,23 +19,12 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ gfortran ];
-  buildInputs =
-    [
-      netcdf
-      hdf5
-      curl
-    ]
-    ++ lib.optionals stdenv.hostPlatform.isDarwin [
-      CoreFoundation
-      CoreServices
-      SystemConfiguration
-    ];
-  env.NIX_LDFLAGS = toString (
-    lib.optionals stdenv.hostPlatform.isDarwin [
-      "-F${CoreServices}/Library/Frameworks"
-      "-F${SystemConfiguration}/Library/Frameworks"
-    ]
-  );
+  buildInputs = [
+    netcdf
+    hdf5
+    curl
+  ];
+
   doCheck = true;
 
   FFLAGS = [ "-std=legacy" ];

--- a/pkgs/development/python-modules/jaxlib/default.nix
+++ b/pkgs/development/python-modules/jaxlib/default.nix
@@ -15,7 +15,6 @@
   cython,
   fetchFromGitHub,
   git,
-  darwin,
   jsoncpp,
   nsync,
   openssl,
@@ -409,10 +408,8 @@ let
       );
 
       # Note: we cannot do most of this patching at `patch` phase as the deps
-      # are not available yet. Framework search paths aren't added by bintools
-      # hook. See https://github.com/NixOS/nixpkgs/pull/41914.
+      # are not available yet.
       preBuild = lib.optionalString effectiveStdenv.hostPlatform.isDarwin ''
-        export NIX_LDFLAGS+=" -F${darwin.apple_sdk.frameworks.IOKit}/Library/Frameworks"
         substituteInPlace ../output/external/rules_cc/cc/private/toolchain/osx_cc_wrapper.sh.tpl \
           --replace "/usr/bin/install_name_tool" "${cctools}/bin/install_name_tool"
         substituteInPlace ../output/external/rules_cc/cc/private/toolchain/unix_cc_configure.bzl \

--- a/pkgs/development/tools/build-managers/bazel/cpp-test.nix
+++ b/pkgs/development/tools/build-managers/bazel/cpp-test.nix
@@ -10,9 +10,7 @@
   runLocal,
   runtimeShell,
   writeScript,
-  writeText,
   distDir,
-  Foundation ? null,
 }:
 
 let
@@ -58,10 +56,6 @@ let
       + lib.optionalString (stdenv.hostPlatform.isDarwin) ''
         --cxxopt=-x --cxxopt=c++ --host_cxxopt=-x --host_cxxopt=c++ \
         --linkopt=-stdlib=libc++ --host_linkopt=-stdlib=libc++ \
-      ''
-      + lib.optionalString (stdenv.hostPlatform.isDarwin && Foundation != null) ''
-        --linkopt=-Wl,-F${Foundation}/Library/Frameworks \
-        --linkopt=-L${darwin.libobjc}/lib \
       '';
   };
 

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -48,10 +48,6 @@
   libxslt,
   libxcrypt,
   hwdata,
-  ApplicationServices,
-  Carbon,
-  Cocoa,
-  Xplugin,
   xorg,
   windows,
   libgbm,
@@ -1220,9 +1216,6 @@ self: super:
             bootstrap_cmds
             automake
             autoconf
-            Xplugin
-            Carbon
-            Cocoa
             mesa
           ];
           propagatedBuildInputs = commonPropagatedBuildInputs ++ [
@@ -1281,7 +1274,6 @@ self: super:
           preConfigure = ''
             mkdir -p $out/Applications
             export NIX_CFLAGS_COMPILE="$NIX_CFLAGS_COMPILE -Wno-error"
-            substituteInPlace hw/xquartz/pbproxy/Makefile.in --replace -F/System -F${ApplicationServices}
           '';
           postInstall = ''
             rm -fr $out/share/X11/xkb/compiled
@@ -1322,15 +1314,12 @@ self: super:
         "--without-dtrace"
       ];
 
-    buildInputs =
-      old.buildInputs
-      ++ [
-        xorg.pixman
-        xorg.libXfont2
-        xorg.xtrans
-        xorg.libxcvt
-      ]
-      ++ lib.optional stdenv.hostPlatform.isDarwin [ Xplugin ];
+    buildInputs = old.buildInputs ++ [
+      xorg.pixman
+      xorg.libXfont2
+      xorg.xtrans
+      xorg.libxcvt
+    ];
   });
 
   lndir = super.lndir.overrideAttrs (attrs: {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10203,9 +10203,7 @@ with pkgs;
     memHierarchy = "L3:16/64/8192K,L2:16/64/2048K,L1:8/64/16K";
   };
 
-  libsamplerate = callPackage ../development/libraries/libsamplerate {
-    inherit (darwin.apple_sdk.frameworks) ApplicationServices Carbon CoreServices;
-  };
+  libsamplerate = callPackage ../development/libraries/libsamplerate { };
 
   # GNU libc provides libiconv so systems with glibc don't need to
   # build libiconv separately. Additionally, Apple forked/repackaged

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12667,8 +12667,6 @@ with pkgs;
       # so as not to have the newly bound xorg items already in scope,  which would
       # have created a cycle.
       overrides = lib.callPackageWith __splicedPackages ../servers/x11/xorg/overrides.nix {
-        inherit (darwin.apple_sdk.frameworks) ApplicationServices Carbon Cocoa;
-        inherit (darwin.apple_sdk.libs) Xplugin;
         inherit (buildPackages.darwin) bootstrap_cmds;
         udev = if stdenv.hostPlatform.isLinux then udev else null;
         libdrm = if stdenv.hostPlatform.isLinux then libdrm else null;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -19295,13 +19295,9 @@ with pkgs;
 
   zncModules = recurseIntoAttrs (callPackage ../applications/networking/znc/modules.nix { });
 
-  bullet = callPackage ../development/libraries/bullet {
-    inherit (darwin.apple_sdk.frameworks) Cocoa OpenGL;
-  };
+  bullet = callPackage ../development/libraries/bullet { };
 
-  bullet-roboschool = callPackage ../development/libraries/bullet/roboschool-fork.nix {
-    inherit (darwin.apple_sdk.frameworks) Cocoa OpenGL;
-  };
+  bullet-roboschool = callPackage ../development/libraries/bullet/roboschool-fork.nix { };
 
   dart = callPackage ../development/compilers/dart { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4462,9 +4462,7 @@ with pkgs;
     hdf5 = hdf5-mpi.override { usev110Api = true; };
   };
 
-  netcdffortran = callPackage ../development/libraries/netcdf-fortran {
-    inherit (darwin.apple_sdk.frameworks) CoreFoundation CoreServices SystemConfiguration;
-  };
+  netcdffortran = callPackage ../development/libraries/netcdf-fortran { };
 
   inherit (callPackage ../servers/web-apps/netbox { }) netbox_3_7;
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13109,8 +13109,6 @@ with pkgs;
   };
 
   odin = callPackage ../by-name/od/odin/package.nix {
-    inherit (pkgs.darwin.apple_sdk_11_0) MacOSX-SDK;
-    inherit (pkgs.darwin.apple_sdk_11_0.frameworks) Security;
     llvmPackages = llvmPackages_18;
   };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -13200,9 +13200,7 @@ self: super: with self; {
 
   pyscaffoldext-travis = callPackage ../development/python-modules/pyscaffoldext-travis { };
 
-  pyscard = callPackage ../development/python-modules/pyscard {
-    inherit (pkgs.darwin.apple_sdk.frameworks) PCSC;
-  };
+  pyscard = callPackage ../development/python-modules/pyscard { };
 
   pyscf = callPackage ../development/python-modules/pyscf { };
 


### PR DESCRIPTION
This patch covers all packages that use stub paths in some way in their
build instructions.

(Except those listed in [this](https://github.com/NixOS/nixpkgs/pull/399040#issuecomment-2814334550) comment.)

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
