### PR TITLE
equ: init at 1.2.5

### DIFF
--- a/pkgs/by-name/eq/equ/package.nix
+++ b/pkgs/by-name/eq/equ/package.nix
@@ -1,0 +1,47 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitLab,
+  makeBinaryWrapper,
+  zlib,
+  xorg,
+  fontconfig,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "equ";
+  version = "1.2.5";
+
+  src = fetchFromGitLab {
+    owner = "cznic";
+    repo = "equ";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-+BCsJhXJgJc++9W4kf4xI6XwSV91R+jxqPOoRH9bd48=";
+  };
+
+  vendorHash = "sha256-I2yLiT1vYvv7x/lfsWp/5A/8800DNSKx8fRk6XeMmnk=";
+
+  # From some reason, wrapping is needed for the GUI - the Go package doesn't
+  # seem to demand these packages automatically.
+  nativeBuildInputs = [
+    makeBinaryWrapper
+  ];
+  postInstall = ''
+    wrapProgram "$out/bin/equ" --prefix LD_LIBRARY_PATH ":" ${
+      lib.makeLibraryPath [
+        zlib
+        xorg.libXft
+        fontconfig.lib
+        xorg.libX11.out
+      ]
+    }
+  '';
+
+  meta = {
+    description = "Plain TeX math editor";
+    homepage = "https://gitlab.com/cznic/equ";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ doronbehar ];
+    mainProgram = "equ";
+  };
+})


### PR DESCRIPTION
Maybe we need to allow for further wrapping changes. 

## Description of changes

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
