### PR TITLE
kanidm: fix provisioning patches for 1.4.x -> 1.5.x update migrations

### DIFF
--- a/pkgs/by-name/ka/kanidm/patches/1_5/oauth2-basic-secret-modify.patch
+++ b/pkgs/by-name/ka/kanidm/patches/1_5/oauth2-basic-secret-modify.patch
@@ -1,27 +1,20 @@
-From e9dfca73e6fb80faf6fc106e7aee6b93c0908525 Mon Sep 17 00:00:00 2001
-From: oddlama <oddlama@oddlama.org>
-Date: Fri, 1 Nov 2024 12:26:17 +0100
+From cf50a972b446b0ae051cfa4b01d82a4f8077386e Mon Sep 17 00:00:00 2001
+From: Benjamin Bädorf <hello@benjaminbaedorf.eu>
+Date: Fri, 28 Mar 2025 19:27:42 +0100
 Subject: [PATCH 1/2] oauth2 basic secret modify
 
 ---
  server/core/src/actors/v1_write.rs | 42 ++++++++++++++++++++++++++++++
  server/core/src/https/v1.rs        |  6 ++++-
  server/core/src/https/v1_oauth2.rs | 29 +++++++++++++++++++++
- server/lib/src/constants/acp.rs    |  6 +++++
- 4 files changed, 82 insertions(+), 1 deletion(-)
+ server/lib/src/constants/acp.rs    |  8 ++++++
+ 4 files changed, 84 insertions(+), 1 deletion(-)
 
 diff --git a/server/core/src/actors/v1_write.rs b/server/core/src/actors/v1_write.rs
-index 732e826c8..0fe66503f 100644
+index 732e826c8..a2b8e503f 100644
 --- a/server/core/src/actors/v1_write.rs
 +++ b/server/core/src/actors/v1_write.rs
-@@ -317,20 +317,62 @@ impl QueryServerWriteV1 {
-         };
- 
-         trace!(?del, "Begin delete event");
- 
-         idms_prox_write
-             .qs_write
-             .delete(&del)
+@@ -324,6 +324,48 @@ impl QueryServerWriteV1 {
              .and_then(|_| idms_prox_write.commit().map(|_| ()))
      }
  
@@ -70,21 +63,11 @@ index 732e826c8..0fe66503f 100644
      #[instrument(
          level = "info",
          skip_all,
