### PR TITLE
zmk-studio: init at 0.3.1

### DIFF
--- a/pkgs/by-name/zm/zmk-studio/darwin-dont-sign.patch
+++ b/pkgs/by-name/zm/zmk-studio/darwin-dont-sign.patch
@@ -1,0 +1,13 @@
+diff --git a/src-tauri/tauri.conf.json b/src-tauri/tauri.conf.json
+index 8fd57bf..6a27557 100644
+--- a/src-tauri/tauri.conf.json
++++ b/src-tauri/tauri.conf.json
+@@ -33,7 +33,7 @@
+       "exceptionDomain": "",
+       "frameworks": [],
+       "providerShortName": null,
+-      "signingIdentity": "-"
++      "signingIdentity": null
+     },
+     "resources": [],
+     "shortDescription": "",

--- a/pkgs/by-name/zm/zmk-studio/package.nix
+++ b/pkgs/by-name/zm/zmk-studio/package.nix
@@ -1,0 +1,98 @@
+{
+  lib,
+  stdenv,
+  rustPlatform,
+  fetchFromGitHub,
+  fetchNpmDeps,
+  npm-lockfile-fix,
+
+  cargo-tauri,
+  makeBinaryWrapper,
+  nodejs,
+  npmHooks,
+  pkg-config,
+  wrapGAppsHook3,
+
+  glib-networking,
+  udev,
+  webkitgtk_4_1,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "zmk-studio";
+  version = "0.3.1";
+
+  src = fetchFromGitHub {
+    owner = "zmkfirmware";
+    repo = "zmk-studio";
+    tag = "v${finalAttrs.version}";
+
+    postFetch = ''
+      # add missing integrity fields to lockfile
+      ${lib.getExe npm-lockfile-fix} $out/package-lock.json
+    '';
+
+    hash = "sha256-7UwY+272JNqzQf1juOzDkiW2DNKHC5xg4cGguwAgwNc=";
+  };
+
+  patches = [
+    ./darwin-dont-sign.patch
+  ];
+
+  # building the download page requires the app to fetch the github API at build-time
+  # this page would only ever be visited if it wasn't built with tauri, so we disable it instead
+  postPatch = ''
+    # turn `npm run generate-data` into a NOOP
+    substituteInPlace package.json \
+      --replace-fail '"generate-data": "' '"generate-data": "true || '
+
+    # remove download page
+    rm download.html src/download.tsx src/DownloadPage.tsx
+    substituteInPlace vite.config.ts \
+      --replace-fail 'download: "./download.html",' ""
+  '';
+
+  cargoRoot = "src-tauri";
+  buildAndTestSubdir = "src-tauri";
+
+  cargoHash = "sha256-BNX2vhsHaSk3eiadVPH6To0CgbOEGJ1JVKkW3Hw7QH0=";
+
+  npmDeps = fetchNpmDeps {
+    name = "zmk-studio-${finalAttrs.version}-npm-deps";
+    inherit (finalAttrs) src patches;
+    hash = "sha256-htCqTX/w1GP3b8wBD9p60Lwpjr2V7sv05unRv2IrP1A=";
+  };
+
+  nativeBuildInputs = [
+    cargo-tauri.hook
+    nodejs
+    npmHooks.npmConfigHook
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
+    pkg-config
+    wrapGAppsHook3
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    makeBinaryWrapper
+  ];
+
+  buildInputs = lib.optionals stdenv.hostPlatform.isLinux [
+    glib-networking # for image loading
+    udev
+    webkitgtk_4_1
+  ];
+
+  postInstall = lib.optionalString stdenv.hostPlatform.isDarwin ''
+    makeWrapper "$out/Application/ZMK Studio.app/Contents/MacOS/zmk-studio" "$out/bin/zmk-studio"
+  '';
+
+  meta = {
+    description = "Tool for runtime keymap updates on ZMK-powered devices without reflashing firmware";
+    homepage = "https://github.com/zmkfirmware/zmk-studio";
+    changelog = "https://github.com/zmkfirmware/zmk-studio/blob/${finalAttrs.src.rev}/CHANGELOG.md";
+    license = lib.licenses.asl20;
+    mainProgram = "zmk-studio";
+    maintainers = with lib.maintainers; [ tomasajt ];
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
+  };
+})


### PR DESCRIPTION
Closes https://github.com/NixOS/nixpkgs/issues/352442

It would be ideal if someone who actually has a compatible device would step up to co-maintain this with me.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
