### PR TITLE
phpExtensions.wikidiff2: init at 1.14.1

### DIFF
--- a/pkgs/development/php-packages/wikidiff2/default.nix
+++ b/pkgs/development/php-packages/wikidiff2/default.nix
@@ -1,0 +1,29 @@
+{
+  lib,
+  buildPecl,
+  fetchFromGitHub,
+  pkg-config,
+  libthai,
+}:
+
+buildPecl rec {
+  pname = "wikidiff2";
+  version = "1.14.1";
+
+  src = fetchFromGitHub {
+    owner = "wikimedia";
+    repo = "mediawiki-php-wikidiff2";
+    tag = version;
+    hash = "sha256-UTOfLXv2QWdjThxfrPQDLB8Mqo4js6LzOKXePivdp9k=";
+  };
+
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [ libthai ];
+
+  meta = {
+    description = "PHP extension which formats changes between two input texts, producing HTML or JSON.";
+    license = lib.licenses.gpl2;
+    homepage = "https://www.mediawiki.org/wiki/Wikidiff2";
+    maintainers = with lib.maintainers; [ georgyo ];
+  };
+}

--- a/pkgs/top-level/php-packages.nix
+++ b/pkgs/top-level/php-packages.nix
@@ -403,6 +403,8 @@ lib.makeScope pkgs.newScope (
 
         vld = callPackage ../development/php-packages/vld { };
 
+        wikidiff2 = callPackage ../development/php-packages/wikidiff2 { };
+
         xdebug = callPackage ../development/php-packages/xdebug { };
 
         yaml = callPackage ../development/php-packages/yaml { };


### PR DESCRIPTION
> Wikidiff2 is a native extension for PHP that provides a faster diff engine to MediaWiki. It is partly based on the original [wikidiff](https://www.mediawiki.org/wiki/Special:MyLanguage/wikidiff), and partly on MediaWiki's DifferenceEngine class. It produces diffs from input text (line-based or word-level) and can format these as HTML or JSON.
>
> Wikidiff2 includes support for character-level diffs for text composed of characters from the Japanese and Thai alphabets and the unified Han, and includes support for Thai segmentation for word-level diffs in that language. Japanese, Chinese and Thai do not use spaces to separate words. The input is assumed to be UTF-8 encoded. Invalid UTF-8 may cause undesirable operation, such as truncation of the output, so the input should be validated by the application. The input text should have Unix-style line endings.

https://www.mediawiki.org/wiki/Wikidiff2

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
