### PR TITLE
ssh-openpgp-auth: 0.2.2 -> 0.2.3

### DIFF
--- a/pkgs/by-name/ss/ssh-openpgp-auth/daemon.nix
+++ b/pkgs/by-name/ss/ssh-openpgp-auth/daemon.nix
@@ -6,8 +6,8 @@
 
 callPackage ./generic.nix {
   pname = "sshd-openpgp-auth";
-  version = "0.3.0";
-  srcHash = "sha256-IV0Nhdqyn12HDOp1jaKz3sKTI3ktFd5b6qybCLWt27I=";
-  cargoHash = "sha256-WyYzDzC83iL1c8gCj+mYDq3/gsFxmxEWKwLhWLEygkI=";
+  version = "0.3.1";
+  srcHash = "sha256-YS8/q8faWSRNciR03wwiiGGgkvZqb5Euto22pde53C8=";
+  cargoHash = "sha256-rBkKQAq1IAc4udS65RvprQe6knxyAFKxCWKGW5k5te4=";
   metaDescription = "Command-line tool for creating and managing OpenPGP based trust anchors for SSH host keys";
 }

--- a/pkgs/by-name/ss/ssh-openpgp-auth/package.nix
+++ b/pkgs/by-name/ss/ssh-openpgp-auth/package.nix
@@ -2,8 +2,8 @@
 
 callPackage ./generic.nix {
   pname = "ssh-openpgp-auth";
-  version = "0.2.2";
-  srcHash = "sha256-5ew6jT6Zr54QYaWFQIGYXd8sqC3yHHZjPfoaCossm8o=";
-  cargoHash = "sha256-PHJiyq7zovn7EA7jDLJQxjxu2ErPHqBMwAlJpb5UVQY=";
+  version = "0.2.3";
+  srcHash = "sha256-YS8/q8faWSRNciR03wwiiGGgkvZqb5Euto22pde53C8=";
+  cargoHash = "sha256-rBkKQAq1IAc4udS65RvprQe6knxyAFKxCWKGW5k5te4=";
   metaDescription = "Command-line tool that provides client-side functionality to transparently verify the identity of remote SSH hosts";
 }


### PR DESCRIPTION
A dilemma worth mentioning:

Upstream has marked the project as archived on 2025-04-24. Should we too remove it and put a `throw` in `aliases.nix`? It is still fully functional.. I tend not to do so at the moment.

## Description of changes


## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
