### PR TITLE
petsc: fixup petscvariable; add external package superlu_dist

### DIFF
--- a/pkgs/by-name/pe/petsc/package.nix
+++ b/pkgs/by-name/pe/petsc/package.nix
@@ -237,6 +237,8 @@ stdenv.mkDerivation (finalAttrs: {
     ) finalAttrs.buildInputs
   );
 
+  __darwinAllowLocalNetworking = true;
+
   # This is needed as the checks need to compile and link the test cases with
   # -lpetsc, which is not available in the checkPhase, which is executed before
   # the installPhase. The installCheckPhase comes after the installPhase, so

--- a/pkgs/by-name/pe/petsc/package.nix
+++ b/pkgs/by-name/pe/petsc/package.nix
@@ -36,6 +36,7 @@
   withHypre ? withCommonDeps && mpiSupport,
   withFftw ? withCommonDeps,
   withSuperLu ? withCommonDeps,
+  withSuperLuDist ? withCommonDeps && mpiSupport,
   withSuitesparse ? withCommonDeps,
 
   # External libraries
@@ -52,6 +53,7 @@
   hypre,
   fftw,
   superlu,
+  superlu_dist,
   suitesparse,
 
   # Used in passthru.tests
@@ -69,6 +71,7 @@ assert withPtscotch -> (mpiSupport && withZlib);
 assert withScalapack -> mpiSupport;
 assert (withMumps && mpiSupport) -> withScalapack;
 assert withHypre -> mpiSupport;
+assert withSuperLuDist -> mpiSupport;
 
 let
   petscPackages = lib.makeScope newScope (self: {
@@ -99,6 +102,7 @@ let
     hypre = self.callPackage hypre.override { };
     fftw = self.callPackage fftw.override { };
     superlu = self.callPackage superlu.override { };
+    superlu_dist = self.callPackage superlu_dist.override { };
     suitesparse = self.callPackage suitesparse.override { };
   });
 in
@@ -141,6 +145,7 @@ stdenv.mkDerivation (finalAttrs: {
     ++ lib.optional withMumps petscPackages.mumps
     ++ lib.optional withHypre petscPackages.hypre
     ++ lib.optional withSuperLu petscPackages.superlu
+    ++ lib.optional withSuperLuDist petscPackages.superlu_dist
     ++ lib.optional withFftw petscPackages.fftw
     ++ lib.optional withSuitesparse petscPackages.suitesparse;
 
@@ -191,6 +196,7 @@ stdenv.mkDerivation (finalAttrs: {
     ++ lib.optional withHdf5 "--with-hdf5=1"
     ++ lib.optional withHypre "--with-hypre=1"
     ++ lib.optional withSuperLu "--with-superlu=1"
+    ++ lib.optional withSuperLuDist "--with-superlu_dist=1"
     ++ lib.optional withFftw "--with-fftw=1"
     ++ lib.optional withSuitesparse "--with-suitesparse=1";
 

--- a/pkgs/by-name/pe/petsc/package.nix
+++ b/pkgs/by-name/pe/petsc/package.nix
@@ -161,8 +161,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   configureFlags =
     [
-      "--with-blas=1"
-      "--with-lapack=1"
+      "--with-blaslapack=1"
       "--with-scalar-type=${scalarType}"
       "--with-precision=${precision}"
       "--with-mpi=${if mpiSupport then "1" else "0"}"

--- a/pkgs/by-name/pe/petsc/package.nix
+++ b/pkgs/by-name/pe/petsc/package.nix
@@ -58,6 +58,7 @@
 
   # Used in passthru.tests
   petsc,
+  mpich,
 }:
 assert withFullDeps -> withCommonDeps;
 
@@ -76,6 +77,7 @@ assert withSuperLuDist -> mpiSupport;
 let
   petscPackages = lib.makeScope newScope (self: {
     inherit
+      mpi
       # global override options
       mpiSupport
       fortranSupport
@@ -86,7 +88,6 @@ let
 
     petscPackages = self;
     # external libraries
-    mpi = self.callPackage mpi.override { };
     blas = self.callPackage blas.override { };
     lapack = self.callPackage lapack.override { };
     hdf5 = self.callPackage hdf5.override {
@@ -286,6 +287,9 @@ stdenv.mkDerivation (finalAttrs: {
         fullDeps = petsc.override {
           withFullDeps = true;
           withParmetis = false;
+        };
+        mpich = petsc.override {
+          mpi = mpich;
         };
       };
   };

--- a/pkgs/by-name/sl/slepc/package.nix
+++ b/pkgs/by-name/sl/slepc/package.nix
@@ -75,6 +75,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   installTargets = [ (if withExamples then "install" else "install-lib") ];
 
+  __darwinAllowLocalNetworking = true;
+
   nativeInstallCheckInputs =
     [
       mpiCheckPhaseHook


### PR DESCRIPTION
superlu_dist is needed in fullCheck of fenics-dolfinx.
since superlu_dist is supported on both linux and darwin platform now, i make it a commonDep when mpiSupport is enabled.

fixup petscvariable is needed when pyop2 in firedrakeProject lookup petscvariable for how to compile the generated c code.

both fenics and firedrake Project is going to publish a release by the end of April. I will make a Pr when release is available.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
