### PR TITLE
rustPlatform.cargoSetupHook: remove references to build directory in binaries

### DIFF
--- a/pkgs/build-support/rust/hooks/cargo-setup-hook.sh
+++ b/pkgs/build-support/rust/hooks/cargo-setup-hook.sh
@@ -27,14 +27,12 @@ cargoSetupPostUnpackHook() {
       config=@defaultConfig@
     fi;
 
-    tmp_config=$(mktemp)
-    substitute $config $tmp_config \
-      --subst-var-by vendor "$cargoDepsCopy"
-    cat ${tmp_config} >> .cargo/config.toml
-
-    cat >> .cargo/config.toml <<'EOF'
+    cat "$config" - >> .cargo/config.toml <<'EOF'
     @cargoConfig@
 EOF
+
+    substituteInPlace .cargo/config.toml \
+      --subst-var-by vendor "$cargoDepsCopy"
 
     echo "Finished cargoSetupPostUnpackHook"
 }

--- a/pkgs/build-support/rust/hooks/cargo-setup-hook.sh
+++ b/pkgs/build-support/rust/hooks/cargo-setup-hook.sh
@@ -32,7 +32,8 @@ cargoSetupPostUnpackHook() {
 EOF
 
     substituteInPlace .cargo/config.toml \
-      --subst-var-by vendor "$cargoDepsCopy"
+      --subst-var-by vendor "$cargoDepsCopy" \
+      --subst-var-by BUILD_TOP "${NIX_BUILD_TOP:-/build}"
 
     echo "Finished cargoSetupPostUnpackHook"
 }

--- a/pkgs/build-support/rust/hooks/default.nix
+++ b/pkgs/build-support/rust/hooks/default.nix
@@ -91,6 +91,8 @@
             lib.concatStringsSep ", " (
               [
                 ''"-Ctarget-feature=${if stdenv.targetPlatform.isStatic then "+" else "-"}crt-static"''
+                ''"--remap-path-prefix"''
+                ''"@BUILD_TOP@=/build"''
               ]
               ++ lib.optional (!stdenv.targetPlatform.isx86_32) ''"-Cforce-frame-pointers=yes"''
             )
@@ -100,7 +102,13 @@
           [target."${stdenv.hostPlatform.rust.rustcTarget}"]
           "linker" = "${stdenv.cc}/bin/${stdenv.cc.targetPrefix}cc"
           "rustflags" = [ ${
-            lib.optionalString (!stdenv.hostPlatform.isx86_32) ''"-Cforce-frame-pointers=yes"''
+            lib.concatStringsSep ", " (
+              [
+                ''"--remap-path-prefix"''
+                ''"@BUILD_TOP@=/build"''
+              ]
+              ++ lib.optional (!stdenv.hostPlatform.isx86_32) ''"-Cforce-frame-pointers=yes"''
+            )
           } ]
         '';
     };

--- a/pkgs/development/compilers/rust/rustc.nix
+++ b/pkgs/development/compilers/rust/rustc.nix
@@ -344,6 +344,9 @@ stdenv.mkDerivation (finalAttrs: {
     directory = "vendor"
     EOF
   ''
+  + ''
+    export RUSTC_DEBUGINFO_MAP="''${NIX_BUILD_TOP:-/build}=/build"
+  ''
   + lib.optionalString (stdenv.hostPlatform.isFreeBSD) ''
     # lzma-sys bundles an old version of xz that doesn't build
     # on modern FreeBSD, use the system one instead


### PR DESCRIPTION
By default, Rust binaries include debug information (e.g. for the panic handler) that specifies source file paths. On sandboxed Linux, this isn't much of an issue since the build will always be in `/build`, but on any other platform (including sandboxed macOS), this will result in potential impurities (e.g. when using `--keep-failed` or building multiple derivations with the same name concurrently).

Luckily, rustc provides an option to remap path prefixes when writing this debug info, in the form of `--remap-path-prefix`. This allows the replacement of any path prefix that would be written to the binary. This change sets this to `$NIX_BUILD_TOP`, falling back to a noop if there is no `$NIX_BUILD_TOP` during build (as cases where it's unset, like devshells, don't really benefit from purity).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [x] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
