### PR TITLE
postgresqlPackages.timescaledb_toolkit: fix passthru tests

### DIFF
--- a/pkgs/servers/sql/postgresql/ext/pgvecto-rs/package.nix
+++ b/pkgs/servers/sql/postgresql/ext/pgvecto-rs/package.nix
@@ -5,7 +5,6 @@
   fetchFromGitHub,
   lib,
   nix-update-script,
-  nixosTests,
   openssl,
   pkg-config,
   postgresql,

--- a/pkgs/servers/sql/postgresql/ext/timescaledb.nix
+++ b/pkgs/servers/sql/postgresql/ext/timescaledb.nix
@@ -3,7 +3,6 @@
   fetchFromGitHub,
   lib,
   libkrb5,
-  nixosTests,
   openssl,
   postgresql,
   postgresqlBuildExtension,

--- a/pkgs/servers/sql/postgresql/ext/timescaledb_toolkit.nix
+++ b/pkgs/servers/sql/postgresql/ext/timescaledb_toolkit.nix
@@ -4,7 +4,6 @@
   fetchFromGitHub,
   lib,
   nix-update-script,
-  nixosTests,
   postgresql,
 }:
 
@@ -27,7 +26,7 @@
 
   passthru = {
     updateScript = nix-update-script { };
-    tests = nixosTests.postgresql.timescaledb.passthru.override postgresql;
+    tests = postgresql.pkgs.timescaledb.tests;
   };
 
   # tests take really long

--- a/pkgs/servers/sql/postgresql/ext/tsja.nix
+++ b/pkgs/servers/sql/postgresql/ext/tsja.nix
@@ -2,7 +2,6 @@
   fetchzip,
   lib,
   mecab,
-  nixosTests,
   postgresql,
   postgresqlTestExtension,
   stdenv,


### PR DESCRIPTION
Fixes https://github.com/NixOS/nixpkgs/pull/398205#issuecomment-2826438078

fyi @trofi

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
