### PR TITLE
nixos/rke2: add auto-deploying capabilities

### DIFF
--- a/nixos/modules/services/cluster/rke2/default.nix
+++ b/nixos/modules/services/cluster/rke2/default.nix
@@ -6,6 +6,74 @@
 }:
 let
   cfg = config.services.rke2;
+  manifestDir = "/var/lib/rancher/rke2/server/manifests";
+  # Manifests need a json suffix to be respected by rke2
+  mkManifestTarget = name: if (lib.hasSuffix ".json" name) then name else name + ".json";
+
+  manifestModule = lib.types.submodule (
+    {
+      name,
+      config,
+      options,
+      ...
+    }:
+    {
+      options = {
+        enable = lib.mkOption {
+          type = lib.types.bool;
+          default = true;
+          description = "Whether this manifest file should be generated.";
+        };
+
+        target = lib.mkOption {
+          type = lib.types.nonEmptyStr;
+          example = "my-manifest.json";
+          description = ''
+            Name of the symlink (relative to {file}`${manifestDir}`). Defaults to the attribute
+            name with a `.json` suffix. Target names should avoid `.yaml` endings, as RKE2 tries
+            to open all YAML manifests with write permissions during startup, which will not work
+            with generated files in the Nix store.
+          '';
+        };
+
+        content = lib.mkOption {
+          type = with lib.types; nullOr (either attrs (listOf attrs));
+          default = null;
+          description = ''
+            Content of the manifest file. A list of attribute sets will generate multiple objects
+            in a single manifest file.
+          '';
+        };
+
+        source = lib.mkOption {
+          type = lib.types.path;
+          example = lib.literalExpression "./manifests/app.yaml";
+          description = ''
+            Path of the source manifest file. This will override the `content` option.
+          '';
+        };
+      };
+
+      config = {
+        target = lib.mkDefault (mkManifestTarget name);
+        source = lib.mkIf (config.content != null) (
+          let
+            name' = "rke2-manifest-" + builtins.baseNameOf name;
+            mkSource =
+              content:
+              builtins.toFile name' (
+                builtins.toJSON {
+                  apiVersion = "v1";
+                  kind = "List";
+                  items = lib.toList content;
+                }
+              );
+          in
+          lib.mkDerivedConfig options.content mkSource
+        );
+      };
+    }
+  );
 in
 {
   imports = [ ];
@@ -212,6 +280,95 @@ in
         HOME = "/root";
       };
     };
+
+    manifests = lib.mkOption {
+      type = lib.types.attrsOf manifestModule;
+      default = { };
+      example = lib.literalExpression ''
+        {
+          deployment.source = ../manifests/deployment.yaml;
+          my-service = {
+            enable = false;
+            target = "app-service.yaml";
+            content = {
+              apiVersion = "v1";
+              kind = "Service";
+              metadata = {
+                name = "app-service";
+              };
+              spec = {
+                selector = {
+                  "app.kubernetes.io/name" = "MyApp";
+                };
+                ports = [
+                  {
+                    name = "name-of-service-port";
+                    protocol = "TCP";
+                    port = 80;
+                    targetPort = "http-web-svc";
+                  }
+                ];
+              };
+            };
+          };
+
+          nginx.content = [
+            {
+              apiVersion = "v1";
+              kind = "Pod";
+              metadata = {
+                name = "nginx";
+                labels = {
+                  "app.kubernetes.io/name" = "MyApp";
+                };
+              };
+              spec = {
+                containers = [
+                  {
+                    name = "nginx";
+                    image = "nginx:1.14.2";
+                    ports = [
+                      {
+                        containerPort = 80;
+                        name = "http-web-svc";
+                      }
+                    ];
+                  }
+                ];
+              };
+            }
+            {
+              apiVersion = "v1";
+              kind = "Service";
+              metadata = {
+                name = "nginx-service";
+              };
+              spec = {
+                selector = {
+                  "app.kubernetes.io/name" = "MyApp";
+                };
+                ports = [
+                  {
+                    name = "name-of-service-port";
+                    protocol = "TCP";
+                    port = 80;
+                    targetPort = "http-web-svc";
+                  }
+                ];
+              };
+            }
+          ];
+        };
+      '';
+      description = ''
+        Auto-deploying manifests (AddOns) that are automatically deployed to Kubernetes in a manner
+        similar to `kubectl apply`. Note that removig manifests will not remove or otherwise modify
+        the resources it created. Use the the `--disable` flag or disable AddOns in the config file
+        to delete/disable AddOns. See the
+        [auto-deploying manifests docs](https://docs.rke2.io/advanced#auto-deploying-manifests)
+        for further information.
+      '';
+    };
   };
 
   config = lib.mkIf cfg.enable {
@@ -257,6 +414,19 @@ in
       "kernel.panic" = 10;
       "kernel.panic_on_oops" = 1;
     };
