### PR TITLE
python3Packages.pygame{,-ce}: unbreak on darwin

### DIFF
--- a/pkgs/by-name/sd/SDL2_classic_image/package.nix
+++ b/pkgs/by-name/sd/SDL2_classic_image/package.nix
@@ -1,0 +1,13 @@
+{
+  SDL2_image,
+  SDL2_classic,
+  enableSTB ? true,
+}:
+
+(SDL2_image.override {
+  SDL2 = SDL2_classic;
+  inherit enableSTB;
+}).overrideAttrs
+  {
+    pname = "SDL2_classic_image";
+  }

--- a/pkgs/by-name/sd/SDL2_classic_mixer/package.nix
+++ b/pkgs/by-name/sd/SDL2_classic_mixer/package.nix
@@ -1,0 +1,11 @@
+{
+  SDL2_mixer,
+  SDL2_classic,
+}:
+
+(SDL2_mixer.override {
+  SDL2 = SDL2_classic;
+}).overrideAttrs
+  {
+    pname = "SDL2_classic_mixer";
+  }

--- a/pkgs/by-name/sd/SDL2_classic_mixer_2_0/package.nix
+++ b/pkgs/by-name/sd/SDL2_classic_mixer_2_0/package.nix
@@ -1,0 +1,8 @@
+{
+  SDL2_mixer_2_0,
+  SDL2_classic_mixer,
+}:
+
+SDL2_mixer_2_0.override {
+  SDL2_mixer = SDL2_classic_mixer;
+}

--- a/pkgs/by-name/sd/SDL2_classic_ttf/package.nix
+++ b/pkgs/by-name/sd/SDL2_classic_ttf/package.nix
@@ -1,0 +1,11 @@
+{
+  SDL2_ttf,
+  SDL2_classic,
+}:
+
+(SDL2_ttf.override {
+  SDL2 = SDL2_classic;
+}).overrideAttrs
+  {
+    pname = "SDL2_classic_ttf";
+  }

--- a/pkgs/by-name/sd/SDL2_image/package.nix
+++ b/pkgs/by-name/sd/SDL2_image/package.nix
@@ -2,10 +2,7 @@
   lib,
   SDL2,
   autoreconfHook,
-  darwin,
   fetchurl,
-  giflib,
-  libXpm,
   libjpeg,
   libpng,
   libtiff,
@@ -19,9 +16,6 @@
   enableSdltest ? (!stdenv.hostPlatform.isDarwin),
 }:
 
-let
-  inherit (darwin.apple_sdk.frameworks) Foundation;
-in
 stdenv.mkDerivation (finalAttrs: {
   pname = "SDL2_image";
   version = "2.8.5";

--- a/pkgs/development/python-modules/pygame-ce/default.nix
+++ b/pkgs/development/python-modules/pygame-ce/default.nix
@@ -126,6 +126,8 @@ buildPythonPackage rec {
     # No audio or video device in test environment
     export SDL_VIDEODRIVER=dummy
     export SDL_AUDIODRIVER=disk
+    # traceback for segfaults
+    export PYTHONFAULTHANDLER=1
   '';
 
   checkPhase = ''

--- a/pkgs/development/python-modules/pygame-ce/default.nix
+++ b/pkgs/development/python-modules/pygame-ce/default.nix
@@ -20,9 +20,9 @@
   libX11,
   portmidi,
   SDL2_classic,
-  SDL2_image,
-  SDL2_mixer,
-  SDL2_ttf,
+  SDL2_classic_image,
+  SDL2_classic_mixer_2_0,
+  SDL2_classic_ttf,
   numpy,
 
   pygame-gui,
@@ -100,9 +100,9 @@ buildPythonPackage rec {
     libpng
     portmidi
     SDL2_classic
-    (SDL2_image.override { enableSTB = false; })
-    SDL2_mixer
-    SDL2_ttf
+    (SDL2_classic_image.override { enableSTB = false; })
+    SDL2_classic_mixer_2_0
+    SDL2_classic_ttf
   ] ++ lib.optionals stdenv.hostPlatform.isDarwin [ AppKit ];
 
   nativeCheckInputs = [
@@ -162,12 +162,5 @@ buildPythonPackage rec {
     license = lib.licenses.lgpl21Plus;
     maintainers = [ lib.maintainers.pbsds ];
     platforms = lib.platforms.unix;
-    badPlatforms = [
-      # loading pygame.tests.font_test
-      # /nix/store/mrvg4qq09d51w5s95v15y4ym05q009fd-stdenv-darwin/setup: line 1771: 64131 Segmentation fault: 11
-      #
-      # https://github.com/NixOS/nixpkgs/issues/400378
-      lib.systems.inspect.patterns.isDarwin
-    ];
   };
 }

--- a/pkgs/development/python-modules/pygame/default.nix
+++ b/pkgs/development/python-modules/pygame/default.nix
@@ -21,9 +21,9 @@
   libpng,
   libX11,
   portmidi,
-  SDL2_image,
-  SDL2_mixer,
-  SDL2_ttf,
+  SDL2_classic_image,
+  SDL2_classic_mixer,
+  SDL2_classic_ttf,
 }:
 
 buildPythonPackage rec {
@@ -87,9 +87,9 @@ buildPythonPackage rec {
     libX11
     portmidi
     SDL2_classic
-    (SDL2_image.override { enableSTB = false; })
-    SDL2_mixer
-    SDL2_ttf
+    (SDL2_classic_image.override { enableSTB = false; })
+    SDL2_classic_mixer
+    SDL2_classic_ttf
   ];
 
   preConfigure = ''
@@ -122,10 +122,5 @@ buildPythonPackage rec {
     license = lib.licenses.lgpl21Plus;
     maintainers = with lib.maintainers; [ emilytrau ];
     platforms = lib.platforms.unix;
-    badPlatforms = [
-      # Several tests segfault
-      # https://github.com/pygame/pygame/issues/4486
-      lib.systems.inspect.patterns.isDarwin
-    ];
   };
 }

--- a/pkgs/development/python-modules/pygame/default.nix
+++ b/pkgs/development/python-modules/pygame/default.nix
@@ -106,6 +106,8 @@ buildPythonPackage rec {
     # No audio or video device in test environment
     export SDL_VIDEODRIVER=dummy
     export SDL_AUDIODRIVER=disk
+    # traceback for segfaults
+    export PYTHONFAULTHANDLER=1
 
     ${python.interpreter} -m pygame.tests -v \
       --exclude opengl,timing \

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -12292,7 +12292,6 @@ self: super: with self; {
 
   pygame-ce = callPackage ../development/python-modules/pygame-ce {
     inherit (pkgs.darwin.apple_sdk.frameworks) AppKit;
-    SDL2_mixer = pkgs.SDL2_mixer_2_0;
   };
 
   pygame-gui = callPackage ../development/python-modules/pygame-gui { };


### PR DESCRIPTION
Turns out linking to both SDL3 and SDL2 results in use-after-free errors and other hard to debug memory errors. This took a long time to debug due to the lack of a sane debugger on darwin.

- **SDL2_classic_image: init at 2.8.5**
- **SDL2_classic_ttf: init at 2.24.0**
- **SDL2_classic_mixer: init at 2.8.1**
- **SDL2_classic_mixer_2_0: init at 2.0.4**
- **SDL2_image: remove unused inputs**
- **python3Packages.pygame-ce: unbreak on darwin**
- **python3Packages.pygame: unbreak on darwin**
- **python3Packages.pygame-ce: add traceback for segfaults in checkPhase**
- **python3Packages.pygame: add traceback for segfaults in checkPhase**

closes https://github.com/NixOS/nixpkgs/issues/400378

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
