### PR TITLE
paretosecurity: 0.1.9 -> 0.2.12

### DIFF
--- a/nixos/modules/services/security/paretosecurity.nix
+++ b/nixos/modules/services/security/paretosecurity.nix
@@ -12,7 +12,11 @@ in
   options.services.paretosecurity = {
     enable = lib.mkEnableOption "[ParetoSecurity](https://paretosecurity.com) [agent](https://github.com/ParetoSecurity/agent) and its root helper";
     package = lib.mkPackageOption pkgs "paretosecurity" { };
-    trayIcon = lib.mkEnableOption "tray icon for ParetoSecurity";
+    trayIcon = lib.mkOption {
+      type = lib.types.bool;
+      default = true;
+      description = "Set to false to disable the tray icon and run as a CLI tool only.";
+    };
   };
 
   config = lib.mkIf cfg.enable {

--- a/nixos/tests/paretosecurity.nix
+++ b/nixos/tests/paretosecurity.nix
@@ -46,10 +46,7 @@
     {
       imports = [ ./common/user-account.nix ];
 
-      services.paretosecurity = {
-        enable = true;
-        trayIcon = true;
-      };
+      services.paretosecurity.enable = true;
 
       services.xserver.enable = true;
       services.xserver.displayManager.lightdm.enable = true;
@@ -119,5 +116,16 @@
     xfce.wait_for_text("Pareto Security")
     xfce.succeed("xdotool click 1")
     xfce.wait_for_text("Run Checks")
+
+    # Test 5: paretosecurity:// URL handler is registered
+    xfce.succeed("su - alice -c 'xdg-open paretosecurity://foo'")
+
+    # Test 6: Desktop entry
+    xfce.succeed("xdotool mousemove 10 10")
+    xfce.succeed("xdotool click 1")  # hide the tray icon window
+    xfce.succeed("xdotool click 1")  # show the Applications menu
+    xfce.succeed("xdotool mousemove 10 200")
+    xfce.succeed("xdotool click 1")
+    xfce.wait_for_text("Pareto Security")
   '';
 }

--- a/pkgs/by-name/pa/paretosecurity/package.nix
+++ b/pkgs/by-name/pa/paretosecurity/package.nix
@@ -17,16 +17,16 @@ buildGoModule (finalAttrs: {
     webkitgtk_4_1
   ];
   pname = "paretosecurity";
-  version = "0.1.9";
+  version = "0.2.12";
 
   src = fetchFromGitHub {
     owner = "ParetoSecurity";
     repo = "agent";
     rev = finalAttrs.version;
-    hash = "sha256-KJs4xC3EtGG4116UE+oIEwAMcuDWIm9gqgZY+Bv14ac=";
+    hash = "sha256-skBxDPC+C8JU1CW6g3SA2C4IawaoPzVi8pdl5BCutUY=";
   };
 
-  vendorHash = "sha256-3plpvwLe32AsGuVzdM2fSmTPkKwRFmhi651NEIRdOxw=";
+  vendorHash = "sha256-YnyACP/hJYxi4AWMwr0We4YUTbWwahKAIYN6RnHmzls=";
   proxyVendor = true;
 
   ldflags = [
@@ -51,6 +51,17 @@ buildGoModule (finalAttrs: {
     install -Dm444 ${finalAttrs.src}/apt/paretosecurity-trayicon.service $out/lib/systemd/user/paretosecurity-trayicon.service
     substituteInPlace $out/lib/systemd/user/paretosecurity-trayicon.service \
         --replace-fail "/usr/bin/paretosecurity" "$out/bin/paretosecurity"
+
+    # Install .desktop files
+    install -Dm444 ${finalAttrs.src}/apt/ParetoSecurity.desktop $out/share/applications/ParetoSecurity.desktop
+    substituteInPlace $out/share/applications/ParetoSecurity.desktop \
+        --replace-fail "/usr/bin/paretosecurity" "$out/bin/paretosecurity"
+    install -Dm444 ${finalAttrs.src}/apt/ParetoSecurityLink.desktop $out/share/applications/ParetoSecurityLink.desktop
+    substituteInPlace $out/share/applications/ParetoSecurityLink.desktop \
+        --replace-fail "/usr/bin/paretosecurity" "$out/bin/paretosecurity"
+
+    # Install icon
+    install -Dm444 ${finalAttrs.src}/assets/icon.png $out/share/icons/hicolor/512x512/apps/ParetoSecurity.png
   '';
 
   passthru.tests = {
@@ -74,10 +85,11 @@ buildGoModule (finalAttrs: {
       root helper that allows you to run the checker in userspace. Some checks
       require root permissions, and the checker asks the helper to run those.
 
-      Additionally, if you enable `services.paretosecurity.trayIcon`, you get a
-      little Vilfredo Pareto living in your systray showing your the current
-      status of checks. This will also enable a systemd timer to update the
-      status of checks once per hour.
+      Additionally, using the NixOS module gets you a little Vilfredo Pareto
+      living in your systray showing your the current status of checks. The
+      NixOS Module also installs a systemd timer to update the status of checks
+      once per hour. If you want to use just the CLI mode, set
+      `services.paretosecurity.trayIcon` to `false`.
 
       Finally, you can run `paretosecurity link` to configure the agent
       to send the status of checks to https://dash.paretosecurity.com to make


### PR DESCRIPTION
Also:
* enable tray icon by default when nixos module is enabled
* install desktop entry
* install paretosecurity:// URL handler
* install app icon


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
