### PR TITLE
[24.11] linuxKernel.kernels.linux_lqx: 6.12.14-lqx1 -> 6.12.16-lqx1

### DIFF
--- a/pkgs/os-specific/linux/kernel/zen-kernels.nix
+++ b/pkgs/os-specific/linux/kernel/zen-kernels.nix
@@ -19,9 +19,9 @@ let
     };
     # ./update-zen.py lqx
     lqx = {
-      version = "6.12.14"; # lqx
+      version = "6.12.16"; # lqx
       suffix = "lqx1"; # lqx
-      sha256 = "097pg0qaqiy75fdgq92vhj4bxk19q3385x67dl4wclfkfrfn5fiv"; # lqx
+      sha256 = "0b4dwfdn65g8w39ihcg5q1nxj3mfplf5rhc3cmks5wzscg8l766h"; # lqx
       isLqx = true;
     };
   };


### PR DESCRIPTION
Manual backport of https://github.com/NixOS/nixpkgs/pull/384049 because the action doesn't seem to be working.