### PR TITLE
buildMozillaMach: Add RELRHACK_LINKER patch

### DIFF
--- a/pkgs/applications/networking/browsers/firefox/build-fix-RELRHACK_LINKER-setting-when-linker-name-i.patch
+++ b/pkgs/applications/networking/browsers/firefox/build-fix-RELRHACK_LINKER-setting-when-linker-name-i.patch
@@ -1,0 +1,57 @@
+From 45d40b3eeb393051bd3a49feebcefe39dc6e4e93 Mon Sep 17 00:00:00 2001
+From: Peter Collingbourne <pcc@google.com>
+Date: Wed, 23 Apr 2025 21:13:38 -0700
+Subject: [PATCH] build: fix RELRHACK_LINKER setting when linker name is target
+ triple prefixed
+
+RELRHACK_LINKER is used as the name of a binary installed in a
+directory specified with -B to override the linker. Both Clang and
+GCC will only look for a binary named "ld" (or "ld.$fuse_ld_setting"
+if -fuse-ld= is specified) in the -B directories, which means that
+if the linker name does not follow this pattern, for example if it
+is named $target_triple-ld", the relrhack linker will not be found,
+the compiler will use the normal linker and the link will fail. To fix
+this problem, use the correct pattern to name the relrhack executable.
+---
+ toolkit/moz.configure | 16 ++++++++--------
+ 1 file changed, 8 insertions(+), 8 deletions(-)
+
+diff --git a/toolkit/moz.configure b/toolkit/moz.configure
+index 6c47287a5b..1a9c368e5e 100644
+--- a/toolkit/moz.configure
++++ b/toolkit/moz.configure
+@@ -1843,23 +1843,23 @@ with only_when("--enable-compile-environment"):
+     use_relrhack = depends(which_elf_hack)(lambda x: x == "relr")
+     set_config("RELRHACK", True, when=use_relrhack)
+ 
+-    @depends(c_compiler, linker_ldflags, when=use_relrhack)
+-    def relrhack_real_linker(c_compiler, linker_ldflags):
++    @depends(linker_ldflags, when=use_relrhack)
++    def relrhack_linker(linker_ldflags):
+         ld = "ld"
+         for flag in linker_ldflags:
+             if flag.startswith("-fuse-ld="):
+                 ld = "ld." + flag[len("-fuse-ld=") :]
++        return ld
++
++    set_config("RELRHACK_LINKER", relrhack_linker)
++
++    @depends(c_compiler, relrhack_linker, when=use_relrhack)
++    def relrhack_real_linker(c_compiler, ld):
+         ld = check_cmd_output(
+             c_compiler.compiler, f"--print-prog-name={ld}", *c_compiler.flags
+         )
+         return ld.rstrip()
+ 
+-    @depends(relrhack_real_linker, when=use_relrhack)
+-    def relrhack_linker(ld):
+-        return os.path.basename(ld)
+-
+-    set_config("RELRHACK_LINKER", relrhack_linker)
+-
+     std_filesystem = host_cxx_compiler.try_run(
+         header="#include <filesystem>",
+         body='auto foo = std::filesystem::absolute("");',
+-- 
+2.49.0.805.g082f7c87e0-goog
+

--- a/pkgs/applications/networking/browsers/firefox/common.nix
+++ b/pkgs/applications/networking/browsers/firefox/common.nix
@@ -357,6 +357,10 @@ buildStdenv.mkDerivation {
       # Fix for missing vector header on macOS
       # https://bugzilla.mozilla.org/show_bug.cgi?id=1939405
       ./firefox-mac-missing-vector-header.patch
+
+      # https://bugzilla.mozilla.org/show_bug.cgi?id=1962497
+      # https://phabricator.services.mozilla.com/D246545
+      ./build-fix-RELRHACK_LINKER-setting-when-linker-name-i.patch
     ]
     ++ extraPatches;
 


### PR DESCRIPTION
Needed to fix cross compiling. Patch also sent upstream: https://phabricator.services.mozilla.com/D246545


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
