### PR TITLE
haskell.packages.ghc9122.cabal2nix-unstable: fix build

### DIFF
--- a/pkgs/development/haskell-modules/cabal2nix-unstable.nix
+++ b/pkgs/development/haskell-modules/cabal2nix-unstable.nix
@@ -35,10 +35,10 @@
 }:
 mkDerivation {
   pname = "cabal2nix";
-  version = "unstable-2025-04-22";
+  version = "unstable-2025-04-23";
   src = fetchzip {
-    url = "https://github.com/NixOS/cabal2nix/archive/e6ed81965def7775aabdda7456d0c13f626295ee.tar.gz";
-    sha256 = "1fh428r4wfrqjj77dxy1l3d9scm4ywz89rp7dhp07y3bq5yr7hs4";
+    url = "https://github.com/NixOS/cabal2nix/archive/43fbd58ec8ef82c4fa627c89218d215442bcc3ac.tar.gz";
+    sha256 = "1620iaxs99rjq15v01xhqjzalvdbk7d69w7bz1ih782g7jqhkqsq";
   };
   postUnpack = "sourceRoot+=/cabal2nix; echo source root reset to $sourceRoot";
   isLibrary = true;

--- a/pkgs/development/haskell-modules/configuration-ghc-9.12.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.12.x.nix
@@ -211,4 +211,7 @@ with haskellLib;
       }
     )
   );
+
+  # Allow Cabal 3.14
+  hpack = doDistribute self.hpack_0_38_0;
 }

--- a/pkgs/development/haskell-modules/configuration-ghc-9.12.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.12.x.nix
@@ -173,6 +173,13 @@ with haskellLib;
   # https://github.com/sjakobi/newtype-generics/pull/28/files
   newtype-generics = warnAfterVersion "0.6.2" (doJailbreak super.newtype-generics);
 
+  # Test failure because of GHC bug:
+  #   https://gitlab.haskell.org/ghc/ghc/-/issues/25937
+  #   https://github.com/sol/interpolate/issues/20
+  interpolate =
+    assert super.ghc.version == "9.12.2";
+    dontCheck super.interpolate;
+
   #
   # Multiple issues
   #


### PR DESCRIPTION
Dependencies build now, but the test-suite of cabal2nix itself fails with this:

```
Building test suite 'regression-test' for cabal2nix-2.20.0...
[1 of 1] Compiling Main             ( test/Main.hs, dist/build/regression-test/regression-test-tmp/Main.o )
test/Main.hs:77:6: error: [8;;https://errors.haskell.org/messages/GHC-83865GHC-838658;;]
    • Couldn't match expected type: IO GenericPackageDescription
                  with actual type: Distribution.Utils.Path.SymbolicPath
                                      Distribution.Utils.Path.Pkg Distribution.Utils.Path.File
                                    -> IO GenericPackageDescription
    • Probable cause: ‘readGenericPackageDescription’ is applied to too few arguments
      In the first argument of ‘(>>=)’, namely
        ‘readGenericPackageDescription silent cabalFile’
      In the fifth argument of ‘goldenVsFileDiff’, namely
        ‘(readGenericPackageDescription silent cabalFile
            >>= writeFileLn nixFile . prettyShow . cabal2nix)’
      In a stmt of a 'do' block:
        goldenVsFileDiff
          nixFile (\ ref new -> ["diff", "-u", ref, ....]) goldenFile nixFile
          (readGenericPackageDescription silent cabalFile
             >>= writeFileLn nixFile . prettyShow . cabal2nix)
   |
77 |     (readGenericPackageDescription silent cabalFile >>= writeFileLn nixFile . prettyShow . cabal2nix)
   |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

test/Main.hs:77:43: error: [8;;https://errors.haskell.org/messages/GHC-83865GHC-838658;;]
    • Couldn't match type: [Char]
                     with: Maybe
                             (Distribution.Utils.Path.SymbolicPath
                                Distribution.Utils.Path.CWD
                                (Distribution.Utils.Path.Dir Distribution.Utils.Path.Pkg))
      Expected: Maybe
                  (Distribution.Utils.Path.SymbolicPath
                     Distribution.Utils.Path.CWD
                     (Distribution.Utils.Path.Dir Distribution.Utils.Path.Pkg))
        Actual: String
    • In the second argument of ‘readGenericPackageDescription’, namely
        ‘cabalFile’
      In the first argument of ‘(>>=)’, namely
        ‘readGenericPackageDescription silent cabalFile’
      In the fifth argument of ‘goldenVsFileDiff’, namely
        ‘(readGenericPackageDescription silent cabalFile
            >>= writeFileLn nixFile . prettyShow . cabal2nix)’
   |
77 |     (readGenericPackageDescription silent cabalFile >>= writeFileLn nixFile . prettyShow . cabal2nix)
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
