### PR TITLE
python3Packages.rendez and reunion: init at unstable-2025-04-20

### DIFF
--- a/pkgs/by-name/hi/highctidh/package.nix
+++ b/pkgs/by-name/hi/highctidh/package.nix
@@ -1,51 +1,97 @@
 {
   fetchgit,
+  # unused for python module package because that provides all field sizes
   fieldSize ? 2048,
   lib,
   stdenv,
   useAssemblyBackendIfAvailable ? true,
+  # `"c-library"` | `"python-module"`
+  package ? "c-library",
+  python3Packages,
 }:
 let
   filename = "libhighctidh_${toString fieldSize}.so";
+
+  commonAttrs = finalAttrs: {
+    version = "1.0.2024092800";
+
+    src = fetchgit {
+      url = "https://codeberg.org/vula/highctidh.git";
+      rev = "v${finalAttrs.version}";
+      hash = "sha256-UStNvXnaFLxL9aiMtxAKB8IbC0qnB6Pw+BObtG1XGKg=";
+    };
+
+    sourceRoot = "${finalAttrs.src.name}/src";
+
+    env.${if useAssemblyBackendIfAvailable then null else "HIGHCTIDH_PORTABLE"} = "1";
+
+    meta = with lib; {
+      homepage = "https://codeberg.org/vula/highctidh";
+      description = "high-ctidh fork as a portable shared library";
+      maintainers = with maintainers; [ mightyiam ];
+      license = licenses.publicDomain;
+    };
+  };
+
+  impl = {
+    c-library = stdenv.mkDerivation (
+      finalAttrs:
+      commonAttrs finalAttrs
+      // {
+        pname = "libhighctidh_${toString fieldSize}";
+
+        buildFlags = [ filename ];
+
+        doCheck = true;
+
+        checkTarget = lib.concatStringsSep " " [
+          "testrandom"
+          "test${toString fieldSize}"
+        ];
+
+        installPhase = ''
+          $preInstall
+
+          mkdir -p $out/include/libhighctidh
+          cp *.h $out/include/libhighctidh
+
+          mkdir -p $out/lib
+          cp ${filename} $out/lib
+
+          $postInstall
+        '';
+      }
+    );
+
+    # Not using `buildPythonPackage` because want attr overrides and
+    # https://github.com/NixOS/nixpkgs/issues/258246
+
+    # Ideally, the python module would depend on the c library package,
+    # but upstream claims that that is currently impossible:
+    # > later, we can - but as of today, it isn't linking it as a library
+    # > the python compiles a .so file (four) internally and uses ctypes to load it.
+    # > This means it can work in a virtual environment regardless of the system library versions of highctidh installed.
+    # > it's a bad idea but it surprisingly works ;)
+    # So the python module builds all four library variants (four field sizes).
+    python-module = stdenv.mkDerivation (
+      finalAttrs:
+      commonAttrs finalAttrs
+      // {
+        pname = "highctidh";
+
+        pyproject = true;
+
+        nativeBuildInputs = with python3Packages; [
+          pypaBuildHook
+          pythonImportsCheckHook
+          pythonRemoveBinBytecodeHook
+          setuptoolsBuildHook
+          pipInstallHook
+        ];
+
+        nativeCheckInputs = [ python3Packages.pytestCheckHook ];
+      }
+    );
+  };
 in
-stdenv.mkDerivation (finalAttrs: {
-  pname = "libhighctidh_${toString fieldSize}";
-  version = "1.0.2024092800";
-
-  src = fetchgit {
-    url = "https://codeberg.org/vula/highctidh.git";
-    rev = "v${finalAttrs.version}";
-    hash = "sha256-UStNvXnaFLxL9aiMtxAKB8IbC0qnB6Pw+BObtG1XGKg=";
-  };
-
-  sourceRoot = "${finalAttrs.src.name}/src";
-
-  buildFlags = [ filename ];
-
-  doCheck = true;
-  checkTarget = lib.concatStringsSep " " [
-    "testrandom"
-    "test${toString fieldSize}"
-  ];
-
-  installPhase = ''
-    $preInstall
-
-    mkdir -p $out/include/libhighctidh
-    cp *.h $out/include/libhighctidh
-
-    mkdir -p $out/lib
-    cp ${filename} $out/lib
-
-    $postInstall
-  '';
-
-  env.${if useAssemblyBackendIfAvailable then null else "HIGHCTIDH_PORTABLE"} = "1";
-
-  meta = with lib; {
-    homepage = "https://codeberg.org/vula/highctidh";
-    description = "high-ctidh fork as a portable shared library";
-    maintainers = with maintainers; [ mightyiam ];
-    license = licenses.publicDomain;
-  };
-})
+impl.${package}

