### PR TITLE
nixos/cook-cli: init module

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2505.section.md
+++ b/nixos/doc/manual/release-notes/rl-2505.section.md
@@ -217,6 +217,8 @@
 
 - [GoDNS](https://github.com/TimothyYe/godns), a dynamic DNS client written in Go, which supports multiple DNS providers. Available as [services.godns](option.html#opt-services.godns.enable).
 
+- [CookCLI](https://cooklang.org/cli/) Server, a web UI for cooklang recipes.
+
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
 
 ## Backward Incompatibilities {#sec-release-25.05-incompatibilities}

--- a/nixos/modules/services/web-apps/cook-cli.nix
+++ b/nixos/modules/services/web-apps/cook-cli.nix
@@ -1,0 +1,113 @@
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}:
+
+let
+  cfg = config.services.cook-cli;
+  inherit (lib)
+    mkIf
+    mkEnableOption
+    mkPackageOption
+    mkOption
+    getExe
+    types
+    ;
+in
+{
+  options = {
+    services.cook-cli = {
+      enable = lib.mkEnableOption "cook-cli";
+
+      package = lib.mkPackageOption pkgs "cook-cli" { };
+
+      autoStart = lib.mkOption {
+        type = lib.types.bool;
+        default = true;
+        description = ''
+          Whether to start cook-cli server automatically.
+        '';
+      };
+
+      port = lib.mkOption {
+        type = lib.types.port;
+        default = 9080;
+        description = ''
+          Which port cook-cli server will use.
+        '';
+      };
+
+      basePath = lib.mkOption {
+        type = lib.types.str;
+        default = "/var/lib/cook-cli";
+        description = ''
+          Path to the directory cook-cli will look for recipes.
+        '';
+      };
+
+      openFirewall = lib.mkOption {
+        type = lib.types.bool;
+        default = false;
+        description = ''
+          Whether to open the cook-cli server port in the firewall.
+        '';
+      };
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    environment.systemPackages = [ cfg.package ];
+
+    systemd.tmpfiles.rules = [
+      "d ${cfg.basePath} 0770 cook-cli users"
+    ];
+
+    users.users.cook-cli = {
+      home = "${cfg.basePath}";
+      group = "cook-cli";
+      isSystemUser = true;
+    };
+    users.groups.cook-cli.members = [
+      "cook-cli"
+    ];
+
+    systemd.services.cook-cli = {
+      description = "cook-cli server";
+      serviceConfig = {
+        ExecStart = "${getExe cfg.package} server --host --port ${toString cfg.port} ${cfg.basePath}";
+        WorkingDirectory = cfg.basePath;
+        User = "cook-cli";
+        Group = "cook-cli";
+        # Hardening options
+        CapabilityBoundingSet = [ "CAP_SYS_NICE" ];
+        AmbientCapabilities = [ "CAP_SYS_NICE" ];
+        LockPersonality = true;
+        NoNewPrivileges = true;
+        PrivateTmp = true;
+        ProtectControlGroups = true;
+        ProtectKernelLogs = true;
+        ProtectKernelModules = true;
+        ProtectKernelTunables = true;
+        ProtectSystem = "strict";
+        ReadWritePaths = cfg.basePath;
+        RestrictNamespaces = true;
+        RestrictSUIDSGID = true;
+        Restart = "on-failure";
+        RestartSec = 5;
+      };
+      wantedBy = mkIf cfg.autoStart [ "multi-user.target" ];
+      wants = [ "network.target" ];
+    };
+
+    networking.firewall = lib.mkIf cfg.openFirewall {
+      allowedTCPPorts = [ cfg.port ];
+    };
+  };
+
+  meta.maintainers = [
+    lib.maintainers.luNeder
+    lib.maintainers.emilioziniades
+  ];
+}


### PR DESCRIPTION
Hey!

I made a nixos module service for the CookCLI Server/webUI. Has autoStart options and stuff, so should make it easier for people to host such a server.

Mentioning the cook-cli maintainer on nixpkgs here: @emilioziniades 

Not sure what the proper etiquette is for cases like this, when making a module for a package that's already on nixpkgs, so I added both of us as module maintainers since you maintain the package. Let me know if you'd rather this to be set differently. \^-^

<!--
^ Please summarize the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
