### PR TITLE
ungoogled-chromium: 135.0.7049.84-1 -> 135.0.7049.95-1

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/info.json
+++ b/pkgs/applications/networking/browsers/chromium/info.json
@@ -787,7 +787,7 @@
     }
   },
   "ungoogled-chromium": {
-    "version": "135.0.7049.84",
+    "version": "135.0.7049.95",
     "deps": {
       "depot_tools": {
         "rev": "85ec2718b5a29990c7eb67778348c9f76a00f392",
@@ -798,16 +798,16 @@
         "hash": "sha256-8NynNvLNCHxy8EYmsnPovKhXu9DcDcYBhg4A6d2QIfY="
       },
       "ungoogled-patches": {
-        "rev": "135.0.7049.84-1",
-        "hash": "sha256-Cncp+sLFWC8nuepXCbkeHZYgAw2cFIAIaQe9wgun/AA="
+        "rev": "135.0.7049.95-1",
+        "hash": "sha256-kLLtJti5GIF9TT0cH8zvsxywJzD22X8u2bB/tqENSjo="
       },
       "npmHash": "sha256-wNrZaugdKJCyV1WchkKXzr/I1OW1AtjiC2p7qTZZOqU="
     },
     "DEPS": {
       "src": {
         "url": "https://chromium.googlesource.com/chromium/src.git",
-        "rev": "6c019e56001911b3fd467e03bf68c435924d62f4",
-        "hash": "sha256-BFw1o2cIHBeBudeigH6YTOuLGsp/+pTOeE1lXBO3aio=",
+        "rev": "de2eb485a1951079e63bdb57ce25544d2dc79c15",
+        "hash": "sha256-6ydyJWsDawt0bfYAFHotTB9ujmIYsqUUpNwB6q6RNQE=",
         "recompress": true
       },
       "src/third_party/clang-format/script": {
@@ -1352,8 +1352,8 @@
       },
       "src/third_party/pdfium": {
         "url": "https://pdfium.googlesource.com/pdfium.git",
-        "rev": "9afffebfa895ea6cdcc05516908c50bd7fe72797",
-        "hash": "sha256-89rJdhwUJtJCMO7FvVoTYO80swFRkoWUB/ZYs1tOLzE="
+        "rev": "2919d07ee57020e3e4b66cce45c61104d80304d2",
+        "hash": "sha256-zE6a0R8NZ3SE0bHwPan3dTh5kmq5JmYTbDQIvyNICeg="
       },
       "src/third_party/perfetto": {
         "url": "https://android.googlesource.com/platform/external/perfetto.git",
@@ -1402,8 +1402,8 @@
       },
       "src/third_party/skia": {
         "url": "https://skia.googlesource.com/skia.git",
-        "rev": "6e445bdea696eb6b6a46681dfc1a63edaa517edb",
-        "hash": "sha256-mSup6nKsEPjJ/HBV7PwjBI4PP7/RdwFm/dnavKeRqzI="
+        "rev": "5a44cdd70f04aa65fa063caa1a7e3028d75236f8",
+        "hash": "sha256-QX3b+S0IuxJKmlMudL6420+bXRhDkWYC7GNRKxKNm8A="
       },
       "src/third_party/smhasher/src": {
         "url": "https://chromium.googlesource.com/external/smhasher.git",


### PR DESCRIPTION
Same underlying changes as #399236

https://chromereleases.googleblog.com/2025/04/stable-channel-update-for-desktop_15.html

This update includes 2 security fixes.

CVEs:
CVE-2025-3619 CVE-2025-3620

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
