### PR TITLE
nixos/cloudlog: fix QSL images, SSTV scans, and awards JSON files

### DIFF
--- a/nixos/modules/services/web-apps/cloudlog.nix
+++ b/nixos/modules/services/web-apps/cloudlog.nix
@@ -62,16 +62,13 @@ let
       ln -s ${configFile} $out/application/config/config.php
       ln -s ${dbFile} $out/application/config/database.php
 
+      # make a copy of the original assets/json to prime the datadir
+      cp -a "$out/assets/json/" "$out/assets/json.original/"
+
       # link writable directories
-      for directory in updates uploads backup logbook; do
+      for directory in updates uploads backup logbook assets/qslcard images/eqsl_card_images assets/sstvimages assets/json; do
         rm -rf $out/$directory
         ln -s ${cfg.dataDir}/$directory $out/$directory
-      done
-
-      # link writable asset files
-      for asset in dok sota wwff; do
-        rm -rf $out/assets/json/$asset.txt
-        ln -s ${cfg.dataDir}/assets/json/$asset.txt $out/assets/json/$asset.txt
       done
     '';
   };
@@ -503,13 +500,26 @@ in
           group = config.services.nginx.group;
         in
         [
-          "d ${cfg.dataDir}                0750 ${cfg.user} ${group} - -"
-          "d ${cfg.dataDir}/updates        0750 ${cfg.user} ${group} - -"
-          "d ${cfg.dataDir}/uploads        0750 ${cfg.user} ${group} - -"
-          "d ${cfg.dataDir}/backup         0750 ${cfg.user} ${group} - -"
-          "d ${cfg.dataDir}/logbook        0750 ${cfg.user} ${group} - -"
-          "d ${cfg.dataDir}/assets/json    0750 ${cfg.user} ${group} - -"
-          "d ${cfg.dataDir}/assets/qslcard 0750 ${cfg.user} ${group} - -"
+          "d ${cfg.dataDir}                         0750 ${cfg.user} ${group} - -"
+          "d ${cfg.dataDir}/updates                 0750 ${cfg.user} ${group} - -"
+          "d ${cfg.dataDir}/uploads                 0750 ${cfg.user} ${group} - -"
+          "d ${cfg.dataDir}/backup                  0750 ${cfg.user} ${group} - -"
+          "d ${cfg.dataDir}/logbook                 0750 ${cfg.user} ${group} - -"
+          "d ${cfg.dataDir}/assets                  0750 ${cfg.user} ${group} - -"
+          "d ${cfg.dataDir}/assets/json             0750 ${cfg.user} ${group} - -"
+          "d ${cfg.dataDir}/assets/qslcard          0750 ${cfg.user} ${group} - -"
+          "d ${cfg.dataDir}/assets/sstvimages       0750 ${cfg.user} ${group} - -"
+          "d ${cfg.dataDir}/images                  0750 ${cfg.user} ${group} - -"
+          "d ${cfg.dataDir}/images/eqsl_card_images 0750 ${cfg.user} ${group} - -"
+          "C ${cfg.dataDir}/assets/json/dok.txt                              0640 ${cfg.user} ${group} - ${package}/assets/json.original/dok.txt"
+          "C ${cfg.dataDir}/assets/json/pota.txt                             0640 ${cfg.user} ${group} - ${package}/assets/json.original/pota.txt"
+          "C ${cfg.dataDir}/assets/json/satellite_data.json                  0640 ${cfg.user} ${group} - ${package}/assets/json.original/satellite_data.json"
+          "C ${cfg.dataDir}/assets/json/sota.txt                             0640 ${cfg.user} ${group} - ${package}/assets/json.original/sota.txt"
+          "C ${cfg.dataDir}/assets/json/US_counties.csv                      0640 ${cfg.user} ${group} - ${package}/assets/json.original/US_counties.csv"
+          "C ${cfg.dataDir}/assets/json/us_national_parksontheair.csv        0640 ${cfg.user} ${group} - ${package}/assets/json.original/us_national_parksontheair.csv"
+          "C ${cfg.dataDir}/assets/json/WABSquares.geojson                   0640 ${cfg.user} ${group} - ${package}/assets/json.original/WABSquares.geojson"
+          "C ${cfg.dataDir}/assets/json/wwff.txt                             0640 ${cfg.user} ${group} - ${package}/assets/json.original/wwff.txt"
+          "C+ ${cfg.dataDir}/assets/json/datatables_languages                0750 ${cfg.user} ${group} - ${package}/assets/json.original/datatables_languages"
         ];
     };
 


### PR DESCRIPTION
This change fixes some of the folders that cloudlog expects to be able to write to and serve from the web server.

This change enables Cloudlog to properly manage additional media and asset files by making these directories writable, persistent, and available from the web server.

Without this change, user uploaded QSL ans SSTV images returns a 404, eQSL loaded from https://eqsl.cc are never cached locally as they do on a plain cloudlog installation without nix.

Without this change most of the lookup functions based on the content of `assets/json` do not work.


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
