### PR TITLE
doc/languages-frameworks/typst: Format Nix expressions

### DIFF
--- a/doc/languages-frameworks/typst.section.md
+++ b/doc/languages-frameworks/typst.section.md
@@ -7,10 +7,12 @@ Typst can be configured to include packages from [Typst Universe](https://typst.
 You can create a custom Typst environment with a selected set of packages from **Typst Universe** using the following code. It is also possible to specify a Typst package with a specific version (e.g., `cetz_0_3_0`). A package without a version number will always refer to its latest version.
 
 ```nix
-typst.withPackages (p: with p; [
-  polylux_0_4_0
-  cetz_0_3_0
-])
+typst.withPackages (
+  p: with p; [
+    polylux_0_4_0
+    cetz_0_3_0
+  ]
+)
 ```
 
 ### Handling Outdated Package Hashes {#typst-handling-outdated-package-hashes}
@@ -18,18 +20,24 @@ typst.withPackages (p: with p; [
 Since **Typst Universe** does not provide a way to fetch a package with a specific hash, the package hashes in `nixpkgs` can sometimes be outdated. To resolve this issue, you can manually override the package source using the following approach:
 
 ```nix
-typst.withPackages.override (old: {
-  typstPackages = old.typstPackages.extend (_: previous: {
-    polylux_0_4_0 = previous.polylux_0_4_0.overrideAttrs (oldPolylux: {
-      src = oldPolylux.src.overrideAttrs {
-        outputHash = YourUpToDatePolyluxHash;
-      };
-    });
-  });
-}) (p: with p; [
-  polylux_0_4_0
-  cetz_0_3_0
-])
+typst.withPackages.override
+  (old: {
+    typstPackages = old.typstPackages.extend (
+      _: previous: {
+        polylux_0_4_0 = previous.polylux_0_4_0.overrideAttrs (oldPolylux: {
+          src = oldPolylux.src.overrideAttrs {
+            outputHash = YourUpToDatePolyluxHash;
+          };
+        });
+      }
+    );
+  })
+  (
+    p: with p; [
+      polylux_0_4_0
+      cetz_0_3_0
+    ]
+  )
 ```
 
 ## Custom Packages {#typst-custom-packages}
@@ -39,12 +47,15 @@ typst.withPackages.override (old: {
 Here's how to define a custom Typst package:
 
 ```nix
-{ buildTypstPackage, typstPackages, fetchzip }:
+{
+  buildTypstPackage,
+  typstPackages,
+}:
 
 buildTypstPackage (finalAttrs: {
   pname = "my-typst-package";
   version = "0.0.1";
-  src = fetchzip { ... };
+  src = ./.;
   typstDeps = with typstPackages; [ cetz_0_3_0 ];
 })
 ```


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Fix un-formatted Nix expressions in the doc's Typst section (https://github.com/NixOS/nixpkgs/pull/369283#issuecomment-2813510460).

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
