### PR TITLE
pkgs.llvmPackages: document adding a patch

### DIFF
--- a/pkgs/development/compilers/llvm/README.md
+++ b/pkgs/development/compilers/llvm/README.md
@@ -85,7 +85,7 @@ To add an LLVM patch in the Nixpkgs tree,
 1. Put the patch in the corresponding directory (`<VERSION>/<PACKAGE>`).
 
    _Example_: If you want your patch to apply to clang version 12 (and, optionally, later versions), put it in `./12/clang`.
-2. Add the patch to the `patches` argument of the corresponding package in `./common`, guarded by a `lib.optional` or `lib.optionals` with the desired version constraints, passed through the `getVersionFile` function.
+2. Add the patch to the `patches` argument of the corresponding package in `./common`, guarded by a `lib.optionals` with the desired version constraints, passed through the `getVersionFile` function.
 
    _Example_: If you want the patch `./12/llvm/fix-llvm-issue-49955.patch` to apply to LLVM 12, add `lib.optional (lib.versions.major release_version == "12") (getVersionFile "llvm/fix-llvm-issue-49955.patch")` to `./common/llvm/default.nix`.
 3. If you wish for this single patch to apply to multiple versions of the package, extend the conditions in the `lib.optional` guard and add the corresponding constraints to `./common/patches.nix`; note that `after` is inclusive and `before` is exclusive.

--- a/pkgs/development/compilers/llvm/README.md
+++ b/pkgs/development/compilers/llvm/README.md
@@ -77,3 +77,22 @@ Instead of applying the patches to the worktree per the above instructions, one 
 For newer LLVM versions, enough has has been upstreamed,
 (see https://reviews.llvm.org/differential/query/5UAfpj_9zHwY/ for my progress upstreaming),
 that I have just assembled new gnu-install-dirs patches from the remaining unmerged patches instead of rebasing from the prior LLVM's gnu install dirs patch.
+
+## Adding a patch
+
+To add an LLVM patch in the Nixpkgs tree,
+
+1. Put the patch in the corresponding directory (`<VERSION>/<PACKAGE>`).
+
+   _Example_: If you want your patch to apply to clang version 12 (and, optionally, later versions), put it in `./12/clang`.
+2. Add the patch to the `patches` argument of the corresponding package in `./common`, guarded by a `lib.optional` or `lib.optionals` with the desired version constraints, passed through the `getVersionFile` function.
+
+   _Example_: If you want the patch `./12/llvm/fix-llvm-issue-49955.patch` to apply to LLVM 12, add `lib.optional (lib.versions.major release_version == "12") (getVersionFile "llvm/fix-llvm-issue-49955.patch")` to `./common/llvm/default.nix`.
+3. If you wish for this single patch to apply to multiple versions of the package, extend the conditions in the `lib.optional` guard and add the corresponding constraints to `./common/patches.nix`; note that `after` is inclusive and `before` is exclusive.
+
+   _Example_:
+   If you want the patch `./12/clang/purity.patch` to apply to versions 12, 13 and 14, you have to
+   - Modify the guard in `./common/clang/default.nix` as follows: `lib.optional (lib.versionAtLeast release_version "12" && lib.versionOlder release_version "15")`
+   - Add `{ "clang/purity.patch" = [ { after = 12; before = 15; path = ../12; } ]; }` to `common/patches.nix`.
+   You may have multiple different patches with the same name that would apply to different versions; in that case, add the necessary constraints to `common/patches.nix`.
+


### PR DESCRIPTION
The `getVersionFile` function in the LLVM packaging is a bit confusing. Clarify its use by making a step-by-step instruction for adding new patches.

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
