### PR TITLE
python312Packages.cx-freeze: 8.0.0 -> 8.2.0

### DIFF
--- a/pkgs/development/python-modules/cx-freeze/default.nix
+++ b/pkgs/development/python-modules/cx-freeze/default.nix
@@ -2,39 +2,48 @@
   lib,
   stdenv,
   buildPythonPackage,
+  fetchFromGitHub,
+
+  # build-system
+  setuptools,
+
+  # dependencies
+  filelock,
+  packaging,
+  tomli,
+  typing-extensions,
+
   distutils,
-  fetchPypi,
   pythonOlder,
   ncurses,
-  packaging,
-  setuptools,
-  filelock,
   patchelf,
-  tomli,
-  importlib-metadata,
-  typing-extensions,
   dmgbuild,
+
+  # tests
+  ensureNewerSourcesForZipFilesHook,
+  pytest-mock,
+  pytestCheckHook,
+  versionCheckHook,
+  writableTmpDirAsHomeHook,
 }:
 
 buildPythonPackage rec {
   pname = "cx-freeze";
-  version = "8.0.0";
+  version = "8.2.0";
   pyproject = true;
 
-  disabled = pythonOlder "3.8";
-
-  src = fetchPypi {
-    pname = "cx_freeze";
-    inherit version;
-    hash = "sha256-gOH4e7FS7Q+X98ZDXgI31Eqt6Zl5knxGJ3cTIqJdVQ0=";
+  src = fetchFromGitHub {
+    owner = "marcelotduarte";
+    repo = "cx_Freeze";
+    tag = version;
+    hash = "sha256-xrSMW7z3XblwAuaC18Rju/XuBZvU+5+xAW+MO6u32EE=";
   };
 
-  postPatch = ''
-    sed -i /patchelf/d pyproject.toml
-    # Build system requirements
-    substituteInPlace pyproject.toml \
-      --replace-fail "setuptools>=70.1,<76" "setuptools"
-  '';
+  patches = [
+    # ValueError: '/nix/store/33ajdw6s479bg0ydhk0zqrxi6p989gbl-python3.12-pytest-8.3.5/lib/python3.12/site-packages'
+    # is not in the subpath of '/nix/store/fqm9bqqlmaqqr02qbalm1bazp810qfiw-python3-3.12.9'
+    ./fix-tests-relative-path.patch
+  ];
 
   build-system = [
     setuptools
@@ -42,9 +51,12 @@ buildPythonPackage rec {
 
   buildInputs = [ ncurses ];
 
+  pythonRemoveDeps = [ "patchelf" ];
+
   dependencies =
     [
       distutils
+      filelock
       packaging
       setuptools
     ]
@@ -52,11 +64,11 @@ buildPythonPackage rec {
       tomli
     ]
     ++ lib.optionals (pythonOlder "3.10") [
-      importlib-metadata
       typing-extensions
     ]
-    ++ lib.optional stdenv.hostPlatform.isLinux filelock
-    ++ lib.optional stdenv.hostPlatform.isDarwin dmgbuild;
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [
+      dmgbuild
+    ];
 
   makeWrapperArgs = [
     "--prefix"
@@ -65,14 +77,81 @@ buildPythonPackage rec {
     (lib.makeBinPath [ patchelf ])
   ];
 
-  # Fails to find Console even though it exists on python 3.x
-  doCheck = false;
+  pythonImportsCheck = [
+    "cx_Freeze"
+  ];
 
-  meta = with lib; {
+  nativeCheckInputs = [
+    pytest-mock
+    pytestCheckHook
+    writableTmpDirAsHomeHook
+    versionCheckHook
+  ];
+  versionCheckProgram = "${placeholder "out"}/bin/cxfreeze";
+  versionCheckProgramArg = "--version";
+
+  preCheck = ''
+    rm -rf cx_Freeze
+  '';
+
+  disabledTests =
+    [
+      # Require internet access
+      "test_bdist_appimage_target_name"
+      "test_bdist_appimage_target_name_and_version"
+      "test_bdist_appimage_target_name_and_version_none"
+
+      # Try to install a module: ValueError: ZIP does not support timestamps before 1980
+      "test___main__"
+      "test_bdist_appimage_simple"
+      "test_bdist_appimage_skip_build"
+      "test_bdist_deb_simple_pyproject"
+      "test_bdist_rpm_simple_pyproject"
+      "test_build"
+      "test_build_constants"
+      "test_build_exe_advanced"
+      "test_build_exe_asmodule"
+      "test_ctypes"
+      "test_cxfreeze"
+      "test_cxfreeze_debug_verbose"
+      "test_cxfreeze_deprecated_behavior"
+      "test_cxfreeze_deprecated_option"
+      "test_cxfreeze_include_path"
+      "test_cxfreeze_target_name_not_isidentifier"
+      "test_excludes"
+      "test_executable_namespace"
+      "test_executable_rename"
+      "test_executables"
+      "test_freezer_zip_filename"
+      "test_install"
+      "test_install_pyproject"
+      "test_multiprocessing"
+      "test_not_found_icon"
+      "test_parser"
+      "test_sqlite"
+      "test_ssl"
+      "test_tz"
+      "test_valid_icon"
+      "test_zip_exclude_packages"
+      "test_zip_include_packages"
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [
+      # error: Path /nix/store/xzjghvsg4fhr2vv6h4scihsdrgk4i76w-python3-3.12.9/lib/libpython3.12.dylib
+      # is not a path referenced from DarwinFile
+      "test_bdist_dmg"
+      "test_bdist_dmg_custom_layout"
+      "test_bdist_mac"
+      "test_plist_items"
+
+      # AssertionError: assert names != []
+      "test_freezer_default_bin_includes"
+    ];
+
+  meta = {
     description = "Set of scripts and modules for freezing Python scripts into executables";
-    homepage = "https://marcelotduarte.github.io/cx_Freeze/";
+    homepage = "https://marcelotduarte.github.io/cx_Freeze";
     changelog = "https://github.com/marcelotduarte/cx_Freeze/releases/tag/${version}";
-    license = licenses.psfl;
+    license = lib.licenses.psfl;
     maintainers = [ ];
     mainProgram = "cxfreeze";
   };

--- a/pkgs/development/python-modules/cx-freeze/fix-tests-relative-path.patch
+++ b/pkgs/development/python-modules/cx-freeze/fix-tests-relative-path.patch
@@ -1,0 +1,15 @@
+diff --git a/tests/conftest.py b/tests/conftest.py
+index 04400a17..1facf55d 100644
+--- a/tests/conftest.py
++++ b/tests/conftest.py
+@@ -46,9 +46,7 @@ class TempPackage:
+         # environment
+         self.system_path: Path = Path(os.getcwd())
+         self.system_prefix: Path = Path(sys.prefix)
+-        self.relative_site = Path(pytest.__file__).parent.parent.relative_to(
+-            self.system_prefix
+-        )
++        self.relative_site = Path(pytest.__file__).resolve().parent.parent
+ 
+         # make a temporary directory and set it as current
+         name = request.node.name


### PR DESCRIPTION
## Things done

Changelog: https://github.com/marcelotduarte/cx_Freeze/releases/tag/8.2.0
Diff: https://github.com/marcelotduarte/cx_Freeze/compare/8.1.0...8.2.0

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