+
+    systemd.tmpfiles.settings."10-rke2" =
+      let
+        enabledManifests = lib.filterAttrs (_: v: v.enable) cfg.manifests;
+        # Make a systemd-tmpfiles rule to link a manifest file
+        mkManifestRule = manifest: {
+          name = "${manifestDir}/${manifest.target}";
+          value = {
+            "L+".argument = "${manifest.source}";
+          };
+        };
+      in
+      (lib.mapAttrs' (_: v: mkManifestRule v) enabledManifests);
 
     systemd.services."rke2-${cfg.role}" = {
       description = "Rancher Kubernetes Engine v2";

--- a/nixos/tests/rke2/multi-node.nix
+++ b/nixos/tests/rke2/multi-node.nix
@@ -60,19 +60,6 @@ import ../make-test-python.nix (
           ...
         }:
         {
-          # Setup image archives to be imported by rke2
-          systemd.tmpfiles.settings."10-rke2" = {
-            "/var/lib/rancher/rke2/agent/images/rke2-images-core.tar.zst" = {
-              "L+".argument = "${coreImages}";
-            };
-            "/var/lib/rancher/rke2/agent/images/rke2-images-canal.tar.zst" = {
-              "L+".argument = "${canalImages}";
-            };
-            "/var/lib/rancher/rke2/agent/images/hello.tar.zst" = {
-              "L+".argument = "${helloImage}";
-            };
-          };
-
           # Canal CNI with VXLAN
           networking.firewall.allowedUDPPorts = [ 8472 ];
           networking.firewall.allowedTCPPorts = [
@@ -104,6 +91,11 @@ import ../make-test-python.nix (
               "rke2-snapshot-controller"
               "rke2-snapshot-controller-crd"
               "rke2-snapshot-validation-webhook"
+            ];
+            images = [
+              coreImages
+              canalImages
+              helloImage
             ];
             manifests = {
               canal-config.content = canalConfig;
@@ -146,19 +138,6 @@ import ../make-test-python.nix (
           ...
         }:
         {
-          # Setup image archives to be imported by rke2
-          systemd.tmpfiles.settings."10-rke2" = {
-            "/var/lib/rancher/rke2/agent/images/rke2-images-core.linux-amd64.tar.zst" = {
-              "L+".argument = "${coreImages}";
-            };
-            "/var/lib/rancher/rke2/agent/images/rke2-images-canal.linux-amd64.tar.zst" = {
-              "L+".argument = "${canalImages}";
-            };
-            "/var/lib/rancher/rke2/agent/images/hello.tar.zst" = {
-              "L+".argument = "${helloImage}";
-            };
-          };
-
           # Canal CNI health checks
           networking.firewall.allowedTCPPorts = [ 9099 ];
           # Canal CNI with VXLAN
@@ -176,6 +155,11 @@ import ../make-test-python.nix (
             serverAddr = "https://${nodes.server.networking.primaryIPAddress}:9345";
             nodeIP = config.networking.primaryIPAddress;
             manifests.canal-config.content = canalConfig;
+            images = [
+              coreImages
+              canalImages
+              helloImage
+            ];
           };
         };
     };

--- a/nixos/tests/rke2/single-node.nix
+++ b/nixos/tests/rke2/single-node.nix
@@ -45,19 +45,6 @@ import ../make-test-python.nix (
         ...
       }:
       {
-        # Setup image archives to be imported by rke2
-        systemd.tmpfiles.settings."10-rke2" = {
-          "/var/lib/rancher/rke2/agent/images/rke2-images-core.tar.zst" = {
-            "L+".argument = "${coreImages}";
-          };
-          "/var/lib/rancher/rke2/agent/images/rke2-images-canal.tar.zst" = {
-            "L+".argument = "${canalImages}";
-          };
-          "/var/lib/rancher/rke2/agent/images/hello.tar.zst" = {
-            "L+".argument = "${helloImage}";
-          };
-        };
-
         # RKE2 needs more resources than the default
         virtualisation.cores = 4;
         virtualisation.memorySize = 4096;
@@ -77,6 +64,11 @@ import ../make-test-python.nix (
             "rke2-snapshot-controller"
             "rke2-snapshot-controller-crd"
             "rke2-snapshot-validation-webhook"
+          ];
+          images = [
+            coreImages
+            canalImages
+            helloImage
           ];
           manifests = {
             test-job.content = {

--- a/nixos/tests/rke2/single-node.nix
+++ b/nixos/tests/rke2/single-node.nix
@@ -26,19 +26,13 @@ import ../make-test-python.nix (
       copyToRoot = pkgs.hello;
       config.Entrypoint = [ "${pkgs.hello}/bin/hello" ];
     };
-    testJobYaml = pkgs.writeText "test.yaml" ''
-      apiVersion: batch/v1
-      kind: Job
-      metadata:
-        name: test
-      spec:
-        template:
-          spec:
-            containers:
-            - name: test
-              image: "test.local/hello:local"
-            restartPolicy: Never
-    '';
+    # A ConfigMap in regular yaml format
+    cmFile = (pkgs.formats.yaml { }).generate "rke2-manifest-from-file.yaml" {
+      apiVersion = "v1";
+      kind = "ConfigMap";
+      metadata.name = "from-file";
+      data.username = "foo-file";
+    };
   in
   {
     name = "${rke2.name}-single-node";
@@ -84,6 +78,42 @@ import ../make-test-python.nix (
             "rke2-snapshot-controller-crd"
             "rke2-snapshot-validation-webhook"
           ];
+          manifests = {
+            test-job.content = {
+              apiVersion = "batch/v1";
+              kind = "Job";
+              metadata.name = "test";
+              spec.template.spec = {
+                containers = [
+                  {
+                    name = "hello";
+                    image = "${helloImage.imageName}:${helloImage.imageTag}";
+                  }
+                ];
+                restartPolicy = "Never";
+              };
+            };
+            disabled = {
+              enable = false;
+              content = {
+                apiVersion = "v1";
+                kind = "ConfigMap";
+                metadata.name = "disabled";
+                data.username = "foo";
+              };
+            };
+            from-file.source = "${cmFile}";
+            custom-target = {
+              enable = true;
+              target = "my-manifest.json";
+              content = {
+                apiVersion = "v1";
+                kind = "ConfigMap";
+                metadata.name = "custom-target";
+                data.username = "foo-custom";
+              };
+            };
+          };
         };
       };
 
@@ -95,14 +125,28 @@ import ../make-test-python.nix (
       ''
         start_all()
 
-        machine.wait_for_unit("rke2-server")
-        machine.succeed("${kubectl} cluster-info")
+        with subtest("Start cluster"):
+          machine.wait_for_unit("rke2-server")
+          machine.succeed("${kubectl} cluster-info")
+          machine.wait_until_succeeds("${kubectl} get serviceaccount default")
 
-        machine.wait_until_succeeds("${kubectl} get serviceaccount default")
-        machine.succeed("${kubectl} apply -f ${testJobYaml}")
-        machine.wait_until_succeeds("${kubectl} wait --for 'condition=complete' job/test")
-        output = machine.succeed("${kubectl} logs -l batch.kubernetes.io/job-name=test")
-        assert output.rstrip() == "Hello, world!", f"unexpected output of test job: {output}"
+        with subtest("Test job completes successfully"):
+          machine.wait_until_succeeds("${kubectl} wait --for 'condition=complete' job/test")
+          output = machine.succeed("${kubectl} logs -l batch.kubernetes.io/job-name=test").rstrip()
+          assert output == "Hello, world!", f"unexpected output of test job: {output}"
+
+        with subtest("ConfigMap from-file exists"):
+          output = machine.succeed("${kubectl} get cm from-file -o=jsonpath='{.data.username}'").rstrip()
+          assert output == "foo-file", f"Unexpected data in Configmap from-file: {output}"
+
+        with subtest("ConfigMap custom-target exists"):
+          # Check that the file exists at the custom target path
+          machine.succeed("ls /var/lib/rancher/rke2/server/manifests/my-manifest.json")
+          output = machine.succeed("${kubectl} get cm custom-target -o=jsonpath='{.data.username}'").rstrip()
+          assert output == "foo-custom", f"Unexpected data in Configmap custom-target: {output}"
+
+        with subtest("Disabled ConfigMap doesn't exist"):
+          machine.fail("${kubectl} get cm disabled")
       '';
   }
 )


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Add an option for auto-deploying manifests (AddOns): https://docs.rke2.io/advanced#auto-deploying-manifests
- Add an option to automatically import container images: https://docs.rke2.io/install/airgap#tarball-method

This allows to configure cluster workloads directly in the Nix config, instead of applying them at runtime, and helps in building reproducible nodes. Both options are used and covered extensively in the RKE2 module tests.

@stefan-bordei @zimbatm 

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
