### PR TITLE
[BACKPORT 24.11] openbao: init at 2.2.0

### DIFF
--- a/pkgs/by-name/op/openbao/package.nix
+++ b/pkgs/by-name/op/openbao/package.nix
@@ -1,0 +1,74 @@
+{
+  lib,
+  fetchFromGitHub,
+  buildGo124Module,
+  testers,
+  openbao,
+  versionCheckHook,
+  nix-update-script,
+}:
+
+buildGo124Module rec {
+  pname = "openbao";
+  version = "2.2.0";
+
+  src = fetchFromGitHub {
+    owner = "openbao";
+    repo = "openbao";
+    tag = "v${version}";
+    hash = "sha256-dDMOeAceMaSrF7P4JZ2MKy6zDa10LxCQKkKwu/Q3kOU=";
+  };
+
+  vendorHash = "sha256-zcMc63B/jTUykPfRKvea27xRxjOV+zytaxKOEQAUz1Q=";
+
+  proxyVendor = true;
+
+  subPackages = [ "." ];
+
+  tags = [
+    "openbao"
+    "bao"
+  ];
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X github.com/openbao/openbao/version.GitCommit=${src.rev}"
+    "-X github.com/openbao/openbao/version.fullVersion=${version}"
+  ];
+
+  postInstall = ''
+    mv $out/bin/openbao $out/bin/bao
+  '';
+
+  # TODO: Enable the NixOS tests after adding OpenBao as a NixOS service in an upcoming PR and
+  # adding NixOS tests
+  #
+  # passthru.tests = { inherit (nixosTests) vault vault-postgresql vault-dev vault-agent; };
+
+  passthru.tests.version = testers.testVersion {
+    package = openbao;
+    command = "HOME=$(mktemp -d) bao --version";
+    version = "v${version}";
+  };
+
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+  versionCheckProgram = "${placeholder "out"}/bin/bao";
+  versionCheckProgramArg = "--version";
+  doInstallCheck = true;
+
+  passthru = {
+    updateScript = nix-update-script { };
+  };
+
+  meta = {
+    homepage = "https://www.openbao.org/";
+    description = "Open source, community-driven fork of Vault managed by the Linux Foundation";
+    changelog = "https://github.com/openbao/openbao/blob/v${version}/CHANGELOG.md";
+    license = lib.licenses.mpl20;
+    mainProgram = "bao";
+    maintainers = with lib.maintainers; [ ];
+  };
+}


### PR DESCRIPTION
**Fix :** 
- https://github.com/NixOS/nixpkgs/issues/399478

**This PR is a backport of :**
- https://github.com/NixOS/nixpkgs/pull/354366
- https://github.com/NixOS/nixpkgs/pull/388158


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
