### PR TITLE
Rename and improve luanti/minetest module

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -607,7 +607,7 @@
   ./services/games/freeciv.nix
   ./services/games/mchprs.nix
   ./services/games/minecraft-server.nix
-  ./services/games/minetest-server.nix
+  ./services/games/luanti-server.nix
   ./services/games/openarena.nix
   ./services/games/quake3-server.nix
   ./services/games/teeworlds.nix

--- a/nixos/modules/services/games/luanti-server.nix
+++ b/nixos/modules/services/games/luanti-server.nix
@@ -41,7 +41,44 @@ let
     );
 
   flag = val: name: lib.optionals (val != null) ["--${name}" (toString val)];
+
+  oldCfg = config.services.minetest-server;
 in {
+  imports = [
+    (lib.mkRemovedOptionModule ["services" "minetest-server"] ''
+      The Minetest server module has been replaced by the Luanti multi-instance configuration.
+      
+      Instead of:
+        services.minetest-server = { ... };
+      
+      Use:
+        services.luanti-servers.<instanceName> = { ... };
+      
+      See https://<your-docs-url> for migration guide.
+    '')
+  ];
+
+  # Add assertions for specific old options
+  assertions = [
+    {
+      assertion = oldCfg.enable;
+      message = ''
+        The minetest-server service has been replaced by luanti-servers!
+        
+        Update your configuration from:
+          services.minetest-server = { ... };
+        to:
+          services.luanti-servers.<instanceName> = { 
+            enable = true;
+            # Old options map to:
+            port = <old-port>;
+            gameId = <old-gameId>;
+            # ... etc ...
+          };
+      '';
+    }
+  ];
+
   options.services.luanti-servers = lib.mkOption {
     type = lib.types.attrsOf (lib.types.submodule {
       options = {

--- a/pkgs/by-name/lu/luanti/package.nix
+++ b/pkgs/by-name/lu/luanti/package.nix
@@ -68,7 +68,7 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.cmakeBool "BUILD_CLIENT" buildClient)
     (lib.cmakeBool "BUILD_SERVER" buildServer)
     (lib.cmakeBool "BUILD_UNITTESTS" (finalAttrs.finalPackage.doCheck or false))
-    (lib.cmakeBool "ENABLE_PROMETHEUS" buildServer)
+    (lib.cmakeBool "ENABLE_PROMETHEUS" false)
     (lib.cmakeBool "USE_SDL2" useSDL2)
     # Ensure we use system libraries
     (lib.cmakeBool "ENABLE_SYSTEM_GMP" true)


### PR DESCRIPTION
Adding this draft PR following the discussion [here](https://github.com/NixOS/nixpkgs/issues/383670#issuecomment-2817121119).

It introduces the following general improvements to the luanti-server module in nixpkgs:

- add `openFirewall` option
- allow multiple instances of minetest servers
- choose the `package` to use for each instance
- rename to luanti
- Use these systemd options instead of creating a minetest user:
   ```nix
   serviceConfig = {
      DynamicUser = true;
      StateDirectory = "minetest-${name}";
    };
  ``` 

This also removes the flag `ENABLE_PROMETHEUS` from the build of minetest/luanti, as it's the default option in the luanti build instructions and it makes it harder to run multiple instances concurrently(see the [discussion](https://github.com/NixOS/nixpkgs/issues/383670#issuecomment-2817121119) mencioned above)

Also added the option `fetchGame` witch might be contentious. By default it fetches the [minetest_game](https://github.com/luanti-org/minetest_game) witch is the base game, but users can use `fetchFromGitHub` or `fetchgit`to get other games like mineclonia or voxeLibre like is explained in the examples in the options.

I tested the module in my own config and it was working, but while making the PR I also changed the name to luanti and added assertions for new users to get instructions on how to migrate to the new configuration, but I never did that before so it might not be done ideally and I didn't test since then, thus I'm keeping this in draft until I get around to testing it or if someone wants to give test it for me as I'm not on unstable branch rn, I'll probably have to make a couple changes to my config before I can test it.

CC @lomenzel @06kellyjac 

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
