### PR TITLE
vgmstream: Various improvements

### DIFF
--- a/pkgs/by-name/au/audacious-plugins/package.nix
+++ b/pkgs/by-name/au/audacious-plugins/package.nix
@@ -110,9 +110,7 @@ stdenv.mkDerivation rec {
   dontWrapQtApps = true;
 
   postInstall = ''
-    ln -s ${
-      vgmstream.override { buildAudaciousPlugin = true; }
-    }/lib/audacious/Input/* $out/lib/audacious/Input
+    ln -s ${vgmstream.audacious}/lib/audacious/Input/* $out/lib/audacious/Input
   '';
 
   meta = audacious-bare.meta // {

--- a/pkgs/by-name/vg/vgmstream/package.nix
+++ b/pkgs/by-name/vg/vgmstream/package.nix
@@ -12,7 +12,6 @@
   libao,
   speex,
   nix-update-script,
-  buildAudaciousPlugin ? false, # only build cli by default, pkgs.audacious-plugins sets this to enable plugin support
 }:
 
 stdenv.mkDerivation rec {
@@ -34,10 +33,16 @@ stdenv.mkDerivation rec {
     ];
   };
 
+  outputs = [
+    "out"
+    "audacious"
+  ];
+
   nativeBuildInputs = [
     cmake
     pkg-config
-  ] ++ lib.optional buildAudaciousPlugin gtk3;
+    gtk3
+  ];
 
   buildInputs = [
     mpg123
@@ -45,17 +50,18 @@ stdenv.mkDerivation rec {
     libvorbis
     libao
     speex
-  ] ++ lib.optional buildAudaciousPlugin audacious-bare;
+    audacious-bare
+  ];
 
   preConfigure = ''
     substituteInPlace cmake/dependencies/audacious.cmake \
-      --replace "pkg_get_variable(AUDACIOUS_PLUGIN_DIR audacious plugin_dir)" "set(AUDACIOUS_PLUGIN_DIR \"$out/lib/audacious\")"
+      --replace "pkg_get_variable(AUDACIOUS_PLUGIN_DIR audacious plugin_dir)" "set(AUDACIOUS_PLUGIN_DIR \"$audacious/lib/audacious\")"
   '';
 
   cmakeFlags = [
     # It always tries to download it, no option to use the system one
     "-DUSE_CELT=OFF"
-  ] ++ lib.optional (!buildAudaciousPlugin) "-DBUILD_AUDACIOUS=OFF";
+  ];
 
   meta = with lib; {
     description = "Library for playback of various streamed audio formats used in video games";

--- a/pkgs/by-name/vg/vgmstream/package.nix
+++ b/pkgs/by-name/vg/vgmstream/package.nix
@@ -10,7 +10,6 @@
   ffmpeg,
   libvorbis,
   libao,
-  jansson,
   speex,
   nix-update-script,
   buildAudaciousPlugin ? false, # only build cli by default, pkgs.audacious-plugins sets this to enable plugin support
@@ -45,7 +44,6 @@ stdenv.mkDerivation rec {
     ffmpeg
     libvorbis
     libao
-    jansson
     speex
   ] ++ lib.optional buildAudaciousPlugin audacious-bare;
 

--- a/pkgs/by-name/vg/vgmstream/package.nix
+++ b/pkgs/by-name/vg/vgmstream/package.nix
@@ -1,6 +1,7 @@
 {
   stdenv,
   lib,
+  fetchzip,
   fetchFromGitHub,
   cmake,
   pkg-config,
@@ -23,6 +24,24 @@ stdenv.mkDerivation rec {
     repo = "vgmstream";
     tag = "r${version}";
     hash = "sha256-TmaWC04XbtFfBYhmTO4ouh3NoByio1BCpDJGJy3r0NY=";
+  };
+
+  # https://github.com/vgmstream/vgmstream/blob/1b6a7915bf98ca14a71a0d44bef7a2c6a75c686d/cmake/dependencies/atrac9.cmake
+  atrac9-src = fetchFromGitHub {
+    owner = "Thealexbarney";
+    repo = "LibAtrac9";
+    rev = "6a9e00f6c7abd74d037fd210b6670d3cdb313049";
+    hash = "sha256-n47CzIbh8NxJ4GzKLjZQeS27k2lGx08trC1m4AOzVZc=";
+  };
+
+  # https://github.com/vgmstream/vgmstream/blob/1b6a7915bf98ca14a71a0d44bef7a2c6a75c686d/cmake/dependencies/celt.cmake
+  celt-0_6_1-src = fetchzip {
+    url = "https://downloads.xiph.org/releases/celt/celt-0.6.1.tar.gz";
+    hash = "sha256-DI1z10mTDQOn/R1FssaegmOa6ZNx3bXNiWHwLnytJWw=";
+  };
+  celt-0_11_0-src = fetchzip {
+    url = "https://downloads.xiph.org/releases/celt/celt-0.11.0.tar.gz";
+    hash = "sha256-JI3b44iCxQ29bqJGNH/L18pEuWiTFZ2132ceaqe8U0E=";
   };
 
   passthru.updateScript = nix-update-script {
@@ -53,21 +72,36 @@ stdenv.mkDerivation rec {
     audacious-bare
   ];
 
-  preConfigure = ''
-    substituteInPlace cmake/dependencies/audacious.cmake \
-      --replace "pkg_get_variable(AUDACIOUS_PLUGIN_DIR audacious plugin_dir)" "set(AUDACIOUS_PLUGIN_DIR \"$audacious/lib/audacious\")"
-  '';
+  preConfigure =
+    ''
+      substituteInPlace cmake/dependencies/audacious.cmake \
+        --replace-fail "pkg_get_variable(AUDACIOUS_PLUGIN_DIR audacious plugin_dir)" "set(AUDACIOUS_PLUGIN_DIR \"$audacious/lib/audacious\")"
+    ''
+    +
+      # cmake/dependencies/celt.cmake uses configure_file to modify ${CELT_0110_PATH}/libcelt/ecintrin.h.
+      # Therefore, CELT_0110_PATH needs to point to a mutable directory.
+      ''
+        mkdir -p dependencies/celt-0.11.0/
+        cp -r ${celt-0_11_0-src}/* dependencies/celt-0.11.0/
+        chmod -R +w dependencies/celt-0.11.0/
+      '';
 
   cmakeFlags = [
-    # It always tries to download it, no option to use the system one
-    "-DUSE_CELT=OFF"
+    "-DATRAC9_PATH=${atrac9-src}"
+    "-DCELT_0061_PATH=${celt-0_6_1-src}"
+    "-DCELT_0110_PATH=../dependencies/celt-0.11.0"
+    # libg719_decode omitted because it doesn't have a free software license
   ];
 
   meta = with lib; {
     description = "Library for playback of various streamed audio formats used in video games";
     homepage = "https://vgmstream.org";
     maintainers = with maintainers; [ zane ];
-    license = with licenses; isc;
+    license = with licenses; [
+      isc # vgmstream itself
+      mit # atrac9
+      bsd2 # celt
+    ];
     platforms = with platforms; unix;
   };
 }


### PR DESCRIPTION
Various improvements to the `vgmstream` package:

1. Remove jansson from buildInputs (vgmstream no longer uses jansson: https://github.com/vgmstream/vgmstream/commit/f28cd1ada9e4e28b5bd6a095647074e4ddcf285c)
2. Install the Audacious plugin to a separate output, instead of using a parameter to decide whether the Audacious plugin should be built or not
3. Enable optional dependencies ATRAC9 and CELT by downloading them with Nix

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
