### PR TITLE
markdown-code-runner: 0-unstable-2025-04-13 -> 0-unstable-2025-04-18

### DIFF
--- a/pkgs/by-name/ma/markdown-code-runner/package.nix
+++ b/pkgs/by-name/ma/markdown-code-runner/package.nix
@@ -6,26 +6,18 @@
 
 rustPlatform.buildRustPackage {
   pname = "markdown-code-runner";
-  version = "0-unstable-2025-04-13";
+  version = "0-unstable-2025-04-18";
 
   src = fetchFromGitHub {
     owner = "drupol";
     repo = "markdown-code-runner";
-    rev = "b39cdf8990e1a25adc958f58e87a12544724ca9d";
-    hash = "sha256-JvsxS+qRrYzWzPlrCAccaPYPROGULCh1Gs5RAlL7dBo=";
+    rev = "9907df63574d714abcd78f9dfdf4bdda73ff30d6";
+    hash = "sha256-Bn+IsZzV07bm5TNRX3+OOuxi3kj7d73gYPzcdIxWMi8=";
   };
 
-  cargoHash = "sha256-JVbBigWKramdtQR9VPRY777vODOw7Fkz+kyNPSnSCJg=";
-  dontUseCargoParallelTests = true;
+  cargoHash = "sha256-HOJCnuzd6i4v1SpR4jstlpNkvSgH/4kvvE6Lsr4cgbI=";
 
-  checkFlags = [
-    # Flaky tests
-    "--skip=test_check_mode_detects_differences"
-    "--skip=test_check_mode_no_changes_returns_zero"
-    "--skip=test_dry_run_allows_command_failure"
-    "--skip=test_dry_run_does_not_fail_on_error"
-    "--skip=test_dry_run_outputs_warning_but_does_not_write"
-  ];
+  dontUseCargoParallelTests = true;
 
   meta = {
     description = "A configurable Markdown code runner that executes and optionally replaces code blocks using external commands";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
