### PR TITLE
rapid-photo-downloader: 0.9.34 -> 0.9.36

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -18858,6 +18858,13 @@
     githubId = 1640697;
     name = "Philipp Hausmann";
   };
+  philipdb = {
+    email = "philipdb.art110@passmail.com";
+    name = "Philip de Bruin";
+    github = "PhiliPdB";
+    githubId = 7051056;
+    keys = [ { fingerprint = "01AE 5EC2 39D9 CE4B DDB0  166A 4EC5 5FB7 07DC 24C4"; } ];
+  };
   Philipp-M = {
     email = "philipp@mildenberger.me";
     github = "Philipp-M";

--- a/pkgs/applications/graphics/rapid-photo-downloader/default.nix
+++ b/pkgs/applications/graphics/rapid-photo-downloader/default.nix
@@ -22,14 +22,49 @@
 
 mkDerivationWith python3Packages.buildPythonApplication rec {
   pname = "rapid-photo-downloader";
-  version = "0.9.34";
+  version = "0.9.36";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "damonlynch";
     repo = "rapid-photo-downloader";
     rev = "v${version}";
-    hash = "sha256-4VC1fwQh9L3c5tgLUaC36p9QHL4dR2vkWc2XlNl0Xzw=";
+    hash = "sha256-fFmIbqymYkg2Z1/x0mNsCNlDCOyqVg65CM4a67t+kPQ=";
   };
+
+  build-system = with python3Packages; [
+    setuptools
+  ];
+
+  dependencies =
+    with python3Packages;
+    [
+      ifuse
+      libimobiledevice
+      # Python dependencies
+      pyqt5
+      pygobject3
+      gphoto2
+      pyzmq
+      tornado
+      psutil
+      pyxdg
+      arrow
+      python-dateutil
+      easygui
+      babel
+      colour
+      pillow
+      pymediainfo
+      sortedcontainers
+      requests
+      colorlog
+      pyprind
+      setuptools
+      show-in-file-manager
+      tenacity
+    ]
+    ++ lib.optional (pythonOlder "3.8") importlib-metadata;
 
   postPatch = ''
     # Drop broken version specifier
@@ -72,36 +107,6 @@ mkDerivationWith python3Packages.buildPythonApplication rec {
   #       launching fails with:
   #       "Namespace [Notify / GExiv2 / GUdev] not available"
   strictDeps = false;
-
-  propagatedBuildInputs =
-    with python3Packages;
-    [
-      ifuse
-      libimobiledevice
-      pyqt5
-      pygobject3
-      gphoto2
-      pyzmq
-      tornado
-      psutil
-      pyxdg
-      arrow
-      python-dateutil
-      easygui
-      babel
-      colour
-      pillow
-      pyheif
-      pymediainfo
-      sortedcontainers
-      requests
-      colorlog
-      pyprind
-      setuptools
-      show-in-file-manager
-      tenacity
-    ]
-    ++ lib.optional (pythonOlder "3.8") importlib-metadata;
 
   preFixup = ''
     makeWrapperArgs+=(

--- a/pkgs/applications/graphics/rapid-photo-downloader/default.nix
+++ b/pkgs/applications/graphics/rapid-photo-downloader/default.nix
@@ -129,12 +129,12 @@ mkDerivationWith python3Packages.buildPythonApplication rec {
     ignoredVersions = "a.*";
   };
 
-  meta = with lib; {
+  meta = {
     description = "Photo and video importer for cameras, phones, and memory cards";
     mainProgram = "rapid-photo-downloader";
     homepage = "https://www.damonlynch.net/rapid/";
-    license = licenses.gpl3Plus;
-    platforms = platforms.linux;
-    maintainers = [ ];
+    license = lib.licenses.gpl3Plus;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ philipdb ];
   };
 }

--- a/pkgs/applications/graphics/rapid-photo-downloader/default.nix
+++ b/pkgs/applications/graphics/rapid-photo-downloader/default.nix
@@ -17,6 +17,7 @@
   gdk-pixbuf,
   libmediainfo,
   vmtouch,
+  gitUpdater,
 }:
 
 mkDerivationWith python3Packages.buildPythonApplication rec {
@@ -117,6 +118,11 @@ mkDerivationWith python3Packages.buildPythonApplication rec {
       "''${qtWrapperArgs[@]}"
     )
   '';
+
+  passthru.updateScript = gitUpdater {
+    rev-prefix = "v";
+    ignoredVersions = "a.*";
+  };
 
   meta = with lib; {
     description = "Photo and video importer for cameras, phones, and memory cards";

--- a/pkgs/development/python-modules/pymediainfo/default.nix
+++ b/pkgs/development/python-modules/pymediainfo/default.nix
@@ -43,11 +43,11 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "pymediainfo" ];
 
-  meta = with lib; {
+  meta = {
     description = "Python wrapper for the mediainfo library";
     homepage = "https://github.com/sbraz/pymediainfo";
     changelog = "https://github.com/sbraz/pymediainfo/releases/tag/v${version}";
-    license = licenses.mit;
-    maintainers = [ ];
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ philipdb ];
   };
 }

--- a/pkgs/development/python-modules/pymediainfo/default.nix
+++ b/pkgs/development/python-modules/pymediainfo/default.nix
@@ -4,7 +4,7 @@
   fetchPypi,
   buildPythonPackage,
   libmediainfo,
-  setuptools-scm,
+  pdm-backend,
   pytest,
   pythonOlder,
 }:
@@ -12,9 +12,9 @@
 buildPythonPackage rec {
   pname = "pymediainfo";
   version = "7.0.1";
-  format = "setuptools";
+  pyproject = true;
 
-  disabled = pythonOlder "3.7";
+  disabled = pythonOlder "3.9";
 
   src = fetchPypi {
     inherit pname version;
@@ -22,7 +22,7 @@ buildPythonPackage rec {
   };
 
   postPatch = ''
-    substituteInPlace pymediainfo/__init__.py \
+    substituteInPlace src/pymediainfo/__init__.py \
       --replace "libmediainfo.0.dylib" \
                 "${libmediainfo}/lib/libmediainfo.0${stdenv.hostPlatform.extensions.sharedLibrary}" \
       --replace "libmediainfo.dylib" \
@@ -31,7 +31,7 @@ buildPythonPackage rec {
                 "${libmediainfo}/lib/libmediainfo${stdenv.hostPlatform.extensions.sharedLibrary}.0"
   '';
 
-  nativeBuildInputs = [ setuptools-scm ];
+  build-system = [ pdm-backend ];
 
   nativeCheckInputs = [
     pytest


### PR DESCRIPTION
Update Rapid Photo Downloader to the latest stable version.
This pull request also includes setting the update script for rapid-photo-downloader.
It also fixes the build of `pymediainfo` introduced in #395156.

Resolves: #400062
The fix for `pymediainfo` also contributes to [ZHF](https://github.com/NixOS/nixpkgs/issues/403336).

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
