### PR TITLE
treewide: possibly inactive maintainer ericsagnes

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7440,12 +7440,6 @@
     githubId = 7820865;
     name = "Eric Dallo";
   };
-  ericsagnes = {
-    email = "eric.sagnes@gmail.com";
-    github = "ericsagnes";
-    githubId = 367880;
-    name = "Eric Sagnes";
-  };
   ericson2314 = {
     email = "John.Ericson@Obsidian.Systems";
     matrix = "@ericson2314:matrix.org";

--- a/nixos/doc/manual/development/meta-attributes.section.md
+++ b/nixos/doc/manual/development/meta-attributes.section.md
@@ -22,7 +22,7 @@ file.
   };
 
   meta = {
-    maintainers = with lib.maintainers; [ ericsagnes ];
+    maintainers = with lib.maintainers; [ ];
     doc = ./default.md;
     buildDocsInSandbox = true;
   };

--- a/nixos/modules/i18n/input-method/default.nix
+++ b/nixos/modules/i18n/input-method/default.nix
@@ -113,7 +113,7 @@ in
   };
 
   meta = {
-    maintainers = with lib.maintainers; [ ericsagnes ];
+    maintainers = with lib.maintainers; [ ];
     doc = ./default.md;
   };
 

--- a/pkgs/applications/version-management/blackbox/default.nix
+++ b/pkgs/applications/version-management/blackbox/default.nix
@@ -58,7 +58,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "Safely store secrets in a VCS repo";
     homepage = "https://github.com/StackExchange/blackbox";
-    maintainers = with maintainers; [ ericsagnes ];
+    maintainers = with maintainers; [ ];
     license = licenses.mit;
     platforms = platforms.all;
   };

--- a/pkgs/by-name/al/albert/package.nix
+++ b/pkgs/by-name/al/albert/package.nix
@@ -77,7 +77,6 @@ stdenv.mkDerivation (finalAttrs: {
     # See: https://github.com/NixOS/nixpkgs/issues/279226
     license = lib.licenses.unfree;
     maintainers = with lib.maintainers; [
-      ericsagnes
       synthetica
       eljamm
     ];

--- a/pkgs/by-name/an/anthy/package.nix
+++ b/pkgs/by-name/an/anthy/package.nix
@@ -39,7 +39,7 @@ stdenv.mkDerivation rec {
     description = "Hiragana text to Kana Kanji mixed text Japanese input method";
     homepage = "https://anthy.osdn.jp/";
     license = licenses.gpl2Plus;
-    maintainers = with maintainers; [ ericsagnes ];
+    maintainers = with maintainers; [ ];
     platforms = platforms.unix;
   };
 

--- a/pkgs/by-name/gn/gnucobol/package.nix
+++ b/pkgs/by-name/gn/gnucobol/package.nix
@@ -142,7 +142,6 @@ stdenv.mkDerivation (finalAttrs: {
       lgpl3Only
     ];
     maintainers = with maintainers; [
-      ericsagnes
       lovesegfault
       techknowlogick
       kiike

--- a/pkgs/by-name/gr/groonga/package.nix
+++ b/pkgs/by-name/gr/groonga/package.nix
@@ -77,7 +77,7 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://groonga.org/";
     description = "Open-source fulltext search engine and column store";
     license = lib.licenses.lgpl21;
-    maintainers = [ lib.maintainers.ericsagnes ];
+    maintainers = [ ];
     platforms = lib.platforms.all;
     longDescription = ''
       Groonga is an open-source fulltext search engine and column store.

--- a/pkgs/by-name/j4/j4-dmenu-desktop/package.nix
+++ b/pkgs/by-name/j4/j4-dmenu-desktop/package.nix
@@ -50,7 +50,7 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/enkore/j4-dmenu-desktop";
     license = licenses.gpl3Only;
     mainProgram = "j4-dmenu-desktop";
-    maintainers = with maintainers; [ ericsagnes ];
+    maintainers = with maintainers; [ ];
     platforms = platforms.linux;
   };
 })

--- a/pkgs/by-name/ky/kytea/package.nix
+++ b/pkgs/by-name/ky/kytea/package.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
 
     license = licenses.asl20;
 
-    maintainers = with maintainers; [ ericsagnes ];
+    maintainers = with maintainers; [ ];
     platforms = platforms.unix;
   };
 

