### PR TITLE
pdfcpu: 0.9.1 -> 0.10.1

### DIFF
--- a/pkgs/by-name/pd/pdfcpu/package.nix
+++ b/pkgs/by-name/pd/pdfcpu/package.nix
@@ -1,19 +1,20 @@
 {
   lib,
   buildGoModule,
+  stdenv,
   fetchFromGitHub,
   writableTmpDirAsHomeHook,
 }:
 
 buildGoModule rec {
   pname = "pdfcpu";
-  version = "0.9.1";
+  version = "0.10.1";
 
   src = fetchFromGitHub {
     owner = "pdfcpu";
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-PJTEaWU/erqVJakvxfB0aYRsi/tcGxYYZjCdEvThmzM=";
+    hash = "sha256-IODE6/TIXZZC5Z8guFK24iiHTwj84fcf9RiAyFkX2F8=";
     # Apparently upstream requires that the compiled executable will know the
     # commit hash and the date of the commit. This information is also presented
     # in the output of `pdfcpu version` which we use as a sanity check in the
@@ -36,7 +37,7 @@ buildGoModule rec {
     '';
   };
 
-  vendorHash = "sha256-x5EXv2LkJg2LAdml+1I4MzgTvNo6Gl+6e6UHVQ+Z9rU=";
+  vendorHash = "sha256-27YTR/vYuNggjUIbpKs3/yEJheUXMaLZk8quGPwgNNk=";
 
   ldflags = [
     "-s"
@@ -60,6 +61,9 @@ buildGoModule rec {
   # `versionCheckHook` uses --ignore-environment
   installCheckPhase = ''
     echo checking the version print of pdfcpu
+    mkdir -p $HOME/"${
+      if stdenv.hostPlatform.isDarwin then "Library/Application Support" else ".config"
+    }"/pdfcpu
     versionOutput="$($out/bin/pdfcpu version)"
     for part in ${version} $(cat COMMIT | cut -c1-8) $(cat SOURCE_DATE); do
       if [[ ! "$versionOutput" =~ "$part" ]]; then

--- a/pkgs/by-name/pd/pdfcpu/package.nix
+++ b/pkgs/by-name/pd/pdfcpu/package.nix
@@ -2,6 +2,7 @@
   lib,
   buildGoModule,
   fetchFromGitHub,
+  writableTmpDirAsHomeHook,
 }:
 
 buildGoModule rec {
@@ -52,12 +53,16 @@ buildGoModule rec {
   # No tests
   doCheck = false;
   doInstallCheck = true;
+  installCheckInputs = [
+    writableTmpDirAsHomeHook
+  ];
+  # NOTE: Can't use `versionCheckHook` since a writeable $HOME is required and
+  # `versionCheckHook` uses --ignore-environment
   installCheckPhase = ''
-    export HOME=$(mktemp -d)
     echo checking the version print of pdfcpu
     $out/bin/pdfcpu version | grep ${version}
-    $out/bin/pdfcpu version | grep $(cat COMMIT | cut -c1-8)
-    $out/bin/pdfcpu version | grep $(cat SOURCE_DATE)
+    $out/bin/pdfcpu version | grep -q $(cat COMMIT | cut -c1-8)
+    $out/bin/pdfcpu version | grep -q $(cat SOURCE_DATE)
   '';
 
   subPackages = [ "cmd/pdfcpu" ];

--- a/pkgs/by-name/pd/pdfcpu/package.nix
+++ b/pkgs/by-name/pd/pdfcpu/package.nix
@@ -60,9 +60,14 @@ buildGoModule rec {
   # `versionCheckHook` uses --ignore-environment
   installCheckPhase = ''
     echo checking the version print of pdfcpu
-    $out/bin/pdfcpu version | grep ${version}
-    $out/bin/pdfcpu version | grep -q $(cat COMMIT | cut -c1-8)
-    $out/bin/pdfcpu version | grep -q $(cat SOURCE_DATE)
+    versionOutput="$($out/bin/pdfcpu version)"
+    for part in ${version} $(cat COMMIT | cut -c1-8) $(cat SOURCE_DATE); do
+      if [[ ! "$versionOutput" =~ "$part" ]]; then
+          echo version output did not contain expected part $part . Output was:
+          echo "$versionOutput"
+          exit 3
+      fi
+    done
   '';
 
   subPackages = [ "cmd/pdfcpu" ];


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
