### PR TITLE
wrkflw: init at v0.3.0

### DIFF
--- a/pkgs/by-name/wr/wrkflw/package.nix
+++ b/pkgs/by-name/wr/wrkflw/package.nix
@@ -1,0 +1,51 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  pkg-config,
+  docker,
+  openssl,
+  nix-update-script,
+  versionCheckHook,
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "wrkflw";
+  version = "0.3.0";
+
+  src = fetchFromGitHub {
+    owner = "bahdotsh";
+    repo = "wrkflw";
+    tag = "v${version}";
+    hash = "sha256-ErzlAVRyDyRo/AAbTjuBhuQtveRttB0ArUugIGuYMiY=";
+  };
+
+  cargoHash = "sha256-SbX0jWaihabl90L7KfRfFakvTDIpJcDjsfOr36T8+Xg=";
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  buildInputs = [
+    docker
+    openssl
+  ];
+
+  # Tests require docker daemon running
+  doCheck = false;
+
+  doInstallCheck = true;
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "GitHub Actions workflow validator and executor";
+    homepage = "https://github.com/bahdotsh/wrkflw";
+    license = lib.licenses.mit;
+    mainProgram = "wrkflw";
+    maintainers = with lib.maintainers; [ linuxmobile ];
+    platforms = lib.platforms.linux;
+  };
+}


### PR DESCRIPTION
Initial packaging of [wrkflw](https://github.com/bahdotsh/wrkflw/), a GitHub Actions workflow validator and executor. Currently packaged from main branch as the project has no tagged releases.

The package provides a TUI-based interface for validating and executing GitHub Actions workflows locally, helping developers test their workflows before pushing to GitHub.

Tested on x86_64-linux.

![image](https://github.com/user-attachments/assets/02ff6df9-871b-4d4e-9503-010f48cd9f70)

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.