### PR TITLE
youtube-music: fix MPRIS's DesktopEntry property

### DIFF
--- a/pkgs/applications/audio/youtube-music/default.nix
+++ b/pkgs/applications/audio/youtube-music/default.nix
@@ -83,6 +83,11 @@ stdenv.mkDerivation (finalAttrs: {
       --inherit-argv0
   '';
 
+  patches = [
+    # MPRIS's DesktopEntry property needs to match the desktop entry basename
+    ./fix-mpris-desktop-entry.patch
+  ];
+
   desktopItems = [
     (makeDesktopItem {
       name = "com.github.th_ch.youtube_music";

--- a/pkgs/applications/audio/youtube-music/fix-mpris-desktop-entry.patch
+++ b/pkgs/applications/audio/youtube-music/fix-mpris-desktop-entry.patch
@@ -1,0 +1,13 @@
+diff --git a/src/plugins/shortcuts/mpris.ts b/src/plugins/shortcuts/mpris.ts
+index 93cb40f9..ad0bede3 100644
+--- a/src/plugins/shortcuts/mpris.ts
++++ b/src/plugins/shortcuts/mpris.ts
+@@ -79,7 +79,7 @@ function setupMPRIS() {
+   instance.canQuit = false;
+   instance.canUsePlayerControls = true;
+   instance.supportedUriSchemes = ['http', 'https'];
+-  instance.desktopEntry = 'youtube-music';
++  instance.desktopEntry = 'com.github.th_ch.youtube_music';
+   return instance;
+ }
+ 


### PR DESCRIPTION
Follow-up PR to https://github.com/NixOS/nixpkgs/pull/399799 , which updated the name of the desktop entry file to fix icons on KDE

`youtube-music.desktop` -> `com.github.th_ch.youtube_music.desktop`

But it broke the icon on Gnome's MPRIS widget (and possibly other MPRIS clients). This PR fixes it.

<hr>

### Why it broke

MPRIS has a DesktopEntry property that needs to match the **basename** of the desktop entry file, as specified here:
https://specifications.freedesktop.org/mpris-spec/latest/Media_Player.html#Property:DesktopEntry

That property is set by the application as `youtube-music`, since it assumes the desktop entry file is named `youtube-music.desktop`. But that's not the case anymore, since the PR liked above.

### What this PR does to fix it

This PR patches youtube-music's MPRIS service to make DesktopEntry match the new desktop entry basename.

### Why patch it here and not upstream

The packages built and released by youtube-music have the desktop entry file named as `youtube-music.desktop`, and so does the AUR package. So no changes are needed there (yet).

This might change it in the future, see https://github.com/th-ch/youtube-music/issues/2806

### Screenshots of the bug when MPRIS's DesktopEntry is wrong

MPRIS clients that rely on DesktopEntry are not able to find the right desktop entry and consequently do not find the right icon to display. This happens with Gnome's MPRIS widget:

|expected MPRIS icon on Gnome|broken MPRIS icon on Gnome|
|-|-|
|![image](https://github.com/user-attachments/assets/d8153908-0c91-41f3-aad7-0643dc61365e)|![image](https://github.com/user-attachments/assets/5d945461-b576-4174-94ad-68138e8a661e)|

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
