### PR TITLE
dformat: init at 0.15.2

### DIFF
--- a/pkgs/by-name/df/dformat/dub-lock.json
+++ b/pkgs/by-name/df/dformat/dub-lock.json
@@ -1,0 +1,8 @@
+{
+  "dependencies": {
+    "libdparse": {
+      "version": "0.25.0",
+      "sha256": "012ihzwhikvpd7crr3ql38hs32lfy9gnkg9qvjgpd7ar3xbsa5sz"
+    }
+  }
+}

--- a/pkgs/by-name/df/dformat/fix_version.patch
+++ b/pkgs/by-name/df/dformat/fix_version.patch
@@ -1,0 +1,13 @@
+diff --git a/dub.json b/dub.json
+index a0d6357..abae578 100644
+--- a/dub.json
++++ b/dub.json
+@@ -13,8 +13,5 @@
+     ],
+     "versions" : [
+         "built_with_dub"
+-    ],
+-    "preBuildCommands" : [
+-      "$DC -run \"$PACKAGE_DIR/dubhash.d\""
+     ]
+ }

--- a/pkgs/by-name/df/dformat/package.nix
+++ b/pkgs/by-name/df/dformat/package.nix
@@ -1,0 +1,53 @@
+{
+  lib,
+  buildDubPackage,
+  fetchFromGitHub,
+  versionCheckHook,
+}:
+
+buildDubPackage rec {
+  pname = "dfmt";
+  version = "0.15.2";
+
+  src = fetchFromGitHub {
+    owner = "dlang-community";
+    repo = "dfmt";
+    tag = "v${version}";
+    hash = "sha256-QjmYPIQFs+91jB1sdaFoenfWt5TLXyEJauSSHP2fd+M=";
+  };
+
+  preBuild = ''
+    mkdir -p bin/
+    echo "v${version}" > bin/dubhash.txt
+  '';
+
+  patches = [
+    # do not run the dubhash tool, we supply the version in preBuild
+    ./fix_version.patch
+  ];
+
+  dubLock = ./dub-lock.json;
+
+  doCheck = true;
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm755 bin/dfmt -t $out/bin
+    runHook postInstall
+  '';
+
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+
+  doInstallCheck = true;
+
+  meta = {
+    description = "Formatter for D source code";
+    changelog = "https://github.com/dlang-community/dfmt/releases/tag/v${version}";
+    homepage = "https://github.com/dlang-community/dfmt";
+    maintainers = with lib.maintainers; [ ipsavitsky ];
+    mainProgram = "dfmt";
+    license = lib.licenses.boost;
+  };
+}


### PR DESCRIPTION
This change introduces `dfmt` - a popular formatter for the D language.

> [!WARNING]
> Because the name of this package (`dfmt`) clashes with another package in nixpkgs, the derivation name is set as `dformat`, which does not appear as an official name of this package anywhere. If there is a better way to resolve this naming conflict - please let me know 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
