### PR TITLE
chromium,chromedriver: 135.0.7049.84 -> 135.0.7049.95

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/info.json
+++ b/pkgs/applications/networking/browsers/chromium/info.json
@@ -1,10 +1,10 @@
 {
   "chromium": {
-    "version": "135.0.7049.84",
+    "version": "135.0.7049.95",
     "chromedriver": {
-      "version": "135.0.7049.85",
-      "hash_darwin": "sha256-L4x/MSCbVt2UIQwbHREDV8br6DmdfuqTJ3//7opK2IU=",
-      "hash_darwin_aarch64": "sha256-vixXGqbc2UYpydg1RILhrtmr5DdbJ5I1sD8aNikejQU="
+      "version": "135.0.7049.96",
+      "hash_darwin": "sha256-MmL/hQGPk/kGBtbXSekE+lHktucPCv3HFr8VYTnff5w=",
+      "hash_darwin_aarch64": "sha256-TGiVrAYgeLGniGBZ2dHUBk6Hg996ouBSJHZm9hXExQ4="
     },
     "deps": {
       "depot_tools": {
@@ -20,8 +20,8 @@
     "DEPS": {
       "src": {
         "url": "https://chromium.googlesource.com/chromium/src.git",
-        "rev": "6c019e56001911b3fd467e03bf68c435924d62f4",
-        "hash": "sha256-BFw1o2cIHBeBudeigH6YTOuLGsp/+pTOeE1lXBO3aio=",
+        "rev": "de2eb485a1951079e63bdb57ce25544d2dc79c15",
+        "hash": "sha256-6ydyJWsDawt0bfYAFHotTB9ujmIYsqUUpNwB6q6RNQE=",
         "recompress": true
       },
       "src/third_party/clang-format/script": {
@@ -566,8 +566,8 @@
       },
       "src/third_party/pdfium": {
         "url": "https://pdfium.googlesource.com/pdfium.git",
-        "rev": "9afffebfa895ea6cdcc05516908c50bd7fe72797",
-        "hash": "sha256-89rJdhwUJtJCMO7FvVoTYO80swFRkoWUB/ZYs1tOLzE="
+        "rev": "2919d07ee57020e3e4b66cce45c61104d80304d2",
+        "hash": "sha256-zE6a0R8NZ3SE0bHwPan3dTh5kmq5JmYTbDQIvyNICeg="
       },
       "src/third_party/perfetto": {
         "url": "https://android.googlesource.com/platform/external/perfetto.git",
@@ -616,8 +616,8 @@
       },
       "src/third_party/skia": {
         "url": "https://skia.googlesource.com/skia.git",
-        "rev": "6e445bdea696eb6b6a46681dfc1a63edaa517edb",
-        "hash": "sha256-mSup6nKsEPjJ/HBV7PwjBI4PP7/RdwFm/dnavKeRqzI="
+        "rev": "5a44cdd70f04aa65fa063caa1a7e3028d75236f8",
+        "hash": "sha256-QX3b+S0IuxJKmlMudL6420+bXRhDkWYC7GNRKxKNm8A="
       },
       "src/third_party/smhasher/src": {
         "url": "https://chromium.googlesource.com/external/smhasher.git",


### PR DESCRIPTION
https://chromereleases.googleblog.com/2025/04/stable-channel-update-for-desktop_15.html

This update includes 2 security fixes.

CVEs:
CVE-2025-3619 CVE-2025-3620

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
