### PR TITLE
php.extensions.excimer: init at 1.2.3

### DIFF
--- a/pkgs/development/php-packages/excimer/default.nix
+++ b/pkgs/development/php-packages/excimer/default.nix
@@ -1,0 +1,28 @@
+{
+  buildPecl,
+  lib,
+  fetchFromGitHub,
+}:
+
+let
+  version = "1.2.3";
+in
+buildPecl {
+  inherit version;
+  pname = "excimer";
+
+  src = fetchFromGitHub {
+    owner = "wikimedia";
+    repo = "mediawiki-php-excimer";
+    tag = version;
+    hash = "sha256-p1tnrrSiTtoin/QSQFeeiX0Di1wFD8CMTdLazOfjWKU=";
+  };
+
+  meta = {
+    changelog = "https://pecl.php.net/package-changelog.php?package=excimer&release=${version}";
+    description = "PHP extension that provides an interrupting timer and a low-overhead sampling profiler";
+    license = lib.licenses.asl20;
+    homepage = "https://mediawiki.org/wiki/Excimer";
+    maintainers = lib.teams.php.members;
+  };
+}

--- a/pkgs/top-level/php-packages.nix
+++ b/pkgs/top-level/php-packages.nix
@@ -297,6 +297,8 @@ lib.makeScope pkgs.newScope (
 
         event = callPackage ../development/php-packages/event { };
 
+        excimer = callPackage ../development/php-packages/excimer { };
+
         gnupg = callPackage ../development/php-packages/gnupg { };
 
         grpc = callPackage ../development/php-packages/grpc { };


### PR DESCRIPTION
Package [Excimer](https://www.mediawiki.org/wiki/Excimer), a PHP 7.1+ extension that provides an interrupting timer and a low-overhead sampling profiler. 

My main motivation to merge this is that it's needed to use the profiling capabilities of sentry.io with their PHP SDK.

I tested basic functionality (means profiling data in my sentry dashboard) with php 8.4. on latest nixos-unstable.  

Is it okay to add teams.php to the maintainers?  whats the process here? 

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
