### PR TITLE
treewide: fix versionCheckHook in nativeInstallCheck

### DIFF
--- a/pkgs/by-name/az/az-pim-cli/package.nix
+++ b/pkgs/by-name/az/az-pim-cli/package.nix
@@ -5,8 +5,9 @@
   installShellFiles,
   stdenv,
   buildPackages,
-  versionCheckHook,
   nix-update-script,
+  testers,
+  az-pim-cli,
 }:
 buildGoModule (finalAttrs: {
   pname = "az-pim-cli";
@@ -37,11 +38,13 @@ buildGoModule (finalAttrs: {
     ''
   );
 
-  doInstallCheck = true;
-  nativeInstallCheck = [ versionCheckHook ];
-  versionCheckProgramArg = "version";
-
-  passthru.updateScript = nix-update-script { };
+  passthru = {
+    updateScript = nix-update-script { };
+    tests.version = testers.testVersion {
+      command = "HOME=$TMPDIR az-pim-cli --version";
+      package = az-pim-cli;
+    };
+  };
 
   meta = {
     description = "List and activate Azure Entra ID Privileged Identity Management roles from the CLI";

--- a/pkgs/by-name/fo/foodfetch/package.nix
+++ b/pkgs/by-name/fo/foodfetch/package.nix
@@ -25,7 +25,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   buildInputs = [ openssl ];
 
   doInstallCheck = true;
-  nativeInstallCheck = [ versionCheckHook ];
+  nativeInstallCheckInputs = [ versionCheckHook ];
 
   passthru.updateScript = nix-update-script { };
 

--- a/pkgs/by-name/kr/krep/package.nix
+++ b/pkgs/by-name/kr/krep/package.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   doCheck = true;
   doInstallCheck = true;
-  nativeInstallCheck = [ versionCheckHook ];
+  nativeInstallCheckInputs = [ versionCheckHook ];
 
   meta = {
     description = "Blazingly fast string search utility designed for performance-critical applications";

--- a/pkgs/by-name/ol/ollama/package.nix
+++ b/pkgs/by-name/ol/ollama/package.nix
@@ -19,7 +19,6 @@
   cudaArches ? cudaPackages.cudaFlags.realArches or [ ],
   darwin,
   autoAddDriverRunpath,
-  versionCheckHook,
 
   # passthru
   nixosTests,
@@ -246,10 +245,6 @@ goBuild {
   ];
 
   __darwinAllowLocalNetworking = true;
-
-  nativeInstallCheck = [ versionCheckHook ];
-  versionCheckProgramArg = "--version";
-  doInstallCheck = true;
 
   passthru = {
     tests =

--- a/pkgs/by-name/pe/petidomo/package.nix
+++ b/pkgs/by-name/pe/petidomo/package.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation (finalAttrs: {
   doCheck = true;
 
   doInstallCheck = true;
-  nativeInstallCheck = [ versionCheckHook ];
+  nativeInstallCheckInputs = [ versionCheckHook ];
 
   meta = {
     homepage = "https://petidomo.sourceforge.net/";

--- a/pkgs/by-name/ru/rust-stakeholder/package.nix
+++ b/pkgs/by-name/ru/rust-stakeholder/package.nix
@@ -2,7 +2,6 @@
   lib,
   fetchFromGitHub,
   rustPlatform,
-  versionCheckHook,
   nix-update-script,
 }:
 rustPlatform.buildRustPackage {
@@ -18,10 +17,6 @@ rustPlatform.buildRustPackage {
 
   useFetchCargoVendor = true;
   cargoHash = "sha256-NxO+7Wh8Ff6RPFtmbEa3EJszfDaZDXGWZDAoXPEAnpI=";
-
-  nativeInstallCheck = [ versionCheckHook ];
-  versionCheckProgramArg = "--version";
-  doInstallCheck = true;
 
   passthru.updateScript = nix-update-script { };
 

--- a/pkgs/by-name/so/sou/package.nix
+++ b/pkgs/by-name/so/sou/package.nix
@@ -3,7 +3,8 @@
   buildGoModule,
   fetchFromGitHub,
   nix-update-script,
-  versionCheckHook,
+  testers,
+  sou,
 }:
 
 buildGoModule (finalAttrs: {
@@ -25,13 +26,16 @@ buildGoModule (finalAttrs: {
     "-X=main.version=${finalAttrs.version}"
   ];
 
-  doInstallCheck = true;
-  nativeInstallCheck = [ versionCheckHook ];
-
   # Some of the tests use localhost networking
   __darwinAllowLocalNetworking = true;
 
-  passthru.updateScript = nix-update-script { };
+  passthru = {
+    updateScript = nix-update-script { };
+    tests.version = testers.testVersion {
+      command = "HOME=$TMPDIR sou --version";
+      package = sou;
+    };
+  };
 
   meta = {
     description = "Tool for exploring files in container image layers";

--- a/pkgs/by-name/tf/tfmigrate/package.nix
+++ b/pkgs/by-name/tf/tfmigrate/package.nix
@@ -24,7 +24,7 @@ buildGoModule (finalAttrs: {
   ];
 
   doInstallCheck = true;
-  nativeInstallCheck = [ versionCheckHook ];
+  nativeInstallCheckInputs = [ versionCheckHook ];
 
   passthru.updateScript = nix-update-script { };
 


### PR DESCRIPTION
Most if not all of these are due to my suggestions. Got this in my head b/c @GaetanLepage [suggested `nativeInstallCheck = [ versionCheckHook ];` on one of my prs](https://github.com/NixOS/nixpkgs/pull/390236#discussion_r2008939689)
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
