### PR TITLE
python312Packages.ipydatagrid: init

### DIFF
--- a/pkgs/development/python-modules/ipydatagrid/default.nix
+++ b/pkgs/development/python-modules/ipydatagrid/default.nix
@@ -1,0 +1,72 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  pytestCheckHook,
+
+  hatchling,
+  hatch-jupyter-builder,
+  jupyterlab,
+  bqplot,
+  ipywidgets,
+  pandas,
+  py2vega,
+  yarn-berry_3,
+}:
+
+let
+  yarn-berry = yarn-berry_3;
+in
+
+buildPythonPackage rec {
+  pname = "ipydatagrid";
+  version = "1.4.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "jupyter-widgets";
+    repo = "ipydatagrid";
+    tag = version;
+    hash = "sha256-6jaIYgLbNXIYzM+mZIVMZ1CXOpcbVK5k9nzGjq5UdLI=";
+  };
+
+  build-system = [
+    hatchling
+    hatch-jupyter-builder
+    jupyterlab
+  ];
+
+  nativeBuildInputs = [
+    yarn-berry.yarnBerryConfigHook
+    yarn-berry
+  ];
+
+  dependencies = [
+    bqplot
+    ipywidgets
+    pandas
+    py2vega
+  ];
+
+  offlineCache = yarn-berry.fetchYarnBerryDeps {
+    inherit src;
+    hash = "sha256-5KZl9mK6xNvy2XdWieH20hEZJ+h/KzvjOfpo78FlWpg=";
+  };
+
+  preConfigure = ''
+    substituteInPlace pyproject.toml package.json \
+      --replace-fail 'jlpm' 'yarn'
+  '';
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  meta = {
+    description = "Fast Datagrid widget for the Jupyter Notebook and JupyterLab";
+    homepage = "https://github.com/jupyter-widgets/ipydatagrid";
+    changelog = "https://github.com/jupyter-widgets/ipydatagrid/releases/tag/${version}";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ flokli ];
+  };
+}

--- a/pkgs/development/python-modules/py2vega/default.nix
+++ b/pkgs/development/python-modules/py2vega/default.nix
@@ -1,0 +1,42 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  pytestCheckHook,
+  setuptools,
+  gast,
+}:
+
+buildPythonPackage rec {
+  pname = "py2vega";
+  version = "0.6.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "QuantStack";
+    repo = "py2vega";
+    tag = version;
+    hash = "sha256-M6vrObEj4cB53nvEi1oQdVWABlqGwG3xc2unY44Yhuc=";
+  };
+
+  pythonRelaxDeps = [ "gast" ];
+
+  build-system = [
+    setuptools
+  ];
+
+  dependencies = [
+    gast
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  meta = {
+    description = "Python to Vega-expression transpiler";
+    homepage = "https://github.com/QuantStack/py2vega";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ flokli ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6811,6 +6811,8 @@ self: super: with self; {
 
   ipycanvas = callPackage ../development/python-modules/ipycanvas { };
 
+  ipydatagrid = callPackage ../development/python-modules/ipydatagrid { };
+
   ipydatawidgets = callPackage ../development/python-modules/ipydatawidgets { };
 
   ipykernel = callPackage ../development/python-modules/ipykernel { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -11747,6 +11747,8 @@ self: super: with self; {
 
   py2bit = callPackage ../development/python-modules/py2bit { };
 
+  py2vega = callPackage ../development/python-modules/py2vega { };
+
   py3buddy = callPackage ../development/python-modules/py3buddy { };
 
   py3dns = callPackage ../development/python-modules/py3dns { };


### PR DESCRIPTION
This adds [`ipydatagrid`](https://github.com/jupyter-widgets/ipydatagrid), a "Fast Datagrid widget for the Jupyter Notebook and JupyterLab" to nixpkgs.

It's the alternative to `ipysheet`, which is not recommended anymore due to https://github.com/jupyter-widgets-contrib/ipysheet?tab=readme-ov-file#warning.

This packages both `ipysheet` and `py2vega`, a dependency.

In addition to running the test, I also tested with an example `jupyter notebook` run as follows:

```
 $(nix-build -E 'with import ./. {}; jupyter.withPackages (p: [p.ipydatagrid p.jupyter])')/bin/jupyter notebook
```

![image](https://github.com/user-attachments/assets/99d450e5-7ede-410a-a6e1-78fcc54b0b8e)

This uses the new yarn-berry fetcher in https://github.com/NixOS/nixpkgs/pull/399404. Thanks @yuyuyureka for your work!

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
