### PR TITLE
linuxPackages.nvidiaPackages.beta: 570.86.16 -> 575.51.02

### DIFF
--- a/pkgs/os-specific/linux/nvidia-x11/default.nix
+++ b/pkgs/os-specific/linux/nvidia-x11/default.nix
@@ -91,12 +91,12 @@ rec {
   });
 
   beta = selectHighestVersion latest (generic {
-    version = "570.86.16";
-    sha256_64bit = "sha256-RWPqS7ZUJH9JEAWlfHLGdqrNlavhaR1xMyzs8lJhy9U=";
-    sha256_aarch64 = "sha256-RiO2njJ+z0DYBo/1DKa9GmAjFgZFfQ1/1Ga+vXG87vA=";
-    openSha256 = "sha256-DuVNA63+pJ8IB7Tw2gM4HbwlOh1bcDg2AN2mbEU9VPE=";
-    settingsSha256 = "sha256-9rtqh64TyhDF5fFAYiWl3oDHzKJqyOW3abpcf2iNRT8=";
-    persistencedSha256 = "sha256-3mp9X/oV8o2TH9720NnoXROxQ4g98nNee+DucXpQy3w=";
+    version = "575.51.02";
+    sha256_64bit = "sha256-XZ0N8ISmoAC8p28DrGHk/YN1rJsInJ2dZNL8O+Tuaa0=";
+    sha256_aarch64 = "sha256-NNeQU9sPfH1sq3d5RUq1MWT6+7mTo1SpVfzabYSVMVI=";
+    openSha256 = "sha256-NQg+QDm9Gt+5bapbUO96UFsPnz1hG1dtEwT/g/vKHkw=";
+    settingsSha256 = "sha256-6n9mVkEL39wJj5FB1HBml7TTJhNAhS/j5hqpNGFQE4w=";
+    persistencedSha256 = "sha256-dgmco+clEIY8bedxHC4wp+fH5JavTzyI1BI8BxoeJJI=";
   });
 
   # Vulkan developer beta driver


### PR DESCRIPTION
- Extended the __NV_DISABLE_EXPLICIT_SYNC environment variable, which was available to EGL applications, to also apply to GLX and Vulkan applications.
- Fixed a bug that could cause Marvel Rivals to crash on startup or when loading levels.
- Fixed a bug that could cause the applications that use the VK_KHR_present_wait extension to hang on Wayland.
- Added support for GLX front buffer rendering on Xwayland.
- Fixed a bug that could cause Minecraft to crash on Xwayland.
- Fixed a bug that prevented PRIME Render Offload from working correctly when using NVIDIA GPUs as both the render offload source and the render offload sink.
- Fixed a bug which prevented VRR from working when overriding an EDID through the /sys/kernel/debug/dri/*/edid_override interface.
- Added support for the DRM plane properties COLOR_ENCODING and COLOR_RANGE.
- Fixed a bug that prevented the Default TGP and Max TGP values from being reported in the nvidia-settings control panel while running notebook systems on battery power.
- Fixed a bug that could lead to display freezes on some systems when toggling Night Mode with GNOME on Wayland.
- Fixed a bug that could cause graphics applications to not render correctly after a system suspend/resume cycle, if using the nvidia.ko kernel module parameter NVreg_PreserveVideoMemoryAllocations=1.
- Added a new kernel module parameter, 'conceal_vrr_caps', to the nvidia-modeset kernel module. This parameter may be used to enable usage of features on some displays such as ULMB (Ultra Low Motion Blur) which are incompatible with VRR. See the "Direct Rendering Manager Kernel Modesetting" (DRM KMS) chapter of the README for further information.
- Added support for NVIDIA Smooth Motion. See the "NVIDIA Smooth Motion" chapter in the README for details.
- Extended the nvidia-powerd daemon to also support Dynamic Boost while a notebook is running on battery power. See the "Dynamic Boost on Linux" chapter in the README for details.
- Updated the nvidia-modeset driver to trim trailing whitespace from the product name passed to the GPU's audio device as part of the EDID-Like Data (ELD).
- Dropped support for NV_PLANE_BLEND_CTM, NV_PLANE_DEGAMMA_TF, NV_PLANE_DEGAMMA_LUT, NV_PLANE_DEGAMMA_LUT_SIZE, and NV_PLANE_DEGAMMA_MULTIPLIER DRM plane properties on Linux kernels earlier than 6.8 to avoid exceeding DRM_OBJECT_MAX_PROPERTY.
- Fixed an issue that could cause render-offloaded applications using KDE Frameworks 6 to crash.

Draft until the open driver is published on github.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
