### PR TITLE
opencamlib: init at 2023.01.11, and use in freecad

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -24640,6 +24640,12 @@
     githubId = 13155277;
     name = "Tom Houle";
   };
+  tomjnixon = {
+    name = "Tom Nixon";
+    email = "nixpkgs@tomn.co.uk";
+    github = "tomjnixon";
+    githubId = 178226;
+  };
   tomkoid = {
     email = "tomaszierl@outlook.com";
     name = "Tomkoid";

--- a/pkgs/by-name/fr/freecad/package.nix
+++ b/pkgs/by-name/fr/freecad/package.nix
@@ -44,6 +44,7 @@ let
     gitpython
     ifcopenshell
     matplotlib
+    opencamlib
     pivy
     ply
     py-slvs
@@ -104,6 +105,7 @@ freecad-utils.makeCustomizable (
         medfile
         mpi
         ode
+        opencamlib
         pivy
         ply # for openSCAD file support
         py-slvs

--- a/pkgs/development/python-modules/opencamlib/default.nix
+++ b/pkgs/development/python-modules/opencamlib/default.nix
@@ -1,0 +1,67 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  scikit-build-core,
+  cmake,
+  ninja,
+  stdenv,
+  llvmPackages,
+  boost,
+  python,
+}:
+
+buildPythonPackage rec {
+  pname = "opencamlib";
+  version = "2023.01.11";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "aewallin";
+    repo = "opencamlib";
+    tag = version;
+    hash = "sha256-pUj71PdWo902dqF9O6SLnpvFooFU2OfLBv8hAVsH/iA=";
+  };
+
+  build-system = [
+    scikit-build-core
+  ];
+
+  buildInputs = [
+    boost
+  ] ++ lib.optionals stdenv.cc.isClang [ llvmPackages.openmp ];
+
+  nativeBuildInputs = [
+    cmake
+    ninja
+  ];
+
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail 'version = "2022.12.18"' 'version = "${version}"'
+  '';
+
+  dontUseCmakeConfigure = true;
+  env.CMAKE_ARGS = "-DVERSION_STRING=${version} -DBoost_USE_STATIC_LIBS=OFF";
+
+  pythonImportsCheck = [ "opencamlib" ];
+
+  checkPhase = ''
+    runHook preCheck
+
+    pushd examples/python
+    # this produces a lot of non-actionalble lines on stdout
+    ${python.interpreter} test.py > /dev/null
+    popd
+
+    runHook postCheck
+  '';
+
+  meta = {
+    homepage = "https://github.com/aewallin/opencamlib";
+    description = "Open source computer aided manufacturing algorithms library";
+    # from src/deb/debian_copyright.txt
+    license = lib.licenses.lgpl21Plus;
+    maintainers = with lib.maintainers; [ tomjnixon ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10243,6 +10243,8 @@ self: super: with self; {
     openbabel = callPackage ../development/libraries/openbabel { inherit (self) python; };
   };
 
+  opencamlib = callPackage ../development/python-modules/opencamlib { };
+
   opencensus = callPackage ../development/python-modules/opencensus { };
 
   opencensus-context = callPackage ../development/python-modules/opencensus-context { };


### PR DESCRIPTION
[opencamlib](https://github.com/aewallin/opencamlib) is an open-source library of CAM (computer aided manufacturing) algorithms. It can be optionally used by FreeCAD to enable some advanced CAM features.

It is included in the FreeCAD appimage releases, is only imported [when explicitly enabled](https://wiki.freecad.org/CAM_experimental), and is quick to build, so this should be a low-impact change.

The only really weird bit about this is the version number:

- Conda releases say they are version `2023.01.11`, in the conda metadata, but contain `opencamlib-2022.12.18.dist-info` (from an outdated version number in pyproject.toml).
- pypi releases say they are version `2023.1.11`, but also contain `opencamlib-2022.12.18.dist-info`.

I chose to align the nixpkgs and python package version numbers with the git tag, which is `2023.01.11`. Unfortunately this is normalised by python to `2023.1.11`, which really shouldn't matter, but is annoying.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage) (checked on `x86_64-linux`, build  tested on `aarch64-linux`)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
