### PR TITLE
nixos/zswap: init module

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -19031,6 +19031,12 @@
     githubId = 7536431;
     name = "Jonas Fierlings";
   };
+  pigsinablanket = {
+    email = "nixpkgs@pigs.dev";
+    github = "pigsinspace";
+    githubId = 28584473;
+    name = "Daniel Reimer";
+  };
   pimeys = {
     email = "julius@nauk.io";
     github = "pimeys";

--- a/nixos/doc/manual/release-notes/rl-2505.section.md
+++ b/nixos/doc/manual/release-notes/rl-2505.section.md
@@ -72,6 +72,8 @@
 
 - [uMurmur](https://umurmur.net), minimalistic Mumble server primarily targeted to run on embedded computers. Available as [services.umurmur](options.html#opt-services.umurmur).
 
+- [zswap](https://www.kernel.org/doc/Documentation/vm/zswap.txt) is a lightweight compressed cache for swap pages. It takes pages that are in the process of being swapped out and attempts to compress them into a dynamically allocated RAM-based memory pool. Available as [zswap](options.html#zswap)
+
 - [Zenoh](https://zenoh.io/), a pub/sub/query protocol with low overhead. The Zenoh router daemon is available as [services.zenohd](options.html#opt-services.zenohd.enable)
 
 - [ytdl-sub](https://github.com/jmbannon/ytdl-sub), a tool that downloads media via yt-dlp and prepares it for your favorite media player, including Kodi, Jellyfin, Plex, Emby, and modern music players. Available as [services.ytdl-sub](options.html#opt-services.ytdl-sub.instances).

--- a/nixos/modules/config/zswap.nix
+++ b/nixos/modules/config/zswap.nix
@@ -1,0 +1,110 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+
+  cfg = config.zswap;
+
+in
+
+{
+  ###### interface
+
+  options = {
+
+    zswap = {
+
+      enable = lib.mkOption {
+        default = false;
+        type = lib.types.bool;
+        description = ''
+          Enable zswap, a lightweight compressed cache for swap pages.
+          See [
+          https://www.kernel.org/doc/Documentation/vm/zswap.txt
+          ] (https://www.kernel.org/doc/Documentation/vm/zswap.txt)
+        '';
+      };
+
+      maxPoolPercent = lib.mkOption {
+        default = 20;
+        type = lib.types.int;
+        description = ''
+          The maximum percentage of memory that the compressed pool can occupy.
+        '';
+      };
+
+      compressor = lib.mkOption {
+        default = "zstd";
+        example = "lzo";
+        type =
+          with lib.types;
+          either (enum [
+            "842"
+            "lzo"
+            "lz4"
+            "lz4hc"
+            "zstd"
+          ]) str;
+        description = ''
+          Compression algorithm. `lzo` has good compression,
+          but is slow. `lz4` has bad compression, but is fast.
+          `zstd` is both good compression and fast.
+        '';
+      };
+
+      zpool = lib.mkOption {
+        default = "zsmalloc";
+        type =
+          with lib.types;
+          either (enum [
+            "zsmalloc"
+            "zbud"
+          ]) str;
+        description = ''
+          Zswap makes use of zpool for managing the compressed memory pool.
+          See [
+            https://docs.kernel.org/admin-guide/mm/zswap.html#design
+          ] (https://docs.kernel.org/admin-guide/mm/zswap.html#design).
+        '';
+      };
+
+      acceptThresholdPercent = lib.mkOption {
+        default = 90;
+        type = lib.types.int;
+        description = ''
+          Sets the threshold at which zswap would start accepting pages again
+          after it became full.
+        '';
+      };
+    };
+
+  };
+
+  config = lib.mkMerge [
+
+    (lib.mkIf cfg.enable {
+      boot.kernelParams = [ "zswap.enabled=1" ];
+
+      system.activationScripts.zswap-activate = ''
+        echo ${toString cfg.maxPoolPercent} > /sys/module/zswap/parameters/max_pool_percent
+        echo ${cfg.compressor} > /sys/module/zswap/parameters/compressor
+        echo ${cfg.zpool} > /sys/module/zswap/parameters/zpool
+        echo ${toString cfg.acceptThresholdPercent} > /sys/module/zswap/parameters/accept_threshold_percent
+        echo "Y" > /sys/module/zswap/parameters/enabled
+      '';
+    })
+
+    (lib.mkIf (!cfg.enable) {
+      system.activationScripts.zswap-activate = ''
+        echo N > /sys/module/zswap/parameters/enabled
+      '';
+    })
+
+  ];
+
+  meta.maintainers = with lib.maintainers; [ pigsinablanket ];
+}

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -45,6 +45,7 @@
   ./config/xdg/sounds.nix
   ./config/xdg/terminal-exec.nix
   ./config/zram.nix
+  ./config/zswap.nix
   ./hardware/acpilight.nix
   ./hardware/all-firmware.nix
   ./hardware/all-hardware.nix

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1500,6 +1500,7 @@ in
   zram-generator = runTest ./zram-generator.nix;
   zrepl = runTest ./zrepl.nix;
   zsh-history = runTest ./zsh-history.nix;
+  zswap = runTest ./zswap.nix;
   zwave-js = runTest ./zwave-js.nix;
   zwave-js-ui = runTest ./zwave-js-ui.nix;
 }

--- a/nixos/tests/zswap.nix
+++ b/nixos/tests/zswap.nix
@@ -1,0 +1,32 @@
+{ lib, ... }:
+{
+  name = "zswap";
+  meta.maintainers = with lib.maintainers; [ pigsinablanket ];
+
+  nodes.machine =
+    { ... }:
+    {
+      zswap = {
+        enable = true;
+        compressor = "zstd";
+        zpool = "zsmalloc";
+        maxPoolPercent = 25;
+        acceptThresholdPercent = 85;
+      };
+
+    };
+
+  testScript = ''
+    machine.start()
+
+    machine.wait_for_unit("multi-user.target")
+
+    machine.succeed("cat /sys/module/zswap/parameters/enabled | grep Y")
+    machine.succeed("cat /sys/module/zswap/parameters/compressor | grep zstd")
+    machine.succeed("cat /sys/module/zswap/parameters/zpool | grep zsmalloc")
+    machine.succeed("cat /sys/module/zswap/parameters/max_pool_percent | grep 25")
+    machine.succeed("cat /sys/module/zswap/parameters/accept_threshold_percent | grep 85")
+
+    machine.succeed("dmesg | grep 'zswap: loaded using pool zstd/zsmalloc'")
+  '';
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Provides a NixOS module for enabling and configuring zswap, a compressed cache for swap pages within the kernel.

Closes #119244.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
