### PR TITLE
darwin: move deprecated packages to aliases

### DIFF
--- a/pkgs/by-name/gm/gmt/package.nix
+++ b/pkgs/by-name/gm/gmt/package.nix
@@ -4,7 +4,7 @@
   fetchFromGitHub,
   cmake,
   curl,
-  darwin,
+  apple-sdk,
   fftwSinglePrec,
   netcdf,
   pcre,
@@ -34,8 +34,7 @@ stdenv.mkDerivation (finalAttrs: {
     NIX_CFLAGS_COMPILE =
       lib.optionalString stdenv.cc.isClang "-Wno-implicit-function-declaration "
       + lib.optionalString (
-        stdenv.hostPlatform.isDarwin
-        && lib.versionOlder (darwin.apple_sdk.MacOSX-SDK.version or darwin.apple_sdk.sdk.version) "13.3"
+        stdenv.hostPlatform.isDarwin && lib.versionOlder apple-sdk.version "13.3"
       ) "-D__LAPACK_int=int";
   };
 

--- a/pkgs/development/haskell-modules/configuration-darwin.nix
+++ b/pkgs/development/haskell-modules/configuration-darwin.nix
@@ -152,9 +152,6 @@ self: super:
     }) super.OpenGLRaw;
     bindings-GLFW = overrideCabal (drv: {
       librarySystemDepends = [ ];
-      libraryHaskellDepends = drv.libraryHaskellDepends ++ [
-        darwin.CF
-      ];
     }) super.bindings-GLFW;
 
     # cabal2nix likes to generate dependencies on hinotify when hfsevents is

--- a/pkgs/os-specific/darwin/apple-sdk-11.0/default.nix
+++ b/pkgs/os-specific/darwin/apple-sdk-11.0/default.nix
@@ -1,13 +1,8 @@
 # Compatibility stubs for packages that used the old SDK frameworks.
-# TODO(@reckenrode) Make these stubs warn after framework usage has been cleaned up in nixpkgs.
 {
   lib,
   callPackage,
-  newScope,
-  overrideSDK,
   pkgs,
-  stdenv,
-  stdenvNoCC,
 }:
 
 let

--- a/pkgs/os-specific/darwin/apple-sdk-12.3/default.nix
+++ b/pkgs/os-specific/darwin/apple-sdk-12.3/default.nix
@@ -1,13 +1,8 @@
 # Compatibility stubs for packages that used the old SDK frameworks.
-# TODO(@reckenrode) Make these stubs warn after framework usage has been cleaned up in nixpkgs.
 {
   lib,
   callPackage,
-  newScope,
-  overrideSDK,
   pkgs,
-  stdenv,
-  stdenvNoCC,
 }:
 
 let

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8175,9 +8175,7 @@ with pkgs;
     jdk = jdk11;
   };
 
