### PR TITLE
davinci-resolve: 19.1.4 -> 20 Beta 1

### DIFF
--- a/pkgs/by-name/da/davinci-resolve/package.nix
+++ b/pkgs/by-name/da/davinci-resolve/package.nix
@@ -35,7 +35,7 @@ let
   davinci = (
     stdenv.mkDerivation rec {
       pname = "davinci-resolve${lib.optionalString studioVariant "-studio"}";
-      version = "19.1.4";
+      version = "20 Beta 1";
 
       nativeBuildInputs = [
         (appimage-run.override { buildFHSEnv = buildFHSEnvChroot; })
@@ -57,9 +57,9 @@ let
             outputHashAlgo = "sha256";
             outputHash =
               if studioVariant then
-                "sha256-OTL83suZXt7DxDz+89zIRJD8R25/HZUQMMGlfS+Ow4I="
+                "sha256-5QIKWORfeynfSYcP8G7u5DY/kbwTp1JmKyvgboSoV5U="
               else
-                "sha256-2u1gkaL3vdI+4RnPl5bEXE+zeRhg2BzPWjni015ISWI=";
+                "sha256-zmaQUc/S2TxtNpePvh8BVq47McpS3CDuiQ9gyib0pO4=";
 
             impureEnvVars = lib.fetchers.proxyImpureEnvVars;
 
@@ -101,7 +101,7 @@ let
           ''
             DOWNLOADID=$(
               curl --silent --compressed "$DOWNLOADSURL" \
-                | jq --raw-output '.downloads[] | .urls.Linux?[]? | select(.downloadTitle | test("^'"$PRODUCT $VERSION"'( Update)?$")) | .downloadId'
+                | jq --raw-output '.downloads[] | .urls.Linux?[]? | select(.downloadTitle | test("^'"$PRODUCT $VERSION"'( Beta \\d+)?( Update)?$")) | .downloadId'
             )
             echo "downloadid is $DOWNLOADID"
             test -n "$DOWNLOADID"
@@ -138,9 +138,22 @@ let
 
       installPhase =
         let
-          appimageName = "DaVinci_Resolve_${lib.optionalString studioVariant "Studio_"}${version}_Linux.run";
+          appimageVersion =
+            if lib.strings.hasInfix "Beta" version then
+              let
+                parts = lib.strings.split " " version;
+                # every odd index is empty list for the space
+                releaseVersion = builtins.elemAt parts 0;
+                # beta = builtins.elemAt parts 2;
+                betaVersion = builtins.elemAt parts 4;
+              in
+              "${releaseVersion}.0b${betaVersion}"
+            else
+              version;
+          appimageName = "DaVinci_Resolve_${lib.optionalString studioVariant "Studio_"}${appimageVersion}_Linux.run";
         in
         ''
+          echo ${appimageName}
           runHook preInstall
 
           export HOME=$PWD/home
@@ -282,13 +295,13 @@ buildFHSEnv {
         currentVersion=${lib.escapeShellArg davinci.version}
         downloadsJSON="$(curl --fail --silent https://www.blackmagicdesign.com/api/support/us/downloads.json)"
 
-        latestLinuxVersion="$(echo "$downloadsJSON" | jq '[.downloads[] | select(.urls.Linux) | .urls.Linux[] | select(.downloadTitle | test("DaVinci Resolve")) | .downloadTitle]' | grep -oP 'DaVinci Resolve \K\d+\.\d+(\.\d+)?' | sort | tail -n 1)"
+        latestLinuxVersion="$(echo "$downloadsJSON" | jq '[.downloads[] | select(.urls.Linux) | .urls.Linux[] | select(.downloadTitle | test("DaVinci Resolve")) | .downloadTitle]' | grep -oP 'DaVinci Resolve \K\d+(\.\d+)?(\.\d+)?( Beta \d+)?' | sort | tail -n 1)"
         update-source-version davinci-resolve "$latestLinuxVersion" --source-key=davinci.src
 
         # Since the standard and studio both use the same version we need to reset it before updating studio
         sed -i -e "s/""$latestLinuxVersion""/""$currentVersion""/" "$drv"
 
-        latestStudioLinuxVersion="$(echo "$downloadsJSON" | jq '[.downloads[] | select(.urls.Linux) | .urls.Linux[] | select(.downloadTitle | test("DaVinci Resolve")) | .downloadTitle]' | grep -oP 'DaVinci Resolve Studio \K\d+\.\d+(\.\d+)?' | sort | tail -n 1)"
+        latestStudioLinuxVersion="$(echo "$downloadsJSON" | jq '[.downloads[] | select(.urls.Linux) | .urls.Linux[] | select(.downloadTitle | test("DaVinci Resolve")) | .downloadTitle]' | grep -oP 'DaVinci Resolve Studio \K\d+(\.\d+)?(\.\d+)?( Beta \d+)?' | sort | tail -n 1)"
         update-source-version davinci-resolve-studio "$latestStudioLinuxVersion" --source-key=davinci.src
       '';
     });


### PR DESCRIPTION
This is a draft for people looking to use the Beta and to maybe discuss if the beta should be added separately to nixpkgs.

I had problems building `libsecret` so I overrode `appimage-run` to use the one from unstable.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
