### PR TITLE
fzf-git-sh: 0-unstable-2024-03-17 -> 0-unstable-2025-02-20

### DIFF
--- a/pkgs/by-name/fz/fzf-git-sh/package.nix
+++ b/pkgs/by-name/fz/fzf-git-sh/package.nix
@@ -14,6 +14,7 @@
   tmux,
   util-linux,
   xdg-utils,
+  unstableGitUpdater,
 }:
 
 stdenv.mkDerivation rec {
@@ -54,6 +55,8 @@ stdenv.mkDerivation rec {
   installPhase = ''
     install -D fzf-git.sh $out/share/${pname}/fzf-git.sh
   '';
+
+  passthru.updateScript = unstableGitUpdater { };
 
   meta = with lib; {
     homepage = "https://github.com/junegunn/fzf-git.sh";

--- a/pkgs/by-name/fz/fzf-git-sh/package.nix
+++ b/pkgs/by-name/fz/fzf-git-sh/package.nix
@@ -11,7 +11,6 @@
   git,
   gnugrep,
   gnused,
-  tmux,
   util-linux,
   xdg-utils,
   unstableGitUpdater,
@@ -19,19 +18,20 @@
 
 stdenv.mkDerivation rec {
   pname = "fzf-git-sh";
-  version = "0-unstable-2024-03-17";
+  version = "0-unstable-2025-02-20";
 
   src = fetchFromGitHub {
     owner = "junegunn";
     repo = "fzf-git.sh";
-    rev = "e4cba1fcf8aed9a2348e47b0ba64299122b81709";
-    hash = "sha256-glI+TldLGGiXyI5ZghaEgjc+2DJCMdmBnho/Z7IgJoE=";
+    rev = "6651e719da630cd8e6e00191af7f225f6d13a801";
+    hash = "sha256-FgJ5eyGU5EXmecwdjbiV+/rnyRaSMi8BLYWayeYgCJw=";
   };
 
   dontBuild = true;
 
   postPatch = ''
     sed -i \
+      -e "s,\bfzf\b,${fzf}/bin/fzf," \
       -e "s,\bawk\b,${gawk}/bin/awk," \
       -e "s,\bbash\b,${bash}/bin/bash," \
       -e "s,\bbat\b,${bat}/bin/bat," \
@@ -40,10 +40,8 @@ stdenv.mkDerivation rec {
       -e "s,\bhead\b,${coreutils}/bin/head," \
       -e "s,\buniq\b,${coreutils}/bin/uniq," \
       -e "s,\bcolumn\b,${util-linux}/bin/column," \
-      -e "s,\bfzf-tmux\b,${fzf}/bin/fzf-tmux," \
       -e "s,\bgrep\b,${gnugrep}/bin/grep," \
       -e "s,\bsed\b,${gnused}/bin/sed," \
-      -e "/fzf-tmux/!s,\btmux\b,${tmux}/bin/tmux," \
       -e "s,\bxargs\b,${findutils}/bin/xargs," \
       -e "s,\bxdg-open\b,${xdg-utils}/bin/xdg-open," \
       -e "/display-message\|fzf-git-\$o-widget\|\burl=\|\$remote_url =~ /!s,\bgit\b,${git}/bin/git,g" \


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Diff: https://github.com/junegunn/fzf-git.sh/compare/e4cba1fcf8aed9a2348e47b0ba64299...6651e719da630cd8e6e00191af7f225f6d13a801

As I understand https://github.com/junegunn/fzf-git.sh/commit/337be336be8d62cbe2ab4556da5f58a80e05a1b3, we don't need to patch for fzf-tmux and tmux since this update.
[The only place where `tmux` is called is guarded by checking whether `$TMUX` is set.](https://github.com/junegunn/fzf-git.sh/blob/6651e719da630cd8e6e00191af7f225f6d13a801/fzf-git.sh#L166)

So I think this update closes #368223

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [x] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

cc: @deejayem @llakala

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
