### PR TITLE
ocamlPackages.raylib: clean & fix

### DIFF
--- a/pkgs/development/ocaml-modules/raylib/default.nix
+++ b/pkgs/development/ocaml-modules/raylib/default.nix
@@ -1,35 +1,43 @@
 {
   lib,
-  fetchFromGitHub,
+  fetchurl,
   buildDunePackage,
   dune-configurator,
   ctypes,
   integers,
   patch,
-  gitUpdater,
+  libGL,
+  libX11,
+  libXcursor,
+  libXi,
+  libXinerama,
+  libXrandr,
 }:
 
 buildDunePackage rec {
   pname = "raylib";
   version = "1.4.0";
 
-  src = fetchFromGitHub {
-    owner = "tjammer";
-    repo = "raylib-ocaml";
-    tag = version;
-    hash = "sha256-Fh79YnmboQF5Kn3VF//JKLaIFKl8QJWVOqRexTzxF0U=";
-    # enable submodules for vendored raylib sources
-    fetchSubmodules = true;
+  src = fetchurl {
+    url = "https://github.com/tjammer/raylib-ocaml/releases/download/${version}/raylib-${version}.tbz";
+    hash = "sha256-/SeKgQOrhsAgMNk6ODAZlopL0mL0lVfCTx1ugmV1P/s=";
   };
 
-  propagatedBuildInputs = [
+  buildInputs = [
     dune-configurator
-    ctypes
-    integers
     patch
   ];
 
-  passthru.updateScript = gitUpdater { };
+  propagatedBuildInputs = [
+    ctypes
+    integers
+    libGL
+    libX11
+    libXcursor
+    libXi
+    libXinerama
+    libXrandr
+  ];
 
   meta = {
     description = "OCaml bindings for Raylib (5.0.0)";

--- a/pkgs/development/ocaml-modules/raylib/raygui.nix
+++ b/pkgs/development/ocaml-modules/raylib/raygui.nix
@@ -1,12 +1,17 @@
 {
   buildDunePackage,
+  fetchurl,
   raylib,
 }:
 
-buildDunePackage {
+buildDunePackage rec {
   pname = "raygui";
+  version = "1.4.0";
 
-  inherit (raylib) src version;
+  src = fetchurl {
+    url = "https://github.com/tjammer/raylib-ocaml/releases/download/${version}/raygui-${version}.tbz";
+    hash = "sha256-PQcVTAQKeTPkOOHk5w3O3Tz0n7jLvkIo3Urvrk66eMs=";
+  };
 
   propagatedBuildInputs = [
     raylib


### PR DESCRIPTION
I don’t think these packages ever built (except by accident in impure contexts).

cc maintainer @r17x.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
