### PR TITLE
stdenv: fix stage1 gettext build (with gcc14)

### DIFF
--- a/pkgs/stdenv/linux/default.nix
+++ b/pkgs/stdenv/linux/default.nix
@@ -348,6 +348,15 @@ assert bootstrapTools.passthru.isFromBootstrapFiles or false; # sanity check
           enableThreading = false;
           enableCrypt = false;
         };
+
+        # Let gettext "checking for working iconv" success without trying
+        # to convert between UTF-8 and EUC-JP which doesn't work here
+        # because of missing locale and gconv, same for libunistring below
+        gettext = super.gettext.overrideAttrs (attrs: {
+          env = attrs.env or { } // {
+            am_cv_func_iconv_works = "yes";
+          };
+        });
       };
 
       # `gettext` comes with obsolete config.sub/config.guess that don't recognize LoongArch64.


### PR DESCRIPTION
Add the same trick for gettext as for libunistring below, skipping "checking for working iconv" which requires locales and gconv modules (and other stuff we don't have in bootstrapTools?)

It tries to run the following check in `iconv.m4` which fails:

```c
#include <iconv.h>
#include <string.h>

int
main (void)
{
int result = 0;

  /* Test against HP-UX 11.11 bug: No converter from EUC-JP to UTF-8 is
     provided.  */
  {
    /* Try standardized names.  */
    iconv_t cd1 = iconv_open ("UTF-8", "EUC-JP");
    /* Try IRIX, OSF/1 names.  */
    iconv_t cd2 = iconv_open ("UTF-8", "eucJP");
    /* Try AIX names.  */
    iconv_t cd3 = iconv_open ("UTF-8", "IBM-eucJP");
    /* Try HP-UX names.  */
    iconv_t cd4 = iconv_open ("utf8", "eucJP");
    if (cd1 == (iconv_t)(-1) && cd2 == (iconv_t)(-1)
        && cd3 == (iconv_t)(-1) && cd4 == (iconv_t)(-1))
      result |= 16;
    if (cd1 != (iconv_t)(-1))
      iconv_close (cd1);
    if (cd2 != (iconv_t)(-1))
      iconv_close (cd2);
    if (cd3 != (iconv_t)(-1))
      iconv_close (cd3);
    if (cd4 != (iconv_t)(-1))
      iconv_close (cd4);
  }
  return result;

  ;
  return 0;
}
```

Then it assumes iconv is not there and tries to use some built-in iconv function? idk

Resulting in following error:

```
iconv-ostream.c:311:3: error: initialization of 'void (*)(struct any_ostream_representation *, ostream_flush_scope_t)' from incompatible pointer type 'void (*)(struct any_ostream_representation *)' []
```

This isn't causing a build failure in other architectures because we haven't updated bootstrapTools to gcc14, so the error isn't noticeable, but it's there. Check https://hydra.nixos.org/build/294707390/nixlog/10

I think maybe update the bootstrap files of other platforms at the same time? Or I just add a condition here and we can remove it when we update bootstrap files next time?

This is required to make https://github.com/NixOS/nixpkgs/pull/399167 really work.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
