### PR TITLE
[24.11] fcgi: 2.4.2 -> 2.4.5

### DIFF
--- a/pkgs/by-name/fc/fcgi/package.nix
+++ b/pkgs/by-name/fc/fcgi/package.nix
@@ -7,13 +7,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "fcgi";
-  version = "2.4.2";
+  version = "2.4.3";
 
   src = fetchFromGitHub {
     owner = "FastCGI-Archives";
     repo = "fcgi2";
     rev = finalAttrs.version;
-    hash = "sha256-4U/Mc2U7tK/fo4B9NBwYKzDuLApvSzWR4mqWzZ00H8o=";
+    hash = "sha256-P8wkiURBc5gV0PxwemkIIpTPOpug6YIZE//3j5U76K0=";
   };
 
   nativeBuildInputs = [ autoreconfHook ];

--- a/pkgs/by-name/fc/fcgi/package.nix
+++ b/pkgs/by-name/fc/fcgi/package.nix
@@ -7,13 +7,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "fcgi";
-  version = "2.4.3";
+  version = "2.4.4";
 
   src = fetchFromGitHub {
     owner = "FastCGI-Archives";
     repo = "fcgi2";
     rev = finalAttrs.version;
-    hash = "sha256-P8wkiURBc5gV0PxwemkIIpTPOpug6YIZE//3j5U76K0=";
+    hash = "sha256-GI2RL0djfCej7bBhxR6cK/FrTbDYEl75SEfQFgl0ctA=";
   };
 
   nativeBuildInputs = [ autoreconfHook ];

--- a/pkgs/by-name/fc/fcgi/package.nix
+++ b/pkgs/by-name/fc/fcgi/package.nix
@@ -7,13 +7,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "fcgi";
-  version = "2.4.4";
+  version = "2.4.5";
 
   src = fetchFromGitHub {
     owner = "FastCGI-Archives";
     repo = "fcgi2";
     rev = finalAttrs.version;
-    hash = "sha256-GI2RL0djfCej7bBhxR6cK/FrTbDYEl75SEfQFgl0ctA=";
+    hash = "sha256-DsL44onRIUnf99Y+hTjMOaEVp6cjbdqksm4V+1od6pU=";
   };
 
   nativeBuildInputs = [ autoreconfHook ];


### PR DESCRIPTION
Fixes CVE-2025-23016.

Backports of #398682, #365118 and #372031.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review pr 401385`

---
### `x86_64-linux`
<details>
  <summary>:fast_forward: 1 package marked as broken and skipped:</summary>
  <ul>
    <li>valum</li>
  </ul>
</details>
<details>
  <summary>:white_check_mark: 14 packages built:</summary>
  <ul>
    <li>fcgi</li>
    <li>fcgiwrap</li>
    <li>fileshelter</li>
    <li>haskellPackages.fastcgi</li>
    <li>haskellPackages.fastcgi.doc</li>
    <li>haskellPackages.happstack-fastcgi</li>
    <li>haskellPackages.happstack-fastcgi.doc</li>
    <li>lms</li>
    <li>mapcache</li>
    <li>mapserver</li>
    <li>qgis</li>
    <li>qgis-ltr</li>
    <li>shibboleth-sp</li>
    <li>wt (wt4)</li>
  </ul>
</details>
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
