### PR TITLE
grafana-logs-drilldown: init at 1.0.10

### DIFF
--- a/pkgs/servers/monitoring/grafana/plugins/grafana-logs-drilldown/default.nix
+++ b/pkgs/servers/monitoring/grafana/plugins/grafana-logs-drilldown/default.nix
@@ -1,0 +1,32 @@
+{
+  grafanaPlugin,
+  fetchurl,
+  lib,
+}:
+let
+  zipHash = "sha256-1+5xil0XmcLCDKpObuxpnoMnQZaT1I62zL6xatlyKc4=";
+in
+(grafanaPlugin {
+  pname = "grafana-logs-drilldown";
+  version = "1.0.10";
+  inherit zipHash;
+  meta = with lib; {
+    description = "Loki log exploration app.";
+    license = licenses.agpl3Only;
+    maintainers = [ lib.maintainers.jonboh ];
+    platforms = platforms.unix;
+  };
+}).overrideAttrs
+  (
+    prev: final:
+    let
+      pluginName = "grafana-lokiexplore-app";
+    in
+    {
+      src = fetchurl {
+        name = "${pluginName}-${prev.version}.zip";
+        hash = zipHash;
+        url = "https://grafana.com/api/plugins/${pluginName}/versions/${prev.version}/download";
+      };
+    }
+  )

--- a/pkgs/servers/monitoring/grafana/plugins/plugins.nix
+++ b/pkgs/servers/monitoring/grafana/plugins/plugins.nix
@@ -14,6 +14,7 @@
   grafana-discourse-datasource = callPackage ./grafana-discourse-datasource { };
   grafana-github-datasource = callPackage ./grafana-github-datasource { };
   grafana-googlesheets-datasource = callPackage ./grafana-googlesheets-datasource { };
+  grafana-logs-drilldown = callPackage ./grafana-logs-drilldown { };
   grafana-mqtt-datasource = callPackage ./grafana-mqtt-datasource { };
   grafana-oncall-app = callPackage ./grafana-oncall-app { };
   grafana-opensearch-datasource = callPackage ./grafana-opensearch-datasource { };


### PR DESCRIPTION
It seems that this package got renamed at some point from grafana-lokiexplore-app to grafana-logs-drilldown. I've kept the latest name by overriding the src of the derivation. 
Let me know if it is better to just use mkDerivation directly in this case.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc