### PR TITLE
immich: 1.131.3 -> 1.132.1

### DIFF
--- a/pkgs/by-name/im/immich/sources.json
+++ b/pkgs/by-name/im/immich/sources.json
@@ -1,26 +1,26 @@
 {
-  "version": "1.131.3",
-  "hash": "sha256-ZSi9DfyGzkEOiCVEdLu16xzjbmwuMIodD9zMwW72Ppo=",
+  "version": "1.132.1",
+  "hash": "sha256-nZ7kG60TTOVB4yGUsRrcHuWwIamsWlJ7zBvJCP9d4zQ=",
   "components": {
     "cli": {
-      "npmDepsHash": "sha256-FNIrVdEvibIWq7yeHU76PNoolwJPPuCtcL3X6OeZ67U=",
-      "version": "2.2.61"
+      "npmDepsHash": "sha256-PZOYCJ5FQboy5uVZCqJ4CfxDVSHburP4kxhi01HrKns=",
+      "version": "2.2.63"
     },
     "server": {
-      "npmDepsHash": "sha256-3557g6XH/FLXwZQ27IxgM55bzKrF+TLUBLI26PNjKec=",
-      "version": "1.131.3"
+      "npmDepsHash": "sha256-p46OKwRpk9n15201ImLMlDokezJPXD+GXUWtSHduGfU=",
+      "version": "1.132.1"
     },
     "web": {
-      "npmDepsHash": "sha256-DIsWAfkEhIYnomC1AFpl2vLFxREhe0ofWs6ntFk9qXA=",
-      "version": "1.131.3"
+      "npmDepsHash": "sha256-HEwmwn1DP+9WnqYSOcR2AoOLU7tTjwi2fN17Vq9cZVE=",
+      "version": "1.132.1"
     },
     "open-api/typescript-sdk": {
-      "npmDepsHash": "sha256-q0cg1yCZVM6DmvGYrI5fyGcA1fOyDhYZYvBsIPV05A8=",
-      "version": "1.131.3"
+      "npmDepsHash": "sha256-Mdn7pmYJmdizQlVINCme6wv6ocqyrBO6U4F5x2xJonc=",
+      "version": "1.132.1"
     },
     "geonames": {
-      "timestamp": "20250331194635",
-      "hash": "sha256-1YAHhoIH0xJvs9qYNekQF02NQROKlDZTa5bAQlUdE3s="
+      "timestamp": "20250424184923",
+      "hash": "sha256-f0IMmEEyw0JSm+u3zgcE4dtTfPpAKvhDFhlqA9F8cVg="
     }
   }
 }

--- a/pkgs/by-name/vi/vips/package.nix
+++ b/pkgs/by-name/vi/vips/package.nix
@@ -54,7 +54,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "vips";
-  version = "8.16.0";
+  version = "8.16.1";
 
   outputs = [
     "bin"
@@ -67,7 +67,7 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "libvips";
     repo = "libvips";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-Cx657BEZecPeB9rCeVym3C/d+/u+YLJn9vwxfe8b0dM=";
+    hash = "sha256-F2ymfvqwuCtNtFIOLgXvqRWATSMaeV7EQKYyQalCNfc=";
     # Remove unicode file names which leads to different checksums on HFS+
     # vs. other filesystems because of unicode normalisation.
     postFetch = ''


### PR DESCRIPTION
Diff: https://github.com/immich-app/immich/compare/refs/tags/v1.131.3...refs/tags/v1.132.1

Changelog:
https://github.com/immich-app/immich/releases/tag/v1.132.0
https://github.com/immich-app/immich/releases/tag/v1.132.1

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
