### PR TITLE
Kernels updates for 2025-04-20

### DIFF
--- a/pkgs/os-specific/linux/kernel/hardened/patches.json
+++ b/pkgs/os-specific/linux/kernel/hardened/patches.json
@@ -52,12 +52,12 @@
     "6.13": {
         "patch": {
             "extra": "-hardened1",
-            "name": "linux-hardened-v6.13.7-hardened1.patch",
-            "sha256": "0s0h6z9qxqcfdz14zbaalapl2py7z40hf4p6405f2hy5hajdcxq3",
-            "url": "https://github.com/anthraxx/linux-hardened/releases/download/v6.13.7-hardened1/linux-hardened-v6.13.7-hardened1.patch"
+            "name": "linux-hardened-v6.13.11-hardened1.patch",
+            "sha256": "1rhvrk5lfrj619dzv8qsjvdnqs4vi66a3vd41g0fz4hpbqqrbj7p",
+            "url": "https://github.com/anthraxx/linux-hardened/releases/download/v6.13.11-hardened1/linux-hardened-v6.13.11-hardened1.patch"
         },
-        "sha256": "07c08x68fgcsgriss5z8w427h69y52s887vas91jzb5p70hbcf9s",
-        "version": "6.13.7"
+        "sha256": "08gcms4gvh8i30wj9vk27rb7d4yrndprxk1m72dhr1f7lywz2azn",
+        "version": "6.13.11"
     },
     "6.6": {
         "patch": {

--- a/pkgs/os-specific/linux/kernel/hardened/patches.json
+++ b/pkgs/os-specific/linux/kernel/hardened/patches.json
@@ -32,12 +32,12 @@
     "6.1": {
         "patch": {
             "extra": "-hardened1",
-            "name": "linux-hardened-v6.1.131-hardened1.patch",
-            "sha256": "005qvy3r69cy007fvj7m4b49m3vplndb280p2q72wnk9mpw8axrp",
-            "url": "https://github.com/anthraxx/linux-hardened/releases/download/v6.1.131-hardened1/linux-hardened-v6.1.131-hardened1.patch"
+            "name": "linux-hardened-v6.1.134-hardened1.patch",
+            "sha256": "12sphlhm7cmgkl0vs8y31k9b38s2x1w389w95qnhax4ff1sc19dz",
+            "url": "https://github.com/anthraxx/linux-hardened/releases/download/v6.1.134-hardened1/linux-hardened-v6.1.134-hardened1.patch"
         },
-        "sha256": "05jvvv3khadvfgdrv43fcrnm606jk4064a7qivkvnk1vc08gbjj4",
-        "version": "6.1.131"
+        "sha256": "08xx0w5gz7w5hqsnpckmizi1zpg38iwfchj20163ivnxf3fhriv0",
+        "version": "6.1.134"
     },
     "6.12": {
         "patch": {

--- a/pkgs/os-specific/linux/kernel/hardened/patches.json
+++ b/pkgs/os-specific/linux/kernel/hardened/patches.json
@@ -2,12 +2,12 @@
     "5.10": {
         "patch": {
             "extra": "-hardened1",
-            "name": "linux-hardened-v5.10.235-hardened1.patch",
-            "sha256": "1xhpwy62jbwbc71s2cglxhrn7radpp256v05d587gf7jwhbi2zmc",
-            "url": "https://github.com/anthraxx/linux-hardened/releases/download/v5.10.235-hardened1/linux-hardened-v5.10.235-hardened1.patch"
+            "name": "linux-hardened-v5.10.236-hardened1.patch",
+            "sha256": "1kc32nw484x92i7ga9yfg042nnx8dm4i8l0wdgs3f1djaglrz76v",
+            "url": "https://github.com/anthraxx/linux-hardened/releases/download/v5.10.236-hardened1/linux-hardened-v5.10.236-hardened1.patch"
         },
-        "sha256": "1k7iq4np3pflkq3d71ya8xs5czhslhy2iha4ls9lma81269y6fwm",
-        "version": "5.10.235"
+        "sha256": "12gv03hbddwm4nl8xxdvdr983nbh2lzrl4jr9p5kmv9rgn7wr9bd",
+        "version": "5.10.236"
     },
     "5.15": {
         "patch": {

--- a/pkgs/os-specific/linux/kernel/hardened/patches.json
+++ b/pkgs/os-specific/linux/kernel/hardened/patches.json
@@ -12,12 +12,12 @@
     "5.15": {
         "patch": {
             "extra": "-hardened1",
-            "name": "linux-hardened-v5.15.179-hardened1.patch",
-            "sha256": "18255w5x7fjx37zdzbmigp641izc5h8fp2h8z7lj33z2mf7gfs9y",
-            "url": "https://github.com/anthraxx/linux-hardened/releases/download/v5.15.179-hardened1/linux-hardened-v5.15.179-hardened1.patch"
+            "name": "linux-hardened-v5.15.180-hardened1.patch",
+            "sha256": "04hbq97adqssmglgs6jw5y8w9mwpmds7v75d9krig35bs0g2wrdq",
+            "url": "https://github.com/anthraxx/linux-hardened/releases/download/v5.15.180-hardened1/linux-hardened-v5.15.180-hardened1.patch"
         },
-        "sha256": "0vqk4wd0cacigz42gigdzbj415hcdn2k2m01yr7k8pcv3rxs86ck",
-        "version": "5.15.179"
+        "sha256": "0ffdy7zhp25z75n49j4rs8fs79icbmz1yy7k3xgcl2p6pfw6h7zm",
+        "version": "5.15.180"
     },
     "5.4": {
         "patch": {

--- a/pkgs/os-specific/linux/kernel/hardened/patches.json
+++ b/pkgs/os-specific/linux/kernel/hardened/patches.json
@@ -42,12 +42,12 @@
     "6.12": {
         "patch": {
             "extra": "-hardened1",
-            "name": "linux-hardened-v6.12.19-hardened1.patch",
-            "sha256": "1f78k1bns49gfb8ari5jg5wkfai206nfpsnwj0y5h5yrjg0x8sx8",
-            "url": "https://github.com/anthraxx/linux-hardened/releases/download/v6.12.19-hardened1/linux-hardened-v6.12.19-hardened1.patch"
+            "name": "linux-hardened-v6.12.23-hardened1.patch",
+            "sha256": "1y15x5i4rgag7adkkznjv5xzwk32xbrgx4n33j8cjnmzmir85xc9",
+            "url": "https://github.com/anthraxx/linux-hardened/releases/download/v6.12.23-hardened1/linux-hardened-v6.12.23-hardened1.patch"
         },
-        "sha256": "0cb5ri6xsd9fyf0s48xrrsbhqzbgjd0iddnid6qk8i60prbz0fyp",
-        "version": "6.12.19"
+        "sha256": "0jbps9sr4bpg4ym6vjib33lfjqjh09azh39ck7v7zsyyz0259nfq",
+        "version": "6.12.23"
     },
     "6.13": {
         "patch": {

--- a/pkgs/os-specific/linux/kernel/hardened/patches.json
+++ b/pkgs/os-specific/linux/kernel/hardened/patches.json
@@ -22,12 +22,12 @@
     "5.4": {
         "patch": {
             "extra": "-hardened1",
-            "name": "linux-hardened-v5.4.291-hardened1.patch",
-            "sha256": "1i7x7pdmqbrj306jbqv75ij1lq4hvdmw1qnfa4975zyzdd8d0khq",
-            "url": "https://github.com/anthraxx/linux-hardened/releases/download/v5.4.291-hardened1/linux-hardened-v5.4.291-hardened1.patch"
+            "name": "linux-hardened-v5.4.292-hardened1.patch",
+            "sha256": "1w9hpwsf6r9m51hwqp5qmaylb95ll8rwwmijimkhaahd613y4hr2",
+            "url": "https://github.com/anthraxx/linux-hardened/releases/download/v5.4.292-hardened1/linux-hardened-v5.4.292-hardened1.patch"
         },
-        "sha256": "0vpgb3lmhgv5iw9b1z0kqr6vdv44if49marfp5858z3a8yj69bdk",
-        "version": "5.4.291"
+        "sha256": "11dy6zvxnripwr4lfg357wdl70kcg5ljs3wxhz2klqpas60gbjqb",
+        "version": "5.4.292"
     },
     "6.1": {
         "patch": {

--- a/pkgs/os-specific/linux/kernel/hardened/patches.json
+++ b/pkgs/os-specific/linux/kernel/hardened/patches.json
@@ -62,11 +62,11 @@
     "6.6": {
         "patch": {
             "extra": "-hardened1",
-            "name": "linux-hardened-v6.6.83-hardened1.patch",
-            "sha256": "0wzgkj4ypa3clbzq40jkm3qjhbnj8wj48wc9vxx8v15gl4rppgga",
-            "url": "https://github.com/anthraxx/linux-hardened/releases/download/v6.6.83-hardened1/linux-hardened-v6.6.83-hardened1.patch"
+            "name": "linux-hardened-v6.6.87-hardened1.patch",
+            "sha256": "0djz9yav55vfzlmjrpmq6mj0xjj07p6cx9rjnqd3ch6bpim170sq",
+            "url": "https://github.com/anthraxx/linux-hardened/releases/download/v6.6.87-hardened1/linux-hardened-v6.6.87-hardened1.patch"
         },
-        "sha256": "0262q81mwhy8plql8hnnfvagp460vfl127kaayya113l7gkbnjw9",
-        "version": "6.6.83"
+        "sha256": "1iks6msk4cajyy0khyhrwsdl123hr81n67xzdnhlgg6dvb1famw9",
+        "version": "6.6.87"
     }
 }

--- a/pkgs/os-specific/linux/kernel/kernels-org.json
+++ b/pkgs/os-specific/linux/kernel/kernels-org.json
@@ -28,8 +28,8 @@
         "hash": "sha256:0jbps9sr4bpg4ym6vjib33lfjqjh09azh39ck7v7zsyyz0259nfq"
     },
     "6.13": {
-        "version": "6.13.11",
-        "hash": "sha256:08gcms4gvh8i30wj9vk27rb7d4yrndprxk1m72dhr1f7lywz2azn"
+        "version": "6.13.12",
+        "hash": "sha256:0hhj49k3ksjcp0dg5yiahqzryjfdpr9c1a9ph6j9slzmkikbn7v1"
     },
     "6.14": {
         "version": "6.14.3",

--- a/pkgs/os-specific/linux/kernel/kernels-org.json
+++ b/pkgs/os-specific/linux/kernel/kernels-org.json
@@ -32,7 +32,7 @@
         "hash": "sha256:08gcms4gvh8i30wj9vk27rb7d4yrndprxk1m72dhr1f7lywz2azn"
     },
     "6.14": {
-        "version": "6.14.2",
-        "hash": "sha256:06rfg9bnn48his9km0nf38i3fp4ylws7v9apjc9r0cgaajiq5in5"
+        "version": "6.14.3",
+        "hash": "sha256:0ak5av0ykf8m65dmbihlcx9ahb1p8rgx6bm04acz0s15qcic7ili"
     }
 }

--- a/pkgs/os-specific/linux/kernel/kernels-org.json
+++ b/pkgs/os-specific/linux/kernel/kernels-org.json
@@ -1,7 +1,7 @@
 {
     "testing": {
-        "version": "6.15-rc1",
-        "hash": "sha256:0kp35q86jihknj5y6f1zspfkhqx0c0npkk3is8p0gf2r3y302cp9"
+        "version": "6.15-rc2",
+        "hash": "sha256:0ldqjmafisf8dx5xhak9y7glwlrk07hppfpi27w2nb5845bqdwfz"
     },
     "6.1": {
         "version": "6.1.134",

--- a/pkgs/os-specific/linux/kernel/kernels-org.json
+++ b/pkgs/os-specific/linux/kernel/kernels-org.json
@@ -24,8 +24,8 @@
         "hash": "sha256:1iks6msk4cajyy0khyhrwsdl123hr81n67xzdnhlgg6dvb1famw9"
     },
     "6.12": {
-        "version": "6.12.23",
-        "hash": "sha256:0jbps9sr4bpg4ym6vjib33lfjqjh09azh39ck7v7zsyyz0259nfq"
+        "version": "6.12.24",
+        "hash": "sha256:078c2gs7f4gzxhc1jr42bfwrfi4yq5f84l7r2bfn05crnp0l4cb4"
     },
     "6.13": {
         "version": "6.13.12",

--- a/pkgs/os-specific/linux/kernel/linux-rt-5.10.nix
+++ b/pkgs/os-specific/linux/kernel/linux-rt-5.10.nix
@@ -10,7 +10,7 @@
 }@args:
 
 let
-  version = "5.10.234-rt127"; # updated by ./update-rt.sh
+  version = "5.10.235-rt129"; # updated by ./update-rt.sh
   branch = lib.versions.majorMinor version;
   kversion = builtins.elemAt (lib.splitString "-" version) 0;
 in
@@ -25,7 +25,7 @@ buildLinux (
 
     src = fetchurl {
       url = "mirror://kernel/linux/kernel/v5.x/linux-${kversion}.tar.xz";
-      sha256 = "1rgb4v6dvqlw1mgzsli0hxaj2d5d4m1nylgcrwm4bkpiwbzc95wm";
+      sha256 = "1k7iq4np3pflkq3d71ya8xs5czhslhy2iha4ls9lma81269y6fwm";
     };
 
     kernelPatches =
@@ -34,7 +34,7 @@ buildLinux (
           name = "rt";
           patch = fetchurl {
             url = "mirror://kernel/linux/kernel/projects/rt/${branch}/older/patch-${version}.patch.xz";
-            sha256 = "1pmfba5sjmhai2hbzgbwhak46jhc45rcxf7zdgx5hbhbpgbl9d49";
+            sha256 = "1zjj34zjy7zvzcbsh3a20p82pj9g8bsg2mm8k2kjp89ngzb2790v";
           };
         };
       in

--- a/pkgs/os-specific/linux/kernel/linux-rt-5.15.nix
+++ b/pkgs/os-specific/linux/kernel/linux-rt-5.15.nix
@@ -10,7 +10,7 @@
 }@args:
 
 let
-  version = "5.15.177-rt83"; # updated by ./update-rt.sh
+  version = "5.15.179-rt84"; # updated by ./update-rt.sh
   branch = lib.versions.majorMinor version;
   kversion = builtins.elemAt (lib.splitString "-" version) 0;
 in
@@ -29,7 +29,7 @@ buildLinux (
 
     src = fetchurl {
       url = "mirror://kernel/linux/kernel/v5.x/linux-${kversion}.tar.xz";
-      sha256 = "1q56w3lqwi3ynny6z7siqzv3h8nryksyw70r3fhghca2il4bi7pa";
+      sha256 = "0vqk4wd0cacigz42gigdzbj415hcdn2k2m01yr7k8pcv3rxs86ck";
     };
 
     kernelPatches =
@@ -38,7 +38,7 @@ buildLinux (
           name = "rt";
           patch = fetchurl {
             url = "mirror://kernel/linux/kernel/projects/rt/${branch}/older/patch-${version}.patch.xz";
-            sha256 = "1rc0cbc5jkgr3q3q2syqidak744lxcq3f5zdq6si2rsfxjz45www";
+            sha256 = "0p2yq4ahv0rwynivvlldhalpw65ka6hmjxh26p3pi5qrv3rbwja1";
           };
         };
       in

--- a/pkgs/os-specific/linux/kernel/linux-rt-6.1.nix
+++ b/pkgs/os-specific/linux/kernel/linux-rt-6.1.nix
@@ -10,7 +10,7 @@
 }@args:
 
 let
-  version = "6.1.128-rt49"; # updated by ./update-rt.sh
+  version = "6.1.134-rt51"; # updated by ./update-rt.sh
   branch = lib.versions.majorMinor version;
   kversion = builtins.elemAt (lib.splitString "-" version) 0;
 in
@@ -29,7 +29,7 @@ buildLinux (
 
     src = fetchurl {
       url = "mirror://kernel/linux/kernel/v6.x/linux-${kversion}.tar.xz";
-      sha256 = "1wshgkgcxaf4mnm4ngngsj8gq1cg8kq56f5kqsdfcw0m339nfkc7";
+      sha256 = "08xx0w5gz7w5hqsnpckmizi1zpg38iwfchj20163ivnxf3fhriv0";
     };
 
     kernelPatches =
@@ -38,7 +38,7 @@ buildLinux (
           name = "rt";
           patch = fetchurl {
             url = "mirror://kernel/linux/kernel/projects/rt/${branch}/older/patch-${version}.patch.xz";
-            sha256 = "1gyy9zwfcczy9v8790f06kaz7gg75a4cf4qpyjffqx3s21lwzbjf";
+            sha256 = "18nznajrbjx9y76lki6aa10jkh33v60fnmyrbc0ds9x9xsnfahzz";
           };
         };
       in

--- a/pkgs/os-specific/linux/kernel/linux-rt-6.6.nix
+++ b/pkgs/os-specific/linux/kernel/linux-rt-6.6.nix
@@ -10,7 +10,7 @@
 }@args:
 
 let
-  version = "6.6.77-rt50"; # updated by ./update-rt.sh
+  version = "6.6.87-rt54"; # updated by ./update-rt.sh
   branch = lib.versions.majorMinor version;
   kversion = builtins.elemAt (lib.splitString "-" version) 0;
 in
@@ -29,7 +29,7 @@ buildLinux (
 
     src = fetchurl {
       url = "mirror://kernel/linux/kernel/v6.x/linux-${kversion}.tar.xz";
-      sha256 = "0km855dnimg1clilnpcz293bd2gpbycvn3llm9kyynhjrzgqj408";
+      sha256 = "1iks6msk4cajyy0khyhrwsdl123hr81n67xzdnhlgg6dvb1famw9";
     };
 
     kernelPatches =
@@ -38,7 +38,7 @@ buildLinux (
           name = "rt";
           patch = fetchurl {
             url = "mirror://kernel/linux/kernel/projects/rt/${branch}/older/patch-${version}.patch.xz";
-            sha256 = "10kzns1c6yqn7az2i7zwm1lnss56mi6w44rw7xm2kk6n1h80590n";
+            sha256 = "0qxfs10y1ndq346gvcmhv0a02bbd3804yn1hvpx3p7bjp91j2as6";
           };
         };
       in


### PR DESCRIPTION
Ran `update.sh` in `pkgs/os-specific/linux/kernel`, the following packages were updated:

* linux_testing: 6.15-rc1 -> 6.15-rc2
* linux_6_14: 6.14.2 -> 6.14.3
* linux_6_13: 6.13.11 -> 6.13.12
* linux_6_12: 6.12.23 -> 6.12.24
* linux-rt_5_10: 5.10.234-rt127 -> 5.10.235-rt129
* linux-rt_5_15: 5.15.177-rt83 -> 5.15.179-rt84
* linux-rt_6_1: 6.1.128-rt49 -> 6.1.134-rt51
* linux-rt_6_6: 6.6.77-rt50 -> 6.6.87-rt54
* linux/hardened/patches/5.10: v5.10.235-hardened1 -> v5.10.236-hardened1
* linux/hardened/patches/5.15: v5.15.179-hardened1 -> v5.15.180-hardened1
* linux/hardened/patches/5.4: v5.4.291-hardened1 -> v5.4.292-hardened1
* linux/hardened/patches/6.1: v6.1.131-hardened1 -> v6.1.134-hardened1
* linux/hardened/patches/6.12: v6.12.19-hardened1 -> v6.12.23-hardened1
* linux/hardened/patches/6.13: v6.13.7-hardened1 -> v6.13.11-hardened1
* linux/hardened/patches/6.6: v6.6.83-hardened1 -> v6.6.87-hardened1

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
