### PR TITLE
igsc: init at 0.9.6

### DIFF
--- a/pkgs/by-name/ig/igsc/package.nix
+++ b/pkgs/by-name/ig/igsc/package.nix
@@ -1,0 +1,42 @@
+{
+  fetchFromGitHub,
+  lib,
+  nix-update-script,
+  stdenv,
+  cmake,
+  metee,
+  udev,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "igsc";
+  version = "0.9.6";
+  src = fetchFromGitHub {
+    owner = "intel";
+    repo = "igsc";
+    tag = "V${finalAttrs.version}";
+    hash = "sha256-ecjcDYirbJC2s48+SOwFuJAJQ6eaabTrmgTjgb+dXrA=";
+  };
+
+  buildInputs = [
+    metee
+    udev
+  ];
+  nativeBuildInputs = [ cmake ];
+
+  cmakeFlags = [
+    "-DMETEE_LIB_PATH=${metee}/lib"
+    "-DMETEE_HEADER_PATH=${metee}/include"
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    mainProgram = "igsc";
+    maintainers = with lib.maintainers; [ xddxdd ];
+    description = "Intel graphics system controller firmware update library";
+    homepage = "https://github.com/intel/igsc";
+    license = lib.licenses.asl20;
+    changelog = "https://github.com/intel/igsc/releases/tag/V${finalAttrs.version}";
+    platforms = lib.platforms.linux;
+  };
+})

--- a/pkgs/by-name/me/metee/package.nix
+++ b/pkgs/by-name/me/metee/package.nix
@@ -1,0 +1,30 @@
+{
+  fetchFromGitHub,
+  lib,
+  nix-update-script,
+  stdenv,
+  cmake,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "metee";
+  version = "6.0.1";
+  src = fetchFromGitHub {
+    owner = "intel";
+    repo = "metee";
+    tag = finalAttrs.version;
+    hash = "sha256-PwIadjg1D7WumqVgkpfnXkdUzIOjzA+b3Jjk30epAE8=";
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    maintainers = with lib.maintainers; [ xddxdd ];
+    description = "C library to access CSE/CSME/GSC firmware via a MEI interface";
+    homepage = "https://github.com/intel/metee";
+    license = lib.licenses.asl20;
+    changelog = "https://github.com/intel/metee/releases/tag/${finalAttrs.version}";
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
`igsc` is a command that does firmware update for Intel Arc GPUs.

This PR also includes `metee` package which is a dependency of `igsc`.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
