### PR TITLE
xow_dongle-firmware: install and use extra firmware blob, linuxPackages.xone: 0.3-unstable-2024-12-23 -> 0.3.1

### DIFF
--- a/pkgs/by-name/xo/xow_dongle-firmware/package.nix
+++ b/pkgs/by-name/xo/xow_dongle-firmware/package.nix
@@ -47,7 +47,10 @@ stdenvNoCC.mkDerivation rec {
     description = "Xbox One wireless dongle firmware";
     homepage = "https://www.xbox.com/en-NZ/accessories/adapters/wireless-adapter-windows";
     license = licenses.unfree;
-    maintainers = with maintainers; [ rhysmdnz ];
+    maintainers = with maintainers; [
+      rhysmdnz
+      fazzi
+    ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/by-name/xo/xow_dongle-firmware/package.nix
+++ b/pkgs/by-name/xo/xow_dongle-firmware/package.nix
@@ -4,36 +4,50 @@
   fetchurl,
   cabextract,
 }:
-
 stdenvNoCC.mkDerivation rec {
   pname = "xow_dongle-firmware";
-  version = "2017-07";
+  version = "0-unstable-2025-04-22";
+
+  srcs = [
+    (fetchurl {
+      name = "xow_dongle.cab";
+      url = "http://download.windowsupdate.com/c/msdownload/update/driver/drvs/2017/07/1cd6a87c-623f-4407-a52d-c31be49e925c_e19f60808bdcbfbd3c3df6be3e71ffc52e43261e.cab";
+      hash = "sha256-ZXNqhP9ANmRbj47GAr7ZGrY1MBnJyzIz3sq5/uwPbwQ=";
+    })
+    (fetchurl {
+      name = "xow_dongle_045e_02e6.cab";
+      url = "https://catalog.s.download.windowsupdate.com/d/msdownload/update/driver/drvs/2015/12/20810869_8ce2975a7fbaa06bcfb0d8762a6275a1cf7c1dd3.cab";
+      hash = "sha256-5jiKJ6dXVpIN5zryRo461V16/vWavDoLUICU4JHRnwg=";
+    })
+  ];
+
+  sourceRoot = ".";
 
   dontConfigure = true;
   dontBuild = true;
 
-  src = fetchurl {
-    url = "http://download.windowsupdate.com/c/msdownload/update/driver/drvs/2017/07/1cd6a87c-623f-4407-a52d-c31be49e925c_e19f60808bdcbfbd3c3df6be3e71ffc52e43261e.cab";
-    sha256 = "013g1zngxffavqrk5jy934q3bdhsv6z05ilfixdn8dj0zy26lwv5";
-  };
-
   nativeBuildInputs = [ cabextract ];
 
-  sourceRoot = ".";
+  unpackPhase = ''
+    sources=($srcs)
 
-  unpackCmd = ''
-    cabextract -F FW_ACC_00U.bin ${src}
+    cabextract -F FW_ACC_00U.bin ''${sources[0]}
+    mv FW_ACC_00U.bin xow_dongle.bin
+
+    cabextract -F FW_ACC_00U.bin ''${sources[1]}
+    mv FW_ACC_00U.bin xow_dongle_045e_02e6.bin
   '';
 
   installPhase = ''
-    install -Dm644 FW_ACC_00U.bin ${placeholder "out"}/lib/firmware/xow_dongle.bin
+    install -Dm644 xow_dongle.bin $out/lib/firmware/xow_dongle.bin
+    install -Dm644 xow_dongle_045e_02e6.bin $out/lib/firmware/xow_dongle_045e_02e6.bin
   '';
 
   meta = with lib; {
     description = "Xbox One wireless dongle firmware";
     homepage = "https://www.xbox.com/en-NZ/accessories/adapters/wireless-adapter-windows";
     license = licenses.unfree;
-    maintainers = with lib.maintainers; [ rhysmdnz ];
+    maintainers = with maintainers; [ rhysmdnz ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/os-specific/linux/xone/default.nix
+++ b/pkgs/os-specific/linux/xone/default.nix
@@ -4,16 +4,15 @@
   fetchFromGitHub,
   kernel,
 }:
-
 stdenv.mkDerivation (finalAttrs: {
   pname = "xone";
-  version = "0.3-unstable-2024-12-23";
+  version = "0.3.1";
 
   src = fetchFromGitHub {
     owner = "dlundqvist";
     repo = "xone";
-    rev = "6b9d59aed71f6de543c481c33df4705d4a590a31";
-    hash = "sha256-MpxP2cb0KEPKaarjfX/yCbkxIFTwwEwVpTMhFcis+A4=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-qMZlQgAe5vB5zfuhyK7EBxIwfhnC5MvnF/qr3BGnDms=";
   };
 
   setSourceRoot = ''
@@ -43,6 +42,6 @@ stdenv.mkDerivation (finalAttrs: {
       fazzi
     ];
     platforms = platforms.linux;
-    broken = kernel.kernelOlder "5.11";
+    broken = kernel.kernelOlder "6";
   };
 })


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This group of PRs does a few things.

- adds myself as a maintainer of `xow_dongle-firmware`
- installs an extra firmware blob which fixes #308028 
- updates `linuxPackages.xone` to take advantage of this new firmware blob with (https://github.com/dlundqvist/xone/commit/0dbd56e51118a5e7d3a4cecad255d99835985680)
- As a bonus, updating `linuxPackages.xone` should also fix the build for upcoming 6.15 kernels. (https://github.com/dlundqvist/xone/pull/45)
- **The release I've bumped xone to is now finally a proper release. No longer unstable, so I've updated the package to use it from the new 0.3.1 tag**

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
