### PR TITLE
lib.getAttrFromPath: fix docs

### DIFF
--- a/lib/attrsets.nix
+++ b/lib/attrsets.nix
@@ -301,9 +301,9 @@ rec {
     Nix has an [attribute selection operator](https://nixos.org/manual/nix/stable/language/operators#attribute-selection) which is sufficient for such queries, as long as the number of attributes is static. For example:
 
     ```nix
-    x.a.b == getAttrByPath ["a" "b"] x
+    x.a.b == getAttrFromPath ["a" "b"] x
     # and
-    x.${f p}."example.com" == getAttrByPath [ (f p) "example.com" ] x
+    x.${f p}."example.com" == getAttrFromPath [ (f p) "example.com" ] x
     ```
 
     # Inputs


### PR DESCRIPTION
Just noticed this, cc @SigmaSquadron :)

---

This work is funded by [Antithesis](https://antithesis.com/) and [Tweag](https://tweag.io) :sparkles:

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
