### PR TITLE
mprime: 30.8b15 -> 30.19b21

### DIFF
--- a/pkgs/by-name/mp/mprime/package.nix
+++ b/pkgs/by-name/mp/mprime/package.nix
@@ -72,8 +72,8 @@ stdenv.mkDerivation {
   enableParallelBuilding = true;
 
   buildPhase = ''
-    make -C gwnum -f ${gwnum}
-    make -C ${srcDir}
+    make -C gwnum -f ${gwnum} ''${enableParallelBuilding:+-j$NIX_BUILD_CORES}
+    make -C ${srcDir} ''${enableParallelBuilding:+-j$NIX_BUILD_CORES}
   '';
 
   installPhase = ''

--- a/pkgs/by-name/mp/mprime/package.nix
+++ b/pkgs/by-name/mp/mprime/package.nix
@@ -29,23 +29,21 @@ let
     ."${stdenv.hostPlatform.system}" or throwSystem;
 in
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation {
   pname = "mprime";
-  version = "30.8b15";
+  version = "30.19b21";
 
   src = fetchurl {
-    url = "https://www.mersenne.org/ftp_root/gimps/p95v${
-      lib.replaceStrings [ "." ] [ "" ] version
-    }.source.zip";
-    hash = "sha256-CNYorZStHV0aESGX9LfLZ4oD5PFR2UOFLN1MiLaKw58=";
+    url = "https://www.mersenne.org/download/software/v30/30.19/p95v3019b21.source.zip";
+    hash = "sha256-vchDpUem+R3GcASj77zZmFivfbB17Nd7cYiyPlrCzio=";
   };
 
   postPatch = ''
     sed -i ${srcDir}/makefile \
       -e 's/^LFLAGS =.*//'
     substituteInPlace ${srcDir}/makefile \
-      --replace '-Wl,-Bstatic'  "" \
-      --replace '-Wl,-Bdynamic' ""
+      --replace-fail '-Wl,-Bstatic'  "" \
+      --replace-fail '-Wl,-Bdynamic' ""
   '';
 
   sourceRoot = ".";
@@ -70,7 +68,7 @@ stdenv.mkDerivation rec {
     install -Dm555 -t $out/bin ${srcDir}/mprime
   '';
 
-  meta = with lib; {
+  meta = {
     description = "Mersenne prime search / System stability tester";
     longDescription = ''
       MPrime is the Linux command-line interface version of Prime95, to be run
@@ -81,7 +79,7 @@ stdenv.mkDerivation rec {
     homepage = "https://www.mersenne.org/";
     # Unfree, because of a license requirement to share prize money if you find
     # a suitable prime. http://www.mersenne.org/legal/#EULA
-    license = licenses.unfree;
+    license = lib.licenses.unfree;
     # Untested on linux-32 and osx. Works in theory.
     platforms = [
       "i686-linux"

--- a/pkgs/by-name/mp/mprime/package.nix
+++ b/pkgs/by-name/mp/mprime/package.nix
@@ -1,8 +1,7 @@
 {
   stdenv,
   lib,
-  fetchurl,
-  unzip,
+  fetchzip,
   boost,
   curl,
   hwloc,
@@ -33,9 +32,10 @@ stdenv.mkDerivation {
   pname = "mprime";
   version = "30.19b21";
 
-  src = fetchurl {
+  src = fetchzip {
     url = "https://www.mersenne.org/download/software/v30/30.19/p95v3019b21.source.zip";
-    hash = "sha256-vchDpUem+R3GcASj77zZmFivfbB17Nd7cYiyPlrCzio=";
+    hash = "sha256-ThZ1A29ZP8RyXGBBdO12+OIBppN0pzNBkXgo/J/z6XQ=";
+    stripRoot = false;
   };
 
   postPatch = ''
@@ -45,10 +45,6 @@ stdenv.mkDerivation {
       --replace-fail '-Wl,-Bstatic'  "" \
       --replace-fail '-Wl,-Bdynamic' ""
   '';
-
-  sourceRoot = ".";
-
-  nativeBuildInputs = [ unzip ];
 
   buildInputs = [
     boost


### PR DESCRIPTION
Tried using it today, noticed a newer version is available...

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
