### PR TITLE
plex-htpc: init at 1.71.1

### DIFF
--- a/pkgs/by-name/pl/plex-htpc/package.nix
+++ b/pkgs/by-name/pl/plex-htpc/package.nix
@@ -1,0 +1,166 @@
+{
+  alsa-lib,
+  autoPatchelfHook,
+  buildFHSEnv,
+  elfutils,
+  extraEnv ? { },
+  fetchurl,
+  ffmpeg_6-headless,
+  lib,
+  libdrm,
+  libgbm,
+  libpulseaudio,
+  libva,
+  libxkbcommon,
+  libxml2_13,
+  makeShellWrapper,
+  minizip,
+  nss,
+  squashfsTools,
+  stdenv,
+  writeShellScript,
+  xkeyboard_config,
+  xorg,
+}:
+let
+  pname = "plex-htpc";
+  version = "1.71.1";
+  rev = "73";
+  meta = {
+    homepage = "https://plex.tv/";
+    description = "Plex HTPC client for the big screen";
+    longDescription = ''
+      Plex HTPC for Linux is your client for playing on your Linux computer
+      connected to the big screen. It features a 10-foot interface with a
+      powerful playback engine.
+    '';
+    maintainers = with lib.maintainers; [ detroyejr ];
+    license = lib.licenses.unfree;
+    platforms = [ "x86_64-linux" ];
+    mainProgram = "plex-htpc";
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+  };
+  plex-htpc = stdenv.mkDerivation {
+    inherit pname version meta;
+
+    src = fetchurl {
+      url = "https://api.snapcraft.io/api/v1/snaps/download/81OP06hEXlwmMrpMAhe5hyLy5bQ9q6Kz_${rev}.snap";
+      hash = "sha512-n9pXRx8s6AwhIJm7PmUIOB8pXqzyNFzdmwJMonQ4WzWvA5tPI27x0slQ6WUxRBQJoLScGckyGAFxIGWRylNr3g==";
+    };
+
+    nativeBuildInputs = [
+      autoPatchelfHook
+      makeShellWrapper
+      squashfsTools
+    ];
+
+    buildInputs = [
+      elfutils
+      ffmpeg_6-headless
+      libgbm
+      libpulseaudio
+      libva
+      libxkbcommon
+      libxml2_13
+      minizip
+      nss
+      stdenv.cc.cc
+      xorg.libXcomposite
+      xorg.libXdamage
+      xorg.libXinerama
+      xorg.libXrandr
+      xorg.libXrender
+      xorg.libXtst
+      xorg.libxshmfence
+      xorg.xcbutilimage
+      xorg.xcbutilkeysyms
+      xorg.xcbutilrenderutil
+      xorg.xcbutilwm
+      xorg.xrandr
+    ];
+
+    strictDeps = true;
+
+    unpackPhase = ''
+      runHook preUnpack
+      unsquashfs "$src"
+      cd squashfs-root
+      runHook postUnpack
+    '';
+
+    dontStrip = true;
+    dontWrapQtApps = true;
+
+    installPhase = ''
+      runHook preInstall
+
+      cp -r . $out
+      rm -r $out/etc
+      rm -r $out/usr
+
+      # flatpak removes these during installation.
+      rm -r $out/lib/dri
+      rm $out/lib/libpciaccess.so*
+      rm $out/lib/libswresample.so*
+      rm $out/lib/libva-*.so*
+      rm $out/lib/libva.so*
+      rm $out/lib/libEGL.so*
+      rm $out/lib/libdrm.so*
+      rm $out/lib/libdrm*
+
+      # Keep some dependencies from the snap.
+      cp usr/lib/x86_64-linux-gnu/liblcms2.so.2 $out/lib/liblcms2.so.2
+      cp usr/lib/x86_64-linux-gnu/libjbig.so.0 $out/lib/libjbig.so.0
+      cp usr/lib/x86_64-linux-gnu/libjpeg.so.8 $out/lib/libjpeg.so.8
+      cp usr/lib/x86_64-linux-gnu/libpci.so.3 $out/lib/libpci.so.3
+      cp usr/lib/x86_64-linux-gnu/libsnappy.so.1 $out/lib/libsnappy.so.1
+      cp usr/lib/x86_64-linux-gnu/libtiff.so.5 $out/lib/libtiff.so.5
+      cp usr/lib/x86_64-linux-gnu/libwebp.so.6 $out/lib/libwebp.so.6
+      cp usr/lib/x86_64-linux-gnu/libxkbfile.so.1 $out/lib/libxkbfile.so.1
+      cp usr/lib/x86_64-linux-gnu/libxslt.so.1 $out/lib/libxslt.so.1
+
+      runHook postInstall
+    '';
+  };
+in
+buildFHSEnv {
+  inherit pname version meta;
+  targetPkgs = pkgs: [
+    alsa-lib
+    libdrm
+    xkeyboard_config
+  ];
+
+  extraInstallCommands = ''
+    mkdir -p $out/share/applications $out/share/icons/hicolor/scalable/apps
+    install -m 444 -D ${plex-htpc}/meta/gui/plex-htpc.desktop $out/share/applications/plex-htpc.desktop
+    substituteInPlace $out/share/applications/plex-htpc.desktop \
+      --replace-fail \
+      'Icon=''${SNAP}/meta/gui/icon.png' \
+      'Icon=${plex-htpc}/meta/gui/icon.png'
+  '';
+
+  runScript = writeShellScript "plex-htpc.sh" ''
+    # Widevine won't download unless this directory exists.
+    mkdir -p $HOME/.cache/plex/
+
+    # Copy the sqlite plugin database on first run.
+    PLEX_DB="$HOME/.local/share/plex/Plex Media Server/Plug-in Support/Databases"
+    if [[ ! -d "$PLEX_DB" ]]; then
+      mkdir -p "$PLEX_DB"
+      cp "${plex-htpc}/resources/com.plexapp.plugins.library.db" "$PLEX_DB"
+    fi
+
+    # db files should have write access.
+    chmod --recursive 750 "$PLEX_DB"
+
+    # These environment variables sometimes silently cause plex to crash.
+    unset QT_QPA_PLATFORM QT_STYLE_OVERRIDE
+
+    set -o allexport
+    ${lib.toShellVars extraEnv}
+    set +o allexport
+    exec ${plex-htpc}/Plex.sh
+  '';
+  passthru.updateScript = ./update.sh;
+}

