### PR TITLE
godot_4{_3,_4}{,-mono}: add source build of export template

### DIFF
--- a/doc/release-notes/rl-2505.section.md
+++ b/doc/release-notes/rl-2505.section.md
@@ -424,6 +424,8 @@
 - [`lib.packagesFromDirectoryRecursive`] now rejects unknown arguments.
   [`lib.packagesFromDirectoryRecursive`]: https://nixos.org/manual/nixpkgs/stable/#function-library-lib.filesystem.packagesFromDirectoryRecursive
 
+- The `godot-export-templates` package now has its content at `share/godot/export_templates/$version` instead of the output root. This makes it more convenient for for symlinking into `~/.local`, but scripts expecting the old layout will need to be changed.
+
 ### Deprecations {#sec-nixpkgs-release-25.05-lib-deprecations}
 
 - `functor` is an implementation detail and should not be relied upon, but since its status wasn't clear and it has had some use cases without alternatives, changes are being handled as gracefully as possible. Deprecations within functor:

--- a/pkgs/by-name/op/opengamepadui/package.nix
+++ b/pkgs/by-name/op/opengamepadui/package.nix
@@ -81,7 +81,7 @@ stdenv.mkDerivation (finalAttrs: {
       GODOT = lib.getExe godot_4_4;
       GODOT_VERSION = lib.elemAt versionAndRelease 0;
       GODOT_RELEASE = lib.elemAt versionAndRelease 1;
-      EXPORT_TEMPLATE = "${godot_4_4.export-templates-bin}";
+      EXPORT_TEMPLATE = "${godot_4_4.export-templates-bin}/share/godot/export_templates";
       BUILD_TYPE = "${finalAttrs.buildType}";
     };
 
@@ -92,8 +92,8 @@ stdenv.mkDerivation (finalAttrs: {
   preBuild = ''
     # Godot looks for export templates in HOME
     export HOME=$(mktemp -d)
-    mkdir -p $HOME/.local/share/godot/export_templates
-    ln -s "${godot_4_4.export-templates-bin}" "$HOME/.local/share/godot/export_templates/$GODOT_VERSION.$GODOT_RELEASE"
+    mkdir -p $HOME/.local/share/godot/
+    ln -s "$EXPORT_TEMPLATE" "$HOME"/.local/share/godot/
   '';
 
   postInstall = ''

--- a/pkgs/by-name/op/opengamepadui/package.nix
+++ b/pkgs/by-name/op/opengamepadui/package.nix
@@ -1,6 +1,5 @@
 {
   alsa-lib,
-  autoPatchelfHook,
   cargo,
   dbus,
   fetchFromGitHub,
@@ -43,32 +42,10 @@ stdenv.mkDerivation (finalAttrs: {
   cargoRoot = "extensions";
 
   nativeBuildInputs = [
-    autoPatchelfHook
     cargo
     godot_4_4
-    godot_4_4.export-templates-bin
     pkg-config
     rustPlatform.cargoSetupHook
-  ];
-
-  runtimeDependencies = [
-    alsa-lib
-    dbus
-    gamescope
-    hwdata
-    libGL
-    libpulseaudio
-    mesa-demos
-    udev
-    upower
-    vulkan-loader
-    xorg.libX11
-    xorg.libXcursor
-    xorg.libXext
-    xorg.libXi
-    xorg.libXrandr
-    xorg.libXres
-    xorg.libXtst
   ];
 
   dontStrip = withDebug;
@@ -81,7 +58,7 @@ stdenv.mkDerivation (finalAttrs: {
       GODOT = lib.getExe godot_4_4;
       GODOT_VERSION = lib.elemAt versionAndRelease 0;
       GODOT_RELEASE = lib.elemAt versionAndRelease 1;
-      EXPORT_TEMPLATE = "${godot_4_4.export-templates-bin}/share/godot/export_templates";
+      EXPORT_TEMPLATE = "${godot_4_4.export-template}/share/godot/export_templates";
       BUILD_TYPE = "${finalAttrs.buildType}";
     };
 
@@ -96,11 +73,22 @@ stdenv.mkDerivation (finalAttrs: {
     ln -s "$EXPORT_TEMPLATE" "$HOME"/.local/share/godot/
   '';
 
-  postInstall = ''
-    # The Godot binary looks in "../lib" for gdextensions
-    mkdir -p $out/share/lib
-    mv $out/share/opengamepadui/*.so $out/share/lib
-  '';
+  postInstall =
+    let
+      runtimeDependencies = [
+        gamescope
+        hwdata
+        mesa-demos
+        udev
+        upower
+      ];
+    in
+    ''
+      # The Godot binary looks in "../lib" for gdextensions
+      mkdir -p $out/share/lib
+      mv $out/share/opengamepadui/*.so $out/share/lib
+      patchelf --add-rpath ${lib.makeLibraryPath runtimeDependencies} $out/share/lib/*.so
+    '';
 
   passthru.updateScript = nix-update-script { };
 

--- a/pkgs/by-name/pi/pixelorama/package.nix
+++ b/pkgs/by-name/pi/pixelorama/package.nix
@@ -1,20 +1,9 @@
 {
   lib,
   stdenv,
-  alsa-lib,
-  autoPatchelfHook,
   fetchFromGitHub,
   godot_4_3,
-  libGL,
-  libpulseaudio,
-  libX11,
-  libXcursor,
-  libXext,
-  libXi,
-  libXrandr,
   nix-update-script,
-  udev,
-  vulkan-loader,
 }:
 
 let
@@ -28,7 +17,6 @@ let
       or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
 
   godot = godot_4_3;
-  godot_version_folder = lib.replaceStrings [ "-" ] [ "." ] godot.version;
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "pixelorama";
@@ -44,21 +32,7 @@ stdenv.mkDerivation (finalAttrs: {
   strictDeps = true;
 
   nativeBuildInputs = [
-    autoPatchelfHook
     godot
-  ];
-
-  runtimeDependencies = map lib.getLib [
-    alsa-lib
-    libGL
-    libpulseaudio
-    libX11
-    libXcursor
-    libXext
-    libXi
-    libXrandr
-    udev
-    vulkan-loader
   ];
 
   buildPhase = ''
@@ -66,7 +40,7 @@ stdenv.mkDerivation (finalAttrs: {
 
     export HOME=$(mktemp -d)
     mkdir -p $HOME/.local/share/godot/
-    ln -s "${godot.export-templates-bin}"/share/godot/export_templates "$HOME"/.local/share/godot/
+    ln -s "${godot.export-template}"/share/godot/export_templates "$HOME"/.local/share/godot/
     mkdir -p build
     godot4 --headless --export-release "${preset}" ./build/pixelorama
 

--- a/pkgs/by-name/pi/pixelorama/package.nix
+++ b/pkgs/by-name/pi/pixelorama/package.nix
@@ -65,8 +65,8 @@ stdenv.mkDerivation (finalAttrs: {
     runHook preBuild
 
     export HOME=$(mktemp -d)
-    mkdir -p $HOME/.local/share/godot/export_templates
-    ln -s "${godot.export-templates-bin}" "$HOME/.local/share/godot/export_templates/${godot_version_folder}"
+    mkdir -p $HOME/.local/share/godot/
+    ln -s "${godot.export-templates-bin}"/share/godot/export_templates "$HOME"/.local/share/godot/
     mkdir -p build
     godot4 --headless --export-release "${preset}" ./build/pixelorama
 

--- a/pkgs/development/tools/godot/4.3/default.nix
+++ b/pkgs/development/tools/godot/4.3/default.nix
@@ -1,6 +1,11 @@
 {
   version = "4.3-stable";
   hash = "sha256-MzElflwXHWLgPtoOIhPLA00xX8eEdQsexZaGIEOzbj0=";
-  exportTemplatesHash = "sha256-9fENuvVqeQg0nmS5TqjCyTwswR+xAUyVZbaKK7Q3uSI=";
-  nugetDeps = ./deps.json;
+  default = {
+    exportTemplatesHash = "sha256-9fENuvVqeQg0nmS5TqjCyTwswR+xAUyVZbaKK7Q3uSI=";
+  };
+  mono = {
+    exportTemplatesHash = "sha256-pkDZfkJHiDtY05TGERwTNDES88SbuFfZVYb5hln6O+U=";
+    nugetDeps = ./deps.json;
+  };
 }

--- a/pkgs/development/tools/godot/4.3/default.nix
+++ b/pkgs/development/tools/godot/4.3/default.nix
@@ -1,6 +1,6 @@
 {
   version = "4.3-stable";
   hash = "sha256-MzElflwXHWLgPtoOIhPLA00xX8eEdQsexZaGIEOzbj0=";
-  exportTemplatesHash = "sha256-XRnKii+eexIkbGf7bqc42SR0NBULFvgMdOpSRNNk6kg=";
+  exportTemplatesHash = "sha256-9fENuvVqeQg0nmS5TqjCyTwswR+xAUyVZbaKK7Q3uSI=";
   nugetDeps = ./deps.json;
 }

--- a/pkgs/development/tools/godot/4.4/default.nix
+++ b/pkgs/development/tools/godot/4.4/default.nix
@@ -1,6 +1,11 @@
 {
   version = "4.4.1-stable";
   hash = "sha256-O4TdPYu1K2zWKMBP/7xd0UPLDb7/4dBnkGM7QydD3Yo=";
-  exportTemplatesHash = "sha256-eo0UreSJ/U0i8XgZMCH+iodqnlEGjtTd4m2sOuTFmog=";
-  nugetDeps = ./deps.json;
+  default = {
+    exportTemplatesHash = "sha256-eo0UreSJ/U0i8XgZMCH+iodqnlEGjtTd4m2sOuTFmog=";
+  };
+  mono = {
+    exportTemplatesHash = "sha256-tk0WS5axndcXWhuj86blg+nU3FB7PRMzVj8ka1gRgj4=";
+    nugetDeps = ./deps.json;
+  };
 }

--- a/pkgs/development/tools/godot/4.4/default.nix
+++ b/pkgs/development/tools/godot/4.4/default.nix
@@ -1,6 +1,6 @@
 {
   version = "4.4.1-stable";
   hash = "sha256-O4TdPYu1K2zWKMBP/7xd0UPLDb7/4dBnkGM7QydD3Yo=";
-  exportTemplatesHash = "sha256-KV4sDBZPiMf7IORaNFR2uEK1midnyyjCUfG9hl6AwHY=";
+  exportTemplatesHash = "sha256-eo0UreSJ/U0i8XgZMCH+iodqnlEGjtTd4m2sOuTFmog=";
   nugetDeps = ./deps.json;
 }

--- a/pkgs/development/tools/godot/CSharpLanguage-fix-crash-in-reload_assemblies-after-.patch
+++ b/pkgs/development/tools/godot/CSharpLanguage-fix-crash-in-reload_assemblies-after-.patch
@@ -1,0 +1,30 @@
+From 42f89dd50dde0896d6c55282c82db9af41cd12d8 Mon Sep 17 00:00:00 2001
+From: David McFarland <corngood@gmail.com>
+Date: Wed, 26 Mar 2025 09:52:17 -0300
+Subject: [PATCH] CSharpLanguage: fix crash in reload_assemblies after editor
+ shutdown
+
+---
+ modules/mono/csharp_script.cpp | 6 ++++--
+ 1 file changed, 4 insertions(+), 2 deletions(-)
+
+diff --git a/modules/mono/csharp_script.cpp b/modules/mono/csharp_script.cpp
+index 36c8a40ed9..2b161fb69b 100644
+--- a/modules/mono/csharp_script.cpp
++++ b/modules/mono/csharp_script.cpp
+@@ -1001,8 +1001,10 @@ void CSharpLanguage::reload_assemblies(bool p_soft_reload) {
+ #ifdef TOOLS_ENABLED
+ 	// FIXME: Hack to refresh editor in order to display new properties and signals. See if there is a better alternative.
+ 	if (Engine::get_singleton()->is_editor_hint()) {
+-		InspectorDock::get_inspector_singleton()->update_tree();
+-		NodeDock::get_singleton()->update_lists();
++		if (InspectorDock::get_singleton())
++			InspectorDock::get_inspector_singleton()->update_tree();
++		if (NodeDock::get_singleton())
++			NodeDock::get_singleton()->update_lists();
+ 	}
+ #endif
+ }
+-- 
+2.48.1
+

--- a/pkgs/development/tools/godot/common.nix
+++ b/pkgs/development/tools/godot/common.nix
@@ -24,6 +24,7 @@
   libXrandr,
   libXrender,
   makeWrapper,
+  perl,
   pkg-config,
   runCommand,
   scons,
@@ -168,6 +169,11 @@ let
         ./CSharpLanguage-fix-crash-in-reload_assemblies-after-.patch
       ];
 
+      postPatch = ''
+        # this stops scons from hiding e.g. NIX_CFLAGS_COMPILE
+        perl -pi -e '{ $r += s:(env = Environment\(.*):\1\nenv["ENV"] = os.environ: } END { exit ($r != 1) }' SConstruct
+      '';
+
       depsBuildBuild = lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [
         buildPackages.stdenv.cc
         pkg-config
@@ -179,6 +185,7 @@ let
         [
           autoPatchelfHook
           installShellFiles
+          perl
           pkg-config
           scons
         ]

--- a/pkgs/development/tools/godot/common.nix
+++ b/pkgs/development/tools/godot/common.nix
@@ -229,7 +229,7 @@ let
       + lib.optionalString withMono ''
         cp -r bin/GodotSharp/ $out/bin/
         wrapProgram $out/bin/godot4${suffix} \
-          --set DOTNET_ROOT ${dotnet-sdk} \
+          --set DOTNET_ROOT ${dotnet-sdk}/share/dotnet \
           --prefix PATH : "${
             lib.makeBinPath [
               dotnet-sdk

--- a/pkgs/development/tools/godot/common.nix
+++ b/pkgs/development/tools/godot/common.nix
@@ -238,7 +238,7 @@ let
       ''
       + ''
         ln -s godot4${suffix} "$out"/bin/godot
-        runHook post Install
+        runHook postInstall
       '';
 
     # patching $debug can crash patchelf

--- a/pkgs/development/tools/godot/common.nix
+++ b/pkgs/development/tools/godot/common.nix
@@ -160,6 +160,9 @@ let
 
         module_mono_enabled = withMono;
 
+        # aliasing bugs exist with hardening+LTO
+        # https://github.com/godotengine/godot/pull/104501
+        ccflags = "-fno-strict-aliasing";
         linkflags = "-Wl,--build-id";
 
         use_sowrap = false;

--- a/pkgs/development/tools/godot/common.nix
+++ b/pkgs/development/tools/godot/common.nix
@@ -326,8 +326,8 @@ let
               runHook preBuild
 
               export HOME=$(mktemp -d)
-              mkdir -p $HOME/.local/share/godot/export_templates
-              ln -s "${pkg.export-templates-bin}" "$HOME/.local/share/godot/export_templates/${dottedVersion}"
+              mkdir -p $HOME/.local/share/godot/
+              ln -s "${pkg.export-templates-bin}"/share/godot/export_templates "$HOME"/.local/share/godot/
 
               godot --headless -s create-scene.gd
 

--- a/pkgs/development/tools/godot/common.nix
+++ b/pkgs/development/tools/godot/common.nix
@@ -2,8 +2,10 @@
   alsa-lib,
   autoPatchelfHook,
   buildPackages,
+  callPackage,
   dbus,
   dotnetCorePackages,
+  exportTemplatesHash,
   fetchFromGitHub,
   fontconfig,
   hash,
@@ -30,6 +32,7 @@
   stdenvNoCC,
   testers,
   udev,
+  updateScript,
   version,
   vulkan-loader,
   wayland,
@@ -42,7 +45,6 @@
   withPrecision ? "single",
   withPulseaudio ? true,
   withSpeechd ? true,
-  withTarget ? "editor",
   withTouch ? true,
   withUdev ? true,
   # Wayland in Godot requires X11 until upstream fix is merged
@@ -59,348 +61,501 @@ let
     k: v: if builtins.isString v then "${k}=${v}" else "${k}=${builtins.toJSON v}"
   );
 
-  suffix = if withMono then "-mono" else "";
-
   arch = stdenv.hostPlatform.linuxArch;
 
   dotnet-sdk = dotnetCorePackages.sdk_8_0-source;
 
-  attrs = finalAttrs: rec {
-    pname = "godot4${suffix}";
-    inherit version;
+  dottedVersion = lib.replaceStrings [ "-" ] [ "." ] version + lib.optionalString withMono ".mono";
 
-    src = fetchFromGitHub {
-      owner = "godotengine";
-      repo = "godot";
-      tag = version;
-      inherit hash;
-      # Required for the commit hash to be included in the version number.
-      #
-      # `methods.py` reads the commit hash from `.git/HEAD` and manually follows
-      # refs.
-      #
-      # See also 'hash' in
-      # https://docs.godotengine.org/en/stable/classes/class_engine.html#class-engine-method-get-version-info
-      leaveDotGit = true;
-      # Only keep HEAD, because leaveDotGit is non-deterministic:
-      # https://github.com/NixOS/nixpkgs/issues/8567
-      postFetch = ''
-        hash=$(git -C "$out" rev-parse HEAD)
-        rm -r "$out"/.git
-        mkdir "$out"/.git
-        echo "$hash" > "$out"/.git/HEAD
-      '';
-    };
+  attrsForTarget =
+    target: finalAttrs:
+    let
+      editor = target == "editor";
+      suffix = lib.optionalString withMono "-mono" + lib.optionalString (!editor) "-template";
+      binary = lib.concatStringsSep "." (
+        [
+          "godot"
+          withPlatform
+          target
+        ]
+        ++ lib.optional (withPrecision != "single") withPrecision
+        ++ [ arch ]
+        ++ lib.optional withMono "mono"
+      );
+    in
+    rec {
+      pname = "godot${suffix}";
+      inherit version;
 
-    outputs = [
-      "out"
-      "man"
-    ];
-    separateDebugInfo = true;
-
-    # Set the build name which is part of the version. In official downloads, this
-    # is set to 'official'. When not specified explicitly, it is set to
-    # 'custom_build'. Other platforms packaging Godot (Gentoo, Arch, Flatpack
-    # etc.) usually set this to their name as well.
-    #
-    # See also 'methods.py' in the Godot repo and 'build' in
-    # https://docs.godotengine.org/en/stable/classes/class_engine.html#class-engine-method-get-version-info
-    BUILD_NAME = "nixpkgs";
-
-    preConfigure = lib.optionalString withMono ''
-      # TODO: avoid pulling in dependencies of windows-only project
-      dotnet sln modules/mono/editor/GodotTools/GodotTools.sln \
-        remove modules/mono/editor/GodotTools/GodotTools.OpenVisualStudio/GodotTools.OpenVisualStudio.csproj
-
-      dotnet restore modules/mono/glue/GodotSharp/GodotSharp.sln
-      dotnet restore modules/mono/editor/GodotTools/GodotTools.sln
-      dotnet restore modules/mono/editor/Godot.NET.Sdk/Godot.NET.Sdk.sln
-    '';
-
-    # From: https://github.com/godotengine/godot/blob/4.2.2-stable/SConstruct
-    sconsFlags = mkSconsFlagsFromAttrSet {
-      # Options from 'SConstruct'
-      precision = withPrecision; # Floating-point precision level
-      production = true; # Set defaults to build Godot for use in production
-      platform = withPlatform;
-      target = withTarget;
-      debug_symbols = true;
-
-      # Options from 'platform/linuxbsd/detect.py'
-      dbus = withDbus; # Use D-Bus to handle screensaver and portal desktop settings
-      fontconfig = withFontconfig; # Use fontconfig for system fonts support
-      pulseaudio = withPulseaudio; # Use PulseAudio
-      speechd = withSpeechd; # Use Speech Dispatcher for Text-to-Speech support
-      touch = withTouch; # Enable touch events
-      udev = withUdev; # Use udev for gamepad connection callbacks
-      wayland = withWayland; # Compile with Wayland support
-      x11 = withX11; # Compile with X11 support
-
-      module_mono_enabled = withMono;
-
-      linkflags = "-Wl,--build-id";
-    };
-
-    enableParallelBuilding = true;
-
-    strictDeps = true;
-
-    depsBuildBuild = lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [
-      buildPackages.stdenv.cc
-      pkg-config
-    ];
-
-    buildInputs = lib.optionals withMono dotnet-sdk.packages;
-
-    nativeBuildInputs =
-      [
-        autoPatchelfHook
-        installShellFiles
-        pkg-config
-        scons
-      ]
-      ++ lib.optionals withWayland [ wayland-scanner ]
-      ++ lib.optionals withMono [
-        dotnet-sdk
-        makeWrapper
-      ];
-
-    postBuild = lib.optionalString withMono ''
-      echo "Generating Glue"
-      if [[ ${withPrecision} == *double* ]]; then
-          bin/godot.${withPlatform}.${withTarget}.${withPrecision}.${arch}.mono --headless --generate-mono-glue modules/mono/glue
-      else
-          bin/godot.${withPlatform}.${withTarget}.${arch}.mono --headless --generate-mono-glue modules/mono/glue
-      fi
-      echo "Building C#/.NET Assemblies"
-      python modules/mono/build_scripts/build_assemblies.py --godot-output-dir bin --precision=${withPrecision}
-    '';
-
-    runtimeDependencies =
-      [
-        alsa-lib
-        libGL
-        vulkan-loader
-      ]
-      ++ lib.optionals withX11 [
-        libX11
-        libXcursor
-        libXext
-        libXfixes
-        libXi
-        libXinerama
-        libxkbcommon
-        libXrandr
-        libXrender
-      ]
-      ++ lib.optionals withWayland [
-        libdecor
-        wayland
-      ]
-      ++ lib.optionals withDbus [
-        dbus
-        dbus.lib
-      ]
-      ++ lib.optionals withFontconfig [
-        fontconfig
-        fontconfig.lib
-      ]
-      ++ lib.optionals withPulseaudio [ libpulseaudio ]
-      ++ lib.optionals withSpeechd [ speechd-minimal ]
-      ++ lib.optionals withUdev [ udev ];
-
-    installPhase =
-      ''
-        runHook preInstall
-
-        mkdir -p "$out/bin"
-        cp bin/godot.* $out/bin/godot4${suffix}
-
-        installManPage misc/dist/linux/godot.6
-
-        mkdir -p "$out"/share/{applications,icons/hicolor/scalable/apps}
-        cp misc/dist/linux/org.godotengine.Godot.desktop "$out/share/applications/org.godotengine.Godot4${suffix}.desktop"
-        substituteInPlace "$out/share/applications/org.godotengine.Godot4${suffix}.desktop" \
-          --replace "Exec=godot" "Exec=$out/bin/godot4${suffix}" \
-          --replace "Godot Engine" "Godot Engine 4"
-        cp icon.svg "$out/share/icons/hicolor/scalable/apps/godot.svg"
-        cp icon.png "$out/share/icons/godot.png"
-      ''
-      + lib.optionalString withMono ''
-        cp -r bin/GodotSharp/ $out/bin/
-        wrapProgram $out/bin/godot4${suffix} \
-          --set DOTNET_ROOT ${dotnet-sdk}/share/dotnet \
-          --prefix PATH : "${
-            lib.makeBinPath [
-              dotnet-sdk
-            ]
-          }"
-      ''
-      + ''
-        ln -s godot4${suffix} "$out"/bin/godot
-        runHook postInstall
-      '';
-
-    # patching $debug can crash patchelf
-    # (https://github.com/NixOS/patchelf/issues/373), so explicitly patch $out
-    dontAutoPatchelf = true;
-
-    postFixup = ''
-      autoPatchelf "$out"
-    '';
-
-    passthru = {
-      tests =
-        let
-          pkg = finalAttrs.finalPackage;
-          dottedVersion = lib.replaceStrings [ "-" ] [ "." ] version;
-          exportedProject = stdenvNoCC.mkDerivation {
-            name = "${pkg.name}-project-export";
-
-            nativeBuildInputs = [
-              pkg
-              autoPatchelfHook
-            ];
-
-            runtimeDependencies = map lib.getLib [
-              alsa-lib
-              libGL
-              libpulseaudio
-              libX11
-              libXcursor
-              libXext
-              libXi
-              libXrandr
-              udev
-              vulkan-loader
-            ];
-
-            unpackPhase = ''
-              runHook preUnpack
-
-              mkdir test
-              cd test
-              touch project.godot
-
-              cat >create-scene.gd <<'EOF'
-              extends SceneTree
-
-              func _initialize():
-                var node = Node.new()
-                var script = ResourceLoader.load("res://test.gd")
-                print(script)
-                node.set_script(script)
-                var scene = PackedScene.new()
-                var scenePath = "res://test.tscn"
-                scene.pack(node)
-                var x = ResourceSaver.save(scene, scenePath)
-                ProjectSettings["application/run/main_scene"] = scenePath
-                ProjectSettings.save()
-                node.free()
-                quit()
-              EOF
-
-              cat >test.gd <<'EOF'
-              extends Node
-              func _ready():
-                print("Hello, World!")
-                get_tree().quit()
-              EOF
-
-              cat >export_presets.cfg <<'EOF'
-              [preset.0]
-              name="build"
-              platform="Linux"
-              runnable=true
-              export_filter="all_resources"
-              include_filter=""
-              exclude_filter=""
-              [preset.0.options]
-              __empty=""
-              EOF
-
-              runHook postUnpack
-            '';
-
-            buildPhase = ''
-              runHook preBuild
-
-              export HOME=$(mktemp -d)
-              mkdir -p $HOME/.local/share/godot/
-              ln -s "${pkg.export-templates-bin}"/share/godot/export_templates "$HOME"/.local/share/godot/
-
-              godot --headless -s create-scene.gd
-
-              runHook postBuild
-            '';
-
-            installPhase = ''
-              runHook preInstall
-
-              mkdir -p "$out"/bin
-              godot --headless --export-release build "$out"/bin/test
-
-              runHook postInstall
-            '';
-          };
-        in
-        {
-          version = testers.testVersion {
-            package = pkg;
-            version = dottedVersion;
-          };
-
-          project-runs = runCommand "${pkg.name}-project-runs" { } ''
-            (
-              set -eo pipefail
-              HOME=$(mktemp -d)
-              "${exportedProject}"/bin/test --headless | tail -n1 | (
-                read output
-                if [[ "$output" != "Hello, World!" ]]; then
-                  echo "unexpected output: $output" >&2
-                  exit 1
-                fi
-              )
-              touch "$out"
-            )
-          '';
-        };
-    };
-
-    requiredSystemFeatures = [
-      # fixes: No space left on device
-      "big-parallel"
-    ];
-
-    meta = {
-      changelog = "https://github.com/godotengine/godot/releases/tag/${version}";
-      description = "Free and Open Source 2D and 3D game engine";
-      homepage = "https://godotengine.org";
-      license = lib.licenses.mit;
-      platforms = [
-        "x86_64-linux"
-        "aarch64-linux"
-      ] ++ lib.optional (!withMono) "i686-linux";
-      maintainers = with lib.maintainers; [
-        shiryel
-        corngood
-      ];
-      mainProgram = "godot4${suffix}";
-    };
-  };
-
-in
-stdenv.mkDerivation (
-  if withMono then
-    dotnetCorePackages.addNuGetDeps {
-      inherit nugetDeps;
-      overrideFetchAttrs = old: rec {
-        runtimeIds = map (system: dotnetCorePackages.systemToDotnetRid system) old.meta.platforms;
-        buildInputs =
-          old.buildInputs
-          ++ lib.concatLists (lib.attrValues (lib.getAttrs runtimeIds dotnet-sdk.targetPackages));
+      src = fetchFromGitHub {
+        owner = "godotengine";
+        repo = "godot";
+        tag = version;
+        inherit hash;
+        # Required for the commit hash to be included in the version number.
+        #
+        # `methods.py` reads the commit hash from `.git/HEAD` and manually follows
+        # refs.
+        #
+        # See also 'hash' in
+        # https://docs.godotengine.org/en/stable/classes/class_engine.html#class-engine-method-get-version-info
+        leaveDotGit = true;
+        # Only keep HEAD, because leaveDotGit is non-deterministic:
+        # https://github.com/NixOS/nixpkgs/issues/8567
+        postFetch = ''
+          hash=$(git -C "$out" rev-parse HEAD)
+          rm -r "$out"/.git
+          mkdir "$out"/.git
+          echo "$hash" > "$out"/.git/HEAD
+        '';
       };
-    } attrs
-  else
-    attrs
-)
+
+      outputs = [
+        "out"
+      ] ++ lib.optional (editor) "man";
+      separateDebugInfo = true;
+
+      # Set the build name which is part of the version. In official downloads, this
+      # is set to 'official'. When not specified explicitly, it is set to
+      # 'custom_build'. Other platforms packaging Godot (Gentoo, Arch, Flatpack
+      # etc.) usually set this to their name as well.
+      #
+      # See also 'methods.py' in the Godot repo and 'build' in
+      # https://docs.godotengine.org/en/stable/classes/class_engine.html#class-engine-method-get-version-info
+      BUILD_NAME = "nixpkgs";
+
+      preConfigure = lib.optionalString withMono ''
+        # TODO: avoid pulling in dependencies of windows-only project
+        dotnet sln modules/mono/editor/GodotTools/GodotTools.sln \
+          remove modules/mono/editor/GodotTools/GodotTools.OpenVisualStudio/GodotTools.OpenVisualStudio.csproj
+
+        dotnet restore modules/mono/glue/GodotSharp/GodotSharp.sln
+        dotnet restore modules/mono/editor/GodotTools/GodotTools.sln
+        dotnet restore modules/mono/editor/Godot.NET.Sdk/Godot.NET.Sdk.sln
+      '';
+
+      # From: https://github.com/godotengine/godot/blob/4.2.2-stable/SConstruct
+      sconsFlags = mkSconsFlagsFromAttrSet {
+        # Options from 'SConstruct'
+        precision = withPrecision; # Floating-point precision level
+        production = true; # Set defaults to build Godot for use in production
+        platform = withPlatform;
+        inherit target;
+        debug_symbols = true;
+
+        # Options from 'platform/linuxbsd/detect.py'
+        dbus = withDbus; # Use D-Bus to handle screensaver and portal desktop settings
+        fontconfig = withFontconfig; # Use fontconfig for system fonts support
+        pulseaudio = withPulseaudio; # Use PulseAudio
+        speechd = withSpeechd; # Use Speech Dispatcher for Text-to-Speech support
+        touch = withTouch; # Enable touch events
+        udev = withUdev; # Use udev for gamepad connection callbacks
+        wayland = withWayland; # Compile with Wayland support
+        x11 = withX11; # Compile with X11 support
+
+        module_mono_enabled = withMono;
+
+        linkflags = "-Wl,--build-id";
+      };
+
+      enableParallelBuilding = true;
+
+      strictDeps = true;
+
+      patches = lib.optionals (lib.versionOlder version "4.4") [
+        # Fix a crash in the mono test project build. It no longer seems to
+        # happen in 4.4, but an existing fix couldn't be identified.
+        ./CSharpLanguage-fix-crash-in-reload_assemblies-after-.patch
+      ];
+
+      depsBuildBuild = lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [
+        buildPackages.stdenv.cc
+        pkg-config
+      ];
+
+      buildInputs = lib.optionals withMono dotnet-sdk.packages;
+
+      nativeBuildInputs =
+        [
+          autoPatchelfHook
+          installShellFiles
+          pkg-config
+          scons
+        ]
+        ++ lib.optionals withWayland [ wayland-scanner ]
+        ++ lib.optionals withMono [
+          dotnet-sdk
+          makeWrapper
+        ];
+
+      postBuild = lib.optionalString (editor && withMono) ''
+        echo "Generating Glue"
+        bin/${binary} --headless --generate-mono-glue modules/mono/glue
+        echo "Building C#/.NET Assemblies"
+        python modules/mono/build_scripts/build_assemblies.py --godot-output-dir bin --precision=${withPrecision}
+      '';
+
+      runtimeDependencies =
+        [
+          alsa-lib
+          libGL
+          vulkan-loader
+        ]
+        ++ lib.optionals withX11 [
+          libX11
+          libXcursor
+          libXext
+          libXfixes
+          libXi
+          libXinerama
+          libxkbcommon
+          libXrandr
+          libXrender
+        ]
+        ++ lib.optionals withWayland [
+          libdecor
+          wayland
+        ]
+        ++ lib.optionals withDbus [
+          dbus
+          dbus.lib
+        ]
+        ++ lib.optionals withFontconfig [
+          fontconfig
+          fontconfig.lib
+        ]
+        ++ lib.optionals withPulseaudio [ libpulseaudio ]
+        ++ lib.optionals withSpeechd [ speechd-minimal ]
+        ++ lib.optionals withUdev [ udev ];
+
+      installPhase =
+        ''
+          runHook preInstall
+
+          mkdir -p "$out"/{bin,libexec}
+          cp -r bin/* "$out"/libexec
+
+          cd "$out"/bin
+          ln -s ../libexec/${binary} godot${lib.versions.majorMinor version}${suffix}
+          ln -s godot${lib.versions.majorMinor version}${suffix} godot${lib.versions.major version}${suffix}
+          ln -s godot${lib.versions.major version}${suffix} godot${suffix}
+          cd -
+        ''
+        + (
+          if editor then
+            ''
+              installManPage misc/dist/linux/godot.6
+
+              mkdir -p "$out"/share/{applications,icons/hicolor/scalable/apps}
+              cp misc/dist/linux/org.godotengine.Godot.desktop "$out/share/applications/org.godotengine.Godot${lib.versions.majorMinor version}${suffix}.desktop"
+              substituteInPlace "$out/share/applications/org.godotengine.Godot${lib.versions.majorMinor version}${suffix}.desktop" \
+                --replace "Exec=godot" "Exec=$out/bin/godot${suffix}" \
+                --replace "Godot Engine" "Godot Engine ${
+                  lib.versions.majorMinor version + lib.optionalString withMono " (Mono)"
+                }"
+              cp icon.svg "$out/share/icons/hicolor/scalable/apps/godot.svg"
+              cp icon.png "$out/share/icons/godot.png"
+            ''
+            + lib.optionalString withMono ''
+              mkdir -p "$out"/share/nuget
+              mv "$out"/libexec/GodotSharp/Tools/nupkgs "$out"/share/nuget/source
+
+              wrapProgram $out/libexec/${binary} \
+                --set DOTNET_ROOT ${dotnet-sdk}/share/dotnet \
+                --prefix PATH : "${
+                  lib.makeBinPath [
+                    dotnet-sdk
+                  ]
+                }"
+            ''
+          else
+            let
+              template =
+                (lib.replaceStrings
+                  [ "template" ]
+                  [
+                    {
+                      linuxbsd = "linux";
+                    }
+                    .${withPlatform}
+                  ]
+                  target
+                )
+                + "."
+                + arch;
+            in
+            ''
+              templates="$out"/share/godot/export_templates/${dottedVersion}
+              mkdir -p "$templates"
+              ln -s "$out"/libexec/${binary} "$templates"/${template}
+            ''
+        )
+        + ''
+          runHook postInstall
+        '';
+
+      # patching $debug can crash patchelf
+      # (https://github.com/NixOS/patchelf/issues/373), so explicitly patch $out
+      dontAutoPatchelf = true;
+
+      postFixup = ''
+        autoPatchelf "$out"
+      '';
+
+      passthru =
+        {
+          inherit updateScript;
+
+          tests =
+            {
+              version = testers.testVersion {
+                package = finalAttrs.finalPackage;
+                version = dottedVersion;
+              };
+            }
+            // lib.optionalAttrs (editor) (
+              let
+                pkg = finalAttrs.finalPackage;
+
+                project-src = runCommand "${pkg.name}-project-src" { } (
+                  ''
+                    mkdir "$out"
+                    cd "$out"
+                    touch project.godot
+
+                    cat >create-scene.gd <<'EOF'
+                    extends SceneTree
+
+                    func _initialize():
+                      var node = Node.new()
+                      var script = ResourceLoader.load("res://test.gd")
+                      node.set_script(script)
+                  ''
+                  + lib.optionalString withMono ''
+                    ${""}
+                      var monoNode = Node.new()
+                      var monoScript = ResourceLoader.load("res://Test.cs")
+                      monoNode.set_script(monoScript)
+                      node.add_child(monoNode)
+                      monoNode.owner = node
+                  ''
+                  + ''
+                      var scene = PackedScene.new()
+                      var scenePath = "res://test.tscn"
+                      scene.pack(node)
+                      node.free()
+                      var x = ResourceSaver.save(scene, scenePath)
+                      ProjectSettings["application/run/main_scene"] = scenePath
+                      ProjectSettings.save()
+                      quit()
+                    EOF
+
+                    cat >test.gd <<'EOF'
+                    extends Node
+                    func _ready():
+                      print("Hello, World!")
+                      get_tree().quit()
+                    EOF
+
+                    cat >export_presets.cfg <<'EOF'
+                    [preset.0]
+                    name="build"
+                    platform="Linux"
+                    runnable=true
+                    export_filter="all_resources"
+                    include_filter=""
+                    exclude_filter=""
+                    [preset.0.options]
+                    __empty=""
+                    EOF
+                  ''
+                  + lib.optionalString withMono ''
+                    cat >Test.cs <<'EOF'
+                    using Godot;
+                    using System;
+
+                    public partial class Test : Node
+                    {
+                      public override void _Ready()
+                      {
+                        GD.Print("Hello, Mono!");
+                        GetTree().Quit();
+                      }
+                    }
+                    EOF
+
+                    sdk_version=$(basename ${pkg}/share/nuget/packages/godot.net.sdk/*)
+                    cat >UnnamedProject.csproj <<EOF
+                    <Project Sdk="Godot.NET.Sdk/$sdk_version">
+                      <PropertyGroup>
+                        <TargetFramework>net8.0</TargetFramework>
+                        <EnableDynamicLoading>true</EnableDynamicLoading>
+                      </PropertyGroup>
+                    </Project>
+                    EOF
+                  ''
+                );
+
+                export-tests = lib.makeExtensible (final: {
+                  inherit (pkg) export-template;
+
+                  export = stdenvNoCC.mkDerivation {
+                    name = "${final.export-template.name}-export";
+
+                    nativeBuildInputs = [
+                      pkg
+                    ] ++ lib.optional withMono dotnet-sdk;
+
+                    src = project-src;
+
+                    postConfigure = lib.optionalString withMono ''
+                      dotnet new sln -n UnnamedProject
+                      message=$(dotnet sln add UnnamedProject.csproj)
+                      echo "$message"
+                      # dotnet sln doesn't return an error when it fails to add the project
+                      [[ $message == "Project \`UnnamedProject.csproj\` added to the solution." ]]
+                    '';
+
+                    exportTemplate = pkg.export-template;
+
+                    buildPhase = ''
+                      runHook preBuild
+
+                      export HOME=$(mktemp -d)
+                      mkdir -p $HOME/.local/share/godot/
+                      ln -s "${final.export-template}"/share/godot/export_templates "$HOME"/.local/share/godot/
+
+                      godot${suffix} --headless --build-solutions -s create-scene.gd
+
+                      runHook postBuild
+                    '';
+
+                    installPhase = ''
+                      runHook preInstall
+
+                      mkdir -p "$out"/bin
+                      godot${suffix} --headless --export-release build "$out"/bin/test
+
+                      runHook postInstall
+                    '';
+                  };
+
+                  run = runCommand "${final.export.name}-runs" { passthru = { inherit (final) export; }; } (
+                    ''
+                      (
+                        set -eo pipefail
+                        HOME=$(mktemp -d)
+                        "${final.export}"/bin/test --headless | tail -n+3 | (
+                    ''
+                    + lib.optionalString withMono ''
+                      # indent
+                          read output
+                          if [[ "$output" != "Hello, Mono!" ]]; then
+                            echo "unexpected output: $output" >&2
+                            exit 1
+                          fi
+                    ''
+                    + ''
+                          read output
+                          if [[ "$output" != "Hello, World!" ]]; then
+                            echo "unexpected output: $output" >&2
+                            exit 1
+                          fi
+                        )
+                        touch "$out"
+                      )
+                    ''
+                  );
+                });
+
+              in
+              {
+                export-runs = export-tests.run;
+
+                export-bin-runs =
+                  (export-tests.extend (
+                    final: prev: {
+                      export-template = pkg.export-templates-bin;
+
+                      export = prev.export.overrideAttrs (prev: {
+                        nativeBuildInputs = prev.nativeBuildInputs or [ ] ++ [
+                          autoPatchelfHook
+                        ];
+
+                        # stripping dlls results in:
+                        # Failed to load System.Private.CoreLib.dll (error code 0x8007000B)
+                        stripExclude = lib.optional withMono [ "*.dll" ];
+
+                        runtimeDependencies =
+                          prev.runtimeDependencies or [ ]
+                          ++ map lib.getLib [
+                            alsa-lib
+                            libpulseaudio
+                            libX11
+                            libXcursor
+                            libXext
+                            libXi
+                            libXrandr
+                            udev
+                            vulkan-loader
+                          ];
+                      });
+                    }
+                  )).run;
+              }
+            );
+        }
+        // lib.optionalAttrs editor {
+          export-template = mkTarget "template_release";
+          export-templates-bin = (
+            callPackage ./export-templates-bin.nix {
+              inherit version withMono;
+              godot = finalAttrs.finalPackage;
+              hash = exportTemplatesHash;
+            }
+          );
+        };
+
+      requiredSystemFeatures = [
+        # fixes: No space left on device
+        "big-parallel"
+      ];
+
+      meta = {
+        changelog = "https://github.com/godotengine/godot/releases/tag/${version}";
+        description = "Free and Open Source 2D and 3D game engine";
+        homepage = "https://godotengine.org";
+        license = lib.licenses.mit;
+        platforms = [
+          "x86_64-linux"
+          "aarch64-linux"
+        ] ++ lib.optional (!withMono) "i686-linux";
+        maintainers = with lib.maintainers; [
+          shiryel
+          corngood
+        ];
+        mainProgram = "godot${suffix}";
+      };
+    };
+
+  mkTarget =
+    target:
+    let
+      attrs = attrsForTarget target;
+    in
+    stdenv.mkDerivation (
+      if withMono then
+        dotnetCorePackages.addNuGetDeps {
+          inherit nugetDeps;
+          overrideFetchAttrs = old: rec {
+            runtimeIds = map (system: dotnetCorePackages.systemToDotnetRid system) old.meta.platforms;
+            buildInputs =
+              old.buildInputs
+              ++ lib.concatLists (lib.attrValues (lib.getAttrs runtimeIds dotnet-sdk.targetPackages));
+          };
+        } attrs
+      else
+        attrs
+    );
+in
+mkTarget "editor"

--- a/pkgs/development/tools/godot/common.nix
+++ b/pkgs/development/tools/godot/common.nix
@@ -394,7 +394,7 @@ let
                     include_filter=""
                     exclude_filter=""
                     [preset.0.options]
-                    __empty=""
+                    binary_format/architecture="${arch}"
                     EOF
                   ''
                   + lib.optionalString withMono ''

--- a/pkgs/development/tools/godot/default.nix
+++ b/pkgs/development/tools/godot/default.nix
@@ -1,5 +1,9 @@
+# TODO:
+# - combine binary and source tests
+# - filter builtInputs by builtin_ flags
 {
   callPackage,
+  lib,
   nix-update-script,
   fetchzip,
 }:
@@ -8,43 +12,40 @@ let
     versionPrefix:
     let
       attrs = import (./. + "/${versionPrefix}/default.nix");
-      inherit (attrs)
-        version
-        hash
-        exportTemplatesHash
-        nugetDeps
-        ;
+      updateScript = [
+        ./update.sh
+        versionPrefix
+        (builtins.unsafeGetAttrPos "version" attrs).file
+      ];
     in
-    rec {
-      godot = (callPackage ./common.nix { inherit version hash nugetDeps; }).overrideAttrs (old: {
-        passthru = old.passthru or { } // {
-          inherit export-templates-bin;
-          updateScript = [
-            ./update.sh
-            versionPrefix
-            (builtins.unsafeGetAttrPos "version" attrs).file
-          ];
-        };
-      });
+    lib.recurseIntoAttrs rec {
+      godot = callPackage ./common.nix {
+        inherit updateScript;
+        inherit (attrs)
+          version
+          hash
+          ;
+        inherit (attrs.default)
+          exportTemplatesHash
+          ;
+      };
 
       godot-mono = godot.override {
         withMono = true;
+        inherit (attrs.mono)
+          exportTemplatesHash
+          nugetDeps
+          ;
       };
 
-      export-templates-bin = (
-        callPackage ./export-templates-bin.nix {
-          inherit version godot;
-          hash = exportTemplatesHash;
-        }
-      );
-    };
+      export-template = godot.export-template;
+      export-template-mono = godot-mono.export-template;
 
-  godotPackages_4_3 = mkGodotPackages "4.3";
-  godotPackages_4_4 = mkGodotPackages "4.4";
-  godotPackages_4 = godotPackages_4_4;
-  godotPackages = godotPackages_4;
+      export-templates-bin = godot.export-templates-bin;
+      export-templates-mono-bin = godot-mono.export-templates-bin;
+    };
 in
-{
+rec {
   godot3 = callPackage ./3 { };
   godot3-export-templates = callPackage ./3/export-templates.nix { };
   godot3-headless = callPackage ./3/headless.nix { };
@@ -55,6 +56,11 @@ in
   godot3-mono-headless = callPackage ./3/mono/headless.nix { };
   godot3-mono-debug-server = callPackage ./3/mono/debug-server.nix { };
   godot3-mono-server = callPackage ./3/mono/server.nix { };
+
+  godotPackages_4_3 = mkGodotPackages "4.3";
+  godotPackages_4_4 = mkGodotPackages "4.4";
+  godotPackages_4 = godotPackages_4_4;
+  godotPackages = godotPackages_4;
 
   godot_4_3 = godotPackages_4_3.godot;
   godot_4_3-mono = godotPackages_4_3.godot-mono;

--- a/pkgs/development/tools/godot/default.nix
+++ b/pkgs/development/tools/godot/default.nix
@@ -58,14 +58,14 @@ in
 
   godot_4_3 = godotPackages_4_3.godot;
   godot_4_3-mono = godotPackages_4_3.godot-mono;
-  godot_4_3-export-templates = godotPackages_4_3.export-templates-bin;
+  godot_4_3-export-templates-bin = godotPackages_4_3.export-templates-bin;
   godot_4_4 = godotPackages_4_4.godot;
   godot_4_4-mono = godotPackages_4_4.godot-mono;
-  godot_4_4-export-templates = godotPackages_4_4.export-templates-bin;
+  godot_4_4-export-templates-bin = godotPackages_4_4.export-templates-bin;
   godot_4 = godotPackages_4.godot;
   godot_4-mono = godotPackages_4.godot-mono;
-  godot_4-export-templates = godotPackages_4.export-templates-bin;
+  godot_4-export-templates-bin = godotPackages_4.export-templates-bin;
   godot = godotPackages.godot;
   godot-mono = godotPackages.godot-mono;
-  godot-export-templates = godotPackages.export-templates-bin;
+  godot-export-templates-bin = godotPackages.export-templates-bin;
 }

--- a/pkgs/development/tools/godot/export-templates-bin.nix
+++ b/pkgs/development/tools/godot/export-templates-bin.nix
@@ -1,20 +1,41 @@
 {
-  fetchzip,
+  fetchurl,
   godot,
   hash,
   lib,
+  stdenvNoCC,
+  unzip,
   version,
 }:
 # Export templates is necessary for setting up Godot engine, it's used when exporting projects.
 # Godot applications/games packages needs to reference export templates.
 # Export templates version should be kept in sync with Godot version.
 # https://docs.godotengine.org/en/stable/tutorials/export/exporting_projects.html#export-templates
-fetchzip {
+stdenvNoCC.mkDerivation {
   pname = "godot-export-templates";
   version = version;
-  extension = "zip";
-  url = "https://github.com/godotengine/godot/releases/download/${version}/Godot_v${version}_export_templates.tpz";
-  inherit hash;
+
+  src = fetchurl {
+    url = "https://github.com/godotengine/godot/releases/download/${version}/Godot_v${version}_export_templates.tpz";
+    inherit hash;
+  };
+
+  nativeBuildInputs = [
+    unzip
+  ];
+
+  unpackPhase = ''
+    runHook preUnpack
+    unzip -q "$src"
+    runHook postUnpack
+  '';
+
+  installPhase = ''
+    templates="$out"/share/godot/export_templates
+    mkdir -p "$templates"
+    read version < templates/version.txt
+    mv templates "$templates/$version"
+  '';
 
   meta = {
     inherit (godot.meta)

--- a/pkgs/development/tools/godot/export-templates-bin.nix
+++ b/pkgs/development/tools/godot/export-templates-bin.nix
@@ -6,45 +6,52 @@
   stdenvNoCC,
   unzip,
   version,
+  withMono ? false,
 }:
 # Export templates is necessary for setting up Godot engine, it's used when exporting projects.
 # Godot applications/games packages needs to reference export templates.
 # Export templates version should be kept in sync with Godot version.
 # https://docs.godotengine.org/en/stable/tutorials/export/exporting_projects.html#export-templates
-stdenvNoCC.mkDerivation {
-  pname = "godot-export-templates-bin";
-  version = version;
+let
+  self = stdenvNoCC.mkDerivation {
+    pname = "godot-export-templates${lib.optionalString withMono "-mono"}-bin";
+    version = version;
 
-  src = fetchurl {
-    url = "https://github.com/godotengine/godot/releases/download/${version}/Godot_v${version}_export_templates.tpz";
-    inherit hash;
+    src = fetchurl {
+      url = "https://github.com/godotengine/godot/releases/download/${version}/Godot_v${version}${lib.optionalString withMono "_mono"}_export_templates.tpz";
+      inherit hash;
+    };
+
+    nativeBuildInputs = [
+      unzip
+    ];
+
+    unpackPhase = ''
+      runHook preUnpack
+      unzip -q "$src"
+      runHook postUnpack
+    '';
+
+    installPhase = ''
+      templates="$out"/share/godot/export_templates
+      mkdir -p "$templates"
+      read version < templates/version.txt
+      mv templates "$templates/$version"
+    '';
+
+    # this allows update-source-version to work
+    passthru.src = self;
+
+    meta = {
+      inherit (godot.meta)
+        changelog
+        description
+        homepage
+        license
+        maintainers
+        ;
+      sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+    };
   };
-
-  nativeBuildInputs = [
-    unzip
-  ];
-
-  unpackPhase = ''
-    runHook preUnpack
-    unzip -q "$src"
-    runHook postUnpack
-  '';
-
-  installPhase = ''
-    templates="$out"/share/godot/export_templates
-    mkdir -p "$templates"
-    read version < templates/version.txt
-    mv templates "$templates/$version"
-  '';
-
-  meta = {
-    inherit (godot.meta)
-      changelog
-      description
-      homepage
-      license
-      maintainers
-      ;
-    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
-  };
-}
+in
+self

--- a/pkgs/development/tools/godot/export-templates-bin.nix
+++ b/pkgs/development/tools/godot/export-templates-bin.nix
@@ -12,7 +12,7 @@
 # Export templates version should be kept in sync with Godot version.
 # https://docs.godotengine.org/en/stable/tutorials/export/exporting_projects.html#export-templates
 stdenvNoCC.mkDerivation {
-  pname = "godot-export-templates";
+  pname = "godot-export-templates-bin";
   version = version;
 
   src = fetchurl {

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -796,6 +796,10 @@ mapAliases {
   grafana-agent = throw "'grafana-agent' has been removed, as it only works with an EOL compiler and will become EOL during the 25.05 release. Consider migrating to 'grafana-alloy' instead"; # Added 2025-04-02
 
   #godot
+  godot_4_3-export-templates = lib.warnOnInstantiate "godot_4_3-export-templates has been renamed to godot_4_3-export-templates-bin" godot_4_3-export-templates-bin;
+  godot_4_4-export-templates = lib.warnOnInstantiate "godot_4_4-export-templates has been renamed to godot_4_4-export-templates-bin" godot_4_4-export-templates-bin;
+  godot_4-export-templates = lib.warnOnInstantiate "godot_4-export-templates has been renamed to godot_4-export-templates-bin" godot_4-export-templates-bin;
+  godot-export-templates = lib.warnOnInstantiate "godot-export-templates has been renamed to godot-export-templates-bin" godot-export-templates-bin;
 
   go-thumbnailer = thud; # Added 2023-09-21
   go-upower-notify = upower-notify; # Added 2024-07-21

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3164,6 +3164,10 @@ with pkgs;
     godot3-mono-headless
     godot3-mono-debug-server
     godot3-mono-server
+    godotPackages_4_3
+    godotPackages_4_4
+    godotPackages_4
+    godotPackages
     godot_4_3
     godot_4_3-mono
     godot_4_3-export-templates-bin

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3166,16 +3166,16 @@ with pkgs;
     godot3-mono-server
     godot_4_3
     godot_4_3-mono
-    godot_4_3-export-templates
+    godot_4_3-export-templates-bin
     godot_4_4
     godot_4_4-mono
-    godot_4_4-export-templates
+    godot_4_4-export-templates-bin
     godot_4
     godot_4-mono
-    godot_4-export-templates
+    godot_4-export-templates-bin
     godot
     godot-mono
-    godot-export-templates
+    godot-export-templates-bin
     ;
 
   goattracker = callPackage ../applications/audio/goattracker { };


### PR DESCRIPTION
This is a pretty big change to godot 4, which adds a new source-built template package, similar to the one we have for godot 3.

It also adds test coverage for building and running projects using the export templates, for all versions, with and without mono.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [x] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
