### PR TITLE
sdwire: init at 0.2.3-unstable-2025-04-24

### DIFF
--- a/pkgs/by-name/sd/sdwire/package.nix
+++ b/pkgs/by-name/sd/sdwire/package.nix
@@ -1,0 +1,50 @@
+{
+  lib,
+  fetchFromGitHub,
+  python3,
+  # tests
+  runCommand,
+  sdwire,
+}:
+
+python3.pkgs.buildPythonApplication rec {
+  pname = "sdwire";
+  version = "0.2.3-unstable-2025-04-24";
+  pyproject = true;
+
+  disabled = python3.pkgs.pythonOlder "3.10";
+  src = fetchFromGitHub {
+    owner = "badger-embedded";
+    repo = "sdwire-cli";
+    rev = "1fb9678eb2459dc08c4feff24d6fa9072234cd19";
+    hash = "sha256-TYzgIqN595UIAXs1MrWAB8A5h/p4R38sGpcsxDDtUlk=";
+  };
+
+  nativeBuildInputs = with python3.pkgs; [
+    poetry-core
+  ];
+
+  propagatedBuildInputs = with python3.pkgs; [
+    click
+    pyusb
+    pyftdi
+    pyudev
+  ];
+
+  pythonImportsCheck = [ "sdwire" ];
+  passthru.tests = {
+    # make sure that sdwire --help is working as expected
+    help = runCommand "${pname}-test" { } ''
+      ${sdwire}/bin/sdwire --help
+      [ "$?" = "0" ] > $out
+    '';
+  };
+
+  meta = {
+    description = "CLI for Badgerd SDWire Devices";
+    mainProgram = "sdwire";
+    homepage = "https://github.com/Badger-Embedded/sdwire-cli";
+    license = lib.licenses.gpl3;
+    maintainers = with lib.maintainers; [ talhaHavadar ];
+  };
+}


### PR DESCRIPTION
Packaged latest available version of "sdwire" application which controls SDWire devices both legacy and new.

Products are listed here: https://badgerd.nl/
And here is the upstream source which describes the usage of the package as well: https://github.com/Badger-Embedded/sdwire-cli

## Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
```
$ ./result/bin/sdwire list
Serial                  Product Info            Block Dev
bdgrd_sdwirec_303       [sd-wire::SRPOL]        /dev/sda
```
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).