-         fields(uuid = ?eventid)
-     )]
-     pub async fn handle_reviverecycled(
-         &self,
-         client_auth_info: ClientAuthInfo,
-         filter: Filter<FilterInvalid>,
-         eventid: Uuid,
 diff --git a/server/core/src/https/v1.rs b/server/core/src/https/v1.rs
 index c410a4b5d..cc67cac6c 100644
 --- a/server/core/src/https/v1.rs
 +++ b/server/core/src/https/v1.rs
-@@ -1,17 +1,17 @@
- //! The V1 API things!
- 
- use axum::extract::{Path, State};
+@@ -4,7 +4,7 @@ use axum::extract::{Path, State};
  use axum::http::{HeaderMap, HeaderValue};
  use axum::middleware::from_fn;
  use axum::response::{IntoResponse, Response};
@@ -93,21 +76,7 @@ index c410a4b5d..cc67cac6c 100644
  use axum::{Extension, Json, Router};
  use axum_extra::extract::cookie::{Cookie, CookieJar, SameSite};
  use compact_jwt::{Jwk, Jws, JwsSigner};
- use kanidm_proto::constants::uri::V1_AUTH_VALID;
- use std::net::IpAddr;
- use uuid::Uuid;
- 
- use kanidm_proto::internal::{
-     ApiToken, AppLink, CUIntentToken, CURequest, CUSessionToken, CUStatus, CreateRequest,
-     CredentialStatus, DeleteRequest, IdentifyUserRequest, IdentifyUserResponse, ModifyRequest,
-@@ -3120,20 +3120,24 @@ pub(crate) fn route_setup(state: ServerState) -> Router<ServerState> {
-         )
-         .route(
-             "/v1/oauth2/:rs_name/_image",
-             post(super::v1_oauth2::oauth2_id_image_post)
-                 .delete(super::v1_oauth2::oauth2_id_image_delete),
-         )
-         .route(
+@@ -3127,6 +3127,10 @@ pub(crate) fn route_setup(state: ServerState) -> Router<ServerState> {
              "/v1/oauth2/:rs_name/_basic_secret",
              get(super::v1_oauth2::oauth2_id_get_basic_secret),
          )
@@ -118,25 +87,11 @@ index c410a4b5d..cc67cac6c 100644
          .route(
              "/v1/oauth2/:rs_name/_scopemap/:group",
              post(super::v1_oauth2::oauth2_id_scopemap_post)
-                 .delete(super::v1_oauth2::oauth2_id_scopemap_delete),
-         )
-         .route(
-             "/v1/oauth2/:rs_name/_sup_scopemap/:group",
-             post(super::v1_oauth2::oauth2_id_sup_scopemap_post)
-                 .delete(super::v1_oauth2::oauth2_id_sup_scopemap_delete),
-         )
 diff --git a/server/core/src/https/v1_oauth2.rs b/server/core/src/https/v1_oauth2.rs
-index d3966a7ad..f89c02c69 100644
+index f399539bc..ffad9921e 100644
 --- a/server/core/src/https/v1_oauth2.rs
 +++ b/server/core/src/https/v1_oauth2.rs
-@@ -144,20 +144,49 @@ pub(crate) async fn oauth2_id_get_basic_secret(
- ) -> Result<Json<Option<String>>, WebError> {
-     let filter = oauth2_id(&rs_name);
-     state
-         .qe_r_ref
-         .handle_oauth2_basic_secret_read(client_auth_info, filter, kopid.eventid)
-         .await
-         .map(Json::from)
+@@ -151,6 +151,35 @@ pub(crate) async fn oauth2_id_get_basic_secret(
          .map_err(WebError::from)
  }
  
@@ -172,25 +127,11 @@ index d3966a7ad..f89c02c69 100644
  #[utoipa::path(
      patch,
      path = "/v1/oauth2/{rs_name}",
-     request_body=ProtoEntry,
-     responses(
-         DefaultApiResponse,
-     ),
-     security(("token_jwt" = [])),
-     tag = "v1/oauth2",
-     operation_id = "oauth2_id_patch"
 diff --git a/server/lib/src/constants/acp.rs b/server/lib/src/constants/acp.rs
-index be1836345..ebf4445be 100644
+index 7c0487745..3cd83ad52 100644
 --- a/server/lib/src/constants/acp.rs
 +++ b/server/lib/src/constants/acp.rs
-@@ -658,36 +658,38 @@ lazy_static! {
-             Attribute::Image,
-         ],
-         modify_present_attrs: vec![
-             Attribute::Description,
-             Attribute::DisplayName,
-             Attribute::OAuth2RsName,
-             Attribute::OAuth2RsOrigin,
+@@ -665,6 +665,7 @@ lazy_static! {
              Attribute::OAuth2RsOriginLanding,
              Attribute::OAuth2RsSupScopeMap,
              Attribute::OAuth2RsScopeMap,
@@ -198,16 +139,7 @@ index be1836345..ebf4445be 100644
              Attribute::OAuth2AllowInsecureClientDisablePkce,
              Attribute::OAuth2JwtLegacyCryptoEnable,
              Attribute::OAuth2PreferShortUsername,
-             Attribute::OAuth2AllowLocalhostRedirect,
-             Attribute::OAuth2RsClaimMap,
-             Attribute::Image,
-         ],
-         create_attrs: vec![
-             Attribute::Class,
-             Attribute::Description,
-             Attribute::DisplayName,
-             Attribute::OAuth2RsName,
-             Attribute::OAuth2RsOrigin,
+@@ -681,6 +682,7 @@ lazy_static! {
              Attribute::OAuth2RsOriginLanding,
              Attribute::OAuth2RsSupScopeMap,
              Attribute::OAuth2RsScopeMap,
@@ -215,21 +147,7 @@ index be1836345..ebf4445be 100644
              Attribute::OAuth2AllowInsecureClientDisablePkce,
              Attribute::OAuth2JwtLegacyCryptoEnable,
              Attribute::OAuth2PreferShortUsername,
-             Attribute::OAuth2AllowLocalhostRedirect,
-             Attribute::OAuth2RsClaimMap,
-             Attribute::Image,
-         ],
-         create_classes: vec![
-             EntryClass::Object,
-             EntryClass::OAuth2ResourceServer,
-@@ -759,37 +761,39 @@ lazy_static! {
-             Attribute::Image,
-         ],
-         modify_present_attrs: vec![
-             Attribute::Description,
-             Attribute::DisplayName,
-             Attribute::Name,
-             Attribute::OAuth2RsOrigin,
+@@ -766,6 +768,7 @@ lazy_static! {
              Attribute::OAuth2RsOriginLanding,
              Attribute::OAuth2RsSupScopeMap,
              Attribute::OAuth2RsScopeMap,
@@ -237,17 +155,7 @@ index be1836345..ebf4445be 100644
              Attribute::OAuth2AllowInsecureClientDisablePkce,
              Attribute::OAuth2JwtLegacyCryptoEnable,
              Attribute::OAuth2PreferShortUsername,
-             Attribute::OAuth2AllowLocalhostRedirect,
-             Attribute::OAuth2RsClaimMap,
-             Attribute::Image,
-         ],
-         create_attrs: vec![
-             Attribute::Class,
-             Attribute::Description,
-             Attribute::Name,
-             Attribute::DisplayName,
-             Attribute::OAuth2RsName,
-             Attribute::OAuth2RsOrigin,
+@@ -783,6 +786,7 @@ lazy_static! {
              Attribute::OAuth2RsOriginLanding,
              Attribute::OAuth2RsSupScopeMap,
              Attribute::OAuth2RsScopeMap,
@@ -255,21 +163,7 @@ index be1836345..ebf4445be 100644
              Attribute::OAuth2AllowInsecureClientDisablePkce,
              Attribute::OAuth2JwtLegacyCryptoEnable,
              Attribute::OAuth2PreferShortUsername,
-             Attribute::OAuth2AllowLocalhostRedirect,
-             Attribute::OAuth2RsClaimMap,
-             Attribute::Image,
-         ],
-         create_classes: vec![
-             EntryClass::Object,
-             EntryClass::Account,
-@@ -864,38 +868,40 @@ lazy_static! {
-             Attribute::OAuth2StrictRedirectUri,
-         ],
-         modify_present_attrs: vec![
-             Attribute::Description,
-             Attribute::DisplayName,
-             Attribute::Name,
-             Attribute::OAuth2RsOrigin,
+@@ -871,6 +875,7 @@ lazy_static! {
              Attribute::OAuth2RsOriginLanding,
              Attribute::OAuth2RsSupScopeMap,
              Attribute::OAuth2RsScopeMap,
@@ -277,18 +171,7 @@ index be1836345..ebf4445be 100644
              Attribute::OAuth2AllowInsecureClientDisablePkce,
              Attribute::OAuth2JwtLegacyCryptoEnable,
              Attribute::OAuth2PreferShortUsername,
-             Attribute::OAuth2AllowLocalhostRedirect,
-             Attribute::OAuth2RsClaimMap,
-             Attribute::Image,
-             Attribute::OAuth2StrictRedirectUri,
-         ],
-         create_attrs: vec![
-             Attribute::Class,
-             Attribute::Description,
-             Attribute::Name,
-             Attribute::DisplayName,
-             Attribute::OAuth2RsName,
-             Attribute::OAuth2RsOrigin,
+@@ -889,6 +894,7 @@ lazy_static! {
              Attribute::OAuth2RsOriginLanding,
              Attribute::OAuth2RsSupScopeMap,
              Attribute::OAuth2RsScopeMap,
@@ -296,13 +179,21 @@ index be1836345..ebf4445be 100644
              Attribute::OAuth2AllowInsecureClientDisablePkce,
              Attribute::OAuth2JwtLegacyCryptoEnable,
              Attribute::OAuth2PreferShortUsername,
-             Attribute::OAuth2AllowLocalhostRedirect,
-             Attribute::OAuth2RsClaimMap,
-             Attribute::Image,
-             Attribute::OAuth2StrictRedirectUri,
-         ],
-         create_classes: vec![
-             EntryClass::Object,
+@@ -980,6 +986,7 @@ lazy_static! {
+             Attribute::OAuth2RsOriginLanding,
+             Attribute::OAuth2RsSupScopeMap,
+             Attribute::OAuth2RsScopeMap,
++            Attribute::OAuth2RsBasicSecret,
+             Attribute::OAuth2AllowInsecureClientDisablePkce,
+             Attribute::OAuth2JwtLegacyCryptoEnable,
+             Attribute::OAuth2PreferShortUsername,
+@@ -999,6 +1006,7 @@ lazy_static! {
+             Attribute::OAuth2RsOriginLanding,
+             Attribute::OAuth2RsSupScopeMap,
+             Attribute::OAuth2RsScopeMap,
++            Attribute::OAuth2RsBasicSecret,
+             Attribute::OAuth2AllowInsecureClientDisablePkce,
+             Attribute::OAuth2JwtLegacyCryptoEnable,
+             Attribute::OAuth2PreferShortUsername,
 -- 
-2.46.1
-
+2.47.2


### PR DESCRIPTION
See:
- https://github.com/oddlama/kanidm-provision/issues/25
- https://github.com/oddlama/kanidm-provision/issues/14#issuecomment-2762144679

Quoting @b12f:
> We've found out that the nixpkgs 1.5 patch does not include the changes for for IDM_ACP_OAUTH2_MANAGE_DL9, only up to IDM_ACP_OAUTH2_MANAGE_DL7.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
