### PR TITLE
jamesdsp: fix build on qt 6.9

### DIFF
--- a/pkgs/applications/audio/jamesdsp/default.nix
+++ b/pkgs/applications/audio/jamesdsp/default.nix
@@ -49,6 +49,7 @@ stdenv.mkDerivation (finalAttrs: {
       hash = "sha256-RtVKlw2ca8An4FodeD0RN95z9yHDHBgAxsEwLAmW7co=";
       name = "fix-build-with-new-pipewire.patch";
     })
+    ./fix-build-on-qt6_9.diff
   ];
 
   buildInputs =

--- a/pkgs/applications/audio/jamesdsp/fix-build-on-qt6_9.diff
+++ b/pkgs/applications/audio/jamesdsp/fix-build-on-qt6_9.diff
@@ -1,0 +1,22 @@
+diff --git a/src/subprojects/AutoEqIntegration/AeqPackageManager.cpp b/src/subprojects/AutoEqIntegration/AeqPackageManager.cpp
+index 01940a1..2ec9c5b 100644
+--- a/src/subprojects/AutoEqIntegration/AeqPackageManager.cpp
++++ b/src/subprojects/AutoEqIntegration/AeqPackageManager.cpp
+@@ -133,7 +133,7 @@ QtPromise::QPromise<AeqVersion> AeqPackageManager::getLocalVersion()
+     return QtPromise::QPromise<AeqVersion>{[&](
+         const QtPromise::QPromiseResolve<AeqVersion>& resolve,
+                 const QtPromise::QPromiseReject<AeqVersion>& reject) {
+-            QFile versionJson = (databaseDirectory() + "/version.json");
++            QFile versionJson(databaseDirectory() + "/version.json");
+             if(!versionJson.exists())
+             {
+                 reject();
+@@ -159,7 +159,7 @@ QtPromise::QPromise<QVector<AeqMeasurement>> AeqPackageManager::getLocalIndex()
+     return QtPromise::QPromise<QVector<AeqMeasurement>>{[&](
+         const QtPromise::QPromiseResolve<QVector<AeqMeasurement>>& resolve,
+                 const QtPromise::QPromiseReject<QVector<AeqMeasurement>>& reject) {
+-            QFile indexJson = (databaseDirectory() + "/index.json");
++            QFile indexJson(databaseDirectory() + "/index.json");
+             if(!indexJson.exists())
+             {
+                 reject();


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

close：https://github.com/NixOS/nixpkgs/issues/399168

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
