### PR TITLE
nixos/nh: change `FLAKE` variable to `NH_FLAKE`; improve option docs

### DIFF
--- a/nixos/modules/programs/nh.nix
+++ b/nixos/modules/programs/nh.nix
@@ -8,7 +8,10 @@ let
   cfg = config.programs.nh;
 in
 {
-  meta.maintainers = [ lib.maintainers.viperML ];
+  meta.maintainers = with lib.maintainers; [
+    NotAShelf
+    viperML
+  ];
 
   options.programs.nh = {
     enable = lib.mkEnableOption "nh, yet another Nix CLI helper";
@@ -19,9 +22,18 @@ in
       type = lib.types.nullOr lib.types.path;
       default = null;
       description = ''
-        The path that will be used for the `FLAKE` environment variable.
+        The path that will be used for the `NH_FLAKE` environment variable.
 
-        `FLAKE` is used by nh as the default flake for performing actions, like `nh os switch`.
+        `NH_FLAKE` is used by nh as the default flake for performing actions, such as
+        `nh os switch`. This behaviour can be overriden per-command with environment
+        variables that will take priority.
+
+        - `NH_OS_FLAKE`: will take priority for `nh os` commands.
+        - `NH_HOME_FLAKE`: will take priority for `nh home` commands.
+        - `NH_DARWIN_FLAKE`: will take priority for `nh darwin` commands.
+
+        The formerly valid `FLAKE` is now deprecated by nh, and will cause hard errors
+        in future releases if `NH_FLAKE` is not set.
       '';
     };
 
@@ -77,7 +89,7 @@ in
     environment = lib.mkIf cfg.enable {
       systemPackages = [ cfg.package ];
       variables = lib.mkIf (cfg.flake != null) {
-        FLAKE = cfg.flake;
+        NH_FLAKE = cfg.flake;
       };
     };
 


### PR DESCRIPTION
Nh now favors `NH_FLAKE` over the `FLAKE` variable. This is fine, as nh will still honor `FLAKE` but I plan to hard-error in the future. Let's fix this while we're at it. Also adds myself as a module maintainer.

(I've forgotten to change this in https://github.com/NixOS/nixpkgs/pull/401205)


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
