### PR TITLE
treewide: remove references to deprecated `darwin.libobjc` stub

### DIFF
--- a/pkgs/applications/blockchains/optimism/geth.nix
+++ b/pkgs/applications/blockchains/optimism/geth.nix
@@ -1,9 +1,7 @@
 {
-  stdenv,
   lib,
   buildGoModule,
   fetchFromGitHub,
-  libobjc,
 }:
 
 buildGoModule rec {
@@ -34,11 +32,6 @@ buildGoModule rec {
   ];
 
   vendorHash = "sha256-pcIydpKWZt3vwShwzGlPKGq+disdxYFOB8gxHou3mVU=";
-
-  # Fix for usb-related segmentation faults on darwin
-  propagatedBuildInputs = lib.optionals stdenv.hostPlatform.isDarwin [
-    libobjc
-  ];
 
   ldflags = [
     "-s"

--- a/pkgs/applications/editors/lapce/default.nix
+++ b/pkgs/applications/editors/lapce/default.nix
@@ -13,7 +13,6 @@
   gtk3,
   openssl,
   libGL,
-  libobjc,
   libxkbcommon,
   wrapGAppsHook3,
   wayland,
@@ -77,9 +76,6 @@ rustPlatform.buildRustPackage rec {
     ]
     ++ lib.optionals stdenv.hostPlatform.isLinux [
       fontconfig
-    ]
-    ++ lib.optionals stdenv.hostPlatform.isDarwin [
-      libobjc
     ];
 
   postInstall =

--- a/pkgs/applications/editors/vim/full.nix
+++ b/pkgs/applications/editors/vim/full.nix
@@ -30,8 +30,6 @@
   makeWrapper,
   wrapGAppsHook3,
 
-  libobjc,
-
   features ? "huge", # One of tiny, small, normal, big or huge
   wrapPythonDrv ? false,
   guiSupport ? config.vim.gui or (if stdenv.hostPlatform.isDarwin then "gtk2" else "gtk3"),
@@ -190,9 +188,6 @@ stdenv.mkDerivation {
     ]
     ++ lib.optional (guiSupport == "gtk2") gtk2-x11
     ++ lib.optional (guiSupport == "gtk3") gtk3-x11
-    ++ lib.optionals darwinSupport [
-      libobjc
-    ]
     ++ lib.optional luaSupport lua
     ++ lib.optional pythonSupport python3
     ++ lib.optional tclSupport tcl

--- a/pkgs/applications/editors/vim/macvim.nix
+++ b/pkgs/applications/editors/vim/macvim.nix
@@ -150,7 +150,6 @@ stdenv.mkDerivation (finalAttrs: {
   postConfigure = ''
     substituteInPlace src/auto/config.mk \
       --replace " -L${stdenv.cc.libc}/lib" "" \
-      --replace " -L${darwin.libobjc}/lib" "" \
       --replace " -L${darwin.libunwind}/lib" "" \
       --replace " -L${libiconv}/lib" ""
 

--- a/pkgs/applications/networking/irc/weechat/default.nix
+++ b/pkgs/applications/networking/irc/weechat/default.nix
@@ -13,7 +13,6 @@
   pkg-config,
   libgcrypt,
   cmake,
-  libobjc,
   libresolv,
   libiconv,
   asciidoctor, # manpages
@@ -150,7 +149,6 @@ stdenv.mkDerivation rec {
       libgcrypt
     ]
     ++ lib.optionals stdenv.hostPlatform.isDarwin [
-      libobjc
       libresolv
     ]
     ++ lib.concatMap (p: p.buildInputs) enabledPlugins

--- a/pkgs/applications/radio/soapyairspy/default.nix
+++ b/pkgs/applications/radio/soapyairspy/default.nix
@@ -5,7 +5,6 @@
   cmake,
   airspy,
   soapysdr,
-  libobjc,
 }:
 
 stdenv.mkDerivation rec {
@@ -20,14 +19,10 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ cmake ];
-  buildInputs =
-    [
-      airspy
-      soapysdr
-    ]
-    ++ lib.optionals stdenv.hostPlatform.isDarwin [
-      libobjc
-    ];
+  buildInputs = [
+    airspy
+    soapysdr
+  ];
 
   cmakeFlags = [ "-DSoapySDR_DIR=${soapysdr}/share/cmake/SoapySDR/" ];
 

--- a/pkgs/applications/radio/soapybladerf/default.nix
+++ b/pkgs/applications/radio/soapybladerf/default.nix
@@ -6,7 +6,6 @@
   pkg-config,
   libbladeRF,
   soapysdr,
-  libobjc,
 }:
 
 let
@@ -28,14 +27,10 @@ stdenv.mkDerivation {
     cmake
     pkg-config
   ];
-  buildInputs =
-    [
-      libbladeRF
-      soapysdr
-    ]
-    ++ lib.optionals stdenv.hostPlatform.isDarwin [
-      libobjc
-    ];
+  buildInputs = [
+    libbladeRF
+    soapysdr
+  ];
 
   cmakeFlags = [ "-DSoapySDR_DIR=${soapysdr}/share/cmake/SoapySDR/" ];
 

--- a/pkgs/applications/radio/soapyhackrf/default.nix
+++ b/pkgs/applications/radio/soapyhackrf/default.nix
@@ -6,7 +6,6 @@
   pkg-config,
   hackrf,
   soapysdr,
-  libobjc,
 }:
 
 let
@@ -28,14 +27,10 @@ stdenv.mkDerivation {
     cmake
     pkg-config
   ];
-  buildInputs =
-    [
-      hackrf
-      soapysdr
-    ]
-    ++ lib.optionals stdenv.hostPlatform.isDarwin [
-      libobjc
-    ];
+  buildInputs = [
+    hackrf
+    soapysdr
+  ];
 
   cmakeFlags = [ "-DSoapySDR_DIR=${soapysdr}/share/cmake/SoapySDR/" ];
 

--- a/pkgs/applications/radio/soapyrtlsdr/default.nix
+++ b/pkgs/applications/radio/soapyrtlsdr/default.nix
@@ -6,7 +6,6 @@
   pkg-config,
   rtl-sdr,
   soapysdr,
-  libobjc,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -24,14 +23,10 @@ stdenv.mkDerivation (finalAttrs: {
     cmake
     pkg-config
   ];
-  buildInputs =
-    [
-      rtl-sdr
-      soapysdr
-    ]
-    ++ lib.optionals stdenv.hostPlatform.isDarwin [
-      libobjc
-    ];
+  buildInputs = [
+    rtl-sdr
+    soapysdr
+  ];
 
   cmakeFlags = [ "-DSoapySDR_DIR=${soapysdr}/share/cmake/SoapySDR/" ];
 

--- a/pkgs/applications/radio/soapyuhd/default.nix
+++ b/pkgs/applications/radio/soapyuhd/default.nix
@@ -7,7 +7,6 @@
   uhd,
   boost,
   soapysdr,
-  libobjc,
 }:
 
 stdenv.mkDerivation rec {
@@ -25,15 +24,11 @@ stdenv.mkDerivation rec {
     cmake
     pkg-config
   ];
-  buildInputs =
-    [
-      uhd
-      boost
-      soapysdr
-    ]
-    ++ lib.optionals stdenv.hostPlatform.isDarwin [
-      libobjc
-    ];
+  buildInputs = [
+    uhd
+    boost
+    soapysdr
+  ];
 
   cmakeFlags = [ "-DSoapySDR_DIR=${soapysdr}/share/cmake/SoapySDR/" ];
 

--- a/pkgs/applications/science/math/R/default.nix
+++ b/pkgs/applications/science/math/R/default.nix
@@ -33,7 +33,6 @@
   blas,
   lapack,
   curl,
-  libobjc,
   tzdata,
   withRecommendedPackages ? true,
   enableStrictBarrier ? false,
@@ -74,48 +73,44 @@ stdenv.mkDerivation (finalAttrs: {
     tzdata
     which
   ];
-  buildInputs =
-    [
-      bzip2
-      gfortran
-      libX11
-      libXmu
-      libXt
-      libXt
-      libjpeg
-      libpng
-      libtiff
-      ncurses
-      pango
-      pcre2
-      readline
-      (texliveSmall.withPackages (
-        ps: with ps; [
-          inconsolata
-          helvetic
-          ps.texinfo
-          fancyvrb
-          cm-super
-          rsfs
-        ]
-      ))
-      xz
-      zlib
-      less
-      texinfo
-      graphviz
-      icu
-      which
-      blas
-      lapack
-      curl
-      tcl
-      tk
-      jdk
-    ]
-    ++ lib.optionals stdenv.hostPlatform.isDarwin [
-      libobjc
-    ];
+  buildInputs = [
+    bzip2
+    gfortran
+    libX11
+    libXmu
+    libXt
+    libXt
+    libjpeg
+    libpng
+    libtiff
+    ncurses
+    pango
+    pcre2
+    readline
+    (texliveSmall.withPackages (
+      ps: with ps; [
+        inconsolata
+        helvetic
+        ps.texinfo
+        fancyvrb
+        cm-super
+        rsfs
+      ]
+    ))
+    xz
+    zlib
+    less
+    texinfo
+    graphviz
+    icu
+    which
+    blas
+    lapack
+    curl
+    tcl
+    tk
+    jdk
+  ];
   strictDeps = true;
 
   patches = [

--- a/pkgs/applications/virtualization/xhyve/default.nix
+++ b/pkgs/applications/virtualization/xhyve/default.nix
@@ -2,7 +2,6 @@
   stdenv,
   lib,
   fetchFromGitHub,
-  libobjc,
   zlib,
 }:
 
@@ -18,7 +17,6 @@ stdenv.mkDerivation rec {
   };
 
   buildInputs = [
-    libobjc
     zlib
   ];
 

--- a/pkgs/by-name/bo/bochs/package.nix
+++ b/pkgs/by-name/bo/bochs/package.nix
@@ -2,7 +2,6 @@
   lib,
   SDL2,
   curl,
-  darwin,
   docbook_xml_dtd_45,
   docbook_xsl,
   fetchurl,
@@ -62,9 +61,6 @@ stdenv.mkDerivation (finalAttrs: {
       libGLU
       libX11
       libXpm
-    ]
-    ++ lib.optionals stdenv.hostPlatform.isDarwin [
-      darwin.libobjc
     ];
 
   configureFlags =

--- a/pkgs/by-name/gn/gn/generic.nix
+++ b/pkgs/by-name/gn/gn/generic.nix
@@ -1,7 +1,6 @@
 {
   stdenv,
   lib,
-  darwin,
   fetchgit,
   fetchpatch,
   cctools,
@@ -55,7 +54,6 @@ stdenv.mkDerivation {
     python3
   ];
   buildInputs = lib.optionals stdenv.hostPlatform.isDarwin [
-    darwin.libobjc
     cctools
   ];
 

--- a/pkgs/by-name/go/go-ethereum/package.nix
+++ b/pkgs/by-name/go/go-ethereum/package.nix
@@ -1,9 +1,7 @@
 {
   lib,
-  stdenv,
   buildGoModule,
   fetchFromGitHub,
-  libobjc,
   nixosTests,
 }:
 
@@ -57,11 +55,6 @@ buildGoModule rec {
 
   # Following upstream: https://github.com/ethereum/go-ethereum/blob/v1.11.6/build/ci.go#L218
   tags = [ "urfave_cli_no_docs" ];
-
-  # Fix for usb-related segmentation faults on darwin
-  propagatedBuildInputs = lib.optionals stdenv.hostPlatform.isDarwin [
-    libobjc
-  ];
 
   passthru.tests = { inherit (nixosTests) geth; };
 

--- a/pkgs/by-name/ha/handbrake/package.nix
+++ b/pkgs/by-name/ha/handbrake/package.nix
@@ -58,8 +58,6 @@
   libdvdnav,
   libdvdcss,
   libbluray,
-  # Darwin-specific
-  darwin,
   # GTK
   # NOTE: 2019-07-19: The gtk3 package has a transitive dependency on dbus,
   # which in turn depends on systemd. systemd is not supported on Darwin, so
@@ -87,7 +85,6 @@
 }:
 
 let
-  inherit (darwin) libobjc;
   version = "1.9.2";
 
   src = fetchFromGitHub {
@@ -290,9 +287,6 @@ let
         udev
       ]
       ++ optional useFdk fdk_aac
-      ++ optionals stdenv.hostPlatform.isDarwin [
-        libobjc
-      ]
       # NOTE: 2018-12-27: Handbrake supports nv-codec-headers for Linux only,
       # look at ./make/configure.py search "enable_nvenc"
       ++ optional stdenv.hostPlatform.isLinux nv-codec-headers;

--- a/pkgs/by-name/li/libfreefare/package.nix
+++ b/pkgs/by-name/li/libfreefare/package.nix
@@ -6,7 +6,6 @@
   pkg-config,
   libnfc,
   openssl,
-  darwin,
 }:
 
 stdenv.mkDerivation {
@@ -22,14 +21,10 @@ stdenv.mkDerivation {
     autoreconfHook
     pkg-config
   ];
-  buildInputs =
-    [
-      libnfc
-      openssl
-    ]
-    ++ lib.optionals stdenv.hostPlatform.isDarwin [
-      darwin.libobjc
-    ];
+  buildInputs = [
+    libnfc
+    openssl
+  ];
 
   env = {
     NIX_CFLAGS_COMPILE = toString [

--- a/pkgs/by-name/li/libui-ng/package.nix
+++ b/pkgs/by-name/li/libui-ng/package.nix
@@ -2,7 +2,6 @@
   lib,
   stdenv,
   cmocka,
-  darwin,
   fetchFromGitHub,
   gtk3,
   meson,
@@ -33,15 +32,9 @@ stdenv.mkDerivation {
     pkg-config
   ];
 
-  buildInputs =
-    if stdenv.hostPlatform.isDarwin then
-      [
-        darwin.libobjc
-      ]
-    else
-      [
-        gtk3
-      ];
+  buildInputs = lib.optionals (!stdenv.hostPlatform.isDarwin) [
+    gtk3
+  ];
 
   mesonFlags = [
     (lib.mesonBool "examples" (!stdenv.hostPlatform.isDarwin))

--- a/pkgs/by-name/mo/movit/package.nix
+++ b/pkgs/by-name/mo/movit/package.nix
@@ -6,7 +6,6 @@
   SDL2,
   fftw,
   gtest,
-  darwin,
   eigen,
   libepoxy,
   libGL,
@@ -33,17 +32,13 @@ stdenv.mkDerivation rec {
     pkg-config
   ];
 
-  buildInputs =
-    [
-      SDL2
-      fftw
-      gtest
-      libGL
-      libX11
-    ]
-    ++ lib.optionals stdenv.hostPlatform.isDarwin [
-      darwin.libobjc
-    ];
+  buildInputs = [
+    SDL2
+    fftw
+    gtest
+    libGL
+    libX11
+  ];
 
   propagatedBuildInputs = [
     eigen

--- a/pkgs/by-name/oc/oculante/package.nix
+++ b/pkgs/by-name/oc/oculante/package.nix
@@ -16,7 +16,6 @@
   wayland,
   stdenv,
   gtk3,
-  darwin,
   perl,
   wrapGAppsHook3,
 }:
@@ -57,9 +56,6 @@ rustPlatform.buildRustPackage rec {
       gtk3
       libxkbcommon
       wayland
-    ]
-    ++ lib.optionals stdenv.hostPlatform.isDarwin [
-      darwin.libobjc
     ];
 
   checkFlags = [

--- a/pkgs/by-name/sd/SDL2_Pango/package.nix
+++ b/pkgs/by-name/sd/SDL2_Pango/package.nix
@@ -2,7 +2,6 @@
   lib,
   SDL2,
   autoreconfHook,
-  darwin,
   fetchFromGitHub,
   freetype,
   pango,
@@ -27,15 +26,11 @@ stdenv.mkDerivation (finalAttrs: {
     pkg-config
   ];
 
-  buildInputs =
-    [
-      SDL2
-      freetype
-      pango
-    ]
-    ++ lib.optionals stdenv.hostPlatform.isDarwin [
-      darwin.libobjc
-    ];
+  buildInputs = [
+    SDL2
+    freetype
+    pango
+  ];
 
   outputs = [
     "out"

--- a/pkgs/by-name/sd/SDL2_gfx/package.nix
+++ b/pkgs/by-name/sd/SDL2_gfx/package.nix
@@ -1,7 +1,6 @@
 {
   lib,
   SDL2,
-  darwin,
   fetchurl,
   pkg-config,
   stdenv,
@@ -25,13 +24,9 @@ stdenv.mkDerivation (finalAttrs: {
     pkg-config
   ];
 
-  buildInputs =
-    [
-      SDL2
-    ]
-    ++ lib.optionals stdenv.hostPlatform.isDarwin [
-      darwin.libobjc
-    ];
+  buildInputs = [
+    SDL2
+  ];
 
   outputs = [
     "out"

--- a/pkgs/by-name/sd/SDL2_net/package.nix
+++ b/pkgs/by-name/sd/SDL2_net/package.nix
@@ -1,7 +1,6 @@
 {
   lib,
   SDL2,
-  darwin,
   fetchFromGitHub,
   pkg-config,
   stdenv,
@@ -28,10 +27,6 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [
     SDL2
     pkg-config
-  ];
-
-  buildInputs = lib.optionals stdenv.hostPlatform.isDarwin [
-    darwin.libobjc
   ];
 
   propagatedBuildInputs = [ SDL2 ];

--- a/pkgs/by-name/sd/SDL2_ttf/package.nix
+++ b/pkgs/by-name/sd/SDL2_ttf/package.nix
@@ -1,7 +1,6 @@
 {
   lib,
   SDL2,
-  darwin,
   fetchurl,
   freetype,
   harfbuzz,
@@ -35,9 +34,6 @@ stdenv.mkDerivation (finalAttrs: {
     ]
     ++ lib.optionals (!stdenv.hostPlatform.isDarwin) [
       libGL
-    ]
-    ++ lib.optionals stdenv.hostPlatform.isDarwin [
-      darwin.libobjc
     ];
 
   configureFlags = [

--- a/pkgs/by-name/sm/smpeg2/package.nix
+++ b/pkgs/by-name/sm/smpeg2/package.nix
@@ -3,7 +3,6 @@
   stdenv,
   autoconf,
   automake,
-  darwin,
   fetchFromGitHub,
   makeWrapper,
   pkg-config,
@@ -28,7 +27,7 @@ stdenv.mkDerivation {
     pkg-config
   ];
 
-  buildInputs = [ SDL2 ] ++ lib.optional stdenv.hostPlatform.isDarwin darwin.libobjc;
+  buildInputs = [ SDL2 ];
 
   outputs = [
     "out"

--- a/pkgs/by-name/so/soapyplutosdr/package.nix
+++ b/pkgs/by-name/so/soapyplutosdr/package.nix
@@ -4,7 +4,6 @@
   fetchFromGitHub,
   cmake,
   pkg-config,
-  darwin,
   libad9361,
   libiio,
   libusb1,
@@ -26,16 +25,12 @@ stdenv.mkDerivation (finalAttrs: {
     cmake
     pkg-config
   ];
-  buildInputs =
-    [
-      libad9361
-      libiio
-      libusb1
-      soapysdr
-    ]
-    ++ lib.optionals stdenv.hostPlatform.isDarwin [
-      darwin.libobjc
-    ];
+  buildInputs = [
+    libad9361
+    libiio
+    libusb1
+    soapysdr
+  ];
 
   cmakeFlags = [ "-DSoapySDR_DIR=${soapysdr}/share/cmake/SoapySDR/" ];
 

--- a/pkgs/development/compilers/mono/4.nix
+++ b/pkgs/development/compilers/mono/4.nix
@@ -1,12 +1,10 @@
 {
   callPackage,
-  libobjc,
   stdenv,
   lib,
 }:
 
 callPackage ./generic.nix {
-  inherit libobjc;
   version = "4.8.1.0";
   sha256 = "1vyvp2g28ihcgxgxr8nhzyzdmzicsh5djzk8dk1hj5p5f2k3ijqq";
   enableParallelBuilding = false; # #32386, https://hydra.nixos.org/build/65600645

--- a/pkgs/development/compilers/mono/5.nix
+++ b/pkgs/development/compilers/mono/5.nix
@@ -1,10 +1,8 @@
 {
   callPackage,
-  libobjc,
 }:
 
 callPackage ./generic.nix {
-  inherit libobjc;
   version = "5.20.1.34";
   sha256 = "12vw5dkhmp1vk9l658pil8jiqirkpdsc5z8dm5mpj595yr6d94fd";
   enableParallelBuilding = true;

--- a/pkgs/development/compilers/mono/6.nix
+++ b/pkgs/development/compilers/mono/6.nix
@@ -1,10 +1,8 @@
 {
   callPackage,
-  libobjc,
 }:
 
 callPackage ./generic.nix {
-  inherit libobjc;
   version = "6.12.0.182";
   srcArchiveSuffix = "tar.xz";
   sha256 = "sha256-VzZqarTztezxEdSFSAMWFbOhANuHxnn8AG6Mik79lCQ=";

--- a/pkgs/development/compilers/mono/generic.nix
+++ b/pkgs/development/compilers/mono/generic.nix
@@ -13,7 +13,6 @@
   zlib,
   bash,
   cacert,
-  libobjc,
   python3,
   version,
   sha256,
@@ -51,19 +50,15 @@ stdenv.mkDerivation rec {
     which
     gnumake42
   ];
-  buildInputs =
-    [
-      glib
-      gettext
-      libgdiplus
-      libX11
-      ncurses
-      zlib
-      bash
-    ]
-    ++ lib.optionals stdenv.hostPlatform.isDarwin [
-      libobjc
-    ];
+  buildInputs = [
+    glib
+    gettext
+    libgdiplus
+    libX11
+    ncurses
+    zlib
+    bash
+  ];
 
   configureFlags = [
     "--x-includes=${libX11.dev}/include"

--- a/pkgs/development/compilers/terra/default.nix
+++ b/pkgs/development/compilers/terra/default.nix
@@ -10,7 +10,6 @@
   cudaPackages,
   enableCUDA ? false,
   libffi,
-  libobjc,
   libpfm,
 }:
 
@@ -63,10 +62,7 @@ stdenv.mkDerivation rec {
       libxml2
     ]
     ++ lib.optionals enableCUDA [ cuda ]
-    ++ lib.optional (!stdenv.hostPlatform.isDarwin) libpfm
-    ++ lib.optionals stdenv.hostPlatform.isDarwin [
-      libobjc
-    ];
+    ++ lib.optional (!stdenv.hostPlatform.isDarwin) libpfm;
 
   cmakeFlags =
     let

--- a/pkgs/development/haskell-modules/configuration-darwin.nix
+++ b/pkgs/development/haskell-modules/configuration-darwin.nix
@@ -165,12 +165,6 @@ self: super:
     # http://openradar.appspot.com/10207999 and similar issues.
     fsnotify = dontCheck super.fsnotify;
 
-    FractalArt = overrideCabal (drv: {
-      librarySystemDepends = [
-        darwin.libobjc
-      ] ++ (drv.librarySystemDepends or [ ]);
-    }) super.FractalArt;
-
     HTF = overrideCabal (drv: {
       # GNU find is not prefixed in stdenv
       postPatch =

--- a/pkgs/development/interpreters/ruby/default.nix
+++ b/pkgs/development/interpreters/ruby/default.nix
@@ -17,7 +17,6 @@
   bison,
   autoconf,
   libiconv,
-  libobjc,
   libunwind,
   buildEnv,
   bundler,
@@ -120,7 +119,6 @@ let
           bundler,
           bundix,
           libiconv,
-          libobjc,
           libunwind,
           makeBinaryWrapper,
           buildRubyGem,
@@ -183,7 +181,6 @@ let
             ++ op (!cursesSupport && stdenv.hostPlatform.isDarwin) readline
             ++ ops stdenv.hostPlatform.isDarwin [
               libiconv
-              libobjc
               libunwind
             ];
           propagatedBuildInputs = op jemallocSupport jemalloc;

--- a/pkgs/development/interpreters/spidermonkey/common.nix
+++ b/pkgs/development/interpreters/spidermonkey/common.nix
@@ -27,7 +27,6 @@
   nspr,
   readline,
   zlib,
-  libobjc,
   libiconv,
 }:
 
@@ -98,7 +97,6 @@ stdenv.mkDerivation (finalAttrs: rec {
       zlib
     ]
     ++ lib.optionals stdenv.hostPlatform.isDarwin [
-      libobjc
       libiconv
     ];
 

--- a/pkgs/development/libraries/libftdi/default.nix
+++ b/pkgs/development/libraries/libftdi/default.nix
@@ -3,7 +3,6 @@
   stdenv,
   fetchurl,
   libusb-compat-0_1,
-  libobjc,
 }:
 
 stdenv.mkDerivation rec {
@@ -15,11 +14,7 @@ stdenv.mkDerivation rec {
     sha256 = "13l39f6k6gff30hsgh0wa2z422g9pyl91rh8a8zz6f34k2sxaxii";
   };
 
-  buildInputs =
-    [ libusb-compat-0_1 ]
-    ++ lib.optionals stdenv.hostPlatform.isDarwin [
-      libobjc
-    ];
+  buildInputs = [ libusb-compat-0_1 ];
 
   propagatedBuildInputs = [ libusb-compat-0_1 ];
 

--- a/pkgs/development/libraries/libticalcs2/default.nix
+++ b/pkgs/development/libraries/libticalcs2/default.nix
@@ -11,7 +11,6 @@
   xz,
   bzip2,
   acl,
-  libobjc,
 }:
 
 stdenv.mkDerivation rec {
@@ -38,9 +37,6 @@ stdenv.mkDerivation rec {
     ]
     ++ lib.optionals stdenv.hostPlatform.isLinux [
       acl
-    ]
-    ++ lib.optionals stdenv.hostPlatform.isDarwin [
-      libobjc
     ];
 
   meta = with lib; {

--- a/pkgs/development/libraries/libusb1/default.nix
+++ b/pkgs/development/libraries/libusb1/default.nix
@@ -8,7 +8,6 @@
   enableUdev ?
     stdenv.hostPlatform.isLinux && !stdenv.hostPlatform.isStatic && !stdenv.hostPlatform.isAndroid,
   udev,
-  libobjc,
   withExamples ? false,
   withStatic ? false,
   withDocs ? stdenv.buildPlatform.canExecute stdenv.hostPlatform,
@@ -34,11 +33,7 @@ stdenv.mkDerivation rec {
     pkg-config
     autoreconfHook
   ] ++ lib.optionals withDocs [ doxygen ];
-  propagatedBuildInputs =
-    lib.optional enableUdev udev
-    ++ lib.optionals stdenv.hostPlatform.isDarwin [
-      libobjc
-    ];
+  propagatedBuildInputs = lib.optional enableUdev udev;
 
   dontDisableStatic = withStatic;
 

--- a/pkgs/development/libraries/qrencode/default.nix
+++ b/pkgs/development/libraries/qrencode/default.nix
@@ -6,7 +6,6 @@
   SDL2,
   libpng,
   libiconv,
-  libobjc,
 }:
 
 stdenv.mkDerivation (finalAttrs: rec {
@@ -30,7 +29,7 @@ stdenv.mkDerivation (finalAttrs: rec {
   buildInputs = [
     libiconv
     libpng
-  ] ++ lib.optionals stdenv.hostPlatform.isDarwin [ libobjc ];
+  ];
 
   nativeCheckInputs = [ SDL2 ];
 

--- a/pkgs/development/libraries/wiiuse/default.nix
+++ b/pkgs/development/libraries/wiiuse/default.nix
@@ -5,7 +5,6 @@
   fetchpatch,
   cmake,
   bluez,
-  libobjc,
 }:
 stdenv.mkDerivation rec {
 
@@ -38,11 +37,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ cmake ];
 
-  buildInputs =
-    lib.optionals stdenv.hostPlatform.isLinux [ bluez ]
-    ++ lib.optionals stdenv.hostPlatform.isDarwin [
-      libobjc
-    ];
+  buildInputs = lib.optionals stdenv.hostPlatform.isLinux [ bluez ];
 
   propagatedBuildInputs = lib.optionals stdenv.hostPlatform.isLinux [ bluez ];
 

--- a/pkgs/development/ruby-modules/gem/default.nix
+++ b/pkgs/development/ruby-modules/gem/default.nix
@@ -24,7 +24,6 @@
   fetchgit,
   makeWrapper,
   gitMinimal,
-  libobjc,
   ruby,
   bundler,
 }@defs:
@@ -125,12 +124,9 @@ lib.makeOverridable (
         ++ lib.optionals (type != "gem") [ bundler ]
         ++ nativeBuildInputs;
 
-      buildInputs =
-        [
-          ruby
-        ]
-        ++ lib.optionals stdenv.hostPlatform.isDarwin [ libobjc ]
-        ++ buildInputs;
+      buildInputs = [
+        ruby
+      ] ++ buildInputs;
 
       #name = builtins.trace (attrs.name or "no attr.name" ) "${namePrefix}${gemName}-${version}";
       name = attrs.name or "${namePrefix}${gemName}-${suffix}";

--- a/pkgs/development/tools/rubyfmt/default.nix
+++ b/pkgs/development/tools/rubyfmt/default.nix
@@ -10,7 +10,6 @@
   zlib,
   readline,
   libiconv,
-  libobjc,
   libunwind,
   libxcrypt,
   libyaml,
@@ -46,7 +45,6 @@ rustPlatform.buildRustPackage rec {
     ++ lib.optionals stdenv.hostPlatform.isDarwin [
       readline
       libiconv
-      libobjc
       libunwind
     ];
 

--- a/pkgs/misc/jackaudio/default.nix
+++ b/pkgs/misc/jackaudio/default.nix
@@ -11,7 +11,6 @@
   wafHook,
   # Darwin Dependencies
   aften,
-  libobjc,
 
   # BSD Dependencies
   freebsd,
@@ -74,7 +73,6 @@ stdenv.mkDerivation (finalAttrs: {
     ]
     ++ lib.optionals stdenv.hostPlatform.isDarwin [
       aften
-      libobjc
     ]
     ++ lib.optionals stdenv.hostPlatform.isFreeBSD [
       freebsd.libsysinfo

--- a/pkgs/tools/misc/timidity/default.nix
+++ b/pkgs/tools/misc/timidity/default.nix
@@ -4,7 +4,6 @@
   fetchurl,
   nixosTests,
   pkg-config,
-  libobjc,
   libjack2,
   ncurses,
   alsa-lib,
@@ -44,9 +43,6 @@ stdenv.mkDerivation rec {
     ]
     ++ lib.optionals stdenv.hostPlatform.isLinux [
       alsa-lib
-    ]
-    ++ lib.optionals stdenv.hostPlatform.isDarwin [
-      libobjc
     ]
     ++ lib.optionals enableVorbis [
       libvorbis

--- a/pkgs/tools/security/gpg-tui/default.nix
+++ b/pkgs/tools/security/gpg-tui/default.nix
@@ -8,7 +8,6 @@
   pkg-config,
   python3,
   libiconv,
-  libobjc,
   libresolv,
   x11Support ? true,
   libxcb,
@@ -47,7 +46,6 @@ rustPlatform.buildRustPackage rec {
     ]
     ++ lib.optionals stdenv.hostPlatform.isDarwin [
       libiconv
-      libobjc
       libresolv
     ];
 

--- a/pkgs/tools/security/softhsm/default.nix
+++ b/pkgs/tools/security/softhsm/default.nix
@@ -4,7 +4,6 @@
   fetchurl,
   botan2,
   sqlite,
-  libobjc,
 }:
 
 stdenv.mkDerivation rec {
@@ -23,10 +22,6 @@ stdenv.mkDerivation rec {
     "--with-objectstore-backend-db"
     "--sysconfdir=$out/etc"
     "--localstatedir=$out/var"
-  ];
-
-  propagatedBuildInputs = lib.optionals stdenv.hostPlatform.isDarwin [
-    libobjc
   ];
 
   buildInputs = [

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2373,7 +2373,7 @@ with pkgs;
   glslviewer = callPackage ../development/tools/glslviewer { };
 
   gpg-tui = callPackage ../tools/security/gpg-tui {
-    inherit (darwin) libobjc libresolv;
+    inherit (darwin) libresolv;
   };
 
   greg = callPackage ../applications/audio/greg {
@@ -2430,9 +2430,7 @@ with pkgs;
 
   krill = callPackage ../servers/krill { };
 
-  lapce = callPackage ../applications/editors/lapce {
-    inherit (darwin) libobjc;
-  };
+  lapce = callPackage ../applications/editors/lapce { };
 
   languagetool-rust = callPackage ../tools/text/languagetool-rust { };
 
@@ -4224,9 +4222,7 @@ with pkgs;
 
   mkgmap-splitter = callPackage ../applications/misc/mkgmap/splitter { };
 
-  op-geth = callPackage ../applications/blockchains/optimism/geth.nix {
-    inherit (darwin) libobjc;
-  };
+  op-geth = callPackage ../applications/blockchains/optimism/geth.nix { };
 
   optimism = callPackage ../applications/blockchains/optimism { };
 
@@ -4830,9 +4826,7 @@ with pkgs;
 
   spoof-mac = python3Packages.callPackage ../tools/networking/spoof-mac { };
 
-  softhsm = callPackage ../tools/security/softhsm {
-    inherit (darwin) libobjc;
-  };
+  softhsm = callPackage ../tools/security/softhsm { };
 
   soundkonverter = libsForQt5.soundkonverter;
 
@@ -5236,9 +5230,7 @@ with pkgs;
     wlroots = wlroots_0_17;
   };
 
-  wiiuse = callPackage ../development/libraries/wiiuse {
-    inherit (darwin) libobjc;
-  };
+  wiiuse = callPackage ../development/libraries/wiiuse { };
 
   wring = nodePackages.wring;
 
@@ -6351,19 +6343,11 @@ with pkgs;
 
   mono = mono6;
 
-  mono4 = lowPrio (
-    callPackage ../development/compilers/mono/4.nix {
-      inherit (darwin) libobjc;
-    }
-  );
+  mono4 = lowPrio (callPackage ../development/compilers/mono/4.nix { });
 
-  mono5 = callPackage ../development/compilers/mono/5.nix {
-    inherit (darwin) libobjc;
-  };
+  mono5 = callPackage ../development/compilers/mono/5.nix { };
 
-  mono6 = callPackage ../development/compilers/mono/6.nix {
-    inherit (darwin) libobjc;
-  };
+  mono6 = callPackage ../development/compilers/mono/6.nix { };
 
   mozart2 = callPackage ../development/compilers/mozart {
     emacs = emacs-nox;
@@ -6599,9 +6583,7 @@ with pkgs;
   # many packages still fail with latest version
   tbb = tbb_2020_3;
 
-  terra = callPackage ../development/compilers/terra {
-    inherit (darwin) libobjc;
-  };
+  terra = callPackage ../development/compilers/terra { };
 
   teyjus = callPackage ../development/compilers/teyjus {
     inherit (ocaml-ng.ocamlPackages_4_14) buildDunePackage;
@@ -7181,9 +7163,7 @@ with pkgs;
 
   inherit (ocamlPackages) reason rtop;
 
-  buildRubyGem = callPackage ../development/ruby-modules/gem {
-    inherit (darwin) libobjc;
-  };
+  buildRubyGem = callPackage ../development/ruby-modules/gem { };
   defaultGemConfig = callPackage ../development/ruby-modules/gem-config {
     inherit (darwin) DarwinTools autoSignDarwinBinariesHook;
   };
@@ -7195,13 +7175,11 @@ with pkgs;
 
   solargraph = rubyPackages.solargraph;
 
-  rubyfmt = callPackage ../development/tools/rubyfmt {
-    inherit (darwin) libobjc;
-  };
+  rubyfmt = callPackage ../development/tools/rubyfmt { };
 
   inherit
     (callPackage ../development/interpreters/ruby {
-      inherit (darwin) libobjc libunwind;
+      inherit (darwin) libunwind;
     })
     mkRubyVersion
     mkRuby
@@ -7230,15 +7208,9 @@ with pkgs;
 
   inherit
     ({
-      spidermonkey_91 = callPackage ../development/interpreters/spidermonkey/91.nix {
-        inherit (darwin) libobjc;
-      };
-      spidermonkey_115 = callPackage ../development/interpreters/spidermonkey/115.nix {
-        inherit (darwin) libobjc;
-      };
-      spidermonkey_128 = callPackage ../development/interpreters/spidermonkey/128.nix {
-        inherit (darwin) libobjc;
-      };
+      spidermonkey_91 = callPackage ../development/interpreters/spidermonkey/91.nix { };
+      spidermonkey_115 = callPackage ../development/interpreters/spidermonkey/115.nix { };
+      spidermonkey_128 = callPackage ../development/interpreters/spidermonkey/128.nix { };
     })
     spidermonkey_91
     spidermonkey_115
@@ -9413,9 +9385,7 @@ with pkgs;
     doCheck = false;
   };
 
-  libftdi = callPackage ../development/libraries/libftdi {
-    inherit (darwin) libobjc;
-  };
+  libftdi = callPackage ../development/libraries/libftdi { };
 
   libgdiplus = callPackage ../development/libraries/libgdiplus { };
 
@@ -9601,9 +9571,7 @@ with pkgs;
 
   libstatgrab = callPackage ../development/libraries/libstatgrab { };
 
-  libticalcs2 = callPackage ../development/libraries/libticalcs2 {
-    inherit (darwin) libobjc;
-  };
+  libticalcs2 = callPackage ../development/libraries/libticalcs2 { };
 
   libtorrent-rasterbar = libtorrent-rasterbar-2_0_x;
 
@@ -9632,9 +9600,7 @@ with pkgs;
 
   libusb-compat-0_1 = callPackage ../development/libraries/libusb-compat/0.1.nix { };
 
-  libusb1 = callPackage ../development/libraries/libusb1 {
-    inherit (darwin) libobjc;
-  };
+  libusb1 = callPackage ../development/libraries/libusb1 { };
 
   libunicode = callPackage ../by-name/li/libunicode/package.nix {
     stdenv = if stdenv.hostPlatform.isDarwin then llvmPackages_17.stdenv else stdenv;
@@ -10388,19 +10354,13 @@ with pkgs;
     scheme = guile;
   };
 
-  soapyairspy = callPackage ../applications/radio/soapyairspy {
-    inherit (darwin) libobjc;
-  };
+  soapyairspy = callPackage ../applications/radio/soapyairspy { };
 
   soapyaudio = callPackage ../applications/radio/soapyaudio { };
 
-  soapybladerf = callPackage ../applications/radio/soapybladerf {
-    inherit (darwin) libobjc;
-  };
+  soapybladerf = callPackage ../applications/radio/soapybladerf { };
 
-  soapyhackrf = callPackage ../applications/radio/soapyhackrf {
-    inherit (darwin) libobjc;
-  };
+  soapyhackrf = callPackage ../applications/radio/soapyhackrf { };
 
   soapysdr = callPackage ../applications/radio/soapysdr { };
 
@@ -10418,13 +10378,9 @@ with pkgs;
     ];
   };
 
-  soapyrtlsdr = callPackage ../applications/radio/soapyrtlsdr {
-    inherit (darwin) libobjc;
-  };
+  soapyrtlsdr = callPackage ../applications/radio/soapyrtlsdr { };
 
-  soapyuhd = callPackage ../applications/radio/soapyuhd {
-    inherit (darwin) libobjc;
-  };
+  soapyuhd = callPackage ../applications/radio/soapyuhd { };
 
   sofia_sip = callPackage ../development/libraries/sofia-sip { };
 
@@ -10920,7 +10876,6 @@ with pkgs;
   R = callPackage ../applications/science/math/R {
     # TODO: split docs into a separate output
     withRecommendedPackages = false;
-    inherit (darwin) libobjc;
   };
 
   rWrapper = callPackage ../development/r-modules/wrapper.nix {
@@ -13591,9 +13546,7 @@ with pkgs;
 
   q4wine = libsForQt5.callPackage ../applications/misc/q4wine { };
 
-  qrencode = callPackage ../development/libraries/qrencode {
-    inherit (darwin) libobjc;
-  };
+  qrencode = callPackage ../development/libraries/qrencode { };
 
   googleearth-pro = libsForQt5.callPackage ../applications/misc/googleearth-pro { };
 
@@ -15232,9 +15185,7 @@ with pkgs;
     timeshift-minimal
     ;
 
-  timidity = callPackage ../tools/misc/timidity {
-    inherit (darwin) libobjc;
-  };
+  timidity = callPackage ../tools/misc/timidity { };
 
   tiny = callPackage ../applications/networking/irc/tiny { };
 
@@ -15348,11 +15299,7 @@ with pkgs;
       }
     );
 
-  vim-full = vimUtils.makeCustomizable (
-    callPackage ../applications/editors/vim/full.nix {
-      inherit (darwin) libobjc;
-    }
-  );
+  vim-full = vimUtils.makeCustomizable (callPackage ../applications/editors/vim/full.nix { });
 
   vim-darwin =
     (vim-full.override {
@@ -15549,7 +15496,6 @@ with pkgs;
   wrapWeechat = callPackage ../applications/networking/irc/weechat/wrapper.nix { };
 
   weechat-unwrapped = callPackage ../applications/networking/irc/weechat {
-    inherit (darwin) libobjc;
     inherit (darwin) libresolv;
     guile = guile_3_0;
   };
@@ -15806,10 +15752,6 @@ with pkgs;
   };
 
   fulcrum = libsForQt5.callPackage ../applications/blockchains/fulcrum { };
-
-  go-ethereum = callPackage ../by-name/go/go-ethereum/package.nix {
-    inherit (darwin) libobjc;
-  };
 
   gridcoin-research = libsForQt5.callPackage ../applications/blockchains/gridcoin-research {
     boost = boost179;
@@ -17433,7 +17375,6 @@ with pkgs;
 
   jack2 = callPackage ../misc/jackaudio {
     libopus = libopus.override { withCustomModes = true; };
-    inherit (darwin) libobjc;
   };
 
   libjack2 = jack2.override { prefix = "lib"; };
@@ -17931,9 +17872,7 @@ with pkgs;
     openssl = openssl_1_1;
   };
 
-  xhyve = callPackage ../applications/virtualization/xhyve {
-    inherit (darwin) libobjc;
-  };
+  xhyve = callPackage ../applications/virtualization/xhyve { };
 
   xsane = callPackage ../applications/graphics/sane/xsane.nix { };
 


### PR DESCRIPTION
This was done with @booxter’s fantastic [nix-clean-apple_sdk] tool, simply modified to look for `libobjc` rather than the existing list he already used in <https://github.com/NixOS/nixpkgs/pull/398707>. Some manual work was applied, including cleaning up a string interpolation in the terrifying MacVim derivation, stray comments, empty lists, function parameters, and `inherit`s, including all of the references in `all-packages.nix`.

[nix-clean-apple_sdk]: https://github.com/booxter/nix-clean-apple_sdk


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
