### PR TITLE
mcpelauncher-ui-qt: fix build on Qt 6.9

### DIFF
--- a/pkgs/by-name/mc/mcpelauncher-ui-qt/package.nix
+++ b/pkgs/by-name/mc/mcpelauncher-ui-qt/package.nix
@@ -3,6 +3,7 @@
   stdenv,
   mcpelauncher-client,
   fetchFromGitHub,
+  fetchpatch,
   cmake,
   pkg-config,
   zlib,
@@ -27,6 +28,16 @@ stdenv.mkDerivation (finalAttrs: {
 
   patches = [
     ./dont_download_glfw_ui.patch
+    # Qt 6.9 no longer implicitly converts non-char types (such as booleans) to
+    # construct a QChar. This leads to a build failure with Qt 6.9. Upstream
+    # has merged a patch, but has not yet formalized it through a release, so
+    # we must fetch it manually. Remove this fetch on the next point release.
+    (fetchpatch {
+      url = "https://github.com/minecraft-linux/mcpelauncher-ui-qt/commit/0526b1fd6234d84f63b216bf0797463f41d2bea0.diff";
+      hash = "sha256-vL5iqbs50qVh4BKDxTOpCwFQWO2gLeqrVLfnpeB6Yp8=";
+      stripLen = 1;
+      extraPrefix = "mcpelauncher-ui-qt/";
+    })
   ];
 
   nativeBuildInputs = [


### PR DESCRIPTION
Resolves #400889.

Qt 6.9 introduces many changes. One of those changes being the removal of implicit conversions of non-char types in the QChar constructor (commit `9ef4c123c39` on the [full Qt 6.9 changelog](https://code.qt.io/cgit/qt/qtreleasenotes.git/about/qt/6.9.0/release-note.md)). This commit leads to a build failure of mcpelauncher-ui-qt.

Upstream has [merged a patch](https://github.com/minecraft-linux/mcpelauncher-ui-qt/pull/57) that fixes this build failure by casting the values as chars. At the moment, there is no release that includes this patch, so fetchpatch must be used to bring in the patch until the next point release.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
