### PR TITLE
rustPlatform.fetchCargoVendor: improve parallel fetching and add timeout

### DIFF
--- a/pkgs/build-support/rust/fetch-cargo-vendor-util.py
+++ b/pkgs/build-support/rust/fetch-cargo-vendor-util.py
@@ -1,12 +1,13 @@
 import functools
 import hashlib
 import json
-import multiprocessing as mp
+import os
 import re
 import shutil
 import subprocess
 import sys
 import tomllib
+from concurrent.futures import FIRST_EXCEPTION, ThreadPoolExecutor, wait
 from os.path import islink, realpath
 from pathlib import Path
 from typing import Any, TypedDict, cast
@@ -15,6 +16,14 @@ from urllib.parse import unquote
 import requests
 import tomli_w
 from requests.adapters import HTTPAdapter, Retry
+
+# Constants for controlling how the crates are downloaded from the registries via `requests`
+# These do not affect the fetching of git dependencies
+MAX_WORKERS = min(5, os.cpu_count() or 1)  # number of workers in the ThreadPoolExecutor
+CONNECT_TIMEOUT = 2  # max seconds for establishing initial connection
+READ_TIMEOUT = 10  # max seconds between receiving data packets
+RETRY_COUNT = 3  # number of retries for fetching an url
+BACKOFF_FACTOR = 0.5  # seconds to wait between retries (gets multiplied by 2 after every retry)
 
 eprint = functools.partial(print, file=sys.stderr)
 
@@ -35,8 +44,8 @@ def get_lockfile_version(cargo_lock_toml: dict[str, Any]) -> int:
 
 def create_http_session() -> requests.Session:
     retries = Retry(
-        total=5,
-        backoff_factor=0.5,
+        total=RETRY_COUNT,
+        backoff_factor=BACKOFF_FACTOR,
         status_forcelist=[500, 502, 503, 504]
     )
     session = requests.Session()
@@ -47,7 +56,7 @@ def create_http_session() -> requests.Session:
 
 def download_file_with_checksum(session: requests.Session, url: str, destination_path: Path) -> str:
     sha256_hash = hashlib.sha256()
-    with session.get(url, stream=True) as response:
+    with session.get(url, stream=True, timeout=(CONNECT_TIMEOUT, READ_TIMEOUT)) as response:
         if not response.ok:
             raise Exception(f"Failed to fetch file from {url}. Status code: {response.status_code}")
         with open(destination_path, "wb") as file:
@@ -158,13 +167,22 @@ def create_vendor_staging(lockfile_path: Path, out_dir: Path) -> None:
         for git_sha_rev, url in git_sha_rev_to_url.items():
             download_git_tree(url, git_sha_rev, out_dir)
 
-    # run tarball download jobs in parallel, with at most 5 concurrent download jobs
-    with mp.Pool(min(5, mp.cpu_count())) as pool:
-        if len(registry_packages) != 0:
+    if len(registry_packages) != 0:
+        # run tarball download jobs in parallel
+        with ThreadPoolExecutor(max_workers=MAX_WORKERS) as executor:
             (out_dir / "tarballs").mkdir()
             session = create_http_session()
-            tarball_args_gen = ((session, pkg, out_dir) for pkg in registry_packages)
-            pool.starmap(download_tarball, tarball_args_gen)
+            eprint(f"Downloading tarballs with {MAX_WORKERS} workers...")
+            futures = [executor.submit(download_tarball, session, pkg, out_dir) for pkg in registry_packages]
+            # fail early if a worker raises an exception
+            done, not_done = wait(futures, return_when=FIRST_EXCEPTION)
+            for f in done:
+                e = f.exception()
+                if not e:
+                    continue
+                for f2 in not_done:
+                    f2.cancel()
+                raise Exception(f"Failed to download tarball: {e}")
 
 
 def get_manifest_metadata(manifest_path: Path) -> dict[str, Any]:


### PR DESCRIPTION
Fixes #397309
Supersedes: https://github.com/NixOS/nixpkgs/pull/400738


This PR moves over to using `concurrent.futures.ThreadPoolExecutor` instead of `multiprocessing.Pool` because we can properly do some fail-early logic with `ThreadPoolExecutor`.

Also, add `timeout=(a,b)` to `session.get` calls, so that we never deadlock the fetcher.
I also lowered the `Retry` object's retry count down to 3.

---

Note: even though this only touches the FOD part of fetchCargoVendor, this file is used by the non-FOD part as well, so we'll get rebuilds :/


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
