### PR TITLE
nixosTests.armagetronad: make test more reliable to fix ZHF

### DIFF
--- a/nixos/tests/armagetronad.nix
+++ b/nixos/tests/armagetronad.nix
@@ -115,7 +115,7 @@ in
           self.node.wait_for_text(text)
           self.send(*keys)
 
-      Server = namedtuple('Server', ('node', 'name', 'address', 'port', 'welcome', 'attacker', 'victim', 'coredump_delay'))
+      Server = namedtuple('Server', ('node', 'name', 'address', 'port', 'welcome', 'player1', 'player2'))
 
       # Clients and their in-game names
       clients = (
@@ -125,9 +125,9 @@ in
 
       # Server configs.
       servers = (
-        Server(server, 'high-rubber', 'server', 4534, 'NixOS Smoke Test Server', 'SmOoThIcE', 'Arduino', 8),
-        Server(server, 'sty', 'server', 4535, 'NixOS Smoke Test sty+ct+ap Server', 'Arduino', 'SmOoThIcE', 8),
-        Server(server, 'trunk', 'server', 4536, 'NixOS Smoke Test 0.4 Server', 'Arduino', 'SmOoThIcE', 8)
+        Server(server, 'high-rubber', 'server', 4534, 'NixOS Smoke Test Server', 'SmOoThIcE', 'Arduino'),
+        Server(server, 'sty', 'server', 4535, 'NixOS Smoke Test sty+ct+ap Server', 'Arduino', 'SmOoThIcE'),
+        Server(server, 'trunk', 'server', 4536, 'NixOS Smoke Test 0.4 Server', 'Arduino', 'SmOoThIcE')
       )
 
       """
@@ -146,8 +146,55 @@ in
           client.node.screenshot(f"screen_{client.name}_{screenshot_idx}")
         return screenshot_idx + 1
 
-      # Wait for the servers to come up.
+      """
+      Sets up a client, waiting for the given barrier on completion.
+      """
+      def client_setup(client, servers, barrier):
+        client.node.wait_for_x()
+
+        # Configure Armagetron so we skip the tutorial.
+        client.node.succeed(
+          run("mkdir -p ~/.armagetronad/var"),
+          run(f"echo 'PLAYER_1 {client.name}' >> ~/.armagetronad/var/autoexec.cfg"),
+          run("echo 'FIRST_USE 0' >> ~/.armagetronad/var/autoexec.cfg")
+        )
+        for idx, srv in enumerate(servers):
+          client.node.succeed(
+            run(f"echo 'BOOKMARK_{idx+1}_ADDRESS {srv.address}' >> ~/.armagetronad/var/autoexec.cfg"),
+            run(f"echo 'BOOKMARK_{idx+1}_NAME {srv.name}' >> ~/.armagetronad/var/autoexec.cfg"),
+            run(f"echo 'BOOKMARK_{idx+1}_PORT {srv.port}' >> ~/.armagetronad/var/autoexec.cfg")
+          )
+
+        # Start Armagetron. Use the recording mode since it skips the splashscreen.
+        client.node.succeed(run("cd; ulimit -c unlimited; armagetronad --record test.aarec >&2 & disown"))
+        client.node.wait_until_succeeds(
+          run(
+            "${xdo "create_new_win-select_main_window" ''
+              search --onlyvisible --name "Armagetron Advanced"
+              windowfocus --sync
+              windowactivate --sync
+            ''}"
+          )
+        )
+
+        # Get into the multiplayer menu.
+        client.send_on('Armagetron Advanced', 'ret')
+        client.send_on('Play Game', 'ret')
+
+        # Online > LAN > Network Setup > Mates > Server Bookmarks
+        client.send_on('Multiplayer', 'down', 'down', 'down', 'down', 'ret')
+
+        barrier.wait()
+
+      # Start everything.
       start_all()
+
+      # Get to the Server Bookmarks screen on both clients. This takes a while so do it asynchronously.
+      barrier = threading.Barrier(len(clients) + 1, timeout=600)
+      for client in clients:
+        threading.Thread(target=client_setup, args=(client, servers, barrier)).start()
+
+      # Wait for the servers to come up.
       for srv in servers:
         srv.node.wait_for_unit(f"armagetronad-{srv.name}")
         srv.node.wait_until_succeeds(f"ss --numeric --udp --listening | grep -q {srv.port}")
@@ -167,55 +214,7 @@ in
           f"journalctl -u armagetronad-{srv.name} -e | grep -q 'Admin: Testing again!'"
         )
 
-      """
-      Sets up a client, waiting for the given barrier on completion.
-      """
-      def client_setup(client, servers, barrier):
-        client.node.wait_for_x()
-
-        # Configure Armagetron.
-        client.node.succeed(
-          run("mkdir -p ~/.armagetronad/var"),
-          run(f"echo 'PLAYER_1 {client.name}' >> ~/.armagetronad/var/autoexec.cfg")
-        )
-        for idx, srv in enumerate(servers):
-          client.node.succeed(
-            run(f"echo 'BOOKMARK_{idx+1}_ADDRESS {srv.address}' >> ~/.armagetronad/var/autoexec.cfg"),
-            run(f"echo 'BOOKMARK_{idx+1}_NAME {srv.name}' >> ~/.armagetronad/var/autoexec.cfg"),
-            run(f"echo 'BOOKMARK_{idx+1}_PORT {srv.port}' >> ~/.armagetronad/var/autoexec.cfg")
-          )
-
-        # Start Armagetron.
-        client.node.succeed(run("ulimit -c unlimited; armagetronad >&2 & disown"))
-        client.node.wait_until_succeeds(
-          run(
-            "${xdo "create_new_win-select_main_window" ''
-              search --onlyvisible --name "Armagetron Advanced"
-              windowfocus --sync
-              windowactivate --sync
-            ''}"
-          )
-        )
-
-        # Get through the tutorial.
-        client.send_on('Language Settings', 'ret')
-        client.send_on('First Setup', 'ret')
-        client.send_on('Welcome to Armagetron Advanced', 'ret')
-        client.send_on('round 1', 'esc')
-        client.send_on('Menu', 'up', 'up', 'ret')
-        client.send_on('We hope you', 'ret')
-        client.send_on('Armagetron Advanced', 'ret')
-        client.send_on('Play Game', 'ret')
-
-        # Online > LAN > Network Setup > Mates > Server Bookmarks
-        client.send_on('Multiplayer', 'down', 'down', 'down', 'down', 'ret')
-
-        barrier.wait()
-
-      # Get to the Server Bookmarks screen on both clients. This takes a while so do it asynchronously.
-      barrier = threading.Barrier(len(clients) + 1, timeout=240)
-      for client in clients:
-        threading.Thread(target=client_setup, args=(client, servers, barrier)).start()
+      # Wait for the client setup to complete.
       barrier.wait()
 
       # Main testing loop. Iterates through each server bookmark and connects to them in sequence.
@@ -245,18 +244,14 @@ in
           f"journalctl -u armagetronad-{srv.name} -e | grep -q 'Go (round 1 of 10)'"
         )
 
-        # Wait a bit
-        srv.node.sleep(srv.coredump_delay)
-
-        # Turn the attacker player's lightcycle left
-        attacker = next(client for client in clients if client.name == srv.attacker)
-        victim = next(client for client in clients if client.name == srv.victim)
-        attacker.send('left')
-        screenshot_idx = take_screenshots(screenshot_idx)
-
-        # Wait for coredump.
+        # Wait for the players to die by running into the wall.
+        player1 = next(client for client in clients if client.name == srv.player1)
+        player2 = next(client for client in clients if client.name == srv.player2)
         srv.node.wait_until_succeeds(
-          f"journalctl -u armagetronad-{srv.name} -e | grep -q '{attacker.name} core dumped {victim.name}'"
+          f"journalctl -u armagetronad-{srv.name} -e | grep -q '{player1.name}.*lost 4 points'"
+        )
+        srv.node.wait_until_succeeds(
+          f"journalctl -u armagetronad-{srv.name} -e | grep -q '{player2.name}.*lost 4 points'"
         )
         screenshot_idx = take_screenshots(screenshot_idx)
 

--- a/pkgs/games/armagetronad/default.nix
+++ b/pkgs/games/armagetronad/default.nix
@@ -70,8 +70,8 @@ let
       # https://gitlab.com/armagetronad/armagetronad/-/commits/trunk/?ref_type=heads
       ${unstableVersionMajor} =
         let
-          rev = "391a74625c1222dd180f069f1b61c3e069a3ba8c";
-          hash = "sha256-fUY0dBj85k0QhnAoDzyBmmKmRh9oCYC6r6X4ukt7/L0=";
+          rev = "1830e09888597b372fad192b0d246aefe555540c";
+          hash = "sha256-svVcg2AMk2GHmg1Szny10KCLZQ6Cly1RrSVNGmf7Fdg=";
         in
         dedicatedServer: {
           version = "${unstableVersionMajor}-${builtins.substring 0 8 rev}";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

OCR was timing out on aarch64 builders. Find a faster path through the tests that requires less OCR. 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
