### PR TITLE
Revert "mongoc: 1.30.2 -> 2.0.0"

### DIFF
--- a/pkgs/by-name/mo/mongoc/package.nix
+++ b/pkgs/by-name/mo/mongoc/package.nix
@@ -14,13 +14,13 @@
 
 stdenv.mkDerivation rec {
   pname = "mongoc";
-  version = "2.0.0";
+  version = "1.30.2";
 
   src = fetchFromGitHub {
     owner = "mongodb";
     repo = "mongo-c-driver";
     tag = version;
-    hash = "sha256-GKXfTrZqdfgxzNi0fM9Ik4XeZGn9IlX75+cXmm5tXPY=";
+    hash = "sha256-RDUrD8MPZd1VBePyR+L5GiT/j5EZIY1KHLQKG5MsuSM=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
Reverts NixOS/nixpkgs#395262

Breaks rsyslog.