### PR TITLE
mono: 6.12.0.182 -> 6.14.1

### DIFF
--- a/pkgs/development/compilers/mono/4.nix
+++ b/pkgs/development/compilers/mono/4.nix
@@ -2,11 +2,11 @@
   callPackage,
   stdenv,
   lib,
+  fetchurl,
 }:
 
-callPackage ./generic.nix {
+callPackage ./generic.nix rec {
   version = "4.8.1.0";
-  sha256 = "1vyvp2g28ihcgxgxr8nhzyzdmzicsh5djzk8dk1hj5p5f2k3ijqq";
   enableParallelBuilding = false; # #32386, https://hydra.nixos.org/build/65600645
   extraPatches = lib.optionals stdenv.hostPlatform.isLinux [ ./mono4-glibc.patch ];
   env.NIX_CFLAGS_COMPILE = toString [
@@ -16,4 +16,8 @@ callPackage ./generic.nix {
     "-Wno-error=int-conversion"
     "-Wno-error=return-mismatch"
   ];
+  src = fetchurl {
+    url = "https://download.mono-project.com/sources/mono/mono-${version}.tar.bz2";
+    sha256 = "1vyvp2g28ihcgxgxr8nhzyzdmzicsh5djzk8dk1hj5p5f2k3ijqq";
+  };
 }

--- a/pkgs/development/compilers/mono/5.nix
+++ b/pkgs/development/compilers/mono/5.nix
@@ -1,10 +1,14 @@
 {
   callPackage,
+  fetchurl,
 }:
 
-callPackage ./generic.nix {
+callPackage ./generic.nix rec {
   version = "5.20.1.34";
-  sha256 = "12vw5dkhmp1vk9l658pil8jiqirkpdsc5z8dm5mpj595yr6d94fd";
   enableParallelBuilding = true;
   env.NIX_CFLAGS_COMPILE = "-Wno-error=incompatible-pointer-types -Wno-error=implicit-function-declaration";
+  src = fetchurl {
+    url = "https://download.mono-project.com/sources/mono/mono-${version}.tar.bz2";
+    sha256 = "12vw5dkhmp1vk9l658pil8jiqirkpdsc5z8dm5mpj595yr6d94fd";
+  };
 }

--- a/pkgs/development/compilers/mono/6.nix
+++ b/pkgs/development/compilers/mono/6.nix
@@ -4,11 +4,11 @@
   fetchpatch,
 }:
 
-callPackage ./generic.nix (rec {
-  version = "6.14.0";
+callPackage ./generic.nix rec {
+  version = "6.14.1";
   src = fetchurl {
     url = "https://dl.winehq.org/mono/sources/mono/mono-${version}.tar.xz";
-    hash = "sha256-bdZLOQD15dX1UBbYnM92NchznLszzbgcHDthYi6R1RA=";
+    hash = "sha256-MCTJfAvIy81hHEAdX5lFKHBBCM6zHzGyjepHgwBNCCA=";
   };
   extraPatches = [
     # https://gitlab.winehq.org/mono/mono/-/merge_requests/101
@@ -18,4 +18,4 @@ callPackage ./generic.nix (rec {
       hash = "sha256-qyc3t1OyDzWBSnNW+W2YpdgFfTBs1Ew13jwdGKs09u0=";
     })
   ];
-})
+}

--- a/pkgs/development/compilers/mono/6.nix
+++ b/pkgs/development/compilers/mono/6.nix
@@ -1,10 +1,21 @@
 {
   callPackage,
+  fetchurl,
+  fetchpatch,
 }:
 
-callPackage ./generic.nix {
-  version = "6.12.0.182";
-  srcArchiveSuffix = "tar.xz";
-  sha256 = "sha256-VzZqarTztezxEdSFSAMWFbOhANuHxnn8AG6Mik79lCQ=";
-  enableParallelBuilding = true;
-}
+callPackage ./generic.nix (rec {
+  version = "6.14.0";
+  src = fetchurl {
+    url = "https://dl.winehq.org/mono/sources/mono/mono-${version}.tar.xz";
+    hash = "sha256-bdZLOQD15dX1UBbYnM92NchznLszzbgcHDthYi6R1RA=";
+  };
+  extraPatches = [
+    # https://gitlab.winehq.org/mono/mono/-/merge_requests/101
+    # fixes a pointer cast on aarch64 that causes crashes
+    (fetchpatch {
+      url = "https://gitlab.winehq.org/mono/mono/-/commit/2224c6915a98f870cc9a3a9f9e3698e7b20e3d27.patch";
+      hash = "sha256-qyc3t1OyDzWBSnNW+W2YpdgFfTBs1Ew13jwdGKs09u0=";
+    })
+  ];
+})

--- a/pkgs/development/compilers/mono/generic.nix
+++ b/pkgs/development/compilers/mono/generic.nix
@@ -1,7 +1,6 @@
 {
   lib,
   stdenv,
-  fetchurl,
   bison,
   pkg-config,
   glib,
@@ -15,7 +14,7 @@
   cacert,
   python3,
   version,
-  sha256,
+  src,
   autoconf,
   libtool,
   automake,
@@ -23,19 +22,13 @@
   which,
   gnumake42,
   enableParallelBuilding ? true,
-  srcArchiveSuffix ? "tar.bz2",
   extraPatches ? [ ],
   env ? { },
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "mono";
-  inherit version env;
-
-  src = fetchurl {
-    inherit sha256;
-    url = "https://download.mono-project.com/sources/mono/${pname}-${version}.${srcArchiveSuffix}";
-  };
+  inherit version src env;
 
   strictDeps = true;
   nativeBuildInputs = [
@@ -49,6 +42,7 @@ stdenv.mkDerivation rec {
     python3
     which
     gnumake42
+    gettext
   ];
   buildInputs = [
     glib
@@ -113,12 +107,22 @@ stdenv.mkDerivation rec {
       (
         stdenv.hostPlatform.isDarwin
         && stdenv.hostPlatform.isAarch64
-        && lib.versionOlder version "6.12.0.129"
+        && lib.versionOlder finalAttrs.version "6.12.0.129"
       )
       || !stdenv.buildPlatform.canExecute stdenv.hostPlatform;
-    homepage = "https://mono-project.com/";
+    homepage =
+      if lib.versionOlder finalAttrs.version "6.14.0" then
+        "https://mono-project.com/"
+      else
+        "https://gitlab.winehq.org/mono/mono";
     description = "Cross platform, open source .NET development framework";
     platforms = with platforms; darwin ++ linux;
+    knownVulnerabilities = lib.optionals (lib.versionOlder finalAttrs.version "6.14.0") [
+      ''
+        mono was archived upstream, see https://www.mono-project.com/
+        While WineHQ has taken over development, consider using 6.14.0 or newer.
+      ''
+    ];
     maintainers = with maintainers; [
       thoughtpolice
       obadz
@@ -142,4 +146,4 @@ stdenv.mkDerivation rec {
     ];
     mainProgram = "mono";
   };
-}
+})


### PR DESCRIPTION
The original Mono project [1] was archived.
It is now maintained by WineHQ on their gitlab [2].

This changes the homepage for the new mono package, and moves the source fetchers to the version profiles.

[1] https://www.mono-project.com/
[2] https://gitlab.winehq.org/mono/mono

Fixes [CVE-2023-35373](https://www.cve.org/CVERecord?id=CVE-2023-35373)

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
