### PR TITLE
nixosTests.printing-{socket,service,socket-notcp,service-notcp}: migrate to runTest

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1091,21 +1091,25 @@ in
   pretalx = runTest ./web-apps/pretalx.nix;
   prefect = runTest ./prefect.nix;
   pretix = runTest ./web-apps/pretix.nix;
-  printing-socket = handleTest ./printing.nix {
-    socket = true;
-    listenTcp = true;
+  printing-socket = runTest {
+    imports = [ ./printing.nix ];
+    _module.args.socket = true;
+    _module.args.listenTcp = true;
   };
-  printing-service = handleTest ./printing.nix {
-    socket = false;
-    listenTcp = true;
+  printing-service = runTest {
+    imports = [ ./printing.nix ];
+    _module.args.socket = false;
+    _module.args.listenTcp = true;
   };
-  printing-socket-notcp = handleTest ./printing.nix {
-    socket = true;
-    listenTcp = false;
+  printing-socket-notcp = runTest {
+    imports = [ ./printing.nix ];
+    _module.args.socket = true;
+    _module.args.listenTcp = false;
   };
-  printing-service-notcp = handleTest ./printing.nix {
-    socket = false;
-    listenTcp = false;
+  printing-service-notcp = runTest {
+    imports = [ ./printing.nix ];
+    _module.args.socket = false;
+    _module.args.listenTcp = false;
   };
   private-gpt = handleTest ./private-gpt.nix { };
   privatebin = runTest ./privatebin.nix;

--- a/nixos/tests/printing.nix
+++ b/nixos/tests/printing.nix
@@ -1,141 +1,138 @@
 # Test printing via CUPS.
+{
+  pkgs,
+  socket ? true, # whether to use socket activation
+  listenTcp ? true, # whether to open port 631 on client
+  ...
+}:
 
-import ./make-test-python.nix (
-  {
-    pkgs,
-    socket ? true, # whether to use socket activation
-    listenTcp ? true, # whether to open port 631 on client
-    ...
-  }:
+let
+  inherit (pkgs) lib;
+in
 
-  let
-    inherit (pkgs) lib;
-  in
+{
+  name = "printing";
+  meta = with lib.maintainers; {
+    maintainers = [
+      domenkozar
+      matthewbauer
+    ];
+  };
 
-  {
-    name = "printing";
-    meta = with lib.maintainers; {
-      maintainers = [
-        domenkozar
-        matthewbauer
+  nodes.server =
+    { ... }:
+    {
+      services.printing = {
+        enable = true;
+        stateless = true;
+        startWhenNeeded = socket;
+        listenAddresses = [ "*:631" ];
+        defaultShared = true;
+        openFirewall = true;
+        extraConf = ''
+          <Location />
+            Order allow,deny
+            Allow from all
+          </Location>
+        '';
+      };
+      # Add a HP Deskjet printer connected via USB to the server.
+      hardware.printers.ensurePrinters = [
+        {
+          name = "DeskjetLocal";
+          deviceUri = "usb://foobar/printers/foobar";
+          model = "drv:///sample.drv/deskjet.ppd";
+        }
       ];
     };
 
-    nodes.server =
-      { ... }:
-      {
-        services.printing = {
-          enable = true;
-          stateless = true;
-          startWhenNeeded = socket;
-          listenAddresses = [ "*:631" ];
-          defaultShared = true;
-          openFirewall = true;
-          extraConf = ''
-            <Location />
-              Order allow,deny
-              Allow from all
-            </Location>
-          '';
-        };
-        # Add a HP Deskjet printer connected via USB to the server.
-        hardware.printers.ensurePrinters = [
-          {
-            name = "DeskjetLocal";
-            deviceUri = "usb://foobar/printers/foobar";
-            model = "drv:///sample.drv/deskjet.ppd";
-          }
-        ];
-      };
+  nodes.client =
+    { lib, ... }:
+    {
+      services.printing.enable = true;
+      services.printing.startWhenNeeded = socket;
+      services.printing.listenAddresses = lib.mkIf (!listenTcp) [ ];
+      # Add printer to the client as well, via IPP.
+      hardware.printers.ensurePrinters = [
+        {
+          name = "DeskjetRemote";
+          deviceUri = "ipp://server/printers/DeskjetLocal";
+          model = "drv:///sample.drv/deskjet.ppd";
+        }
+      ];
+      hardware.printers.ensureDefaultPrinter = "DeskjetRemote";
+    };
 
-    nodes.client =
-      { lib, ... }:
-      {
-        services.printing.enable = true;
-        services.printing.startWhenNeeded = socket;
-        services.printing.listenAddresses = lib.mkIf (!listenTcp) [ ];
-        # Add printer to the client as well, via IPP.
-        hardware.printers.ensurePrinters = [
-          {
-            name = "DeskjetRemote";
-            deviceUri = "ipp://server/printers/DeskjetLocal";
-            model = "drv:///sample.drv/deskjet.ppd";
-          }
-        ];
-        hardware.printers.ensureDefaultPrinter = "DeskjetRemote";
-      };
+  testScript = ''
+    import os
+    import re
 
-    testScript = ''
-      import os
-      import re
+    start_all()
 
-      start_all()
+    with subtest("Make sure that cups is up on both sides and printers are set up"):
+        server.wait_for_unit("ensure-printers.service")
+        client.wait_for_unit("ensure-printers.service")
 
-      with subtest("Make sure that cups is up on both sides and printers are set up"):
-          server.wait_for_unit("ensure-printers.service")
-          client.wait_for_unit("ensure-printers.service")
+    assert "scheduler is running" in client.succeed("lpstat -r")
 
-      assert "scheduler is running" in client.succeed("lpstat -r")
+    with subtest("UNIX socket is used for connections"):
+        assert "/var/run/cups/cups.sock" in client.succeed("lpstat -H")
 
-      with subtest("UNIX socket is used for connections"):
-          assert "/var/run/cups/cups.sock" in client.succeed("lpstat -H")
+    with subtest("HTTP server is available too"):
+        ${lib.optionalString listenTcp ''client.succeed("curl --fail http://localhost:631/")''}
+        client.succeed(f"curl --fail http://{server.name}:631/")
+        server.fail(f"curl --fail --connect-timeout 2 http://{client.name}:631/")
 
-      with subtest("HTTP server is available too"):
-          ${lib.optionalString listenTcp ''client.succeed("curl --fail http://localhost:631/")''}
-          client.succeed(f"curl --fail http://{server.name}:631/")
-          server.fail(f"curl --fail --connect-timeout 2 http://{client.name}:631/")
+    with subtest("LP status checks"):
+        assert "DeskjetRemote accepting requests" in client.succeed("lpstat -a")
+        assert "DeskjetLocal accepting requests" in client.succeed(
+            f"lpstat -h {server.name}:631 -a"
+        )
+        client.succeed("cupsdisable DeskjetRemote")
+        out = client.succeed("lpq")
+        print(out)
+        assert re.search(
+            "DeskjetRemote is not ready.*no entries",
+            client.succeed("lpq"),
+            flags=re.DOTALL,
+        )
+        client.succeed("cupsenable DeskjetRemote")
+        assert re.match(
+            "DeskjetRemote is ready.*no entries", client.succeed("lpq"), flags=re.DOTALL
+        )
 
-      with subtest("LP status checks"):
-          assert "DeskjetRemote accepting requests" in client.succeed("lpstat -a")
-          assert "DeskjetLocal accepting requests" in client.succeed(
-              f"lpstat -h {server.name}:631 -a"
-          )
-          client.succeed("cupsdisable DeskjetRemote")
-          out = client.succeed("lpq")
-          print(out)
-          assert re.search(
-              "DeskjetRemote is not ready.*no entries",
-              client.succeed("lpq"),
-              flags=re.DOTALL,
-          )
-          client.succeed("cupsenable DeskjetRemote")
-          assert re.match(
-              "DeskjetRemote is ready.*no entries", client.succeed("lpq"), flags=re.DOTALL
-          )
+    # Test printing various file types.
+    for file in [
+        "${pkgs.groff.doc}/share/doc/*/examples/mom/penguin.pdf",
+        "${pkgs.groff.doc}/share/doc/*/meref.ps",
+        "${pkgs.cups.out}/share/doc/cups/images/cups.png",
+        "${pkgs.pcre.doc}/share/doc/pcre/pcre.txt",
+    ]:
+        file_name = os.path.basename(file)
+        with subtest(f"print {file_name}"):
+            # Print the file on the client.
+            print(client.succeed("lpq"))
+            client.succeed(f"lp {file}")
+            client.wait_until_succeeds(
+                f"lpq; lpq | grep -q -E 'active.*root.*{file_name}'"
+            )
 
-      # Test printing various file types.
-      for file in [
-          "${pkgs.groff.doc}/share/doc/*/examples/mom/penguin.pdf",
-          "${pkgs.groff.doc}/share/doc/*/meref.ps",
-          "${pkgs.cups.out}/share/doc/cups/images/cups.png",
-          "${pkgs.pcre.doc}/share/doc/pcre/pcre.txt",
-      ]:
-          file_name = os.path.basename(file)
-          with subtest(f"print {file_name}"):
-              # Print the file on the client.
-              print(client.succeed("lpq"))
-              client.succeed(f"lp {file}")
-              client.wait_until_succeeds(
-                  f"lpq; lpq | grep -q -E 'active.*root.*{file_name}'"
-              )
+            # Ensure that a raw PCL file appeared in the server's queue
+            # (showing that the right filters have been applied).  Of
+            # course, since there is no actual USB printer attached, the
+            # file will stay in the queue forever.
+            server.wait_for_file("/var/spool/cups/d*-001")
+            server.wait_until_succeeds(f"lpq -a | grep -q -E '{file_name}'")
 
-              # Ensure that a raw PCL file appeared in the server's queue
-              # (showing that the right filters have been applied).  Of
-              # course, since there is no actual USB printer attached, the
-              # file will stay in the queue forever.
-              server.wait_for_file("/var/spool/cups/d*-001")
-              server.wait_until_succeeds(f"lpq -a | grep -q -E '{file_name}'")
+            # Delete the job on the client.  It should disappear on the
+            # server as well.
+            client.succeed("lprm")
+            client.wait_until_succeeds("lpq -a | grep -q -E 'no entries'")
 
-              # Delete the job on the client.  It should disappear on the
-              # server as well.
-              client.succeed("lprm")
-              client.wait_until_succeeds("lpq -a | grep -q -E 'no entries'")
+            retry(lambda _: "no entries" in server.succeed("lpq -a"))
 
-              retry(lambda _: "no entries" in server.succeed("lpq -a"))
-
-              # The queue is empty already, so this should be safe.
-              # Otherwise, pairs of "c*"-"d*-001" files might persist.
-              server.execute("rm /var/spool/cups/*")
-    '';
-  }
-)
+            # The queue is empty already, so this should be safe.
+            # Otherwise, pairs of "c*"-"d*-001" files might persist.
+            server.execute("rm /var/spool/cups/*")
+  '';
+}


### PR DESCRIPTION
Part of #386873

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
