### PR TITLE
pkgs/top-level/stage.nix: move most nixpkgs sets to variants

### DIFF
--- a/doc/release-notes/rl-2511.section.md
+++ b/doc/release-notes/rl-2511.section.md
@@ -3,7 +3,7 @@
 ## Highlights {#sec-nixpkgs-release-25.11-highlights}
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
 
-- Create the first release note entry in this section!
+- Added `allowVariants` to gate availability of package sets like `pkgsLLVM`, `pkgsMusl`, `pkgsZig`, etc.
 
 ## Backward Incompatibilities {#sec-nixpkgs-release-25.11-incompatibilities}
 

--- a/pkgs/top-level/config.nix
+++ b/pkgs/top-level/config.nix
@@ -137,6 +137,18 @@ let
       '';
     };
 
+    allowVariants = mkOption {
+      type = types.bool;
+      default = true;
+      description = ''
+        Whether to expose the nixpkgs variants.
+
+        Variants are instances of the current nixpkgs instance with different stdenvs or other applied options.
+        This allows for using different toolchains, libcs, or global build changes across nixpkgs.
+        Disabling can ensure nixpkgs is only building for the platform which you specified.
+      '';
+    };
+
     cudaSupport = mkMassRebuild {
       type = types.bool;
       default = false;

--- a/pkgs/top-level/stage.nix
+++ b/pkgs/top-level/stage.nix
@@ -191,6 +191,16 @@ let
 
   aliases = self: super: lib.optionalAttrs config.allowAliases (import ./aliases.nix lib self super);
 
+  variants = import ./variants.nix {
+    inherit
+      lib
+      nixpkgsFun
+      stdenv
+      overlays
+      makeMuslParsedPlatform
+      ;
+  };
+
   # stdenvOverrides is used to avoid having multiple of versions
   # of certain dependencies that were used in bootstrapping the
   # standard environment.
@@ -214,6 +224,7 @@ let
   # - pkgsCross.<system> where system is a member of lib.systems.examples
   # - pkgsMusl
   # - pkgsi686Linux
+  # NOTE: add new non-critical package sets to "pkgs/top-level/variants.nix"
   otherPackageSets = self: super: {
     # This maps each entry in lib.systems.examples to its own package
     # set. Each of these will contain all packages cross compiled for
@@ -221,69 +232,6 @@ let
     # will refer to the "hello" package built for the ARM6-based
     # Raspberry Pi.
     pkgsCross = lib.mapAttrs (n: crossSystem: nixpkgsFun { inherit crossSystem; }) lib.systems.examples;
-
-    pkgsLLVM = nixpkgsFun {
-      overlays = [
-        (self': super': {
-          pkgsLLVM = super';
-        })
-      ] ++ overlays;
-      # Bootstrap a cross stdenv using the LLVM toolchain.
-      # This is currently not possible when compiling natively,
-      # so we don't need to check hostPlatform != buildPlatform.
-      crossSystem = stdenv.hostPlatform // {
-        useLLVM = true;
-        linker = "lld";
-      };
-    };
-
-    pkgsArocc = nixpkgsFun {
-      overlays = [
-        (self': super': {
-          pkgsArocc = super';
-        })
-      ] ++ overlays;
-      # Bootstrap a cross stdenv using the Aro C compiler.
-      # This is currently not possible when compiling natively,
-      # so we don't need to check hostPlatform != buildPlatform.
-      crossSystem = stdenv.hostPlatform // {
-        useArocc = true;
-        linker = "lld";
-      };
-    };
-
-    pkgsZig = nixpkgsFun {
-      overlays = [
-        (self': super': {
-          pkgsZig = super';
-        })
-      ] ++ overlays;
-      # Bootstrap a cross stdenv using the Zig toolchain.
-      # This is currently not possible when compiling natively,
-      # so we don't need to check hostPlatform != buildPlatform.
-      crossSystem = stdenv.hostPlatform // {
-        useZig = true;
-        linker = "lld";
-      };
-    };
-
-    # All packages built with the Musl libc. This will override the
-    # default GNU libc on Linux systems. Non-Linux systems are not
-    # supported. 32-bit is also not supported.
-    pkgsMusl =
-      if stdenv.hostPlatform.isLinux && stdenv.buildPlatform.is64bit then
-        nixpkgsFun {
-          overlays = [
-            (self': super': {
-              pkgsMusl = super';
-            })
-          ] ++ overlays;
-          ${if stdenv.hostPlatform == stdenv.buildPlatform then "localSystem" else "crossSystem"} = {
-            config = lib.systems.parse.tripleFromSystem (makeMuslParsedPlatform stdenv.hostPlatform.parsed);
-          };
-        }
-      else
-        throw "Musl libc only supports 64-bit Linux systems.";
 
     # All packages built for i686 Linux.
     # Used by wine, firefox with debugging version of Flash, ...
@@ -376,45 +324,6 @@ let
           // stdenv.hostPlatform.gcc or { };
       };
     });
