### PR TITLE
bootspec: generalize the bootspec tooling packaging

### DIFF
--- a/nixos/modules/system/activation/bootspec.nix
+++ b/nixos/modules/system/activation/bootspec.nix
@@ -111,6 +111,8 @@ in
             Enable this option if you want to ascertain that your documents are correct
     '';
 
+    package = lib.mkPackageOption pkgs "bootspec" { };
+
     extensions = lib.mkOption {
       # NOTE(RaitoBezarius): this is not enough to validate: extensions."osRelease" = drv; those are picked up by cue validation.
       type = lib.types.attrsOf lib.types.anything; # <namespace>: { ...namespace-specific fields }

--- a/nixos/modules/system/boot/loader/systemd-boot/systemd-boot.nix
+++ b/nixos/modules/system/boot/loader/systemd-boot/systemd-boot.nix
@@ -47,7 +47,7 @@ let
 
       systemd = config.systemd.package;
 
-      bootspecTools = pkgs.bootspec;
+      bootspecTools = config.boot.bootspec.package;
 
       nix = config.nix.package.out;
 

--- a/pkgs/by-name/bo/bootspec-lix/package.nix
+++ b/pkgs/by-name/bo/bootspec-lix/package.nix
@@ -1,0 +1,39 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitea,
+  fetchpatch,
+}:
+rustPlatform.buildRustPackage rec {
+  pname = "bootspec-lix";
+  version = "1.0.0";
+
+  src = fetchFromGitea {
+    domain = "git.lix.systems";
+    owner = "lix-community";
+    repo = "bootspec";
+    rev = "v${version}";
+    hash = "sha256-5IGSMHeL0eKfl7teDejAckYQjc8aeLwfwIQSzQ8YaAg=";
+  };
+
+  patches = [
+    # https://github.com/DeterminateSystems/bootspec/pull/127
+    # Fixes the synthesize tool for aarch64-linux
+    (fetchpatch {
+      name = "aarch64-support.patch";
+      url = "https://github.com/DeterminateSystems/bootspec/commit/1d0e925f360f0199f13422fb7541225fd162fd4f.patch";
+      sha256 = "sha256-wU/jWnOqVBrU2swANdXbQfzRpNd/JIS4cxSyCvixZM0=";
+    })
+  ];
+
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-65jk8UlXZgQoxuwRcGlMnI4e+LpCJuP2TaqK+Kn4GnQ=";
+
+  meta = with lib; {
+    description = "Vendor-neutral implementation of RFC-0125's datatype and synthesis tooling";
+    homepage = "https://git.lix.systems/lix-community/bootspec";
+    license = licenses.mit;
+    maintainers = [ lib.maintainers.raitobezarius ];
+    platforms = platforms.unix;
+  };
+}


### PR DESCRIPTION
After RFC-0125 implementation, Determinate Systems was pinged multiple
times to transfer the repository ownership of the tooling to a
vendor-neutral repository.

Unfortunately, this never manifested (this is not a negative comment on Determinate Systems, I can understand they have other plans or never had the time to do it). Additionally, the leadership of
the NixOS project was too dysfunctional to deal with this sort of
problem. It might even still be the case up to this day.

Nonetheless, nixpkgs is about enabling end users to enact their own
policies. It would be better to live in a world where there is one
obvious choice of bootspec tooling, in the meantime, we can live in a
world where people can choose their bootspec tooling.

The Lix forge possess one fork of the Bootspec tooling:
https://git.lix.systems/lix-community/bootspec which will live its own
life from now on.

Signed-off-by: Raito Bezarius <masterancpp@gmail.com>

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
