### PR TITLE
telepathy-logger: revert drop

### DIFF
--- a/nixos/modules/services/desktops/telepathy.nix
+++ b/nixos/modules/services/desktops/telepathy.nix
@@ -41,6 +41,7 @@
     # Enable runtime optional telepathy in gnome-shell
     services.xserver.desktopManager.gnome.sessionPath = with pkgs; [
       telepathy-glib
+      telepathy-logger
     ];
   };
 

--- a/pkgs/by-name/te/telepathy-logger/package.nix
+++ b/pkgs/by-name/te/telepathy-logger/package.nix
@@ -1,0 +1,73 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  dbus-glib,
+  libxml2,
+  sqlite,
+  telepathy-glib,
+  python3,
+  pkg-config,
+  dconf,
+  makeWrapper,
+  intltool,
+  libxslt,
+  gobject-introspection,
+  dbus,
+  fetchpatch,
+  darwin,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "telepathy-logger";
+  version = "0.8.2";
+
+  src = fetchurl {
+    url = "https://telepathy.freedesktop.org/releases/telepathy-logger/telepathy-logger-${version}.tar.bz2";
+    sha256 = "1bjx85k7jyfi5pvl765fzc7q2iz9va51anrc2djv7caksqsdbjlg";
+  };
+
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/archlinux/svntogit-packages/raw/2b5bdbb4739d3517f5e7300edc8dab775743b96d/trunk/0001-tools-Fix-the-build-with-Python-3.patch";
+      hash = "sha256-o1lfdZIIqaxn7ntQZnoOMqquc6efTHgSIxB5dpFWRgg=";
+    })
+  ];
+
+  nativeBuildInputs = [
+    makeWrapper
+    pkg-config
+    intltool
+    libxslt
+    gobject-introspection
+    python3
+  ];
+  buildInputs =
+    [
+      dbus-glib
+      libxml2
+      sqlite
+      telepathy-glib
+      dbus
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [
+      darwin.apple_sdk.frameworks.AppKit
+      darwin.apple_sdk.frameworks.Foundation
+    ];
+
+  configureFlags = [ "--enable-call" ];
+
+  preFixup = ''
+    wrapProgram "$out/libexec/telepathy-logger" \
+      --prefix GIO_EXTRA_MODULES : "${lib.getLib dconf}/lib/gio/modules" \
+      --prefix XDG_DATA_DIRS : "$GSETTINGS_SCHEMAS_PATH"
+  '';
+
+  meta = with lib; {
+    description = "Logger service for Telepathy framework";
+    homepage = "https://telepathy.freedesktop.org/components/telepathy-logger/";
+    license = licenses.lgpl21Plus;
+    maintainers = [ ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/by-name/te/telepathy-logger/package.nix
+++ b/pkgs/by-name/te/telepathy-logger/package.nix
@@ -55,6 +55,8 @@ stdenv.mkDerivation rec {
       darwin.apple_sdk.frameworks.Foundation
     ];
 
+  env.CFLAGS = "-Wno-error=incompatible-pointer-types";
+
   configureFlags = [ "--enable-call" ];
 
   preFixup = ''

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -1730,7 +1730,6 @@ mapAliases {
   teamspeak5_client = teamspeak6-client; # Added 2025-01-29
   teck-programmer = throw "teck-programmer was removed because it was broken and unmaintained"; # added 2024-08-23
   telepathy-gabble = throw "'telepathy-gabble' has been removed as it was unmaintained, unused, broken and used outdated libraries"; # Added 2025-04-20
-  telepathy-logger = throw "'telepathy-logger' has been removed as it was unmaintained, unused and broken"; # Added 2025-04-20
   teleport_13 = throw "teleport 13 has been removed as it is EOL. Please upgrade to Teleport 14 or later"; # Added 2024-05-26
   teleport_14 = throw "teleport 14 has been removed as it is EOL. Please upgrade to Teleport 15 or later"; # Added 2024-10-18
   teleport_15 = throw "teleport 15 has been removed as it is EOL. Please upgrade to Teleport 16 or later"; # Added 2025-03-28


### PR DESCRIPTION
Partial revert of https://github.com/NixOS/nixpkgs/pull/400308
Reverts https://github.com/NixOS/nixpkgs/pull/400329
Includes https://github.com/NixOS/nixpkgs/pull/384284
Part of https://github.com/NixOS/nixpkgs/issues/388196

Judging by https://github.com/NixOS/nixpkgs/pull/400308#issuecomment-2824601721, people are still using `telepathy-logger` and it shouldn't have been removed.

I kept the fix commit as authored by @poly2it.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
