### PR TITLE
vorbis-tools: 1.4.2 -> 1.4.3

### DIFF
--- a/pkgs/applications/audio/vorbis-tools/default.nix
+++ b/pkgs/applications/audio/vorbis-tools/default.nix
@@ -2,7 +2,6 @@
   lib,
   stdenv,
   fetchurl,
-  fetchpatch,
   libogg,
   libvorbis,
   libao,
@@ -16,21 +15,12 @@
 
 stdenv.mkDerivation rec {
   pname = "vorbis-tools";
-  version = "1.4.2";
+  version = "1.4.3";
 
   src = fetchurl {
     url = "http://downloads.xiph.org/releases/vorbis/vorbis-tools-${version}.tar.gz";
-    sha256 = "1c7h4ivgfdyygz2hyh6nfibxlkz8kdk868a576qkkjgj5gn78xyv";
+    hash = "sha256-of493Gd3vc6/a3l+ft/gQ3lUskdW/8yMa4FrY+BGDd4=";
   };
-
-  patches = [
-    # Fixes a call to undeclared function `utf8_decode`.
-    # https://github.com/xiph/vorbis-tools/pull/33
-    (fetchpatch {
-      url = "https://github.com/xiph/vorbis-tools/commit/8a645f78b45ae7e370c0dc2a52d0f2612aa6110b.patch";
-      hash = "sha256-RkT9Xa0pRu/oO9E9qhDa17L0luWgYHI2yINIkPZanmI=";
-    })
-  ];
 
   # ld64 on darwin doesn't support nested archives and as the nested lib
   # (libbase64.a) is not required to build so leave it out


### PR DESCRIPTION
Fixes CVE-2023-43361.

https://github.com/xiph/vorbis-tools/blob/235540c05ad3f9cdc673ca09c237c9a9b5bda6eb/CHANGES


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review pr 399564`

---
### `x86_64-linux`
<details>
  <summary>:fast_forward: 2 packages marked as broken and skipped:</summary>
  <ul>
    <li>mkchromecast</li>
    <li>mkchromecast.dist</li>
  </ul>
</details>
<details>
  <summary>:x: 1 package failed to build:</summary>
  <ul>
    <li>colobot</li>
  </ul>
</details>
<details>
  <summary>:white_check_mark: 17 packages built:</summary>
  <ul>
    <li>abcde</li>
    <li>asunder</li>
    <li>bpm-tools</li>
    <li>crip</li>
    <li>cuetools</li>
    <li>dr14_tmeter</li>
    <li>dr14_tmeter.dist</li>
    <li>dvd-slideshow</li>
    <li>flac2all</li>
    <li>flac2all.dist</li>
    <li>flacon</li>
    <li>soundkonverter (libsForQt5.soundkonverter)</li>
    <li>pulseaudio-dlna</li>
    <li>pulseaudio-dlna.dist</li>
    <li>solfege</li>
    <li>uade</li>
    <li>vorbis-tools</li>
  </ul>
</details>
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
