### PR TITLE
poco: propagate utf8proc

### DIFF
--- a/pkgs/applications/networking/mumble/default.nix
+++ b/pkgs/applications/networking/mumble/default.nix
@@ -13,7 +13,6 @@
   protobuf,
   speex,
   libcap,
-  utf8proc,
   alsa-lib,
   python3,
   rnnoise,
@@ -100,7 +99,6 @@ let
           qt5.qtsvg
           rnnoise
           speex
-          utf8proc
         ]
         ++ lib.optional (!jackSupport) alsa-lib
         ++ lib.optional jackSupport libjack2

--- a/pkgs/applications/radio/pothos/default.nix
+++ b/pkgs/applications/radio/pothos/default.nix
@@ -18,7 +18,6 @@
   alsa-lib,
   muparserx,
   python3,
-  utf8proc,
 }:
 
 mkDerivation rec {
@@ -69,7 +68,6 @@ mkDerivation rec {
     alsa-lib
     muparserx
     python3
-    utf8proc
   ];
 
   postInstall = ''

--- a/pkgs/by-name/li/litebrowser/package.nix
+++ b/pkgs/by-name/li/litebrowser/package.nix
@@ -7,7 +7,6 @@
   gtk3,
   gtkmm3,
   curl,
-  poco,
   gumbo, # litehtml dependency
 }:
 
@@ -32,7 +31,6 @@ stdenv.mkDerivation {
     gtk3
     gtkmm3
     curl
-    poco
     gumbo
   ];
 

--- a/pkgs/by-name/mu/multipass/multipassd.nix
+++ b/pkgs/by-name/mu/multipass/multipassd.nix
@@ -24,7 +24,6 @@
   qt6,
   slang,
   stdenv,
-  utf8proc,
   xterm,
 }:
 
@@ -121,7 +120,6 @@ stdenv.mkDerivation {
     protobuf
     qt6.qtbase
     qt6.qtwayland
-    utf8proc
   ];
 
   nativeBuildInputs = [

--- a/pkgs/by-name/po/poco/package.nix
+++ b/pkgs/by-name/po/poco/package.nix
@@ -7,11 +7,11 @@
   pkg-config,
   zlib,
   pcre2,
+  utf8proc,
   expat,
   sqlite,
   openssl,
   unixODBC,
-  utf8proc,
   libmysqlclient,
 }:
 
@@ -34,13 +34,13 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     unixODBC
-    utf8proc
     libmysqlclient
   ];
 
   propagatedBuildInputs = [
     zlib
     pcre2
+    utf8proc
     expat
     sqlite
     openssl


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Packages that depend on Poco Foundation using CMake always require utf8proc to be available. See: https://github.com/NixOS/nixpkgs/pull/383163#issuecomment-2811024981

Also, remove litebrowser's dependency on Poco, as this dependency was removed upstream.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

cc @dwt