### PR TITLE
cc-wrapper: add support for `strictflexarrays1` & `strictflexarrays3` hardening flags

### DIFF
--- a/doc/release-notes/rl-2511.section.md
+++ b/doc/release-notes/rl-2511.section.md
@@ -15,7 +15,7 @@
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
 
-- Create the first release note entry in this section!
+- New hardening flags, `strictflexarrays1` and `strictflexarrays3` were made available, corresponding to the gcc/clang options `-fstrict-flex-arrays=1` and `-fstrict-flex-arrays=3` respectively.
 
 ## Nixpkgs Library {#sec-nixpkgs-release-25.11-lib}
 

--- a/doc/stdenv/stdenv.chapter.md
+++ b/doc/stdenv/stdenv.chapter.md
@@ -1620,6 +1620,22 @@ Adds the `-fPIE` compiler and `-pie` linker options. Position Independent Execut
 Static libraries need to be compiled with `-fPIE` so that executables can link them in with the `-pie` linker option.
 If the libraries lack `-fPIE`, you will get the error `recompile with -fPIE`.
 
+#### `strictflexarrays1` {#strictflexarrays1}
+
+This flag adds the `-fstrict-flex-arrays=1` compiler option, which reduces the cases the compiler treats as "flexible arrays" to those declared with length `[1]`, `[0]` or (the correct) `[]`. This increases the coverage of fortify checks, because such arrays declared as the trailing element of a structure can normally not have their intended length determined by the compiler.
+
+Enabling this flag on packages that still use length declarations of flexible arrays >1 may cause the package to fail to compile citing accesses beyond the bounds of an array or even crash at runtime by detecting an array access as an "overrun". Few projects still use length declarations of flexible arrays >1.
+
+Disabling `strictflexarrays1` implies disablement of `strictflexarrays3`.
+
+#### `strictflexarrays3` {#strictflexarrays3}
+
+This flag adds the `-fstrict-flex-arrays=3` compiler option, which reduces the cases the compiler treats as "flexible arrays" to only those declared with length as (the correct) `[]`. This increases the coverage of fortify checks, because such arrays declared as the trailing element of a structure can normally not have their intended length determined by the compiler.
+
+Enabling this flag on packages that still use non-empty length declarations for flexible arrays may cause the package to fail to compile citing accesses beyond the bounds of an array or even crash at runtime by detecting an array access as an "overrun". Many projects still use such non-empty length declarations for flexible arrays.
+
+Enabling this flag implies enablement of `strictflexarrays1`. Disabling this flag does not imply disablement of `strictflexarrays1`.
+
 #### `shadowstack` {#shadowstack}
 
 Adds the `-fcf-protection=return` compiler option. This enables the Shadow Stack feature supported by some newer processors, which maintains a user-inaccessible copy of the program's stack containing only return-addresses. When returning from a function, the processor compares the return-address value on the two stacks and throws an error if they do not match, considering it a sign of corruption and possible tampering. This should significantly increase the difficulty of ROP attacks.

--- a/pkgs/build-support/cc-wrapper/add-hardening.sh
+++ b/pkgs/build-support/cc-wrapper/add-hardening.sh
@@ -10,6 +10,7 @@ for flag in ${NIX_HARDENING_ENABLE_@suffixSalt@-}; do
   hardeningEnableMap["$flag"]=1
 done
 
+
 # fortify3 implies fortify enablement - make explicit before
 # we filter unsupported flags because unsupporting fortify3
 # doesn't mean we should unsupport fortify too
@@ -31,8 +32,31 @@ if [[ -n "${hardeningEnableMap[fortify3]-}" ]]; then
   unset -v "hardeningEnableMap['fortify']"
 fi
 