--- a/pkgs/by-name/li/libchewing/package.nix
+++ b/pkgs/by-name/li/libchewing/package.nix
@@ -26,7 +26,6 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://chewing.im/";
     license = licenses.lgpl21Only;
     maintainers = with maintainers; [
-      ericsagnes
       ShamrockLee
     ];
     platforms = platforms.all;

--- a/pkgs/by-name/li/libpinyin/package.nix
+++ b/pkgs/by-name/li/libpinyin/package.nix
@@ -51,7 +51,6 @@ stdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.gpl3Plus;
     maintainers = with lib.maintainers; [
       linsui
-      ericsagnes
     ];
     platforms = lib.platforms.linux;
   };

--- a/pkgs/by-name/mo/mozc/package.nix
+++ b/pkgs/by-name/mo/mozc/package.nix
@@ -106,7 +106,6 @@ buildBazelPackage rec {
     license = licenses.free;
     platforms = platforms.linux;
     maintainers = with maintainers; [
-      ericsagnes
       pineapplehunter
     ];
   };

--- a/pkgs/by-name/pa/pamix/package.nix
+++ b/pkgs/by-name/pa/pamix/package.nix
@@ -42,7 +42,7 @@ stdenv.mkDerivation (finalAttrs: {
     changelog = "https://github.com/patroclos/PAmix/releases/tag/${finalAttrs.version}";
     license = lib.licenses.mit;
     platforms = lib.platforms.linux;
-    maintainers = with lib.maintainers; [ ericsagnes ];
+    maintainers = with lib.maintainers; [ ];
     mainProgram = "pamix";
   };
 })

