### PR TITLE
fontconfig: 2.16.0 -> 2.16.2 

### DIFF
--- a/pkgs/development/libraries/fontconfig/default.nix
+++ b/pkgs/development/libraries/fontconfig/default.nix
@@ -11,6 +11,7 @@
   dejavu_fonts,
   autoreconfHook,
   testers,
+  nix-update-script,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -89,10 +90,14 @@ stdenv.mkDerivation (finalAttrs: {
     mv fonts.conf.tmp $out/etc/fonts/fonts.conf
   '';
 
-  passthru.tests = {
-    pkg-config = testers.hasPkgConfigModules {
-      package = finalAttrs.finalPackage;
+  passthru = {
+    tests = {
+      pkg-config = testers.hasPkgConfigModules {
+        package = finalAttrs.finalPackage;
+      };
     };
+
+    updateScript = nix-update-script { };
   };
 
   meta = with lib; {

--- a/pkgs/development/libraries/fontconfig/default.nix
+++ b/pkgs/development/libraries/fontconfig/default.nix
@@ -17,7 +17,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "fontconfig";
-  version = "2.16.0";
+  version = "2.16.2";
 
   outputs = [
     "bin"
@@ -31,7 +31,7 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "fontconfig";
     repo = "fontconfig";
     tag = finalAttrs.version;
-    hash = "sha256-ELn1WL2kueFj97GfjvjDa82iAJKFv4J5mkHon9vqtXE=";
+    hash = "sha256-R2y5H4JbtpCLRW7BvLXj5H6NrzVZf6+DsaQCuIhibzM=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/libraries/fontconfig/default.nix
+++ b/pkgs/development/libraries/fontconfig/default.nix
@@ -10,6 +10,7 @@
   gperf,
   dejavu_fonts,
   autoreconfHook,
+  versionCheckHook,
   testers,
   nix-update-script,
 }:
@@ -89,6 +90,13 @@ stdenv.mkDerivation (finalAttrs: {
       > fonts.conf.tmp
     mv fonts.conf.tmp $out/etc/fonts/fonts.conf
   '';
+
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+  doInstallCheck = true;
+  versionCheckProgram = "${placeholder "bin"}/bin/fc-list";
+  versionCheckProgramArg = "--version";
 
   passthru = {
     tests = {

--- a/pkgs/development/libraries/fontconfig/default.nix
+++ b/pkgs/development/libraries/fontconfig/default.nix
@@ -100,6 +100,16 @@ stdenv.mkDerivation (finalAttrs: {
   versionCheckProgram = "${placeholder "bin"}/bin/fc-list";
   versionCheckProgramArg = "--version";
 
+  installCheckPhase = ''
+    runHook preInstallCheck
+
+    [ -d "$bin/share/man/man1" ]
+    [ -d "$bin/share/man/man5" ]
+    echo "man pages exist"
+
+    runHook postInstallCheck
+  '';
+
   passthru = {
     tests = {
       pkg-config = testers.hasPkgConfigModules {

--- a/pkgs/development/libraries/fontconfig/default.nix
+++ b/pkgs/development/libraries/fontconfig/default.nix
@@ -1,7 +1,7 @@
 {
   stdenv,
   lib,
-  fetchurl,
+  fetchFromGitLab,
   pkg-config,
   python3,
   freetype,
@@ -24,11 +24,12 @@ stdenv.mkDerivation (finalAttrs: {
     "out"
   ]; # $out contains all the config
 
-  src = fetchurl {
-    url =
-      with finalAttrs;
-      "https://www.freedesktop.org/software/fontconfig/release/${pname}-${version}.tar.xz";
-    hash = "sha256-ajPcVVzJuosQyvdpWHjvE07rNtCvNmBB9jmx2ptu0iA=";
+  src = fetchFromGitLab {
+    domain = "gitlab.freedesktop.org";
+    owner = "fontconfig";
+    repo = "fontconfig";
+    tag = finalAttrs.version;
+    hash = "sha256-ELn1WL2kueFj97GfjvjDa82iAJKFv4J5mkHon9vqtXE=";
   };
 
   nativeBuildInputs = [
@@ -86,9 +87,6 @@ stdenv.mkDerivation (finalAttrs: {
       ${./make-fonts-conf.xsl} $out/etc/fonts/fonts.conf \
       > fonts.conf.tmp
     mv fonts.conf.tmp $out/etc/fonts/fonts.conf
-    # We don't keep section 3 of the manpages, as they are quite large and
-    # probably not so useful.
-    rm -r $bin/share/man/man3
   '';
 
   passthru.tests = {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Diff: https://gitlab.freedesktop.org/fontconfig/fontconfig/-/compare/2.16.0...2.16.2

This PR aims to fix [failing updater](https://nixpkgs-update-logs.nix-community.org/fontconfig/2025-04-15.log)

https://www.freedesktop.org/software/fontconfig/release/ does not include latest releases such as 2.6.1 and 2.6.2.

They use GitLab and the releases since 2.16.1.
It was announced in https://lists.freedesktop.org/archives/fontconfig/2025-March/007154.html.

This change drops man pages it looks not contained in the repository.
I don't know how to keep them in this update.

Before
---

```console
> nix build nixpkgs/nixos-unstable#fontconfig
> tree -a ./result-bin
./result-bin
├── bin
│   ├── fc-cache
│   ├── fc-cat
│   ├── fc-conflist
│   ├── fc-list
│   ├── fc-match
│   ├── fc-pattern
│   ├── fc-query
│   ├── fc-scan
│   └── fc-validate
└── share
    └── man
        ├── man1
        │   ├── fc-cache.1.gz
        │   ├── fc-cat.1.gz
        │   ├── fc-conflist.1.gz
        │   ├── fc-list.1.gz
        │   ├── fc-match.1.gz
        │   ├── fc-pattern.1.gz
        │   ├── fc-query.1.gz
        │   ├── fc-scan.1.gz
        │   └── fc-validate.1.gz
        └── man5
            └── fonts-conf.5.gz

6 directories, 19 files
```

After
---

```console
> nix build .#fontconfig
> tree -a ./result-bin
./result-bin
└── bin
    ├── fc-cache
    ├── fc-cat
    ├── fc-conflist
    ├── fc-list
    ├── fc-match
    ├── fc-pattern
    ├── fc-query
    ├── fc-scan
    └── fc-validate

2 directories, 9 files
```


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

cc: @NixOS/freedesktop 

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
