### PR TITLE
fluxcd-operator: init at 0.19.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -15028,6 +15028,17 @@
     githubId = 3139724;
     name = "Matteo Pacini";
   };
+  mattfield = {
+    email = "matt@mild.systems";
+    github = "mattfield";
+    githubId = 686826;
+    name = "Matt Field";
+    keys = [
+      {
+        fingerprint = "8BEE 1295 D9EC 9560 0273  7E57 45B8 21B5 CB29 C07A";
+      }
+    ];
+  };
   matthewbauer = {
     email = "mjbauer95@gmail.com";
     github = "matthewbauer";

--- a/pkgs/by-name/fl/fluxcd-operator/package.nix
+++ b/pkgs/by-name/fl/fluxcd-operator/package.nix
@@ -1,0 +1,66 @@
+{
+  lib,
+  buildGo124Module,
+  fetchFromGitHub,
+  installShellFiles,
+  versionCheckHook,
+  nix-update-script,
+  stdenv,
+}:
+buildGo124Module (finalAttrs: {
+  pname = "fluxcd-operator";
+  version = "0.19.0";
+
+  src = fetchFromGitHub {
+    owner = "controlplaneio-fluxcd";
+    repo = "fluxcd-operator";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-2AkO8nie2ep3ASy0hkM9JEryv0ekyRNPkCoZ3WgBQwU=";
+  };
+
+  vendorHash = "sha256-sQhp89AzICeu3oRVh3ys93PyeU5A24T36QwQsHxMSaY=";
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X main.VERSION=${finalAttrs.version}"
+  ];
+
+  subPackages = [ "cmd/cli" ];
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgram = "${placeholder "out"}/bin/flux-operator";
+  versionCheckProgramArg = "--version";
+  doInstallCheck = true;
+
+  env.CGO_ENABLED = 0;
+
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+    mv $out/bin/cli $out/bin/flux-operator
+    for shell in bash fish zsh; do
+      installShellCompletion --cmd flux-operator \
+        --$shell <($out/bin/flux-operator completion $shell)
+    done
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Kubernetes controller for managing the lifecycle of Flux CD";
+    homepage = "https://fluxcd.control-plane.io/operator/";
+    downloadPage = "https://github.com/controlplaneio-fluxcd/flux-operator";
+    longDescription = ''
+      The Flux Operator is a Kubernetes CRD controller that manages the lifecycle of CNCF Flux CD
+      and the ControlPlane enterprise distribution. The operator extends Flux with self-service
+      capabilities and preview environments for GitLab and GitHub pull requests testing.
+    '';
+    changelog = "https://github.com/controlplaneio-fluxcd/flux-operator/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.agpl3Only;
+    maintainers = with lib.maintainers; [
+      mattfield
+    ];
+    mainProgram = "flux-operator";
+  };
+})


### PR DESCRIPTION
Adds [FluxCD Operator](https://fluxcd.control-plane.io/operator/) package and myself as maintainer of said package.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
