### PR TITLE
bitwuzla: fix `kissat not compiled in` error

### DIFF
--- a/pkgs/by-name/bi/bitwuzla/package.nix
+++ b/pkgs/by-name/bi/bitwuzla/package.nix
@@ -37,8 +37,8 @@ stdenv.mkDerivation (finalAttrs: {
     git
     ninja
     cmake
-    kissat
   ];
+
   buildInputs = [
     cadical
     cryptominisat
@@ -46,7 +46,7 @@ stdenv.mkDerivation (finalAttrs: {
     symfpu
     gmp
     zlib
-    kissat.lib
+    kissat
   ];
 
   mesonFlags = [

--- a/pkgs/by-name/bi/bitwuzla/package.nix
+++ b/pkgs/by-name/bi/bitwuzla/package.nix
@@ -49,8 +49,6 @@ stdenv.mkDerivation (finalAttrs: {
     kissat.lib
   ];
 
-  preConfigure = "export PKG_CONFIG_PATH=${kissatPkgConfig}/lib/pkgconfig:$PKG_CONFIG_PATH";
-
   mesonFlags = [
     # note: the default value for default_library fails to link dynamic dependencies
     # but setting it to shared works even in pkgsStatic

--- a/pkgs/by-name/bi/bitwuzla/package.nix
+++ b/pkgs/by-name/bi/bitwuzla/package.nix
@@ -18,34 +18,6 @@
   cmake,
 }:
 
-let
-  kissatPkgConfig = stdenv.mkDerivation {
-    name = "kissat-pkgconfig";
-    inherit (kissat) version;
-
-    dontUnpack = true;
-    dontConfigure = true;
-    dontBuild = true;
-
-    outputs = [ "out" ];
-
-    installPhase = ''
-      mkdir -p $out/lib/pkgconfig
-      cat > $out/lib/pkgconfig/kissat.pc <<EOF
-      prefix=${kissat.dev}
-      exec_prefix=\''${prefix}
-      libdir=${kissat.lib}/lib
-      includedir=\''${prefix}/include
-
-      Name: kissat
-      Description: 'keep it simple and clean bare metal SAT solver' written in C
-      Version: ${kissat.version}
-      Libs: -L\''${libdir} -lkissat
-      Cflags: -I\''${includedir}
-      EOF
-    '';
-  };
-in
 stdenv.mkDerivation (finalAttrs: {
   pname = "bitwuzla";
   version = "0.7.0";
@@ -65,7 +37,7 @@ stdenv.mkDerivation (finalAttrs: {
     git
     ninja
     cmake
-    kissatPkgConfig
+    kissat
   ];
   buildInputs = [
     cadical

--- a/pkgs/by-name/bi/bitwuzla/package.nix
+++ b/pkgs/by-name/bi/bitwuzla/package.nix
@@ -22,7 +22,7 @@ let
   kissatPkgConfig = stdenv.mkDerivation {
     name = "kissat-pkgconfig";
     inherit (kissat) version;
-    
+
     dontUnpack = true;
     dontConfigure = true;
     dontBuild = true;

--- a/pkgs/by-name/bi/bitwuzla/package.nix
+++ b/pkgs/by-name/bi/bitwuzla/package.nix
@@ -40,6 +40,7 @@ stdenv.mkDerivation (finalAttrs: {
   buildInputs = [
     cadical
     cryptominisat
+    kissat
     btor2tools
     symfpu
     gmp
@@ -51,6 +52,7 @@ stdenv.mkDerivation (finalAttrs: {
     # but setting it to shared works even in pkgsStatic
     "-Ddefault_library=shared"
     "-Dcryptominisat=true"
+    "-Dkissat=true"
 
     (lib.strings.mesonEnable "testing" finalAttrs.finalPackage.doCheck)
   ];
@@ -77,6 +79,7 @@ stdenv.mkDerivation (finalAttrs: {
     set -euxo pipefail;
     $out/bin/bitwuzla -S cms -j 3 -m file.smt2 | tee /dev/stderr | grep $needle;
     $out/bin/bitwuzla -S cadical -m file.smt2 | tee /dev/stderr | grep $needle;
+    $out/bin/bitwuzla -S kissat -m file.smt2 | tee /dev/stderr | grep $needle;
     )
 
     runHook postInstallCheck

--- a/pkgs/by-name/ki/kissat/package.nix
+++ b/pkgs/by-name/ki/kissat/package.nix
@@ -4,8 +4,25 @@
   fetchFromGitHub,
   drat-trim,
   p7zip,
+  pkg-config,
 }:
 
+let
+  # Early meta to reference in pkgconfig generation
+  meta = with lib; {
+    description = "'keep it simple and clean bare metal SAT solver' written in C";
+    mainProgram = "kissat";
+    longDescription = ''
+      Kissat is a "keep it simple and clean bare metal SAT solver" written in C.
+      It is a port of CaDiCaL back to C with improved data structures,
+      better scheduling of inprocessing and optimized algorithms and implementation.
+    '';
+    maintainers = with maintainers; [ shnarazk ];
+    platforms = platforms.unix;
+    license = licenses.mit;
+    homepage = "https://fmv.jku.at/kissat";
+  };
+in
 stdenv.mkDerivation rec {
   pname = "kissat";
   version = "4.0.2";
@@ -23,6 +40,10 @@ stdenv.mkDerivation rec {
     "lib"
   ];
 
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
   nativeCheckInputs = [
     drat-trim
     p7zip
@@ -37,6 +58,14 @@ stdenv.mkDerivation rec {
   dontAddPrefix = true;
   setOutputFlags = false;
 
+  configurePhase = ''
+    ./configure
+  '';
+
+  buildPhase = ''
+    make -j$NIX_BUILD_CORES
+  '';
+
   installPhase = ''
     runHook preInstall
 
@@ -46,20 +75,23 @@ stdenv.mkDerivation rec {
     mkdir -p "$out/share/doc/kissat/"
     install -Dm0644 {LICEN?E,README*,VERSION} "$out/share/doc/kissat/"
 
+    # Create pkgconfig
+    mkdir -p $dev/lib/pkgconfig
+    cat > $dev/lib/pkgconfig/kissat.pc <<EOF
+    prefix=${placeholder "dev"}
+    exec_prefix=\''${prefix}
+    libdir=${placeholder "lib"}/lib
+    includedir=\''${prefix}/include
+
+    Name: ${pname}
+    Description: ${meta.description}
+    Version: ${version}
+    Libs: -L\''${libdir} -lkissat
+    Cflags: -I\''${includedir}
+    EOF
+
     runHook postInstall
   '';
 
-  meta = with lib; {
-    description = "'keep it simple and clean bare metal SAT solver' written in C";
-    mainProgram = "kissat";
-    longDescription = ''
-      Kissat is a "keep it simple and clean bare metal SAT solver" written in C.
-      It is a port of CaDiCaL back to C with improved data structures,
-      better scheduling of inprocessing and optimized algorithms and implementation.
-    '';
-    maintainers = with maintainers; [ shnarazk ];
-    platforms = platforms.unix;
-    license = licenses.mit;
-    homepage = "https://fmv.jku.at/kissat";
-  };
+  inherit meta;
 }


### PR DESCRIPTION
Invooking `bitwuzla -S kissat` with the current build produces an error:
```
[error] invalid configuration for option --sat-solver, Kissat not compiled in
```

This is a solution to compile kissat in for bitwuzla.
Tested and working, against an smt2 file.

This PR also alters kissat to provide a pkgconfig.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
