### PR TITLE
rustPlatform.fetchCargoVendor: refactor, support other registries, use registry's config.json for download urls

### DIFF
--- a/pkgs/build-support/rust/fetch-cargo-vendor-util.py
+++ b/pkgs/build-support/rust/fetch-cargo-vendor-util.py
@@ -1,46 +1,199 @@
 import functools
 import hashlib
 import json
-import multiprocessing as mp
+import os
 import re
 import shutil
 import subprocess
 import sys
+import tempfile
 import tomllib
+from concurrent.futures import FIRST_EXCEPTION, Future, ThreadPoolExecutor, wait
+from dataclasses import dataclass, field
 from os.path import islink, realpath
 from pathlib import Path
-from typing import Any, TypedDict, cast
+from typing import Any, cast
 from urllib.parse import unquote
 
 import requests
 import tomli_w
 from requests.adapters import HTTPAdapter, Retry
 
+# Constants for controlling how the crates are downloaded from the registries via `requests`
+# These do not affect the fetching of git dependencies
+MAX_WORKERS = min(5, os.cpu_count() or 1)  # number of workers in the ThreadPoolExecutor
+CONNECT_TIMEOUT = 2  # max seconds for establishing initial connection
+READ_TIMEOUT = 10  # max seconds between receiving data packets
+TIMEOUT = (CONNECT_TIMEOUT, READ_TIMEOUT)
+RETRY_COUNT = 3  # number of retries for fetching an url
+BACKOFF_FACTOR = 0.5  # seconds to wait between retries (gets multiplied by 2 after every retry)
+
 eprint = functools.partial(print, file=sys.stderr)
 
 
-def load_toml(path: Path) -> dict[str, Any]:
-    with open(path, "rb") as f:
-        return tomllib.load(f)
+@dataclass
+class RegistrySource:
+    raw: str
+    url: str
+    is_sparse: bool
+    ind: int = field(init=False)
 
 
-def get_lockfile_version(cargo_lock_toml: dict[str, Any]) -> int:
-    # lockfile v1 and v2 don't have the `version` key, so assume v2
-    version = cargo_lock_toml.get("version", 2)
+@dataclass
+class RegistryPackage:
+    name: str
+    version: str
+    source: RegistrySource
+    checksum: str
 
-    # TODO: add logic for differentiating between v1 and v2
 
