### PR TITLE
python312Packages.uncertainties: 3.2.2 -> 3.2.3

### DIFF
--- a/pkgs/development/python-modules/lmfit/default.nix
+++ b/pkgs/development/python-modules/lmfit/default.nix
@@ -1,6 +1,7 @@
 {
   lib,
   buildPythonPackage,
+  fetchpatch,
   asteval,
   dill,
   fetchPypi,
@@ -26,6 +27,13 @@ buildPythonPackage rec {
     inherit pname version;
     hash = "sha256-czIea4gfL2hiNXIaffwCr2uw8DCiXv62Zjj2KxxgU6E=";
   };
+  patches = [
+    # https://github.com/lmfit/lmfit-py/issues/999
+    (fetchpatch {
+      url = "https://github.com/lmfit/lmfit-py/commit/d4f4e3755d50cb9720c616fcff2cd7b58fbabba5.patch";
+      hash = "sha256-h1WK3ajnoX3pOZOduFBKpPz3exfoKzkbO/QNgROLT7c=";
+    })
+  ];
 
   postPatch = ''
     substituteInPlace pyproject.toml \

--- a/pkgs/development/python-modules/uncertainties/default.nix
+++ b/pkgs/development/python-modules/uncertainties/default.nix
@@ -39,10 +39,10 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "uncertainties" ];
 
-  meta = with lib; {
+  meta = {
     homepage = "https://pythonhosted.org/uncertainties/";
     description = "Transparent calculations with uncertainties on the quantities involved (aka error propagation)";
-    maintainers = with maintainers; [ rnhmjoj ];
-    license = licenses.bsd3;
+    maintainers = with lib.maintainers; [ rnhmjoj ];
+    license = lib.licenses.bsd3;
   };
 }

--- a/pkgs/development/python-modules/uncertainties/default.nix
+++ b/pkgs/development/python-modules/uncertainties/default.nix
@@ -16,14 +16,14 @@
 
 buildPythonPackage rec {
   pname = "uncertainties";
-  version = "3.2.2";
+  version = "3.2.3";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "lmfit";
     repo = "uncertainties";
     tag = version;
-    hash = "sha256-cm0FeJCxyBLN0GCKPnscBCx9p9qCDQdwRfhBRgQIhAo=";
+    hash = "sha256-YapujmwTlmUfTQwHsuh01V+jqsBbTd0Q9adGNiE8Go0=";
   };
 
   build-system = [

--- a/pkgs/development/python-modules/uncertainties/default.nix
+++ b/pkgs/development/python-modules/uncertainties/default.nix
@@ -42,7 +42,10 @@ buildPythonPackage rec {
   meta = {
     homepage = "https://pythonhosted.org/uncertainties/";
     description = "Transparent calculations with uncertainties on the quantities involved (aka error propagation)";
-    maintainers = with lib.maintainers; [ rnhmjoj ];
+    maintainers = with lib.maintainers; [
+      rnhmjoj
+      doronbehar
+    ];
     license = lib.licenses.bsd3;
   };
 }

--- a/pkgs/development/python-modules/uncertainties/default.nix
+++ b/pkgs/development/python-modules/uncertainties/default.nix
@@ -40,7 +40,7 @@ buildPythonPackage rec {
   pythonImportsCheck = [ "uncertainties" ];
 
   meta = {
-    homepage = "https://pythonhosted.org/uncertainties/";
+    homepage = "https://uncertainties.readthedocs.io/";
     description = "Transparent calculations with uncertainties on the quantities involved (aka error propagation)";
     maintainers = with lib.maintainers; [
       rnhmjoj


### PR DESCRIPTION
## Description of changes


## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage) Direct dependencies:
  - [ ] `python31{2,3}Packages.lmfit`
  - [x] `python31{2,3}Packages.pint`
  - [ ] `python31{2,3}Packages.pymatgen`
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
