### PR TITLE
libblake3: fix FreeBSD cross-compile builds

### DIFF
--- a/pkgs/by-name/li/libblake3/package.nix
+++ b/pkgs/by-name/li/libblake3/package.nix
@@ -3,6 +3,7 @@
   stdenv,
   cmake,
   fetchFromGitHub,
+  fetchpatch,
   tbb_2021_11,
 
   useTBB ? true,
@@ -26,6 +27,15 @@ stdenv.mkDerivation (finalAttrs: {
   propagatedBuildInputs = lib.optionals useTBB [
     # 2022.0 crashes on macOS at the moment
     tbb_2021_11
+  ];
+
+  patches = [
+    # build(cmake): Relax Clang frontend variant detection (BLAKE3-team/BLAKE3#477)
+    (fetchpatch {
+      url = "https://patch-diff.githubusercontent.com/raw/BLAKE3-team/BLAKE3/pull/477.patch";
+      hash = "sha256-kidCMGd/i9D9HLLTt7l1DbiU71sFTEyr3Vew4XHUHls=";
+      relative = "c";
+    })
   ];
 
   cmakeFlags = [

--- a/pkgs/development/libraries/tbb/2022_0.nix
+++ b/pkgs/development/libraries/tbb/2022_0.nix
@@ -34,11 +34,12 @@ stdenv.mkDerivation rec {
       url = "https://patch-diff.githubusercontent.com/raw/oneapi-src/oneTBB/pull/899.patch";
       hash = "sha256-kU6RRX+sde0NrQMKlNtW3jXav6J4QiVIUmD50asmBPU=";
     })
-  ];
-
-  cmakeFlags = [
-    # Skip tests to work around https://github.com/uxlfoundation/oneTBB/issues/1695
-    (lib.cmakeBool "TBB_TEST" (!stdenv.hostPlatform.isWindows))
+    # Fix tests on FreeBSD and Windows
+    (fetchpatch {
+      name = "fix-tbb-freebsd-and-windows-tests.patch";
+      url = "https://patch-diff.githubusercontent.com/raw/uxlfoundation/oneTBB/pull/1696.patch";
+      hash = "sha256-yjX2FkOK8bz29a/XSA7qXgQw9lxzx8VIgEBREW32NN4=";
+    })
   ];
 
   # Fix build with modern gcc

--- a/pkgs/development/libraries/tbb/default.nix
+++ b/pkgs/development/libraries/tbb/default.nix
@@ -44,11 +44,12 @@ stdenv.mkDerivation rec {
       url = "https://patch-diff.githubusercontent.com/raw/oneapi-src/oneTBB/pull/1193.patch";
       hash = "sha256-ZQbwUmuIZoGVBof8QNR3V8vU385e2X7EvU3+Fbj4+M8=";
     })
-  ];
-
-  cmakeFlags = [
-    # Skip tests to work around https://github.com/uxlfoundation/oneTBB/issues/1695
-    (lib.cmakeBool "TBB_TEST" (!stdenv.hostPlatform.isWindows))
+    # Fix tests on FreeBSD and Windows
+    (fetchpatch {
+      name = "fix-tbb-freebsd-and-windows-tests.patch";
+      url = "https://patch-diff.githubusercontent.com/raw/uxlfoundation/oneTBB/pull/1696.patch";
+      hash = "sha256-yjX2FkOK8bz29a/XSA7qXgQw9lxzx8VIgEBREW32NN4=";
+    })
   ];
 
   # Fix build with modern gcc


### PR DESCRIPTION
This PR fixes `libblake3` cross-compile builds for FreeBSD.

It also patches `tbb` to fix the tests on FreeBSD and Windows.

Follows from discussion at https://github.com/NixOS/nixpkgs/pull/401156

- Built on platform(s)
  - [x] mingw32
  - [x] x86_64-freebsd
  - [x] x86_64-linux