### PR TITLE
notion: 4.0.2 -> 4.0.3; fix build failure

### DIFF
--- a/pkgs/by-name/no/notion/package.nix
+++ b/pkgs/by-name/no/notion/package.nix
@@ -19,7 +19,6 @@
   xmessage,
   xterm,
 }:
-
 stdenv.mkDerivation (finalAttrs: {
   pname = "notion";
   version = "4.0.2";
@@ -31,8 +30,13 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-u5KoTI+OcnQu9m8/Lmsmzr8lEk9tulSE7RRFhj1oXJM=";
   };
 
-  # error: 'PATH_MAX' undeclared
   postPatch = ''
+    # Fix build failure due missing headers
+    sed -i '1i#define _POSIX_C_SOURCE 200809L' mod_notionflux/notionflux/notionflux.c
+    sed -i '2i#include <stdio.h>' mod_notionflux/notionflux/notionflux.c
+    sed -i '3i#include <string.h>' mod_notionflux/notionflux/notionflux.c
+
+    # error: 'PATH_MAX' undeclared
     sed 1i'#include <linux/limits.h>' -i mod_notionflux/notionflux/notionflux.c
   '';
 

--- a/pkgs/by-name/no/notion/package.nix
+++ b/pkgs/by-name/no/notion/package.nix
@@ -96,6 +96,7 @@ stdenv.mkDerivation (finalAttrs: {
     maintainers = with lib.maintainers; [
       jfb
       raboof
+      NotAShelf
     ];
     platforms = lib.platforms.linux;
   };

--- a/pkgs/by-name/no/notion/package.nix
+++ b/pkgs/by-name/no/notion/package.nix
@@ -21,13 +21,13 @@
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "notion";
-  version = "4.0.2";
+  version = "4.0.3";
 
   src = fetchFromGitHub {
     owner = "raboof";
     repo = "notion";
-    rev = finalAttrs.version;
-    hash = "sha256-u5KoTI+OcnQu9m8/Lmsmzr8lEk9tulSE7RRFhj1oXJM=";
+    tag = finalAttrs.version;
+    hash = "sha256-Ll4thDS8fHxkm2IuGjePPVPyPPrz7yDzpKVloFuk/yE=";
   };
 
   postPatch = ''


### PR DESCRIPTION
Fixes build errors in Notion (the tiling WM) by including missing headers
(`stdio.h`, `string.h`, `linux/limits.h`) and defining `_POSIX_C_SOURCE`. This
fixes issues with strdup, fdopen, and PATH_MAX when compiling under stricter C
standards, which we enforce.

I've also taken the liberty of updating the package to the latest tag, and adding myself to maintainers.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