--- a/pkgs/by-name/hi/highctidh/package.nix
+++ b/pkgs/by-name/hi/highctidh/package.nix
@@ -1,0 +1,51 @@
+{
+  fetchgit,
+  fieldSize ? 2048,
+  lib,
+  stdenv,
+  useAssemblyBackendIfAvailable ? true,
+}:
+let
+  filename = "libhighctidh_${toString fieldSize}.so";
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "libhighctidh_${toString fieldSize}";
+  version = "1.0.2024092800";
+
+  src = fetchgit {
+    url = "https://codeberg.org/vula/highctidh.git";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-UStNvXnaFLxL9aiMtxAKB8IbC0qnB6Pw+BObtG1XGKg=";
+  };
+
+  sourceRoot = "${finalAttrs.src.name}/src";
+
+  buildFlags = [ filename ];
+
+  doCheck = true;
+  checkTarget = lib.concatStringsSep " " [
+    "testrandom"
+    "test${toString fieldSize}"
+  ];
+
+  installPhase = ''
+    $preInstall
+
+    mkdir -p $out/include/libhighctidh
+    cp *.h $out/include/libhighctidh
+
+    mkdir -p $out/lib
+    cp ${filename} $out/lib
+
+    $postInstall
+  '';
+
+  env.${if useAssemblyBackendIfAvailable then null else "HIGHCTIDH_PORTABLE"} = "1";
+
+  meta = with lib; {
+    homepage = "https://codeberg.org/vula/highctidh";
+    description = "high-ctidh fork as a portable shared library";
+    maintainers = with maintainers; [ mightyiam ];
+    license = licenses.publicDomain;
+  };
+})

--- a/pkgs/development/python-modules/pymonocypher/default.nix
+++ b/pkgs/development/python-modules/pymonocypher/default.nix
@@ -1,0 +1,49 @@
+{
+  buildPythonPackage,
+  cython,
+  fetchFromGitHub,
+  lib,
+  monocypher,
+  numpy,
+  setuptools,
+  unittestCheckHook,
+}:
+let
+  version = "4.0.2.5";
+in
+buildPythonPackage {
+  pname = "pymonocypher";
+  inherit version;
+
+  pyproject = true;
+  build-system = [
+    cython
+    setuptools
+  ];
+
+  src = fetchFromGitHub {
+    owner = "jetperch";
+    repo = "pymonocypher";
+    rev = "v${version}";
+    hash = "sha256-3vnF2MnrjI7pRiOTjPZ0D8tDojfdGJ2kSlLqF7Kkp5Y=";
+  };
+
+  buildInputs = [ monocypher ];
+
+  doCheck = true;
+
+  pythonImportsCheck = [ "monocypher" ];
+
+  nativeCheckInputs = [ unittestCheckHook ];
+  checkInputs = [ numpy ];
+
+  meta = with lib; {
+    description = "Python bindings for Monocypher crypto library";
+    homepage = "https://github.com/jetperch/pymonocypher";
+    license = [
+      licenses.bsd2
+      licenses.cc0
+    ];
+    maintainers = with maintainers; [ mightyiam ];
+  };
+}

