### PR TITLE
treewide: mkDerivation rec {} -> mkDerivation (finalAttrs: {})

### DIFF
--- a/pkgs/games/amoeba/data.nix
+++ b/pkgs/games/amoeba/data.nix
@@ -4,12 +4,12 @@
   fetchurl,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "amoeba-data";
   version = "1.1";
 
   src = fetchurl {
-    url = "http://http.debian.net/debian/pool/non-free/a/amoeba-data/amoeba-data_${version}.orig.tar.gz";
+    url = "http://http.debian.net/debian/pool/non-free/a/amoeba-data/amoeba-data_${finalAttrs.version}.orig.tar.gz";
     sha256 = "1bgclr1v63n14bj9nwzm5zxg48nm0cla9bq1rbd5ylxra18k0jbg";
   };
 
@@ -25,4 +25,4 @@ stdenv.mkDerivation rec {
     maintainers = [ maintainers.dezgeg ];
     platforms = platforms.all;
   };
-}
+})

--- a/pkgs/games/amoeba/default.nix
+++ b/pkgs/games/amoeba/default.nix
@@ -14,18 +14,18 @@
   installShellFiles,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "amoeba";
   version = "1.1";
   debver = "31";
 
   srcs = [
     (fetchurl {
-      url = "http://http.debian.net/debian/pool/contrib/a/amoeba/amoeba_${version}.orig.tar.gz";
+      url = "http://http.debian.net/debian/pool/contrib/a/amoeba/amoeba_${finalAttrs.version}.orig.tar.gz";
       hash = "sha256-NT6oMuAlTcVZEnYjMCF+BD+k3/w7LfWEmj6bkQln3sM=";
     })
     (fetchurl {
-      url = "http://http.debian.net/debian/pool/contrib/a/amoeba/amoeba_${version}-${debver}.debian.tar.xz";
+      url = "http://http.debian.net/debian/pool/contrib/a/amoeba/amoeba_${finalAttrs.version}-${finalAttrs.debver}.debian.tar.xz";
       hash = "sha256-Ga/YeXbPXjkG/6qd9Z201d14Hlj/Je6DxgzeIQOqrWc=";
     })
   ];
@@ -67,4 +67,4 @@ stdenv.mkDerivation rec {
     maintainers = [ maintainers.dezgeg ];
     platforms = platforms.linux;
   };
-}
+})

--- a/pkgs/games/chiaki-ng/default.nix
+++ b/pkgs/games/chiaki-ng/default.nix
@@ -34,14 +34,14 @@
   xxHash,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "chiaki-ng";
   version = "1.9.6";
 
   src = fetchFromGitHub {
     owner = "streetpea";
     repo = "chiaki-ng";
-    rev = "v${version}";
+    rev = "v${finalAttrs.version}";
     hash = "sha256-TY27Xc13RiTcAgrUFJ3M3ALnxgeY+/4re3cjZ5kNwc8=";
     fetchSubmodules = true;
   };
@@ -124,4 +124,4 @@ stdenv.mkDerivation rec {
     platforms = platforms.linux;
     mainProgram = "chiaki";
   };
-}
+})

--- a/pkgs/games/construo/default.nix
+++ b/pkgs/games/construo/default.nix
@@ -10,12 +10,12 @@
   libglut ? null,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "construo";
   version = "0.2.3";
 
   src = fetchurl {
-    url = "https://github.com/Construo/construo/releases/download/v${version}/${pname}-${version}.tar.gz";
+    url = "https://github.com/Construo/construo/releases/download/v${finalAttrs.version}/${finalAttrs.pname}-${finalAttrs.version}.tar.gz";
     sha256 = "1wmj527hbj1qv44cdsj6ahfjrnrjwg2dp8gdick8nd07vm062qxa";
   };
 
@@ -40,4 +40,4 @@ stdenv.mkDerivation rec {
     homepage = "http://fs.fsf.org/construo/";
     license = lib.licenses.gpl3;
   };
-}
+})

--- a/pkgs/games/cutemaze/default.nix
+++ b/pkgs/games/cutemaze/default.nix
@@ -10,12 +10,12 @@
   qtsvg,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "cutemaze";
   version = "1.3.5";
 
   src = fetchurl {
-    url = "https://gottcode.org/cutemaze/cutemaze-${version}.tar.bz2";
+    url = "https://gottcode.org/cutemaze/cutemaze-${finalAttrs.version}.tar.bz2";
     hash = "sha256-a+QIOD0TB0AGnqIUgtkMBZuPUCQbXp4NtZ6b0vk/J0c=";
   };
 