-  valgrind = callPackage ../development/tools/analysis/valgrind {
-    inherit (buildPackages.darwin) xnu bootstrap_cmds;
-  };
+  valgrind = callPackage ../development/tools/analysis/valgrind { };
   valgrind-light = (res.valgrind.override { gdb = null; }).overrideAttrs (oldAttrs: {
     meta = oldAttrs.meta // {
       description = "${oldAttrs.meta.description} (without GDB)";

--- a/pkgs/top-level/darwin-aliases.nix
+++ b/pkgs/top-level/darwin-aliases.nix
@@ -44,9 +44,69 @@ let
   mapAliases = lib.mapAttrs (
     n: alias: removeDistribute (removeRecurseForDerivations (checkInPkgs n alias))
   );
+
+  # Old Darwin pattern stubs; remove these by 25.11.
+
+  mkStub = pkgs.callPackage ../os-specific/darwin/apple-sdk/mk-stub.nix { };
+
+  warnStub =
+    prefix:
+    lib.warn "${prefix} these stubs do nothing and will be removed in Nixpkgs 25.11; see <https://nixos.org/manual/nixpkgs/stable/#sec-darwin> for documentation and migration instructions";
+
+  apple_sdk_11_0 = warnStub "darwin.apple_sdk_11_0.*:" (
+    pkgs.callPackage ../os-specific/darwin/apple-sdk-11.0 { }
+  );
+
+  apple_sdk_12_3 =
+    warnStub
+      "darwin.apple_sdk_12_3.*: add `apple-sdk_12` to build inputs instead to use the macOS 12 SDK."
+      (pkgs.callPackage ../os-specific/darwin/apple-sdk-12.3 { });
+
+  apple_sdk = apple_sdk_11_0;
+
+  stubs =
+    {
+      inherit apple_sdk apple_sdk_11_0 apple_sdk_12_3;
+    }
+    // lib.genAttrs [
+      "CF"
+      "CarbonHeaders"
+      "CommonCrypto"
+      "CoreSymbolication"
+      "IOKit"
+      "Libc"
+      "Libinfo"
+      "Libm"
+      "Libnotify"
+      "Librpcsvc"
+      "Libsystem"
+      "LibsystemCross"
+      "Security"
+      "architecture"
+      "cf-private"
+      "configd"
+      "configdHeaders"
+      "darwin-stubs"
+      "dtrace"
+      "eap8021x"
+      "hfs"
+      "hfsHeaders"
+      "launchd"
+      "libclosure"
+      "libdispatch"
+      "libmalloc"
+      "libobjc"
+      "libplatform"
+      "libpthread"
+      "mDNSResponder"
+      "objc4"
+      "ppp"
+      "xnu"
+    ] (name: warnStub "darwin.${name}:" (mkStub "11.0" name));
 in
 
-mapAliases ({
+stubs
+// mapAliases ({
   ### A ###
 
   apple_sdk_10_12 = throw "darwin.apple_sdk_10_12 was removed as Nixpkgs no longer supports macOS 10.12; see the 25.05 release notes"; # Added 2024-10-27
@@ -63,8 +123,6 @@ mapAliases ({
   cctools-llvm = pkgs.cctools; # added 2024-07-01
   cctools-port = pkgs.cctools; # added 2024-07-17
 
-  cf-private = throw "'cf-private' has been renamed to 'apple_sdk.frameworks.CoreFoundation'.";
-
   ### D ###
 
   discrete-scroll = pkgs.discrete-scroll; # added 2024-11-27
@@ -78,7 +136,13 @@ mapAliases ({
   ### L ###
 
   libauto = throw "'darwin.libauto' has been removed, as it was broken and unmaintained"; # added 2024-05-10
+  libresolvHeaders = lib.warn "darwin.libresolvHeaders: use `lib.getInclude darwin.libresolv`; this will be removed in 25.11" (
+    lib.getDev self.libresolv
+  ); # added 2025-04-20
   libtapi = pkgs.libtapi; # 2024-08-16
+  libutilHeaders = lib.warn "darwin.libutilHeaders: use `lib.getInclude darwin.libutil`; this will be removed in 25.11" (
+    lib.getDev self.libutil
+  ); # added 2025-04-20
 
   ### M ###
 
@@ -98,6 +162,13 @@ mapAliases ({
 
   ### S ###
 
+  stdenvNoCF =
+    lib.warn "darwin.stdenvNoCF: use `stdenv` or `stdenvNoCC`; this will be removed in 25.11"
+      (
+        pkgs.stdenv.override {
+          extraBuildInputs = [ ];
+        }
+      ); # added 2025-04-20
   stubs = throw "'darwin.stubs.*' have been removed as they were unused"; # added 2025-04-20
   swift-corelibs-foundation = throw "'darwin.swift-corelibs-foundation' has been removed, as it was broken and is no longer used"; # added 2025-04-20
 })

--- a/pkgs/top-level/darwin-packages.nix
+++ b/pkgs/top-level/darwin-packages.nix
@@ -26,13 +26,10 @@ let
           pkg
       ) (old.extraBuildInputs or [ ]);
     });
-
-  mkStub = pkgs.callPackage ../os-specific/darwin/apple-sdk/mk-stub.nix { };
 in
 
 makeScopeWithSplicing' {
   otherSplices = generateSplicesForMkScope "darwin";
-  extra = spliced: spliced.apple_sdk.frameworks;
   f = lib.extends aliases (
     self:
     let
@@ -44,72 +41,13 @@ makeScopeWithSplicing' {
         directory = ../os-specific/darwin/apple-source-releases;
       };
 
-      # Compatibility packages that aren’t necessary anymore
-      apple-source-headers = {
-        libresolvHeaders = lib.getDev self.libresolv;
-        libutilHeaders = lib.getDev self.libutil;
-      };
-
       # Must use pkgs.callPackage to avoid infinite recursion.
       impure-cmds = pkgs.callPackage ../os-specific/darwin/impure-cmds { };
-
-      # macOS 11.0 SDK
-      apple_sdk_11_0 = pkgs.callPackage ../os-specific/darwin/apple-sdk-11.0 { };
-
-      # macOS 12.3 SDK
-      apple_sdk_12_3 = pkgs.callPackage ../os-specific/darwin/apple-sdk-12.3 { };
-
-      apple_sdk = apple_sdk_11_0;
-
-      stubs =
-        {
-          inherit apple_sdk apple_sdk_11_0 apple_sdk_12_3;
-          libobjc = self.objc4;
-        }
-        // lib.genAttrs [
-          "CF"
-          "CarbonHeaders"
-          "CommonCrypto"
-          "CoreSymbolication"
-          "IOKit"
-          "Libc"
-          "Libinfo"
-          "Libm"
-          "Libnotify"
-          "Librpcsvc"
-          "Libsystem"
-          "LibsystemCross"
-          "Security"
-          "architecture"
-          "configd"
-          "configdHeaders"
-          "darwin-stubs"
-          "dtrace"
-          "eap8021x"
-          "hfs"
-          "hfsHeaders"
-          "launchd"
-          "libclosure"
-          "libdispatch"
-          "libmalloc"
-          "libplatform"
-          "libpthread"
-          "mDNSResponder"
-          "objc4"
-          "ppp"
-          "xnu"
-        ] (mkStub apple_sdk.version);
     in
 
     impure-cmds
     // apple-source-packages
-    // apple-source-headers
-    // stubs
     // {
-
-      stdenvNoCF = stdenv.override {
-        extraBuildInputs = [ ];
-      };
 
       inherit (self.adv_cmds) ps;
 


### PR DESCRIPTION
Depends on https://github.com/NixOS/nixpkgs/pull/399609, https://github.com/NixOS/nixpkgs/pull/399630, https://github.com/NixOS/nixpkgs/pull/400402, https://github.com/NixOS/nixpkgs/pull/400424, and https://github.com/NixOS/nixpkgs/pull/400427.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
