### PR TITLE
kdePackages.itinerary: make compatible with Qt 6.9

### DIFF
--- a/pkgs/kde/gear/itinerary/default.nix
+++ b/pkgs/kde/gear/itinerary/default.nix
@@ -1,5 +1,6 @@
 {
   mkKdeDerivation,
+  fetchpatch,
   pkg-config,
   qtlocation,
   qtpositioning,
@@ -9,8 +10,31 @@
 mkKdeDerivation {
   pname = "itinerary";
 
-  # FIXME: this should really be fixed at ECM level somehow
-  patches = [ ./optional-runtime-dependencies.patch ];
+  patches = [
+    # FIXME: this should really be fixed at ECM level somehow
+    ./optional-runtime-dependencies.patch
+    # make compatible with Qt 6.9 (QTBUG-98101)
+    (fetchpatch {
+      name = "Make-code-work-with-Qt-6.9-too.patch";
+      url = "https://invent.kde.org/pim/itinerary/-/commit/4ac22f865b0577f0a11440417e416670231cf9dd.patch";
+      hash = "sha256-JiDuGD71g0xtGolbP2NrXIW0owjJy5JeguGFwbLFAys=";
+    })
+  ];
+
+  # make compatible with Qt 6.9 (QTBUG-98101)
+  postPatch = ''
+    substituteInPlace src/app/PassPage.qml \
+      --replace-fail \
+        'import Qt.labs.qmlmodels as Models' \
+        'import Qt.labs.qmlmodels
+    import QtQml.Models' \
+      --replace-fail \
+        'Models.DelegateChoice' \
+        'DelegateChoice' \
+      --replace-fail \
+        'Models.DelegateChooser' \
+        'DelegateChooser'
+  '';
 
   extraNativeBuildInputs = [
     pkg-config


### PR DESCRIPTION
## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc