### PR TITLE
CONTRIBUTING: Clarify commit separation convention

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -491,19 +491,27 @@ To get a sense for what changes are considered mass rebuilds, see [previously me
 ## Commit conventions
 [commit-conventions]: #commit-conventions
 
-- Create a commit for each logical unit.
+- Commits should be independent and understandable by themselves.
+
+  For example:
+  - For example, when adding yourself as maintainer in the same pull request,
+    make a separate commit with the message `maintainers: add <handle>`.
+    Add the commit before those making changes to the package or module.
+    See [Nixpkgs Maintainers](./maintainers/README.md) for details.
+
+- Later commits that undo changes from earlier commits should be combined.
+
+  For example:
+  - If you have commits `pkg-name: oh, forgot to insert whitespace`: squash commits in this case. Use `git rebase -i`.
+    See [Squashing Commits](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History#_squashing) for additional information.
+
+> [!Note]
+> Reviewers should _not_ ask commit authors to make changes to the commit history unless it _clearly_ violates a written guideline.
+> Notably there is a wide range of acceptable options for the commit history, ranging from many small independent commits to larger commits that are still independent and understandable by themselves.
 
 - Check for unnecessary whitespace with `git diff --check` before committing.
 
-- If you have commits `pkg-name: oh, forgot to insert whitespace`: squash commits in this case. Use `git rebase -i`.
-  See [Squashing Commits](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History#_squashing) for additional information.
-
 - For consistency, there should not be a period at the end of the commit message's summary line (the first line of the commit message).
-
-- When adding yourself as maintainer in the same pull request, make a separate
-  commit with the message `maintainers: add <handle>`.
-  Add the commit before those making changes to the package or module.
-  See [Nixpkgs Maintainers](./maintainers/README.md) for details.
 
 - Make sure you read about any commit conventions specific to the area you're touching. See:
   - [Commit conventions](./pkgs/README.md#commit-conventions) for changes to `pkgs`.


### PR DESCRIPTION
There is frequent turmoil among reviewers as to how to best organise the commit history, most recently https://github.com/NixOS/nixpkgs/pull/398764.

This improves on that by clarifying the guidelines.

Relates to https://github.com/NixOS/nixpkgs/issues/387072

### The new guidelines
- Commits should be independent and understandable by themselves.
- Later commits that undo changes from earlier commits should be combined.
> [!Note]
> Reviewers should _not_ ask commit authors to make changes to the commit history unless it _clearly_ violates a written guideline.
> Notably there is a wide range of acceptable options for the commit history, ranging from many small independent commits to larger commits that are still independent and understandable by themselves.

---

This work is funded by [Antithesis](https://antithesis.com/) and [Tweag](https://tweag.io) :sparkles:

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
