### PR TITLE
webcord: add darwin building to package

### DIFF
--- a/pkgs/by-name/we/webcord/package.nix
+++ b/pkgs/by-name/we/webcord/package.nix
@@ -7,89 +7,185 @@
   xdg-utils,
   electron,
   makeDesktopItem,
+  stdenv,
+  zip,
 }:
+let
+  base = rec {
+    pname = "webcord";
+    version = "4.10.4";
 
-buildNpmPackage rec {
-  pname = "webcord";
-  version = "4.10.4";
+    src = fetchFromGitHub {
+      owner = "SpacingBat3";
+      repo = "WebCord";
+      tag = "v${version}";
+      hash = "sha256-rBOQutAPmNiw9bJ3nYSddbAwSqYHAlSNHpkMvxzmUnA=";
+    };
 
-  src = fetchFromGitHub {
-    owner = "SpacingBat3";
-    repo = "WebCord";
-    tag = "v${version}";
-    hash = "sha256-rBOQutAPmNiw9bJ3nYSddbAwSqYHAlSNHpkMvxzmUnA=";
-  };
+    npmDepsHash = "sha256-CjXEwFRGVjJv+kuyq9IZHdiYKJ6lbSDZnIxBer3qnOI=";
 
-  npmDepsHash = "sha256-CjXEwFRGVjJv+kuyq9IZHdiYKJ6lbSDZnIxBer3qnOI=";
+    makeCacheWritable = true;
 
-  makeCacheWritable = true;
+    nativeBuildInputs = [
+      copyDesktopItems
+      python3
+      zip
+    ];
 
-  nativeBuildInputs = [
-    copyDesktopItems
-    python3
-  ];
+    env = {
+      # npm install will error when electron tries to download its binary
+      # we don't need it anyways since we wrap the program with our nixpkgs electron
+      ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
 
-  # npm install will error when electron tries to download its binary
-  # we don't need it anyways since we wrap the program with our nixpkgs electron
-  env.ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
+      # Build Flags in Electron Forge for WebCord
+      # DOCS: https://github.com/SpacingBat3/WebCord/blob/master/docs/Flags.md
+      WEBCORD_BUILD = "release"; # WebCord is usually built in release mode
+      WEBCORD_ASAR = "true"; # default is true for WebCord
+      WEBCORD_UPDATE_NOTIFICATIONS = "false"; # Disable update notifications
+    };
 
-  # remove husky commit hooks, errors and aren't needed for packaging
-  postPatch = ''
-    rm -rf .husky
-  '';
-
-  # override installPhase so we can copy the only folders that matter
-  installPhase =
-    let
-      binPath = lib.makeBinPath [ xdg-utils ];
-    in
-    ''
-      runHook preInstall
-
-      # Remove dev deps that aren't necessary for running the app
-      npm prune --omit=dev
-
-      mkdir -p $out/lib/node_modules/webcord
-      cp -r app node_modules sources package.json $out/lib/node_modules/webcord/
-
-      install -Dm644 sources/assets/icons/app.png $out/share/icons/hicolor/256x256/apps/webcord.png
-
-      # Add xdg-utils to path via suffix, per PR #181171
-      makeWrapper '${lib.getExe electron}' $out/bin/webcord \
-        --suffix PATH : "${binPath}" \
-        --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true}}" \
-        --add-flags $out/lib/node_modules/webcord/
-
-      runHook postInstall
+    # remove husky commit hooks, errors and aren't needed for packaging
+    postPatch = ''
+      rm -rf .husky
     '';
 
