### PR TITLE
xgboost: 2.1.4 -> 3.0.0

### DIFF
--- a/pkgs/by-name/xg/xgboost/package.nix
+++ b/pkgs/by-name/xg/xgboost/package.nix
@@ -48,14 +48,14 @@ effectiveStdenv.mkDerivation rec {
   #   in \
   #   rWrapper.override{ packages = [ xgb ]; }"
   pname = lib.optionalString rLibrary "r-" + pnameBase;
-  version = "2.1.4";
+  version = "3.0.0";
 
   src = fetchFromGitHub {
     owner = "dmlc";
     repo = pnameBase;
     rev = "v${version}";
     fetchSubmodules = true;
-    hash = "sha256-k1k6K11cWpG6PtzTt99q/rrkN3FyxCVEzfPI9fCTAjM=";
+    hash = "sha256-OwsZ1RzVi6ba+XJqFbIW1Rmqu5OVttBfcpDe84gmQxI=";
   };
 
   nativeBuildInputs =
@@ -87,6 +87,9 @@ effectiveStdenv.mkDerivation rec {
     ]
     ++ lib.optionals ncclSupport [ "-DUSE_NCCL=ON" ]
     ++ lib.optionals rLibrary [ "-DR_LIB=ON" ];
+
+  # on Darwin, cmake uses find_library to locate R instead of using the PATH
+  env.NIX_LDFLAGS = "-L${R}/lib/R/lib";
 
   preConfigure = lib.optionals rLibrary ''
     substituteInPlace cmake/RPackageInstall.cmake.in --replace "CMD INSTALL" "CMD INSTALL -l $out/library"
@@ -124,12 +127,14 @@ effectiveStdenv.mkDerivation rec {
         "Approx.PartitionerColumnSplit"
         "BroadcastTest.Basic"
         "CPUHistogram.BuildHistColSplit"
+        "CPUHistogram.BuildHistColumnSplit"
         "CPUPredictor.CategoricalPredictLeafColumnSplit"
         "CPUPredictor.CategoricalPredictionColumnSplit"
         "ColumnSplit/ColumnSplitTrainingTest*"
         "ColumnSplit/TestApproxColumnSplit*"
         "ColumnSplit/TestHistColumnSplit*"
         "ColumnSplitObjective/TestColumnSplit*"
+        "Cpu/ColumnSplitTrainingTest*"
         "CommGroupTest.Basic"
         "CommTest.Channel"
         "CpuPredictor.BasicColumnSplit"
@@ -150,6 +155,8 @@ effectiveStdenv.mkDerivation rec {
         "Quantile.SortedDistributedBasic"
         "QuantileHist.MultiPartitionerColumnSplit"
         "QuantileHist.PartitionerColumnSplit"
+        "Stats.SampleMean"
+        "Stats.WeightedSampleMean"
         "SimpleDMatrix.ColumnSplit"
         "TrackerAPITest.CAPI"
         "TrackerTest.AfterShutdown"
@@ -174,7 +181,6 @@ effectiveStdenv.mkDerivation rec {
     ''
     + ''
       cmake --install .
-      cp -r ../rabit/include/rabit $out/include
       runHook postInstall
     '';
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Updating xgboost to [3.0.0](https://xgboost.readthedocs.io/en/latest/changes/v3.0.0.html).
- Completed basic checks of R and python libraries, including builds with GPU and NCCL features.
- Disabled several new networking tests. 
- Rabit is no longer in the include

The Darwin build was and still is failing, although adding NIX_LDFLAGS helped to locate R. Anyone with an interest in building xgboost on Mac is welcome to take a look.

@b-rodrigues, @jbedo

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