@@ -49,7 +49,7 @@ stdenv.mkDerivation rec {
       null;
 
   meta = with lib; {
-    changelog = "https://github.com/gottcode/cutemaze/blob/v${version}/ChangeLog";
+    changelog = "https://github.com/gottcode/cutemaze/blob/v${finalAttrs.version}/ChangeLog";
     description = "Simple, top-down game in which mazes are randomly generated";
     mainProgram = "cutemaze";
     homepage = "https://gottcode.org/cutemaze/";
@@ -57,4 +57,4 @@ stdenv.mkDerivation rec {
     maintainers = with maintainers; [ dotlambda ];
     platforms = platforms.unix;
   };
-}
+})

--- a/pkgs/games/deliantra/arch.nix
+++ b/pkgs/games/deliantra/arch.nix
@@ -5,12 +5,12 @@
   deliantra-server,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "deliantra-arch";
   version = "3.1";
 
   src = fetchurl {
-    url = "http://dist.schmorp.de/deliantra/${pname}-${version}.tar.xz";
+    url = "http://dist.schmorp.de/deliantra/${finalAttrs.pname}-${finalAttrs.version}.tar.xz";
     sha256 = "1xzhv48g90hwkzgx9nfjm81ivg6hchkik9ldimi8ijb4j393kvsz";
   };
 
@@ -30,4 +30,4 @@ stdenv.mkDerivation rec {
     platforms = platforms.linux;
     maintainers = with maintainers; [ ToxicFrog ];
   };
-}
+})

--- a/pkgs/games/deliantra/maps.nix
+++ b/pkgs/games/deliantra/maps.nix
@@ -5,12 +5,12 @@
   deliantra-server,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "deliantra-maps";
   version = "3.1";
 
   src = fetchurl {
-    url = "http://dist.schmorp.de/deliantra/${pname}-${version}.tar.xz";
+    url = "http://dist.schmorp.de/deliantra/${finalAttrs.pname}-${finalAttrs.version}.tar.xz";
     sha256 = "0zbwzya28s1xpnbrmqkqvfrzns03zdjd8a9w9nk665aif6rw2zbz";
   };
 
@@ -30,4 +30,4 @@ stdenv.mkDerivation rec {
     platforms = platforms.linux;
     maintainers = with maintainers; [ ToxicFrog ];
   };
-}
+})

--- a/pkgs/games/deliantra/server.nix
+++ b/pkgs/games/deliantra/server.nix
@@ -36,12 +36,12 @@ let
     YAMLLibYAML
   ];
 in
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "deliantra-server";
   version = "3.1";
 
   src = fetchurl {
-    url = "http://dist.schmorp.de/deliantra/${pname}-${version}.tar.xz";
+    url = "http://dist.schmorp.de/deliantra/${finalAttrs.pname}-${finalAttrs.version}.tar.xz";
     sha256 = "0v0m2m9fxq143aknh7jb3qj8bnpjrs3bpbbx07c18516y3izr71d";
   };
 
@@ -90,4 +90,4 @@ stdenv.mkDerivation rec {
     platforms = platforms.linux;
     maintainers = with maintainers; [ ToxicFrog ];
   };
-}
+})

--- a/pkgs/games/duckmarines/default.nix
+++ b/pkgs/games/duckmarines/default.nix
@@ -8,7 +8,7 @@
   makeDesktopItem,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "duckmarines";
   version = "1.0c";
 
