### PR TITLE
koreader: 2024.11 -> 2025.04

### DIFF
--- a/pkgs/by-name/ko/koreader/package.nix
+++ b/pkgs/by-name/ko/koreader/package.nix
@@ -11,6 +11,7 @@
   luajit,
   sdcv,
   SDL2,
+  openssl,
   nix-update-script,
 }:
 let
@@ -18,21 +19,21 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "koreader";
-  version = "2024.11";
+  version = "2025.04";
 
   src =
     {
       aarch64-linux = fetchurl {
         url = "https://github.com/koreader/koreader/releases/download/v${version}/koreader-${version}-arm64.deb";
-        hash = "sha256-uy+4+pNyz10xrGM0QF9q0y6UpQK1B9PGNqrcK6nENQY=";
+        hash = "sha256-bpKNP+1C0oHZEv6HGL4dBziv3RfCow882yV8JFLtDJ4=";
       };
       armv7l-linux = fetchurl {
         url = "https://github.com/koreader/koreader/releases/download/v${version}/koreader-${version}-armhf.deb";
-        hash = "sha256-lTc12qmoe0kGUhrStlGfDRw+cNJnX7F09/jKKc/1U9g=";
+        hash = "sha256-q3M33f0b5FAU/nmPfzsXu93mVZOhXMVgBbfwnieqkeM=";
       };
       x86_64-linux = fetchurl {
         url = "https://github.com/koreader/koreader/releases/download/v${version}/koreader-${version}-amd64.deb";
-        hash = "sha256-ibehFrOcJqhM+CMAcHDn3Xwy6CueB8kdnoYMMDe/2Js=";
+        hash = "sha256-ZZujk98YVvNJmffW2fDg+n+z1xgtkha7y1LasYEhCR4=";
       };
     }
     .${stdenv.hostPlatform.system} or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
@@ -40,9 +41,9 @@ stdenv.mkDerivation rec {
   src_repo = fetchFromGitHub {
     repo = "koreader";
     owner = "koreader";
-    rev = "v${version}";
+    tag = "v${version}";
     fetchSubmodules = true;
-    sha256 = "sha256-EI8UOQuwhJqcAp8QnLYhI0K+uV/7ZqxdHNk8mPkDWA0=";
+    hash = "sha256-Kt00AZARfQjGY8FzDcQB8UaowWW2+KWyXJzexFNmZmM=";
   };
 
   nativeBuildInputs = [
@@ -56,6 +57,7 @@ stdenv.mkDerivation rec {
     luajit_lua52
     sdcv
     SDL2
+    openssl
   ];
 
   dontConfigure = true;
@@ -63,18 +65,31 @@ stdenv.mkDerivation rec {
 
   installPhase = ''
     mkdir -p $out
+    dpkg-deb -x $src .
     cp -R usr/* $out/
+
+    # Link required binaries
     ln -sf ${luajit_lua52}/bin/luajit $out/lib/koreader/luajit
     ln -sf ${sdcv}/bin/sdcv $out/lib/koreader/sdcv
     ln -sf ${gnutar}/bin/tar $out/lib/koreader/tar
+
+    # Link SSL/network libraries
+    ln -sf ${openssl.out}/lib/libcrypto.so.3 $out/lib/koreader/libs/libcrypto.so.1.1
+    ln -sf ${openssl.out}/lib/libssl.so.3 $out/lib/koreader/libs/libssl.so.1.1
+
+    # Copy fonts
     find ${src_repo}/resources/fonts -type d -execdir cp -r '{}' $out/lib/koreader/fonts \;
+
+    # Remove broken symlinks
     find $out -xtype l -print -delete
-    wrapProgram $out/bin/koreader --prefix LD_LIBRARY_PATH : ${
+
+    wrapProgram $out/bin/koreader --prefix LD_LIBRARY_PATH : $out/lib/koreader/libs:${
       lib.makeLibraryPath [
         gtk3-x11
         SDL2
         glib
         stdenv.cc.cc
+        openssl.out
       ]
     }
   '';


### PR DESCRIPTION
Changelog : https://github.com/koreader/koreader/releases/tag/v2025.04
Diff : https://github.com/koreader/koreader/compare/v2024.11...v2025.04
Fix : https://github.com/NixOS/nixpkgs/issues/387453

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
