### PR TITLE
Updating scipoptsuite 9.2.1 -> 9.2.2 (except `scipopt-gcg`)

### DIFF
--- a/pkgs/by-name/sc/scipopt-papilo/package.nix
+++ b/pkgs/by-name/sc/scipopt-papilo/package.nix
@@ -12,16 +12,16 @@
 
 stdenv.mkDerivation rec {
   pname = "scipopt-papilo";
-  version = "2.4.1";
+  version = "2.4.2";
 
   # To correlate scipVersion and version, check: https://scipopt.org/#news
-  scipVersion = "9.2.1";
+  scipVersion = "9.2.2";
 
   src = fetchFromGitHub {
     owner = "scipopt";
     repo = "papilo";
     tag = "v${version}";
-    hash = "sha256-oQ9iq5UkFK0ghUx6uxdJIOo5niQjniHegSZptqi2fgE=";
+    hash = "sha256-/1AsAesUh/5YXeCU2OYopoG3SXAwAecPD88QvGkb2bY=";
   };
 
   nativeBuildInputs = [ cmake ];
@@ -42,10 +42,6 @@ stdenv.mkDerivation rec {
     #   > include/boost/multiprecision/mpfr.hpp:22: fatal error: mpfr.h: No such file or directory
     #   > compilation terminated.
     (lib.cmakeBool "SOPLEX" false)
-
-    # (lib.cmakeBool "GMP" true)
-    # (lib.cmakeBool "QUADMATH" true)
-    # (lib.cmakeBool "TBB" true)
   ];
   doCheck = true;
   meta = {

--- a/pkgs/by-name/sc/scipopt-scip/package.nix
+++ b/pkgs/by-name/sc/scipopt-scip/package.nix
@@ -20,13 +20,13 @@
 
 stdenv.mkDerivation rec {
   pname = "scipopt-scip";
-  version = "9.2.1";
+  version = "9.2.2";
 
   src = fetchFromGitHub {
     owner = "scipopt";
     repo = "scip";
     tag = "v${lib.replaceStrings [ "." ] [ "" ] version}";
-    hash = "sha256-xYxbMZYYqFNInlct8Ju0SrksfJlwV9Q+AHjxq7xhfAs=";
+    hash = "sha256-gxR308XrlmuUym/ujwGcD9a7Z+Z7vQNHaK4zO/PWPBQ=";
   };
 
   nativeBuildInputs = [ cmake ];

--- a/pkgs/by-name/sc/scipopt-soplex/package.nix
+++ b/pkgs/by-name/sc/scipopt-soplex/package.nix
@@ -11,16 +11,16 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "scipopt-soplex";
-  version = "713";
+  version = "714";
 
   # To correlate scipVersion and version, check: https://scipopt.org/#news
-  scipVersion = "9.2.1";
+  scipVersion = "9.2.2";
 
   src = fetchFromGitHub {
     owner = "scipopt";
     repo = "soplex";
     rev = "release-${builtins.replaceStrings [ "." ] [ "" ] finalAttrs.version}";
-    hash = "sha256-qI7VGPAm3ALzeiD/OgvlZ1w2GzHRYdBajTW5XdIN9pU=";
+    hash = "sha256-j5dsCAjEaReVpHHCM8FUyDIhxZ4P2yk2h89k5omTh8o=";
   };
 
   nativeBuildInputs = [ cmake ];

--- a/pkgs/by-name/sc/scipopt-ug/package.nix
+++ b/pkgs/by-name/sc/scipopt-ug/package.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
   version = "1.0.0-beta6";
 
   # To correlate scipVersion and version, check: https://scipopt.org/#news
-  scipVersion = "9.2.1";
+  scipVersion = "9.2.2";
 
   # Take the SCIPOptSuite source since no other source exists publicly.
   src = fetchzip {

--- a/pkgs/by-name/sc/scipopt-zimpl/package.nix
+++ b/pkgs/by-name/sc/scipopt-zimpl/package.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
   version = "362";
 
   # To correlate scipVersion and version, check: https://scipopt.org/#news
-  scipVersion = "9.2.1";
+  scipVersion = "9.2.2";
 
   src = fetchFromGitHub {
     owner = "scipopt";


### PR DESCRIPTION
Closes #399887
Closes #399124
Closes #399130

## Things done

Updated five packages to fit the new version of the SCIP Optimization Suite (9.2.2).

`scipopt-gcg` has no updated release tag on GitHub yet, so it is not touched.

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