--- a/pkgs/by-name/po/ponymix/package.nix
+++ b/pkgs/by-name/po/ponymix/package.nix
@@ -32,6 +32,6 @@ stdenv.mkDerivation rec {
     mainProgram = "ponymix";
     license = licenses.mit;
     platforms = platforms.linux;
-    maintainers = with maintainers; [ ericsagnes ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/by-name/st/styx/package.nix
+++ b/pkgs/by-name/st/styx/package.nix
@@ -77,7 +77,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "Nix based static site generator";
-    maintainers = with maintainers; [ ericsagnes ];
+    maintainers = with maintainers; [ ];
     homepage = "https://styx-static.github.io/styx-site/";
     downloadPage = "https://github.com/styx-static/styx/";
     platforms = platforms.all;

--- a/pkgs/by-name/tm/tmuxinator/package.nix
+++ b/pkgs/by-name/tm/tmuxinator/package.nix
@@ -58,7 +58,6 @@ buildRubyGem rec {
     license = licenses.mit;
     maintainers = with maintainers; [
       auntie
-      ericsagnes
     ];
     platforms = platforms.unix;
     mainProgram = "tmuxinator";

--- a/pkgs/by-name/wi/wireguard-tools/package.nix
+++ b/pkgs/by-name/wi/wireguard-tools/package.nix
@@ -89,7 +89,6 @@ stdenv.mkDerivation rec {
     homepage = "https://www.wireguard.com/";
     license = licenses.gpl2Only;
     maintainers = with maintainers; [
-      ericsagnes
       zx2c4
       globin
       ma27

--- a/pkgs/development/python-modules/cached-property/default.nix
+++ b/pkgs/development/python-modules/cached-property/default.nix
@@ -42,6 +42,6 @@ buildPythonPackage rec {
     changelog = "https://github.com/pydanny/cached-property/releases/tag/${version}";
     license = licenses.bsd3;
     platforms = platforms.unix;
-    maintainers = with maintainers; [ ericsagnes ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/pocket/default.nix
+++ b/pkgs/development/python-modules/pocket/default.nix
@@ -21,6 +21,6 @@ buildPythonPackage rec {
     description = "Wrapper for the pocket API";
     homepage = "https://github.com/tapanpandita/pocket";
     license = licenses.bsd3;
-    maintainers = with maintainers; [ ericsagnes ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/development/python-modules/torchvision/default.nix
+++ b/pkgs/development/python-modules/torchvision/default.nix
@@ -101,6 +101,6 @@ buildPythonPackage {
     changelog = "https://github.com/pytorch/vision/releases/tag/v${version}";
     license = lib.licenses.bsd3;
     platforms = with lib.platforms; linux ++ lib.optionals (!cudaSupport) darwin;
-    maintainers = with lib.maintainers; [ ericsagnes ];
+    maintainers = with lib.maintainers; [ ];
   };
 }

--- a/pkgs/tools/inputmethods/ibus-engines/ibus-anthy/default.nix
+++ b/pkgs/tools/inputmethods/ibus-engines/ibus-anthy/default.nix
@@ -54,8 +54,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/fujiwarat/ibus-anthy";
     license = licenses.gpl2Plus;
     platforms = platforms.linux;
-    maintainers = with maintainers; [
-      ericsagnes
-    ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/tools/inputmethods/ibus-engines/ibus-hangul/default.nix
+++ b/pkgs/tools/inputmethods/ibus-engines/ibus-hangul/default.nix
@@ -59,7 +59,7 @@ stdenv.mkDerivation rec {
     mainProgram = "ibus-setup-hangul";
     homepage = "https://github.com/libhangul/ibus-hangul";
     license = licenses.gpl2Plus;
-    maintainers = with maintainers; [ ericsagnes ];
+    maintainers = with maintainers; [ ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/tools/inputmethods/ibus-engines/ibus-libpinyin/default.nix
+++ b/pkgs/tools/inputmethods/ibus-engines/ibus-libpinyin/default.nix
@@ -69,7 +69,6 @@ stdenv.mkDerivation rec {
     license = lib.licenses.gpl3Plus;
     maintainers = with lib.maintainers; [
       linsui
-      ericsagnes
     ];
     platforms = lib.platforms.linux;
   };

--- a/pkgs/tools/inputmethods/ibus-engines/ibus-m17n/default.nix
+++ b/pkgs/tools/inputmethods/ibus-engines/ibus-m17n/default.nix
@@ -52,6 +52,6 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/ibus/ibus-m17n";
     license = licenses.gpl2Plus;
     platforms = platforms.linux;
-    maintainers = with maintainers; [ ericsagnes ];
+    maintainers = with maintainers; [ ];
   };
 }

--- a/pkgs/tools/inputmethods/uim/default.nix
+++ b/pkgs/tools/inputmethods/uim/default.nix
@@ -174,7 +174,6 @@ stdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.bsd3;
     platforms = lib.platforms.unix;
     maintainers = with lib.maintainers; [
-      ericsagnes
       oxij
     ];
   };


### PR DESCRIPTION
Hello! I'm opening this PR to check whether @ericsagnes is still active as a maintainer, in line with
[this policy](https://github.com/NixOS/nixpkgs/tree/master/maintainers#how-to-lose-maintainer-status). I've seen them not respond to issues in which they were pinged, which is why I suspect they might be inactive. Also, the last commit I've found from them is from 2018.

Of course, maintainership comes in many shapes and forms, and it's not a requirement that a maintainer makes commits themselves or responds to every single ping. It is very possible that @ericsagnes is still active and I just missed that. This PR is not meant as criticism for inactivity: whether or not we merge this PR, their maintainership is much appreciated. However, if they're indeed inactive, it would be good to have the packaging reflect that, to correctly set expectations.

If @ericsagnes responds here that they'd like to continue to act as a maintainer when needed, or if someone else shares a recent interaction, then I'm happy to close this PR without further action.

We can merge this PR if @ericsagnes confirms they've moved on. If there's no response, I propose we keep this PR open for at least 3 weeks before merging. Even then, we can revert when they want to become active again.