### PR TITLE
 upgrade nodejs_18 dependents in prevision for upcoming EOL

### DIFF
--- a/nixos/modules/services/web-apps/peertube.nix
+++ b/nixos/modules/services/web-apps/peertube.nix
@@ -489,7 +489,7 @@ in
       environment = env;
 
       path = with pkgs; [
-        nodejs_18
+        nodejs_20
         yarn
         ffmpeg-headless
         openssl
@@ -945,7 +945,7 @@ in
       })
       (lib.attrsets.setAttrByPath
         [ cfg.user "packages" ]
-        [ peertubeEnv pkgs.nodejs_18 pkgs.yarn pkgs.ffmpeg-headless ]
+        [ peertubeEnv pkgs.nodejs_20 pkgs.yarn pkgs.ffmpeg-headless ]
       )
       (lib.mkIf cfg.redis.enableUnixSocket {
         ${config.services.peertube.user}.extraGroups = [ "redis-peertube" ];

--- a/nixos/modules/services/web-apps/wiki-js.nix
+++ b/nixos/modules/services/web-apps/wiki-js.nix
@@ -151,7 +151,7 @@ in
         WorkingDirectory = "/var/lib/${cfg.stateDirectoryName}";
         DynamicUser = true;
         PrivateTmp = true;
-        ExecStart = "${pkgs.nodejs_18}/bin/node ${pkgs.wiki-js}/server";
+        ExecStart = "${pkgs.nodejs_20}/bin/node ${pkgs.wiki-js}/server";
       };
     };
   };

--- a/pkgs/by-name/cl/clever-tools/package.nix
+++ b/pkgs/by-name/cl/clever-tools/package.nix
@@ -2,7 +2,7 @@
   lib,
   buildNpmPackage,
   fetchFromGitHub,
-  nodejs_18,
+  nodejs_20,
   installShellFiles,
   makeWrapper,
   stdenv,
@@ -13,7 +13,7 @@ buildNpmPackage rec {
 
   version = "3.12.0";
 
-  nodejs = nodejs_18;
+  nodejs = nodejs_20;
 
   src = fetchFromGitHub {
     owner = "CleverCloud";

--- a/pkgs/by-name/db/db-rest/package.nix
+++ b/pkgs/by-name/db/db-rest/package.nix
@@ -2,7 +2,7 @@
   lib,
   buildNpmPackage,
   fetchFromGitHub,
-  nodejs_18,
+  nodejs,
   nix-update-script,
   nixosTests,
 }:
@@ -10,7 +10,7 @@ buildNpmPackage rec {
   pname = "db-rest";
   version = "6.1.0";
 
-  nodejs = nodejs_18;
+  inherit nodejs;
 
   src = fetchFromGitHub {
     owner = "derhuerst";

--- a/pkgs/by-name/pe/peertube/package.nix
+++ b/pkgs/by-name/pe/peertube/package.nix
@@ -10,7 +10,7 @@
   fixup-yarn-lock,
   jq,
   fd,
-  nodejs_18,
+  nodejs_20,
   which,
   yarn,
 }:
@@ -92,7 +92,7 @@ stdenv.mkDerivation rec {
     fd
   ];
 
-  buildInputs = [ nodejs_18 ];
+  buildInputs = [ nodejs_20 ];
 
   buildPhase = ''
     # Build node modules

--- a/pkgs/by-name/pu/pulsar/update.mjs
+++ b/pkgs/by-name/pu/pulsar/update.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env nix-shell
 /*
-#!nix-shell -i node -p nodejs_18
+#!nix-shell -i node -p nodejs
 */
 
 import { promises as fs } from 'node:fs';

--- a/pkgs/by-name/sl/slskd/package.nix
+++ b/pkgs/by-name/sl/slskd/package.nix
@@ -6,14 +6,14 @@
   fetchFromGitHub,
   fetchNpmDeps,
   mono,
-  nodejs_18,
+  nodejs_20,
   slskd,
   testers,
   nix-update-script,
 }:
 
 let
-  nodejs = nodejs_18;
+  nodejs = nodejs_20;
   # https://github.com/NixOS/nixpkgs/blob/d88947e91716390bdbefccdf16f7bebcc41436eb/pkgs/build-support/node/build-npm-package/default.nix#L62
   npmHooks = buildPackages.npmHooks.override { inherit nodejs; };
 in

--- a/pkgs/development/compilers/elm/default.nix
+++ b/pkgs/development/compilers/elm/default.nix
@@ -2,7 +2,7 @@
   pkgs,
   lib,
   makeWrapper,
-  nodejs ? pkgs.nodejs_18,
+  nodejs ? pkgs.nodejs_20,
 }:
 
 let

--- a/pkgs/development/compilers/elm/packages/node/node-composition.nix
+++ b/pkgs/development/compilers/elm/packages/node/node-composition.nix
@@ -5,7 +5,7 @@
     inherit system;
   },
   system ? builtins.currentSystem,
-  nodejs ? pkgs."nodejs_18",
+  nodejs ? pkgs."nodejs_20",
 }:
 
 let

--- a/pkgs/misc/base16-builder/node-packages.nix
+++ b/pkgs/misc/base16-builder/node-packages.nix
@@ -5,7 +5,7 @@
     inherit system;
   },
   system ? builtins.currentSystem,
-  nodejs ? pkgs."nodejs_18",
+  nodejs ? pkgs."nodejs_20",
 }:
 
 let

--- a/pkgs/tools/admin/meshcentral/default.nix
+++ b/pkgs/tools/admin/meshcentral/default.nix
@@ -3,7 +3,7 @@
   fetchzip,
   fetchYarnDeps,
   yarn2nix-moretea,
-  nodejs_18,
+  nodejs_20,
   dos2unix,
 }:
 
@@ -37,7 +37,7 @@ yarn2nix-moretea.mkYarnPackage {
   preFixup = ''
     mkdir -p $out/bin
     chmod a+x $out/libexec/meshcentral/deps/meshcentral/meshcentral.js
-    sed -i '1i#!${nodejs_18}/bin/node' $out/libexec/meshcentral/deps/meshcentral/meshcentral.js
+    sed -i '1i#!${nodejs_20}/bin/node' $out/libexec/meshcentral/deps/meshcentral/meshcentral.js
     ln -s $out/libexec/meshcentral/deps/meshcentral/meshcentral.js $out/bin/meshcentral
   '';
 

--- a/pkgs/tools/security/onlykey/onlykey.nix
+++ b/pkgs/tools/security/onlykey/onlykey.nix
@@ -5,7 +5,7 @@
     inherit system;
   },
   system ? builtins.currentSystem,
-  nodejs ? pkgs.nodejs_18,
+  nodejs ? pkgs.nodejs_20,
 }:
 
 let


### PR DESCRIPTION
#399426 may not land just now as there are still a couple of packages that are not building, however it's probably a good idea to land those who build without waiting
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
