### PR TITLE
xnviewmp: init at 1.8.8

### DIFF
--- a/pkgs/by-name/xn/xnviewmp/package.nix
+++ b/pkgs/by-name/xn/xnviewmp/package.nix
@@ -1,0 +1,67 @@
+{
+  appimageTools,
+  fetchurl,
+  runCommand,
+  lib,
+  makeDesktopItem,
+  copyDesktopItems,
+  imagemagick,
+}:
+let
+  icon =
+    runCommand "xnviewmp-icon.png"
+      {
+        nativeBuildInputs = [ imagemagick ];
+        src = fetchurl {
+          url = "https://www.xnview.com/img/app-xnsoft-360.webp";
+          hash = "sha256-wIzF/WOsPcrYFYC/kGZi6FSJFuErci5EMONjrx1VCdQ=";
+        };
+      }
+      ''
+        convert $src $out
+      '';
+in
+appimageTools.wrapType2 rec {
+  pname = "xnviewmp";
+  version = "1.8.8";
+
+  src = fetchurl {
+    url = "https://download.xnview.com/old_versions/XnView_MP/XnView_MP-${version}.glibc2.17-x86_64.AppImage";
+    hash = "sha256-zPlb2r+oKNq1iv8dAWE/wbXtKAf3A+XOsSOkciHM6OA=";
+  };
+
+  nativeBuildInputs = [
+    copyDesktopItems
+  ];
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "xnviewmp";
+      desktopName = "XnView MP";
+      exec = "xnviewmp %F";
+      icon = "xnviewmp";
+      comment = "An efficient multimedia viewer, browser and converter";
+      categories = [ "Graphics" ];
+    })
+  ];
+
+  extraPkgs = pkgs: [
+    pkgs.qt5.qtbase
+  ];
+
+  extraInstallCommands = ''
+    install -m 444 -D ${icon} $out/share/icons/hicolor/512x512/apps/xnviewmp.png
+  '';
+
+  meta = {
+    description = "Efficient multimedia viewer, browser and converter";
+    changelog = "https://www.xnview.com/mantisbt/changelog_page.php";
+    homepage = "https://www.xnview.com/en/xnviewmp/";
+    downloadPage = "https://download.xnview.com/old_versions/XnView_MP/";
+    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+    license = lib.licenses.unfree;
+    mainProgram = "xnviewmp";
+    maintainers = with lib.maintainers; [ oddlama ];
+    platforms = lib.platforms.linux;
+  };
+}


### PR DESCRIPTION
This packages XnView MP, a classic image viewer and organizer. The package is unfree (i.e. freeware, source not available)
and thus is packages from the provided AppImage.

Closes #277560. Closes #339634.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
