### PR TITLE
znc: 1.8.2 → 1.9.1

### DIFF
--- a/pkgs/applications/networking/znc/module_builds.patch
+++ b/pkgs/applications/networking/znc/module_builds.patch
@@ -1,0 +1,89 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index a38513d9..674f320a 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -445,6 +445,9 @@ install(FILES
+ configure_file("znc-buildmod.cmake.in" "znc-buildmod" @ONLY)
+ install(PROGRAMS "${PROJECT_BINARY_DIR}/znc-buildmod"
+ 	DESTINATION "${CMAKE_INSTALL_BINDIR}")
++configure_file("znc-buildmod-old.cmake.in" "znc-buildmod-old" @ONLY)
++install(PROGRAMS "${PROJECT_BINARY_DIR}/znc-buildmod-old"
++	DESTINATION "${CMAKE_INSTALL_BINDIR}")
+ 
+ configure_file("znc.pc.cmake.in" "znc.pc" @ONLY)
+ install(FILES "${PROJECT_BINARY_DIR}/znc.pc"
+diff --git a/znc-buildmod-old.cmake.in b/znc-buildmod-old.cmake.in
+new file mode 100755
+index 00000000..da6ce7a7
+--- /dev/null
++++ b/znc-buildmod-old.cmake.in
+@@ -0,0 +1,69 @@
++#!/bin/sh
++
++ERROR="[ !! ]"
++WARNING="[ ** ]"
++OK="[ ok ]"
++
++# Check if we got everything we need
++
++check_binary()
++{
++	which $1 > /dev/null 2>&1
++	if test $? = 1 ; then
++		echo "${ERROR} Could not find $1. $2"
++		exit 1
++	fi
++}
++
++if test "x$CXX" = "x" ; then
++	CXX="@CMAKE_CXX_COMPILER@"
++fi
++if test "x$CXX" = "x" ; then
++	CXX=g++
++fi
++
++check_binary ${CXX} "What happened to your compiler?"
++
++if test -z "$1"; then
++	echo "${WARNING} USAGE: $0 <file.cpp> [file.cpp ... ]"
++	exit 1
++fi
++
++CXXFLAGS="  -O2 -Wall -W -Wno-unused-parameter -Woverloaded-virtual -Wshadow -I@openssl@/include -I@icu@/include -fvisibility=hidden -fPIC -include znc/zncconfig.h -I${prefix}/@CMAKE_INSTALL_INCLUDEDIR@ $CXXFLAGS"
++LIBS="-L@openssl@/lib -lssl -lcrypto -lz -L@icu@/lib -licuuc -licudata $LIBS"
++MODLINK="-shared $MODLINK"
++VERSION="@ZNC_VERSION@"
++
++# Ugly cygwin stuff :(
++if test -n "@LIBZNC@"; then
++	prefix="@prefix@"
++	exec_prefix="${prefix}"
++	LDFLAGS="-L${exec_prefix}/lib $LDFLAGS"
++	LIBS="-lznc $LIBS"
++fi
++
++while test -n "$1"
++do
++	FILE=$1
++	shift
++
++	MOD="${FILE%.cpp}"
++	MOD="${MOD%.cc}"
++	MOD="${MOD##*/}"
++
++	if test ! -f "${FILE}"; then
++		echo "${ERROR} Building \"${MOD}\" for ZNC $VERSION... File not found"
++		exit 1
++	else
++		printf "Building \"${MOD}.so\" for ZNC $VERSION... "
++		printf "${CXX} ${CXXFLAGS} ${INCLUDES} ${LDFLAGS} ${MODLINK} -o \"${MOD}.so\" \"${FILE}\" ${LIBS}"
++		if ${CXX} ${CXXFLAGS} ${INCLUDES} ${LDFLAGS} ${MODLINK} -o "${MOD}.so" "${FILE}" ${LIBS} ; then
++			echo "${OK}"
++		else
++			echo "${ERROR} Error while building \"${MOD}.so\""
++			exit 1
++		fi
++	fi
++done
++
++exit 0

--- a/pkgs/applications/networking/znc/modules.nix
+++ b/pkgs/applications/networking/znc/modules.nix
@@ -3,6 +3,8 @@
   stdenv,
   fetchFromGitHub,
   znc,
+  python3,
+  cmake,
 }:
 
 let
@@ -11,7 +13,7 @@ let
       pname,
       src,
       module_name,
-      buildPhase ? "${znc}/bin/znc-buildmod ${module_name}.cpp",
+      buildPhase ? "${znc}/bin/znc-buildmod-old ${module_name}.cpp",
       installPhase ? "install -D ${module_name}.so $out/lib/znc/${module_name}.so",
       ...
     }:
@@ -21,7 +23,9 @@ let
         inherit buildPhase;
         inherit installPhase;
 
-        buildInputs = znc.buildInputs;
+        buildInputs = znc.buildInputs ++ [ python3 ];
+        nativeBuildInputs = znc.nativeBuildInputs;
+        dontUseCmakeConfigure = true;
 
         meta = a.meta // {
           platforms = lib.platforms.unix;
@@ -33,7 +37,7 @@ let
 in
 {
 
-  backlog = zncDerivation {
+  backlog = zncDerivation rec {
     pname = "znc-backlog";
     version = "unstable-2017-06-13";
     module_name = "backlog";


### PR DESCRIPTION
I've fixed the ZNC module builds by hacking together enough of the old build system to let older modules build while still letting new modules build with the new process.
This also upgrades the ZNC version from 1.8.2 to 1.9.1.

I have tested these and they work, even the older modules (at least the modules that I use).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
