### PR TITLE
{libGL,libGLU,libglut}: don’t use deprecated stubs on Darwin

### DIFF
--- a/pkgs/by-name/fr/freeglut/package.nix
+++ b/pkgs/by-name/fr/freeglut/package.nix
@@ -38,11 +38,9 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   cmakeFlags = lib.optionals stdenv.hostPlatform.isDarwin [
-    "-DOPENGL_INCLUDE_DIR=${libGLX.dev}/include"
-    "-DOPENGL_gl_LIBRARY:FILEPATH=${libGLX}/lib/libGL.dylib"
-    "-DOPENGL_glu_LIBRARY:FILEPATH=${libGLU}/lib/libGLU.dylib"
+    "-DOPENGL_INCLUDE_DIR=${lib.getInclude libGLX}/include"
+    "-DOPENGL_gl_LIBRARY:FILEPATH=${lib.getLib libGLX}/lib/libGL.dylib"
     "-DFREEGLUT_BUILD_DEMOS:BOOL=OFF"
-    "-DFREEGLUT_BUILD_STATIC:BOOL=OFF"
   ];
 
   passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;

--- a/pkgs/by-name/re/renpy/package.nix
+++ b/pkgs/by-name/re/renpy/package.nix
@@ -65,20 +65,6 @@ stdenv.mkDerivation (finalAttrs: {
       tkinter
     ]);
 