-    return version
+GIT_SOURCE_REGEX = re.compile(r"git\+(?P<url>[^?]+)(\?(?P<type>rev|tag|branch)=(?P<value>.*))?#(?P<git_sha_rev>.*)")
+
+
+@dataclass
+class GitSource:
+    raw: str
+    url: str
+    type: str | None
+    value: str | None
+    git_sha_rev: str
+    ind: int = field(init=False)
+
+
+@dataclass
+class GitPackage:
+    name: str
+    version: str
+    source: GitSource
+
+
+Source = RegistrySource | GitSource
+Package = RegistryPackage | GitPackage
+
+
+@dataclass
+class Lockfile:
+    version: int
+    sources: list[Source]
+    packages: list[Package]
+
+
+def parse_git_source(raw_source: str, lockfile_version: int) -> GitSource:
+    match = GIT_SOURCE_REGEX.match(raw_source)
+    if match is None:
+        raise Exception(f"Unable to process git source: {raw_source}.")
+
+    parsed_dict = match.groupdict(default=None)
+    url = cast(str, parsed_dict["url"])
+    git_sha_rev = cast(str, parsed_dict["git_sha_rev"])
+
+    source = GitSource(raw_source, url, parsed_dict["type"], parsed_dict["value"], git_sha_rev)
+
+    # the source URL is URL-encoded in lockfile_version >=4
+    # since we just used regex to parse it we have to manually decode the escaped branch/tag name
+    if lockfile_version >= 4 and source.value is not None:
+        source.value = unquote(source.value)
+
+    return source
+
+
+def parse_source(raw_source: str, lockfile_version: int) -> Source:
+    if raw_source.startswith("git+"):
+        return parse_git_source(raw_source, lockfile_version)
+    elif raw_source.startswith("registry+"):
+        return RegistrySource(raw=raw_source, url=raw_source[9:], is_sparse=False)
+    elif raw_source.startswith("sparse+"):
+        return RegistrySource(raw=raw_source, url=raw_source[7:].rstrip("/"), is_sparse=True)
+    raise Exception(f"Cannot process source: {raw_source}")
+
+
+def load_lockfile(path: Path) -> Lockfile:
+    with path.open("rb") as f:
+        cargo_lock_toml = tomllib.load(f)
+
+    # lockfile v1 and v2 don't have the `version` key, so assume v2 for now
+    lockfile_version = cargo_lock_toml.get("version", 2)
+
+    raw_packages: list[dict[str, str]] = cargo_lock_toml["package"]
+
+    sources: list[Source] = []
+    raw_source_to_source: dict[str, Source] = {}
+
+    # we'll mark every source with an index in order of appearance
+    # both git and registry sources have a different incrementing index
+    # we reserve registry index 0 for both of the default crates-io registries
+
+    for raw_source in ["registry+https://github.com/rust-lang/crates.io-index", "sparse+https://index.crates.io/"]:
+        source = parse_source(raw_source, lockfile_version)
+        source.ind = 0
+        sources.append(source)
+        raw_source_to_source[source.raw] = source
+
+    next_registry_ind = 1
+    next_git_ind = 0
+
+    git_selector_tuple_to_git_ind: dict[tuple[str, str | None, str | None], int] = {}
+
+    for raw_pkg in raw_packages:
+        raw_source = raw_pkg.get("source", None)
+        if raw_source is None:  # Skip local dependencies
+            continue
+        if raw_source in raw_source_to_source:
+            continue
+
+        source = parse_source(raw_source, lockfile_version)
+        match source:
+            case RegistrySource():
+                source.ind = next_registry_ind
+                next_registry_ind += 1
+            case GitSource():
+                # git sources may get the same `ind` value if their selectors match
+                tup = (source.url, source.type, source.value)
+                if tup not in git_selector_tuple_to_git_ind:
+                    git_selector_tuple_to_git_ind[tup] = next_git_ind
+                    next_git_ind += 1
+                source.ind = git_selector_tuple_to_git_ind[tup]
+
+        sources.append(source)
+        raw_source_to_source[source.raw] = source
+
+    packages: list[Package] = []
+
+    for raw_pkg in raw_packages:
+        name = raw_pkg["name"]
+        version = raw_pkg["version"]
+        raw_source = raw_pkg.get("source", None)
+        if raw_source is None:  # Skip local dependencies
+            continue
+        source = raw_source_to_source[raw_source]
+
+        match source:
+            case RegistrySource():
+                checksum = raw_pkg.get("checksum", None)
+
+                # lockfile v1 has the checksum values in a separate metadata table
+                if checksum is None:
+                    lockfile_version = 1
+                    checksum_key = f"checksum {name} {version} ({source})"
+                    checksum = cargo_lock_toml["metadata"][checksum_key]
+
+                pkg = RegistryPackage(name, version, source, checksum)
+            case GitSource():
+                pkg = GitPackage(name, version, source)
+
+        packages.append(pkg)
+
+    return Lockfile(lockfile_version, sources, packages)
 
 
 def create_http_session() -> requests.Session:
     retries = Retry(
-        total=5,
-        backoff_factor=0.5,
+        total=RETRY_COUNT,
+        backoff_factor=BACKOFF_FACTOR,
         status_forcelist=[500, 502, 503, 504]
     )
     session = requests.Session()
-    session.headers["User-Agent"] = "nixpkgs-fetchCargoVendor/2 (https://github.com/NixOS/nixpkgs)"
+    session.headers["User-Agent"] = "cargo/1.95.0 (f2d3ce0bd 2026-03-21)"
     session.mount('http://', HTTPAdapter(max_retries=retries))
     session.mount('https://', HTTPAdapter(max_retries=retries))
     return session
