### PR TITLE
tree-wide: use `stdenv.cc.libcxx` instead of `libcxx` on Darwin 

### DIFF
--- a/pkgs/applications/science/math/R/default.nix
+++ b/pkgs/applications/science/math/R/default.nix
@@ -36,7 +36,6 @@
   Cocoa,
   Foundation,
   libobjc,
-  libcxx,
   tzdata,
   withRecommendedPackages ? true,
   enableStrictBarrier ? false,
@@ -120,7 +119,6 @@ stdenv.mkDerivation (finalAttrs: {
       Cocoa
       Foundation
       libobjc
-      libcxx
     ];
   strictDeps = true;
 
@@ -173,8 +171,8 @@ stdenv.mkDerivation (finalAttrs: {
       --disable-R-framework
       --without-x
       OBJC="clang"
-      CPPFLAGS="-isystem ${lib.getDev libcxx}/include/c++/v1"
-      LDFLAGS="-L${lib.getLib libcxx}/lib"
+      CPPFLAGS="-isystem ${lib.getInclude stdenv.cc.libcxx}/include/c++/v1"
+      LDFLAGS="-L${lib.getLib stdenv.cc.libcxx}/lib"
     ''
     + ''
       )

--- a/pkgs/by-name/fh/fh/package.nix
+++ b/pkgs/by-name/fh/fh/package.nix
@@ -6,7 +6,6 @@
   stdenv,
   darwin,
   gcc,
-  libcxx,
   cacert,
 }:
 
@@ -38,7 +37,7 @@ rustPlatform.buildRustPackage rec {
   ];
 
   env = lib.optionalAttrs stdenv.hostPlatform.isDarwin {
-    NIX_CFLAGS_COMPILE = "-I${lib.getDev libcxx}/include/c++/v1";
+    NIX_CFLAGS_COMPILE = "-I${lib.getInclude stdenv.cc.libcxx}/include/c++/v1";
   };
 
   postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''

--- a/pkgs/by-name/mo/moltenvk/package.nix
+++ b/pkgs/by-name/mo/moltenvk/package.nix
@@ -6,7 +6,6 @@
   gitUpdater,
   apple-sdk_15,
   cereal,
-  libcxx,
   glslang,
   spirv-cross,
   spirv-headers,
@@ -103,7 +102,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   env.NIX_CFLAGS_COMPILE = toString (
     [
-      "-isystem ${lib.getDev libcxx}/include/c++/v1"
+      "-isystem ${lib.getInclude stdenv.cc.libcxx}/include/c++/v1"
       "-I${lib.getDev spirv-cross}/include/spirv_cross"
       "-I${lib.getDev spirv-headers}/include/spirv/unified1"
 

--- a/pkgs/by-name/se/servo/package.nix
+++ b/pkgs/by-name/se/servo/package.nix
@@ -28,7 +28,6 @@
   freetype,
   gst_all_1,
   harfbuzz,
-  libcxx,
   libGL,
   libunwind,
   libxkbcommon,
@@ -131,10 +130,9 @@ rustPlatform.buildRustPackage {
     ]
     ++ lib.optionals stdenv.hostPlatform.isDarwin [
       apple-sdk_14
-      libcxx
     ];
 
-  env.NIX_CFLAGS_COMPILE = lib.optionalString stdenv.hostPlatform.isDarwin "-I${lib.getDev libcxx}/include/c++/v1";
+  env.NIX_CFLAGS_COMPILE = lib.optionalString stdenv.hostPlatform.isDarwin "-I${lib.getInclude stdenv.cc.libcxx}/include/c++/v1";
 
   # copy resources into `$out` to be used during runtime
   # link runtime libraries

--- a/pkgs/by-name/so/solana-cli/package.nix
+++ b/pkgs/by-name/so/solana-cli/package.nix
@@ -6,7 +6,6 @@
   darwin,
   udev,
   protobuf,
-  libcxx,
   rocksdb_8_3,
   installShellFiles,
   pkg-config,
@@ -99,7 +98,6 @@ rustPlatform.buildRustPackage rec {
     ]
     ++ lib.optionals stdenv.hostPlatform.isLinux [ udev ]
     ++ lib.optionals stdenv.hostPlatform.isDarwin [
-      libcxx
       IOKit
       Security
       AppKit
@@ -133,8 +131,8 @@ rustPlatform.buildRustPackage rec {
 
   # Require this on darwin otherwise the compiler starts rambling about missing
   # cmath functions
-  CPPFLAGS = lib.optionals stdenv.hostPlatform.isDarwin "-isystem ${lib.getDev libcxx}/include/c++/v1";
-  LDFLAGS = lib.optionals stdenv.hostPlatform.isDarwin "-L${lib.getLib libcxx}/lib";
+  CPPFLAGS = lib.optionals stdenv.hostPlatform.isDarwin "-isystem ${lib.getInclude stdenv.cc.libcxx}/include/c++/v1";
+  LDFLAGS = lib.optionals stdenv.hostPlatform.isDarwin "-L${lib.getLib stdenv.cc.libcxx}/lib";
 
   # If set, always finds OpenSSL in the system, even if the vendored feature is enabled.
   OPENSSL_NO_VENDOR = 1;

--- a/pkgs/development/ocaml-modules/eigen/default.nix
+++ b/pkgs/development/ocaml-modules/eigen/default.nix
@@ -4,7 +4,6 @@
   buildDunePackage,
   fetchFromGitHub,
   ctypes,
-  libcxx,
 }:
 
 buildDunePackage rec {
@@ -22,7 +21,7 @@ buildDunePackage rec {
 
   minimalOCamlVersion = "4.02";
 
-  env.NIX_CFLAGS_COMPILE = lib.optionalString stdenv.hostPlatform.isDarwin "-I${lib.getDev libcxx}/include/c++/v1";
+  env.NIX_CFLAGS_COMPILE = lib.optionalString stdenv.hostPlatform.isDarwin "-I${lib.getInclude stdenv.cc.libcxx}/include/c++/v1";
 
   propagatedBuildInputs = [ ctypes ];
 

--- a/pkgs/development/python-modules/datatable/default.nix
+++ b/pkgs/development/python-modules/datatable/default.nix
@@ -6,7 +6,6 @@
   pipInstallHook,
   blessed,
   docutils,
-  libcxx,
   llvm,
   pytestCheckHook,
   typesentry,
@@ -53,7 +52,7 @@ buildPythonPackage rec {
   ];
 
   LLVM = llvm;
-  env.NIX_CFLAGS_COMPILE = lib.optionalString stdenv.hostPlatform.isDarwin "-isystem ${lib.getDev libcxx}/include/c++/v1";
+  env.NIX_CFLAGS_COMPILE = lib.optionalString stdenv.hostPlatform.isDarwin "-isystem ${lib.getInclude stdenv.cc.libcxx}/include/c++/v1";
 
   # test suite is very cpu intensive, only run small subset to ensure package is working as expected
   pytestFlagsArray = [ "tests/test-sets.py" ];

--- a/pkgs/development/python-modules/kivy/default.nix
+++ b/pkgs/development/python-modules/kivy/default.nix
@@ -13,7 +13,6 @@
   SDL2_image,
   SDL2_ttf,
   SDL2_mixer,
-  libcxx,
   withGstreamer ? true,
   gst_all_1,
   pygments,
@@ -82,7 +81,7 @@ buildPythonPackage rec {
       "-Wno-error=incompatible-pointer-types"
     ]
     ++ lib.optionals stdenv.hostPlatform.isDarwin [
-      "-I${lib.getDev libcxx}/include/c++/v1"
+      "-I${lib.getInclude stdenv.cc.libcxx}/include/c++/v1"
     ]
   );
 

--- a/pkgs/development/python-modules/kiwisolver/default.nix
+++ b/pkgs/development/python-modules/kiwisolver/default.nix
@@ -3,7 +3,6 @@
   buildPythonPackage,
   fetchPypi,
   stdenv,
-  libcxx,
   cppy,
   setuptools-scm,
   pythonOlder,
@@ -21,7 +20,7 @@ buildPythonPackage rec {
     hash = "sha256-I9XwI73Ix+VOtl8Dyl1bsltgHqxNfxoEKIih9FI3mH4=";
   };
 
-  env.NIX_CFLAGS_COMPILE = lib.optionalString stdenv.hostPlatform.isDarwin "-I${lib.getDev libcxx}/include/c++/v1";
+  env.NIX_CFLAGS_COMPILE = lib.optionalString stdenv.hostPlatform.isDarwin "-I${lib.getInclude stdenv.cc.libcxx}/include/c++/v1";
 
   nativeBuildInputs = [ setuptools-scm ];
 

--- a/pkgs/development/python-modules/numba/default.nix
+++ b/pkgs/development/python-modules/numba/default.nix
@@ -10,7 +10,6 @@
   numpy,
   numpy_1,
   llvmlite,
-  libcxx,
   replaceVars,
   writers,
   numba,
@@ -74,7 +73,7 @@ buildPythonPackage rec {
         'numpy_version >= (3, 0)'
   '';
 
-  env.NIX_CFLAGS_COMPILE = lib.optionalString stdenv.hostPlatform.isDarwin "-I${lib.getDev libcxx}/include/c++/v1";
+  env.NIX_CFLAGS_COMPILE = lib.optionalString stdenv.hostPlatform.isDarwin "-I${lib.getInclude stdenv.cc.libcxx}/include/c++/v1";
 
   build-system = [
     setuptools

--- a/pkgs/development/python-modules/py3exiv2/default.nix
+++ b/pkgs/development/python-modules/py3exiv2/default.nix
@@ -5,7 +5,6 @@
   buildPythonPackage,
   exiv2,
   fetchPypi,
-  libcxx,
   pythonOlder,
 }:
 
@@ -27,7 +26,7 @@ buildPythonPackage rec {
   ];
 
   # Work around Python distutils compiling C++ with $CC (see issue #26709)
-  env.NIX_CFLAGS_COMPILE = lib.optionalString stdenv.hostPlatform.isDarwin "-I${lib.getDev libcxx}/include/c++/v1";
+  env.NIX_CFLAGS_COMPILE = lib.optionalString stdenv.hostPlatform.isDarwin "-I${lib.getInclude stdenv.cc.libcxx}/include/c++/v1";
 
   pythonImportsCheck = [ "pyexiv2" ];
 

--- a/pkgs/development/r-modules/generic-builder.nix
+++ b/pkgs/development/r-modules/generic-builder.nix
@@ -2,7 +2,6 @@
   stdenv,
   lib,
   R,
-  libcxx,
   xvfb-run,
   util-linux,
   Cocoa,
@@ -38,7 +37,7 @@ stdenv.mkDerivation (
         libiconv
       ];
 
-    env.NIX_CFLAGS_COMPILE = lib.optionalString stdenv.hostPlatform.isDarwin "-I${lib.getDev libcxx}/include/c++/v1";
+    env.NIX_CFLAGS_COMPILE = lib.optionalString stdenv.hostPlatform.isDarwin "-I${lib.getInclude stdenv.cc.libcxx}/include/c++/v1";
 
     enableParallelBuilding = true;
 

--- a/pkgs/development/tools/build-managers/bazel/bazel_5/default.nix
+++ b/pkgs/development/tools/build-managers/bazel/bazel_5/default.nix
@@ -28,7 +28,6 @@
   writeScript,
   # Apple dependencies
   cctools,
-  libcxx,
   sigtool,
   # Allow to independently override the jdks used to build and run respectively
   buildJdk,
@@ -451,7 +450,7 @@ stdenv.mkDerivation rec {
 
         # libcxx includes aren't added by libcxx hook
         # https://github.com/NixOS/nixpkgs/pull/41589
-        export NIX_CFLAGS_COMPILE="$NIX_CFLAGS_COMPILE -isystem ${lib.getDev libcxx}/include/c++/v1"
+        export NIX_CFLAGS_COMPILE="$NIX_CFLAGS_COMPILE -isystem ${lib.getInclude stdenv.cc.libcxx}/include/c++/v1"
         # for CLang 16 compatibility in external/{absl,upb} dependencies and in execlog
         export NIX_CFLAGS_COMPILE+=" -Wno-deprecated-builtins -Wno-gnu-offsetof-extensions -Wno-implicit-function-declaration"
 
@@ -622,7 +621,6 @@ stdenv.mkDerivation rec {
     ]
     ++ lib.optionals (stdenv.hostPlatform.isDarwin) [
       cctools
-      libcxx
     ];
 
   # Bazel makes extensive use of symlinks in the WORKSPACE.

--- a/pkgs/development/tools/build-managers/bazel/bazel_6/default.nix
+++ b/pkgs/development/tools/build-managers/bazel/bazel_6/default.nix
@@ -31,7 +31,6 @@
   writeScript,
   # Apple dependencies
   cctools,
-  libcxx,
   sigtool,
   # Allow to independently override the jdks used to build and run respectively
   buildJdk,
@@ -521,7 +520,7 @@ stdenv.mkDerivation rec {
 
         # libcxx includes aren't added by libcxx hook
         # https://github.com/NixOS/nixpkgs/pull/41589
-        export NIX_CFLAGS_COMPILE="$NIX_CFLAGS_COMPILE -isystem ${lib.getDev libcxx}/include/c++/v1"
+        export NIX_CFLAGS_COMPILE="$NIX_CFLAGS_COMPILE -isystem ${lib.getInclude stdenv.cc.libcxx}/include/c++/v1"
         # for CLang 16 compatibility in external/{absl,upb} dependencies
         export NIX_CFLAGS_COMPILE+=" -Wno-deprecated-builtins -Wno-gnu-offsetof-extensions"
 
@@ -690,7 +689,6 @@ stdenv.mkDerivation rec {
     ]
     ++ lib.optionals (stdenv.hostPlatform.isDarwin) [
       cctools
-      libcxx
       sigtool
     ];
 

--- a/pkgs/development/tools/build-managers/bazel/bazel_7/default.nix
+++ b/pkgs/development/tools/build-managers/bazel/bazel_7/default.nix
@@ -34,7 +34,6 @@
   python3,
   # Apple dependencies
   cctools,
-  libcxx,
   libtool,
   sigtool,
   # Allow to independently override the jdks used to build and run respectively
@@ -406,7 +405,7 @@ stdenv.mkDerivation rec {
 
         # libcxx includes aren't added by libcxx hook
         # https://github.com/NixOS/nixpkgs/pull/41589
-        export NIX_CFLAGS_COMPILE="$NIX_CFLAGS_COMPILE -isystem ${lib.getDev libcxx}/include/c++/v1"
+        export NIX_CFLAGS_COMPILE="$NIX_CFLAGS_COMPILE -isystem ${lib.getInclude stdenv.cc.libcxx}/include/c++/v1"
         # for CLang 16 compatibility in external/upb dependency
         export NIX_CFLAGS_COMPILE+=" -Wno-gnu-offsetof-extensions"
 
@@ -554,7 +553,6 @@ stdenv.mkDerivation rec {
     ]
     ++ lib.optionals (stdenv.hostPlatform.isDarwin) [
       cctools
-      libcxx
     ];
 
   # Bazel makes extensive use of symlinks in the WORKSPACE.


### PR DESCRIPTION
This was split off from https://github.com/NixOS/nixpkgs/pull/398727. It is primarily targeted at workarounds for the issue where Clang is invoked as `clang`, and it doesn’t include the C++ headers. These changes shouldn’t cause any rebuilds. 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
