### PR TITLE
python312Packages.pybind11-protobuf: 0-unstable-2024-11-01 -> 0-unstable-2025-02-10

### DIFF
--- a/pkgs/development/python-modules/pybind11-protobuf/add-install-target-for-cmake-builds.patch
+++ b/pkgs/development/python-modules/pybind11-protobuf/add-install-target-for-cmake-builds.patch
@@ -1,0 +1,78 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 4ec0f64..48b619a 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -39,3 +39,54 @@ add_subdirectory(cmake/dependencies dependencies)
+ set(TOP_LEVEL_DIR ${CMAKE_CURRENT_LIST_DIR})
+ include_directories(${TOP_LEVEL_DIR} ${pybind11_INCLUDE_DIRS})
+ add_subdirectory(pybind11_protobuf)
++
++# ============================================================================
++
++# pybind11_protobuf CMake Config module
++include(CMakePackageConfigHelpers)
++configure_package_config_file(
++  ${CMAKE_CURRENT_SOURCE_DIR}/cmake/Config.cmake.in
++  "${CMAKE_CURRENT_BINARY_DIR}/pybind11_protobuf-config.cmake"
++  INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/pybind11_protobuf
++  NO_CHECK_REQUIRED_COMPONENTS_MACRO)
++install(FILES "${CMAKE_CURRENT_BINARY_DIR}/pybind11_protobuf-config.cmake"
++        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/pybind11_protobuf)
++
++# ============================================================================
++
++add_library(pybind11_protobuf::native ALIAS pybind11_native_proto_caster)
++
++install(
++  TARGETS pybind11_native_proto_caster
++  EXPORT pybind11_protobuf_native_targets
++  DESTINATION ${CMAKE_INSTALL_LIBDIR}
++  INCLUDES
++  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/pybind11_protobuf)
++install(
++  FILES pybind11_protobuf/native_proto_caster.h
++        pybind11_protobuf/check_unknown_fields.h
++        pybind11_protobuf/enum_type_caster.h
++        pybind11_protobuf/proto_caster_impl.h
++        pybind11_protobuf/proto_cast_util.h
++  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/pybind11_protobuf)
++install(
++  EXPORT pybind11_protobuf_native_targets
++  FILE pybind11_protobuf_native-targets.cmake
++  NAMESPACE pybind11_protobuf::
++  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/pybind11_protobuf)
++
++add_library(pybind11_protobuf::wrapped ALIAS pybind11_wrapped_proto_caster)
++
++install(
++  TARGETS pybind11_wrapped_proto_caster
++  EXPORT pybind11_protobuf_wrapped_targets
++  DESTINATION ${CMAKE_INSTALL_LIBDIR}
++  INCLUDES
++  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/pybind11_protobuf)
++install(FILES pybind11_protobuf/wrapped_proto_caster.h
++        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/pybind11_protobuf)
++install(
++  EXPORT pybind11_protobuf_wrapped_targets
++  FILE pybind11_protobuf_wrapped-targets.cmake
++  NAMESPACE pybind11_protobuf::
++  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/pybind11_protobuf)
+diff --git a/cmake/Config.cmake.in b/cmake/Config.cmake.in
+new file mode 100644
+index 0000000..00dae69
+--- /dev/null
++++ b/cmake/Config.cmake.in
+@@ -0,0 +1,13 @@
++@PACKAGE_INIT@
++
++set(_pybind11_protobuf_supported_components native wrapped)
++
++foreach(_comp ${pybind11_protobuf_FIND_COMPONENTS})
++  if(NOT _comp IN_LIST _pybind11_protobuf_supported_components)
++    set(pybind11_protobuf_FOUND False)
++    set(pybind11_protobuf_NOT_FOUND_MESSAGE "Unsupported component: ${_comp}")
++  endif()
++endforeach()
++foreach(_comp ${_pybind11_protobuf_supported_components})
++  include("${CMAKE_CURRENT_LIST_DIR}/pybind11_protobuf_${_comp}-targets.cmake")
++endforeach()

--- a/pkgs/development/python-modules/pybind11-protobuf/default.nix
+++ b/pkgs/development/python-modules/pybind11-protobuf/default.nix
@@ -1,46 +1,56 @@
 {
   lib,
+  stdenv,
   buildPythonPackage,
   fetchFromGitHub,
-  fetchpatch,
   cmake,
-  abseil-cpp_202301,
-  protobuf_23,
+  abseil-cpp,
+  protobuf,
   pybind11,
+  zlib,
 }:
 
 buildPythonPackage {
   pname = "pybind11-protobuf";
-  version = "0-unstable-2024-11-01";
+  version = "0-unstable-2025-02-10";
   pyproject = false;
 
   src = fetchFromGitHub {
     owner = "pybind";
     repo = "pybind11_protobuf";
-    rev = "90b1a5b9de768340069c15b603d467c21cac5e0b";
-    hash = "sha256-3OuwRP9MhxmcfeDx+p74Fz6iLqi9FXbR3t3BtafesKk=";
+    rev = "f02a2b7653bc50eb5119d125842a3870db95d251";
+    hash = "sha256-jlZcxQKYYYvTOGhk+0Sgtek4oKy6R1wDGiBOf2t+KiU=";
   };
 
   patches = [
-    (fetchpatch {
-      name = "0006-Add-install-target-for-CMake-builds.patch";
-      url = "https://build.opensuse.org/public/source/openSUSE:Factory/pybind11_protobuf/0006-Add-install-target-for-CMake-builds.patch?rev=2";
-      hash = "sha256-tjaOr6f+JCRft0SWd0Zfte7FEOYOP7RrW0Vjz34rX6I=";
-    })
-    (fetchpatch {
-      name = "0007-CMake-Use-Python-Module.patch";
-      url = "https://build.opensuse.org/public/source/openSUSE:Factory/pybind11_protobuf/0007-CMake-Use-Python-Module.patch?rev=2";
-      hash = "sha256-A1dhfh31FMBHBdCfoYmQrInZvO/DeuVMUL57PpUHYfA=";
-    })
+    # Rebase of the OpenSUSE patch: https://build.opensuse.org/projects/openSUSE:Factory/packages/pybind11_protobuf/files/0006-Add-install-target-for-CMake-builds.patch?expand=1
+    # on top of: https://github.com/pybind/pybind11_protobuf/pull/188/commits/5f0ac3d8c10cbb8b3b81063467c71085cd39624f
+    ./add-install-target-for-cmake-builds.patch
   ];
 
   nativeBuildInputs = [ cmake ];
 
   buildInputs = [
-    abseil-cpp_202301
-    protobuf_23
+    abseil-cpp
+    protobuf
     pybind11
+    zlib
   ];
+
+  cmakeFlags =
+    [
+      (lib.cmakeBool "USE_SYSTEM_ABSEIL" true)
+      (lib.cmakeBool "USE_SYSTEM_PROTOBUF" true)
+      (lib.cmakeBool "USE_SYSTEM_PYBIND" true)
+
+      # The find_package calls are local to the dependencies subdirectory
+      (lib.cmakeBool "CMAKE_FIND_PACKAGE_TARGETS_GLOBAL" true)
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [
+      # Without it, Cmake prefers using Find-module which is mysteriously broken
+      # But the generated Config works
+      (lib.cmakeBool "CMAKE_FIND_PACKAGE_PREFER_CONFIG" true)
+    ];
 
   meta = {
     description = "Pybind11 bindings for Google's Protocol Buffers";


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
