### PR TITLE
cosmic: allow users to exclude packages

### DIFF
--- a/nixos/modules/services/desktop-managers/cosmic.nix
+++ b/nixos/modules/services/desktop-managers/cosmic.nix
@@ -13,6 +13,32 @@
 
 let
   cfg = config.services.desktopManager.cosmic;
+  # **ONLY ADD PACKAGES WITHOUT WHICH COSMIC CRASHES, NOTHING ELSE**
+  corePkgs =
+    with pkgs;
+    [
+      cosmic-applets
+      cosmic-applibrary
+      cosmic-bg
+      cosmic-comp
+      cosmic-files
+      config.services.displayManager.cosmic-greeter.package
+      cosmic-idle
+      cosmic-launcher
+      cosmic-notifications
+      cosmic-osd
+      cosmic-panel
+      cosmic-session
+      cosmic-settings
+      cosmic-settings-daemon
+      cosmic-workspaces-epoch
+    ]
+    ++ lib.optionals cfg.xwayland.enable [
+      # Why would you want to enable XWayland but exclude the package
+      # providing XWayland support? Doesn't make sense. Add `xwayland` to the
+      # `corePkgs` list.
+      xwayland
+    ];
 in
 {
   meta.maintainers = lib.teams.cosmic.members;
@@ -41,44 +67,30 @@ in
       "/share/cosmic"
     ];
     environment.systemPackages = utils.removePackagesByName (
-      with pkgs;
-      [
-        adwaita-icon-theme
-        alsa-utils
-        cosmic-applets
-        cosmic-applibrary
-        cosmic-bg
-        cosmic-comp
-        cosmic-edit
-        cosmic-files
-        config.services.displayManager.cosmic-greeter.package
-        cosmic-icons
-        cosmic-idle
-        cosmic-launcher
-        cosmic-notifications
-        cosmic-osd
-        cosmic-panel
-        cosmic-player
-        cosmic-randr
-        cosmic-screenshot
-        cosmic-session
-        cosmic-settings
-        cosmic-settings-daemon
-        cosmic-term
-        cosmic-wallpapers
-        cosmic-workspaces-epoch
-        hicolor-icon-theme
-        playerctl
-        pop-icon-theme
-        pop-launcher
-        xdg-user-dirs
-      ]
-      ++ lib.optionals cfg.xwayland.enable [
-        xwayland
-      ]
-      ++ lib.optionals config.services.flatpak.enable [
-        cosmic-store
-      ]
+      corePkgs
+      ++ (
+        with pkgs;
+        [
+          adwaita-icon-theme
+          alsa-utils
+          cosmic-edit
+          cosmic-icons
+          cosmic-player
+          cosmic-randr
+          cosmic-screenshot
+          cosmic-term
+          cosmic-wallpapers
+          hicolor-icon-theme
+          playerctl
+          pop-icon-theme
+          pop-launcher
+          xdg-user-dirs
+        ]
+        ++ lib.optionals config.services.flatpak.enable [
+          # User may have Flatpaks enabled but might not want the `cosmic-store` package.
+          cosmic-store
+        ]
+      )
     ) config.environment.cosmic.excludePackages;
 
     # Distro-wide defaults for graphical sessions

--- a/nixos/modules/services/desktop-managers/cosmic.nix
+++ b/nixos/modules/services/desktop-managers/cosmic.nix
@@ -7,6 +7,7 @@
   config,
   lib,
   pkgs,
+  utils,
   ...
 }:
 
@@ -24,6 +25,13 @@ in
         default = true;
       };
     };
+
+    environment.cosmic.excludePackages = lib.mkOption {
+      description = "List of packages to exclude from the COSMIC environment.";
+      type = lib.types.listOf lib.types.package;
+      default = [ ];
+      example = lib.literalExpression "[ pkgs.cosmic-player ]";
+    };
   };
 
   config = lib.mkIf cfg.enable {
@@ -32,7 +40,7 @@ in
       "/share/backgrounds"
       "/share/cosmic"
     ];
-    environment.systemPackages =
+    environment.systemPackages = utils.removePackagesByName (
       with pkgs;
       [
         adwaita-icon-theme
@@ -70,7 +78,8 @@ in
       ]
       ++ lib.optionals config.services.flatpak.enable [
         cosmic-store
-      ];
+      ]
+    ) config.environment.cosmic.excludePackages;
 
     # Distro-wide defaults for graphical sessions
     services.graphical-desktop.enable = true;


### PR DESCRIPTION
Closes #399993 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
