### PR TITLE
abracadabra: 3.0.0 -> 3.1.0

### DIFF
--- a/pkgs/by-name/ab/abracadabra/package.nix
+++ b/pkgs/by-name/ab/abracadabra/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  fetchpatch,
   cmake,
   qt6,
   faad2,
@@ -15,14 +16,28 @@
 
 stdenv.mkDerivation rec {
   pname = "abracadabra";
-  version = "3.0.0";
+  version = "3.1.0";
 
   src = fetchFromGitHub {
     owner = "KejPi";
     repo = "AbracaDABra";
     rev = "v${version}";
-    hash = "sha256-yCjMinDCoBTOC5Ks4MUd0MQeitfrIe8bI3Q4ahz36kQ=";
+    hash = "sha256-kH84xDK1873ekxIYlOw6M3kVH+Sm/Sofb3AAbs4XzE0=";
   };
+
+  patches = [
+    # upstream patches, remove with next upgrade
+    (fetchpatch {
+      name = "no-qcustomplot";
+      url = "https://github.com/KejPi/AbracaDABra/commit/b0800cfe7abebf79f1edb915b3cf55fe96129017.patch";
+      hash = "sha256-8FiXix/riLvkxd2uTJCoUESInPiCsF6B+qaxRGbeUcs=";
+    })
+    (fetchpatch {
+      name = "fix-missing-include";
+      url = "https://github.com/KejPi/AbracaDABra/commit/8f88a3351fccea93c3c83bbfa94e98fb0823b0ae.patch";
+      hash = "sha256-9AloBgpUuewUBGM/NTHYUqd0uctJ17QJ0GA5RJN1GLQ=";
+    })
+  ];
 
   nativeBuildInputs = [
     cmake


### PR DESCRIPTION
## Things done
Changelog: https://github.com/KejPi/AbracaDABra/releases/tag/v3.1.0


- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- x25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
