### PR TITLE
readline: Cleanup further

### DIFF
--- a/pkgs/development/libraries/readline/8.2.nix
+++ b/pkgs/development/libraries/readline/8.2.nix
@@ -9,121 +9,114 @@
   curses-library ? if stdenv.hostPlatform.isWindows then termcap else ncurses,
 }:
 
-stdenv.mkDerivation (
-  finalAttrs:
-  let
-    inherit (finalAttrs) upstreamPatches meta;
-  in
-  {
-    pname = "readline";
-    version = "8.2p${toString (builtins.length upstreamPatches)}";
+stdenv.mkDerivation (finalAttrs: {
+  pname = "readline";
+  version = "8.2p${toString (builtins.length finalAttrs.upstreamPatches)}";
 
-    src = fetchurl {
-      url = "mirror://gnu/readline/readline-${meta.branch}.tar.gz";
-      sha256 = "sha256-P+txcfFqhO6CyhijbXub4QmlLAT0kqBTMx19EJUAfDU=";
-    };
+  src = fetchurl {
+    url = "mirror://gnu/readline/readline-${finalAttrs.meta.branch}.tar.gz";
+    sha256 = "sha256-P+txcfFqhO6CyhijbXub4QmlLAT0kqBTMx19EJUAfDU=";
+  };
 
-    outputs = [
-      "out"
-      "dev"
-      "man"
-      "doc"
-      "info"
+  outputs = [
+    "out"
+    "dev"
+    "man"
+    "doc"
+    "info"
+  ];
+
+  strictDeps = true;
+  propagatedBuildInputs = [ curses-library ];
+  nativeBuildInputs = [ updateAutotoolsGnuConfigScriptsHook ];
+
+  patchFlags = [ "-p0" ];
+
+  upstreamPatches = (
+    let
+      patch =
+        nr: sha256:
+        fetchurl {
+          url = "mirror://gnu/readline/readline-${finalAttrs.meta.branch}-patches/readline82-${nr}";
+          inherit sha256;
+        };
+    in
+    import ./readline-8.2-patches.nix patch
+  );
+
+  patches =
+    lib.optionals (curses-library.pname == "ncurses") [
+      ./link-against-ncurses.patch
+    ]
+    ++ [
+      ./no-arch_only-8.2.patch
+    ]
+    ++ finalAttrs.upstreamPatches
+    ++ lib.optionals stdenv.hostPlatform.isWindows [
+      (fetchpatch {
+        name = "0001-sigwinch.patch";
+        url = "https://github.com/msys2/MINGW-packages/raw/90e7536e3b9c3af55c336d929cfcc32468b2f135/mingw-w64-readline/0001-sigwinch.patch";
+        stripLen = 1;
+        hash = "sha256-sFK6EJrSNl0KLWqFv5zBXaQRuiQoYIZVoZfa8BZqfKA=";
+      })
+      (fetchpatch {
+        name = "0002-event-hook.patch";
+        url = "https://github.com/msys2/MINGW-packages/raw/3476319d2751a676b911f3de9e1ec675081c03b8/mingw-w64-readline/0002-event-hook.patch";
+        stripLen = 1;
+        hash = "sha256-F8ytYuIjBtH83ZCJdf622qjwSw+wZEVyu53E/mPsoAo=";
+      })
+      (fetchpatch {
+        name = "0003-fd_set.patch";
+        url = "https://github.com/msys2/MINGW-packages/raw/35830ab27e5ed35c2a8d486961ab607109f5af50/mingw-w64-readline/0003-fd_set.patch";
+        stripLen = 1;
+        hash = "sha256-UiaXZRPjKecpSaflBMCphI2kqOlcz1JkymlCrtpMng4=";
+      })
+      (fetchpatch {
+        name = "0004-locale.patch";
+        url = "https://github.com/msys2/MINGW-packages/raw/f768c4b74708bb397a77e3374cc1e9e6ef647f20/mingw-w64-readline/0004-locale.patch";
+        stripLen = 1;
+        hash = "sha256-dk4343KP4EWXdRRCs8GRQlBgJFgu1rd79RfjwFD/nJc=";
+      })
     ];
 
-    strictDeps = true;
-    propagatedBuildInputs = [ curses-library ];
-    nativeBuildInputs = [ updateAutotoolsGnuConfigScriptsHook ];
+  # Make mingw-w64 provide a dummy alarm() function
+  #
+  # Method borrowed from
+  # https://github.com/msys2/MINGW-packages/commit/35830ab27e5ed35c2a8d486961ab607109f5af50
+  CFLAGS = lib.optionalString stdenv.hostPlatform.isMinGW "-D__USE_MINGW_ALARM -D_POSIX";
 
-    patchFlags = [ "-p0" ];
+  # This install error is caused by a very old libtool. We can't autoreconfHook this package,
+  # so this is the best we've got!
+  postInstall = lib.optionalString stdenv.hostPlatform.isOpenBSD ''
+    ln -s $out/lib/libhistory.so* $out/lib/libhistory.so
+    ln -s $out/lib/libreadline.so* $out/lib/libreadline.so
+  '';
 
-    upstreamPatches = (
-      let
-        patch =
-          nr: sha256:
-          fetchurl {
-            url = "mirror://gnu/readline/readline-${meta.branch}-patches/readline82-${nr}";
-            inherit sha256;
-          };
-      in
-      import ./readline-8.2-patches.nix patch
-    );
+  meta = with lib; {
+    description = "Library for interactive line editing";
 
-    patches =
-      lib.optionals (curses-library.pname == "ncurses") [
-        ./link-against-ncurses.patch
-      ]
-      ++ [
-        ./no-arch_only-8.2.patch
-      ]
-      ++ upstreamPatches
-      ++ lib.optionals stdenv.hostPlatform.isWindows [
-        (fetchpatch {
-          name = "0001-sigwinch.patch";
-          url = "https://github.com/msys2/MINGW-packages/raw/90e7536e3b9c3af55c336d929cfcc32468b2f135/mingw-w64-readline/0001-sigwinch.patch";
-          stripLen = 1;
-          hash = "sha256-sFK6EJrSNl0KLWqFv5zBXaQRuiQoYIZVoZfa8BZqfKA=";
-        })
-        (fetchpatch {
-          name = "0002-event-hook.patch";
-          url = "https://github.com/msys2/MINGW-packages/raw/3476319d2751a676b911f3de9e1ec675081c03b8/mingw-w64-readline/0002-event-hook.patch";
-          stripLen = 1;
-          hash = "sha256-F8ytYuIjBtH83ZCJdf622qjwSw+wZEVyu53E/mPsoAo=";
-        })
-        (fetchpatch {
-          name = "0003-fd_set.patch";
-          url = "https://github.com/msys2/MINGW-packages/raw/35830ab27e5ed35c2a8d486961ab607109f5af50/mingw-w64-readline/0003-fd_set.patch";
-          stripLen = 1;
-          hash = "sha256-UiaXZRPjKecpSaflBMCphI2kqOlcz1JkymlCrtpMng4=";
-        })
-        (fetchpatch {
-          name = "0004-locale.patch";
-          url = "https://github.com/msys2/MINGW-packages/raw/f768c4b74708bb397a77e3374cc1e9e6ef647f20/mingw-w64-readline/0004-locale.patch";
-          stripLen = 1;
-          hash = "sha256-dk4343KP4EWXdRRCs8GRQlBgJFgu1rd79RfjwFD/nJc=";
-        })
-      ];
+    longDescription = ''
+      The GNU Readline library provides a set of functions for use by
+      applications that allow users to edit command lines as they are
+      typed in.  Both Emacs and vi editing modes are available.  The
+      Readline library includes additional functions to maintain a
+      list of previously-entered command lines, to recall and perhaps
+      reedit those lines, and perform csh-like history expansion on
+      previous commands.
 
-    # This install error is caused by a very old libtool. We can't autoreconfHook this package,
-    # so this is the best we've got!
-    postInstall = lib.optionalString stdenv.hostPlatform.isOpenBSD ''
-      ln -s $out/lib/libhistory.so* $out/lib/libhistory.so
-      ln -s $out/lib/libreadline.so* $out/lib/libreadline.so
+      The history facilities are also placed into a separate library,
+      the History library, as part of the build process.  The History
+      library may be used without Readline in applications which
+      desire its capabilities.
     '';
 
-    meta = with lib; {
-      description = "Library for interactive line editing";
+    homepage = "https://savannah.gnu.org/projects/readline/";
 
-      longDescription = ''
-        The GNU Readline library provides a set of functions for use by
-        applications that allow users to edit command lines as they are
-        typed in.  Both Emacs and vi editing modes are available.  The
-        Readline library includes additional functions to maintain a
-        list of previously-entered command lines, to recall and perhaps
-        reedit those lines, and perform csh-like history expansion on
-        previous commands.
+    license = licenses.gpl3Plus;
 
-        The history facilities are also placed into a separate library,
-        the History library, as part of the build process.  The History
-        library may be used without Readline in applications which
-        desire its capabilities.
-      '';
+    maintainers = with maintainers; [ dtzWill ];
 
-      homepage = "https://savannah.gnu.org/projects/readline/";
-
-      license = licenses.gpl3Plus;
-
-      maintainers = with maintainers; [ dtzWill ];
-
-      platforms = platforms.unix ++ platforms.windows;
-      branch = "8.2";
-    };
-  }
-  // lib.optionalAttrs stdenv.hostPlatform.isMinGW {
-    # Make mingw-w64 provide a dummy alarm() function
-    #
-    # Method borrowed from
-    # https://github.com/msys2/MINGW-packages/commit/35830ab27e5ed35c2a8d486961ab607109f5af50
-    CFLAGS = "-D__USE_MINGW_ALARM -D_POSIX";
-  }
-)
+    platforms = platforms.unix ++ platforms.windows;
+    branch = "8.2";
+  };
+})

