### PR TITLE
dscanner: init at 0.15.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -11109,17 +11109,17 @@
     githubId = 16307070;
     name = "iosmanthus";
   };
-  iqubic = {
-    email = "sophia.b.caspe@gmail.com";
-    github = "iqubic";
-    githubId = 22628816;
-    name = "Sophia Caspe";
-  };
   ipsavitsky = {
     email = "ipsavitsky234@gmail.com";
     github = "ipsavitsky";
     githubId = 33558632;
     name = "Ilya Savitsky";
+  };
+  iqubic = {
+    email = "sophia.b.caspe@gmail.com";
+    github = "iqubic";
+    githubId = 22628816;
+    name = "Sophia Caspe";
   };
   iquerejeta = {
     github = "iquerejeta";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -11115,6 +11115,12 @@
     githubId = 22628816;
     name = "Sophia Caspe";
   };
+  ipsavitsky = {
+    email = "ipsavitsky234@gmail.com";
+    github = "ipsavitsky";
+    githubId = 33558632;
+    name = "Ilya Savitsky";
+  };
   iquerejeta = {
     github = "iquerejeta";
     githubId = 31273774;

--- a/pkgs/by-name/ds/dscanner/dub-lock.json
+++ b/pkgs/by-name/ds/dscanner/dub-lock.json
@@ -1,0 +1,32 @@
+{
+  "dependencies": {
+    "dcd": {
+      "version": "0.16.0-beta.2",
+      "sha256": "0756q02q1jbimrqn814b3j7q042vlxb7vva1rq823jx148r23d4d"
+    },
+    "dsymbol": {
+      "version": "0.13.0",
+      "sha256": "1lpwdri2bv5avs3hr0j1i00kjwdbs9nkc13wzlmjalfzjhqqqvci"
+    },
+    "emsi_containers": {
+      "version": "0.9.0",
+      "sha256": "1viz1fjh6jhfvl0d25bb1q7aclm1hrs0d7hhcx1d9c0gg5k6lcpm"
+    },
+    "inifiled": {
+      "version": "1.3.3",
+      "sha256": "01hw0lb9n6vwmx6vj5nq2awg54l5pvngqhzxfj2kmg99az84dg6d"
+    },
+    "libddoc": {
+      "version": "0.8.0",
+      "sha256": "0vxhkd92rxrkrz0svapdnkzh1bdqhws6wakhjj7szmkvykjgwksc"
+    },
+    "libdparse": {
+      "version": "0.23.2",
+      "sha256": "0bcaasam3iiqisilyx4ysxahjmgifn7i8ny155nwg64bjjibd8dk"
+    },
+    "stdx-allocator": {
+      "version": "2.77.5",
+      "sha256": "1g8382wr49sjyar0jay8j7y2if7h1i87dhapkgxphnizp24d7kaj"
+    }
+  }
+}

--- a/pkgs/by-name/ds/dscanner/fix_version.patch
+++ b/pkgs/by-name/ds/dscanner/fix_version.patch
@@ -1,0 +1,12 @@
+diff --git a/dub.json b/dub.json
+index 72cb269..1ea3903 100644
+--- a/dub.json
++++ b/dub.json
+@@ -21,7 +21,4 @@
+   "stringImportPaths" : [
+     "bin"
+   ],
+-  "preBuildCommands" : [
+-    "\"$DC\" -run \"$PACKAGE_DIR/dubhash.d\""
+-  ]
+ }

--- a/pkgs/by-name/ds/dscanner/package.nix
+++ b/pkgs/by-name/ds/dscanner/package.nix
@@ -1,0 +1,52 @@
+{
+  lib,
+  buildDubPackage,
+  fetchFromGitHub,
+  versionCheckHook,
+}:
+
+buildDubPackage rec {
+  pname = "dscanner";
+  version = "0.15.2";
+
+  src = fetchFromGitHub {
+    owner = "dlang-community";
+    repo = "D-Scanner";
+    tag = "v${version}";
+    hash = "sha256-7lZhYlK07VWpSRnzawJ2RL69/U/AH/qPyQY4VfbnVn4=";
+  };
+
+  preBuild = ''
+    mkdir -p bin/
+    echo "v${version}" > bin/dubhash.txt
+  '';
+
+  patches = [
+    ./fix_version.patch
+  ];
+
+  dubLock = ./dub-lock.json;
+
+  doCheck = true;
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm755 bin/dscanner -t $out/bin
+    runHook postInstall
+  '';
+
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+
+  doInstallCheck = true;
+
+  meta = {
+    description = "Swiss-army knife for D source code";
+    changelog = "https://github.com/dlang-community/D-Scanner/releases/tag/v${version}";
+    homepage = "https://github.com/dlang-community/D-Scanner";
+    mainProgram = "dscanner";
+    maintainers = with lib.maintainers; [ ipsavitsky ];
+    license = lib.licenses.boost;
+  };
+}


### PR DESCRIPTION
This change adds a popular linter for dlang - dscanner.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
