### PR TITLE
tidal-hifi: 5.18.2 -> 5.19.0

### DIFF
--- a/pkgs/by-name/ti/tidal-hifi/electron.nix
+++ b/pkgs/by-name/ti/tidal-hifi/electron.nix
@@ -1,0 +1,31 @@
+{
+  fetchzip,
+  lib,
+}:
+let
+  /*
+    see:
+    https://github.com/Mastermindzh/tidal-hifi/blob/master/build/electron-builder.base.yml
+     for the expected version
+  */
+  version = "35.1.1";
+in
+(fetchzip {
+  url = "https://github.com/castlabs/electron-releases/releases/download/v${version}+wvcus/electron-v${version}+wvcus-linux-x64.zip";
+  hash = "sha256-AkPKeG7MrCBlk41qXZxFPRukUPRcIUanq6fJPx5d3RU=";
+  stripRoot = false;
+
+}).overrideAttrs
+  (
+    final: _: {
+      name = "castlabs-electron-${version}";
+      inherit version;
+      pname = "castlabs-electron";
+      passthru.dist = final.finalPackage.outPath;
+
+      meta = {
+        license = lib.licenses.unfreeRedistributable;
+        sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+      };
+    }
+  )

--- a/pkgs/by-name/ti/tidal-hifi/package.nix
+++ b/pkgs/by-name/ti/tidal-hifi/package.nix
@@ -1,98 +1,109 @@
 {
   lib,
+  buildNpmPackage,
+  fetchFromGitHub,
+  callPackage,
+  libdbusmenu,
+  xdg-utils,
+  makeShellWrapper,
+  copyDesktopItems,
+  makeDesktopItem,
   stdenv,
-  fetchurl,
-  autoPatchelfHook,
-  dpkg,
-  makeWrapper,
   wrapGAppsHook3,
-  alsa-lib,
+  glib,
+  gtk3,
+  gtk4,
   at-spi2-atk,
-  at-spi2-core,
-  atk,
+  libdrm,
+  libgbm,
+  libxkbcommon,
+  libxshmfence,
+  libGL,
+  vulkan-loader,
+  alsa-lib,
   cairo,
   cups,
   dbus,
   expat,
-  ffmpeg,
-  fontconfig,
-  freetype,
   gdk-pixbuf,
-  glib,
-  gtk3,
-  libappindicator-gtk3,
-  libdbusmenu,
-  libdrm,
-  libnotify,
-  libpulseaudio,
-  libsecret,
-  libuuid,
-  libxkbcommon,
-  libgbm,
   nss,
+  nspr,
+  libX11,
+  libxcb,
+  libXcomposite,
+  libXdamage,
+  libXext,
+  libXfixes,
+  libXrandr,
+  libxkbfile,
   pango,
   systemd,
-  xdg-utils,
-  xorg,
-  libGL,
+  pciutils,
+  libnotify,
+  pipewire,
+  libsecret,
+  libpulseaudio,
+  speechd-minimal,
+
+  castlabs-electron ? callPackage ./electron.nix { },
 }:
 
