### PR TITLE
crystalline: 0.15.0 -> 0.17.1 with added updateScript

### DIFF
--- a/pkgs/development/tools/language-servers/crystalline/default.nix
+++ b/pkgs/development/tools/language-servers/crystalline/default.nix
@@ -11,6 +11,8 @@
   runCommand,
   writeShellScript,
   gitUpdater,
+  testers,
+  crystalline,
 }:
 
 let
@@ -76,6 +78,11 @@ crystal.buildCrystalPackage rec {
     shardLock = runCommand "shard.lock" { inherit src; } ''
       cp $src/shard.lock $out
     '';
+
+    # Since doInstallCheck causes another test error, versionCheckHook is avoided.
+    tests.version = testers.testVersion {
+      package = crystalline;
+    };
   };
 
   meta = {

--- a/pkgs/development/tools/language-servers/crystalline/default.nix
+++ b/pkgs/development/tools/language-servers/crystalline/default.nix
@@ -4,6 +4,7 @@
   fetchFromGitHub,
   llvmPackages,
   openssl,
+  shards,
   makeWrapper,
   _experimental-update-script-combinators,
   crystal2nix,
@@ -13,7 +14,7 @@
 }:
 
 let
-  version = "0.15.0";
+  version = "0.17.1";
 in
 crystal.buildCrystalPackage rec {
   pname = "crystalline";
@@ -23,7 +24,7 @@ crystal.buildCrystalPackage rec {
     owner = "elbywan";
     repo = "crystalline";
     rev = "v${version}";
-    hash = "sha256-6ZAogEuOJH1QQ6NSJ+8KZUSFSgQAcvd4U9vWNAGix/M=";
+    hash = "sha256-SIfInDY6KhEwEPZckgobOrpKXBDDd0KhQt/IjdGBhWo=";
   };
 
   format = "crystal";
@@ -33,6 +34,7 @@ crystal.buildCrystalPackage rec {
     llvmPackages.llvm
     openssl
     makeWrapper
+    shards
   ];
 
   doCheck = false;

--- a/pkgs/development/tools/language-servers/crystalline/shards.nix
+++ b/pkgs/development/tools/language-servers/crystalline/shards.nix
@@ -19,9 +19,4 @@
     rev = "e448ce83486f99ef016c311e10ec0cac805cded3";
     sha256 = "13yp7805xpd605jpfpb3srqb0psy25w7n6x9mpkcyvzhqmpnpfyq";
   };
-  version_from_shard = {
-    url = "https://github.com/hugopl/version_from_shard.git";
-    rev = "v1.2.5";
-    sha256 = "0xizj0q4rd541rwjbx04cjifc2gfx4l5v6q2y7gmd0ndjmkgb8ik";
-  };
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Diff: https://github.com/elbywan/crystalline/compare/v0.15.0...v0.17.1

- This PR aims to fix [failing automatic updates](https://nixpkgs-update-logs.nix-community.org/crystalline/2025-04-20.log)
- We can use `--version` flag since https://github.com/elbywan/crystalline/commit/a761ed9cf923070da9333fd84706a27ab5a3e8b5
- We should inject shards CLI in build inputs since https://github.com/elbywan/crystalline/commit/70b1947488972ff92da00ed35d51e148caf6df70

Strictly speaking, crystalline 0.17 is supposed to be compatible with Crystal 1.16, but as I understand it, there is already a discrepancy—crystalline is currently at version 0.15, which corresponds to Crystal 1.14.

With that in mind, I wasn’t sure whether I should wait for [this PR](https://github.com/NixOS/nixpkgs/pull/399318) to be merged before submitting mine.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [x] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

cc: @donovanglover 

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
