### PR TITLE
[Backport 24.11] teleport_17: 17.4.2 -> 17.4.5; teleport_16: 16.5.0 -> 16.5.3; teleport_15: 15.4.30 -> 15.4.33

### DIFF
--- a/pkgs/servers/teleport/15/default.nix
+++ b/pkgs/servers/teleport/15/default.nix
@@ -2,11 +2,11 @@
 import ../generic.nix (
   args
   // {
-    version = "15.4.30";
-    hash = "sha256-qLGlhCDfIPVJfKI37Wv2XNl5tdloq48wJu8V/ww0yHc=";
-    vendorHash = "sha256-aM7VYauCC6zytFELKNyUa30H17ErFmBkyEr+eDoF92g=";
-    yarnHash = "sha256-63JX0rAMyZA58CdaqHlTXlL7npvKcYnhVIh1NaJEmBk=";
-    cargoHash = "sha256-2lIhtIWl26xoH7XxhPEmG/2FpfwgTC7kmahCim1W4To=";
+    version = "15.4.31";
+    hash = "sha256-3jbz10ru5SqSGLH9m5rTmPfN9fxSmYJXrbV7B2Bh2Mo=";
+    vendorHash = "sha256-J4N2VbiIzfyZJtFvmwW6xZLxB2F9bDRRDfOaWLoHT/4=";
+    yarnHash = "sha256-3Ady46LXa3TSSwmWY+GDiS1j5qR5VIuJ5Z+iW5g0SAA=";
+    cargoHash = "sha256-aXKrUo+Q9gK09TP9W2PQ3TjDwBtIlUopZL6AJVAiszE=";
 
     wasm-bindgen-cli = wasm-bindgen-cli.override {
       version = "0.2.100";

--- a/pkgs/servers/teleport/15/default.nix
+++ b/pkgs/servers/teleport/15/default.nix
@@ -2,8 +2,8 @@
 import ../generic.nix (
   args
   // {
-    version = "15.4.31";
-    hash = "sha256-3jbz10ru5SqSGLH9m5rTmPfN9fxSmYJXrbV7B2Bh2Mo=";
+    version = "15.4.33";
+    hash = "sha256-glf0JCsUZD0o3C+3lJ9V2wvamZa8bKySVi/sLo11Mvk=";
     vendorHash = "sha256-J4N2VbiIzfyZJtFvmwW6xZLxB2F9bDRRDfOaWLoHT/4=";
     yarnHash = "sha256-3Ady46LXa3TSSwmWY+GDiS1j5qR5VIuJ5Z+iW5g0SAA=";
     cargoHash = "sha256-aXKrUo+Q9gK09TP9W2PQ3TjDwBtIlUopZL6AJVAiszE=";

--- a/pkgs/servers/teleport/16/default.nix
+++ b/pkgs/servers/teleport/16/default.nix
@@ -2,11 +2,11 @@
 import ../generic.nix (
   args
   // {
-    version = "16.5.0";
-    hash = "sha256-d634UB/YGDdAeBEJcRsRE5gqd31oQX3P4HJ+PoMQUmk=";
-    vendorHash = "sha256-0/ZYG8mYv3B0YJ89NJVG7M29/hU2zBtSXmoD32VEqpk=";
-    pnpmHash = "sha256-dqCfwMzSnEPQXz1bsroqSihkvw2Kcvyz+A4fpa52LVk=";
-    cargoHash = "sha256-NASNBk4QVoqe2cz4l94aXo6pUtF8Qxwb61XRI/ErjTs=";
+    version = "16.5.1";
+    hash = "sha256-qDXJuKQ1IJ0+v4m5glEKNZVUBuLhG95MOzo0u3Ma2Qw=";
+    vendorHash = "sha256-pHAiJ080lyWtb7xbwSeD9g8JlyXZyqtZC2IpsUJ7YaY=";
+    pnpmHash = "sha256-XHiox+UYhGYgo+inrnOVy0qvPXm7xoCaGfAC4FQmaMM=";
+    cargoHash = "sha256-04zykCcVTptEPGy35MIWG+tROKFzEepLBmn04mSbt7I=";
 
     # wasm-bindgen-cli version must match the version of wasm-bindgen in Cargo.lock
     wasm-bindgen-cli = wasm-bindgen-cli.override {

--- a/pkgs/servers/teleport/16/default.nix
+++ b/pkgs/servers/teleport/16/default.nix
@@ -2,10 +2,10 @@
 import ../generic.nix (
   args
   // {
-    version = "16.5.1";
-    hash = "sha256-qDXJuKQ1IJ0+v4m5glEKNZVUBuLhG95MOzo0u3Ma2Qw=";
+    version = "16.5.3";
+    hash = "sha256-yaHy75oS+HuO++qHEDaGByz11vwAqfaDT9qb94iKs3Y=";
     vendorHash = "sha256-pHAiJ080lyWtb7xbwSeD9g8JlyXZyqtZC2IpsUJ7YaY=";
-    pnpmHash = "sha256-XHiox+UYhGYgo+inrnOVy0qvPXm7xoCaGfAC4FQmaMM=";
+    pnpmHash = "sha256-JQca2eFxcKJDHIaheJBg93ivZU95UWMRgbcK7QE4R10=";
     cargoHash = "sha256-04zykCcVTptEPGy35MIWG+tROKFzEepLBmn04mSbt7I=";
 
     # wasm-bindgen-cli version must match the version of wasm-bindgen in Cargo.lock

--- a/pkgs/servers/teleport/17/default.nix
+++ b/pkgs/servers/teleport/17/default.nix
@@ -2,10 +2,10 @@
 import ../generic.nix (
   args
   // {
-    version = "17.4.2";
-    hash = "sha256-hiitFUN7bJR68sh/HrWsQMUm1lM2J3yjSoIT7mv/ldo=";
+    version = "17.4.3";
+    hash = "sha256-MdtvtM5Nd+e7eSmHf4OwdjuQ2rUjwsAusvO7kATnru0=";
     vendorHash = "sha256-03qkUH7UfAF0FwbG5enKf9Ke1teN89vmzk8yRfGvmPg=";
-    pnpmHash = "sha256-Hh4R+mkJJp9CR4NHw+VFzLPxb7e9T1BQkey0in2t934=";
+    pnpmHash = "sha256-zx1OKAeFo5zWvGHDdOOvtmYB+tX9sW5sIrXY2AXjPN0=";
     cargoHash = "sha256-0PT9y56V/WHo3M5TcpVWBuHcQMZ0w2L4rEuXuTvVNFU=";
   }
 )

--- a/pkgs/servers/teleport/17/default.nix
+++ b/pkgs/servers/teleport/17/default.nix
@@ -2,10 +2,10 @@
 import ../generic.nix (
   args
   // {
-    version = "17.4.3";
-    hash = "sha256-MdtvtM5Nd+e7eSmHf4OwdjuQ2rUjwsAusvO7kATnru0=";
-    vendorHash = "sha256-03qkUH7UfAF0FwbG5enKf9Ke1teN89vmzk8yRfGvmPg=";
-    pnpmHash = "sha256-zx1OKAeFo5zWvGHDdOOvtmYB+tX9sW5sIrXY2AXjPN0=";
-    cargoHash = "sha256-0PT9y56V/WHo3M5TcpVWBuHcQMZ0w2L4rEuXuTvVNFU=";
+    version = "17.4.5";
+    hash = "sha256-VsgwX/ffHY4640FsXLtEht5acUX4bnaAlLDxMnLb0Mg=";
+    vendorHash = "sha256-3G7Vw/R08vG/tC16RBNPM0oOu6lLOgNpRLN/FAaKvuQ=";
+    pnpmHash = "sha256-gc1m76w3o0N1F6xYr2ZS6DOGvwbjK8k6bC8G8+xVFVQ=";
+    cargoHash = "sha256-qz8gkooQTuBlPWC4lHtvBQpKkd+nEZ0Hl7AVg9JkPqs=";
   }
 )

--- a/pkgs/servers/teleport/disable-wasm-opt-for-ironrdp.patch
+++ b/pkgs/servers/teleport/disable-wasm-opt-for-ironrdp.patch
@@ -1,0 +1,15 @@
+# Based on https://github.com/gravitational/teleport/commit/994890fb05360b166afd981312345a4cf01bc422.patch?full_index=1
+diff --git a/web/packages/shared/libs/ironrdp/Cargo.toml b/web/packages/shared/libs/ironrdp/Cargo.toml
+index 4252ba95372bdab9a1e2f74e164e303bedd5eee8..4c203290984223564f50ee775a137e86f3c2ddf0 100644
+--- a/web/packages/shared/libs/ironrdp/Cargo.toml
++++ b/web/packages/shared/libs/ironrdp/Cargo.toml
+@@ -7,6 +7,9 @@ publish.workspace = true
+ 
+ # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+ 
++[package.metadata.wasm-pack.profile.release]
++wasm-opt = false
++
+ [lib]
+ crate-type = ["cdylib"]
+ 

--- a/pkgs/servers/teleport/generic.nix
+++ b/pkgs/servers/teleport/generic.nix
@@ -121,11 +121,7 @@ let
       );
 
     patches = lib.optional (lib.versionAtLeast version "16") [
-      (fetchpatch {
-        name = "disable-wasm-opt-for-ironrdp.patch";
-        url = "https://github.com/gravitational/teleport/commit/994890fb05360b166afd981312345a4cf01bc422.patch?full_index=1";
-        hash = "sha256-Y5SVIUQsfi5qI28x5ccoRkBjpdpeYn0mQk8sLO644xo=";
-      })
+      ./disable-wasm-opt-for-ironrdp.patch
     ];
 
     configurePhase = ''
@@ -152,10 +148,14 @@ let
       ${
         if lib.versionAtLeast version "15" then
           ''
-            pushd web/packages/teleport
+            pushd web/packages
+            pushd shared
             # https://github.com/gravitational/teleport/blob/6b91fe5bbb9e87db4c63d19f94ed4f7d0f9eba43/web/packages/teleport/README.md?plain=1#L18-L20
-            RUST_MIN_STACK=16777216 wasm-pack build ./src/ironrdp --target web --mode no-install
+            RUST_MIN_STACK=16777216 wasm-pack build ./libs/ironrdp --target web --mode no-install
+            popd
+            pushd teleport
             vite build
+            popd
             popd
           ''
         else


### PR DESCRIPTION
Backport of #397809. Because of teleport_15 already dropped on `master`, I had to amend a commit and add a new commit for the 15 update.
Includes an update of golang.org/x/net, which addresses https://github.com/advisories/GHSA-qxp5-gwg8-xv66.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
