### PR TITLE
qt6.qtwebengine: remove nondeterminism from build

### DIFF
--- a/pkgs/development/libraries/qt-6/modules/qtwebengine/default.nix
+++ b/pkgs/development/libraries/qt-6/modules/qtwebengine/default.nix
@@ -113,6 +113,8 @@ qtModule {
 
     # Fix build with Pipewire 1.4
     ./pipewire-1.4.patch
+    # Reproducibility QTBUG-136068
+    ./gn-object-sorted.patch
   ];
 
   postPatch =

--- a/pkgs/development/libraries/qt-6/modules/qtwebengine/gn-object-sorted.patch
+++ b/pkgs/development/libraries/qt-6/modules/qtwebengine/gn-object-sorted.patch
@@ -1,0 +1,32 @@
+diff --git a/gn/src/gn/rsp_target_writer.cc b/gn/src/gn/rsp_target_writer.cc
+index 6c1c687e99d..097b84b317e 100644
+--- a/src/3rdparty/gn/src/gn/rsp_target_writer.cc
++++ b/src/3rdparty/gn/src/gn/rsp_target_writer.cc
+@@ -117,8 +117,7 @@ void RspTargetWriter::Run() {
+       PathOutput path_output(settings->build_settings()->build_dir(),
+                              settings->build_settings()->root_path_utf8(),
+                              ESCAPE_NONE);
+-      std::vector<SourceFile> object_files;
+-      object_files.reserve(target_->sources().size());
++      std::set<SourceFile> object_files;
+ 
+       for (const auto& source : target_->sources()) {
+         const char* tool_type = nullptr;
+@@ -128,7 +127,7 @@ void RspTargetWriter::Run() {
+             other_files.push_back(source);
+           continue;  // No output for this source.
+         }
+-        object_files.push_back(
++        object_files.insert(
+             tool_outputs[0].AsSourceFile(settings->build_settings()));
+       }
+       if (target_->config_values().has_precompiled_headers()) {
+@@ -137,7 +136,7 @@ void RspTargetWriter::Run() {
+         if (tool_cxx && tool_cxx->precompiled_header_type() == CTool::PCH_MSVC) {
+           GetPCHOutputFiles(target_, CTool::kCToolCxx, &tool_outputs);
+           if (!tool_outputs.empty())
+-            object_files.push_back(
++            object_files.insert(
+                 tool_outputs[0].AsSourceFile(settings->build_settings()));
+         }
+       }


### PR DESCRIPTION
This patch makes sure the intermediate resource `QtWebEngineCore_objects.rsp` is sorted, which appears to remove the unreproducibility.

fixes the qt6 instance of #393832

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
