### PR TITLE
gopass-jsonapi: 1.15.15 -> 1.15.16

### DIFF
--- a/pkgs/by-name/go/gopass-jsonapi/package.nix
+++ b/pkgs/by-name/go/gopass-jsonapi/package.nix
@@ -13,7 +13,7 @@
 
 let
 
-  # https://github.com/gopasspw/gopass-jsonapi/blob/v1.15.15/internal/jsonapi/manifest/manifest_path_linux.go
+  # https://github.com/gopasspw/gopass-jsonapi/blob/v1.15.16/internal/jsonapi/manifest/manifest_path_linux.go
   manifestPaths = {
     firefox = "$out/lib/mozilla/native-messaging-hosts/com.justwatch.gopass.json";
     chrome = "$out/etc/opt/chrome/native-messaging-hosts/com.justwatch.gopass.json";
@@ -27,16 +27,16 @@ let
 in
 buildGoModule rec {
   pname = "gopass-jsonapi";
-  version = "1.15.15";
+  version = "1.15.16";
 
   src = fetchFromGitHub {
     owner = "gopasspw";
     repo = "gopass-jsonapi";
     rev = "v${version}";
-    hash = "sha256-nayg7NTJH6bAPiguyuN37JivfWkpOUX/xI/+PHDi3UI=";
+    hash = "sha256-Nl69SSqs18zG7eYhBafXFGBVNQglSeffg7Z0Y8zuLmc=";
   };
 
-  vendorHash = "sha256-khX1CdzN+5T8q2hA3NyCxtz7uw9uDd9u61q3UslTtqs=";
+  vendorHash = "sha256-zncWJSA6cUthwcFZQXtJmwJZujaXt0Rubcga8D0+ZQc=";
 
   subPackages = [ "." ];
 
@@ -72,7 +72,7 @@ buildGoModule rec {
       # `gopass-jsonapi configure` will ask for them. (`--libpath` and `--global`
       # are overriden by `--manifest-path`. `--libpath` is only used to
       # compute Firefox's global manifest path. See
-      # https://github.com/gopasspw/gopass-jsonapi/blob/v1.15.15/setup_others.go#L33-L46)
+      # https://github.com/gopasspw/gopass-jsonapi/blob/v1.15.16/setup_others.go#L33-L46)
       #
       # `gopass-jsonapi configure` ask for confirmation before writing any files,
       # `echo y` gives it.


### PR DESCRIPTION
## Description of changes


## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
