### PR TITLE
bitwarden-cli: patch out advertisement in --help message

### DIFF
--- a/pkgs/by-name/bi/bitwarden-cli/package.nix
+++ b/pkgs/by-name/bi/bitwarden-cli/package.nix
@@ -22,6 +22,8 @@ buildNpmPackage rec {
     hash = "sha256-SFwDyff3BHx0QKQZbhESUvjPT906/HGxGr1bA0PAvTQ=";
   };
 
+  patches = [ ./remove-ad.patch ];
+
   postPatch = ''
     # remove code under unfree license
     rm -r bitwarden_license

--- a/pkgs/by-name/bi/bitwarden-cli/remove-ad.patch
+++ b/pkgs/by-name/bi/bitwarden-cli/remove-ad.patch
@@ -1,0 +1,16 @@
+diff --git i/apps/cli/src/program.ts w/apps/cli/src/program.ts
+index c6b79c7dff..139ebf0323 100644
+--- i/apps/cli/src/program.ts
++++ w/apps/cli/src/program.ts
+@@ -74,11 +74,6 @@ export class Program extends BaseProgram {
+     });
+ 
+     program.on("--help", () => {
+-      writeLn(
+-        chalk.yellowBright(
+-          "\n  Tip: Managing and retrieving secrets for dev environments is easier with Bitwarden Secrets Manager. Learn more under https://bitwarden.com/products/secrets-manager/",
+-        ),
+-      );
+       writeLn("\n  Examples:");
+       writeLn("");
+       writeLn("    bw login");


### PR DESCRIPTION
Before:

![bitwarden-cli-before](https://github.com/user-attachments/assets/4b2bede6-8b1d-4460-85d7-22ffb7d2b485)

After:

![bitwarden-cli-after](https://github.com/user-attachments/assets/71d0a61d-103c-42d5-ade2-25a44da656b7)

pinging package maintainer: @dotlambda 

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review`

---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 13 packages built:</summary>
  <ul>
    <li>bitwarden-cli</li>
    <li>python312Packages.jupyter-collaboration</li>
    <li>python312Packages.jupyter-collaboration.dist</li>
    <li>python312Packages.jupyter-server-ydoc</li>
    <li>python312Packages.jupyter-server-ydoc.dist</li>
    <li>python312Packages.jupyter-ydoc</li>
    <li>python312Packages.jupyter-ydoc.dist</li>
    <li>python313Packages.jupyter-collaboration</li>
    <li>python313Packages.jupyter-collaboration.dist</li>
    <li>python313Packages.jupyter-server-ydoc</li>
    <li>python313Packages.jupyter-server-ydoc.dist</li>
    <li>python313Packages.jupyter-ydoc</li>
    <li>python313Packages.jupyter-ydoc.dist</li>
  </ul>
</details>

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
