### PR TITLE
isponsorblocktv: fix

### DIFF
--- a/pkgs/by-name/is/isponsorblocktv/package.nix
+++ b/pkgs/by-name/is/isponsorblocktv/package.nix
@@ -1,5 +1,6 @@
 {
   fetchFromGitHub,
+  fetchpatch,
   lib,
   python3Packages,
 }:
@@ -15,6 +16,20 @@ python3Packages.buildPythonApplication rec {
     tag = "v${version}";
     hash = "sha256-/lUs4EuifHKKyA8QiLsbqz0h6mxJpsFMjovpYE8+SxY=";
   };
+
+  patches = [
+    # Port iSponsorBlockTV to pyytlounge v3
+    (fetchpatch {
+      url = "https://github.com/lukegb/iSponsorBlockTV/commit/89b7b1c029cfbe3b5a481647cdd2d03dec5259ce.patch";
+      hash = "sha256-ISMrNrfPTnEbb0lZbREf+kAniJopWx3FePMGFm4ycJY=";
+    })
+
+    # Update setup_wizard for Textual v3
+    (fetchpatch {
+      url = "https://github.com/lukegb/iSponsorBlockTV/commit/89dd1d65335689c73a78509689396888599bbe58.patch";
+      hash = "sha256-hhWXcqNK3b3mXLCK7W0eXNWgP4lPSl6qgB59Fx8+yeA=";
+    })
+  ];
 
   build-system = with python3Packages; [
     hatchling


### PR DESCRIPTION
We're using different versions of dependencies, and the package is a major version behind on textual (a TUI library - nonessential, just used for the setup TUI; there's a setup text interface which works fine), and pyytlounge (essential, because this wraps the YT API used).

This provides two temporary fixes that work around the problems. The textual patch can be upstreamed; the pyytlounge patch probably won't be since I think a more robust approach will be forthcoming from the iSponsorBlockTV author.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
