### PR TITLE
octoprint: 1.10.3 -> 1.11.0

### DIFF
--- a/pkgs/by-name/oc/octoprint/package.nix
+++ b/pkgs/by-name/oc/octoprint/package.nix
@@ -4,7 +4,6 @@
   callPackage,
   lib,
   fetchFromGitHub,
-  fetchPypi,
   python3,
   replaceVars,
   nix-update-script,
@@ -17,59 +16,6 @@ let
   py = python3.override {
     self = py;
     packageOverrides = lib.foldr lib.composeExtensions (self: super: { }) ([
-      (
-        # Due to flask > 2.3 the login will not work
-        self: super: {
-          werkzeug = super.werkzeug.overridePythonAttrs (oldAttrs: rec {
-            version = "2.2.3";
-            format = "setuptools";
-            pyproject = null;
-            src = fetchPypi {
-              pname = "Werkzeug";
-              inherit version;
-              hash = "sha256-LhzMlBfU2jWLnebxdOOsCUOR6h1PvvLWZ4ZdgZ39Cv4=";
-            };
-            doCheck = false;
-          });
-          flask = super.flask.overridePythonAttrs (oldAttrs: rec {
-            version = "2.2.5";
-            format = "setuptools";
-            pyproject = null;
-            src = fetchPypi {
-              pname = "Flask";
-              inherit version;
-              hash = "sha256-7e6bCn/yZiG9WowQ/0hK4oc3okENmbC7mmhQx/uXeqA=";
-            };
-            doCheck = false;
-          });
-          flask-login = super.flask-login.overridePythonAttrs (oldAttrs: rec {
-            version = "0.6.3";
-            src = fetchPypi {
-              pname = "Flask-Login";
-              inherit version;
-              hash = "sha256-XiPRSmB+8SgGxplZC4nQ8ODWe67sWZ11lHv5wUczAzM=";
-            };
-            build-system = [ self.setuptools ];
-            doCheck = false; # DeprecationWarnings
-          });
-          pytest-httpbin = super.pytest-httpbin.overridePythonAttrs (oldAttrs: {
-            doCheck = false; # fails in current overlay
-          });
-          httpcore = super.httpcore.overridePythonAttrs (oldAttrs: {
-            doCheck = false; # fails in current overlay
-          });
-
-          netaddr = super.netaddr.overridePythonAttrs (oldAttrs: rec {
-            version = "0.9.0";
-
-            src = fetchPypi {
-              pname = "netaddr";
-              inherit version;
-              hash = "sha256-e0b6mxotcf1d6eSjeE7zOXAKU6CMgEDwi69fEZTaASg=";
-            };
-          });
-        })
-
       # Built-in dependency
       (self: super: {
         octoprint-filecheck = self.buildPythonPackage rec {
@@ -105,14 +51,14 @@ let
       (self: super: {
         octoprint-pisupport = self.buildPythonPackage rec {
           pname = "OctoPrint-PiSupport";
-          version = "2023.5.24";
+          version = "2023.10.10";
           format = "setuptools";
 
           src = fetchFromGitHub {
             owner = "OctoPrint";
             repo = "OctoPrint-PiSupport";
             rev = version;
-            hash = "sha256-KfkZXJ2f02G2ee+J1w+YQRKz+LSWwxVIIwmdevDGhew=";
+            hash = "sha256-VSzDoFq4Yn6KOn+RNi1uVJHzH44973kd/VoMjqzyBRA=";
           };
 
           # requires octoprint itself during tests
@@ -127,13 +73,13 @@ let
       (self: super: {
         octoprint = self.buildPythonPackage rec {
           pname = "OctoPrint";
-          version = "1.10.3";
+          version = "1.11.0";
 
           src = fetchFromGitHub {
             owner = "OctoPrint";
             repo = "OctoPrint";
             rev = version;
-            hash = "sha256-BToW1/AcQ01OK7RWZrkstX2M4+uKuL/wFB6HGkVUflk=";
+            hash = "sha256-HvIMssPpRhzG//eyf0SfM5ddTUMr82F4ZS7c9tp88qw=";
           };
 
           propagatedBuildInputs =
@@ -153,7 +99,6 @@ let
               flask-login
               flask-limiter
               frozendict
-              future
               itsdangerous
               immutabledict
               jinja2


### PR DESCRIPTION
fixes [CVE-2025-32788](https://nvd.nist.gov/vuln/detail/CVE-2025-32788) ([GitHub Security Advisory](https://github.com/OctoPrint/OctoPrint/security/advisories/GHSA-qw93-h6pf-226x))

see https://github.com/OctoPrint/OctoPrint/releases/tag/1.11.0

@abbradar @WhittlesJr 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
