### PR TITLE
libblake3: 1.8.0 -> 1.8.2

### DIFF
--- a/pkgs/by-name/li/libblake3/package.nix
+++ b/pkgs/by-name/li/libblake3/package.nix
@@ -5,23 +5,18 @@
   fetchFromGitHub,
   tbb_2021_11,
 
-  # Until we have a release with
-  # https://github.com/BLAKE3-team/BLAKE3/pull/461 and similar, or those
-  # PRs are patched onto this current release. Even then, I think we
-  # still need to disable for MinGW build because
-  # https://github.com/BLAKE3-team/BLAKE3/issues/467
-  useTBB ? false,
+  useTBB ? true,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "libblake3";
-  version = "1.8.0";
+  version = "1.8.2";
 
   src = fetchFromGitHub {
     owner = "BLAKE3-team";
     repo = "BLAKE3";
     tag = finalAttrs.version;
-    hash = "sha256-Krh0yVNZKL6Mb0McqWTIMNownsgM3MUEX2IP+F/fu+k=";
+    hash = "sha256-IABVErXWYQFXZcwsFKfQhm3ox7UZUcW5uzVrGwsSp94=";
   };
 
   sourceRoot = finalAttrs.src.name + "/c";


### PR DESCRIPTION
This PR updates `libblake3` to version `1.8.2`.

This release resolves issues around CMake and pkgconfig and also the MinGW builds.

Related:

- https://github.com/NixOS/nix/issues/12889
- https://github.com/NixOS/nixpkgs/pull/397773
- https://github.com/NixOS/nix/pull/12676

CC @Ericson2314 @Mic92 

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin