### PR TITLE
mpvScripts.buildLua: fix buildLua's runtime-dependencies argument

### DIFF
--- a/pkgs/applications/video/mpv/scripts/buildLua.nix
+++ b/pkgs/applications/video/mpv/scripts/buildLua.nix
@@ -81,14 +81,12 @@ lib.makeOverridable (
             inherit scriptName;
           }
           // lib.optionalAttrs (runtime-dependencies != [ ]) {
-            extraWrapperArgs =
-              [
-                "--prefix"
-                "PATH"
-                ":"
-              ]
-              ++ (map lib.makeBinPath runtime-dependencies)
-              ++ args.passthru.extraWrapperArgs or [ ];
+            extraWrapperArgs = [
+              "--prefix"
+              "PATH"
+              ":"
+              (lib.makeBinPath runtime-dependencies)
+            ] ++ args.passthru.extraWrapperArgs or [ ];
           };
         meta =
           {


### PR DESCRIPTION
```
Fix buildLua's runtime-dependencies argument to prevent the following
nasty error, introduced in commit e67cceafda6d ("mpvScripts.twitch-chat:
refactor using buildLua's `runtime-dependencies`"):

    error: expected a list but found a set: { [...] }

Fixes: e2596ac22d42 ("mpvScripts.buildLua: add a `runtime-dependencies` option")
```

---

> Change LGTM.
>
> I have also tested this PR. Note that the hash of the file passed via `--script` does not even change:
>
> ```
> /nix/store/ncnpq4hxzihhzyrlw91aykn9xvx1y17b-twitch-chat-0-unstable-2024-06-23/share/mpv/scripts/twitch-chat.lua
> ```
>
> -- https://github.com/NixOS/nixpkgs/pull/388458#pullrequestreview-2671364693

Unsure why my build did not fail when I originally tested the faulty commit. Maybe some unrelated later change manifested the failure. Either way, this fix should be the correct behavior.

---

@nbraud, as the author of https://github.com/NixOS/nixpkgs/pull/388458 and https://github.com/NixOS/nixpkgs/pull/388475, this fix may of interest to you.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
