### PR TITLE
wayfirePlugins.qwf-overview: init at 1.0.0

### DIFF
--- a/pkgs/applications/window-managers/wayfire/plugins.nix
+++ b/pkgs/applications/window-managers/wayfire/plugins.nix
@@ -8,6 +8,7 @@ lib.makeScope pkgs.newScope (
   {
     firedecor = callPackage ./firedecor.nix { };
     focus-request = callPackage ./focus-request.nix { };
+    qwf-overview = callPackage ./qwf-overview.nix { };
     wayfire-plugins-extra = callPackage ./wayfire-plugins-extra.nix { };
     wayfire-shadows = callPackage ./wayfire-shadows.nix { };
     wcm = callPackage ./wcm.nix { };

--- a/pkgs/applications/window-managers/wayfire/qwf-overview.nix
+++ b/pkgs/applications/window-managers/wayfire/qwf-overview.nix
@@ -1,0 +1,63 @@
+{
+  stdenv,
+  lib,
+  fetchFromGitea,
+  gitUpdater,
+  meson,
+  ninja,
+  pkg-config,
+  wayfire,
+  libGL,
+  libinput,
+  libxkbcommon,
+  nlohmann_json,
+  xcbutilwm,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "qwf-overview";
+  version = "1.0.0";
+
+  src = fetchFromGitea {
+    domain = "codeberg.org";
+    owner = "qtea";
+    repo = "qwf-overview";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-nyTb91n1Qz1UKGrbp7Z/Jlv25Eu6/SLI5ooYjmW9PYM=";
+  };
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+  ];
+
+  buildInputs = [
+    wayfire
+    libGL
+    libinput
+    libxkbcommon
+    nlohmann_json
+    xcbutilwm
+  ];
+
+  # Don't use git to determine version
+  postPatch = ''
+    substituteInPlace meson.build \
+      --replace-fail "run_command('version.sh', 'get-vcs').stdout().strip()" "'$version'"
+  '';
+
+  env = {
+    PKG_CONFIG_WAYFIRE_METADATADIR = "${placeholder "out"}/share/wayfire/metadata";
+  };
+
+  passthru.updateScript = gitUpdater { rev-prefix = "v"; };
+
+  meta = {
+    homepage = "https://codeberg.org/qtea/qwf-overview";
+    description = "Wayfire overview plugin inspired by the GNOME Activity Overview";
+    license = lib.licenses.gpl2Plus;
+    maintainers = with lib.maintainers; [ teatwig ];
+    inherit (wayfire.meta) platforms;
+  };
+})


### PR DESCRIPTION
This adds a new overview plugin for wayfire.

https://codeberg.org/qtea/qwf-overview

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
