### PR TITLE
openmolcas: use cmakeFlagsArray only for options where needed.

### DIFF
--- a/pkgs/by-name/op/openmolcas/package.nix
+++ b/pkgs/by-name/op/openmolcas/package.nix
@@ -123,24 +123,25 @@ stdenv.mkDerivation rec {
 
   passthru = lib.optionalAttrs enableMpi { inherit mpi; };
 
+  cmakeFlags = [
+    "-DOPENMP=ON"
+    "-DTOOLS=ON"
+    "-DHDF5=ON"
+    "-DFDE=ON"
+    "-DEXTERNAL_LIBXC=${lib.getDev libxc}"
+    (lib.strings.cmakeBool "DMRG" enableQcmaquis)
+    (lib.strings.cmakeBool "NEVPT2" enableQcmaquis)
+    "-DCMAKE_SKIP_BUILD_RPATH=ON"
+    (lib.strings.cmakeBool "BUILD_STATIC_LIBS" stdenv.hostPlatform.isStatic)
+    (lib.strings.cmakeBool "BUILD_SHARED_LIBS" (!stdenv.hostPlatform.isStatic))
+    "-DLINALG=Manual"
+    (lib.strings.cmakeBool "DGA" enableMpi)
+    (lib.strings.cmakeBool "MPI" enableMpi)
+  ];
+
   preConfigure =
     ''
-      cmakeFlagsArray+=(
-        "-DOPENMP=ON"
-        "-DTOOLS=ON"
-        "-DHDF5=ON"
-        "-DFDE=ON"
-        "-DEXTERNAL_LIBXC=${lib.getDev libxc}"
-        ${lib.strings.cmakeBool "DMRG" enableQcmaquis}
-        ${lib.strings.cmakeBool "NEVPT2" enableQcmaquis}
-        "-DCMAKE_SKIP_BUILD_RPATH=ON"
-        ${lib.strings.cmakeBool "BUILD_STATIC_LIBS" stdenv.hostPlatform.isStatic}
-        ${lib.strings.cmakeBool "BUILD_SHARED_LIBS" (!stdenv.hostPlatform.isStatic)}
-        "-DLINALG=Manual"
-        "-DLINALG_LIBRARIES=-lblas -llapack"
-        ${lib.strings.cmakeBool "DGA" enableMpi}
-        ${lib.strings.cmakeBool "MPI" enableMpi}
-      )
+      cmakeFlagsArray+=("-DLINALG_LIBRARIES=-lblas -llapack")
     ''
     + lib.optionalString enableMpi ''
       export GAROOT=${globalarrays};


### PR DESCRIPTION
Move back all options from `cmakeFlagsArray` to `cmakeFlags`, except for blas/lapack lib flags.
I.e. use `cmakeFlagsArray` only where needed.
Removing `cmakeFlags` breaks all downstream packages use `overrideAttrs`. 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
