### PR TITLE
python3Packages.{imagecodecs, sdflit, swcgeom}: init at {2025.3.30, 0.2.6, 0.19.3}

### DIFF
--- a/pkgs/development/python-modules/imagecodecs/default.nix
+++ b/pkgs/development/python-modules/imagecodecs/default.nix
@@ -1,0 +1,90 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  cython,
+  numpy,
+  setuptools,
+  pkgs,
+  jxrlib,
+  lcms2,
+  lerc,
+  libdeflate,
+  libpng,
+  libtiff,
+  libwebp,
+  openjpeg,
+  xz,
+  zlib,
+  zstd,
+  pytest,
+}:
+
+let
+  version = "2025.3.30";
+in
+buildPythonPackage {
+  pname = "imagecodecs";
+  inherit version;
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "cgohlke";
+    repo = "imagecodecs";
+    tag = "v${version}";
+    hash = "sha256-KtrQNABQOr3mNiWOfaZBcFceSCixPGV8Hte2uPKn1+k=";
+  };
+
+  build-system = [
+    cython
+    numpy
+    setuptools
+  ];
+
+  nativeBuildInputs = [
+    pkgs.lz4.dev # lz4 was hidden by python3Packages.lz4
+    lcms2.dev
+    openjpeg.dev
+  ];
+
+  buildInputs = [
+    pkgs.lz4
+    jxrlib
+    lcms2
+    lerc
+    libdeflate
+    libpng
+    libtiff
+    libwebp
+    openjpeg
+    xz # liblzma
+    zlib
+    zstd
+  ];
+
+  dependencies = [
+    numpy
+  ];
+
+  prePatch = ''
+    substituteInPlace setup.py \
+      --replace-fail "/usr/include/openjpeg" "${openjpeg.dev}/include/openjpeg" \
+      --replace-fail "/usr/include/jxrlib" "${jxrlib}/include/jxrlib"
+  '';
+
+  nativeCheckInputs = [
+    pytest
+  ];
+
+  pythonImportsCheck = [
+    "imagecodecs"
+  ];
+
+  meta = {
+    description = "Image transformation, compression, and decompression codecs";
+    homepage = "https://github.com/cgohlke/imagecodecs";
+    changelog = "https://github.com/cgohlke/imagecodecs/blob/v${version}/CHANGES.rst";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ yzx9 ];
+  };
+}

--- a/pkgs/development/python-modules/sdflit/default.nix
+++ b/pkgs/development/python-modules/sdflit/default.nix
@@ -1,0 +1,47 @@
+{
+  lib,
+  fetchFromGitHub,
+  buildPythonPackage,
+  cargo,
+  rustPlatform,
+  rustc,
+}:
+
+let
+  version = "0.2.6";
+
+  src = fetchFromGitHub {
+    owner = "yzx9";
+    repo = "sdflit";
+    tag = "v${version}";
+    hash = "sha256-Ze3J5Dp+TskhIiGP6kMK3AIHLnhVBuEaKJokccIr+SM=";
+  };
+in
+buildPythonPackage {
+  pname = "sdflit";
+  inherit version src;
+  pyproject = true;
+
+  cargoDeps = rustPlatform.fetchCargoVendor {
+    inherit src;
+    hash = "sha256-CrMe5DuO9sQZZ50Hy+av4nF4gbOe296zSWJfJ8th7zs=";
+  };
+
+  build-system = [
+    cargo
+    rustPlatform.cargoSetupHook
+    rustPlatform.maturinBuildHook
+    rustc
+  ];
+
+  pythonImportsCheck = [
+    "sdflit"
+  ];
+
+  meta = {
+    description = "Fast and Robust Signed Distance Function Library";
+    homepage = "https://github.com/yzx9/sdflit";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ yzx9 ];
+  };
+}

--- a/pkgs/development/python-modules/swcgeom/default.nix
+++ b/pkgs/development/python-modules/swcgeom/default.nix
@@ -1,0 +1,90 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  cython,
+  numpy,
+  setuptools,
+  wheel,
+  imagecodecs,
+  matplotlib,
+  pandas,
+  pynrrd,
+  scipy,
+  sdflit,
+  seaborn,
+  tifffile,
+  tqdm,
+  typing-extensions,
+  beautifulsoup4,
+  certifi,
+  chardet,
+  lmdb,
+  requests,
+  urllib3,
+  pytest,
+}:
+
+let
+  version = "0.19.3";
+in
+buildPythonPackage {
+  pname = "swcgeom";
+  inherit version;
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "yzx9";
+    repo = "swcgeom";
+    tag = "v${version}";
+    hash = "sha256-mpp8Dw0XcU59fYt7vjswAnXCmrRP3mhbgTDG+J4UwzI=";
+  };
+
+  build-system = [
+    cython
+    numpy
+    setuptools
+    wheel
+  ];
+
+  dependencies = [
+    imagecodecs
+    matplotlib
+    numpy
+    pandas
+    pynrrd
+    scipy
+    sdflit
+    seaborn
+    tifffile
+    tqdm
+    typing-extensions
+  ];
+
+  optional-dependencies = {
+    all = [
+      beautifulsoup4
+      certifi
+      chardet
+      lmdb
+      requests
+      urllib3
+    ];
+  };
+
+  nativeCheckInputs = [
+    pytest
+  ];
+
+  pythonImportsCheck = [
+    "swcgeom"
+  ];
+
+  meta = {
+    description = "Neuron geometry library for swc format";
+    homepage = "https://github.com/yzx9/swcgeom";
+    changelog = "https://github.com/yzx9/swcgeom/blob/v${version}/CHANGELOG.md";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ yzx9 ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -16765,6 +16765,8 @@ self: super: with self; {
 
   swagger-ui-bundle = callPackage ../development/python-modules/swagger-ui-bundle { };
 
+  swcgeom = callPackage ../development/python-modules/swcgeom { };
+
   swh-auth = callPackage ../development/python-modules/swh-auth { };
 
   swh-core = callPackage ../development/python-modules/swh-core { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6572,6 +6572,8 @@ self: super: with self; {
 
   image-go-nord = callPackage ../development/python-modules/image-go-nord { };
 
+  imagecodecs = callPackage ../development/python-modules/imagecodecs { };
+
   imagecodecs-lite = callPackage ../development/python-modules/imagecodecs-lite { };
 
   imagecorruptions = callPackage ../development/python-modules/imagecorruptions { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -15469,6 +15469,8 @@ self: super: with self; {
 
   sdds = callPackage ../development/python-modules/sdds { };
 
+  sdflit = callPackage ../development/python-modules/sdflit { };
+
   sdjson = callPackage ../development/python-modules/sdjson { };
 
   sdkmanager = callPackage ../development/python-modules/sdkmanager { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

- [imagecodecs](https://github.com/cgohlke/imagecodecs): Image transformation, compression, and decompression codecs.
  - We previously had `python3Packages.imagecodecs-lite`, but it has been marked as deprecated in PyPI. It is now recommended to use the imagecodecs package instead.
- [sdflit](https://github.com/yzx9/sdflit): Fast and Robust Signed Distance Function Library
- [swcgeom](https://github.com/yzx9/swcgeom):  Neuron geometry library for swc format.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [x] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
