### PR TITLE
juliaup: init at v1.17.13

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -21330,6 +21330,13 @@
     githubId = 255667;
     name = "Linus Karl";
   };
+  reubenj = {
+    name = "Reuben Gardos Reid";
+    email = "reuben@reuben.gr.com";
+    github = "reubenj";
+    githubId = 5456207;
+    keys = [ { fingerprint = "15F6 C0B6 3BFD 555A 6C7F  B50D CA2B 4722 79C4 937B"; } ];
+  };
   revol-xut = {
     email = "revol-xut@protonmail.com";
     name = "Tassilo Tanneberger";

--- a/pkgs/by-name/ju/juliaup/package.nix
+++ b/pkgs/by-name/ju/juliaup/package.nix
@@ -1,0 +1,32 @@
+{
+  lib,
+  fetchFromGitHub,
+  rustPlatform,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "juliaup";
+  version = "1.17.13";
+
+  src = fetchFromGitHub {
+    owner = "JuliaLang";
+    repo = "juliaup";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-a1TNWvkEV5mb7Tuy8OqPrQoPwuhrjAzn2wP1vD+IhJo=";
+  };
+
+  cargoHash = "sha256-GMu3PVy647TMTg/AYSxkfgFqSvluH/sBSvwbPrNVKe0=";
+
+  checkFlags = [
+    # fail due to the filesystem being read-only
+    "--skip=command_gc"
+    "--skip=command_remove"
+  ];
+
+  meta = {
+    description = "Julia installer and version multiplexer";
+    homepage = "https://github.com/JuliaLang/juliaup";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ reubenj ];
+    mainProgram = "juliaup";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

[`juliaup`](https://github.com/JuliaLang/juliaup) is a Julia installer and version multiplexer.

Adding it to `nixpkgs` is useful for easy access to old, unsupported versions of Julia, or also for quickly trying development versions of Julia.

Last year, #184592 started working on adding `juliaup`, but it looks like there were some issues with self-updating and linking/not linking the `julia` binaries installed by the tool. Additionally, the `juliaup` README specifically says that they do not support installing the tool from any source other than their install script at this time, leading the PR's author to abandon efforts for the time being.

I decided to try adding the package again because issues linked in #184592 in the `juliaup` repo have been addressed and/or closed. ~Compared to the previous attempt that set `doCheck = false`, only two failing tests are skipped here. The rest of the tests pass.~ Edit: didn't initially test in sandbox, so there are more tests failing.

I would greatly appreciate access to `juliaup` as some specific tools within the ecosystem ([`BinarBuilder`](https://binarybuilder.org/), in particular, relies on `v1.7`) rely on older versions of `julia` that are not supported in `nixpkgs`--especially not on `aarch64-darwin`. Getting `juliaup` added to the repository seems to be a much easier route than adding support/updating older versions of `julia` directly.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc