### PR TITLE
kimai, nixos/kimai: 2.31.0 -> 2.32.0, fix upgrading by clearing cache earlier

### DIFF
--- a/nixos/modules/services/web-apps/kimai.nix
+++ b/nixos/modules/services/web-apps/kimai.nix
@@ -324,12 +324,14 @@ in
                 ${pkg hostName cfg}/bin/console lint:yaml --parse-tags \
                   ${pkg hostName cfg}/share/php/kimai/config
 
-                # Run kimai:install to ensure database is created or updated.
+                # Before running any further console commands, clear cache. This
+                # avoids errors due to old cache getting used with new version
+                # of Kimai.
+                ${pkg hostName cfg}/bin/console cache:clear --env=prod
+                # Then, run kimai:install to ensure database is created or updated.
                 # Note that kimai:update is an alias to kimai:install.
                 ${pkg hostName cfg}/bin/console kimai:install --no-cache
-                # Clear cache and warmup cache separately, to avoid "Cannot declare
-                # class App\Entity\Timesheet" error on first init after upgrade.
-                ${pkg hostName cfg}/bin/console cache:clear --env=prod
+                # Finally, warm up cache.
                 ${pkg hostName cfg}/bin/console cache:warmup --env=prod
               '';
 

--- a/pkgs/by-name/ki/kimai/package.nix
+++ b/pkgs/by-name/ki/kimai/package.nix
@@ -7,13 +7,13 @@
 
 php.buildComposerProject2 (finalAttrs: {
   pname = "kimai";
-  version = "2.31.0";
+  version = "2.33.0";
 
   src = fetchFromGitHub {
     owner = "kimai";
     repo = "kimai";
     tag = finalAttrs.version;
-    hash = "sha256-aVRqek8nMgos1V247ZmJenVFfAmqEpNGtYWScWHD/gg=";
+    hash = "sha256-YkACx0xl+6yN8pgH56WPdEoNAZxAxHIPLay28V1S5WQ=";
   };
 
   php = php.buildEnv {
@@ -38,7 +38,7 @@ php.buildComposerProject2 (finalAttrs: {
     '';
   };
 
-  vendorHash = "sha256-uPIP3g8oJb+JnW/WnAdW/ZSLAQwyXI9X006rrA7pnKI=";
+  vendorHash = "sha256-smDAz4RnVEgPcGjsQmN0NC8kWgLw78YFuef9gbajAeQ=";
 
   composerNoPlugins = false;
   composerNoScripts = false;


### PR DESCRIPTION
This PR supersedes auto-upgrade PR [^1].

Changelog available at:
- https://github.com/kimai/kimai/releases/tag/2.32.0
- https://github.com/kimai/kimai/releases/tag/2.33.0

During testing, it's been found that fixes done in PR 371917 [^2] is not enough to prevent error in the case of upgrading from 2.31 to 2.32.

Hinted by an upstream issue [^3], make sure that the cache is cleared
before running `kimai:install`, not after. This fixes upgrading from
2.31 to 2.32, and should prevent similar issue from popping up again.

[^1]: https://github.com/NixOS/nixpkgs/pull/396666
[^2]: https://github.com/NixOS/nixpkgs/pull/371917
[^3]: https://github.com/kimai/kimai/issues/5437

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
