### PR TITLE
treewide: possibly inactive maintainer: jfb / tftio / James Felix Black

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -11223,12 +11223,6 @@
     githubId = 110620;
     name = "Jevin Maltais";
   };
-  jfb = {
-    email = "james@yamtime.com";
-    github = "tftio";
-    githubId = 143075;
-    name = "James Felix Black";
-  };
   jfchevrette = {
     email = "jfchevrette@gmail.com";
     github = "jfchevrette";

--- a/pkgs/by-name/gx/gxmessage/package.nix
+++ b/pkgs/by-name/gx/gxmessage/package.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
     description = "GTK enabled dropin replacement for xmessage";
     homepage = "https://trmusson.dreamhosters.com/programs.html#gxmessage";
     license = lib.licenses.gpl3Plus;
-    maintainers = with lib.maintainers; [ jfb ];
+    maintainers = with lib.maintainers; [ ];
     platforms = with lib.platforms; linux;
     mainProgram = "gxmessage";
   };

--- a/pkgs/by-name/no/notion/package.nix
+++ b/pkgs/by-name/no/notion/package.nix
@@ -90,7 +90,6 @@ stdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.lgpl21;
     mainProgram = "notion";
     maintainers = with lib.maintainers; [
-      jfb
       raboof
     ];
     platforms = lib.platforms.linux;


### PR DESCRIPTION
Hello! I'm opening this PR to check whether @tftio is still active as a maintainer, in line with
[this policy](https://github.com/NixOS/nixpkgs/tree/master/maintainers#how-to-lose-maintainer-status). I've seen them not respond to issues in which they were pinged, which is why I suspect they might be inactive. Also, the last commit I've found from them is from 2015.

Of course, maintainership comes in many shapes and forms, and it's not a requirement that a maintainer makes commits themselves or responds to every single ping. It is very possible that @tftio is still active and I just missed that. This PR is not meant as criticism for inactivity: whether or not we merge this PR, their maintainership is much appreciated. However, if they're indeed inactive, it would be good to have the packaging reflect that, to correctly set expectations.

If @tftio responds here that they'd like to continue to act as a maintainer when needed, or if someone else shares a recent interaction, then I'm happy to close this PR without further action.

We can merge this PR if @tftio confirms they've moved on. If there's no response, I propose we keep this PR open for at least 3 weeks before merging. Even then, we can revert when they want to become active again.