-
-    # Full package set with rocm on cuda off
-    # Mostly useful for asserting pkgs.pkgsRocm.torchWithRocm == pkgs.torchWithRocm and similar
-    pkgsRocm = nixpkgsFun ({
-      config = super.config // {
-        cudaSupport = false;
-        rocmSupport = true;
-      };
-    });
-
-    pkgsExtraHardening = nixpkgsFun {
-      overlays = [
-        (
-          self': super':
-          {
-            pkgsExtraHardening = super';
-            stdenv = super'.withDefaultHardeningFlags (
-              super'.stdenv.cc.defaultHardeningFlags
-              ++ [
-                "shadowstack"
-                "nostrictaliasing"
-                "pacret"
-                "trivialautovarinit"
-              ]
-            ) super'.stdenv;
-            glibc = super'.glibc.override rec {
-              enableCET = if self'.stdenv.hostPlatform.isx86_64 then "permissive" else false;
-              enableCETRuntimeDefault = enableCET != false;
-            };
-          }
-          // lib.optionalAttrs (with super'.stdenv.hostPlatform; isx86_64 && isLinux) {
-            # causes shadowstack disablement
-            pcre = super'.pcre.override { enableJit = false; };
-            pcre-cpp = super'.pcre-cpp.override { enableJit = false; };
-            pcre16 = super'.pcre16.override { enableJit = false; };
-          }
-        )
-      ] ++ overlays;
-    };
   };
 
   # The complete chain of package set builders, applied from top to bottom.
@@ -430,6 +339,7 @@ let
       allPackages
       otherPackageSets
       aliases
+      variants
       configOverrides
     ]
     ++ overlays

--- a/pkgs/top-level/variants.nix
+++ b/pkgs/top-level/variants.nix
@@ -1,0 +1,127 @@
+/*
+  This file contains all of the different variants of nixpkgs instances.
+
+  Unlike the other package sets like pkgsCross, pkgsi686Linux, etc., this
+  contains non-critical package sets. The intent is to be a shorthand
+  for things like using different toolchains in every package in nixpkgs.
+*/
+{
+  lib,
+  stdenv,
+  nixpkgsFun,
+  overlays,
+  makeMuslParsedPlatform,
+}:
+let
+  makeLLVMParsedPlatform =
+    parsed:
+    (
+      parsed
+      // {
+        abi = lib.systems.parse.abis.llvm;
+      }
+    );
+in
+self: super: {
+  pkgsLLVM = nixpkgsFun {
+    overlays = [
+      (self': super': {
+        pkgsLLVM = super';
+      })
+    ] ++ overlays;
+    # Bootstrap a cross stdenv using the LLVM toolchain.
+    # This is currently not possible when compiling natively,
+    # so we don't need to check hostPlatform != buildPlatform.
+    crossSystem = stdenv.hostPlatform // {
+      useLLVM = true;
+      linker = "lld";
+    };
+  };
+
+  pkgsArocc = nixpkgsFun {
+    overlays = [
+      (self': super': {
+        pkgsArocc = super';
+      })
+    ] ++ overlays;
+    # Bootstrap a cross stdenv using the Aro C compiler.
+    # This is currently not possible when compiling natively,
+    # so we don't need to check hostPlatform != buildPlatform.
+    crossSystem = stdenv.hostPlatform // {
+      useArocc = true;
+      linker = "lld";
+    };
+  };
+
+  pkgsZig = nixpkgsFun {
+    overlays = [
+      (self': super': {
+        pkgsZig = super';
+      })
+    ] ++ overlays;
+    # Bootstrap a cross stdenv using the Zig toolchain.
+    # This is currently not possible when compiling natively,
+    # so we don't need to check hostPlatform != buildPlatform.
+    crossSystem = stdenv.hostPlatform // {
+      useZig = true;
+      linker = "lld";
+    };
+  };
+
+  # All packages built with the Musl libc. This will override the
+  # default GNU libc on Linux systems. Non-Linux systems are not
+  # supported. 32-bit is also not supported.
+  pkgsMusl =
+    if stdenv.hostPlatform.isLinux && stdenv.buildPlatform.is64bit then
+      nixpkgsFun {
+        overlays = [
+          (self': super': {
+            pkgsMusl = super';
+          })
+        ] ++ overlays;
+        ${if stdenv.hostPlatform == stdenv.buildPlatform then "localSystem" else "crossSystem"} = {
+          config = lib.systems.parse.tripleFromSystem (makeMuslParsedPlatform stdenv.hostPlatform.parsed);
+        };
+      }
+    else
+      throw "Musl libc only supports 64-bit Linux systems.";
+
+  # Full package set with rocm on cuda off
+  # Mostly useful for asserting pkgs.pkgsRocm.torchWithRocm == pkgs.torchWithRocm and similar
+  pkgsRocm = nixpkgsFun ({
+    config = super.config // {
+      cudaSupport = false;
+      rocmSupport = true;
+    };
+  });
+
+  pkgsExtraHardening = nixpkgsFun {
+    overlays = [
+      (
+        self': super':
+        {
+          pkgsExtraHardening = super';
+          stdenv = super'.withDefaultHardeningFlags (
+            super'.stdenv.cc.defaultHardeningFlags
+            ++ [
+              "shadowstack"
+              "nostrictaliasing"
+              "pacret"
+              "trivialautovarinit"
+            ]
+          ) super'.stdenv;
+          glibc = super'.glibc.override rec {
+            enableCET = if self'.stdenv.hostPlatform.isx86_64 then "permissive" else false;
+            enableCETRuntimeDefault = enableCET != false;
+          };
+        }
+        // lib.optionalAttrs (with super'.stdenv.hostPlatform; isx86_64 && isLinux) {
+          # causes shadowstack disablement
+          pcre = super'.pcre.override { enableJit = false; };
+          pcre-cpp = super'.pcre-cpp.override { enableJit = false; };
+          pcre16 = super'.pcre16.override { enableJit = false; };
+        }
+      )
+    ] ++ overlays;
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Idea comes from https://github.com/NixOS/nixpkgs/pull/375435#discussion_r1927770569.

Add separate nixpkgs variants which can be disabled or enabled as needed.

Also add `mkOptionalOverlay`, this allows us to throw an error when an attribute from an overlay isn't available unless enabled.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
