### PR TITLE
cc-wrapper: add lto support

### DIFF
--- a/lib/systems/default.nix
+++ b/lib/systems/default.nix
@@ -103,6 +103,7 @@ let
             throw "2022-05-23: isCompatible has been removed in favor of canExecute, refer to the 22.11 changelog for details";
           # Derived meta-data
           useLLVM = final.isFreeBSD || final.isOpenBSD;
+          useLTO = false;
 
           libc =
             if final.isDarwin then

--- a/lib/systems/examples.nix
+++ b/lib/systems/examples.nix
@@ -84,6 +84,15 @@ rec {
     useLLVM = true;
   };
 
+  aarch64-linux-gnu-neoverse-n1 = {
+    config = "aarch64-unknown-linux-gnu";
+    gcc = {
+      arch = "armv8-a";
+      tune = "neoverse-n1";
+    };
+    useLLVM = true;
+  };
+
   pogoplug4 = {
     config = "armv5tel-unknown-linux-gnueabi";
   } // platforms.pogoplug4;

--- a/pkgs/build-support/cc-wrapper/bintools-wrapper.sh
+++ b/pkgs/build-support/cc-wrapper/bintools-wrapper.sh
@@ -1,0 +1,9 @@
+#! @shell@
+set -eu -o pipefail +o posix
+shopt -s nullglob
+
+if (( "${NIX_DEBUG:-0}" >= 7 )); then
+    set -x
+fi
+
+exec @prog@ --plugin @plugin@ $@

--- a/pkgs/build-support/cc-wrapper/default.nix
+++ b/pkgs/build-support/cc-wrapper/default.nix
@@ -490,6 +490,11 @@ stdenvNoCC.mkDerivation {
       elif [ -e $ccPath/cpp ]; then
         wrap ${targetPrefix}cpp $wrapper $ccPath/cpp
       fi
+
+      if [ -e $ccPath/${targetPrefix}gcc-nm ]; then
+        export plugin="${cc}/libexec/gcc/${targetPlatform.config}/14.2.1/liblto_plugin.so"
+        wrap ${targetPrefix}gcc-nm ${./bintools-wrapper.sh} $ccPath/${targetPrefix}gcc-nm
+      fi
     ''
 
     # No need to wrap gnat, gnatkr, gnatname or gnatprep; we can just symlink them in

--- a/pkgs/build-support/cc-wrapper/default.nix
+++ b/pkgs/build-support/cc-wrapper/default.nix
@@ -854,6 +854,11 @@ stdenvNoCC.mkDerivation {
       echo " -flto -fuse-linker-plugin" >> $out/nix-support/cc-ldflags
     ''
 
+    + optionalString (targetPlatform.useLTO && isGNU) ''
+      echo " -fuse-linker-plugin -Wl,--plugin=${cc}/libexec/gcc/${targetPlatform.config}/14.2.1/liblto_plugin.so" >> $out/nix-support/cc-cflags
+      echo " -fuse-linker-plugin --plugin=${cc}/libexec/gcc/${targetPlatform.config}/14.2.1/liblto_plugin.so" >> $out/nix-support/cc-ldflags
+    ''
+
     ##
     ## Extra custom steps
     ##

--- a/pkgs/build-support/cc-wrapper/default.nix
+++ b/pkgs/build-support/cc-wrapper/default.nix
@@ -845,6 +845,15 @@ stdenvNoCC.mkDerivation {
       substituteAll ${./add-clang-cc-cflags-before.sh} $out/nix-support/add-local-cc-cflags-before.sh
     ''
 
+    ###
+    ### LTO support
+    ###
+
+    + optionalString (targetPlatform.useLTO) ''
+      echo " -flto -fuse-linker-plugin" >> $out/nix-support/cc-cflags
+      echo " -flto -fuse-linker-plugin" >> $out/nix-support/cc-ldflags
+    ''
+
     ##
     ## Extra custom steps
     ##

--- a/pkgs/development/tools/misc/binutils/default.nix
+++ b/pkgs/development/tools/misc/binutils/default.nix
@@ -21,6 +21,7 @@ in
   enableGold ? withGold stdenv.targetPlatform,
   enableGoldDefault ? false,
   enableShared ? !stdenv.hostPlatform.isStatic,
+  enableLTO ? stdenv.hostPlatform.hasSharedLibraries,
   # WARN: Enabling all targets increases output size to a multiple.
   withAllTargets ? false,
 }:
@@ -223,8 +224,8 @@ stdenv.mkDerivation (finalAttrs: {
     ++ lib.optionals withAllTargets [ "--enable-targets=all" ]
     ++ lib.optionals enableGold [
       "--enable-gold${lib.optionalString enableGoldDefault "=default"}"
-      "--enable-plugins"
     ]
+    ++ lib.optional (enableGold || enableLTO) "--enable-plugins"
     ++ (
       if enableShared then
         [
@@ -237,6 +238,9 @@ stdenv.mkDerivation (finalAttrs: {
           "--enable-static"
         ]
     )
+    ++ lib.optionals enableLTO [
+      "--enable-lto"
+    ]
     ++ (lib.optionals (stdenv.cc.bintools.isLLVM && lib.versionAtLeast stdenv.cc.bintools.version "17")
       [
         # lld17+ passes `--no-undefined-version` by default and makes this a hard

--- a/pkgs/top-level/release-attrpaths-superset.nix
+++ b/pkgs/top-level/release-attrpaths-superset.nix
@@ -57,6 +57,7 @@ let
     pkgsx86_64Darwin = true;
     pkgsi686Linux = true;
     pkgsLinux = true;
+    pkgsLTO = true;
     pkgsExtraHardening = true;
   };
 

--- a/pkgs/top-level/release.nix
+++ b/pkgs/top-level/release.nix
@@ -398,6 +398,10 @@ let
           "x86_64-linux"
           "aarch64-linux"
         ];
+        pkgsLTO.stdenv = [
+          "x86_64-linux"
+          "aarch64-linux"
+        ];
 
         tests = packagePlatforms pkgs.tests;
 

--- a/pkgs/top-level/stage.nix
+++ b/pkgs/top-level/stage.nix
@@ -410,6 +410,20 @@ let
       };
     });
 
+    pkgsLTO = nixpkgsFun {
+      overlays = [
+        (self': super': {
+          pkgsLTO = super';
+        })
+      ] ++ overlays;
+      # Bootstrap a cross stdenv with LTO.
+      # This is currently not possible when compiling natively,
+      # so we don't need to check hostPlatform != buildPlatform.
+      crossSystem = stdenv.hostPlatform // {
+        useLTO = true;
+      };
+    };
+
     pkgsExtraHardening = nixpkgsFun {
       overlays = [
         (


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Adds the ability to use LTO.

Can be used via setting `useLTO = true` in `crossSystem` when importing nixpkgs.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
