### PR TITLE
nixos/systemd-resolved: add RFC6762 (MuilticastDNS) support

### DIFF
--- a/nixos/modules/system/boot/resolved.nix
+++ b/nixos/modules/system/boot/resolved.nix
@@ -19,6 +19,7 @@ let
     ${optionalString (cfg.fallbackDns != null) "FallbackDNS=${concatStringsSep " " cfg.fallbackDns}"}
     ${optionalString (cfg.domains != [ ]) "Domains=${concatStringsSep " " cfg.domains}"}
     LLMNR=${cfg.llmnr}
+    MulticastDNS=${cfg.multicastdns}
     DNSSEC=${cfg.dnssec}
     DNSOverTLS=${cfg.dnsovertls}
     ${config.services.resolved.extraConfig}
@@ -87,6 +88,31 @@ in
         - `"true"`: Enables full LLMNR responder and resolver support.
         - `"false"`: Disables both.
         - `"resolve"`: Only resolution support is enabled, but responding is disabled.
+
+        Note that systemd-networkd.service(8) also maintains per-link Multicast DNS settings.
+        Multicast DNS will be enabled on a link only if the per-link and the global setting is on.
+      '';
+    };
+
+    services.resolved.multicastdns = mkOption {
+      default = "true";
+      example = "false";
+      type = types.enum [
+        "true"
+        "resolve"
+        "false"
+      ];
+      description = ''
+        Controls Link-Local Multicast Name Resolution support
+        (RFC 6762) on the local host.
+
+        If set to
+        - `"true"`: Enables full MulticastDNS responder and resolver support.
+        - `"false"`: Disables both.
+        - `"resolve"`: Only resolution support is enabled, but responding is disabled.
+
+        Note that systemd-networkd.service(8) also maintains per-link Multicast DNS settings.
+        Multicast DNS will be enabled on a link only if the per-link and the global setting is on.
       '';
     };
 


### PR DESCRIPTION
Add nixos systemd-resolved MulticastDNS configuration option support, add configuration notes.

Rationale:
- Systemd-Resoved declarative configuration currently only supports [LLMNR / RFC4795 / year:2007](https://datatracker.ietf.org/doc/html/rfc4795) configuration.
- Since 2017 [systemd-resolved-234](httips://www.freedesktop.org/software/systemd/man/latest/resolved.conf.html) introduced  [MulticastDNS / RFC 6762 / year:2013](https://datatracker.ietf.org/doc/html/rfc6762).
- We are at system 257.3 and MulticastDNS defaults to true. 
- Nixos lacks a programmatic configuration option to control MulticastDNS (eg. for hardening/security). 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [X] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
