### PR TITLE
calamares: update to qt6

### DIFF
--- a/pkgs/tools/misc/calamares/0004-Adds-unfree-qml-to-packagechooserq.patch
+++ b/pkgs/tools/misc/calamares/0004-Adds-unfree-qml-to-packagechooserq.patch
@@ -4,17 +4,17 @@ Date: Thu, 1 Aug 2024 16:00:43 -0400
 Subject: [PATCH] Adds unfree qml to packagechooserq
 
 ---
- .../packagechooserq/packagechooserq.qrc       |  1 +
+ .../packagechooserq/packagechooserq-qt6.qrc   |  1 +
  .../packagechooserq@unfree.qml                | 75 +++++++++++++++++++
  src/modules/packagechooserq/unfree.conf       | 11 +++
  3 files changed, 87 insertions(+)
  create mode 100644 src/modules/packagechooserq/packagechooserq@unfree.qml
  create mode 100644 src/modules/packagechooserq/unfree.conf
 
-diff --git a/src/modules/packagechooserq/packagechooserq.qrc b/src/modules/packagechooserq/packagechooserq.qrc
+diff --git a/src/modules/packagechooserq/packagechooserq-qt6.qrc b/src/modules/packagechooserq/packagechooserq-qt6.qrc
 index 1b892dce1..ee80a934b 100644
---- a/src/modules/packagechooserq/packagechooserq.qrc
-+++ b/src/modules/packagechooserq/packagechooserq.qrc
+--- a/src/modules/packagechooserq/packagechooserq-qt6.qrc
++++ b/src/modules/packagechooserq/packagechooserq-qt6.qrc
 @@ -4,5 +4,6 @@
          <file>images/libreoffice.jpg</file>
          <file>images/no-selection.png</file>

--- a/pkgs/tools/misc/calamares/default.nix
+++ b/pkgs/tools/misc/calamares/default.nix
@@ -4,33 +4,25 @@
   boost,
   cmake,
   extra-cmake-modules,
-  kparts,
-  kpmcore,
-  kirigami2,
-  kservice,
+  kdePackages,
   libatasmart,
   libxcb,
   yaml-cpp,
   libpwquality,
   parted,
-  polkit-qt,
   python3,
-  qtbase,
-  qtquickcontrols,
-  qtsvg,
-  qttools,
-  qtwebengine,
+  qt6,
+  stdenv,
   util-linux,
   tzdata,
   ckbcomp,
   xkeyboard_config,
-  mkDerivation,
   nixos-extensions ? false,
   # passthru.tests
   calamares-nixos,
 }:
 
-mkDerivation rec {
+stdenv.mkDerivation rec {
   pname = "calamares";
   version = "3.3.13";
 
@@ -60,25 +52,25 @@ mkDerivation rec {
   nativeBuildInputs = [
     cmake
     extra-cmake-modules
+    qt6.wrapQtAppsHook
   ];
   buildInputs = [
     boost
-    kparts.dev
-    kpmcore.out
-    kservice.dev
-    kirigami2
+    kdePackages.kparts.dev
+    kdePackages.kpmcore.dev
+    kdePackages.kservice.dev
+    kdePackages.kirigami
     libatasmart
     libxcb
     yaml-cpp
     libpwquality
     parted
-    polkit-qt
+    kdePackages.polkit-qt-1
     python3
-    qtbase
-    qtquickcontrols
-    qtsvg
-    qttools
-    qtwebengine.dev
+    qt6.qtbase
+    qt6.qtsvg
+    qt6.qttools
+    qt6.qtwebengine.dev
     util-linux
   ];
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1992,7 +1992,7 @@ with pkgs;
       '';
     });
 
-  calamares = libsForQt5.callPackage ../tools/misc/calamares {
+  calamares = callPackage ../tools/misc/calamares {
     boost = boost.override {
       enablePython = true;
       python = python3;


### PR DESCRIPTION
calamares is the only remaining dependency on qt5.qtwebengine in the graphical installer

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
