### PR TITLE
taskflow: fix cross build

### DIFF
--- a/pkgs/by-name/ta/taskflow/package.nix
+++ b/pkgs/by-name/ta/taskflow/package.nix
@@ -35,6 +35,11 @@ stdenv.mkDerivation rec {
     cmake
   ];
 
+  cmakeFlags = [
+    # building the tests implies running them in the buildPhase
+    (lib.cmakeBool "TF_BUILD_TESTS" (stdenv.buildPlatform.canExecute stdenv.hostPlatform))
+  ];
+
   doCheck = true;
 
   meta = {

--- a/pkgs/by-name/ta/taskflow/package.nix
+++ b/pkgs/by-name/ta/taskflow/package.nix
@@ -7,14 +7,14 @@
   stdenv,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "taskflow";
   version = "3.9.0";
 
   src = fetchFromGitHub {
     owner = "taskflow";
     repo = "taskflow";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-omon02xgf4vV7JzpLFtHgf2MXxR6JowI+pDyAswXMUY=";
   };
 
@@ -37,7 +37,7 @@ stdenv.mkDerivation rec {
 
   cmakeFlags = [
     # building the tests implies running them in the buildPhase
-    (lib.cmakeBool "TF_BUILD_TESTS" (stdenv.buildPlatform.canExecute stdenv.hostPlatform))
+    (lib.cmakeBool "TF_BUILD_TESTS" finalAttrs.finalPackage.doCheck)
   ];
 
   doCheck = true;
@@ -47,11 +47,11 @@ stdenv.mkDerivation rec {
     homepage = "https://taskflow.github.io/";
     changelog =
       let
-        release = lib.replaceStrings [ "." ] [ "-" ] version;
+        release = lib.replaceStrings [ "." ] [ "-" ] finalAttrs.version;
       in
       "https://taskflow.github.io/taskflow/release-${release}.html";
     license = lib.licenses.mit;
     platforms = lib.platforms.unix;
     maintainers = with lib.maintainers; [ dotlambda ];
   };
-}
+})


### PR DESCRIPTION
This package's CMake setup conflates building and running tests, so we must disable test building explicitly for cross builds.

Note: I haven't checked whether the `checkPhase` does anything useful here, maybe it runs more tests?

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux (cross)
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).