### PR TITLE
nixos/nextcloud: S3: Rename autocreate (a no-op) to verify_bucket_exists

### DIFF
--- a/nixos/modules/services/web-apps/nextcloud.nix
+++ b/nixos/modules/services/web-apps/nextcloud.nix
@@ -205,7 +205,7 @@ let
             'class' => '\\OC\\Files\\ObjectStore\\S3',
             'arguments' => [
               'bucket' => '${s3.bucket}',
-              'autocreate' => ${boolToString s3.autocreate},
+              'verify_bucket_exists' => ${boolToString s3.verify_bucket_exists},
               'key' => '${s3.key}',
               'secret' => nix_read_secret('s3_secret'),
               ${optionalString (s3.hostname != null) "'hostname' => '${s3.hostname}',"}
@@ -343,6 +343,10 @@ in
     (mkRenamedOptionModule
       [ "services" "nextcloud" "extraOptions" ]
       [ "services" "nextcloud" "settings" ]
+    )
+    (mkRenamedOptionModule
+      [ "services" "nextcloud" "config" "objectstore" "s3" "autocreate" ]
+      [ "services" "nextcloud" "config" "objectstore" "s3" "verify_bucket_exists" ]
     )
   ];
 
@@ -654,10 +658,11 @@ in
               The name of the S3 bucket.
             '';
           };
-          autocreate = mkOption {
+          verify_bucket_exists = mkOption {
             type = types.bool;
+            default = true;
             description = ''
-              Create the objectstore if it does not exist.
+              Create the objectstore bucket if it does not exist.
             '';
           };
           key = mkOption {


### PR DESCRIPTION
This is #275165 but rebased.

The `autocreate` option always was a no-op in nextcloud: https://github.com/nextcloud/documentation/issues/10436

A bit of info for `verify_bucket_exists` can be found in the nextcloud docs:

> verify_bucket_exists defaults to true [Note: Setting this to false after confirming the bucket has been created may provide a performance benefit, but may not be possible in multibucket scenarios.]

Source: https://docs.nextcloud.com/server/31/admin_manual/configuration_files/primary_storage.html#configuration

Also the Code isn't really complicated:

https://github.com/nextcloud/server/blob/c3370204463f2be4c053c384d220ded79917481b/lib/private/Files/ObjectStore/S3ConnectionTrait.php#L132-L149

It checks wheter the bucket exists and if not the bucket is created.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