+
+# strictflexarrays3 implies strictflexarrays1 enablement - make explicit before
+# we filter unsupported flags because unsupporting strictflexarrays3
+# doesn't mean we should unsupport strictflexarrays1 too
+if [[ -n "${hardeningEnableMap[strictflexarrays3]-}" ]]; then
+  hardeningEnableMap["strictflexarrays1"]=1
+fi
+
+# Remove unsupported flags.
+for flag in @hardening_unsupported_flags@; do
+  unset -v "hardeningEnableMap[$flag]"
+  # strictflexarrays1 being unsupported implies strictflexarrays3 is unsupported
+  if [[ "$flag" = 'strictflexarrays1' ]] ; then
+    unset -v "hardeningEnableMap['strictflexarrays3']"
+  fi
+done
+
+# now make strictflexarrays1 and strictflexarrays3 mutually exclusive
+if [[ -n "${hardeningEnableMap[strictflexarrays3]-}" ]]; then
+  unset -v "hardeningEnableMap['strictflexarrays1']"
+fi
+
+
 if (( "${NIX_DEBUG:-0}" >= 1 )); then
-  declare -a allHardeningFlags=(fortify fortify3 shadowstack stackprotector stackclashprotection nostrictaliasing pacret pie pic strictoverflow format trivialautovarinit zerocallusedregs)
+  declare -a allHardeningFlags=(fortify fortify3 shadowstack stackprotector stackclashprotection nostrictaliasing pacret strictflexarrays1 strictflexarrays3 pie pic strictoverflow format trivialautovarinit zerocallusedregs)
   declare -A hardeningDisableMap=()
 
   # Determine which flags were effectively disabled so we can report below.
@@ -78,6 +102,14 @@ for flag in "${!hardeningEnableMap[@]}"; do
     shadowstack)
       if (( "${NIX_DEBUG:-0}" >= 1 )); then echo HARDENING: enabling shadowstack >&2; fi
       hardeningCFlagsBefore+=('-fcf-protection=return')
+      ;;
+    strictflexarrays1)
+      if (( "${NIX_DEBUG:-0}" >= 1 )); then echo HARDENING: enabling strictflexarrays1 >&2; fi
+      hardeningCFlagsBefore+=('-fstrict-flex-arrays=1')
+      ;;
+    strictflexarrays3)
+      if (( "${NIX_DEBUG:-0}" >= 1 )); then echo HARDENING: enabling strictflexarrays3 >&2; fi
+      hardeningCFlagsBefore+=('-fstrict-flex-arrays=3')
       ;;
     pacret)
       if (( "${NIX_DEBUG:-0}" >= 1 )); then echo HARDENING: enabling pacret >&2; fi

