### PR TITLE
vgmstream: disable CELT support on non-x86_64

### DIFF
--- a/pkgs/by-name/vg/vgmstream/package.nix
+++ b/pkgs/by-name/vg/vgmstream/package.nix
@@ -15,17 +15,7 @@
   nix-update-script,
 }:
 
-stdenv.mkDerivation rec {
-  pname = "vgmstream";
-  version = "1980";
-
-  src = fetchFromGitHub {
-    owner = "vgmstream";
-    repo = "vgmstream";
-    tag = "r${version}";
-    hash = "sha256-TmaWC04XbtFfBYhmTO4ouh3NoByio1BCpDJGJy3r0NY=";
-  };
-
+let
   # https://github.com/vgmstream/vgmstream/blob/1b6a7915bf98ca14a71a0d44bef7a2c6a75c686d/cmake/dependencies/atrac9.cmake
   atrac9-src = fetchFromGitHub {
     owner = "Thealexbarney";
@@ -42,6 +32,18 @@ stdenv.mkDerivation rec {
   celt-0_11_0-src = fetchzip {
     url = "https://downloads.xiph.org/releases/celt/celt-0.11.0.tar.gz";
     hash = "sha256-JI3b44iCxQ29bqJGNH/L18pEuWiTFZ2132ceaqe8U0E=";
+  };
+in
+
+stdenv.mkDerivation rec {
+  pname = "vgmstream";
+  version = "1980";
+
+  src = fetchFromGitHub {
+    owner = "vgmstream";
+    repo = "vgmstream";
+    tag = "r${version}";
+    hash = "sha256-TmaWC04XbtFfBYhmTO4ouh3NoByio1BCpDJGJy3r0NY=";
   };
 
   passthru.updateScript = nix-update-script {
@@ -80,28 +82,34 @@ stdenv.mkDerivation rec {
     +
       # cmake/dependencies/celt.cmake uses configure_file to modify ${CELT_0110_PATH}/libcelt/ecintrin.h.
       # Therefore, CELT_0110_PATH needs to point to a mutable directory.
-      ''
+      lib.optionalString (stdenv.system == "x86_64-linux") ''
         mkdir -p dependencies/celt-0.11.0/
         cp -r ${celt-0_11_0-src}/* dependencies/celt-0.11.0/
         chmod -R +w dependencies/celt-0.11.0/
       '';
 
-  cmakeFlags = [
-    "-DATRAC9_PATH=${atrac9-src}"
-    "-DCELT_0061_PATH=${celt-0_6_1-src}"
-    "-DCELT_0110_PATH=../dependencies/celt-0.11.0"
-    # libg719_decode omitted because it doesn't have a free software license
-  ];
+  cmakeFlags =
+    [
+      "-DATRAC9_PATH=${atrac9-src}"
+    ]
+    # Only supported on x86_64-linux
+    ++ lib.optionals (stdenv.system == "x86_64-linux") [
+      "-DCELT_0061_PATH=${celt-0_6_1-src}"
+      "-DCELT_0110_PATH=../dependencies/celt-0.11.0"
+      # libg719_decode omitted because it doesn't have a free software license
+    ];
 
   meta = with lib; {
     description = "Library for playback of various streamed audio formats used in video games";
     homepage = "https://vgmstream.org";
     maintainers = with maintainers; [ zane ];
-    license = with licenses; [
-      isc # vgmstream itself
-      mit # atrac9
-      bsd2 # celt
-    ];
+    license =
+      with licenses;
+      [
+        isc # vgmstream itself
+        mit # atrac9
+      ]
+      ++ optional (stdenv.system == "x86_64-linux") bsd2;
     platforms = with platforms; unix;
   };
 }


### PR DESCRIPTION
This fixes build on aarch64-linux.

Due to code rot in the versions of celt required, the vendored autotools
cannot handle aarch64, and nixos is presently unable to regenerate it.
It currently happens to work on x86_64-linux, so disable it everywhere
else.

This fixes #399389.

cc @FraGag 

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