@@ -19,8 +19,8 @@ stdenv.mkDerivation rec {
 
   desktopItem = makeDesktopItem {
     name = "duckmarines";
-    exec = pname;
-    icon = icon;
+    exec = finalAttrs.pname;
+    icon = finalAttrs.icon;
     comment = "Duck-themed action puzzle video game";
     desktopName = "Duck Marines";
     genericName = "duckmarines";
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
   };
 
   src = fetchurl {
-    url = "https://github.com/SimonLarsen/${pname}/releases/download/v${version}/${pname}-1.0c.love";
+    url = "https://github.com/SimonLarsen/${finalAttrs.pname}/releases/download/v${finalAttrs.version}/${finalAttrs.pname}-1.0c.love";
     sha256 = "1rvgpkvi4h9zhc4fwb4knhsa789yjcx4a14fi4vqfdyybhvg5sh9";
   };
 
@@ -44,13 +44,13 @@ stdenv.mkDerivation rec {
     mkdir -p $out/bin
     mkdir -p $out/share/games/lovegames
 
-    cp -v ${src} $out/share/games/lovegames/${pname}.love
+    cp -v ${finalAttrs.src} $out/share/games/lovegames/${finalAttrs.pname}.love
 
-    makeWrapper ${love}/bin/love $out/bin/${pname} --add-flags $out/share/games/lovegames/${pname}.love
+    makeWrapper ${love}/bin/love $out/bin/${finalAttrs.pname} --add-flags $out/share/games/lovegames/${finalAttrs.pname}.love
 
-    chmod +x $out/bin/${pname}
+    chmod +x $out/bin/${finalAttrs.pname}
     mkdir -p $out/share/applications
-    ln -s ${desktopItem}/share/applications/* $out/share/applications/
+    ln -s ${finalAttrs.desktopItem}/share/applications/* $out/share/applications/
   '';
 
   meta = with lib; {
@@ -61,5 +61,4 @@ stdenv.mkDerivation rec {
     license = licenses.free;
     downloadPage = "http://tangramgames.dk/games/duckmarines";
   };
-
-}
+})

--- a/pkgs/games/dxx-rebirth/assets.nix
+++ b/pkgs/games/dxx-rebirth/assets.nix
@@ -9,14 +9,14 @@ let
   generic =
     ver: source:
     let
-      pname = "descent${toString ver}";
+      shortName = "descent${toString ver}";
     in
-    stdenv.mkDerivation rec {
-      name = "${pname}-assets-${version}";
+    stdenv.mkDerivation (finalAttrs: {
+      pname = "${shortName}-assets";
       version = "2.0.0.7";
 
       src = requireFile rec {
-        name = "setup_descent12_${version}.exe";
+        name = "setup_descent12_${finalAttrs.version}.exe";
         sha256 = "1r1drbfda6czg21f9qqiiwgnkpszxgmcn5bafp5ljddh34swkn3f";
         message = ''
           While the Descent ${toString ver} game engine is free, the game assets are not.
@@ -38,10 +38,10 @@ let
       installPhase = ''
         runHook preInstall
 
-        mkdir -p $out/share/{games/${pname},doc/${pname}/examples}
+        mkdir -p $out/share/{games/${shortName},doc/${shortName}/examples}
         pushd "app/${source}"
-        mv dosbox*.conf $out/share/doc/${pname}/examples
-        mv *.txt *.pdf  $out/share/doc/${pname}
+        mv dosbox*.conf $out/share/doc/${shortName}/examples
+        mv *.txt *.pdf  $out/share/doc/${shortName}
         cp -r * $out/share/games/descent${toString ver}
         popd
 
@@ -55,7 +55,7 @@ let
         maintainers = with maintainers; [ peterhoeg ];
         hydraPlatforms = [ ];
       };
-    };
+    });
 
 in
 {

--- a/pkgs/games/exult/default.nix
+++ b/pkgs/games/exult/default.nix
@@ -18,14 +18,14 @@
   AudioUnit,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "exult";
   version = "1.10.1";
 
   src = fetchFromGitHub {
     owner = "exult";
     repo = "exult";
-    rev = "v${version}";
+    rev = "v${finalAttrs.version}";
     hash = "sha256-NlvtYtmJNYhOC1BtIxIij3NEQHWAGOeD4XgRq7evjzE=";
   };
 
@@ -78,4 +78,4 @@ stdenv.mkDerivation rec {
     maintainers = [ ];
     mainProgram = "exult";
   };
-}
+})

--- a/pkgs/games/flightgear/default.nix
+++ b/pkgs/games/flightgear/default.nix
@@ -37,7 +37,7 @@
 
 let
   version = "2024.1.1";
-  data = stdenv.mkDerivation rec {
+  data = stdenv.mkDerivation (finalAttrs: {
     pname = "flightgear-data";
     inherit version;
 
@@ -52,11 +52,11 @@ let
 
     installPhase = ''
       mkdir -p "$out/share/FlightGear"
-      cp ${src}/* -a "$out/share/FlightGear/"
+      cp ${finalAttrs.src}/* -a "$out/share/FlightGear/"
     '';
-  };
+  });
 in
-stdenv.mkDerivation rec {
+stdenv.mkDerivation {
   pname = "flightgear";
   # inheriting data for `nix-prefetch-url -A pkgs.flightgear.data.src`
   inherit version data;

--- a/pkgs/games/leela-zero/default.nix
+++ b/pkgs/games/leela-zero/default.nix
@@ -10,14 +10,14 @@
   zlib,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "leela-zero";
   version = "0.17";
 
   src = fetchFromGitHub {
     owner = "gcp";
     repo = "leela-zero";
-    rev = "v${version}";
+    rev = "v${finalAttrs.version}";
     hash = "sha256-AQRp2rkL9KCZdsJN6uz2Y+3kV4lyRLYjWn0p7UOjBMw=";
     fetchSubmodules = true;
   };
@@ -44,4 +44,4 @@ stdenv.mkDerivation rec {
     ];
     platforms = platforms.linux;
   };
-}
+})

--- a/pkgs/games/linthesia/default.nix
+++ b/pkgs/games/linthesia/default.nix
@@ -18,7 +18,7 @@
   wrapGAppsHook3,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "linthesia";
   version = "unstable-2023-05-23";
 
@@ -60,4 +60,4 @@ stdenv.mkDerivation rec {
     platforms = platforms.linux;
     maintainers = [ ];
   };
-}
+})

--- a/pkgs/games/openspades/default.nix
+++ b/pkgs/games/openspades/default.nix
@@ -23,7 +23,7 @@
   libXext,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "openspades";
   version = "0.1.3";
   devPakVersion = "33";
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "yvt";
     repo = "openspades";
-    rev = "v${version}";
+    rev = "v${finalAttrs.version}";
     sha256 = "1fvmqbif9fbipd0vphp57pk6blb4yp8xvqlc2ppipk5pjv6a3d2h";
   };
 
@@ -74,7 +74,7 @@ stdenv.mkDerivation rec {
   ];
 
   devPak = fetchurl {
-    url = "https://github.com/yvt/openspades-paks/releases/download/r${devPakVersion}/OpenSpadesDevPackage-r${devPakVersion}.zip";
+    url = "https://github.com/yvt/openspades-paks/releases/download/r${finalAttrs.devPakVersion}/OpenSpadesDevPackage-r${finalAttrs.devPakVersion}.zip";
     sha256 = "1bd2fyn7mlxa3xnsvzj08xjzw02baimqvmnix07blfhb78rdq9q9";
   };
 
@@ -108,4 +108,4 @@ stdenv.mkDerivation rec {
     broken =
       stdenv.hostPlatform.isDarwin || (stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isAarch64);
   };
-}
+})

--- a/pkgs/games/pokerth/default.nix
+++ b/pkgs/games/pokerth/default.nix
@@ -19,14 +19,14 @@
   target ? "client",
 }:
 
-mkDerivation rec {
+mkDerivation (finalAttrs: {
   pname = "pokerth-${target}";
   version = "1.1.2";
 
   src = fetchFromGitHub {
     owner = "pokerth";
     repo = "pokerth";
-    rev = "v${version}";
+    rev = "v${finalAttrs.version}";
     hash = "sha256-j4E3VMpaPqX7+hE3wYRZZUeRD//F+K2Gp8oPmJqX5FQ=";
   };
 
@@ -91,4 +91,4 @@ mkDerivation rec {
     maintainers = with maintainers; [ obadz ];
     platforms = platforms.all;
   };
-}
+})

--- a/pkgs/games/pro-office-calculator/default.nix
+++ b/pkgs/games/pro-office-calculator/default.nix
@@ -7,14 +7,14 @@
   qtbase,
   qtmultimedia,
 }:
-mkDerivation rec {
+mkDerivation (finalAttrs: {
   version = "1.0.13";
   pname = "pro-office-calculator";
 
   src = fetchFromGitHub {
     owner = "RobJinman";
     repo = "pro_office_calc";
-    rev = "v${version}";
+    rev = "v${finalAttrs.version}";
     sha256 = "1v75cysargmp4fk7px5zgib1p6h5ya4w39rndbzk614fcnv0iipd";
   };
 
@@ -34,4 +34,4 @@ mkDerivation rec {
     platforms = platforms.linux;
     license = licenses.gpl3;
   };
-}
+})

--- a/pkgs/games/qtads/default.nix
+++ b/pkgs/games/qtads/default.nix
@@ -12,14 +12,14 @@
   qtbase,
 }:
 
-mkDerivation rec {
+mkDerivation (finalAttrs: {
   pname = "qtads";
   version = "3.4.0";
 
   src = fetchFromGitHub {
     owner = "realnc";
-    repo = pname;
-    rev = "v${version}";
+    repo = "qtads";
+    tag = "v${finalAttrs.version}";
     sha256 = "sha256-KIqufpvl7zeUtDBXUOAZxBIbfv+s51DoSaZr3jol+bw=";
   };
 
@@ -45,4 +45,4 @@ mkDerivation rec {
     platforms = platforms.linux;
     maintainers = with maintainers; [ orivej ];
   };
-}
+})

--- a/pkgs/games/quakespasm/default.nix
+++ b/pkgs/games/quakespasm/default.nix
@@ -25,16 +25,16 @@
   useSDL2 ? stdenv.hostPlatform.isDarwin, # TODO: CoreAudio fails to initialize with SDL 1.x for some reason.
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "quakespasm";
   version = "0.96.3";
 
   src = fetchurl {
-    url = "mirror://sourceforge/quakespasm/quakespasm-${version}.tar.gz";
+    url = "mirror://sourceforge/quakespasm/quakespasm-${finalAttrs.version}.tar.gz";
     sha256 = "sha256-tXjWzkpPf04mokRY8YxLzI04VK5iUuuZgu6B2V5QGA4=";
   };
 
-  sourceRoot = "${pname}-${version}/Quake";
+  sourceRoot = "${finalAttrs.pname}-${finalAttrs.version}/Quake";
 
   patches = lib.optionals stdenv.hostPlatform.isDarwin [
     # Makes Darwin Makefile use system libraries instead of ones from app bundle
@@ -145,4 +145,4 @@ stdenv.mkDerivation rec {
     maintainers = with maintainers; [ mikroskeem ];
     mainProgram = "quake";
   };
-}
+})

--- a/pkgs/games/rott/default.nix
+++ b/pkgs/games/rott/default.nix
@@ -7,7 +7,6 @@
   SDL_mixer,
   makeDesktopItem,
   copyDesktopItems,
-  runtimeShell,
   buildShareware ? false,
 }:
 
@@ -22,12 +21,12 @@ let
   '';
 
 in
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "rott";
   version = "1.1.2";
 
   src = fetchurl {
-    url = "https://icculus.org/rott/releases/${pname}-${version}.tar.gz";
+    url = "https://icculus.org/rott/releases/${finalAttrs.pname}-${finalAttrs.version}.tar.gz";
     sha256 = "1zr7v5dv2iqx40gzxbg8mhac7fxz3kqf28y6ysxv1xhjqgl1c98h";
   };
 
@@ -38,7 +37,7 @@ stdenv.mkDerivation rec {
     SDL_mixer
   ];
 
-  sourceRoot = "rott-${version}/rott";
+  sourceRoot = "rott-${finalAttrs.version}/rott";
 
   makeFlags = [
     "SHAREWARE=${if buildShareware then "1" else "0"}"
@@ -71,4 +70,4 @@ stdenv.mkDerivation rec {
     maintainers = with maintainers; [ sander ];
     platforms = platforms.all;
   };
-}
+})

--- a/pkgs/games/speed-dreams/default.nix
+++ b/pkgs/games/speed-dreams/default.nix
@@ -40,7 +40,7 @@ let
   version = "2.3.0-r8786";
   shortVersion = builtins.substring 0 5 version;
 in
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   inherit version;
   pname = "speed-dreams";
 
@@ -68,9 +68,9 @@ stdenv.mkDerivation rec {
 
   postUnpack = ''
     echo Unpacking data
-    tar -xf ${cars-and-tracks}
-    tar -xf ${more-cars-and-tracks}
-    tar -xf ${wip-cars-and-tracks}
+    tar -xf ${finalAttrs.cars-and-tracks}
+    tar -xf ${finalAttrs.more-cars-and-tracks}
+    tar -xf ${finalAttrs.wip-cars-and-tracks}
   '';
 
   preBuild = ''
@@ -154,4 +154,4 @@ stdenv.mkDerivation rec {
     platforms = lib.platforms.linux;
     hydraPlatforms = [ ];
   };
-}
+})

--- a/pkgs/games/spring/default.nix
+++ b/pkgs/games/spring/default.nix
@@ -28,12 +28,12 @@
   withAI ? true, # support for AI Interfaces and Skirmish AIs
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "spring";
   version = "106.0";
 
   src = fetchurl {
-    url = "https://springrts.com/dl/buildbot/default/master/${version}/source/spring_${version}_src.tar.gz";
+    url = "https://springrts.com/dl/buildbot/default/master/${finalAttrs.version}/source/spring_${finalAttrs.version}_src.tar.gz";
     sha256 = "sha256-mSA4ioIv68NMEB72lYnwDb1QOuWr1VHwu4+grAoHlV0=";
   };
 
@@ -104,4 +104,4 @@ stdenv.mkDerivation rec {
     platforms = [ "x86_64-linux" ];
     broken = true;
   };
-}
+})

--- a/pkgs/games/spring/springlobby.nix
+++ b/pkgs/games/spring/springlobby.nix
@@ -24,12 +24,12 @@
   jsoncpp,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "springlobby";
   version = "0.273";
 
   src = fetchurl {
-    url = "https://springlobby.springrts.com/dl/stable/springlobby-${version}.tar.bz2";
+    url = "https://springlobby.springrts.com/dl/stable/springlobby-${finalAttrs.version}.tar.bz2";
     sha256 = "sha256-XkU6i6ABCgw3H9vJu0xjHRO1BglueYM1LyJxcZdOrDk=";
   };
 
@@ -81,4 +81,4 @@ stdenv.mkDerivation rec {
       "x86_64-linux"
     ];
   };
-}
+})

--- a/pkgs/games/stuntrally/default.nix
+++ b/pkgs/games/stuntrally/default.nix
@@ -33,20 +33,20 @@ let
   };
 in
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "stuntrally";
   version = "2.7";
 
   src = fetchFromGitHub {
     owner = "stuntrally";
     repo = "stuntrally";
-    rev = version;
+    rev = finalAttrs.version;
     hash = "sha256-0Eh9ilIHSh/Uz8TuPnXxLQfy7KF7qqNXUgBXQUCz9ys=";
   };
   tracks = fetchFromGitHub {
     owner = "stuntrally";
     repo = "tracks";
-    rev = version;
+    rev = finalAttrs.version;
     hash = "sha256-fglm1FetFGHM/qGTtpxDb8+k2iAREn5DQR5GPujuLms=";
   };
 
@@ -59,7 +59,7 @@ stdenv.mkDerivation rec {
 
   preConfigure = ''
     rmdir data/tracks
-    ln -s ${tracks}/ data/tracks
+    ln -s ${finalAttrs.tracks}/ data/tracks
   '';
 
   nativeBuildInputs = [
@@ -90,4 +90,4 @@ stdenv.mkDerivation rec {
     maintainers = with maintainers; [ pSub ];
     platforms = platforms.linux;
   };
-}
+})

--- a/pkgs/games/tibia/default.nix
+++ b/pkgs/games/tibia/default.nix
@@ -9,12 +9,14 @@
   libGL,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "tibia";
   version = "10.90";
 
   src = fetchurl {
-    url = "http://static.tibia.com/download/tibia${lib.replaceStrings [ "." ] [ "" ] version}.tgz";
+    url = "http://static.tibia.com/download/tibia${
+      lib.replaceStrings [ "." ] [ "" ] finalAttrs.version
+    }.tgz";
     sha256 = "11mkh2dynmbpay51yfaxm5dmcys3rnpk579s9ypfkhblsrchbkhx";
   };
 
@@ -70,4 +72,4 @@ stdenv.mkDerivation rec {
     platforms = [ "i686-linux" ];
     maintainers = [ ];
   };
-}
+})

--- a/pkgs/games/vessel/default.nix
+++ b/pkgs/games/vessel/default.nix
@@ -8,22 +8,22 @@
   runtimeShell,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "vessel";
   version = "12082012";
 
   goBuyItNow = ''
     We cannot download the full version automatically, as you require a license.
     Once you bought a license, you need to add your downloaded version to the nix store.
-    You can do this by using "nix-prefetch-url file://\$PWD/vessel-${version}-bin" in the
+    You can do this by using "nix-prefetch-url file://\$PWD/vessel-${finalAttrs.version}-bin" in the
     directory where you saved it.
   '';
 
   src =
     if (stdenv.hostPlatform.isi686) then
       requireFile {
-        message = goBuyItNow;
-        name = "vessel-${version}-bin";
+        message = finalAttrs.goBuyItNow;
+        name = "vessel-${finalAttrs.version}-bin";
         sha256 = "1vpwcrjiln2mx43h7ib3jnccyr3chk7a5x2bw9kb4lw8ycygvg96";
       }
     else
@@ -100,5 +100,4 @@ stdenv.mkDerivation rec {
     license = licenses.unfree;
     maintainers = with maintainers; [ jcumming ];
   };
-
-}
+})

--- a/pkgs/games/warsow/default.nix
+++ b/pkgs/games/warsow/default.nix
@@ -6,12 +6,12 @@
   makeWrapper,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "warsow";
   version = "2.1.2";
 
   src = fetchurl {
-    url = "http://warsow.net/${pname}-${version}.tar.gz";
+    url = "http://warsow.net/${finalAttrs.pname}-${finalAttrs.version}.tar.gz";
     sha256 = "07y2airw5qg3s1bf1c63a6snjj22riz0mqhk62jmfm9nrarhavrc";
   };
 
@@ -44,4 +44,4 @@ stdenv.mkDerivation rec {
     ];
     platforms = warsow-engine.meta.platforms;
   };
-}
+})

--- a/pkgs/games/xpilot/bloodspilot-client.nix
+++ b/pkgs/games/xpilot/bloodspilot-client.nix
@@ -12,12 +12,12 @@
   SDL_image,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   version = "1.5.0";
   pname = "bloodspilot-client";
 
   src = fetchurl {
-    url = "mirror://sourceforge/project/bloodspilot/client-sdl/v${version}/bloodspilot-client-sdl-${version}.tar.gz";
+    url = "mirror://sourceforge/project/bloodspilot/client-sdl/v${finalAttrs.version}/bloodspilot-client-sdl-${finalAttrs.version}.tar.gz";
     sha256 = "1qwl95av5an2zl01m7saj6fyy49xpixga7gbn4lwbpgpqs1rbwxj";
   };
 
@@ -44,4 +44,4 @@ stdenv.mkDerivation rec {
     maintainers = [ lib.maintainers.raskin ];
     platforms = lib.platforms.linux;
   };
-}
+})

--- a/pkgs/games/xpilot/bloodspilot-server.nix
+++ b/pkgs/games/xpilot/bloodspilot-server.nix
@@ -5,12 +5,12 @@
   expat,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "bloodspilot-xpilot-fxi-server";
   version = "1.4.6";
 
   src = fetchurl {
-    url = "mirror://sourceforge/project/bloodspilot/server/server%20v${version}/xpilot-${version}fxi.tar.gz";
+    url = "mirror://sourceforge/project/bloodspilot/server/server%20v${finalAttrs.version}/xpilot-${finalAttrs.version}fxi.tar.gz";
     sha256 = "0d7hnpshifq6gy9a0g6il6h1hgqqjyys36n8w84hr8d4nhg4d1ji";
   };
 
@@ -31,4 +31,4 @@ stdenv.mkDerivation rec {
     maintainers = [ maintainers.raskin ];
     platforms = platforms.linux;
   };
-}
+})

--- a/pkgs/games/xpilot/default.nix
+++ b/pkgs/games/xpilot/default.nix
@@ -14,13 +14,15 @@
   zlib,
   libXxf86misc,
 }:
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "xpilot-ng";
   version = "4.7.3";
+
   src = fetchurl {
-    url = "mirror://sourceforge/xpilot/xpilot_ng/${pname}-${version}/${pname}-${version}.tar.gz";
-    sha256 = "02a7pnp88kh88fzda5q8mzlckk6y9r5fw47j00h26wbsfly0k1zj";
+    url = "mirror://sourceforge/xpilot/xpilot_ng/${finalAttrs.pname}-${finalAttrs.version}/${finalAttrs.pname}-${finalAttrs.version}.tar.gz";
+    hash = "02a7pnp88kh88fzda5q8mzlckk6y9r5fw47j00h26wbsfly0k1zj";
   };
+
   buildInputs = [
     libX11
     libSM
@@ -47,4 +49,4 @@ stdenv.mkDerivation rec {
     maintainers = [ maintainers.raskin ];
     platforms = platforms.linux;
   };
-}
+})


### PR DESCRIPTION
`mkDerivation` has been able to take a single-arg lambda for a while, so it's basically a crime to pass a `rec` to it.

Will be performed in a couple of batches (Lord, give me strength).

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