--- a/pkgs/development/libraries/readline/8.2.nix
+++ b/pkgs/development/libraries/readline/8.2.nix
@@ -79,6 +79,14 @@ stdenv.mkDerivation rec {
       })
     ];
 
+  # Make mingw-w64 provide a dummy alarm() function
+  #
+  # Method borrowed from
+  # https://github.com/msys2/MINGW-packages/commit/35830ab27e5ed35c2a8d486961ab607109f5af50
+  #
+  # `null` is used to avoid mass rebuild, will fix on staging.
+  CFLAGS = if !stdenv.hostPlatform.isMinGW then null else "-D__USE_MINGW_ALARM -D_POSIX";
+
   # This install error is caused by a very old libtool. We can't autoreconfHook this package,
   # so this is the best we've got!
   postInstall = lib.optionalString stdenv.hostPlatform.isOpenBSD ''

--- a/pkgs/development/libraries/readline/8.2.nix
+++ b/pkgs/development/libraries/readline/8.2.nix
@@ -9,116 +9,121 @@
   curses-library ? if stdenv.hostPlatform.isWindows then termcap else ncurses,
 }:
 
-stdenv.mkDerivation rec {
-  pname = "readline";
-  version = "8.2p${toString (builtins.length upstreamPatches)}";
+stdenv.mkDerivation (
+  finalAttrs:
+  let
+    inherit (finalAttrs) upstreamPatches meta;
+  in
+  {
+    pname = "readline";
+    version = "8.2p${toString (builtins.length upstreamPatches)}";
 
-  src = fetchurl {
-    url = "mirror://gnu/readline/readline-${meta.branch}.tar.gz";
-    sha256 = "sha256-P+txcfFqhO6CyhijbXub4QmlLAT0kqBTMx19EJUAfDU=";
-  };
+    src = fetchurl {
+      url = "mirror://gnu/readline/readline-${meta.branch}.tar.gz";
+      sha256 = "sha256-P+txcfFqhO6CyhijbXub4QmlLAT0kqBTMx19EJUAfDU=";
+    };
 
-  outputs = [
-    "out"
-    "dev"
-    "man"
-    "doc"
-    "info"
-  ];
-
-  strictDeps = true;
-  propagatedBuildInputs = [ curses-library ];
-  nativeBuildInputs = [ updateAutotoolsGnuConfigScriptsHook ];
-
-  patchFlags = [ "-p0" ];
-
-  upstreamPatches = (
-    let
-      patch =
-        nr: sha256:
-        fetchurl {
-          url = "mirror://gnu/readline/readline-${meta.branch}-patches/readline82-${nr}";
-          inherit sha256;
-        };
-    in
-    import ./readline-8.2-patches.nix patch
-  );
-
-  patches =
-    lib.optionals (curses-library.pname == "ncurses") [
-      ./link-against-ncurses.patch
-    ]
-    ++ [
-      ./no-arch_only-8.2.patch
-    ]
-    ++ upstreamPatches
-    ++ lib.optionals stdenv.hostPlatform.isWindows [
-      (fetchpatch {
-        name = "0001-sigwinch.patch";
-        url = "https://github.com/msys2/MINGW-packages/raw/90e7536e3b9c3af55c336d929cfcc32468b2f135/mingw-w64-readline/0001-sigwinch.patch";
-        stripLen = 1;
-        hash = "sha256-sFK6EJrSNl0KLWqFv5zBXaQRuiQoYIZVoZfa8BZqfKA=";
-      })
-      (fetchpatch {
-        name = "0002-event-hook.patch";
-        url = "https://github.com/msys2/MINGW-packages/raw/3476319d2751a676b911f3de9e1ec675081c03b8/mingw-w64-readline/0002-event-hook.patch";
-        stripLen = 1;
-        hash = "sha256-F8ytYuIjBtH83ZCJdf622qjwSw+wZEVyu53E/mPsoAo=";
-      })
-      (fetchpatch {
-        name = "0003-fd_set.patch";
-        url = "https://github.com/msys2/MINGW-packages/raw/35830ab27e5ed35c2a8d486961ab607109f5af50/mingw-w64-readline/0003-fd_set.patch";
-        stripLen = 1;
-        hash = "sha256-UiaXZRPjKecpSaflBMCphI2kqOlcz1JkymlCrtpMng4=";
-      })
-      (fetchpatch {
-        name = "0004-locale.patch";
-        url = "https://github.com/msys2/MINGW-packages/raw/f768c4b74708bb397a77e3374cc1e9e6ef647f20/mingw-w64-readline/0004-locale.patch";
-        stripLen = 1;
-        hash = "sha256-dk4343KP4EWXdRRCs8GRQlBgJFgu1rd79RfjwFD/nJc=";
-      })
+    outputs = [
+      "out"
+      "dev"
+      "man"
+      "doc"
+      "info"
     ];
 
-  # Make mingw-w64 provide a dummy alarm() function
-  #
-  # Method borrowed from
-  # https://github.com/msys2/MINGW-packages/commit/35830ab27e5ed35c2a8d486961ab607109f5af50
-  #
-  # `null` is used to avoid mass rebuild, will fix on staging.
-  CFLAGS = if !stdenv.hostPlatform.isMinGW then null else "-D__USE_MINGW_ALARM -D_POSIX";
+    strictDeps = true;
+    propagatedBuildInputs = [ curses-library ];
+    nativeBuildInputs = [ updateAutotoolsGnuConfigScriptsHook ];
 
-  # This install error is caused by a very old libtool. We can't autoreconfHook this package,
-  # so this is the best we've got!
-  postInstall = lib.optionalString stdenv.hostPlatform.isOpenBSD ''
-    ln -s $out/lib/libhistory.so* $out/lib/libhistory.so
-    ln -s $out/lib/libreadline.so* $out/lib/libreadline.so
-  '';
+    patchFlags = [ "-p0" ];
 
-  meta = with lib; {
-    description = "Library for interactive line editing";
+    upstreamPatches = (
+      let
+        patch =
+          nr: sha256:
+          fetchurl {
+            url = "mirror://gnu/readline/readline-${meta.branch}-patches/readline82-${nr}";
+            inherit sha256;
+          };
+      in
+      import ./readline-8.2-patches.nix patch
+    );
 
-    longDescription = ''
-      The GNU Readline library provides a set of functions for use by
-      applications that allow users to edit command lines as they are
-      typed in.  Both Emacs and vi editing modes are available.  The
-      Readline library includes additional functions to maintain a
-      list of previously-entered command lines, to recall and perhaps
-      reedit those lines, and perform csh-like history expansion on
-      previous commands.
+    patches =
+      lib.optionals (curses-library.pname == "ncurses") [
+        ./link-against-ncurses.patch
+      ]
+      ++ [
+        ./no-arch_only-8.2.patch
+      ]
+      ++ upstreamPatches
+      ++ lib.optionals stdenv.hostPlatform.isWindows [
+        (fetchpatch {
+          name = "0001-sigwinch.patch";
+          url = "https://github.com/msys2/MINGW-packages/raw/90e7536e3b9c3af55c336d929cfcc32468b2f135/mingw-w64-readline/0001-sigwinch.patch";
+          stripLen = 1;
+          hash = "sha256-sFK6EJrSNl0KLWqFv5zBXaQRuiQoYIZVoZfa8BZqfKA=";
+        })
+        (fetchpatch {
+          name = "0002-event-hook.patch";
+          url = "https://github.com/msys2/MINGW-packages/raw/3476319d2751a676b911f3de9e1ec675081c03b8/mingw-w64-readline/0002-event-hook.patch";
+          stripLen = 1;
+          hash = "sha256-F8ytYuIjBtH83ZCJdf622qjwSw+wZEVyu53E/mPsoAo=";
+        })
+        (fetchpatch {
+          name = "0003-fd_set.patch";
+          url = "https://github.com/msys2/MINGW-packages/raw/35830ab27e5ed35c2a8d486961ab607109f5af50/mingw-w64-readline/0003-fd_set.patch";
+          stripLen = 1;
+          hash = "sha256-UiaXZRPjKecpSaflBMCphI2kqOlcz1JkymlCrtpMng4=";
+        })
+        (fetchpatch {
+          name = "0004-locale.patch";
+          url = "https://github.com/msys2/MINGW-packages/raw/f768c4b74708bb397a77e3374cc1e9e6ef647f20/mingw-w64-readline/0004-locale.patch";
+          stripLen = 1;
+          hash = "sha256-dk4343KP4EWXdRRCs8GRQlBgJFgu1rd79RfjwFD/nJc=";
+        })
+      ];
 
-      The history facilities are also placed into a separate library,
-      the History library, as part of the build process.  The History
-      library may be used without Readline in applications which
-      desire its capabilities.
+    # This install error is caused by a very old libtool. We can't autoreconfHook this package,
+    # so this is the best we've got!
+    postInstall = lib.optionalString stdenv.hostPlatform.isOpenBSD ''
+      ln -s $out/lib/libhistory.so* $out/lib/libhistory.so
+      ln -s $out/lib/libreadline.so* $out/lib/libreadline.so
     '';
 
-    homepage = "https://savannah.gnu.org/projects/readline/";
+    meta = with lib; {
+      description = "Library for interactive line editing";
 
-    license = licenses.gpl3Plus;
+      longDescription = ''
+        The GNU Readline library provides a set of functions for use by
+        applications that allow users to edit command lines as they are
+        typed in.  Both Emacs and vi editing modes are available.  The
+        Readline library includes additional functions to maintain a
+        list of previously-entered command lines, to recall and perhaps
+        reedit those lines, and perform csh-like history expansion on
+        previous commands.
 
-    maintainers = with maintainers; [ dtzWill ];
+        The history facilities are also placed into a separate library,
+        the History library, as part of the build process.  The History
+        library may be used without Readline in applications which
+        desire its capabilities.
+      '';
 
-    platforms = platforms.unix ++ platforms.windows;
-    branch = "8.2";
-  };
-}
+      homepage = "https://savannah.gnu.org/projects/readline/";
+
+      license = licenses.gpl3Plus;
+
+      maintainers = with maintainers; [ dtzWill ];
+
+      platforms = platforms.unix ++ platforms.windows;
+      branch = "8.2";
+    };
+  }
+  // lib.optionalAttrs stdenv.hostPlatform.isMinGW {
+    # Make mingw-w64 provide a dummy alarm() function
+    #
+    # Method borrowed from
+    # https://github.com/msys2/MINGW-packages/commit/35830ab27e5ed35c2a8d486961ab607109f5af50
+    CFLAGS = "-D__USE_MINGW_ALARM -D_POSIX";
+  }
+)


### PR DESCRIPTION
Note: the first 2 commits already went to `master`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
