### PR TITLE
treewide: move extra-cmake-modules to nativeBuildInputs

### DIFF
--- a/pkgs/applications/video/natron/default.nix
+++ b/pkgs/applications/video/natron/default.nix
@@ -60,6 +60,7 @@ stdenv.mkDerivation {
 
   nativeBuildInputs = [
     cmake
+    extra-cmake-modules
     pkg-config
     wrapQtAppsHook
   ];
@@ -71,7 +72,6 @@ stdenv.mkDerivation {
     python3
     python3.pkgs.pyside2
     python3.pkgs.shiboken2
-    extra-cmake-modules
     wayland
     glog
     ceres-solver

--- a/pkgs/by-name/du/duckstation/package.nix
+++ b/pkgs/by-name/du/duckstation/package.nix
@@ -46,6 +46,7 @@ llvmPackages.stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [
     cmake
+    extra-cmake-modules
     ninja
     pkg-config
     qttools
@@ -57,7 +58,6 @@ llvmPackages.stdenv.mkDerivation (finalAttrs: {
     SDL2
     cpuinfo
     curl
-    extra-cmake-modules
     libXrandr
     libbacktrace
     libwebp

--- a/pkgs/by-name/fc/fcitx5-mcbopomofo/package.nix
+++ b/pkgs/by-name/fc/fcitx5-mcbopomofo/package.nix
@@ -31,7 +31,6 @@ stdenv.mkDerivation rec {
   ];
 
   buildInputs = [
-    extra-cmake-modules
     fcitx5
     fmt
     gtest

--- a/pkgs/by-name/li/licensedigger/package.nix
+++ b/pkgs/by-name/li/licensedigger/package.nix
@@ -3,7 +3,7 @@
   fetchFromGitLab,
   stdenv,
   cmake,
-  kdePackages,
+  extra-cmake-modules,
   libsForQt5,
 }:
 stdenv.mkDerivation {
@@ -18,10 +18,12 @@ stdenv.mkDerivation {
     hash = "sha256-/ZEja+iDx0lVkJaLshPd1tZD4ZUspVeFHY1TNXjr4qg=";
   };
 
-  nativeBuildInputs = [ cmake ];
+  nativeBuildInputs = [
+    cmake
+    extra-cmake-modules
+  ];
 
   buildInputs = [
-    kdePackages.extra-cmake-modules
     libsForQt5.qtbase
   ];
 

--- a/pkgs/by-name/me/melonDS/package.nix
+++ b/pkgs/by-name/me/melonDS/package.nix
@@ -38,6 +38,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [
     cmake
+    extra-cmake-modules
     pkg-config
     wrapQtAppsHook
   ];
@@ -46,7 +47,6 @@ stdenv.mkDerivation (finalAttrs: {
     [
       SDL2
       enet
-      extra-cmake-modules
       libarchive
       libslirp
       libGL

--- a/pkgs/by-name/mk/mkcal/package.nix
+++ b/pkgs/by-name/mk/mkcal/package.nix
@@ -44,6 +44,7 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs =
     [
       cmake
+      extra-cmake-modules
       doxygen
       graphviz
       perl
@@ -53,16 +54,12 @@ stdenv.mkDerivation (finalAttrs: {
       wrapQtAppsHook
     ]);
 
-  buildInputs =
-    [
-      extra-cmake-modules
-    ]
-    ++ (with libsForQt5; [
-      kcalendarcore
-      qtbase
-      qtpim
-      timed
-    ]);
+  buildInputs = with libsForQt5; [
+    kcalendarcore
+    qtbase
+    qtpim
+    timed
+  ];
 
   nativeCheckInputs = [
     tzdata

--- a/pkgs/by-name/on/one-click-backup/package.nix
+++ b/pkgs/by-name/on/one-click-backup/package.nix
@@ -21,13 +21,13 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [
     cmake
+    extra-cmake-modules
     ninja
     qt6.wrapQtAppsHook
   ];
 
   buildInputs = [
     qt6.qtdeclarative
-    extra-cmake-modules
   ];
 
   meta = with lib; {

--- a/pkgs/by-name/pc/pcsx2/package.nix
+++ b/pkgs/by-name/pc/pcsx2/package.nix
@@ -54,6 +54,7 @@ llvmPackages.stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [
     cmake
+    extra-cmake-modules
     pkg-config
     strip-nondeterminism
     wrapQtAppsHook
@@ -62,7 +63,6 @@ llvmPackages.stdenv.mkDerivation (finalAttrs: {
 
   buildInputs = [
     curl
-    extra-cmake-modules
     ffmpeg
     libaio
     libbacktrace

--- a/pkgs/by-name/pr/previewqt/package.nix
+++ b/pkgs/by-name/pr/previewqt/package.nix
@@ -29,6 +29,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [
     cmake
+    extra-cmake-modules
     pkg-config
     qt6Packages.wrapQtAppsHook
   ];
@@ -36,7 +37,6 @@ stdenv.mkDerivation (finalAttrs: {
   buildInputs =
     [
       exiv2
-      extra-cmake-modules
       imagemagick
       libarchive
       libdevil

--- a/pkgs/by-name/qt/qtorganizer-mkcal/package.nix
+++ b/pkgs/by-name/qt/qtorganizer-mkcal/package.nix
@@ -31,12 +31,12 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [
     cmake
+    extra-cmake-modules
     pkg-config
   ];
 
   buildInputs =
     [
-      extra-cmake-modules
       mkcal
     ]
     ++ (with libsForQt5; [

--- a/pkgs/by-name/wl/wlay/package.nix
+++ b/pkgs/by-name/wl/wlay/package.nix
@@ -30,12 +30,12 @@ stdenv.mkDerivation {
 
   nativeBuildInputs = [
     cmake
+    extra-cmake-modules
     pkg-config
     wayland-scanner
   ];
 
   buildInputs = [
-    extra-cmake-modules
     glfw3
     libX11
     libXau

--- a/pkgs/by-name/xc/xcb-imdkit/package.nix
+++ b/pkgs/by-name/xc/xcb-imdkit/package.nix
@@ -25,12 +25,12 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [
     cmake
+    extra-cmake-modules
     xorgproto
     uthash
   ];
 
   buildInputs = [
-    extra-cmake-modules
     xcbutil
     xcbutilkeysyms
   ];

--- a/pkgs/development/libraries/kf5gpgmepp/default.nix
+++ b/pkgs/development/libraries/kf5gpgmepp/default.nix
@@ -20,13 +20,15 @@ mkDerivation {
   };
 
   buildInputs = [
-    extra-cmake-modules
     qtbase
     boost
   ];
   propagatedBuildInputs = [ gpgme ];
 
-  nativeBuildInputs = [ cmake ];
+  nativeBuildInputs = [
+    cmake
+    extra-cmake-modules
+  ];
 
   meta = with lib; {
     license = [ licenses.lgpl2 ];

--- a/pkgs/tools/filesystems/kdiskmark/default.nix
+++ b/pkgs/tools/filesystems/kdiskmark/default.nix
@@ -24,13 +24,13 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [
     cmake
+    extra-cmake-modules
     wrapQtAppsHook
   ];
 
   buildInputs = [
     qtbase
     qttools
-    extra-cmake-modules
     polkit-qt
   ];
 

--- a/pkgs/tools/inputmethods/fcitx5/default.nix
+++ b/pkgs/tools/inputmethods/fcitx5/default.nix
@@ -68,7 +68,6 @@ stdenv.mkDerivation rec {
   ];
 
   buildInputs = [
-    extra-cmake-modules # required to please CMake
     expat
     fmt
     isocodes

--- a/pkgs/tools/inputmethods/fcitx5/fcitx5-bamboo.nix
+++ b/pkgs/tools/inputmethods/fcitx5/fcitx5-bamboo.nix
@@ -25,13 +25,13 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [
     cmake
+    extra-cmake-modules
     gettext
     go
   ];
 
   buildInputs = [
     fcitx5
-    extra-cmake-modules
   ];
 
   preConfigure = ''


### PR DESCRIPTION
- it's a dependency only for build time, not run time. the majority of packages place this in nativeBuildInputs, these few were outliars.
- labeling as cross-compilation because getting the `extra-cmake-modules` dependency correct enables more packages to cross compile (e.g. `wlay`, `xcb-imdkit`)

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
