### PR TITLE
[staging] shaderc: 2024.0 -> 2025.2, koboldcpp: 1.86.2 -> 1.92

### DIFF
--- a/pkgs/by-name/ko/koboldcpp/package.nix
+++ b/pkgs/by-name/ko/koboldcpp/package.nix
@@ -25,6 +25,7 @@
 
   vulkanSupport ? (!stdenv.hostPlatform.isDarwin),
   vulkan-loader,
+  shaderc,
   metalSupport ? stdenv.hostPlatform.isDarwin,
   nix-update-script,
 }:
@@ -40,13 +41,13 @@ let
 in
 effectiveStdenv.mkDerivation (finalAttrs: {
   pname = "koboldcpp";
-  version = "1.86.2";
+  version = "1.92";
 
   src = fetchFromGitHub {
     owner = "LostRuins";
     repo = "koboldcpp";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-zB/X4tfygpf3ZrQ9FtQCd3sxN11Ewlxz1+YCiw7iUZU=";
+    hash = "sha256-tVY8j3RlRiZ3UK5YTzyhV77nk97jRF8frtjq4Ws84WU=";
   };
 
   enableParallelBuilding = true;
@@ -72,7 +73,10 @@ effectiveStdenv.mkDerivation (finalAttrs: {
       clblast
       ocl-icd
     ]
-    ++ lib.optionals vulkanSupport [ vulkan-loader ];
+    ++ lib.optionals vulkanSupport [
+      vulkan-loader
+      shaderc
+    ];
 
   pythonPath = finalAttrs.pythonInputs;
 

--- a/pkgs/by-name/ko/koboldcpp/package.nix
+++ b/pkgs/by-name/ko/koboldcpp/package.nix
@@ -23,7 +23,7 @@
   clblast,
   ocl-icd,
 
-  vulkanSupport ? (!stdenv.hostPlatform.isDarwin),
+  vulkanSupport ? true,
   vulkan-loader,
   shaderc,
   metalSupport ? stdenv.hostPlatform.isDarwin,

--- a/pkgs/development/compilers/shaderc/default.nix
+++ b/pkgs/development/compilers/shaderc/default.nix
@@ -16,25 +16,25 @@ let
   glslang = fetchFromGitHub {
     owner = "KhronosGroup";
     repo = "glslang";
-    rev = "6be56e45e574b375d759b89dad35f780bbd4792f";
-    hash = "sha256-tktdsj4sxwQHBavHzu1x8H28RrIqSQs/fp2TQcVCm2g=";
+    rev = "15.3.0";
+    hash = "sha256-HwFP4KJuA+BMQVvBWV0BCRj9U5I3CLEU+5bBtde2f6w=";
   };
   spirv-tools = fetchFromGitHub {
     owner = "KhronosGroup";
     repo = "SPIRV-Tools";
-    rev = "360d469b9eac54d6c6e20f609f9ec35e3a5380ad";
-    hash = "sha256-Bned5Pa6zCFByfNvqD0M5t3l4uAJYkDlpe6wu8e7a3U=";
+    rev = "v2025.1";
+    hash = "sha256-2Wv0dxVQ8NvuDRTcsXkH1GKmuA6lsIuwTl0j6kbTefo=";
   };
   spirv-headers = fetchFromGitHub {
     owner = "KhronosGroup";
     repo = "SPIRV-Headers";
-    rev = "4183b260f4cccae52a89efdfcdd43c4897989f42";
-    hash = "sha256-RKjw3H1z02bl6730xsbo38yjMaOCsHZP9xJOQbmWpnw=";
+    rev = "vulkan-sdk-1.4.309.0";
+    hash = "sha256-Q1i6i5XimULuGufP6mimwDW674anAETUiIEvDQwvg5Y=";
   };
 in
 stdenv.mkDerivation rec {
   pname = "shaderc";
-  version = "2024.0";
+  version = "2025.2";
 
   outputs = [
     "out"
@@ -48,7 +48,7 @@ stdenv.mkDerivation rec {
     owner = "google";
     repo = "shaderc";
     rev = "v${version}";
-    hash = "sha256-Cwp7WbaKWw/wL9m70wfYu47xoUGQW+QGeoYhbyyzstQ=";
+    hash = "sha256-u3gmH2lrkwBTZg9j4jInQceXK4MUWhKZPSPsN98mEkk=";
   };
 
   postPatch = ''

--- a/pkgs/development/compilers/shaderc/default.nix
+++ b/pkgs/development/compilers/shaderc/default.nix
@@ -7,11 +7,13 @@
   autoSignDarwinBinariesHook,
   cctools,
 }:
-# Like many google projects, shaderc doesn't gracefully support separately compiled dependencies, so we can't easily use
-# the versions of glslang and spirv-tools used by vulkan-loader. Exact revisions are taken from
+# Like many google projects, shaderc doesn't gracefully support separately
+# compiled dependencies, so we can't easily use the versions of glslang and
+# spirv-tools used by vulkan-loader. Exact revisions are taken from
 # https://github.com/google/shaderc/blob/known-good/known_good.json
 
-# Future work: extract and fetch all revisions automatically based on a revision of shaderc's known-good branch.
+# Future work: extract and fetch all revisions automatically based on a revision
+# of shaderc's known-good branch.
 let
   glslang = fetchFromGitHub {
     owner = "KhronosGroup";
@@ -32,7 +34,7 @@ let
     hash = "sha256-Q1i6i5XimULuGufP6mimwDW674anAETUiIEvDQwvg5Y=";
   };
 in
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "shaderc";
   version = "2025.2";
 
@@ -47,7 +49,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "google";
     repo = "shaderc";
-    rev = "v${version}";
+    rev = "v${finalAttrs.version}";
     hash = "sha256-u3gmH2lrkwBTZg9j4jInQceXK4MUWhKZPSPsN98mEkk=";
   };
 
@@ -77,14 +79,14 @@ stdenv.mkDerivation rec {
   # Fix the paths in .pc, even though it's unclear if all these .pc are really useful.
   postFixup = ''
     substituteInPlace "$dev"/lib/pkgconfig/*.pc \
-      --replace '=''${prefix}//' '=/' \
-      --replace "$dev/$dev/" "$dev/"
+      --replace-fail '=''${prefix}//' '=/' \
+      --replace-fail "$dev/$dev/" "$dev/"
   '';
 
-  meta = with lib; {
-    inherit (src.meta) homepage;
+  meta = {
     description = "Collection of tools, libraries and tests for shader compilation";
-    platforms = platforms.all;
-    license = [ licenses.asl20 ];
+    inherit (finalAttrs.src.meta) homepage;
+    license = lib.licenses.asl20;
+    platforms = lib.platforms.all;
   };
-}
+})


### PR DESCRIPTION
## Things done

Changelog: https://github.com/LostRuins/koboldcpp/releases/tag/v1.92
Diff: https://github.com/LostRuins/koboldcpp/compare/v1.86.2...v1.92

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
