### PR TITLE
python3Packages.brevo-python: init at 1.1.2; python3Packages.june-analytics-python: init at unstable-2022-07-26; python3Packages.livekit-protocol: init at 1.0.2; python3Packages.livekit-api: init at 1.0.2

### DIFF
--- a/pkgs/development/python-modules/brevo-python/default.nix
+++ b/pkgs/development/python-modules/brevo-python/default.nix
@@ -1,0 +1,46 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  certifi,
+  python-dateutil,
+  six,
+  urllib3,
+  pytestCheckHook,
+}:
+
+buildPythonPackage rec {
+  pname = "brevo-python";
+  version = "1.1.2";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "getbrevo";
+    repo = "brevo-python";
+    tag = "v${version}";
+    hash = "sha256-XOUFyUrqVlI7Qr4uzeXr6GJuQ+QTVhsueT1xxVQMm14=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    certifi
+    python-dateutil
+    six
+    urllib3
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "brevo_python" ];
+
+  meta = {
+    description = "Fully-featured Python API client to interact with Brevo";
+    homepage = "https://github.com/getbrevo/brevo-python";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ soyouzpanda ];
+  };
+}

--- a/pkgs/development/python-modules/june-analytics-python/default.nix
+++ b/pkgs/development/python-modules/june-analytics-python/default.nix
@@ -1,0 +1,50 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  dateutils,
+  requests,
+  monotonic,
+  backoff,
+  unittestCheckHook,
+}:
+
+buildPythonPackage {
+  pname = "june-analytics-python";
+  version = "unstable-2022-07-26";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "juneHQ";
+    repo = "analytics-python";
+    rev = "462b523a617fbadc016ace45e6eec5762a8ae45f";
+    hash = "sha256-9IcikYQW1Q3aAyjIZw6UltD6cYFE+tBK+/EMQpRGCoQ=";
+  };
+
+  pythonRelaxDeps = true;
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    dateutils
+    requests
+    monotonic
+    backoff
+  ];
+
+  nativeCheckInputs = [
+    unittestCheckHook
+  ];
+
+  unittestFlagsArray = [ "june" ];
+
+  pythonImportsCheck = [ "june" ];
+
+  meta = {
+    description = "Hassle-free way to integrate analytics into any python application";
+    homepage = "https://github.com/juneHQ/analytics-python";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ soyouzpanda ];
+  };
+}

--- a/pkgs/development/python-modules/livekit-api/default.nix
+++ b/pkgs/development/python-modules/livekit-api/default.nix
@@ -1,0 +1,53 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  pyjwt,
+  aiohttp,
+  protobuf,
+  livekit-protocol,
+  pytestCheckHook,
+}:
+
+buildPythonPackage rec {
+  pname = "livekit-api";
+  version = "1.0.2";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "livekit";
+    repo = "python-sdks";
+    tag = "api-v${version}";
+    hash = "sha256-QFUCMqRshEid08IbNjyvJvJSVhYfVJRjvXjSTlNlzlU=";
+  };
+
+  pypaBuildFlags = [ "livekit-api" ];
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    pyjwt
+    aiohttp
+    protobuf
+    livekit-protocol
+  ];
+
+  pythonRemoveDeps = [ "types-protobuf" ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  pytestFlagsArray = [ "livekit-api/tests" ];
+
+  pythonImportsCheck = [ "livekit" ];
+
+  meta = {
+    description = "LiveKit real-time and server SDKs for Python";
+    homepage = "https://github.com/livekit/python-sdks/";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ soyouzpanda ];
+    platforms = lib.platforms.all;
+  };
+}

--- a/pkgs/development/python-modules/livekit-protocol/default.nix
+++ b/pkgs/development/python-modules/livekit-protocol/default.nix
@@ -1,0 +1,42 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  protobuf,
+}:
+
+buildPythonPackage rec {
+  pname = "livekit-protocol";
+  version = "1.0.2";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "livekit";
+    repo = "python-sdks";
+    tag = "protocol-v${version}";
+    hash = "sha256-1La7XYTo9onQFNx84CwabPM6N6LXIn/7swH50hFQvB8=";
+  };
+
+  pypaBuildFlags = [ "livekit-protocol" ];
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    protobuf
+  ];
+
+  pythonRemoveDeps = [ "types-protobuf" ];
+
+  doCheck = false; # no tests
+
+  pythonImportsCheck = [ "livekit" ];
+
+  meta = {
+    description = "LiveKit real-time and server SDKs for Python";
+    homepage = "https://github.com/livekit/python-sdks/";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ soyouzpanda ];
+    platforms = lib.platforms.all;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7165,6 +7165,8 @@ self: super: with self; {
 
   julius = callPackage ../development/python-modules/julius { };
 
+  june-analytics-python = callPackage ../development/python-modules/june-analytics-python { };
+
   junit-xml = callPackage ../development/python-modules/junit-xml { };
 
   junit2html = callPackage ../development/python-modules/junit2html { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8007,6 +8007,8 @@ self: super: with self; {
 
   littleutils = callPackage ../development/python-modules/littleutils { };
 
+  livekit-protocol = callPackage ../development/python-modules/livekit-protocol { };
+
   livelossplot = callPackage ../development/python-modules/livelossplot { };
 
   livereload = callPackage ../development/python-modules/livereload { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8007,6 +8007,8 @@ self: super: with self; {
 
   littleutils = callPackage ../development/python-modules/littleutils { };
 
+  livekit-api = callPackage ../development/python-modules/livekit-api { };
+
   livekit-protocol = callPackage ../development/python-modules/livekit-protocol { };
 
   livelossplot = callPackage ../development/python-modules/livelossplot { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2041,6 +2041,8 @@ self: super: with self; {
 
   brelpy = callPackage ../development/python-modules/brelpy { };
 
+  brevo-python = callPackage ../development/python-modules/brevo-python { };
+
   brian2 = callPackage ../development/python-modules/brian2 { };
 
   bring-api = callPackage ../development/python-modules/bring-api { };


### PR DESCRIPTION
https://github.com/getbrevo/brevo-python
https://github.com/juneHQ/analytics-python
https://github.com/livekit/python-sdks

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
