### PR TITLE
criu: support cross-compile for loongarch64-linux

### DIFF
--- a/pkgs/by-name/cr/criu/package.nix
+++ b/pkgs/by-name/cr/criu/package.nix
@@ -48,7 +48,6 @@ stdenv.mkDerivation rec {
     asciidoc
     xmlto
     libpaper
-    libuuid
     docbook_xsl
     which
     makeWrapper
@@ -64,6 +63,7 @@ stdenv.mkDerivation rec {
     libnet
     nftables
     libbsd
+    libuuid
   ];
   propagatedBuildInputs =
     [
@@ -95,6 +95,7 @@ stdenv.mkDerivation rec {
         "powerpc" = "ppc64";
         "s390" = "s390";
         "mips" = "mips";
+        "loongarch" = "loongarch64";
       };
     in
     [
@@ -146,6 +147,7 @@ stdenv.mkDerivation rec {
       "x86_64-linux"
       "aarch64-linux"
       "armv7l-linux"
+      "loongarch64-linux"
     ];
     maintainers = [ maintainers.thoughtpolice ];
   };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

This fixes the criu package to support cross-compilation to loongarch64 architectures (tested on an x86 build host). 
- add new archmap for loongarch64.
- move `libuuid` from `nativeBuildInputs` to `buildInputs`  to pass the cross-compilation process.

The following pkgs have been tested on a x86 host:
  - pkgs.criu
  - pkgsCross.aarch64-multiplatform.criu 
  - pkgsCross.loongarch64-linux.criu

---

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
