### PR TITLE
python313Packages.dockerflow: init at 2024.04.2; python313Packages.nested-multipart-parser: init at 1.5.0

### DIFF
--- a/pkgs/development/python-modules/dockerflow/default.nix
+++ b/pkgs/development/python-modules/dockerflow/default.nix
@@ -1,0 +1,104 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  # build-system
+  setuptools,
+  setuptools-scm,
+
+  # optional dependencies
+  asgiref,
+  blinker,
+  django,
+  fastapi,
+  flask,
+  sanic,
+
+  # tests
+  django-redis,
+  pytest-django,
+  httpx,
+  fakeredis,
+  jsonschema,
+  pytestCheckHook,
+  pytest-cov-stub,
+  pytest-mock,
+  redis,
+  redisTestHook,
+}:
+
+buildPythonPackage rec {
+  pname = "dockerflow";
+  version = "2024.04.2";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "mozilla-services";
+    repo = "python-dockerflow";
+    tag = version;
+    hash = "sha256-5Ov605FyhX+n6vFks2sdtviGqkrgDIMXpcvgqR85jmQ=";
+  };
+
+  build-system = [
+    setuptools
+    setuptools-scm
+  ];
+
+  optional-dependencies = {
+    django = [ django ];
+    flask = [
+      blinker
+      flask
+    ];
+    sanic = [ sanic ];
+    fastapi = [
+      asgiref
+      fastapi
+    ];
+  };
+
+  nativeCheckInputs = [
+    fakeredis
+    jsonschema
+    pytestCheckHook
+    pytest-cov-stub
+    pytest-mock
+    redis
+    redisTestHook
+
+    # django
+    django-redis
+    pytest-django
+
+    # fastapi
+    httpx
+  ] ++ lib.flatten (lib.attrValues optional-dependencies);
+
+  disabledTests = [
+    # AssertionError: assert 'c7a05e2b-8a21-4255-a3ed-92cea1e74a62' is None
+    "test_mozlog_without_correlation_id_middleware"
+  ];
+
+  disabledTestPaths = [
+    # missing flask-redis dependency
+    "tests/flask/test_flask.py"
+    # missing sanic-redis dependency
+    "tests/sanic/test_sanic.py"
+  ];
+
+  preCheck = ''
+    export DJANGO_SETTINGS_MODULE=tests.django.settings
+  '';
+
+  pythonImportsCheck = [
+    "dockerflow"
+  ];
+
+  meta = {
+    changelog = "https://github.com/mozilla-services/python-dockerflow/releases/tag/${src.tag}";
+    description = "A Python package to implement tools and helpers for Mozilla Dockerflow";
+    homepage = "https://github.com/mozilla-services/python-dockerflow";
+    license = lib.licenses.mpl20;
+  };
+}

--- a/pkgs/development/python-modules/nested-multipart-parser/default.nix
+++ b/pkgs/development/python-modules/nested-multipart-parser/default.nix
@@ -1,0 +1,45 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  # build-system
+  setuptools,
+
+  # tests
+  django,
+  djangorestframework,
+  pytestCheckHook,
+}:
+
+buildPythonPackage rec {
+  pname = "nested-multipart-parser";
+  version = "1.5.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "remigermain";
+    repo = "nested-multipart-parser";
+    tag = version;
+    hash = "sha256-9IGfYb6mVGkoE/6iDg0ap8c+0vrBDKK1DxzLRyfeWOk=";
+  };
+
+  build-system = [ setuptools ];
+
+  nativeCheckInputs = [
+    django
+    djangorestframework
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [
+    "nested_multipart_parser"
+  ];
+
+  meta = {
+    changelog = "https://github.com/remigermain/nested-multipart-parser/releases/tag/${src.tag}";
+    description = "Parser for nested data for 'multipart/form'";
+    homepage = "https://github.com/remigermain/nested-multipart-parser";
+    license = lib.licenses.mit;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9747,6 +9747,8 @@ self: super: with self; {
 
   nested-lookup = callPackage ../development/python-modules/nested-lookup { };
 
+  nested-multipart-parser = callPackage ../development/python-modules/nested-multipart-parser { };
+
   nestedtext = callPackage ../development/python-modules/nestedtext { };
 
   netaddr = callPackage ../development/python-modules/netaddr { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4028,6 +4028,8 @@ self: super: with self; {
 
   dockerfile-parse = callPackage ../development/python-modules/dockerfile-parse { };
 
+  dockerflow = callPackage ../development/python-modules/dockerflow { };
+
   dockerpty = callPackage ../development/python-modules/dockerpty { };
 
   dockerspawner = callPackage ../development/python-modules/dockerspawner { };


### PR DESCRIPTION
https://github.com/mozilla-services/python-dockerflow
https://github.com/remigermain/nested-multipart-parser/

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
