### PR TITLE
sof-firmware: clean up package; provide update script

### DIFF
--- a/pkgs/by-name/so/sof-firmware/package.nix
+++ b/pkgs/by-name/so/sof-firmware/package.nix
@@ -27,20 +27,20 @@ stdenvNoCC.mkDerivation rec {
     runHook postInstall
   '';
 
-  meta = with lib; {
+  meta = {
     changelog = "https://github.com/thesofproject/sof-bin/releases/tag/v${version}";
     description = "Sound Open Firmware";
     homepage = "https://www.sofproject.org/";
-    license = with licenses; [
+    license = with lib.licenses; [
       bsd3
       isc
     ];
-    maintainers = with maintainers; [
+    maintainers = with lib.maintainers; [
       lblasc
       evenbrenden
       hmenke
     ];
-    platforms = with platforms; linux;
-    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
+    platforms = with lib.platforms; linux;
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
   };
 }

--- a/pkgs/by-name/so/sof-firmware/package.nix
+++ b/pkgs/by-name/so/sof-firmware/package.nix
@@ -2,6 +2,7 @@
   lib,
   fetchurl,
   stdenvNoCC,
+  nix-update-script,
 }:
 
 stdenvNoCC.mkDerivation (finalAttrs: {
@@ -24,6 +25,8 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
     runHook postInstall
   '';
+
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     changelog = "https://github.com/thesofproject/sof-bin/releases/tag/v${finalAttrs.version}";

--- a/pkgs/by-name/so/sof-firmware/package.nix
+++ b/pkgs/by-name/so/sof-firmware/package.nix
@@ -11,7 +11,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "https://github.com/thesofproject/sof-bin/releases/download/v${finalAttrs.version}/sof-bin-${finalAttrs.version}.tar.gz";
-    sha256 = "sha256-o2IQ2cJF6BsNlnTWsn0f1BIpaM+SWu/FW0htNlD4gyM=";
+    hash = "sha256-o2IQ2cJF6BsNlnTWsn0f1BIpaM+SWu/FW0htNlD4gyM=";
   };
 
   dontFixup = true; # binaries must not be stripped or patchelfed

--- a/pkgs/by-name/so/sof-firmware/package.nix
+++ b/pkgs/by-name/so/sof-firmware/package.nix
@@ -4,12 +4,12 @@
   stdenvNoCC,
 }:
 
-stdenvNoCC.mkDerivation rec {
+stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "sof-firmware";
   version = "2025.01.1";
 
   src = fetchurl {
-    url = "https://github.com/thesofproject/sof-bin/releases/download/v${version}/sof-bin-${version}.tar.gz";
+    url = "https://github.com/thesofproject/sof-bin/releases/download/v${finalAttrs.version}/sof-bin-${finalAttrs.version}.tar.gz";
     sha256 = "sha256-o2IQ2cJF6BsNlnTWsn0f1BIpaM+SWu/FW0htNlD4gyM=";
   };
 
@@ -28,7 +28,7 @@ stdenvNoCC.mkDerivation rec {
   '';
 
   meta = {
-    changelog = "https://github.com/thesofproject/sof-bin/releases/tag/v${version}";
+    changelog = "https://github.com/thesofproject/sof-bin/releases/tag/v${finalAttrs.version}";
     description = "Sound Open Firmware";
     homepage = "https://www.sofproject.org/";
     license = with lib.licenses; [
@@ -43,4 +43,4 @@ stdenvNoCC.mkDerivation rec {
     platforms = with lib.platforms; linux;
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
   };
-}
+})

--- a/pkgs/by-name/so/sof-firmware/package.nix
+++ b/pkgs/by-name/so/sof-firmware/package.nix
@@ -17,13 +17,11 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
   installPhase = ''
     runHook preInstall
+
     mkdir -p $out/lib/firmware/intel
-    cp -av sof $out/lib/firmware/intel/sof
-    cp -av sof-tplg $out/lib/firmware/intel/sof-tplg
-    cp -av sof-ace-tplg $out/lib/firmware/intel/sof-ace-tplg
-    cp -av sof-ipc4 $out/lib/firmware/intel/sof-ipc4
-    cp -av sof-ipc4-tplg $out/lib/firmware/intel/sof-ipc4-tplg
-    cp -av sof-ipc4-lib $out/lib/firmware/intel/sof-ipc4-lib
+    # copy sof and sof-* recursively, preserving symlinks
+    cp -R -d sof{,-*} $out/lib/firmware/intel/
+
     runHook postInstall
   '';
 


### PR DESCRIPTION
- provide update script
- simplify install phase
- use `finalAttrs` pattern
- remove use of `with lib;`
- replace `src.sha256` with `src.hash`

These changes should not affect package outputs.

The simplified install phase assumes that all firmware files reside in directories named `sof` or `sof-*`. This might ease maintenance in case new ones are added, but perhaps copying specific directories was intentional and I can drop this commit from the PR if needed.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
