### PR TITLE
flac-metadata-bindings: init at 0.1.0

### DIFF
--- a/pkgs/development/lisp-modules/packages.nix
+++ b/pkgs/development/lisp-modules/packages.nix
@@ -540,6 +540,26 @@ let
         };
       });
 
+      flac-metadata-bindings = build-asdf-system {
+          pname = "flac-metadata-bindings";
+          version = "0.1.0";
+          src = pkgs.fetchFromGitLab {
+              domain = "forge.tedomum.net";
+              owner = "koizel";
+              repo = "cl-flac-metadata-bindings";
+              rev = "b0a4fb6c943dd7426b0f65dab1cfac1552f6d7bc";
+              hash = "sha256-3peGwYdwDeZc7tMxclQYHfv8546U0Ld2CM9PKinksIM=";
+          };
+          lispLibs = builtins.attrValues { inherit (self) anaphora cffi cl-ppcre check-it; };
+          nativeLibs = [ pkgs.flac ];
+          nativeBuildInputs = [ pkgs.flac ];
+          meta = {
+              description = "Bindings for the metadata part of the FLAC library";
+              homepage = "https://forge.tedomum.net/koizel/cl-flac-metadata-bindings";
+              license = pkgs.lib.licenses.bsd2;
+          };
+      };
+
     }
     // optionalAttrs pkgs.config.allowAliases {
       cl-glib_dot_gio = throw "cl-glib_dot_gio was replaced by cl-gio";

--- a/pkgs/development/lisp-modules/packages.nix
+++ b/pkgs/development/lisp-modules/packages.nix
@@ -541,23 +541,30 @@ let
       });
 
       flac-metadata-bindings = build-asdf-system {
-          pname = "flac-metadata-bindings";
-          version = "0.1.0";
-          src = pkgs.fetchFromGitLab {
-              domain = "forge.tedomum.net";
-              owner = "koizel";
-              repo = "cl-flac-metadata-bindings";
-              rev = "b0a4fb6c943dd7426b0f65dab1cfac1552f6d7bc";
-              hash = "sha256-3peGwYdwDeZc7tMxclQYHfv8546U0Ld2CM9PKinksIM=";
-          };
-          lispLibs = builtins.attrValues { inherit (self) anaphora cffi cl-ppcre check-it; };
-          nativeLibs = [ pkgs.flac ];
-          nativeBuildInputs = [ pkgs.flac ];
-          meta = {
-              description = "Bindings for the metadata part of the FLAC library";
-              homepage = "https://forge.tedomum.net/koizel/cl-flac-metadata-bindings";
-              license = pkgs.lib.licenses.bsd2;
-          };
+        pname = "flac-metadata-bindings";
+        version = "0.1.0";
+        src = pkgs.fetchFromGitLab {
+          domain = "forge.tedomum.net";
+          owner = "koizel";
+          repo = "cl-flac-metadata-bindings";
+          rev = "b0a4fb6c943dd7426b0f65dab1cfac1552f6d7bc";
+          hash = "sha256-3peGwYdwDeZc7tMxclQYHfv8546U0Ld2CM9PKinksIM=";
+        };
+        lispLibs = builtins.attrValues {
+          inherit (self)
+            anaphora
+            cffi
+            cl-ppcre
+            check-it
+            ;
+        };
+        nativeLibs = [ pkgs.flac ];
+        nativeBuildInputs = [ pkgs.flac ];
+        meta = {
+          description = "Bindings for the metadata part of the FLAC library";
+          homepage = "https://forge.tedomum.net/koizel/cl-flac-metadata-bindings";
+          license = pkgs.lib.licenses.bsd2;
+        };
       };
 
     }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Added the `flac-metadata-bindings` lisp module, a library that interfaces some part of the FLAC library with common lisp, mainly to read metadatas from files.

The library is hosted at https://forge.tedomum.net/koizel/cl-flac-metadata-bindings
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