--- a/pkgs/development/python-modules/rendez/default.nix
+++ b/pkgs/development/python-modules/rendez/default.nix
@@ -1,0 +1,59 @@
+{
+  asgiref,
+  buildPythonPackage,
+  click,
+  cryptography,
+  fetchgit,
+  flask,
+  flit-core,
+  highctidh,
+  ifaddr,
+  lib,
+  pymonocypher,
+  pysocks,
+  requests,
+  stem,
+  toml,
+  unittestCheckHook,
+}:
+buildPythonPackage {
+  pname = "rendez";
+  version = "1.2.1-unstable-2025-04-20";
+
+  src = fetchgit {
+    url = "https://codeberg.org/rendezvous/reunion.git";
+    rev = "070fff7bcd233afde008b222413c6d757ee4b9a7";
+    hash = "sha256-5aHHSeydDUA/Umf6YCzywVaTdmuLIu6RSCJuypUKWcQ=";
+  };
+
+  pyproject = true;
+  nativeBuildInputs = [ flit-core ];
+
+  dependencies = [
+    asgiref
+    click
+    cryptography
+    flask
+    flask.optional-dependencies.async
+    highctidh
+    ifaddr
+    pymonocypher
+    pysocks
+    requests
+    stem
+    toml
+  ];
+
+  doCheck = true;
+
+  pythonImportsCheck = [ "rendez" ];
+
+  nativeCheckInputs = [ unittestCheckHook ];
+
+  meta = with lib; {
+    description = "The reference implementation of the REUNION cryptographic redezvous protocol";
+    homepage = "https://codeberg.org/rendezvous/reunion";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ mightyiam ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8940,6 +8940,11 @@ with pkgs;
     inherit (darwin.apple_sdk.frameworks) Cocoa IOKit;
   };
 
+  highctidh_511 = callPackage ../by-name/hi/highctidh/package.nix { fieldSize = 511; };
+  highctidh_512 = callPackage ../by-name/hi/highctidh/package.nix { fieldSize = 512; };
+  highctidh_1024 = callPackage ../by-name/hi/highctidh/package.nix { fieldSize = 1024; };
+  highctidh_2048 = callPackage ../by-name/hi/highctidh/package.nix { fieldSize = 2048; };
+
   highfive-mpi = highfive.override { hdf5 = hdf5-mpi; };
 
   hivex = callPackage ../development/libraries/hivex {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4676,6 +4676,8 @@ with pkgs;
   inherit (callPackage ../development/misc/resholve { })
     resholve;
 
+  reunion = with python3Packages; toPythonApplication rendez;
+
   reuse = with python3.pkgs; toPythonApplication reuse;
 
   riemann-tools = callPackage ../tools/misc/riemann-tools { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6195,6 +6195,13 @@ self: super: with self; {
 
   hieroglyph = callPackage ../development/python-modules/hieroglyph { };
 
+  highctidh = toPythonModule (
+    pkgs.highctidh.override {
+      python3Packages = self;
+      package = "python-module";
+    }
+  );
+
   highdicom = callPackage ../development/python-modules/highdicom { };
 
   highspy = callPackage ../development/python-modules/highspy { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -12619,6 +12619,8 @@ self: super: with self; {
 
   pymongo-inmemory = callPackage ../development/python-modules/pymongo-inmemory { };
 
+  pymonocypher = callPackage ../development/python-modules/pymonocypher { };
+
   pymoo = callPackage ../development/python-modules/pymoo { };
 
   pymorphy2 = callPackage ../development/python-modules/pymorphy2 { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -14764,6 +14764,8 @@ self: super: with self; {
 
   rencode = callPackage ../development/python-modules/rencode { };
 
+  rendez = callPackage ../development/python-modules/rendez { };
+
   reno = callPackage ../development/python-modules/reno { };
 
   renson-endura-delta = callPackage ../development/python-modules/renson-endura-delta { };


### PR DESCRIPTION
The reference implementation of the REUNION cryptographic redezvous protocol

https://codeberg.org/rendezvous/reunion

Dependencies:
- https://github.com/NixOS/nixpkgs/pull/401063 (cherry picked here)
- https://github.com/NixOS/nixpkgs/pull/395228 (this PR is based on top of that)

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
