### PR TITLE
taxi: 2.0.2 -> 2.0.2-unstable-2024-12-26

### DIFF
--- a/pkgs/by-name/ta/taxi/package.nix
+++ b/pkgs/by-name/ta/taxi/package.nix
@@ -1,13 +1,13 @@
 {
   lib,
   stdenv,
+  desktop-file-utils,
   fetchFromGitHub,
   gobject-introspection,
-  gtk3,
-  libgee,
-  libhandy,
+  gtk4,
+  libadwaita,
   libsecret,
-  libsoup_2_4,
+  libsoup_3,
   meson,
   ninja,
   nix-update-script,
@@ -15,52 +15,46 @@
   pkg-config,
   python3,
   vala,
-  wrapGAppsHook3,
+  wrapGAppsHook4,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation {
   pname = "taxi";
-  version = "2.0.2";
+  version = "2.0.2-unstable-2024-12-26";
 
   src = fetchFromGitHub {
-    owner = "Alecaddd";
+    owner = "ellie-commons";
     repo = "taxi";
-    rev = version;
-    sha256 = "1a4a14b2d5vqbk56drzbbldp0nngfqhwycpyv8d3svi2nchkvpqa";
+    rev = "b1c81490641f102005d9451a33d21610c0637e22";
+    sha256 = "sha256-boPwRSHzFpbrzRoSmNWf/fgi3cJDEt9qjZHWQWutL+o=";
   };
 
   nativeBuildInputs = [
+    desktop-file-utils
     gobject-introspection
     meson
     ninja
     pkg-config
     python3
     vala
-    wrapGAppsHook3
+    wrapGAppsHook4
   ];
 
   buildInputs = [
-    gtk3
-    libgee
-    libhandy
+    gtk4
+    libadwaita
     libsecret
-    libsoup_2_4
-    pantheon.granite
+    libsoup_3
+    pantheon.granite7
   ];
-
-  postPatch = ''
-    chmod +x meson/post_install.py
-    patchShebangs meson/post_install.py
-  '';
-
   passthru.updateScript = nix-update-script { };
 
   meta = with lib; {
-    homepage = "https://github.com/Alecaddd/taxi";
+    homepage = "https://github.com/ellie-commons/taxi";
     description = "FTP Client that drives you anywhere";
     license = licenses.lgpl3Plus;
     maintainers = with maintainers; [ ] ++ teams.pantheon.members;
     platforms = platforms.linux;
-    mainProgram = "com.github.alecaddd.taxi";
+    mainProgram = "io.github.ellie_commons.taxi";
   };
 }


### PR DESCRIPTION
This includes updates to:
- gtk4 and granite7 [1]
- libsoup_3 [2]
- gnome post_install [3]

[1] https://github.com/ellie-commons/taxi/commit/4dcb5b2ad7df0c53ed311c4db13477f00a90d31c
[2] https://github.com/ellie-commons/taxi/commit/c65e7de3c157dc73986e4ab4b997df234ae65056
[3] https://github.com/ellie-commons/taxi/commit/b7e3b7226abe9a04cb156881252f32d0e7482aed

Part of https://github.com/NixOS/nixpkgs/issues/360897

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
