### PR TITLE
haskell.packages.{ghc981,ghc982,ghc983}.ghc-lib-parser: fix build

### DIFF
--- a/pkgs/development/haskell-modules/configuration-ghc-9.8.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.8.x.nix
@@ -87,6 +87,17 @@ self: super:
   # 2023-12-23: It needs this to build under ghc-9.6.3.
   #   A factor of 100 is insufficient, 200 seems seems to work.
   hip = appendConfigureFlag "--ghc-options=-fsimpl-tick-factor=200" super.hip;
+
+  # 2025-04-21: "flavor" for GHC 9.8.5 is missing a fix introduced for 9.8.4. See:
+  # https://github.com/digital-asset/ghc-lib/pull/571#discussion_r2052684630
+  ghc-lib-parser =
+    assert super.ghc-lib-parser.version == "9.8.5.20250214";
+    overrideCabal {
+      postPatch = ''
+        substituteInPlace compiler/cbits/genSym.c \
+          --replace-fail "HsWord64 u = atomic_inc64" "HsWord64 u = atomic_inc"
+      '';
+    } super.ghc-lib-parser;
 }
 // lib.optionalAttrs (lib.versionAtLeast super.ghc.version "9.8.3") {
   # Breakage related to GHC 9.8.3 / deepseq 1.5.1.0


### PR DESCRIPTION
This should unbreak hlint and HLS for GHC 9.8.x < 9.8.4, but I did not build further, yet. (Edit: Confirmed both for GHC 9.8.3)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
