### PR TITLE
x2gokdriveclient: init at 0.0.0.1-unstable-2025-09-10

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -12397,6 +12397,12 @@
     githubId = 62934740;
     keys = [ { fingerprint = "E9C6 44C7 F6AA A865 4CB9  2723 22C8 B0CE B9AC 4AFF"; } ];
   };
+  juliabru = {
+    name = "Julia Brunenberg";
+    email = "julia@jjim.de";
+    github = "juliadin";
+    githubId = 7837969;
+  };
   JulianFP = {
     name = "Julian Partanen";
     github = "JulianFP";

--- a/pkgs/applications/networking/remote/x2gokdriveclient/default.nix
+++ b/pkgs/applications/networking/remote/x2gokdriveclient/default.nix
@@ -1,0 +1,78 @@
+{
+  stdenv,
+  lib,
+  fetchgit,
+  qt5,
+  qtbase,
+  qtx11extras,
+  qttools,
+  zlib,
+  gnumake,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "x2gokdriveclient";
+  version = "0.0.0.1-unstable-2024-09-10";
+
+  src = fetchgit {
+    #url = "https://code.x2go.org/git/x2gokdriveclient.git";
+
+    # in reference to https://github.com/NixOS/nixpkgs/tree/master/pkgs#sources
+    # I am aware that this is bad practice. The HTTPS url above responds with a 500 and is hopelessly
+    # overloaded. the X2Go project doesn't seem to maintain a good and healthy code repository on github
+    # either.
+    url = "git://code.x2go.org/x2gokdriveclient.git";
+    rev = "ed53784a236ef4fe00adce726be492c4bf227d73";
+    hash = "sha256-hWPM0bye4I34T7y2ipZOULY2+ehVanmTj4V80+lc+iw=";
+  };
+
+  buildInputs = [
+    qtbase
+    qtx11extras
+    qttools
+    zlib
+  ];
+
+  nativeBuildInputs = [
+    qt5.wrapQtAppsHook
+  ];
+
+  postPatch = ''
+    substituteInPlace Makefile \
+      --replace-fail "SHELL=/bin/bash" "SHELL=$SHELL" \
+      --replace-fail "MAKEOVERRIDES" "NOMAKEOVERRIDES " \
+      --replace-fail ".MAKEFLAGS" ".NOFLAGS " \
+      --replace-fail "qmake" "${qtbase.dev}/bin/qmake" \
+      --replace-fail "-o root -g root" ""
+    substituteInPlace \
+      VERSION.x2gokdriveclient \
+      x2gokdriveclient.spec \
+      man/man1/x2gokdriveclient.1 \
+      --replace-fail "0.0.0.2" "${finalAttrs.version}"
+  '';
+
+  makeFlags = [
+    "PREFIX=$(out)"
+    "ETCDIR=$(out)/etc"
+    "build_client"
+    "build_man"
+  ];
+
+  installTargets = [
+    "install_client"
+    "install_man"
+  ];
+
+  qtWrapperArgs = [
+    "--set QT_QPA_PLATFORM xcb"
+  ];
+
+  meta = with lib; {
+    description = "Graphical NoMachine NX3 remote desktop client (KDrive client)";
+    mainProgram = "x2gokdriveclient";
+    homepage = "https://x2go.org/";
+    maintainers = with maintainers; [ juliabru ];
+    license = licenses.gpl3;
+    platforms = platforms.linux;
+  };
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14556,6 +14556,8 @@ with pkgs;
 
   x2goclient = libsForQt5.callPackage ../applications/networking/remote/x2goclient { };
 
+  x2gokdriveclient = libsForQt5.callPackage ../applications/networking/remote/x2gokdriveclient { };
+
   x32edit = callPackage ../applications/audio/midas/x32edit.nix { };
 
   xbindkeys-config = callPackage ../tools/X11/xbindkeys-config {


### PR DESCRIPTION
X2Go KDrive Client is currently not available. It is the client component of X2Go KDrive as described here: [wiki:advanced:x2gokdrive:start](https://wiki.x2go.org/doku.php/wiki:advanced:x2gokdrive:start)

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [X] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
