### PR TITLE
immersed: add option to open firewall ports and libraries for hardware encoding support

### DIFF
--- a/nixos/modules/programs/immersed.nix
+++ b/nixos/modules/programs/immersed.nix
@@ -26,6 +26,12 @@ in
     programs.immersed = {
       enable = lib.mkEnableOption "immersed";
 
+      openPorts = lib.mkOption {
+        type = lib.types.bool;
+        default = false;
+        description = "Whether to open firewall ports for Immersed";
+      };
+
       package = lib.mkPackageOption pkgs "immersed" { };
     };
   };
@@ -43,6 +49,15 @@ in
     };
 
     environment.systemPackages = [ cfg.package ];
+
+    # https://immersed.helpscoutdocs.com/article/23-connection-troubleshooting-linux
+    networking.firewall = lib.mkIf cfg.openPorts {
+      allowedTCPPorts = [ 21000 ];
+      allowedUDPPorts = [
+        21000
+        21010
+      ];
+    };
   };
 
   meta.maintainers = pkgs.immersed.meta.maintainers;

--- a/pkgs/by-name/im/immersed/linux.nix
+++ b/pkgs/by-name/im/immersed/linux.nix
@@ -25,6 +25,13 @@ appimageTools.wrapAppImage {
 
   extraPkgs =
     pkgs: with pkgs; [
+      libva
+      # VAAPI backends
+      intel-media-driver
+      intel-vaapi-driver
+      nvidia-vaapi-driver
+      mesa
+      # Other dependencies
       libgpg-error
       fontconfig
       libGL


### PR DESCRIPTION
This Pull Request updates Immersed NixOS Module and Package to:
- Add an option to open the firewall [ports used by the application](https://medium.com/immersedteam/linux-connection-troubleshooting-6e7cf0f35c74)
- Include the libraries needed to support hardware encoding with Intel, Nvidia and AMD GPUs (`libva`, `intel-media-driver`, `intel-vaapi-driver`, `nvidia-vaapi-driver` and `mesa`)

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