-stdenv.mkDerivation (finalAttrs: {
-  pname = "tidal-hifi";
-  version = "5.18.2";
+let
+  version = "5.19.0";
 
-  src = fetchurl {
-    url = "https://github.com/Mastermindzh/tidal-hifi/releases/download/${finalAttrs.version}/tidal-hifi_${finalAttrs.version}_amd64.deb";
-    sha256 = "sha256-jo3vnq7ul7e+UsaBswil8EctUxVJMcTxo77YyQ2ncIM=";
-  };
-
-  nativeBuildInputs = [
-    autoPatchelfHook
-    dpkg
-    makeWrapper
-    wrapGAppsHook3
-  ];
-
-  buildInputs = [
+  electronLibPath = lib.makeLibraryPath [
     alsa-lib
     at-spi2-atk
-    at-spi2-core
-    atk
     cairo
     cups
     dbus
     expat
-    ffmpeg
-    fontconfig
-    freetype
     gdk-pixbuf
     glib
     gtk3
-    pango
-    systemd
-    libgbm
+    gtk4
     nss
-    libuuid
-    libdrm
+    nspr
+    libX11
+    libxcb
+    libXcomposite
+    libXdamage
+    libXext
+    libXfixes
+    libXrandr
+    libxkbfile
+    pango
+    pciutils
+    stdenv.cc.cc
+    systemd
     libnotify
+    pipewire
     libsecret
     libpulseaudio
+    speechd-minimal
+    libdrm
+    libgbm
     libxkbcommon
-    libappindicator-gtk3
-    xorg.libX11
-    xorg.libxcb
-    xorg.libXcomposite
-    xorg.libXcursor
-    xorg.libXdamage
-    xorg.libXext
-    xorg.libXfixes
-    xorg.libXi
-    xorg.libXrandr
-    xorg.libXrender
-    xorg.libXScrnSaver
-    xorg.libxshmfence
-    xorg.libXtst
+    libxshmfence
     libGL
+    vulkan-loader
+  ];
+in
+buildNpmPackage {
+  pname = "tidal-hifi";
+  inherit version;
+
+  src = fetchFromGitHub {
+    owner = "Mastermindzh";
+    repo = "tidal-hifi";
+    tag = version;
+    hash = "sha256-/pPmfgKwrtOrEu7YVJTuQF/FIMa+W6uSnFbMFuyURFQ=";
+  };
+
+  nativeBuildInputs = [
+    makeShellWrapper
+    wrapGAppsHook3
+    copyDesktopItems
   ];
 
   runtimeDependencies = [
@@ -102,36 +113,101 @@ stdenv.mkDerivation (finalAttrs: {
     xdg-utils
   ];
 
+  npmDepsHash = "sha256-TNhD/ZkqJtsidAEIOL/WmJZw09BuFgd4ECnzbieNhVY=";
+  forceGitDeps = true;
+  makeCacheWritable = true;
+
+  env.ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
+
+  buildPhase = ''
+    runHook preBuild
+
+    npm run compile
+    npm exec electron-builder -- \
+        --dir \
+        --config build/electron-builder.base.yml \
+        -c.electronDist=${castlabs-electron.dist} \
+        -c.electronVersion=${castlabs-electron.version}
+
+    runHook postBuild
+  '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "TIDAL Hi-Fi";
+      desktopName = "tidal-hifi";
+      genericName = "TIDAL Hi-Fi";
+      comment = "The web version of listen.tidal.com running in electron with hifi support thanks to widevine.";
+      icon = "tidal-hifi";
+      startupNotify = true;
+      terminal = false;
+      type = "Application";
+      categories = [
+        "Network"
+        "Application"
+        "AudioVideo"
+        "Audio"
+        "Video"
+      ];
+      startupWMClass = "tidal-hifi";
+      mimeTypes = [ "x-scheme-handler/tidal" ];
+      extraConfig.X-PulseAudio-Properties = "media.role=music";
+    })
+  ];
+
+  dontWrapGApps = true;
+
   installPhase = ''
     runHook preInstall
 
-    mkdir -p "$out/bin"
-    cp -R "opt" "$out"
-    cp -R "usr/share" "$out/share"
-    chmod -R g-w "$out"
+    for i in 16 22 24 32 48 64 128 256 384; do
+      install -Dm644 "assets/icons/$i"x"$i.png" "$out/share/icons/hicolor/$i"x"$i/apps/tidal-hifi.png"
+    done
+
+    mv dist/linux-unpacked "$out/share/tidal-hifi"
 
     runHook postInstall
   '';
 
+  # see: pkgs/development/tools/electron/binary/generic.nix
   postFixup = ''
-    makeWrapper $out/opt/tidal-hifi/tidal-hifi $out/bin/tidal-hifi \
-      --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath finalAttrs.buildInputs}" \
-      --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true}}" \
+    patchelf \
+      --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
+      --set-rpath "${electronLibPath}:$out/share/tidal-hifi" \
+      $out/share/tidal-hifi/tidal-hifi \
+      $out/share/tidal-hifi/chrome_crashpad_handler
+
+    # patch libANGLE
+    patchelf \
+      --set-rpath "${
+        lib.makeLibraryPath [
+          libGL
+          pciutils
+          vulkan-loader
+        ]
+      }" \
+      $out/share/tidal-hifi/lib*GL*
+
+    # replace bundled vulkan-loader
+    rm "$out/share/tidal-hifi/libvulkan.so.1"
+    ln -s -t "$out/share/tidal-hifi" "${lib.getLib vulkan-loader}/lib/libvulkan.so.1"
+
+    makeShellWrapper "$out/share/tidal-hifi/tidal-hifi" "$out/bin/tidal-hifi" \
+      --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations}}" \
       "''${gappsWrapperArgs[@]}"
-    substituteInPlace $out/share/applications/tidal-hifi.desktop \
-      --replace "/opt/tidal-hifi/tidal-hifi" "tidal-hifi"
   '';
 
   meta = {
-    changelog = "https://github.com/Mastermindzh/tidal-hifi/releases/tag/${finalAttrs.version}";
+    changelog = "https://github.com/Mastermindzh/tidal-hifi/releases/tag/${version}";
     description = "Web version of Tidal running in electron with hifi support thanks to widevine";
     homepage = "https://github.com/Mastermindzh/tidal-hifi";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
+      gerg-l
       qbit
       spikespaz
     ];
     platforms = lib.platforms.linux;
     mainProgram = "tidal-hifi";
   };
-})
+}


### PR DESCRIPTION
closes: #340449
supersedes: #252307
related to: #296939

we should also check on: #366368

it is now built from source as much as possible.
`castlabs-electron` is now marked as unfree, while `tidal-hifi` remains MIT.

someone please test wayland capabilites
i'm also not too sure about supporting `NIXOS_OZONE_WL` because if you go to `settings` -> `advanced` there's a `Wayland support` toggle, which i'm pretty sure enables the same flags as `NIXOS_OZONE_WL`

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
