### PR TITLE
lutris: migrate to the new meson build system

### DIFF
--- a/pkgs/applications/misc/lutris/default.nix
+++ b/pkgs/applications/misc/lutris/default.nix
@@ -6,6 +6,7 @@
   # build inputs
   atk,
   file,
+  glib,
   gdk-pixbuf,
   glib-networking,
   gnome-desktop,
@@ -16,6 +17,8 @@
   pango,
   webkitgtk_4_1,
   wrapGAppsHook3,
+  meson,
+  ninja,
 
   # check inputs
   xvfb-run,
@@ -45,11 +48,15 @@
   pulseaudio,
   p7zip,
   xgamma,
+  gettext,
   libstrangle,
   fluidsynth,
   xorgserver,
   xorg,
   util-linux,
+  pkg-config,
+  desktop-file-utils,
+  appstream-glib,
 }:
 
 let
@@ -83,9 +90,18 @@ buildPythonApplication rec {
     hash = "sha256-CAXKnx5+60MITRM8enkYgFl5ZKM6HCXhCYNyG7kHhuQ=";
   };
 
+  format = "other";
+
   nativeBuildInputs = [
-    wrapGAppsHook3
+    appstream-glib
+    desktop-file-utils
+    gettext
+    glib
     gobject-introspection
+    meson
+    ninja
+    wrapGAppsHook3
+    pkg-config
   ];
   buildInputs =
     [
@@ -126,20 +142,6 @@ buildPythonApplication rec {
   postPatch = ''
     substituteInPlace lutris/util/magic.py \
       --replace '"libmagic.so.1"' "'${lib.getLib file}/lib/libmagic.so.1'"
-  '';
-
-  nativeCheckInputs = [
-    xvfb-run
-    nose2
-    flake8
-  ] ++ requiredTools;
-  checkPhase = ''
-    runHook preCheck
-
-    export HOME=$PWD
-    xvfb-run -s '-screen 0 800x600x24' make test
-
-    runHook postCheck
   '';
 
   # avoid double wrapping

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13207,7 +13207,9 @@ with pkgs;
 
   luddite = with python3Packages; toPythonApplication luddite;
 
-  lutris-unwrapped = python3.pkgs.callPackage ../applications/misc/lutris { };
+  lutris-unwrapped = python3.pkgs.callPackage ../applications/misc/lutris {
+    inherit (pkgs) meson;
+  };
   lutris = callPackage ../applications/misc/lutris/fhsenv.nix { };
   lutris-free = lutris.override {
     steamSupport = false;


### PR DESCRIPTION
This commit makes the Lutris package use the meson build system, which is more appropriate to build the desktop app. Indeed, the meson build of Lutris is the only one supporting translations for the desktop app. However, the presence of the Makefile at the source root is preventing the Nix build system from building the package with meson without overriding the different build phases.

- Closes #399050 

This should probably be backported too.

**Edit**: force-pushes are due to my unintentional deletion of postPatch phase which was fixing libmagic.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