-  RENPY_DEPS_INSTALL = lib.concatStringsSep "::" [
-    ffmpeg.lib
-    freetype
-    fribidi
-    glew.dev
-    harfbuzz.dev
-    libGL
-    libGLU
-    libpng
-    SDL2
-    (lib.getDev SDL2)
-    zlib
-  ];
-
   enableParallelBuilding = true;
 
   patches = [

--- a/pkgs/by-name/sn/snes9x/package.nix
+++ b/pkgs/by-name/sn/snes9x/package.nix
@@ -5,7 +5,7 @@
   cmake,
   fetchFromGitHub,
   gtkmm3,
-  libGL,
+  libGLX,
   libX11,
   libXdmcp,
   libXext,
@@ -91,11 +91,11 @@ stdenv.mkDerivation (finalAttrs: {
       "--enable-avx2"
     ];
 
-  postPatch = ''
+  postPatch = lib.optionalString withGtk ''
     substituteInPlace external/glad/src/egl.c \
-      --replace-fail libEGL.so.1 "${lib.getLib libGL}/lib/libEGL.so.1"
+      --replace-fail libEGL.so.1 "${lib.getLib libGLX}/lib/libEGL.so.1"
     substituteInPlace external/glad/src/glx.c \
-      --replace-fail libGL.so.1 ${lib.getLib libGL}/lib/libGL.so.1
+      --replace-fail libGL.so.1 ${lib.getLib libGLX}/lib/libGL.so.1
   '';
 
   preConfigure = ''

--- a/pkgs/development/python-modules/pyglet/default.nix
+++ b/pkgs/development/python-modules/pyglet/default.nix
@@ -110,6 +110,7 @@ buildPythonPackage rec {
     homepage = "http://www.pyglet.org/";
     description = "Cross-platform windowing and multimedia library";
     license = licenses.bsd3;
-    inherit (mesa.meta) platforms;
+    # The patch needs adjusting for non‐Linux platforms.
+    platforms = platforms.linux;
   };
 }

--- a/pkgs/development/python-modules/pythonocc-core/default.nix
+++ b/pkgs/development/python-modules/pythonocc-core/default.nix
@@ -29,12 +29,6 @@ stdenv.mkDerivation rec {
     hash = "sha256-0o2PQEN0/Z7FUPZEo2HxFFa+mN2bZnYI++HVu4ONpNA=";
   };
 
-  postPatch = ''
-    substituteInPlace CMakeLists.txt \
-    --replace "/usr/X11R6/lib/libGL.dylib" "${libGL}/lib/libGL.dylib" \
-    --replace "/usr/X11R6/lib/libGLU.dylib" "${libGLU}/lib/libGLU.dylib"
-  '';
-
   nativeBuildInputs = [
     cmake
     swig

--- a/pkgs/kde/lib/mk-kde-derivation.nix
+++ b/pkgs/kde/lib/mk-kde-derivation.nix
@@ -98,7 +98,9 @@ let
     attrName: attrValue:
     let
       pretty = lib.generators.toPretty { };
-      duplicates = builtins.filter (dep: (builtins.elem (lib.getName dep) filteredDepNames)) attrValue;
+      duplicates = builtins.filter (
+        dep: dep != null && builtins.elem (lib.getName dep) filteredDepNames
+      ) attrValue;
     in
     if duplicates != [ ] then
       lib.warn "Duplicate dependencies in ${attrName} of package ${pname}: ${pretty duplicates}"

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9785,12 +9785,15 @@ with pkgs;
   #
   # Android NDK provides an OpenGL implementation, we can just use that.
   #
-  # On macOS, we use the OpenGL framework. Packages that still need GLX
-  # specifically can pull in libGLX instead. If you have a package that
-  # should work without X11 but it can’t find the library, it may help
-  # to add the path to `NIX_CFLAGS_COMPILE`:
+  # On macOS, the SDK provides the OpenGL framework in `stdenv`.
+  # Packages that still need GLX specifically can pull in `libGLX`
+  # instead. If you have a package that should work without X11 but it
+  # can’t find the library, it may help to add the path to
+  # `$NIX_CFLAGS_COMPILE`:
   #
-  #     -L${libGL}/Library/Frameworks/OpenGL.framework/Versions/Current/Libraries
+  #    preConfigure = ''
+  #      export NIX_CFLAGS_COMPILE+=" -L$SDKROOT/System/Library/Frameworks/OpenGL.framework/Versions/Current/Libraries"
+  #    '';
   #
   # If you still can’t get it working, please don’t hesitate to ping
   # @NixOS/darwin-maintainers to ask an expert to take a look.
@@ -9798,25 +9801,26 @@ with pkgs;
     if stdenv.hostPlatform.useAndroidPrebuilt then
       stdenv
     else if stdenv.hostPlatform.isDarwin then
-      darwin.apple_sdk.frameworks.OpenGL
+      null
     else
       libglvnd;
 
-  # On macOS, we use the OpenGL framework. Packages that use libGLX on
-  # macOS may need to depend on mesa_glu directly if this doesn’t work.
-  libGLU = if stdenv.hostPlatform.isDarwin then darwin.apple_sdk.frameworks.OpenGL else mesa_glu;
+  # On macOS, the SDK provides the OpenGL framework in `stdenv`.
+  # Packages that use `libGLX` on macOS may need to depend on
+  # `mesa_glu` directly if this doesn’t work.
+  libGLU = if stdenv.hostPlatform.isDarwin then null else mesa_glu;
 
-  # libglvnd does not work (yet?) on macOS.
+  # `libglvnd` does not work (yet?) on macOS.
   libGLX = if stdenv.hostPlatform.isDarwin then mesa else libglvnd;
 
-  # On macOS, we use the GLUT framework. Packages that use libGLX on
-  # macOS may need to depend on freeglut directly if this doesn’t work.
-  libglut = if stdenv.hostPlatform.isDarwin then darwin.apple_sdk.frameworks.GLUT else freeglut;
+  # On macOS, the SDK provides the GLUT framework in `stdenv`. Packages
+  # that use `libGLX` on macOS may need to depend on `freeglut`
+  # directly if this doesn’t work.
+  libglut = if stdenv.hostPlatform.isDarwin then null else freeglut;
 
   mesa =
     if stdenv.hostPlatform.isDarwin then
-      callPackage ../development/libraries/mesa/darwin.nix {
-      }
+      callPackage ../development/libraries/mesa/darwin.nix { }
     else
       callPackage ../development/libraries/mesa { };
 

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -26609,6 +26609,7 @@ with self;
         artistic1
         gpl1Plus
       ]; # taken from EPEL
+      badPlatforms = lib.platforms.darwin;
     };
   };
 


### PR DESCRIPTION
~~cc @reckenrode who had some reservations about the choice of `apple-sdk` over `null` here.~~

~~I have commits to make channel eval pass with `null`, but they’re a little ugly (e.g. changing packages that already don’t eval on Darwin, fixing stuff in KDE and Perl that doesn’t expect `null` build inputs) and since it broke a good handful of things in Nixpkgs, even ones that aren’t doing incorrect string interpolations, I figure it’d probably break external users too, and `apple-sdk` is strictly more correct in a sense (although sadly it becomes less strictly more correct in the presence of multiple SDK versions).~~

~~I’ve left in the truly benign/net‐positive clean‐ups I did on the road to making `null` work, though. I’m happy to change this to use `null` and restore the additional fix‐up commits if that’s preferred.~~
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