-  desktopItems = [
-    (makeDesktopItem {
-      name = "webcord";
-      exec = "webcord";
-      icon = "webcord";
-      desktopName = "WebCord";
-      comment = meta.description;
-      categories = [
-        "Network"
-        "InstantMessaging"
+    passthru.updateScript = ./update.sh;
+
+    meta = {
+      description = "A Discord and SpaceBar electron-based client implemented without Discord API";
+      homepage = "https://github.com/SpacingBat3/WebCord";
+      downloadPage = "https://github.com/SpacingBat3/WebCord/releases";
+      changelog = "https://github.com/SpacingBat3/WebCord/releases/tag/v${version}";
+      license = lib.licenses.mit;
+      mainProgram = "webcord";
+      maintainers = with lib.maintainers; [
+        huantian
+        NotAShelf
       ];
-    })
-  ];
-
-  passthru.updateScript = ./update.sh;
-
-  meta = {
-    description = "A Discord and SpaceBar electron-based client implemented without Discord API";
-    homepage = "https://github.com/SpacingBat3/WebCord";
-    downloadPage = "https://github.com/SpacingBat3/WebCord/releases";
-    changelog = "https://github.com/SpacingBat3/WebCord/releases/tag/v${version}";
-    license = lib.licenses.mit;
-    mainProgram = "webcord";
-    maintainers = with lib.maintainers; [
-      huantian
-      NotAShelf
-    ];
-    platforms = lib.platforms.linux;
+      platforms = lib.platforms.linux ++ lib.platforms.darwin;
+    };
   };
-}
+
+  linuxArgs =
+    let
+      inherit (base) meta;
+    in
+    {
+      # override installPhase so we can copy the only folders that matter
+      installPhase =
+        let
+          binPath = lib.makeBinPath [ xdg-utils ];
+        in
+        ''
+          runHook preInstall
+
+          # Remove dev deps that aren't necessary for running the app
+          npm prune --omit=dev --no-save
+
+          # Copy files to the output directory
+          mkdir -p $out/lib/node_modules/webcord
+          cp -r app node_modules sources package.json $out/lib/node_modules/webcord/
+
+          # Install the app icon
+          install -Dm644 sources/assets/icons/app.png $out/share/icons/hicolor/256x256/apps/webcord.png
+
+          # Add xdg-utils to path via suffix, per PR #181171
+          makeWrapper '${lib.getExe electron}' $out/bin/webcord \
+            --suffix PATH : "${binPath}" \
+            --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true}}" \
+            --add-flags $out/lib/node_modules/webcord/
+
+          runHook postInstall
+        '';
+
+      desktopItems = lib.optionals stdenv.isLinux [
+        (makeDesktopItem {
+          name = "webcord";
+          exec = "webcord";
+          icon = "webcord";
+          desktopName = "WebCord";
+          comment = meta.description;
+          categories = [
+            "Network"
+            "InstantMessaging"
+          ];
+        })
+      ];
+    };
+
+  darwinArgs =
+    let
+      inherit (base) version;
+
+      platform = "darwin";
+      arch = if stdenv.isAarch64 then "arm64" else "x64";
+
+      electronZipPath = "nix-electron-zip";
+      electronNewFolderName = "electron-v${electron.version}-darwin-arm64";
+      electronZipFile = "${electronNewFolderName}.zip";
+      electronVersion = electron.version;
+    in
+    {
+      preBuild = ''
+        # Set build flags
+        # DOCS: https://github.com/SpacingBat3/WebCord/blob/master/docs/Flags.md
+        cat > buildInfo.json <<EOF
+        {
+          "type": "release",
+          "features": { "updateNotifications": false }
+        }
+        EOF
+
+        # zip electron for use by electron-packager
+        mkdir -p nix-electron-zip
+        cp -r ${electron}/Applications ${electronZipPath}/${electronNewFolderName}
+        chmod -R 755 ${electronZipPath}/${electronNewFolderName}
+        cd ${electronZipPath}/${electronNewFolderName}
+        zip -r ../${electronZipFile} Electron.app
+        cd ../..
+        rm -rf ${electronZipPath}/${electronNewFolderName}
+      '';
+
+      # override the buildPhase for darwin
+      buildPhase = ''
+        runHook preBuild
+
+        # compile TS to JS
+        npx tsc
+
+        # package for macOS for arm64 and x64
+        npx electron-packager . WebCord \
+          --platform=${platform} \
+          --arch=${arch} \
+          --out=$out \
+          --overwrite \
+          --app-bundle-id=com.electron.webcord \
+          --app-version=${version} \
+          --asar \
+          --electron-version=${electronVersion} \
+          --electron-zip-dir=${electronZipPath} \
+          --icon=sources/assets/icons/app.icns
+
+        runHook postBuild
+      '';
+
+      # clean up the build directory
+      postBuild = ''
+        # Remove the zip file
+        rm -rf ${electronZipPath}
+      '';
+
+      installPhase = ''
+        runHook preInstall
+
+        # Remove dev deps that aren't necessary for running the app
+        npm prune --omit=dev --no-save
+
+        # Rename the output folder to the standard name
+        mv $out/WebCord-${platform}-${arch}/ $out/Applications/
+
+        runHook postInstall;
+      '';
+    };
+in
+buildNpmPackage (if stdenv.isLinux then base // linuxArgs else base // darwinArgs)


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

I added darwin capabilities to the WebCord package. I also added build flags from the documentation. I made sure to not change as much of the Linux building of this package. However, it could be possible to build the package in a similar way to the darwin build process but it is not entirely necessary.

Also, there could be a better way to build the package on darwin, but this is the best way that I could come up.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