--- a/pkgs/by-name/pl/plex-htpc/update.sh
+++ b/pkgs/by-name/pl/plex-htpc/update.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env nix-shell
+#! nix-shell -i bash -p curl jq git gnused gnugrep
+
+
+# executing this script without arguments will
+# - find the newest stable plex-htpc version avaiable on snapcraft (https://snapcraft.io/plex-htpc)
+# - read the current plex-htpc version from the current nix expression
+# - update the nix expression if the versions differ
+# - try to build the updated version, exit if that fails
+# - give instructions for upstreaming
+
+# As an optional argument you can specify the snapcraft channel to update to.
+# Default is `stable` and only stable updates should be pushed to nixpkgs. For
+# testing you may specify `candidate` or `edge`.
+
+
+channel="${1:-stable}" # stable/candidate/edge
+nixpkgs="$(git rev-parse --show-toplevel)"
+plex_nix="$nixpkgs/pkgs/by-name/pl/plex-htpc/package.nix"
+
+
+#
+# find the newest stable plex-htpc version avaiable on snapcraft
+#
+
+# create bash array from snap info
+snap_info=($(
+  curl -s -H 'X-Ubuntu-Series: 16' \
+    "https://api.snapcraft.io/api/v1/snaps/details/plex-htpc?channel=$channel" \
+  | jq --raw-output \
+    '.revision,.download_sha512,.version,.last_updated'
+))
+
+# "revision" is the actual version identifier on snapcraft, the "version" is
+# just for human consumption. Revision is just an integer that gets increased
+# by one every (stable or unstable) release.
+revision="${snap_info[0]}"
+# We need to escape the slashes
+hash="$(nix-hash --to-sri --type sha512 ${snap_info[1]} | sed 's|/|\\/|g')"
+upstream_version="${snap_info[2]}"
+last_updated="${snap_info[3]}"
+echo "Latest $channel release is $upstream_version from $last_updated."
+#
+# read the current plex-htpc version from the currently *committed* nix expression
+#
+
+current_version=$(
+  grep 'version\s*=' "$plex_nix" \
+  | sed -Ene 's/.*"(.*)".*/\1/p'
+)
+
+echo "Current version: $current_version"
+
+#
+# update the nix expression if the versions differ
+#
+
+if [[ "$current_version" == "$upstream_version" ]]; then
+  echo "Plex is already up-to-date"
+  exit 0
+fi
+
+echo "Updating from ${current_version} to ${upstream_version}, released on ${last_updated}"
+
+# search-and-replace revision, hash and version
+sed --regexp-extended \
+  -e 's/rev\s*=\s*"[0-9]+"\s*;/rev = "'"${revision}"'";/' \
+  -e 's/hash\s*=\s*"[^"]*"\s*;/hash = "'"${hash}"'";/' \
+  -e 's/version\s*=\s*".*"\s*;/version = "'"${upstream_version}"'";/' \
+  -i "$plex_nix"
+


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Similar to the plex for desktop application in nixpkgs already, but we get an interface that's a little nicer for TV's and hand held devices like the steam deck. Practically the same build/install instructions as [plex-desktop](https://github.com/nixos/nixpkgs/tree/master/pkgs/by-name/pl/plex-desktop/package.nix) so it shouldn't be much more in terms of maintenance.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
