### PR TITLE
piglit: unstable-2020-10-23 -> unstable-2025-04-15

### DIFF
--- a/pkgs/by-name/pi/piglit/package.nix
+++ b/pkgs/by-name/pi/piglit/package.nix
@@ -3,6 +3,9 @@
   fetchFromGitLab,
   lib,
   cmake,
+  glslang,
+  libffi,
+  libgbm,
   libglut,
   libGL,
   libGLU,
@@ -11,8 +14,12 @@
   ninja,
   pkg-config,
   python3,
+  vulkan-loader,
   waffle,
   wayland,
+  wayland-protocols,
+  wayland-scanner,
+  libXau,
   libX11,
   libXrender,
   libxcb,
@@ -22,21 +29,25 @@
 
 stdenv.mkDerivation {
   pname = "piglit";
-  version = "unstable-2020-10-23";
+  version = "unstable-2025-04-15";
 
   src = fetchFromGitLab {
     domain = "gitlab.freedesktop.org";
     owner = "mesa";
     repo = "piglit";
-    rev = "59e695c16fdcdd4ea4f16365f0e397a93cef7b80";
-    sha256 = "kx0+2Sdvdc3SbpAIl2OuGCWCpaLJC/7cXG+ZLvf92g8=";
+    rev = "d06f7bac988e67db53cbc05dc0b096b00856ab93";
+    hash = "sha256-bH9NjLEldlZwylq7S0q2vC5IQhUej0xZ6wD+mrWBK5A=";
   };
 
   buildInputs = [
+    glslang
+    libffi
+    libgbm
     libglut
     libGL
     libGLU
     libglvnd
+    libXau
     libX11
     libXrender
     libxcb
@@ -47,8 +58,11 @@ stdenv.mkDerivation {
         numpy
       ]
     ))
+    vulkan-loader
     waffle
     wayland
+    wayland-protocols
+    wayland-scanner
   ];
 
   nativeBuildInputs = [


### PR DESCRIPTION
The previous version was not buildable against numpy 2.x, due to <https://gitlab.freedesktop.org/mesa/piglit/-/merge_requests/927>.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

Tested the binaries `result/bin/piglit` and `lib/piglit/bin/shader_test`.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
