### PR TITLE
weechat-unwrapped: 4.5.1 -> 4.6.2

### DIFF
--- a/pkgs/applications/networking/irc/weechat/default.nix
+++ b/pkgs/applications/networking/irc/weechat/default.nix
@@ -188,7 +188,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     homepage = "https://weechat.org/";
-    changelog = "https://weechat.org/files/doc/weechat/ChangeLog-${version}.html";
+    changelog = "https://github.com/weechat/weechat/releases/tag/v${version}";
     description = "Fast, light and extensible chat client";
     longDescription = ''
       You can find more documentation as to how to customize this package

--- a/pkgs/applications/networking/irc/weechat/default.nix
+++ b/pkgs/applications/networking/irc/weechat/default.nix
@@ -38,6 +38,7 @@
   pcre2,
   libargon2,
   extraBuildInputs ? [ ],
+  writeScript,
 }:
 
 let
@@ -169,6 +170,20 @@ stdenv.mkDerivation rec {
   doInstallCheck = true;
   installCheckPhase = ''
     $out/bin/weechat --version
+  '';
+
+  passthru.updateScript = writeScript "update-weechat" ''
+    #!/usr/bin/env nix-shell
+    #!nix-shell -i bash -p coreutils gawk git gnugrep common-updater-scripts
+    set -eu -o pipefail
+
+    version="$(git ls-remote --refs https://github.com/weechat/weechat | \
+      awk '{ print $2 }' | \
+      grep "refs/tags/v" | \
+      sed -E -e 's,refs/tags/v(.*)$,\1,' | \
+      sort --version-sort --reverse | \
+      head -n1)"
+    update-source-version weechat-unwrapped "$version"
   '';
 
   meta = {

--- a/pkgs/applications/networking/irc/weechat/default.nix
+++ b/pkgs/applications/networking/irc/weechat/default.nix
@@ -101,14 +101,14 @@ let
 in
 assert lib.all (p: p.enabled -> !(builtins.elem null p.buildInputs)) plugins;
 stdenv.mkDerivation rec {
-  version = "4.5.1";
+  version = "4.6.2";
   pname = "weechat";
 
   hardeningEnable = [ "pie" ];
 
   src = fetchurl {
     url = "https://weechat.org/files/src/weechat-${version}.tar.xz";
-    hash = "sha256-Z8FDx7xw5om56obfZ0yan/PPRMzJzf8hvmpWHV6vxSg=";
+    hash = "sha256-D6AkKhgRb+J/dG27giEhgF2mu129QHUNQsYzBuSJZig=";
   };
 
   # Why is this needed? https://github.com/weechat/weechat/issues/2031


### PR DESCRIPTION
https://github.com/weechat/weechat/releases/tag/v4.5.2
https://github.com/weechat/weechat/releases/tag/v4.6.0
https://github.com/weechat/weechat/releases/tag/v4.6.1
https://github.com/weechat/weechat/releases/tag/v4.6.2

Adds an update script, fixes meta.changelog and refactors the derivation slightly.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
