### PR TITLE
snander: init at 1.7.8

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3341,6 +3341,12 @@
     github = "bmilanov";
     githubId = 30090366;
   };
+  bmwagner18 = {
+    name = "Ben Wagner";
+    email = "bmwagner@proton.me";
+    github = "bmwagner18";
+    githubId = 64104085;
+  };
   bmwalters = {
     name = "Bradley Walters";
     email = "oss@walters.app";

--- a/pkgs/by-name/sn/snander/package.nix
+++ b/pkgs/by-name/sn/snander/package.nix
@@ -1,0 +1,53 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  versionCheckHook,
+  nix-update-script,
+  libusb1,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "snander";
+  version = "1.7.8";
+
+  src = fetchFromGitHub {
+    owner = "Droid-Max";
+    repo = "SNANDer";
+    tag = "v.${finalAttrs.version}";
+    hash = "sha256-YsNWjlbUTAURD6eOt8ZVDBGMZT4w0hGFO6N42CdX2XA=";
+  };
+
+  buildInputs = [ libusb1 ];
+
+  makeFlags = [
+    "-C"
+    "src"
+  ];
+
+  installFlags = [
+    "DESTDIR=${placeholder "out"}"
+    "PREFIX="
+  ];
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgramArg = "-h";
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [
+      "--version-regex"
+      ''^v\.(\d+\.\d+\.\d+)$''
+    ];
+  };
+
+  meta = {
+    description = "Serial Nor/nAND/Eeprom programmeR (based on CH341A)";
+    homepage = "https://github.com/Droid-Max/SNANDer";
+    changelog = "https://github.com/Droid-Max/SNANDer/releases/tag/v.${finalAttrs.version}";
+    license = lib.licenses.gpl2Plus;
+    maintainers = with lib.maintainers; [ bmwagner18 ];
+    mainProgram = "snander";
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
https://github.com/Droid-MAX/SNANDer

C program for reading and flashing flash chips using CH341A programmers.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
