### PR TITLE
nixos/unifi: refactor test and package + update to 9.1.119

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1395,7 +1395,7 @@ in
   ulogd = handleTest ./ulogd/ulogd.nix { };
   umurmur = handleTest ./umurmur.nix { };
   unbound = handleTest ./unbound.nix { };
-  unifi = handleTest ./unifi.nix { };
+  unifi = runTest ./unifi.nix;
   unit-php = runTest ./web-servers/unit-php.nix;
   unit-perl = handleTest ./web-servers/unit-perl.nix { };
   upnp.iptables = handleTest ./upnp.nix { useNftables = false; };

--- a/nixos/tests/unifi.nix
+++ b/nixos/tests/unifi.nix
@@ -1,45 +1,30 @@
-# Test UniFi controller
+{ lib, ... }:
 
 {
-  system ? builtins.currentSystem,
-  config ? {
-    allowUnfree = true;
-  },
-  pkgs ? import ../.. { inherit system config; },
-}:
+  name = "unifi";
 
-with import ../lib/testing-python.nix { inherit system pkgs; };
-with pkgs.lib;
+  meta.maintainers = with lib.maintainers; [
+    patryk27
+    zhaofengli
+  ];
 
-let
-  makeAppTest =
-    unifi:
-    makeTest {
-      name = "unifi-controller-${unifi.version}";
-      meta = with pkgs.lib.maintainers; {
-        maintainers = [
-          patryk27
-          zhaofengli
-        ];
-      };
+  node.pkgsReadOnly = false;
 
-      nodes.server = {
-        nixpkgs.config = config;
+  nodes.machine = {
+    nixpkgs.config.allowUnfree = true;
 
-        services.unifi = {
-          enable = true;
-          unifiPackage = unifi;
-          openFirewall = false;
-        };
-      };
+    services.unifi.enable = true;
+  };
 
-      testScript = ''
-        server.wait_for_unit("unifi.service")
-        server.wait_until_succeeds("curl -Lk https://localhost:8443 >&2", timeout=300)
-      '';
-    };
-in
-with pkgs;
-{
-  unifi8 = makeAppTest unifi8;
+  testScript = ''
+    import json
+
+    start_all()
+
+    machine.wait_for_unit("unifi.service")
+    machine.wait_for_open_port(8880)
+
+    status = json.loads(machine.succeed("curl --silent --show-error --fail-with-body http://localhost:8880/status"))
+    assert status["meta"]["rc"] == "ok"
+  '';
 }

--- a/pkgs/by-name/un/unifi/package.nix
+++ b/pkgs/by-name/un/unifi/package.nix
@@ -10,12 +10,12 @@
 
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "unifi-controller";
-  version = "9.0.114";
+  version = "9.1.119";
 
   # see https://community.ui.com/releases / https://www.ui.com/download/unifi
   src = fetchurl {
     url = "https://dl.ui.com/unifi/${finalAttrs.version}/unifi_sysvinit_all.deb";
-    hash = "sha256-3xumIIzr+tx60kPhPfSs2Kz2iJ39Kt5934Vca/MpUu4=";
+    hash = "sha256-YKioJZG8lnVCIh1hrMxFElBKLPHurxWiGJMHKDlX1yE=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/un/unifi/package.nix
+++ b/pkgs/by-name/un/unifi/package.nix
@@ -1,59 +1,55 @@
 {
   lib,
-  stdenv,
+  stdenvNoCC,
   dpkg,
   fetchurl,
   nixosTests,
   systemd,
+  autoPatchelfHook,
 }:
 
-stdenv.mkDerivation rec {
+stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "unifi-controller";
   version = "9.0.114";
 
   # see https://community.ui.com/releases / https://www.ui.com/download/unifi
   src = fetchurl {
-    url = "https://dl.ui.com/unifi/${version}/unifi_sysvinit_all.deb";
+    url = "https://dl.ui.com/unifi/${finalAttrs.version}/unifi_sysvinit_all.deb";
     hash = "sha256-3xumIIzr+tx60kPhPfSs2Kz2iJ39Kt5934Vca/MpUu4=";
   };
 
-  nativeBuildInputs = [ dpkg ];
+  nativeBuildInputs = [
+    dpkg
+    autoPatchelfHook
+  ];
+
+  buildInputs = [
+    systemd
+  ];
 
   installPhase = ''
     runHook preInstall
 
     mkdir -p $out
-    cd ./usr/lib/unifi
-    cp -ar dl lib webapps $out
+    cp -ar usr/lib/unifi/{dl,lib,webapps} $out
 
     runHook postInstall
   '';
 
-  postInstall =
-    if stdenv.hostPlatform.system == "x86_64-linux" then
-      ''
-        patchelf --add-needed "${systemd}/lib/libsystemd.so.0" "$out/lib/native/Linux/x86_64/libubnt_sdnotify_jni.so"
-      ''
-    else if stdenv.hostPlatform.system == "aarch64-linux" then
-      ''
-        patchelf --add-needed "${systemd}/lib/libsystemd.so.0" "$out/lib/native/Linux/aarch64/libubnt_sdnotify_jni.so"
-      ''
-    else
-      null;
-
-  passthru.tests = {
-    unifi = nixosTests.unifi;
-  };
+  passthru.tests = { inherit (nixosTests) unifi; };
 
   meta = with lib; {
-    homepage = "http://www.ubnt.com/";
+    homepage = "https://www.ui.com";
     description = "Controller for Ubiquiti UniFi access points";
     sourceProvenance = with sourceTypes; [ binaryBytecode ];
     license = licenses.unfree;
-    platforms = platforms.unix;
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+    ];
     maintainers = with maintainers; [
       globin
       patryk27
     ];
   };
-}
+})


### PR DESCRIPTION
- use autoPatchElf
- correct supported platforms
- use finalAttrs and stdenvNoCC
- use runTest
- attest the status of the service
- update to 9.1.119


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