@@ -48,10 +201,10 @@ def create_http_session() -> requests.Session:
 
 def download_file_with_checksum(session: requests.Session, url: str, destination_path: Path) -> str:
     sha256_hash = hashlib.sha256()
-    with session.get(url, stream=True) as response:
+    with session.get(url, stream=True, timeout=TIMEOUT) as response:
         if not response.ok:
             raise Exception(f"Failed to fetch file from {url}. Status code: {response.status_code}")
-        with open(destination_path, "wb") as file:
+        with destination_path.open("wb") as file:
             for chunk in response.iter_content(1024):  # Download in chunks
                 if chunk:  # Filter out keep-alive chunks
                     file.write(chunk)
@@ -62,31 +215,64 @@ def download_file_with_checksum(session: requests.Session, url: str, destination
     return checksum
 
 
-def get_download_url_for_tarball(pkg: dict[str, Any]) -> str:
-    # TODO: support other registries
-    #       maybe fetch config.json from the registry root and get the dl key
-    #       See: https://doc.rust-lang.org/cargo/reference/registry-index.html#index-configuration
-    if pkg["source"] != "registry+https://github.com/rust-lang/crates.io-index":
-        raise Exception("Only the default crates.io registry is supported.")
+# Fetch the config.json file and get the .dl key from it
+# See: https://doc.rust-lang.org/cargo/reference/registry-index.html#index-configuration
+def fetch_dl_for_registry_source(source: RegistrySource, session: requests.Session) -> str:
+    if source.is_sparse:
+        url = source.url + "/config.json"
 
-    # Use static.crates.io (CDN) instead of crates.io/api to avoid the 1 req/sec
-    # rate limit on the API servers.
-    return f"https://static.crates.io/crates/{pkg["name"]}/{pkg["version"]}/download"
+        # https://doc.rust-lang.org/cargo/reference/registry-web-api.html#web-api
+        headers = {
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+        }
+
+        with session.get(url, headers=headers, timeout=TIMEOUT) as response:
+            registry_config: dict[str, str] = response.json()
+    else:
+        # use spare-checkout to only get the config.json file from the registry's git repo
+        tmp_dir = Path(tempfile.mkdtemp())
+        cmd = ["nix-prefetch-git", "--builder", "--quiet", "--url", source.url, "--rev", "HEAD", "--sparse-checkout", "config.json", "--out", str(tmp_dir)]
+        subprocess.check_output(cmd)
+        with (tmp_dir / "config.json").open("rb") as f:
+            registry_config: dict[str, str] = json.load(f)
+
+    dl = registry_config["dl"]
+    auth_required = registry_config.get("auth-required", False)
+    if auth_required:
+        eprint(f'Warning: Registry "{source.url}" requires authentication!')
+    return dl
 
 
-def download_tarball(session: requests.Session, pkg: dict[str, Any], out_dir: Path) -> None:
+# See: https://doc.rust-lang.org/cargo/reference/registry-index.html#index-files
+def name_to_prefix(name: str) -> str:
+    nl = len(name)
+    if nl <= 2:
+        return str(nl)
+    if nl == 3:
+        return "3/" + name[0]
+    return name[0:2] + "/" + name[2:4]
 
-    url = get_download_url_for_tarball(pkg)
-    filename = f"{pkg["name"]}-{pkg["version"]}.tar.gz"
 
-    # TODO: allow legacy checksum specification, see importCargoLock for example
-    #       also, don't forget about the other usage of the checksum
-    expected_checksum = pkg["checksum"]
+# See: https://doc.rust-lang.org/cargo/reference/registry-index.html#index-configuration
+def make_download_url_for_tarball(pkg: RegistryPackage, dl: str) -> str:
+    # Assume default substitutions if no substitutions are specified
+    url = dl if "{" in dl else dl + "/{crate}/{version}/download"
 
-    tarball_out_dir = out_dir / "tarballs" / filename
-    eprint(f"Fetching {url} -> tarballs/{filename}")
+    prefix = name_to_prefix(pkg.name)
+    url = url.replace("{crate}", pkg.name)
+    url = url.replace("{version}", pkg.version)
+    url = url.replace("{prefix}", prefix)
+    url = url.replace("{lowerprefix}", prefix.lower())
+    url = url.replace("{sha256-checksum}", pkg.checksum)
+    return url
 
-    calculated_checksum = download_file_with_checksum(session, url, tarball_out_dir)
+
+def download_crate_tarball(session: requests.Session, url: str, out_path: Path, expected_checksum: str) -> None:
+    out_path.parent.mkdir(exist_ok=True)
+
+    eprint(f"Fetching {url} -> {out_path}")
+    calculated_checksum = download_file_with_checksum(session, url, out_path)
 
     if calculated_checksum != expected_checksum:
         raise Exception(f"Hash mismatch! File fetched from {url} had checksum {calculated_checksum}, expected {expected_checksum}.")
@@ -101,73 +287,56 @@ def download_git_tree(url: str, git_sha_rev: str, out_dir: Path) -> None:
     subprocess.check_output(cmd)
 
 
-GIT_SOURCE_REGEX = re.compile("git\\+(?P<url>[^?]+)(\\?(?P<type>rev|tag|branch)=(?P<value>.*))?#(?P<git_sha_rev>.*)")
-
-
-class GitSourceInfo(TypedDict):
-    url: str
-    type: str | None
-    value: str | None
-    git_sha_rev: str
-
-
-def parse_git_source(source: str, lockfile_version: int) -> GitSourceInfo:
-    match = GIT_SOURCE_REGEX.match(source)
-    if match is None:
-        raise Exception(f"Unable to process git source: {source}.")
-
-    source_info = cast(GitSourceInfo, match.groupdict(default=None))
-
-    # the source URL is URL-encoded in lockfile_version >=4
-    # since we just used regex to parse it we have to manually decode the escaped branch/tag name
-    if lockfile_version >= 4 and source_info["value"] is not None:
-        source_info["value"] = unquote(source_info["value"])
-
-    return source_info
-
-
 def create_vendor_staging(lockfile_path: Path, out_dir: Path) -> None:
-    cargo_lock_toml = load_toml(lockfile_path)
-    lockfile_version = get_lockfile_version(cargo_lock_toml)
+    lockfile = load_lockfile(lockfile_path)
 
-    git_packages: list[dict[str, Any]] = []
-    registry_packages: list[dict[str, Any]] = []
+    git_sources = [source for source in lockfile.sources if isinstance(source, GitSource)]
+    registry_sources = [source for source in lockfile.sources if isinstance(source, RegistrySource)]
+    registry_packages = [pkg for pkg in lockfile.packages if isinstance(pkg, RegistryPackage)]
 
-    for pkg in cargo_lock_toml["package"]:
-        # ignore local dependenices
-        if "source" not in pkg.keys():
-            eprint(f"Skipping local dependency: {pkg["name"]}")
-            continue
-        source = pkg["source"]
+    session = create_http_session()
 
-        if source.startswith("git+"):
-            git_packages.append(pkg)
-        elif source.startswith("registry+"):
-            registry_packages.append(pkg)
-        else:
-            raise Exception(f"Can't process source: {source}.")
-
-    git_sha_rev_to_url: dict[str, str] = {}
-    for pkg in git_packages:
-        source_info = parse_git_source(pkg["source"], lockfile_version)
-        git_sha_rev_to_url[source_info["git_sha_rev"]] = source_info["url"]
+    raw_registry_source_to_dl: dict[str, str] = {}
+    for source in registry_sources:
+        raw_registry_source_to_dl[source.raw] = fetch_dl_for_registry_source(source, session)
 
     out_dir.mkdir(exist_ok=True)
     shutil.copy(lockfile_path, out_dir / "Cargo.lock")
 
     # fetch git trees sequentially, since fetching concurrently leads to flaky behaviour
-    if len(git_packages) != 0:
+    if len(git_sources) != 0:
         (out_dir / "git").mkdir()
-        for git_sha_rev, url in git_sha_rev_to_url.items():
-            download_git_tree(url, git_sha_rev, out_dir)
+        for source in git_sources:
+            download_git_tree(source.url, source.git_sha_rev, out_dir)
 
-    # run tarball download jobs in parallel, with at most 5 concurrent download jobs
-    with mp.Pool(min(5, mp.cpu_count())) as pool:
-        if len(registry_packages) != 0:
-            (out_dir / "tarballs").mkdir()
-            session = create_http_session()
-            tarball_args_gen = ((session, pkg, out_dir) for pkg in registry_packages)
-            pool.starmap(download_tarball, tarball_args_gen)
+    if len(registry_packages) != 0:
+        (out_dir / "tarballs").mkdir()
+
+        eprint(f"Downloading tarballs with {MAX_WORKERS} workers...")
+        with ThreadPoolExecutor(max_workers=MAX_WORKERS) as executor:
+            futures: list[Future[None]] = []
+
+            for pkg in registry_packages:
+                source = pkg.source
+
+                dl = raw_registry_source_to_dl[source.raw]
+                url = make_download_url_for_tarball(pkg, dl)
+
+                checksum = pkg.checksum
+                filename = f'{pkg.name}-{pkg.version}.tar.gz'
+                out_path = out_dir / "tarballs" / filename
+
+                future = executor.submit(download_crate_tarball, session, url, out_path, checksum)
+                futures.append(future)
+
+            # fail early if a worker raises an exception
+            done, _ = wait(futures, return_when=FIRST_EXCEPTION)
+            for f in done:
+                e = f.exception()
+                if e is None:
+                    continue
+                executor.shutdown(cancel_futures=True)
+                raise Exception(f"Failed to download tarball: {e}")
 
 
 def get_manifest_metadata(manifest_path: Path) -> dict[str, Any]:
@@ -244,8 +413,7 @@ def copy_and_patch_git_crate_subtree(git_tree: Path, crate_name: str, crate_out_
     shutil.copytree(crate_tree, crate_out_dir, ignore=ignore_func)
     crate_out_dir.chmod(0o755)
 
-    with open(crate_manifest_path, "r") as f:
-        manifest_data = f.read()
+    manifest_data = crate_manifest_path.read_text()
 
     if "workspace" in manifest_data:
         crate_manifest_metadata = get_manifest_metadata(crate_manifest_path)
@@ -268,16 +436,16 @@ def extract_crate_tarball_contents(tarball_path: Path, crate_out_dir: Path) -> N
     subprocess.check_output(cmd)
 
 
-def make_git_source_selector(source_info: GitSourceInfo) -> dict[str, str]:
+def make_git_source_selector(source: GitSource) -> dict[str, str]:
     selector = {}
-    selector["git"] = source_info["url"]
-    if source_info["type"] is not None:
-        selector[source_info["type"]] = source_info["value"]
+    selector["git"] = source.url
+    if source.type is not None:
+        selector[source.type] = source.value
     return selector
 
 
-def make_registry_source_selector(source: str) -> dict[str, str]:
-    registry = source[9:] if source.startswith("registry+") else source
+def make_registry_source_selector(source: RegistrySource) -> dict[str, str]:
+    registry = source.raw if source.is_sparse else source.url
     selector = {}
     selector["registry"] = registry
     return selector
@@ -288,14 +456,9 @@ def create_vendor(vendor_staging_dir: Path, out_dir: Path) -> None:
     out_dir.mkdir(exist_ok=True)
     shutil.copy(lockfile_path, out_dir / "Cargo.lock")
 
-    cargo_lock_toml = load_toml(lockfile_path)
-    lockfile_version = get_lockfile_version(cargo_lock_toml)
+    lockfile = load_lockfile(lockfile_path)
 
-    source_to_ind: dict[str, str] = {}
-    selector_to_ind: dict[tuple, str] = {}
     source_config = {}
-    next_registry_ind = 0
-    next_git_ind = 0
 
     def add_source_replacement(
         orig_key: str,
@@ -308,104 +471,84 @@ def create_vendor(vendor_staging_dir: Path, out_dir: Path) -> None:
         source_config[orig_key] = orig_selector
         source_config[orig_key]["replace-with"] = vendored_key
 
-    # we reserve registry index 0 for crates-io
-    source_to_ind["registry+https://github.com/rust-lang/crates.io-index"] = "registry-0"
-    source_to_ind["sparse+https://index.crates.io/"] = "registry-0"
     add_source_replacement(
         orig_key="crates-io",
         orig_selector={},  # there is an internal selector defined for the `crates-io` source
-        vendored_key="vendored-source-registry-0",
-        vendored_dir="@vendor@/source-registry-0"
+        vendored_key="vendored-registry-source-0",
+        vendored_dir="@vendor@/source-registry"
     )
-    next_registry_ind += 1
 
-    for pkg in cargo_lock_toml["package"]:
-        # ignore local dependencies
-        if "source" not in pkg.keys():
-            continue
-        source: str = pkg["source"]
-        if source in source_to_ind:
-            continue
+    processed_git_inds = set()
 
-        if source.startswith("git+"):
-            source_info = parse_git_source(source, lockfile_version)
-            selector = make_git_source_selector(source_info)
-            selector_key = (source_info["url"], source_info["type"], source_info["value"])
-            if selector_key in selector_to_ind:
-                ind = selector_to_ind[selector_key]
-            else:
-                ind = f"git-{next_git_ind}"
-                next_git_ind += 1
-                selector_to_ind[selector_key] = ind
+    for source in lockfile.sources:
+        match source:
+            case RegistrySource():
+                if source.ind == 0:  # crates-io already handled separately above
+                    continue
                 add_source_replacement(
-                    orig_key=f"original-source-{ind}",
-                    orig_selector=selector,
-                    vendored_key=f"vendored-source-{ind}",
-                    vendored_dir=f"@vendor@/source-{ind}"
+                    orig_key=f"original-registry-source-{source.ind}",
+                    orig_selector=make_registry_source_selector(source),
+                    vendored_key=f"vendored-registry-source-{source.ind}",
+                    vendored_dir="@vendor@/source-registry"
                 )
-        elif source.startswith("registry+") or source.startswith("sparse+"):
-            ind = f"registry-{next_registry_ind}"
-            next_registry_ind += 1
-            selector = make_registry_source_selector(source)
-            add_source_replacement(
-                orig_key=f"original-source-{ind}",
-                orig_selector=selector,
-                vendored_key=f"vendored-source-{ind}",
-                vendored_dir=f"@vendor@/source-{ind}"
-            )
-        else:
-            raise Exception(f"Can't process source: {source}.")
+            case GitSource():
+                # In some cases multiple git sources can have the same selector, thus the same git ind
+                # but source replacements can't be made for the same selector multiple times
+                if source.ind in processed_git_inds:
+                    continue
+                processed_git_inds.add(source.ind)
 
-        source_to_ind[source] = ind
+                add_source_replacement(
+                    orig_key=f"original-git-source-{source.ind}",
+                    orig_selector=make_git_source_selector(source),
+                    vendored_key=f"vendored-git-source-{source.ind}",
+                    vendored_dir=f"@vendor@/source-git-{source.ind}"
+                )
 
     config_path = out_dir / ".cargo" / "config.toml"
     config_path.parent.mkdir()
 
-    with open(config_path, "wb") as config_file:
+    with config_path.open("wb") as config_file:
         tomli_w.dump({"source": source_config}, config_file)
 
-    for pkg in cargo_lock_toml["package"]:
+    for pkg in lockfile.packages:
+        match pkg:
+            case RegistryPackage():
+                crate_out_dir = out_dir / "source-registry" / f"{pkg.name}-{pkg.version}"
+                crate_out_dir.parent.mkdir(exist_ok=True)
 
-        # ignore local dependenices
-        if "source" not in pkg.keys():
-            continue
+                filename = f"{pkg.name}-{pkg.version}.tar.gz"
 
-        source: str = pkg["source"]
-        source_ind = source_to_ind[source]
-        crate_dir_name = f"{pkg["name"]}-{pkg["version"]}"
-        source_dir_name = f"source-{source_ind}"
-        crate_out_dir = out_dir / source_dir_name / crate_dir_name
-        crate_out_dir.parent.mkdir(exist_ok=True)
+                tarball_path = vendor_staging_dir / "tarballs" / filename
 
-        if source.startswith("git+"):
+                extract_crate_tarball_contents(tarball_path, crate_out_dir)
 
-            source_info = parse_git_source(source, lockfile_version)
+                # non-git based crates need the package checksum at minimum
+                with (crate_out_dir / ".cargo-checksum.json").open("w") as f:
+                    json.dump({"files": {}, "package": pkg.checksum}, f)
 
-            git_sha_rev = source_info["git_sha_rev"]
-            git_tree = vendor_staging_dir / "git" / git_sha_rev
+            case GitPackage():
+                crate_out_dir = out_dir / f"source-git-{pkg.source.ind}" / f"{pkg.name}-{pkg.version}"
+                crate_out_dir.parent.mkdir(exist_ok=True)
 
-            copy_and_patch_git_crate_subtree(git_tree, pkg["name"], crate_out_dir)
+                if crate_out_dir.exists():
+                    raise Exception(
+                        f"{crate_out_dir} already exists!\n"
+                        "This likely due to multiple packages having the same name, version and git selector, but not the same locked git revision\n"
+                        "As a workaround, change all conflicting packages to have different git selectors\n"
+                        "e.g. specifying an exact rev=<hash> selector for each affected package in both Cargo.toml and Cargo.lock\n"
+                        "If it is not possible or difficult to do so (e.g. it's a transient dependency), as a hack, you could also consider keeping\n"
+                        "the package with the most up-to-date revision and removing all other duplicated entries from Cargo.lock"
+                    )
 
-            # git based crates allow having no checksum information
-            with open(crate_out_dir / ".cargo-checksum.json", "w") as f:
-                json.dump({"files": {}}, f)
+                git_sha_rev = pkg.source.git_sha_rev
+                git_tree = vendor_staging_dir / "git" / git_sha_rev
 
-        elif source.startswith("registry+") or source.startswith("sparse+"):
-            filename = f"{pkg["name"]}-{pkg["version"]}.tar.gz"
+                copy_and_patch_git_crate_subtree(git_tree, pkg.name, crate_out_dir)
 
-            # TODO: change this when non-crates-io registries are supported
-            dir_name = "tarballs"
-
-            tarball_path = vendor_staging_dir / dir_name / filename
-
-            extract_crate_tarball_contents(tarball_path, crate_out_dir)
-
-            # non-git based crates need the package checksum at minimum
-            with open(crate_out_dir / ".cargo-checksum.json", "w") as f:
-                json.dump({"files": {}, "package": pkg["checksum"]}, f)
-
-        else:
-            raise Exception(f"Can't process source: {source}.")
+                # git based crates allow having no checksum information
+                with (crate_out_dir / ".cargo-checksum.json").open("w") as f:
+                    json.dump({"files": {}}, f)
 
 
 def main() -> None:


### PR DESCRIPTION
Related: https://github.com/NixOS/nixpkgs/issues/377558

Supersedes: https://github.com/NixOS/nixpkgs/pull/393016
Fixes: https://github.com/NixOS/nixpkgs/issues/392872

Supersedes: https://github.com/NixOS/nixpkgs/pull/400865

Supersedes: https://github.com/NixOS/nixpkgs/pull/549664

TODO: add proper error message when a name+version is duplicated across registries

Notes:
- non-crates-io registries are very rarely used
  - this is probably mostly useful for internal registries of companies
    - but then we'd probably also need to figure out authentication
- the way crate tarballs are currently stored is not the best if we wanted to have separate directories
  - we have `/tarballs` currently
    - this doesn't have distinction between registries
  - during testing, I tried using the separate directory method, but it caused some problems
    - I think custom registries are used so rarely, that having an exact name+version conflict between a crates-io package and a custom registry package is VERY unlikely...

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
