### PR TITLE
python313Packages.tlslite-ng: 0.8.0b1-unstable-2024-06-24 -> 0.8.2

### DIFF
--- a/pkgs/development/python-modules/tlslite-ng/default.nix
+++ b/pkgs/development/python-modules/tlslite-ng/default.nix
@@ -1,24 +1,24 @@
 {
   lib,
   buildPythonPackage,
-  fetchFromGitHub,
-  setuptools,
   ecdsa,
+  fetchFromGitHub,
   hypothesis,
-  pythonAtLeast,
   pytestCheckHook,
+  pythonAtLeast,
+  setuptools,
 }:
 
-buildPythonPackage {
+buildPythonPackage rec {
   pname = "tlslite-ng";
-  version = "0.8.0b1-unstable-2024-06-24";
+  version = "0.8.2";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "tlsfuzzer";
     repo = "tlslite-ng";
-    rev = "4d2c6b8fc8d14bb5c90c8360bdb6f617e8e38591";
-    hash = "sha256-VCQjxZIs4rzlFrIakXI7YeLz7Ws9WRf8zGPcSryO9Ko=";
+    tag = "v${version}";
+    hash = "sha256-lKSFPJ4Dm8o1zUgvXjUUpStV5M+xf7s6wOg2ceYbpbw=";
   };
 
   build-system = [ setuptools ];
@@ -36,9 +36,9 @@ buildPythonPackage {
   ];
 
   meta = with lib; {
-    changelog = "https://github.com/tlsfuzzer/tlslite-ng/releases/tag/v${version}";
-    description = "Pure python implementation of SSL and TLS";
+    description = "Implementation of SSL and TLS";
     homepage = "https://github.com/tlsfuzzer/tlslite-ng";
+    changelog = "https://github.com/tlsfuzzer/tlslite-ng/releases/tag/${src.tag}";
     license = licenses.lgpl21Only;
     maintainers = [ ];
   };


### PR DESCRIPTION
Changelog: https://github.com/tlsfuzzer/tlslite-ng/releases/tag/v0.8.2


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
