### PR TITLE
nixosTests.mailhog: remove unsupported flags from sendmail & migrate to runTest

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -766,7 +766,7 @@ in
   magic-wormhole-mailbox-server = runTest ./magic-wormhole-mailbox-server.nix;
   magnetico = handleTest ./magnetico.nix { };
   mailcatcher = runTest ./mailcatcher.nix;
-  mailhog = handleTest ./mailhog.nix { };
+  mailhog = runTest ./mailhog.nix;
   mailpit = runTest ./mailpit.nix;
   mailman = handleTest ./mailman.nix { };
   man = handleTest ./man.nix { };

--- a/nixos/tests/mailhog.nix
+++ b/nixos/tests/mailhog.nix
@@ -1,30 +1,28 @@
-import ./make-test-python.nix (
-  { lib, ... }:
-  {
-    name = "mailhog";
-    meta.maintainers = with lib.maintainers; [
-      jojosch
-      RTUnreal
-    ];
+{ lib, ... }:
+{
+  name = "mailhog";
+  meta.maintainers = with lib.maintainers; [
+    jojosch
+    RTUnreal
+  ];
 
-    nodes.machine =
-      { pkgs, ... }:
-      {
-        services.mailhog.enable = true;
-      };
+  nodes.machine =
+    { pkgs, ... }:
+    {
+      services.mailhog.enable = true;
+    };
 
-    testScript = ''
-      start_all()
+  testScript = ''
+    start_all()
 
-      machine.wait_for_unit("mailhog.service")
-      machine.wait_for_open_port(1025)
-      machine.wait_for_open_port(8025)
-      # Test sendmail wrapper (this uses smtp, which tests the connection)
-      machine.succeed('printf "To: root@example.com\r\n\r\nthis is the body of the email" | sendmail -f sender@example.com')
-      res = machine.succeed(
-          "curl --fail http://localhost:8025/api/v2/messages"
-      )
-      assert all(msg in res for msg in ["this is the body of the email", "sender@example.com", "root@example.com"])
-    '';
-  }
-)
+    machine.wait_for_unit("mailhog.service")
+    machine.wait_for_open_port(1025)
+    machine.wait_for_open_port(8025)
+    # Test sendmail wrapper (this uses smtp, which tests the connection)
+    machine.succeed('printf "To: root@example.com\r\n\r\nthis is the body of the email" | sendmail -f sender@example.com')
+    res = machine.succeed(
+        "curl --fail http://localhost:8025/api/v2/messages"
+    )
+    assert all(msg in res for msg in ["this is the body of the email", "sender@example.com", "root@example.com"])
+  '';
+}

--- a/nixos/tests/mailhog.nix
+++ b/nixos/tests/mailhog.nix
@@ -20,7 +20,7 @@ import ./make-test-python.nix (
       machine.wait_for_open_port(1025)
       machine.wait_for_open_port(8025)
       # Test sendmail wrapper (this uses smtp, which tests the connection)
-      machine.succeed('printf "To: root@example.com\r\n\r\nthis is the body of the email" | sendmail -t -i -f sender@example.com')
+      machine.succeed('printf "To: root@example.com\r\n\r\nthis is the body of the email" | sendmail -f sender@example.com')
       res = machine.succeed(
           "curl --fail http://localhost:8025/api/v2/messages"
       )


### PR DESCRIPTION
Part of https://github.com/NixOS/nixpkgs/issues/386873

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
