### PR TITLE
python3Packages.xgi: init at 0.10

### DIFF
--- a/pkgs/development/python-modules/xgi/default.nix
+++ b/pkgs/development/python-modules/xgi/default.nix
@@ -20,7 +20,7 @@
 buildPythonPackage rec {
   pname = "xgi";
   version = "0.10";
-  format = "pyproject";
+  pyproject = true;
 
   disabled = pythonOlder "3.10";
 
@@ -29,13 +29,16 @@ buildPythonPackage rec {
     hash = "sha256-0QchgZ1Egcx5/8vSJPGLlN13A0KC+Q3dbAhWVB77Hdk=";
   };
 
-  nativeBuildInputs = [
-    hatchling
+  build-system = [
     setuptools
+    hatchling
+  ];
+
+  nativeBuildInputs = [
     wheel
   ];
 
-  propagatedBuildInputs = [
+  dependencies = [
     matplotlib
     networkx
     numpy
@@ -56,12 +59,12 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "xgi" ];
 
-  meta = with lib; {
+  meta = {
     changelog = "https://github.com/xgi-org/xgi/blob/main/CHANGELOG.md#${
       builtins.replaceStrings [ "." ] [ "" ] version
     }";
     description = "Software for higher-order networks";
     homepage = "https://xgi.readthedocs.io/";
-    license = with licenses; [ bsd3 ];
+    license = with lib.licenses; [ bsd3 ];
   };
 }

--- a/pkgs/development/python-modules/xgi/default.nix
+++ b/pkgs/development/python-modules/xgi/default.nix
@@ -54,12 +54,14 @@ buildPythonPackage rec {
   # propogating from matplotlib. see matplotlib/default.nix.
   doCheck = false;
 
-  pythonImportsCheck = ["xgi"];
+  pythonImportsCheck = [ "xgi" ];
 
   meta = with lib; {
-    changelog = "https://github.com/xgi-org/xgi/blob/main/CHANGELOG.md#${builtins.replaceStrings ["."] [""] version}";
+    changelog = "https://github.com/xgi-org/xgi/blob/main/CHANGELOG.md#${
+      builtins.replaceStrings ["."] [""] version
+    }";
     description = "Software for higher-order networks";
     homepage = "https://xgi.readthedocs.io/";
-    license = with licenses; [bsd3];
+    license = with licenses; [ bsd3 ];
   };
 }

--- a/pkgs/development/python-modules/xgi/default.nix
+++ b/pkgs/development/python-modules/xgi/default.nix
@@ -58,7 +58,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     changelog = "https://github.com/xgi-org/xgi/blob/main/CHANGELOG.md#${
-      builtins.replaceStrings ["."] [""] version
+      builtins.replaceStrings [ "." ] [ "" ] version
     }";
     description = "Software for higher-order networks";
     homepage = "https://xgi.readthedocs.io/";

--- a/pkgs/development/python-modules/xgi/default.nix
+++ b/pkgs/development/python-modules/xgi/default.nix
@@ -1,0 +1,65 @@
+{
+  buildPythonPackage,
+  fetchPypi,
+  hatchling,
+  lib,
+  pytest-xdist,
+  pytestCheckHook,
+  pythonOlder,
+  setuptools,
+  wheel,
+  # python packages
+  matplotlib,
+  networkx,
+  numpy,
+  pandas,
+  requests,
+  scipy,
+  seaborn,
+}:
+buildPythonPackage rec {
+  pname = "xgi";
+  version = "0.10";
+  format = "pyproject";
+
+  disabled = pythonOlder "3.10";
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-0QchgZ1Egcx5/8vSJPGLlN13A0KC+Q3dbAhWVB77Hdk=";
+  };
+
+  nativeBuildInputs = [
+    hatchling
+    setuptools
+    wheel
+  ];
+
+  propagatedBuildInputs = [
+    matplotlib
+    networkx
+    numpy
+    pandas
+    requests
+    scipy
+    seaborn
+  ];
+
+  nativeCheckInputs = [
+    pytest-xdist
+    pytestCheckHook
+  ];
+
+  # set to false because of the issues with freetype versioning,
+  # propogating from matplotlib. see matplotlib/default.nix.
+  doCheck = false;
+
+  pythonImportsCheck = ["xgi"];
+
+  meta = with lib; {
+    changelog = "https://github.com/xgi-org/xgi/blob/main/CHANGELOG.md#${builtins.replaceStrings ["."] [""] version}";
+    description = "Software for higher-order networks";
+    homepage = "https://xgi.readthedocs.io/";
+    license = with licenses; [bsd3];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -19004,6 +19004,8 @@ self: super: with self; {
 
   xgboost = callPackage ../development/python-modules/xgboost { inherit (pkgs) xgboost; };
 
+  xgi = callPackage ../development/python-modules/xgi { };
+
   xgrammar = callPackage ../development/python-modules/xgrammar { };
 
   xhtml2pdf = callPackage ../development/python-modules/xhtml2pdf { };


### PR DESCRIPTION
add [XGI](https://github.com/xgi-org/xgi) as a Python 3 package. XGI is a python library for higher-order networks, e.g. [hypergraphs](https://en.m.wikipedia.org/wiki/Hypergraph) and [simplicial complexes](https://en.m.wikipedia.org/wiki/Simplicial_complex).

Note that `doCheck = false;` here. This is because matplotlib is a runtime dependency, and its tests fail. Please inform if there is a better way of accomplishing this.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
