### PR TITLE
nixos/homepage-dashboard: Set ALLOWED_HOSTS env var.

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2505.section.md
+++ b/nixos/doc/manual/release-notes/rl-2505.section.md
@@ -416,6 +416,8 @@
 
 - `programs.clash-verge.tunMode` was deprecated and removed because now service mode is necessary to start program. Without `programs.clash-verge.enable`, clash-verge-rev will refuse to start.
 
+- `services.homepage-dashboard` now requires the `allowedHosts` option to be set in accordance with the [documentation](https://gethomepage.dev/installation/#homepage_allowed_hosts).
+
 - `services.netbird.tunnels` was renamed to [`services.netbird.clients`](#opt-services.netbird.clients),
   hardened (using dedicated less-privileged users) and significantly extended.
 

--- a/nixos/modules/services/misc/homepage-dashboard.nix
+++ b/nixos/modules/services/misc/homepage-dashboard.nix
@@ -4,7 +4,6 @@
   lib,
   ...
 }:
-
 let
   cfg = config.services.homepage-dashboard;
   # Define the settings format used for this program
@@ -27,6 +26,19 @@ in
         type = lib.types.int;
         default = 8082;
         description = "Port for Homepage to bind to.";
+      };
+
+      allowedHosts = lib.mkOption {
+        type = lib.types.str;
+        default = "localhost:8082,127.0.0.1:8082";
+        example = "example.com";
+        description = ''
+          Hosts that homepage-dashboard will be running under.
+          You will want to change this in order to acess homepage from anything other than localhost.
+          see the upsream documentation:
+
+          <https://gethomepage.dev/installation/#homepage_allowed_hosts>
+        '';
       };
 
       environmentFile = lib.mkOption {
@@ -215,6 +227,7 @@ in
         NIXPKGS_HOMEPAGE_CACHE_DIR = "/var/cache/homepage-dashboard";
         PORT = toString cfg.listenPort;
         LOG_TARGETS = "stdout";
+        HOMEPAGE_ALLOWED_HOSTS = cfg.allowedHosts;
       };
 
       serviceConfig = {


### PR DESCRIPTION
homepage 1.0.0 requires HOMEPAGE_ALLOWED_HOSTS var to be set, this change allows setting it without building an environmentFile, allowing the environment file to be kept just for secrets.

fixes #399175

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->
@jnsgruk 
---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
