### PR TITLE
xfce.tumbler: backport PDF thumbnail generation fix

### DIFF
--- a/pkgs/desktops/xfce/core/tumbler/default.nix
+++ b/pkgs/desktops/xfce/core/tumbler/default.nix
@@ -26,6 +26,16 @@ mkXfceDerivation {
 
   sha256 = "sha256-GmEMdG8Ikd4Tq/1ntCHiN0S7ehUXqzMX7OtXsycLd6E=";
 
+  patches = [
+    # Fixes PDF previews staying low resolution
+    # https://gitlab.xfce.org/xfce/tumbler/-/merge_requests/35
+    (fetchpatch {
+      name = "only-use-embedded-pdf-thumbnail-if-resolution-suffices.patch";
+      url = "https://gitlab.xfce.org/xfce/tumbler/-/commit/69a704e0f4e622861ce4007f6f3f4f6f6b962689.patch";
+      hash = "sha256-aFJoWWzTaikqCw6C1LH+BFxst/uKkOGT1QK9Mx8/8/c=";
+    })
+  ];
+
   buildInputs = [
     libxfce4util
     ffmpegthumbnailer
@@ -58,14 +68,6 @@ mkXfceDerivation {
   postFixup = ''
     wrapGApp $out/lib/tumbler-1/tumblerd
   '';
-
-  patches = [
-    (fetchpatch {
-      name = "only-use-embedded-pdf-thumbnail-if-resolution-suffices.patch";
-      url = "https://gitlab.xfce.org/xfce/tumbler/-/merge_requests/35.patch";
-      hash = "sha256-aFJoWWzTaikqCw6C1LH+BFxst/uKkOGT1QK9Mx8/8/c=";
-    })
-  ];
 
   meta = with lib; {
     description = "D-Bus thumbnailer service";

--- a/pkgs/desktops/xfce/core/tumbler/default.nix
+++ b/pkgs/desktops/xfce/core/tumbler/default.nix
@@ -1,6 +1,7 @@
 {
   lib,
   mkXfceDerivation,
+  fetchpatch,
   ffmpegthumbnailer,
   gdk-pixbuf,
   glib,
@@ -57,6 +58,14 @@ mkXfceDerivation {
   postFixup = ''
     wrapGApp $out/lib/tumbler-1/tumblerd
   '';
+
+  patches = [
+    (fetchpatch {
+      name = "only-use-embedded-pdf-thumbnail-if-resolution-suffices.patch";
+      url = "https://gitlab.xfce.org/xfce/tumbler/-/merge_requests/35.patch";
+      hash = "sha256-aFJoWWzTaikqCw6C1LH+BFxst/uKkOGT1QK9Mx8/8/c=";
+    })
+  ];
 
   meta = with lib; {
     description = "D-Bus thumbnailer service";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

tumbler had a [problem](https://gitlab.xfce.org/xfce/tumbler/-/issues/99) where it will reuse extremely small embedded PDF thumbnails rather than generating a properly-sized thumbnail. This is [fixed](https://gitlab.xfce.org/xfce/tumbler/-/merge_requests/35) in version 4.21, but since XFCE 4.22 may not release for a while and the patch applies cleanly to version 4.20, it would be nice to include the fix in nixpkgs' version for now.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
