### PR TITLE
errbot: add hlad as maintainer

### DIFF
--- a/pkgs/by-name/er/errbot/package.nix
+++ b/pkgs/by-name/er/errbot/package.nix
@@ -58,13 +58,13 @@ python3.pkgs.buildPythonApplication rec {
 
   pythonImportsCheck = [ "errbot" ];
 
-  meta = with lib; {
+  meta = {
     changelog = "https://github.com/errbotio/errbot/blob/${version}/CHANGES.rst";
     description = "Chatbot designed to be simple to extend with plugins written in Python";
     homepage = "http://errbot.io/";
-    maintainers = [ ];
-    license = licenses.gpl3Plus;
-    platforms = platforms.linux;
+    maintainers = with lib.maintainers; [ hlad ];
+    license = lib.licenses.gpl3Plus;
+    platforms = lib.platforms.linux;
     # flaky on darwin, "RuntimeError: can't start new thread"
     mainProgram = "errbot";
   };


### PR DESCRIPTION
there is no maintainer at the moment

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
