### PR TITLE
nixos/livekit: init, nixos/lk-jwt-service: init

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -750,6 +750,7 @@
   ./services/matrix/dendrite.nix
   ./services/matrix/hebbot.nix
   ./services/matrix/hookshot.nix
+  ./services/matrix/lk-jwt-service.nix
   ./services/matrix/matrix-alertmanager.nix
   ./services/matrix/maubot.nix
   ./services/matrix/mautrix-meta.nix

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1178,6 +1178,7 @@
   ./services/networking/lambdabot.nix
   ./services/networking/legit.nix
   ./services/networking/libreswan.nix
+  ./services/networking/livekit.nix
   ./services/networking/lldpd.nix
   ./services/networking/logmein-hamachi.nix
   ./services/networking/lokinet.nix

--- a/nixos/modules/services/matrix/lk-jwt-service.nix
+++ b/nixos/modules/services/matrix/lk-jwt-service.nix
@@ -1,0 +1,93 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.services.lk-jwt-service;
+in
+{
+  meta.maintainers = [ lib.maintainers.quadradical ];
+  options.services.lk-jwt-service = {
+    enable = lib.mkEnableOption "Enable lk-jwt-service";
+    package = lib.mkPackageOption pkgs "lk-jwt-service" { };
+
+    livekitUrl = lib.mkOption {
+      type = lib.types.strMatching "^wss?://.*";
+      example = "wss://example.com/livekit/sfu";
+      description = ''
+        The public websocket URL for livekit.
+        The proto needs to be either  `wss://` (recommended) or `ws://` (insecure).
+      '';
+    };
+
+    keyFile = lib.mkOption {
+      type = lib.types.path;
+      description = ''
+        Path to a file containing the credential mapping (`<keyname>: <secret>`) to access LiveKit.
+
+        Example:
+        ```
+          lk-jwt-service: f6lQGaHtM5HfgZjIcec3cOCRfiDqIine4CpZZnqdT5cE
+        ```
+
+        For more information, see <https://github.com/element-hq/lk-jwt-service#configuration>.
+      '';
+    };
+
+    port = lib.mkOption {
+      type = lib.types.port;
+      default = 8080;
+      description = "Port that lk-jwt-service should listen on.";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    systemd.services.lk-jwt-service = {
+      description = "Minimal service to issue LiveKit JWTs for MatrixRTC";
+      documentation = [ "https://github.com/element-hq/lk-jwt-service" ];
+      wantedBy = [ "multi-user.target" ];
+      wants = [ "network-online.target" ];
+      after = [ "network-online.target" ];
+      environment = {
+        LIVEKIT_URL = cfg.livekitUrl;
+        LIVEKIT_JWT_PORT = toString cfg.port;
+        LIVEKIT_KEY_FILE = "/run/credentials/lk-jwt-service.service/livekit-secrets";
+      };
+
+      serviceConfig = {
+        LoadCredential = [ "livekit-secrets:${cfg.keyFile}" ];
+        ExecStart = lib.getExe cfg.package;
+        DynamicUser = true;
+        LockPersonality = true;
+        MemoryDenyWriteExecute = true;
+        ProtectClock = true;
+        ProtectControlGroups = true;
+        ProtectHostname = true;
+        ProtectKernelLogs = true;
+        ProtectKernelModules = true;
+        ProtectKernelTunables = true;
+        PrivateDevices = true;
+        PrivateMounts = true;
+        PrivateUsers = true;
+        RestrictAddressFamilies = [
+          "AF_INET"
+          "AF_INET6"
+        ];
+        RestrictNamespaces = true;
+        RestrictRealtime = true;
+        ProtectHome = true;
+        SystemCallArchitectures = "native";
+        SystemCallFilter = [
+          "@system-service"
+          "~@privileged"
+          "~@resources"
+        ];
+        Restart = "on-failure";
+        RestartSec = 5;
+        UMask = "077";
+      };
+    };
+  };
+}

--- a/nixos/modules/services/networking/livekit.nix
+++ b/nixos/modules/services/networking/livekit.nix
@@ -1,0 +1,141 @@
+{
+  config,
+  lib,
+  pkgs,
+  utils,
+  ...
+}:
+let
+  cfg = config.services.livekit;
+  format = pkgs.formats.json { };
+in
+{
+  meta.maintainers = with lib.maintainers; [ quadradical ];
+  options.services.livekit = {
+    enable = lib.mkEnableOption "Enable the livekit server";
+    package = lib.mkPackageOption pkgs "livekit" { };
+
+    keyFile = lib.mkOption {
+      type = lib.types.path;
+      description = ''
+        LiveKit key file holding one or multiple application secrets. Use `livekit-server generate-keys` to generate a random key name and secret.
+
+        The file should have the format `<keyname>: <secret>`. Example:
+        ```
+          lk-jwt-service: f6lQGaHtM5HfgZjIcec3cOCRfiDqIine4CpZZnqdT5cE
+        ```
+
+        Individual key/secret pairs need to be passed to clients to connect to this instance.
+      '';
+    };
+
+    openFirewall = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = "Opens port range for LiveKit on the firewall.";
+    };
+
+    settings = lib.mkOption {
+      type = lib.types.submodule {
+        freeformType = format.type;
+        options = {
+          port = lib.mkOption {
+            type = lib.types.port;
+            default = 7880;
+            description = "Main TCP port for RoomService and RTC endpoint.";
+          };
+
+          rtc = {
+            port_range_start = lib.mkOption {
+              type = lib.types.int;
+              default = 50000;
+              description = "Start of UDP port range for WebRTC";
+            };
+
+            port_range_end = lib.mkOption {
+              type = lib.types.int;
+              default = 51000;
+              description = "End of UDP port range for WebRTC";
+            };
+
+            use_external_ip = lib.mkOption {
+              type = lib.types.bool;
+              default = false;
+              description = ''
+                When set to true, attempts to discover the host's public IP via STUN.
+                This is useful for cloud environments such as AWS & Google where hosts have an internal IP that maps to an external one.
+              '';
+            };
+          };
+        };
+      };
+      default = { };
+      description = ''
+        LiveKit configuration file expressed in nix.
+
+        For an example configuration, see <https://docs.livekit.io/home/self-hosting/deployment/#configuration>.
+        For all possible values, see <https://github.com/livekit/livekit/blob/master/config-sample.yaml>.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    networking.firewall = lib.mkIf cfg.openFirewall {
+      allowedTCPPorts = [
+        cfg.settings.port
+      ];
+      allowedUDPPortRanges = [
+        {
+          from = cfg.settings.rtc.port_range_start;
+          to = cfg.settings.rtc.port_range_end;
+        }
+      ];
+    };
+
+    systemd.services.livekit = {
+      description = "LiveKit SFU server";
+      documentation = [ "https://docs.livekit.io" ];
+      wantedBy = [ "multi-user.target" ];
+      wants = [ "network-online.target" ];
+      after = [ "network-online.target" ];
+
+      serviceConfig = {
+        LoadCredential = [ "livekit-secrets:${cfg.keyFile}" ];
+        ExecStart = utils.escapeSystemdExecArgs [
+          (lib.getExe cfg.package)
+          "--config=${format.generate "livekit.json" cfg.settings}"
+          "--key-file=/run/credentials/livekit.service/livekit-secrets"
+        ];
+        DynamicUser = true;
+        LockPersonality = true;
+        MemoryDenyWriteExecute = true;
+        ProtectClock = true;
+        ProtectControlGroups = true;
+        ProtectHostname = true;
+        ProtectKernelLogs = true;
+        ProtectKernelModules = true;
+        ProtectKernelTunables = true;
+        PrivateDevices = true;
+        PrivateMounts = true;
+        PrivateUsers = true;
+        RestrictAddressFamilies = [
+          "AF_INET"
+          "AF_INET6"
+          "AF_NETLINK"
+        ];
+        RestrictNamespaces = true;
+        RestrictRealtime = true;
+        ProtectHome = true;
+        SystemCallArchitectures = "native";
+        SystemCallFilter = [
+          "@system-service"
+          "~@privileged"
+          "~@resources"
+        ];
+        Restart = "on-failure";
+        RestartSec = 5;
+        UMask = "077";
+      };
+    };
+  };
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -737,6 +737,7 @@ in
   listmonk = handleTestOn [ "x86_64-linux" "aarch64-linux" ] ./listmonk.nix { };
   litellm = runTest ./litellm.nix;
   litestream = handleTest ./litestream.nix { };
+  lk-jwt-service = runTest ./matrix/lk-jwt-service.nix;
   lldap = handleTest ./lldap.nix { };
   localsend = handleTest ./localsend.nix { };
   locate = handleTest ./locate.nix { };

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -731,6 +731,7 @@ in
   lidarr = handleTest ./lidarr.nix { };
   lightdm = handleTest ./lightdm.nix { };
   lighttpd = runTest ./lighttpd.nix;
+  livekit = runTest ./networking/livekit.nix;
   limesurvey = handleTest ./limesurvey.nix { };
   limine = import ./limine { inherit runTest; };
   listmonk = handleTestOn [ "x86_64-linux" "aarch64-linux" ] ./listmonk.nix { };

--- a/nixos/tests/matrix/lk-jwt-service.nix
+++ b/nixos/tests/matrix/lk-jwt-service.nix
@@ -1,0 +1,26 @@
+{
+  pkgs,
+  lib,
+  ...
+}:
+{
+  name = "lk-jwt-service";
+  meta.maintainers = [ lib.maintainers.quadradical ];
+
+  nodes.machine = {
+    services.lk-jwt-service = {
+      enable = true;
+      keyFile = pkgs.writers.writeYAML "keys.yaml" {
+        key = "f6lQGaHtM5HfgZjIcec3cOCRfiDqIine4CpZZnqdT5cE";
+      };
+      livekitUrl = "wss://127.0.0.1:8100";
+      port = 8000;
+    };
+  };
+
+  testScript = ''
+    machine.wait_for_unit("lk-jwt-service.service")
+    machine.wait_for_open_port(8000)
+    machine.succeed('curl 127.0.0.1:8000/sfu/get -sLX POST -w "%{http_code}" | grep -q "^400"')
+  '';
+}

--- a/nixos/tests/networking/livekit.nix
+++ b/nixos/tests/networking/livekit.nix
@@ -1,0 +1,25 @@
+{
+  pkgs,
+  lib,
+  ...
+}:
+{
+  name = "livekit";
+  meta.maintainers = [ lib.maintainers.quadradical ];
+
+  nodes.machine = {
+    services.livekit = {
+      enable = true;
+      keyFile = pkgs.writers.writeYAML "keys.yaml" {
+        key = "f6lQGaHtM5HfgZjIcec3cOCRfiDqIine4CpZZnqdT5cE";
+      };
+      settings.port = 8000;
+    };
+  };
+
+  testScript = ''
+    machine.wait_for_unit("livekit.service")
+    machine.wait_for_open_port(8000)
+    machine.succeed("curl 127.0.0.1:8000 -L --fail")
+  '';
+}

--- a/pkgs/by-name/li/livekit/package.nix
+++ b/pkgs/by-name/li/livekit/package.nix
@@ -2,6 +2,7 @@
   lib,
   buildGoModule,
   fetchFromGitHub,
+  nixosTests,
 }:
 
 buildGoModule rec {
@@ -22,6 +23,8 @@ buildGoModule rec {
   postInstall = ''
     mv $out/bin/server $out/bin/livekit-server
   '';
+
+  passthru.tests = nixosTests.livekit;
 
   meta = with lib; {
     description = "End-to-end stack for WebRTC. SFU media server and SDKs";

--- a/pkgs/by-name/lk/lk-jwt-service/package.nix
+++ b/pkgs/by-name/lk/lk-jwt-service/package.nix
@@ -2,6 +2,7 @@
   lib,
   buildGoModule,
   fetchFromGitHub,
+  nixosTests,
 }:
 
 buildGoModule (finalAttrs: {
@@ -16,6 +17,8 @@ buildGoModule (finalAttrs: {
   };
 
   vendorHash = "sha256-47eJO1Ai78RuhlEPn/J1cd+YSqvmfUD8cuPZIqsdxvI=";
+
+  passthru.tests = nixosTests.lk-jwt-service;
 
   meta = with lib; {
     changelog = "https://github.com/element-hq/lk-jwt-service/releases/tag/${finalAttrs.src.tag}";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
Added a module for lk-jwt-service, and livekit, needed for running element-call (already packaged). For a usage example, see here: https://git.henryhiles.com/Henry-Hiles/nixos/src/branch/main/clients/quadraticserver/element-call.nix
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
