### PR TITLE
python312Packages.jupysql: 0.10.17 -> 0.11.1

### DIFF
--- a/pkgs/development/python-modules/jupysql/default.nix
+++ b/pkgs/development/python-modules/jupysql/default.nix
@@ -33,11 +33,12 @@
   # tests
   pytestCheckHook,
   psutil,
+  writableTmpDirAsHomeHook,
 }:
 
 buildPythonPackage rec {
   pname = "jupysql";
-  version = "0.10.17";
+  version = "0.11.1";
 
   pyproject = true;
 
@@ -45,7 +46,7 @@ buildPythonPackage rec {
     owner = "ploomber";
     repo = "jupysql";
     tag = version;
-    hash = "sha256-0lrcNKDKmM3Peodc9ZzgqkzwPHPLMxxXHAj4OOKWZxA=";
+    hash = "sha256-7wfKvKqDf8LlUiLoevNRxmq8x5wLheOgIeWz72oFcuw=";
   };
 
   pythonRelaxDeps = [ "sqlalchemy" ];
@@ -80,12 +81,14 @@ buildPythonPackage rec {
   nativeCheckInputs = [
     pytestCheckHook
     psutil
+    writableTmpDirAsHomeHook
   ] ++ optional-dependencies.dev;
 
   disabledTests =
     [
       # AttributeError: 'DataFrame' object has no attribute 'frame_equal'
       "test_resultset_polars_dataframe"
+
       # all of these are broken with later versions of duckdb; see
       # https://github.com/ploomber/jupysql/issues/1030
       "test_resultset_getitem"
@@ -99,11 +102,12 @@ buildPythonPackage rec {
       "test_resultset_repr_html_with_reduced_feedback"
       "test_invalid_operation_error"
       "test_resultset_config_autolimit_dict"
+
       # fails due to strict warnings
       "test_calling_legacy_plotting_functions_displays_warning"
     ]
     ++ lib.optionals stdenv.hostPlatform.isDarwin [
-      # Fatal Python error: Aborted (in matplotlib)
+      # RuntimeError: *** -[__NSPlaceholderArray initWithObjects:count:]: attempt to insert nil object from objects[1]
       "test_no_errors_with_stored_query"
     ];
 
@@ -121,11 +125,6 @@ buildPythonPackage rec {
     # require js2py (which is unmaintained and insecure)
     "src/tests/test_widget.py"
   ];
-
-  preCheck = ''
-    # tests need to write temp data
-    export HOME=$(mktemp -d)
-  '';
 
   pythonImportsCheck = [ "sql" ];
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Diff: https://github.com/ploomber/jupysql/compare/refs/tags/0.10.17...refs/tags/0.11.1
Changelog: https://github.com/ploomber/jupysql/blob/0.11.1/CHANGELOG.md

cc @pacien
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
