### PR TITLE
python312Packages.rioxarray: 0.18.2 -> 0.19.0

### DIFF
--- a/pkgs/development/python-modules/rioxarray/default.nix
+++ b/pkgs/development/python-modules/rioxarray/default.nix
@@ -1,17 +1,18 @@
 {
   lib,
   buildPythonPackage,
-  pythonOlder,
   fetchFromGitHub,
 
   # build-system
   setuptools,
+
   # dependencies
   numpy,
   packaging,
   pyproj,
   rasterio,
   xarray,
+
   # tests
   dask,
   netcdf4,
@@ -21,15 +22,14 @@
 
 buildPythonPackage rec {
   pname = "rioxarray";
-  version = "0.18.2";
+  version = "0.19.0";
   pyproject = true;
-  disabled = pythonOlder "3.10";
 
   src = fetchFromGitHub {
     owner = "corteva";
     repo = "rioxarray";
     tag = version;
-    hash = "sha256-HNtMLY83e6MQakIlmsJohmhjDWiM5/hqq25qSY1dPBw=";
+    hash = "sha256-tNcBuMyBVDVPbmujfn4WauquutOEn727lxcR19hfyuE=";
   };
 
   build-system = [ setuptools ];
@@ -49,21 +49,22 @@ buildPythonPackage rec {
   ];
 
   disabledTests =
-    [ "test_clip_geojson__no_drop" ]
-    ++ lib.optionals
-      (stdenv.hostPlatform.system == "aarch64-linux" || stdenv.hostPlatform.system == "aarch64-darwin")
-      [
-        # numerical errors
-        "test_clip_geojson"
-        "test_open_rasterio_mask_chunk_clip"
-      ];
+    [
+      # AssertionError: assert 535727386 == 535691205
+      "test_clip_geojson__no_drop"
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isAarch64 [
+      # numerical errors
+      "test_clip_geojson"
+      "test_open_rasterio_mask_chunk_clip"
+    ];
 
   pythonImportsCheck = [ "rioxarray" ];
 
   meta = {
-    description = "geospatial xarray extension powered by rasterio";
+    description = "Geospatial xarray extension powered by rasterio";
     homepage = "https://corteva.github.io/rioxarray/";
-    changelog = "https://github.com/corteva/rioxarray/releases/tag/${src.tag}";
+    changelog = "https://github.com/corteva/rioxarray/releases/tag/${version}";
     license = lib.licenses.asl20;
     maintainers = lib.teams.geospatial.members;
   };


### PR DESCRIPTION
## Things done

Diff: https://github.com/corteva/rioxarray/compare/refs/tags/0.18.2...refs/tags/0.19.0
Changelog: https://github.com/corteva/rioxarray/releases/tag/0.19.0

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
