### PR TITLE
doc: add dark mode and other styling improvements

### DIFF
--- a/doc/doc-support/package.nix
+++ b/doc/doc-support/package.nix
@@ -13,6 +13,7 @@
   writeShellScriptBin,
   nixpkgs ? { },
   markdown-code-runner,
+  roboto,
 }:
 
 stdenvNoCC.mkDerivation (
@@ -91,6 +92,8 @@ stdenvNoCC.mkDerivation (
       mkdir -p "$(dirname "$dest")"
       mv out "$dest"
       mv "$dest/index.html" "$dest/manual.html"
+
+      cp ${roboto.src}/web/Roboto\[ital\,wdth\,wght\].ttf "$dest/Roboto.ttf"
 
       cp ${epub} "$dest/nixpkgs-manual.epub"
 

--- a/doc/style.css
+++ b/doc/style.css
@@ -486,3 +486,8 @@ div.appendix .variablelist .term {
         font-weight: 400;
     }
 }
+
+@font-face {
+    font-family: Roboto;
+    src: url(Roboto.ttf);
+}

--- a/doc/style.css
+++ b/doc/style.css
@@ -113,7 +113,7 @@ html {
 
 body {
     font-size: 1rem;
-    font-family: 'Roboto', sans-serif;
+    font-family: "Roboto", sans-serif;
     font-weight: 300;
     color: #000000;
     background-color: #ffffff;
@@ -214,7 +214,7 @@ h6 {
     font-weight: 800;
     line-height: 110%;
     margin-bottom: 1rem;
-    font-size: 120%
+    font-size: 120%;
 }
 
 strong {
@@ -226,13 +226,13 @@ p {
     margin-bottom: 1rem;
 }
 
-dt>*:first-child,
-dd>*:first-child {
+dt > *:first-child,
+dd > *:first-child {
     margin-top: 0;
 }
 
-dt>*:last-child,
-dd>*:last-child {
+dt > *:last-child,
+dd > *:last-child {
     margin-bottom: 0;
 }
 
@@ -277,16 +277,16 @@ div.appendix .important {
     background: #f4f4f4;
 }
 
-div.book .note>.title,
-div.book .tip>.title,
-div.book .warning>.title,
-div.book .caution>.title,
-div.book .important>.title,
-div.appendix .note>.title,
-div.appendix .tip>.title,
-div.appendix .warning>.title,
-div.appendix .caution>.title,
-div.appendix .important>.title {
+div.book .note > .title,
+div.book .tip > .title,
+div.book .warning > .title,
+div.book .caution > .title,
+div.book .important > .title,
+div.appendix .note > .title,
+div.appendix .tip > .title,
+div.appendix .warning > .title,
+div.appendix .caution > .title,
+div.appendix .important > .title {
     font-weight: 800;
     /* font-family: 'Overpass', serif; */
     line-height: 110%;
@@ -295,29 +295,29 @@ div.appendix .important>.title {
     margin-bottom: 0;
 }
 
-div.book .note> :first-child,
-div.book .tip> :first-child,
-div.book .warning> :first-child,
-div.book .caution> :first-child,
-div.book .important> :first-child,
-div.appendix .note> :first-child,
-div.appendix .tip> :first-child,
-div.appendix .warning> :first-child,
-div.appendix .caution> :first-child,
-div.appendix .important> :first-child {
+div.book .note > :first-child,
+div.book .tip > :first-child,
+div.book .warning > :first-child,
+div.book .caution > :first-child,
+div.book .important > :first-child,
+div.appendix .note > :first-child,
+div.appendix .tip > :first-child,
+div.appendix .warning > :first-child,
+div.appendix .caution > :first-child,
+div.appendix .important > :first-child {
     margin-top: 0;
 }
 
-div.book .note> :last-child,
-div.book .tip> :last-child,
-div.book .warning> :last-child,
-div.book .caution> :last-child,
-div.book .important> :last-child,
-div.appendix .note> :last-child,
-div.appendix .tip> :last-child,
-div.appendix .warning> :last-child,
-div.appendix .caution> :last-child,
-div.appendix .important> :last-child {
+div.book .note > :last-child,
+div.book .tip > :last-child,
+div.book .warning > :last-child,
+div.book .caution > :last-child,
+div.book .important > :last-child,
+div.appendix .note > :last-child,
+div.appendix .tip > :last-child,
+div.appendix .warning > :last-child,
+div.appendix .caution > :last-child,
+div.appendix .important > :last-child {
     margin-bottom: 0;
 }
 
@@ -358,8 +358,8 @@ div.appendix div.example details[open] {
     border-radius: 4px;
 }
 
-div.book div.example details>summary,
-div.appendix div.example details>summary {
+div.book div.example details > summary,
+div.appendix div.example details > summary {
     cursor: pointer;
 }
 
@@ -368,13 +368,13 @@ div.appendix br.example-break {
     display: none;
 }
 
-div.book div.footnotes>hr,
-div.appendix div.footnotes>hr {
+div.book div.footnotes > hr,
+div.appendix div.footnotes > hr {
     border-color: #d8d8d8;
 }
 
-div.book div.footnotes>br,
-div.appendix div.footnotes>br {
+div.book div.footnotes > br,
+div.appendix div.footnotes > br {
     display: none;
 }
 

--- a/doc/style.css
+++ b/doc/style.css
@@ -119,8 +119,8 @@ body {
     font-size: 1rem;
     font-family: "Roboto", sans-serif;
     font-weight: 300;
-    color: #000000;
-    background-color: #ffffff;
+    color: var(--main-text-color);
+    background-color: var(--background);
     min-height: 100vh;
     display: flex;
     flex-direction: column;
@@ -136,7 +136,7 @@ body {
 a {
     text-decoration: none;
     border-bottom: 1px solid;
-    color: #405d99;
+    color: var(--link-color);
 }
 
 ul {
@@ -167,7 +167,7 @@ h1 {
     line-height: 110%;
     font-size: 200%;
     margin-bottom: 1rem;
-    color: #6586c8;
+    color: var(--heading-color);
 }
 
 h2 {
@@ -175,7 +175,7 @@ h2 {
     line-height: 110%;
     font-size: 170%;
     margin-bottom: 0.625rem;
-    color: #6586c8;
+    color: var(--heading-color);
 }
 
 h2:not(:first-child) {
@@ -187,7 +187,7 @@ h3 {
     line-height: 110%;
     margin-bottom: 1rem;
     font-size: 150%;
-    color: #6586c8;
+    color: var(--heading-color);
 }
 
 .note h3,
@@ -203,7 +203,7 @@ h4 {
     line-height: 110%;
     margin-bottom: 1rem;
     font-size: 140%;
-    color: #6586c8;
+    color: var(--heading-color);
 }
 
 h5 {
@@ -211,7 +211,7 @@ h5 {
     line-height: 110%;
     margin-bottom: 1rem;
     font-size: 130%;
-    color: #6a6a6a;
+    color: var(--small-heading-color);
 }
 
 h6 {
@@ -260,8 +260,8 @@ div.appendix .programlisting {
     border-radius: 0.5rem;
     padding: 1rem;
     overflow: auto;
-    background: #f2f8fd;
-    color: #000000;
+    background: var(--codeblock-background);
+    color: var(--codeblock-text-color);
 }
 
 div.book .note,
@@ -292,7 +292,6 @@ div.appendix .warning > .title,
 div.appendix .caution > .title,
 div.appendix .important > .title {
     font-weight: 800;
-    /* font-family: 'Overpass', serif; */
     line-height: 110%;
     margin-bottom: 1rem;
     color: inherit;
@@ -329,16 +328,16 @@ div.book .note,
 div.book .tip,
 div.appendix .note,
 div.appendix .tip {
-    color: #5277c3;
-    background: #f2f8fd;
+    color: var(--note-text-color);
+    background: var(--note-background);
 }
 
 div.book .warning,
 div.book .caution,
 div.appendix .warning,
 div.appendix .caution {
-    color: #cc3900;
-    background-color: #fff5e1;
+    color: var(--warning-text-color);
+    background-color: var(--warning-background);
 }
 
 div.book .section,
@@ -447,4 +446,43 @@ div.appendix .variablelist .term {
 .hljs-meta.prompt_ {
     user-select: none;
     -webkit-user-select: none;
+}
+
+:root {
+    --background: #fff;
+    --main-text-color: #000;
+    --link-color: #405d99;
+    --heading-color: #6586c8;
+    --small-heading-color: #6a6a6a;
+    --note-text-color: #5277c3;
+    --note-background: #f2f8fd;
+    --warning-text-color: #cc3900;
+    --warning-background: #fff5e1;
+    --codeblock-background: #f2f8fd;
+    --codeblock-text-color: #000;
+}
+
+@media (prefers-color-scheme: dark) {
+    :root {
+        --background: #242424;
+        --main-text-color: #fff;
+        --link-color: #6586c8;
+        --small-heading-color: #fff;
+        --note-background: none;
+        --warning-background: none;
+        --codeblock-background: #393939;
+        --codeblock-text-color: #fff;
+    }
+
+    div.book .note,
+    div.book .tip,
+    div.appendix .note,
+    div.appendix .tip,
+    div.book .warning,
+    div.book .caution,
+    div.appendix .warning,
+    div.appendix .caution {
+        border: 2px solid;
+        font-weight: 400;
+    }
 }

--- a/doc/style.css
+++ b/doc/style.css
@@ -7,25 +7,29 @@ body {
     margin: 0;
 }
 
-.book {
+.book,
+.appendix {
     margin: auto;
     width: 100%;
 }
 
 @media screen and (min-width: 768px) {
-    .book {
+    .book,
+    .appendix {
         max-width: 46rem;
     }
 }
 
 @media screen and (min-width: 992px) {
-    .book {
+    .book,
+    .appendix {
         max-width: 60rem;
     }
 }
 
 @media screen and (min-width: 1200px) {
-    .book {
+    .book,
+    .appendix {
         max-width: 73rem;
     }
 }

--- a/nixos/doc/manual/default.nix
+++ b/nixos/doc/manual/default.nix
@@ -160,6 +160,8 @@ rec {
           ./manual.md \
           $dst/${common.indexPath}
 
+        cp ${pkgs.roboto.src}/web/Roboto\[ital\,wdth\,wght\].ttf "$dst/Roboto.ttf"
+
         mkdir -p $out/nix-support
         echo "nix-build out $out" >> $out/nix-support/hydra-build-products
         echo "doc manual $dst" >> $out/nix-support/hydra-build-products

--- a/pkgs/misc/documentation-highlighter/mono-blue.css
+++ b/pkgs/misc/documentation-highlighter/mono-blue.css
@@ -23,7 +23,7 @@ code.hljs {
     font-weight: bold;
 }
 .hljs-comment {
-    color: #738191;
+    color: var(--color-1);
 }
 .hljs-string,
 .hljs-title,
@@ -37,7 +37,7 @@ code.hljs {
 .hljs-name,
 .hljs-selector-id,
 .hljs-selector-class {
-    color: #0048ab;
+    color: var(--color-2);
 }
 .hljs-meta,
 .hljs-subst,
@@ -49,8 +49,22 @@ code.hljs {
 .hljs-template-variable,
 .hljs-link,
 .hljs-bullet {
-    color: #4c81c9;
+    color: var(--color-3);
 }
 .hljs-emphasis {
     font-style: italic;
+}
+
+:root {
+    --color-1: #738191;
+    --color-2: #0048ab;
+    --color-3: #4c81c9;
+}
+
+@media (prefers-color-scheme: dark) {
+    :root {
+        --color-1: #8b9caf;
+        --color-2: #3b85e7;
+        --color-3: #5795e7;
+    }
 }

--- a/pkgs/misc/documentation-highlighter/mono-blue.css
+++ b/pkgs/misc/documentation-highlighter/mono-blue.css
@@ -1,17 +1,17 @@
 pre code.hljs {
-  display: block;
-  overflow-x: auto;
-  padding: 1em
+    display: block;
+    overflow-x: auto;
+    padding: 1em;
 }
 code.hljs {
-  padding: 3px 5px
+    padding: 3px 5px;
 }
 /*
   Five-color theme from a single blue hue.
 */
 .hljs {
-  background: #eaeef3;
-  color: #00193a
+    background: #eaeef3;
+    color: #00193a;
 }
 .hljs-keyword,
 .hljs-selector-tag,
@@ -20,10 +20,10 @@ code.hljs {
 .hljs-doctag,
 .hljs-name,
 .hljs-strong {
-  font-weight: bold
+    font-weight: bold;
 }
 .hljs-comment {
-  color: #738191
+    color: #738191;
 }
 .hljs-string,
 .hljs-title,
@@ -37,7 +37,7 @@ code.hljs {
 .hljs-name,
 .hljs-selector-id,
 .hljs-selector-class {
-  color: #0048ab
+    color: #0048ab;
 }
 .hljs-meta,
 .hljs-subst,
@@ -49,8 +49,8 @@ code.hljs {
 .hljs-template-variable,
 .hljs-link,
 .hljs-bullet {
-  color: #4c81c9
+    color: #4c81c9;
 }
 .hljs-emphasis {
-  font-style: italic
+    font-style: italic;
 }


### PR DESCRIPTION
This adds dark mode to the HTML manuals and also centers the appendix sections. The dark background is based on search.nixos.org

The dark mode is currently not quite ready, as `pkgs/misc/documentation-highlighter/mono-blue.css` will need to be changed as well as code blocks have bad contrast. If you have any ideas on how to change the higlighting colours for dark mode, please share.

Also, the "Note" and "Warning" sections don't have very good contrast either, I'm looking for suggestions for those too. (hopefully without making them look too different from their original light mode design)

@NixOS/documentation-team 
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
