### PR TITLE
forscape: init at 0.0.2-unstable-2025-04-28

### DIFF
--- a/pkgs/by-name/fo/forscape/package.nix
+++ b/pkgs/by-name/fo/forscape/package.nix
@@ -1,0 +1,55 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+
+  # nativeBuildInputs
+  cmake,
+  qt6,
+  python3,
+
+  # buildInputs
+  eigen,
+  parallel-hashmap,
+  readerwriterqueue,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "forscape";
+  version = "0.0.2-unstable-2025-04-28";
+
+  src = fetchFromGitHub {
+    owner = "JohnDTill";
+    repo = "Forscape";
+    rev = "1b6d82cdee7ed1ffeee8adffa56ca2b0a866cb34";
+    hash = "sha256-Ee3SAFZG8I0ZEbggLVViqTYu4SFjNJ62xLcpfLgFlR0=";
+  };
+  cmakeFlags = [
+    "-DUSE_CONAN=OFF"
+  ];
+  # Relative to build directory
+  cmakeDir = "../app";
+
+  nativeBuildInputs = [
+    cmake
+    qt6.wrapQtAppsHook
+    python3
+  ];
+
+  buildInputs = [
+    eigen
+    parallel-hashmap
+    readerwriterqueue
+    qt6.qtbase
+    qt6.qtsvg
+  ];
+
+  meta = {
+    description = "Scientific computing language";
+    homepage = "https://github.com/JohnDTill/Forscape";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ doronbehar ];
+    mainProgram = "Forscape";
+    platforms = lib.platforms.all;
+  };
+})

--- a/pkgs/by-name/re/readerwriterqueue/package.nix
+++ b/pkgs/by-name/re/readerwriterqueue/package.nix
@@ -1,0 +1,32 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "readerwriterqueue";
+  # Not using a stable version since this one produces
+  # readerwriterqueueConfig.cmake needed by dependent packages.
+  version = "1.0.6-2024-07-09";
+
+  src = fetchFromGitHub {
+    owner = "cameron314";
+    repo = "readerwriterqueue";
+    rev = "16b48ae1148284e7b40abf72167206a4390a4592";
+    hash = "sha256-m4cUIXiDFxTguDZ7d0svjlOSkUNYY0bbUp3t7adBwOo=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+  ];
+
+  meta = {
+    description = "Fast single-producer, single-consumer lock-free queue for C";
+    homepage = "https://github.com/cameron314/readerwriterqueue";
+    license = lib.licenses.bsd2;
+    maintainers = with lib.maintainers; [ doronbehar ];
+    platforms = lib.platforms.all;
+  };
+})


### PR DESCRIPTION
## Description of changes


## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
