### PR TITLE
vesktop: fix error & hang at startup when using system vencord

### DIFF
--- a/pkgs/by-name/ve/vesktop/use_system_vencord.patch
+++ b/pkgs/by-name/ve/vesktop/use_system_vencord.patch
@@ -1,5 +1,5 @@
 diff --git a/src/main/constants.ts b/src/main/constants.ts
-index 40d91a5..7b46bbf 100644
+index 01bdd80..e72b065 100644
 --- a/src/main/constants.ts
 +++ b/src/main/constants.ts
 @@ -49,7 +49,7 @@ export const VENCORD_THEMES_DIR = join(DATA_DIR, "themes");
@@ -11,3 +11,17 @@ index 40d91a5..7b46bbf 100644
  
  export const USER_AGENT = `Vesktop/${app.getVersion()} (https://github.com/Vencord/Vesktop)`;
  
+diff --git a/src/main/utils/vencordLoader.ts b/src/main/utils/vencordLoader.ts
+index 85b6112..5cdf4bc 100644
+--- a/src/main/utils/vencordLoader.ts
++++ b/src/main/utils/vencordLoader.ts
+@@ -63,8 +63,7 @@ const existsAsync = (path: string) =>
+         .catch(() => false);
+ 
+ export async function isValidVencordInstall(dir: string) {
+-    const results = await Promise.all(["package.json", ...FILES_TO_DOWNLOAD].map(f => existsAsync(join(dir, f))));
+-    return !results.includes(false);
++    return true;
+ }
+ 
+ export async function ensureVencordFiles() {


### PR DESCRIPTION
After Vesktop v1.5.6, the following error is observed at startup, and the application hangs on the startup sequence:
```
Vesktop v1.5.6
(node:241303) UnhandledPromiseRejectionWarning: Error: EROFS: read-only file system, open '/nix/store/mrbmnrr5sik0559ccwgg6gmfbh7hn5q6-vencord-1.11.9/package.json'
    at async open (node:internal/fs/promises:639:25)
    at async writeFile (node:internal/fs/promises:1216:14)
    at async Promise.all (index 1)
    at async fo (VCDMain:13:846)
    at async Te (VCDMain:15:4976)
(Use `electron --trace-warnings ...` to show where the warning was created) (node:241303) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). To terminate the node process on unhandled promise rejection, use the CLI flag `--unhandled-rejections=strict` (see https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). (rejection id: 3)
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