--- a/pkgs/by-name/da/dash/package.nix
+++ b/pkgs/by-name/da/dash/package.nix
@@ -25,6 +25,8 @@ stdenv.mkDerivation (finalAttrs: {
   depsBuildBuild = [ buildPackages.stdenv.cc ];
   buildInputs = [ libedit ];
 
+  hardeningDisable = [ "strictflexarrays3" ];
+
   configureFlags = [ "--with-libedit" ];
   preConfigure = lib.optional stdenv.hostPlatform.isStatic ''
     export LIBS="$(''${PKG_CONFIG:-pkg-config} --libs --static libedit)"

--- a/pkgs/by-name/el/elfutils/package.nix
+++ b/pkgs/by-name/el/elfutils/package.nix
@@ -117,6 +117,8 @@ stdenv.mkDerivation rec {
 
   propagatedNativeBuildInputs = [ setupDebugInfoDirs ];
 
+  hardeningDisable = [ "strictflexarrays3" ];
+
   configureFlags =
     [
       "--program-prefix=eu-" # prevent collisions with binutils

--- a/pkgs/by-name/gd/gdbm/package.nix
+++ b/pkgs/by-name/gd/gdbm/package.nix
@@ -24,6 +24,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [ updateAutotoolsGnuConfigScriptsHook ];
 
+  hardeningDisable = [ "strictflexarrays3" ];
+
   configureFlags = [ (lib.enableFeature true "libgdbm-compat") ];
 
   outputs = [

--- a/pkgs/by-name/li/libarchive/package.nix
+++ b/pkgs/by-name/li/libarchive/package.nix
@@ -123,6 +123,8 @@ stdenv.mkDerivation (finalAttrs: {
     acl
   ];
 
+  hardeningDisable = [ "strictflexarrays3" ];
+
   configureFlags = lib.optional (!xarSupport) "--without-xml2";
 
   preBuild = lib.optionalString stdenv.hostPlatform.isCygwin ''

--- a/pkgs/by-name/li/libgcrypt/package.nix
+++ b/pkgs/by-name/li/libgcrypt/package.nix
@@ -32,10 +32,16 @@ stdenv.mkDerivation rec {
     "out"
   ];
 
-  # The CPU Jitter random number generator must not be compiled with
-  # optimizations and the optimize -O0 pragma only works for gcc.
-  # The build enables -O2 by default for everything else.
-  hardeningDisable = lib.optional stdenv.cc.isClang "fortify";
+  hardeningDisable =
+    [
+      "strictflexarrays3"
+    ]
+    ++ lib.optionals stdenv.cc.isClang [
+      # The CPU Jitter random number generator must not be compiled with
+      # optimizations and the optimize -O0 pragma only works for gcc.
+      # The build enables -O2 by default for everything else.
+      "fortify"
+    ];
 
   depsBuildBuild = [ buildPackages.stdenv.cc ];
 

--- a/pkgs/by-name/li/libgpg-error/package.nix
+++ b/pkgs/by-name/li/libgpg-error/package.nix
@@ -36,6 +36,8 @@ stdenv.mkDerivation (
       sed '/BUILD_TIMESTAMP=/s/=.*/=1970-01-01T00:01+0000/' -i ./configure
     '';
 
+    hardeningDisable = [ "strictflexarrays3" ];
+
     configureFlags = [
       # See https://dev.gnupg.org/T6257#164567
       "--enable-install-gpg-error-config"

--- a/pkgs/by-name/li/libksba/package.nix
+++ b/pkgs/by-name/li/libksba/package.nix
@@ -26,6 +26,8 @@ stdenv.mkDerivation rec {
   propagatedBuildInputs = [ libgpg-error ];
   depsBuildBuild = [ buildPackages.stdenv.cc ];
 
+  hardeningDisable = [ "strictflexarrays3" ];
+
   configureFlags = [ "--with-libgpg-error-prefix=${libgpg-error.dev}" ];
 
   postInstall = ''

--- a/pkgs/by-name/li/libtpms/package.nix
+++ b/pkgs/by-name/li/libtpms/package.nix
@@ -19,6 +19,8 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-YKs/XYJ8UItOtSinl28/G9XFVzobFd4ZDKtClQDLXFk=";
   };
 
+  hardeningDisable = [ "strictflexarrays3" ];
+
   nativeBuildInputs = [
     autoreconfHook
     pkg-config

--- a/pkgs/by-name/un/unzip/package.nix
+++ b/pkgs/by-name/un/unzip/package.nix
@@ -16,7 +16,10 @@ stdenv.mkDerivation rec {
     sha256 = "0dxx11knh3nk95p2gg2ak777dd11pr7jx5das2g49l262scrcv83";
   };
 
-  hardeningDisable = [ "format" ];
+  hardeningDisable = [
+    "format"
+    "strictflexarrays3"
+  ];
 
   patchFlags = [
     "-p1"

--- a/pkgs/development/compilers/gcc/default.nix
+++ b/pkgs/development/compilers/gcc/default.nix
@@ -428,6 +428,10 @@ pipe
             "fortify3"
             "trivialautovarinit"
           ]
+          ++ optionals (!atLeast13) [
+            "strictflexarrays1"
+            "strictflexarrays3"
+          ]
           ++ optional (
             !(targetPlatform.isLinux && targetPlatform.isx86_64 && targetPlatform.libc == "glibc")
           ) "shadowstack"

--- a/pkgs/development/compilers/llvm/common/clang/default.nix
+++ b/pkgs/development/compilers/llvm/common/clang/default.nix
@@ -299,6 +299,8 @@ stdenv.mkDerivation (
         ++ lib.optional (
           (lib.versionOlder release_version "15") || !(targetPlatform.isx86_64 || targetPlatform.isAarch64)
         ) "zerocallusedregs"
+        ++ lib.optional (lib.versionOlder release_version "15") "strictflexarrays1"
+        ++ lib.optional (lib.versionOlder release_version "16") "strictflexarrays3"
         ++ (finalAttrs.passthru.hardeningUnsupportedFlags or [ ]);
     };
 

--- a/pkgs/development/libraries/glibc/default.nix
+++ b/pkgs/development/libraries/glibc/default.nix
@@ -64,6 +64,7 @@ in
       "fortify"
       "pie"
       "stackprotector"
+      "strictflexarrays3"
     ];
 
     env = (previousAttrs.env or { }) // {

--- a/pkgs/test/cc-wrapper/flex-arrays-fortify-example.c
+++ b/pkgs/test/cc-wrapper/flex-arrays-fortify-example.c
@@ -1,0 +1,33 @@
+/* an example that should be protected by FORTIFY_SOURCE=2 but
+ * only if the appropriate -fstrict-flex-arrays= argument is used
+ * for the corresponding value used for BUFFER_DEF_SIZE
+ */
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+struct buffer_with_header {
+    char header[1];
+    char buffer[BUFFER_DEF_SIZE];
+};
+
+int main(int argc, char *argv[]) {
+    /* use volatile pointer to prevent compiler
+     * using the outer allocation length with a
+     * fortified strcpy, which would throw off
+     * the function-name-sniffing fortify-detecting
+     * approaches
+     */
+    struct buffer_with_header *volatile b = \
+      (struct buffer_with_header *)malloc(sizeof(struct buffer_with_header)+1);
+
+    /* if there are no arguments, skip the write to allow
+     * builds with BUFFER_DEF_SIZE=0 to have a case where
+     * the program passes even with strict protection.
+     */
+    if (argc > 1) {
+        strcpy(b->buffer, argv[1]);
+        puts(b->buffer);
+    }
+    return 0;
+}

--- a/pkgs/test/cc-wrapper/hardening.nix
+++ b/pkgs/test/cc-wrapper/hardening.nix
@@ -37,6 +37,8 @@ let
   f2exampleWithStdEnv = writeCBinWithStdenv ./fortify2-example.c;
   f3exampleWithStdEnv = writeCBinWithStdenv ./fortify3-example.c;
 
+  flexArrF2ExampleWithStdEnv = writeCBinWithStdenv ./flex-arrays-fortify-example.c;
+
   # for when we need a slightly more complicated program
   helloWithStdEnv =
     stdenv': env:
@@ -146,13 +148,15 @@ let
     })
   );
 
+  fortifyExecTest = fortifyExecTestFull true "012345 7" "0123456 7";
+
   # returning a specific exit code when aborting due to a fortify
   # check isn't mandated. so it's better to just ensure that a
   # nonzero exit code is returned when we go a single byte beyond
   # the buffer, with the example programs being designed to be
   # unlikely to genuinely segfault for such a small overflow.
-  fortifyExecTest =
-    testBin:
+  fortifyExecTestFull =
+    expectProtection: saturatedArgs: oneTooFarArgs: testBin:
     runCommand "exec-test"
       {
         buildInputs = [
@@ -164,9 +168,15 @@ let
         (
           export PATH=$HOST_PATH
           echo "Saturated buffer:" # check program isn't completly broken
-          test-bin 012345 7
-          echo "One byte too far:" # eighth byte being the null terminator
-          (! test-bin 0123456 7) || (echo 'Expected failure, but succeeded!' && exit 1)
+          test-bin ${saturatedArgs}
+          echo "One byte too far:" # overflow byte being the null terminator?
+          (
+            ${if expectProtection then "!" else ""} test-bin ${oneTooFarArgs}
+          ) || (
+            echo 'Expected ${if expectProtection then "failure" else "success"}, but ${
+              if expectProtection then "succeeded" else "failed"
+            }!' && exit 1
+          )
         )
         echo "Expected behaviour observed"
         touch $out
@@ -310,6 +320,128 @@ nameDrvAfterAttrName (
           )
         );
 
+    sfa1explicitEnabled =
+      checkTestBin
+        (flexArrF2ExampleWithStdEnv stdenv {
+          hardeningEnable = [
+            "fortify"
+            "strictflexarrays1"
+          ];
+          env = {
+            TEST_EXTRA_FLAGS = "-DBUFFER_DEF_SIZE=7";
+          };
+        })
+        {
+          ignoreFortify = false;
+        };
+
+    # musl implementation is effectively FORTIFY_SOURCE=1-only
+    sfa1explicitEnabledExecTest = brokenIf stdenv.hostPlatform.isMusl (
+      fortifyExecTestFull true "012345" "0123456" (
+        flexArrF2ExampleWithStdEnv stdenv {
+          hardeningEnable = [
+            "fortify"
+            "strictflexarrays1"
+          ];
+          env = {
+            TEST_EXTRA_FLAGS = "-DBUFFER_DEF_SIZE=7";
+          };
+        }
+      )
+    );
+
+    sfa1explicitEnabledDoesntProtectDefLen1 =
+      checkTestBin
+        (flexArrF2ExampleWithStdEnv stdenv {
+          hardeningEnable = [
+            "fortify"
+            "strictflexarrays1"
+          ];
+          env = {
+            TEST_EXTRA_FLAGS = "-DBUFFER_DEF_SIZE=1";
+          };
+        })
+        {
+          ignoreFortify = false;
+          expectFailure = true;
+        };
+
+    # musl implementation is effectively FORTIFY_SOURCE=1-only
+    sfa1explicitEnabledDoesntProtectDefLen1ExecTest = brokenIf stdenv.hostPlatform.isMusl (
+      fortifyExecTestFull false "''" "0" (
+        flexArrF2ExampleWithStdEnv stdenv {
+          hardeningEnable = [
+            "fortify"
+            "strictflexarrays1"
+          ];
+          env = {
+            TEST_EXTRA_FLAGS = "-DBUFFER_DEF_SIZE=1";
+          };
+        }
+      )
+    );
+
+    sfa3explicitEnabledProtectsDefLen1 =
+      checkTestBin
+        (flexArrF2ExampleWithStdEnv stdenv {
+          hardeningEnable = [
+            "fortify"
+            "strictflexarrays3"
+          ];
+          env = {
+            TEST_EXTRA_FLAGS = "-DBUFFER_DEF_SIZE=1";
+          };
+        })
+        {
+          ignoreFortify = false;
+        };
+
+    # musl implementation is effectively FORTIFY_SOURCE=1-only
+    sfa3explicitEnabledProtectsDefLen1ExecTest = brokenIf stdenv.hostPlatform.isMusl (
+      fortifyExecTestFull true "''" "0" (
+        flexArrF2ExampleWithStdEnv stdenv {
+          hardeningEnable = [
+            "fortify"
+            "strictflexarrays3"
+          ];
+          env = {
+            TEST_EXTRA_FLAGS = "-DBUFFER_DEF_SIZE=1";
+          };
+        }
+      )
+    );
+
+    sfa3explicitEnabledDoesntProtectCorrectFlex =
+      checkTestBin
+        (flexArrF2ExampleWithStdEnv stdenv {
+          hardeningEnable = [
+            "fortify"
+            "strictflexarrays3"
+          ];
+          env = {
+            TEST_EXTRA_FLAGS = "-DBUFFER_DEF_SIZE=";
+          };
+        })
+        {
+          ignoreFortify = false;
+          expectFailure = true;
+        };
+
+    # musl implementation is effectively FORTIFY_SOURCE=1-only
+    sfa3explicitEnabledDoesntProtectCorrectFlexExecTest = brokenIf stdenv.hostPlatform.isMusl (
+      fortifyExecTestFull false "" "0" (
+        flexArrF2ExampleWithStdEnv stdenv {
+          hardeningEnable = [
+            "fortify"
+            "strictflexarrays3"
+          ];
+          env = {
+            TEST_EXTRA_FLAGS = "-DBUFFER_DEF_SIZE=";
+          };
+        }
+      )
+    );
+
     pieExplicitEnabled = brokenIf stdenv.hostPlatform.isStatic (
       checkTestBin
         (f2exampleWithStdEnv stdenv {
@@ -420,6 +552,99 @@ nameDrvAfterAttrName (
           ignoreFortify = false;
         };
 
+    # musl implementation is effectively FORTIFY_SOURCE=1-only
+    sfa1explicitDisabled = brokenIf stdenv.hostPlatform.isMusl (
+      checkTestBin
+        (flexArrF2ExampleWithStdEnv stdenv {
+          hardeningEnable = [ "fortify" ];
+          hardeningDisable = [ "strictflexarrays1" ];
+          env = {
+            TEST_EXTRA_FLAGS = "-DBUFFER_DEF_SIZE=7";
+          };
+        })
+        {
+          ignoreFortify = false;
+          expectFailure = true;
+        }
+    );
+
+    sfa1explicitDisabledExecTest = fortifyExecTestFull false "012345" "0123456" (
+      flexArrF2ExampleWithStdEnv stdenv {
+        hardeningEnable = [ "fortify" ];
+        hardeningDisable = [ "strictflexarrays1" ];
+        env = {
+          TEST_EXTRA_FLAGS = "-DBUFFER_DEF_SIZE=7";
+        };
+      }
+    );
+
+    # musl implementation is effectively FORTIFY_SOURCE=1-only
+    sfa1explicitDisabledDisablesSfa3 = brokenIf stdenv.hostPlatform.isMusl (
+      checkTestBin
+        (flexArrF2ExampleWithStdEnv stdenv {
+          hardeningEnable = [
+            "fortify"
+            "strictflexarrays3"
+          ];
+          hardeningDisable = [ "strictflexarrays1" ];
+          env = {
+            TEST_EXTRA_FLAGS = "-DBUFFER_DEF_SIZE=1";
+          };
+        })
+        {
+          ignoreFortify = false;
+          expectFailure = true;
+        }
+    );
+
+    # musl implementation is effectively FORTIFY_SOURCE=1-only
+    sfa1explicitDisabledDisablesSfa3ExecTest = brokenIf stdenv.hostPlatform.isMusl (
+      fortifyExecTestFull false "''" "0" (
+        flexArrF2ExampleWithStdEnv stdenv {
+          hardeningEnable = [
+            "fortify"
+            "strictflexarrays3"
+          ];
+          hardeningDisable = [ "strictflexarrays1" ];
+          env = {
+            TEST_EXTRA_FLAGS = "-DBUFFER_DEF_SIZE=1";
+          };
+        }
+      )
+    );
+
+    sfa3explicitDisabledDoesntDisableSfa1 =
+      checkTestBin
+        (flexArrF2ExampleWithStdEnv stdenv {
+          hardeningEnable = [
+            "fortify"
+            "strictflexarrays1"
+          ];
+          hardeningDisable = [ "strictflexarrays3" ];
+          env = {
+            TEST_EXTRA_FLAGS = "-DBUFFER_DEF_SIZE=7";
+          };
+        })
+        {
+          ignoreFortify = false;
+        };
+
+    # musl implementation is effectively FORTIFY_SOURCE=1-only
+    sfa3explicitDisabledDoesntDisableSfa1ExecTest = brokenIf stdenv.hostPlatform.isMusl (
+      fortifyExecTestFull true "012345" "0123456" (
+        flexArrF2ExampleWithStdEnv stdenv {
+          hardeningEnable = [
+            "fortify"
+            "strictflexarrays1"
+          ];
+          hardeningDisable = [ "strictflexarrays3" ];
+          env = {
+            TEST_EXTRA_FLAGS = "-DBUFFER_DEF_SIZE=7";
+          };
+        }
+      )
+    );
+
     pieExplicitDisabled = brokenIf (stdenv.hostPlatform.isMusl && stdenv.cc.isClang) (
       checkTestBin
         (f2exampleWithStdEnv stdenv {
@@ -527,6 +752,90 @@ nameDrvAfterAttrName (
       }
     );
 
+    sfa1StdenvUnsupp =
+      checkTestBin
+        (flexArrF2ExampleWithStdEnv
+          (stdenvUnsupport [
+            "strictflexarrays1"
+            "strictflexarrays3"
+          ])
+          {
+            hardeningEnable = [
+              "fortify"
+              "strictflexarrays1"
+            ];
+            env = {
+              TEST_EXTRA_FLAGS = "-DBUFFER_DEF_SIZE=7";
+            };
+          }
+        )
+        {
+          ignoreFortify = false;
+          expectFailure = true;
+        };
+
+    sfa3StdenvUnsupp =
+      checkTestBin
+        (flexArrF2ExampleWithStdEnv (stdenvUnsupport [ "strictflexarrays3" ]) {
+          hardeningEnable = [
+            "fortify"
+            "strictflexarrays3"
+          ];
+          env = {
+            TEST_EXTRA_FLAGS = "-DBUFFER_DEF_SIZE=1";
+          };
+        })
+        {
+          ignoreFortify = false;
+          expectFailure = true;
+        };
+
+    sfa1StdenvUnsuppUnsupportsSfa3 =
+      checkTestBin
+        (flexArrF2ExampleWithStdEnv (stdenvUnsupport [ "strictflexarrays1" ]) {
+          hardeningEnable = [
+            "fortify"
+            "strictflexarrays3"
+          ];
+          env = {
+            TEST_EXTRA_FLAGS = "-DBUFFER_DEF_SIZE=1";
+          };
+        })
+        {
+          ignoreFortify = false;
+          expectFailure = true;
+        };
+
+    sfa3StdenvUnsuppDoesntUnsuppSfa1 =
+      checkTestBin
+        (flexArrF2ExampleWithStdEnv (stdenvUnsupport [ "strictflexarrays3" ]) {
+          hardeningEnable = [
+            "fortify"
+            "strictflexarrays1"
+          ];
+          env = {
+            TEST_EXTRA_FLAGS = "-DBUFFER_DEF_SIZE=7";
+          };
+        })
+        {
+          ignoreFortify = false;
+        };
+
+    # musl implementation is effectively FORTIFY_SOURCE=1-only
+    sfa3StdenvUnsuppDoesntUnsuppSfa1ExecTest = brokenIf stdenv.hostPlatform.isMusl (
+      fortifyExecTestFull true "012345" "0123456" (
+        flexArrF2ExampleWithStdEnv (stdenvUnsupport [ "strictflexarrays3" ]) {
+          hardeningEnable = [
+            "fortify"
+            "strictflexarrays1"
+          ];
+          env = {
+            TEST_EXTRA_FLAGS = "-DBUFFER_DEF_SIZE=7";
+          };
+        }
+      )
+    );
+
     stackProtectorStdenvUnsupp =
       checkTestBin
         (f2exampleWithStdEnv (stdenvUnsupport [ "stackprotector" ]) {
@@ -624,6 +933,58 @@ nameDrvAfterAttrName (
           postConfigure = ''
             export NIX_HARDENING_ENABLE="fortify"
           '';
+        })
+        {
+          ignoreFortify = false;
+          expectFailure = true;
+        };
+
+    sfa3EnabledEnvEnablesSfa1 =
+      checkTestBin
+        (flexArrF2ExampleWithStdEnv stdenv {
+          hardeningDisable = [
+            "strictflexarrays1"
+            "strictflexarrays3"
+          ];
+          postConfigure = ''
+            export NIX_HARDENING_ENABLE="fortify strictflexarrays3"
+          '';
+          env = {
+            TEST_EXTRA_FLAGS = "-DBUFFER_DEF_SIZE=7";
+          };
+        })
+        {
+          ignoreFortify = false;
+        };
+
+    sfa3EnabledEnvEnablesSfa1ExecTest = fortifyExecTestFull true "012345" "0123456" (
+      f1exampleWithStdEnv stdenv {
+        hardeningDisable = [
+          "strictflexarrays1"
+          "strictflexarrays3"
+        ];
+        postConfigure = ''
+          export NIX_HARDENING_ENABLE="fortify strictflexarrays3"
+        '';
+        env = {
+          TEST_EXTRA_FLAGS = "-DBUFFER_DEF_SIZE=7";
+        };
+      }
+    );
+
+    sfa1EnabledEnvDoesntEnableSfa3 =
+      checkTestBin
+        (flexArrF2ExampleWithStdEnv stdenv {
+          hardeningDisable = [
+            "strictflexarrays1"
+            "strictflexarrays3"
+          ];
+          postConfigure = ''
+            export NIX_HARDENING_ENABLE="fortify strictflexarrays1"
+          '';
+          env = {
+            TEST_EXTRA_FLAGS = "-DBUFFER_DEF_SIZE=1";
+          };
         })
         {
           ignoreFortify = false;

--- a/pkgs/test/cc-wrapper/hardening.nix
+++ b/pkgs/test/cc-wrapper/hardening.nix
@@ -281,16 +281,13 @@ nameDrvAfterAttrName (
     );
 
     # musl implementation is effectively FORTIFY_SOURCE=1-only,
-    # clang-on-glibc also only appears to support FORTIFY_SOURCE=1 (!)
-    fortifyExplicitEnabledExecTest =
-      brokenIf (stdenv.hostPlatform.isMusl || (stdenv.cc.isClang && stdenv.hostPlatform.libc == "glibc"))
-        (
-          fortifyExecTest (
-            f2exampleWithStdEnv stdenv {
-              hardeningEnable = [ "fortify" ];
-            }
-          )
-        );
+    fortifyExplicitEnabledExecTest = brokenIf stdenv.hostPlatform.isMusl (
+      fortifyExecTest (
+        f2exampleWithStdEnv stdenv {
+          hardeningEnable = [ "fortify" ];
+        }
+      )
+    );
 
     fortify3ExplicitEnabled = brokenIf (!stdenv.cc.isGNU || lib.versionOlder stdenv.cc.version "12") (
       checkTestBin

--- a/pkgs/test/cc-wrapper/hardening.nix
+++ b/pkgs/test/cc-wrapper/hardening.nix
@@ -116,7 +116,7 @@ let
       (
         ''
           if ${lib.optionalString (!expectFailure) "!"} {
-            hardening-check --nocfprotection \
+            hardening-check --nocfprotection --nobranchprotection \
               ${lib.optionalString ignoreBindNow "--nobindnow"} \
               ${lib.optionalString ignoreFortify "--nofortify"} \
               ${lib.optionalString ignorePie "--nopie"} \

--- a/pkgs/top-level/variants.nix
+++ b/pkgs/top-level/variants.nix
@@ -104,6 +104,7 @@ self: super: {
           stdenv = super'.withDefaultHardeningFlags (
             super'.stdenv.cc.defaultHardeningFlags
             ++ [
+              "strictflexarrays1"
               "shadowstack"
               "nostrictaliasing"
               "pacret"


### PR DESCRIPTION
More background on these flags: https://best.openssf.org/Compiler-Hardening-Guides/Compiler-Options-Hardening-Guide-for-C-and-C++.html#enable-strict-flexible-arrays

In short, they improve coverage of fortify checks by reducing the number of cases the compiler has to be permissive with.

Initially I was just going to add `strictflexarrays3` and be satisfied with leaving it as a `pkgsExtraHardening` flag until projects had caught up and stopped using old-fashioned flexible array declarations, but as you can see from the number of `strictflexarrays3` disablements I've added, there are quite a lot of projects with this problem (and this is only the tip of the iceberg - cpython heavily uses `[1]`-style declarations in its API, meaning much of the python ecosystem will fail to compile with `strictflexarrays3` - see https://github.com/python/cpython/issues/84301). So I've also added `strictflexarrays1`which is the strictest mode python will compile with, and used _that_ for `pkgsExtraHardening`. `strictflexarrays3` is left for those who want to experiment and/or don't need many python packages.

The behaviour of the two flags exactly mirrors the behaviours of `fortify` and `fortify3` and in fact is largely implemented through a copy-pasta of most of those code fragments. A number of `tests.hardeningFlags` tests are added to prove this. As ever, tinkering with the hardening flags tests caused me to do a bit of refactoring.

As ever, neither of these new flags are enabled by default for normal packagesets.

Tested build of many packages with `strictflexarrays3` default-enabled on aarch64-linux and macos 12 x86_64 (enough to gather the various fixes included in this PR). Successfully bootstapped `pkgsMusl`, `pkgsStatic`, `pkgsCross.riscv64` on aarch64-linux.

Tested `tests.hardeningFlags` on the default packageset for aarch64-linux and macos 12 x86_64, `pkgsLLVM`, `pkgsi686Linux`, `pkgsMusl`, `pkgsStatic` with expected results.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
