### PR TITLE
boulder: 2024-07-16 -> 2025-04-17

### DIFF
--- a/pkgs/by-name/bo/boulder/package.nix
+++ b/pkgs/by-name/bo/boulder/package.nix
@@ -4,6 +4,7 @@
   buildGoModule,
   testers,
   boulder,
+  nix-update-script,
 }:
 
 buildGoModule rec {
@@ -318,9 +319,12 @@ buildGoModule rec {
     done
   '';
 
-  passthru.tests.version = testers.testVersion {
-    package = boulder;
-    inherit version;
+  passthru = {
+    tests.version = testers.testVersion {
+      package = boulder;
+      inherit version;
+    };
+    updateScript = nix-update-script { };
   };
 
   meta = {

--- a/pkgs/by-name/bo/boulder/package.nix
+++ b/pkgs/by-name/bo/boulder/package.nix
@@ -8,12 +8,12 @@
 
 buildGoModule rec {
   pname = "boulder";
-  version = "2024-07-16";
+  version = "2025-04-17";
 
   src = fetchFromGitHub {
     owner = "letsencrypt";
     repo = "boulder";
-    rev = "release-${version}";
+    tag = "release-${version}";
     leaveDotGit = true;
     postFetch = ''
       pushd $out
@@ -21,7 +21,7 @@ buildGoModule rec {
       find $out -name .git -print0 | xargs -0 rm -rf
       popd
     '';
-    hash = "sha256-mIUT9qVBPWrL0ySORwgEH6azaQmzMCl7ha/eYRtvAg4=";
+    hash = "sha256-FXk+JZJ1azpgN6IQ9aYmpUEO1CGs9/3sog1NjrfB4d8=";
   };
 
   vendorHash = null;
@@ -58,6 +58,7 @@ buildGoModule rec {
     "TestAddPrecertificateKeyHash"
     "TestAddPrecertificateNoOCSP"
     "TestAddRegistration"
+    "TestAddReplacementOrder"
     "TestAddSerial"
     "TestAdministrativelyRevokeCertificate"
     "TestAuthorization500"
@@ -81,6 +82,7 @@ buildGoModule rec {
     "TestCheckCertReturnsDNSNames"
     "TestCheckExactCertificateLimit"
     "TestCheckFQDNSetRateLimitOverride"
+    "TestCheckIdentifiersPaused"
     "TestCheckWildcardCert"
     "TestCheckWildcardCert"
     "TestClientTransportCredentials"
@@ -99,6 +101,7 @@ buildGoModule rec {
     "TestDeactivateAuthorization"
     "TestDeactivateRegistration"
     "TestDedupOnRegistration"
+    "TestDialerTimeout"
     "TestDirectory"
     "TestDontFindRevokedCert"
     "TestEarlyOrderRateLimiting"
@@ -106,8 +109,10 @@ buildGoModule rec {
     "TestEnforceJWSAuthType"
     "TestExactPublicSuffixCertLimit"
     "TestExtractJWK"
+    "TestFQDNSetExists"
     "TestFQDNSetTimestampsForWindow"
     "TestFQDNSets"
+    "TestFQDNSetsExists"
     "TestFQDNSetsExists"
     "TestFailExit"
     "TestFasterGetOrderForNames"
@@ -116,6 +121,7 @@ buildGoModule rec {
     "TestFinalizeOrderWildcard"
     "TestFinalizeOrderWithMixedSANAndCN"
     "TestFinalizeSCTError"
+    "TestFinalizeWithMustStaple"
     "TestFindCertsAtCapacity"
     "TestFindExpiringCertificates"
     "TestFindIDs"
@@ -145,6 +151,8 @@ buildGoModule rec {
     "TestGetOrder"
     "TestGetOrderExpired"
     "TestGetOrderForNames"
+    "TestGetPausedIdentifiers"
+    "TestGetPausedIdentifiersOnlyUnpausesOneAccount"
     "TestGetPendingAuthorization2"
     "TestGetRevokedCerts"
     "TestGetSerialMetadata"
@@ -221,12 +229,15 @@ buildGoModule rec {
     "TestPOST404"
     "TestPanicStackTrace"
     "TestParseJWSRequest"
+    "TestPauseIdentifiers"
     "TestPendingAuthorizationsUnlimited"
     "TestPerformValidationAlreadyValid"
     "TestPerformValidationBadChallengeType"
     "TestPerformValidationExpired"
     "TestPerformValidationSuccess"
     "TestPerformValidationVAError"
+    "TestPerformValidation_FailedThenSuccessfulValidationResetsPauseIdentifiersRatelimit"
+    "TestPerformValidation_FailedValidationsTriggerPauseIdentifiersRatelimit"
     "TestPrepAuthzForDisplay"
     "TestPreresolvedDialerTimeout"
     "TestProcessCerts"
@@ -242,6 +253,7 @@ buildGoModule rec {
     "TestRegistrationsPerIPOverrideUsage"
     "TestRehydrateHostPort"
     "TestRelativeDirectory"
+    "TestReplacementOrderExists"
     "TestReplicationLagRetries"
     "TestResolveContacts"
     "TestRevokeCertByApplicant_Controller"
@@ -260,6 +272,7 @@ buildGoModule rec {
     "TestSerialsFromPrivateKey"
     "TestSetAndGet"
     "TestSetOrderProcessing"
+    "TestSetReplacementOrderFinalized"
     "TestSingleton"
     "TestStart"
     "TestStatusForOrder"
@@ -268,6 +281,7 @@ buildGoModule rec {
     "TestTLSALPN01DialTimeout"
     "TestTLSConfigLoad"
     "TestTimeouts"
+    "TestUnpauseAccount"
     "TestUpdateCRLShard"
     "TestUpdateChallengeFinalizedAuthz"
     "TestUpdateChallengeRAError"
@@ -275,6 +289,8 @@ buildGoModule rec {
     "TestUpdateMissingAuthorization"
     "TestUpdateNowWithAllFailingSRV"
     "TestUpdateNowWithOneFailingSRV"
+    "TestUpdateRegistrationContact"
+    "TestUpdateRegistrationKey"
     "TestUpdateRegistrationSame"
     "TestUpdateRevokedCertificate"
     "TestValidJWSForKey"
@@ -307,7 +323,7 @@ buildGoModule rec {
     inherit version;
   };
 
-  meta = with lib; {
+  meta = {
     homepage = "https://github.com/letsencrypt/boulder";
     description = "ACME-based certificate authority, written in Go";
     longDescription = ''
@@ -317,7 +333,7 @@ buildGoModule rec {
       revoke certificates for their domains. Boulder is the software that runs
       Let's Encrypt.
     '';
-    license = licenses.mpl20;
+    license = lib.licenses.mpl20;
     mainProgram = "boulder";
     maintainers = [ ];
   };


### PR DESCRIPTION
Also deactivate tests that are failing

The build currently fails due to the old version being incompatible with go 1.24, but the current tag _is_ compatible.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
