### PR TITLE
new package: Sui mainnet 1.46.3 to close #303467

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -22681,6 +22681,12 @@
     github = "syvb";
     githubId = 10530973;
   };
+  smolpatches = {
+    name = "Robert Hall";
+    github = "SmolPatches";
+    githubId = 102612257;
+    matrix = "@smolp:matrix.org";
+  };
   smona = {
     name = "Mel Bourgeois";
     email = "mason.bourgeois@gmail.com";

--- a/pkgs/by-name/su/sui/package.nix
+++ b/pkgs/by-name/su/sui/package.nix
@@ -1,0 +1,91 @@
+# build a sui derivation based on some configurable params
+{
+  lib,
+  platform ? stdenv.hostPlatform,
+  stdenv,
+  fetchzip,
+  autoPatchelfHook,
+  gccForLibs,
+}:
+
+let
+  hash_table = {
+    "aarch64-darwin" = "sha256-o8O5TwszzS7O+6Oq+QuEbMRwUMbjwjuFnfT2NW634RA=";
+    "x86_64-darwin" = "sha256-YqapFtl9j6L4ZCasS3X+w7ph9+qPPkyO3LVfXuT5tlI=";
+    "aarch64-linux" = "sha256-n3WUneDvCwCJ29ur6z3aSMMpWuX1/2r8vddzEz5rzNU=";
+    "x86_64-linux" = "sha256-kwoibkFDrBLs3OB1dgofgdJTqyOiyozXWncN5MJ1Uco=";
+  };
+  mk_release =
+    # builder function
+    {
+      type ? "mainnet",
+      version_number,
+      arch,
+      vhash,
+    }:
+    let
+      triple =
+        if platform.isLinux then
+          "ubuntu-${arch}"
+        else if arch == "aarch64" then
+          "macos-arm64"
+        else
+          "macos-x86_64"; # src tarball triple
+    in
+
+    # sui package built from binary
+    # source builds blocked on rust / git issues
+    # https://github.com/NixOS/nixpkgs/pull/282798
+    # https://github.com/NixOS/nixpkgs/issues/303467
+    stdenv.mkDerivation (finalAttrs: {
+      pname = "sui-mainnet";
+      version = version_number;
+      src = fetchzip {
+        url = "https://github.com/MystenLabs/sui/releases/download/${type}-v${finalAttrs.version}/sui-${type}-v${finalAttrs.version}-${triple}.tgz";
+        hash = vhash;
+        stripRoot = false;
+      };
+      nativeBuildInputs = lib.optionals platform.isLinux [
+        autoPatchelfHook
+      ];
+      buildInputs = lib.optionals platform.isLinux [ gccForLibs.lib ];
+      installPhase = ''
+        runHook preInstall
+        install -m 755 -d $out/bin
+        install -m 755 sui* move-analyzer $out/bin
+        runHook postInstall
+      '';
+      # check the version for each binary
+      installCheckPhase = ''
+        runHook preInstallCheck
+        for f in $out/bin/*; do
+             echo Checking version for $f
+             if [[ ! $f =~ "${finalAttrs.version}" ]] then
+                  echo FAILED $f: "${finalAttrs.version}"
+                  exit 1
+              fi
+         done
+         runHook postInstallCheck
+      '';
+      doInstallCheck = true;
+      meta = {
+        longDescription = "Sui, a next-generation smart contract platform with high throughput, low latency, and an asset-oriented programming model powered by the Move programming language";
+        description = "patched Sui binaries for nix compat";
+        homepage = "https://sui.io/";
+        changelog = "https://github.com/MystenLabs/sui/releases/tag/${type}-v${version_number}";
+        downloadPage = "https://github.com/MystenLabs/sui";
+        license = lib.licenses.asl20;
+        platforms = lib.platforms.linux ++ lib.platforms.darwin;
+        mainProgram = "sui";
+        maintainers = with lib.maintainers; [ smolpatches ];
+      };
+    });
+in
+mk_release {
+  type = "mainnet";
+  # which system to build from
+  # this is used to select the right download url
+  arch = if lib.strings.hasInfix "x86_64" platform.system then "x86_64" else "aarch64";
+  version_number = "1.46.3";
+  vhash = hash_table."${platform.system}";
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
This is a simple packaging of the Ubuntu binaries released by Mysten Labs for the [Sui blockchain](https://github.com/MystenLabs/sui/) for NixOS / Nix compat, via patchelf.  

Currently we are *blocked* from doing source builds until a certain issue is fixed, #282798.  
Some discussion for the package request has been done here, #303467.

Its a little something I put together while working on my [overlay](https://github.com/smolPatches/suichain-overlay) for Sui, I decided to adjust it for Nixpkgs in the meantime.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
