### PR TITLE
make-bootstrap-tools-cross: add loongarch64-unknown-linux-gnu

### DIFF
--- a/pkgs/stdenv/linux/make-bootstrap-tools-cross.nix
+++ b/pkgs/stdenv/linux/make-bootstrap-tools-cross.nix
@@ -36,6 +36,7 @@ lib.mapAttrs (n: make) (
     powerpc64le-unknown-linux-gnu = powernv;
     riscv64-unknown-linux-gnu = riscv64;
     s390x-unknown-linux-gnu = s390x;
+    loongarch64-unknown-linux-gnu = loongarch64-linux;
 
     # musl
     aarch64-unknown-linux-musl = aarch64-multiplatform-musl;

--- a/pkgs/stdenv/linux/stdenv-bootstrap-tools.nix
+++ b/pkgs/stdenv/linux/stdenv-bootstrap-tools.nix
@@ -66,7 +66,6 @@ stdenv.mkDerivation (finalAttrs: {
           cp -d ${libc.out}/lib/libnsl*.so* $out/lib
         ''
         + ''
-          cp -d ${libc.out}/lib/libutil*.so* $out/lib
           cp -d ${libc.out}/lib/libnss*.so* $out/lib
           cp -d ${libc.out}/lib/libresolv*.so* $out/lib
           # Copy all runtime files to enable non-PIE, PIE, static PIE and profile-generated builds

--- a/pkgs/stdenv/linux/stdenv-bootstrap-tools.nix
+++ b/pkgs/stdenv/linux/stdenv-bootstrap-tools.nix
@@ -1,7 +1,7 @@
 {
   lib,
   stdenv,
-  bash,
+  bashNonInteractive,
   binutils,
   bootBinutils,
   bootGCC,
@@ -111,7 +111,7 @@ stdenv.mkDerivation (finalAttrs: {
       cp -d ${coreutilsMinimal.out}/bin/* $out/bin
       (cd $out/bin && rm vdir dir sha*sum pinky factor pathchk runcon shuf who whoami shred users)
 
-      cp ${bash.out}/bin/bash $out/bin
+      cp ${bashNonInteractive.out}/bin/bash $out/bin
       cp ${findutils.out}/bin/find $out/bin
       cp ${findutils.out}/bin/xargs $out/bin
       cp -d ${diffutils.out}/bin/* $out/bin


### PR DESCRIPTION
Require #399694 to actually work with stage1 but the bootstrap tarball is here. (so do any other architectures when they are updated to use gcc14 in bootstrap)

Successfully approached `pkgs.hello`.