### PR TITLE
yelp: CVE-2025-3155

### DIFF
--- a/pkgs/by-name/ye/yelp-xsl/cve-2025-3155.patch
+++ b/pkgs/by-name/ye/yelp-xsl/cve-2025-3155.patch
@@ -1,0 +1,79 @@
+diff --git a/xslt/common/html.xsl b/xslt/common/html.xsl
+index 77aed075..82832fb4 100644
+--- a/xslt/common/html.xsl
++++ b/xslt/common/html.xsl
+@@ -266,6 +266,16 @@ certain tokens, and you can add your own with {html.sidebar.mode}. See
+ -->
+ <xsl:param name="html.sidebar.right" select="''"/>
+ 
++<!--@@==========================================================================
++html.csp.nonce
++An optional CSP nonce string to allow the execution of scripts and styles.
++@revision[version=42.2 date=2025-02-22 status=final]
++
++This parameter takes a string value that will be added to the 'nonce' attribute
++of all 'style' and 'script' tags in the generated HTML output. This paramter is used
++to whitelist script and style tags that are allowed to be executed.
++-->
++<xsl:param name="html.csp.nonce" select="false()"/>
+ 
+ <!--**==========================================================================
+ html.output
+@@ -1124,6 +1134,11 @@ dimensions. All parameters can be automatically computed if not provided.
+     </xsl:call-template>
+   </xsl:param>
+   <style type="text/css">
++    <xsl:if test="$html.csp.nonce">
++      <xsl:attribute name="nonce">
++        <xsl:value-of select="$html.csp.nonce" />
++      </xsl:attribute>
++    </xsl:if>
+     <xsl:call-template name="html.css.content">
+       <xsl:with-param name="node" select="$node"/>
+       <xsl:with-param name="direction" select="$direction"/>
+@@ -1533,6 +1548,11 @@ copy, override this template and provide the necessary files.
+   <xsl:param name="node" select="."/>
+   <xsl:if test="$node//mml:*[1]">
+     <script type="text/javascript">
++      <xsl:if test="$html.csp.nonce">
++        <xsl:attribute name="nonce">
++          <xsl:value-of select="$html.csp.nonce" />
++        </xsl:attribute>
++      </xsl:if>
+       <xsl:attribute name="src">
+         <xsl:text>http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=MML_HTMLorMML</xsl:text>
+       </xsl:attribute>
+@@ -1558,6 +1578,11 @@ result of {html.js.content} to that file.
+ <xsl:template name="html.js.script">
+   <xsl:param name="node" select="."/>
+   <script type="text/javascript">
++    <xsl:if test="$html.csp.nonce">
++      <xsl:attribute name="nonce">
++        <xsl:value-of select="$html.csp.nonce" />
++      </xsl:attribute>
++    </xsl:if>
+     <xsl:call-template name="html.js.content">
+       <xsl:with-param name="node" select="$node"/>
+     </xsl:call-template>
+@@ -2035,8 +2060,19 @@ on all `code` elements with `"syntax"` in the class value.
+ <xsl:template name="html.js.syntax">
+   <xsl:param name="node" select="."/>
+   <xsl:if test="$html.syntax.highlight">
+-  <script type="text/javascript" src="{$html.js.root}highlight.pack.js"></script>
+-  <script><![CDATA[
++    <script type="text/javascript" src="{$html.js.root}highlight.pack.js">
++      <xsl:if test="$html.csp.nonce">
++        <xsl:attribute name="nonce">
++          <xsl:value-of select="$html.csp.nonce" />
++        </xsl:attribute>
++      </xsl:if>
++    </script>
++    <script>
++    <xsl:if test="$html.csp.nonce">
++      <xsl:attribute name="nonce">
++        <xsl:value-of select="$html.csp.nonce" />
++      </xsl:attribute>
++    </xsl:if><![CDATA[
+ document.addEventListener('DOMContentLoaded', function() {
+   var matches = document.querySelectorAll('code.syntax')
+   for (var i = 0; i < matches.length; i++) {

--- a/pkgs/by-name/ye/yelp-xsl/package.nix
+++ b/pkgs/by-name/ye/yelp-xsl/package.nix
@@ -29,6 +29,10 @@ stdenv.mkDerivation rec {
 
   doCheck = true;
 
+  patches = [
+    ./cve-2025-3155.patch
+  ];
+
   passthru = {
     updateScript = gnome.updateScript {
       packageName = "yelp-xsl";

--- a/pkgs/by-name/ye/yelp/cve-2025-3155.patch
+++ b/pkgs/by-name/ye/yelp/cve-2025-3155.patch
@@ -1,0 +1,101 @@
+diff --git a/data/xslt/mal2html.xsl.in b/data/xslt/mal2html.xsl.in
+index 9e44b734..0a74da55 100644
+--- a/data/xslt/mal2html.xsl.in
++++ b/data/xslt/mal2html.xsl.in
+@@ -19,6 +19,11 @@
+ <xsl:param name="mal.link.prefix" select="'xref:'"/>
+ <xsl:param name="mal.link.extension" select="''"/>
+ 
++<xsl:template name="html.head.top.custom">
++  <xsl:param name="node" select="."/>
++  <meta http-equiv="Content-Security-Policy" content="default-src bogus-ghelp: bogus-gnome-help: bogus-help: bogus-help-list: bogus-info: bogus-man: ; script-src 'nonce-{$html.csp.nonce}'; style-src 'nonce-{$html.csp.nonce}'; "/>
++</xsl:template>
++
+ <xsl:template name="mal.link.target.custom">
+   <xsl:param name="node" select="."/>
+   <xsl:param name="action" select="$node/@action"/>
+diff --git a/data/xslt/man2html.xsl.in b/data/xslt/man2html.xsl.in
+index 676ce3eb..56bc1f5c 100644
+--- a/data/xslt/man2html.xsl.in
++++ b/data/xslt/man2html.xsl.in
+@@ -131,7 +131,7 @@
+   the correct styling and a single character which we measure the
+   width of and update each sheet as required.
+ -->
+-<script type="text/javascript" language="javascript">
++<script type="text/javascript" language="javascript" nonce="{$html.csp.nonce}">
+ <xsl:text>
+ $(document).ready (function () {
+   var div = document.getElementById("invisible-char");
+diff --git a/data/xslt/yelp-common.xsl.in b/data/xslt/yelp-common.xsl.in
+index 0c1ec9bb..421fc02d 100644
+--- a/data/xslt/yelp-common.xsl.in
++++ b/data/xslt/yelp-common.xsl.in
+@@ -15,6 +15,13 @@
+ <xsl:param name="html.syntax.highlight" select="true()"/>
+ <xsl:param name="html.js.root" select="'file://@XSL_JSDIR@/'"/>
+ 
++<xsl:param name="html.csp.nonce" select="yelp:generate_nonce()"/>
++
++<xsl:template name="html.head.top.custom">
++  <xsl:param name="node" select="."/>
++  <meta http-equiv="Content-Security-Policy" content="default-src bogus-ghelp: bogus-gnome-help: bogus-help: bogus-help-list: bogus-info: bogus-man: ; script-src 'nonce-{$html.csp.nonce}'; style-src 'unsafe-inline'; "/>
++</xsl:template>
++
+ <xsl:template name="html.js.mathjax">
+   <xsl:param name="node" select="."/>
+   <xsl:if test="$node//mml:*[1]">
+diff --git a/libyelp/yelp-transform.c b/libyelp/yelp-transform.c
+index e74eb463..2ce1d05b 100644
+--- a/libyelp/yelp-transform.c
++++ b/libyelp/yelp-transform.c
+@@ -71,6 +71,8 @@ static void      xslt_yelp_cache            (xsltTransformContextPtr  ctxt,
+                                              xsltStylePreCompPtr      comp);
+ static void      xslt_yelp_aux              (xmlXPathParserContextPtr ctxt,
+                                              int                      nargs);
++static void      xslt_yelp_generate_nonce   (xmlXPathParserContextPtr ctxt,
++                                             int                      nargs);
+ 
+ enum {
+     PROP_0,
+@@ -412,6 +414,10 @@ transform_run (YelpTransform *transform)
+                              BAD_CAST "input",
+                              BAD_CAST YELP_NAMESPACE,
+                              (xmlXPathFunction) xslt_yelp_aux);
++    xsltRegisterExtFunction (priv->context,
++                         BAD_CAST "generate_nonce",
++                         BAD_CAST YELP_NAMESPACE,
++                         (xmlXPathFunction) xslt_yelp_generate_nonce);
+ 
+     priv->output = xsltApplyStylesheetUser (priv->stylesheet,
+                                             priv->input,
+@@ -607,3 +613,16 @@ xslt_yelp_aux (xmlXPathParserContextPtr ctxt, int nargs)
+     xsltExtensionInstructionResultRegister (tctxt, ret);
+     valuePush (ctxt, ret);
+ }
++
++static void
++xslt_yelp_generate_nonce (xmlXPathParserContextPtr ctxt, int nargs)
++{
++    GRand* rand;
++    gchar* nonce_str;
++
++    rand = g_rand_new ();
++    nonce_str = g_strdup_printf("%08x%08x", g_rand_int (rand), g_rand_int (rand));
++    xmlXPathReturnString (ctxt, xmlStrdup ((xmlChar *) nonce_str));
++    g_free(nonce_str);
++    g_rand_free(rand);
++}
+diff --git a/libyelp/yelp-view.c b/libyelp/yelp-view.c
+index 32ae131e..d544c5df 100644
+--- a/libyelp/yelp-view.c
++++ b/libyelp/yelp-view.c
+@@ -971,7 +971,7 @@ view_external_uri (YelpView *view,
+ 
+     if (app_info)
+       {
+-        if (!strstr (g_app_info_get_executable (app_info), "yelp"))
++        if (!strstr (g_app_info_get_executable (app_info), "yelp") && !strstr (struri, "%3C") && !strstr (struri, "%3E"))
+           {
+             GList l;
+ 

--- a/pkgs/by-name/ye/yelp/package.nix
+++ b/pkgs/by-name/ye/yelp/package.nix
@@ -49,6 +49,10 @@ stdenv.mkDerivation rec {
     gst_all_1.gst-plugins-good
   ];
 
+  patches = [
+    ./cve-2025-3155.patch
+  ];
+
   passthru = {
     updateScript = gnome.updateScript {
       packageName = "yelp";


### PR DESCRIPTION
Yelp aka Gnome Help has a [dangerous vulnerability that isn't fixed upstread](https://gitlab.gnome.org/GNOME/yelp/-/issues/221#top)

It was made public ~12h ago here: https://blogs.gnome.org/mcatanzaro/2025/04/15/dangerous-arbitrary-file-read-vulnerability-in-yelp-cve-2025-3155/


The patches are from the reporter: https://gitlab.gnome.org/GNOME/yelp/-/issues/221#note_2359937

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
