### PR TITLE
haskell-modules: keep things sorted

### DIFF
--- a/maintainers/scripts/haskell/mark-broken.sh
+++ b/maintainers/scripts/haskell/mark-broken.sh
@@ -35,19 +35,19 @@ trap "rm ${tmpfile}" 0
 
 echo "Remember that you need to manually run 'maintainers/scripts/haskell/hydra-report.hs get-report' sometime before running this script."
 echo "Generating a list of broken builds and displaying for manual confirmation ..."
-maintainers/scripts/haskell/hydra-report.hs mark-broken-list $mark_broken_list_flags | sort -i > "$tmpfile"
+maintainers/scripts/haskell/hydra-report.hs mark-broken-list $mark_broken_list_flags | LC_ALL=C.UTF-8 sort --ignore-case > "$tmpfile"
 
 $EDITOR "$tmpfile"
 
 tail -n +3 "$broken_config" >> "$tmpfile"
 
 cat > "$broken_config" << EOF
+# These packages don't compile.
 broken-packages:
-  # These packages don't compile.
 EOF
 
 # clear environment here to avoid things like allowing broken builds in
-sort -iu "$tmpfile" >> "$broken_config"
+LC_ALL=C.UTF-8 sort --ignore-case --unique "$tmpfile" >> "$broken_config"
 clear="env -u HOME -u NIXPKGS_CONFIG"
 $clear maintainers/scripts/haskell/regenerate-hackage-packages.sh
 evalline=$(maintainers/scripts/haskell/hydra-report.hs eval-info)

--- a/maintainers/scripts/haskell/regenerate-transitive-broken-packages.sh
+++ b/maintainers/scripts/haskell/regenerate-transitive-broken-packages.sh
@@ -20,6 +20,6 @@ cat > $tmpfile << EOF
 dont-distribute-packages:
 EOF
 
-nix-instantiate --eval --option restrict-eval true -I . --strict --json maintainers/scripts/haskell/transitive-broken-packages.nix | jq -r . | LC_ALL=C.UTF-8 sort -i >> $tmpfile
+nix-instantiate --eval --option restrict-eval true -I . --strict --json maintainers/scripts/haskell/transitive-broken-packages.nix | jq -r . | LC_ALL=C.UTF-8 sort --ignore-case >> $tmpfile
 
 mv $tmpfile $config_file

--- a/maintainers/scripts/haskell/update-stackage.sh
+++ b/maintainers/scripts/haskell/update-stackage.sh
@@ -46,7 +46,7 @@ sed -r \
     -e '/^with-compiler:/d' \
     -e '/installed$/d' \
     -e '/^$/d' \
-    < "${tmpfile}" | sort --ignore-case >"${tmpfile_new}"
+    < "${tmpfile}" | LC_ALL=C.UTF-8 sort --ignore-case >"${tmpfile_new}"
 
 cat > $stackage_config << EOF
 # Stackage $version

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1287,8 +1287,8 @@ self: super:
   dhall-yaml = self.generateOptparseApplicativeCompletions [ "dhall-to-yaml-ng" "yaml-to-dhall" ] (
     doJailbreak super.dhall-yaml
   ); # bytestring <0.12, text<2.1
+  # 2025-02-14: see also https://github.com/dhall-lang/dhall-haskell/issues/2638
   dhall-bash = doJailbreak super.dhall-bash; # bytestring <0.12, text <2.1
-  # see also https://github.com/dhall-lang/dhall-haskell/issues/2638
 
   # musl fixes
   # dontCheck: use of non-standard strptime "%s" which musl doesn't support; only used in test
@@ -1712,14 +1712,11 @@ self: super:
   # So let's not go there and just disable the tests altogether.
   hspec-core = dontCheck super.hspec-core;
 
-  # - Deps are required during the build for testing and also during execution,
-  #   so add them to build input and also wrap the resulting binary so they're in
-  #   PATH.
-  # - Patch can be removed on next package set bump (for v0.2.11)
-
-  # 2023-06-26: Test failure: https://hydra.nixos.org/build/225081865
   update-nix-fetchgit =
     let
+      # Deps are required during the build for testing and also during execution,
+      # so add them to build input and also wrap the resulting binary so they're in
+      # PATH.
       deps = [
         pkgs.git
         pkgs.nix
@@ -1727,6 +1724,7 @@ self: super:
       ];
     in
     lib.pipe super.update-nix-fetchgit [
+      # 2023-06-26: Test failure: https://hydra.nixos.org/build/225081865
       dontCheck
       (self.generateOptparseApplicativeCompletions [ "update-nix-fetchgit" ])
       (overrideCabal (drv: {

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -18,6 +18,7 @@ in
 
 with haskellLib;
 
+# To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead.
 self: super:
 {
   # Hackage's accelerate is from 2020 and incomptible with our GHC.

--- a/pkgs/development/haskell-modules/configuration-hackage2nix/main.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/main.yaml
@@ -23,6 +23,7 @@
 # WARNING: We import a list of default-package-overrides from stackage which is
 # tracked in stackage.yaml. Adding conflicting overrides with stackage here will
 # not work.
+# keep-sorted start skip_lines=1 case=no numeric=yes
 default-package-overrides:
   # 2021-11-09: ghc-bignum is bundled starting with 9.0.1; only 1.0 builds with GHCs prior to 9.2.1
   - ghc-bignum == 1.0
@@ -36,7 +37,9 @@ default-package-overrides:
   - htree < 0.2.0.0
   # 2025-01-17: need to match stackage version of hosc
   - hsc3 < 0.21
+# keep-sorted end
 
+# keep-sorted start skip_lines=1 case=no numeric=yes
 extra-packages:
   - Cabal == 3.2.*                      # Used for packages needing newer Cabal on ghc 8.6 and 8.8
   - Cabal == 3.10.*
@@ -119,7 +122,9 @@ extra-packages:
   - weeder == 2.2.*                     # 2022-02-21: preserve for GHC 8.10.7
   - weeder == 2.3.*                     # 2022-05-31: preserve for GHC 9.0.2
   - weeder == 2.4.*                     # 2023-02-02: preserve for GHC 9.2.*
+# keep-sorted end
 
+# keep-sorted start skip_lines=1 case=no
 package-maintainers:
   abbradar:
     - Agda
@@ -668,7 +673,9 @@ package-maintainers:
   wolfgangwalther:
     - postgres-websockets
     - postgrest
+# keep-sorted end
 
+# keep-sorted start skip_lines=1 case=no
 unsupported-platforms:
   Allure:                                       [ platforms.darwin ]
   bdcs-api:                                     [ platforms.darwin ]
@@ -871,6 +878,7 @@ supported-platforms:
   Win32-services-wrapper:                       [ platforms.windows ]
   XInput:                                       [ platforms.windows ]
   yesod-auth-simple:                            [ platforms.x86 ] # requires scrypt which only supports x86
+# keep-sorted end
 
 dont-distribute-packages:
   # Depends on shine, which is a ghcjs project.

--- a/pkgs/development/haskell-modules/configuration-hackage2nix/main.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/main.yaml
@@ -25,30 +25,22 @@
 # not work.
 # keep-sorted start skip_lines=1 case=no numeric=yes
 default-package-overrides:
-  # 2021-11-09: ghc-bignum is bundled starting with 9.0.1; only 1.0 builds with GHCs prior to 9.2.1
-  - ghc-bignum == 1.0
-  - extensions < 0.1.0.2 # Incompatible with Cabal < 3.12, the newest extensions version is only needed on ghc 9.10
   - chs-cabal < 0.1.1.2 # Incompatible with Cabal < 3.12
-  # 2024-08-17: Stackage doesn't contain hnix-store-core >= 0.8 yet, so we need to restrict hnix-store-remote
-  - hnix-store-remote < 0.7
   # 2024-12-23: last version to be compatible with Stackage LTS 22/23 (due to data-default)
   - diagrams-input < 0.1.4
-  # 2024-12-31: last version that's compatible with GHC < 9.9
-  - htree < 0.2.0.0
+  - extensions < 0.1.0.2 # Incompatible with Cabal < 3.12, the newest extensions version is only needed on ghc 9.10
+  # 2021-11-09: ghc-bignum is bundled starting with 9.0.1; only 1.0 builds with GHCs prior to 9.2.1
+  - ghc-bignum == 1.0
+  # 2024-08-17: Stackage doesn't contain hnix-store-core >= 0.8 yet, so we need to restrict hnix-store-remote
+  - hnix-store-remote < 0.7
   # 2025-01-17: need to match stackage version of hosc
   - hsc3 < 0.21
+  # 2024-12-31: last version that's compatible with GHC < 9.9
+  - htree < 0.2.0.0
 # keep-sorted end
 
 # keep-sorted start skip_lines=1 case=no numeric=yes
 extra-packages:
-  - Cabal == 3.2.*                      # Used for packages needing newer Cabal on ghc 8.6 and 8.8
-  - Cabal == 3.10.*
-  - Cabal == 3.12.*                     # version required for cabal-install and other packages
-  - Cabal-syntax == 3.6.*               # Dummy package that ensures packages depending on Cabal-syntax can work for Cabal < 3.8
-  - Cabal-syntax == 3.8.*               # version required for ormolu and fourmolu on ghc 9.0
-  - Cabal-syntax == 3.10.*
-  - Cabal-syntax == 3.12.*              # version required for cabal-install and other packages
-  - ShellCheck == 0.9.0                 # 2024-03-21: pinned by haskell-ci
   - aeson < 2                           # required by pantry-0.5.2
   - algebraic-graphs < 0.7              # 2023-08-14: Needed for building weeder < 2.6.0
   - ansi-terminal < 1.1                 # 2025-02-27: required for ghcjs
@@ -56,6 +48,13 @@ extra-packages:
   - ansi-wl-pprint >= 0.6 && < 0.7      # 2024-03-23: required for ghcjs
   - apply-refact == 0.9.*               # 2022-12-12: needed for GHC < 9.2
   - attoparsec == 0.13.*                # 2022-02-23: Needed to compile elm for now
+  - Cabal == 3.2.*                      # Used for packages needing newer Cabal on ghc 8.6 and 8.8
+  - Cabal == 3.10.*
+  - Cabal == 3.12.*                     # version required for cabal-install and other packages
+  - Cabal-syntax == 3.6.*               # Dummy package that ensures packages depending on Cabal-syntax can work for Cabal < 3.8
+  - Cabal-syntax == 3.8.*               # version required for ormolu and fourmolu on ghc 9.0
+  - Cabal-syntax == 3.10.*
+  - Cabal-syntax == 3.12.*              # version required for cabal-install and other packages
   - commonmark-pandoc < 0.2.3           # 2025-04-06: Needed for pandoc 3.6
   - extensions == 0.1.0.2               # 2024-10-20: for GHC 9.10/Cabal 3.12
   - fourmolu == 0.14.0.0                # 2023-11-13: for ghc-lib-parser 9.6 compat
@@ -112,6 +111,7 @@ extra-packages:
   - primitive-unlifted == 0.1.3.1       # 2024-03-16: preserve for ghc 9.2
   - retrie < 1.2.0.0                    # 2022-12-30: preserve for ghc < 9.2
   - shake-cabal < 0.2.2.3               # 2023-07-01: last version to support Cabal 3.6.*
+  - ShellCheck == 0.9.0                 # 2024-03-21: pinned by haskell-ci
   - simple-get-opt < 0.5                # 2025-05-01: for crux-0.7.2
   - stylish-haskell == 0.14.4.0         # 2022-09-19: preserve for ghc 9.0
   - stylish-haskell == 0.14.5.0         # 2025-04-14: needed for hls with ghc-lib 9.6
@@ -198,12 +198,12 @@ package-maintainers:
     - hevm
   athas:
     - futhark
+  bdesham:
+    - pinboard-notes-backup
   berberman:
     - nvfetcher
     - arch-web
     - uusi
-  bdesham:
-    - pinboard-notes-backup
   cdepillabout:
     - cloudy
     - password
@@ -355,6 +355,27 @@ package-maintainers:
     - tz
     - weeder
     - witch
+  mpscholten:
+    - ihp-hsx
+    - push-notify-apn
+    - hs-pkpass
+    - raven-haskell
+    - stripe-concepts
+    - stripe-signature
+    - http2-client
+    - zip
+    - currencies
+    - string-random
+    - inflections
+    - pcre-heavy
+    - mmark
+    - mmark-ext
+    - typerep-map
+    - minio-hs
+    - smtp-mail
+    - pdftotext
+    - warp-systemd
+    - amazonka
   ncfavier:
     - irc-client
     - lambdabot
@@ -509,24 +530,6 @@ package-maintainers:
     - rest-rewrite
   terlar:
     - nix-diff
-  turion:
-    - Agda
-    - cabal-gild
-    - dunai
-    - essence-of-live-coding
-    - essence-of-live-coding-gloss
-    - essence-of-live-coding-pulse
-    - essence-of-live-coding-quickcheck
-    - essence-of-live-coding-warp
-    - finite-typelits
-    - has-transformers
-    - monad-bayes
-    - monad-schedule
-    - pulse-simple
-    - rhine
-    - rhine-gloss
-    - simple-affine-space
-    - time-domain
   thielema:
     - accelerate-arithmetic
     - accelerate-fftw
@@ -645,193 +648,124 @@ package-maintainers:
     - magico
     - resistor-cube
     - linear-circuit
+  turion:
+    - Agda
+    - cabal-gild
+    - dunai
+    - essence-of-live-coding
+    - essence-of-live-coding-gloss
+    - essence-of-live-coding-pulse
+    - essence-of-live-coding-quickcheck
+    - essence-of-live-coding-warp
+    - finite-typelits
+    - has-transformers
+    - monad-bayes
+    - monad-schedule
+    - pulse-simple
+    - rhine
+    - rhine-gloss
+    - simple-affine-space
+    - time-domain
   utdemir:
     - nix-tree
-  zowoq:
-    - ShellCheck
-  mpscholten:
-    - ihp-hsx
-    - push-notify-apn
-    - hs-pkpass
-    - raven-haskell
-    - stripe-concepts
-    - stripe-signature
-    - http2-client
-    - zip
-    - currencies
-    - string-random
-    - inflections
-    - pcre-heavy
-    - mmark
-    - mmark-ext
-    - typerep-map
-    - minio-hs
-    - smtp-mail
-    - pdftotext
-    - warp-systemd
-    - amazonka
   wolfgangwalther:
     - postgres-websockets
     - postgrest
+  zowoq:
+    - ShellCheck
 # keep-sorted end
 
 # keep-sorted start skip_lines=1 case=no
 unsupported-platforms:
-  Allure:                                       [ platforms.darwin ]
-  bdcs-api:                                     [ platforms.darwin ]
-  bindings-directfb:                            [ platforms.darwin ]
-  bindings-sane:                                [ platforms.darwin ]
-  bustle:                                       [ platforms.darwin ] # uses glibc-specific ptsname_r
-  bytelog:                                      [ platforms.darwin ] # due to posix-api
-  camfort:                                      [ aarch64-linux ]
-  chalkboard:                                   [ platforms.darwin ] # depends on Codec-Image-DevIL
-  chalkboard-viewer:                            [ platforms.darwin ] # depends on chalkboard
-  charsetdetect:                                [ aarch64-linux ] # not supported by vendored lib / not configured properly https://github.com/batterseapower/libcharsetdetect/issues/3
-  Codec-Image-DevIL:                            [ platforms.darwin ] # depends on mesa
-  coinor-clp:                                   [ aarch64-linux ] # aarch64-linux is not supported by required system dependency clp
-  cut-the-crap:                                 [ platforms.darwin ]
-  essence-of-live-coding-PortMidi:              [ platforms.darwin ]
-  Euterpea:                                     [ platforms.darwin ]
-  follow-file:                                  [ platforms.darwin ]
-  freenect:                                     [ platforms.darwin ]
-  FTGL:                                         [ platforms.darwin ]
-  fuzzytime:                                    [ platforms.darwin ] # https://github.com/kamwitsta/fuzzytime/issues/2
-  ghc-gc-hook:                                  [ platforms.darwin ] # requires C11 threads which Apple doesn't support
-  gi-adwaita:                                   [ platforms.darwin ]
-  gi-dbusmenugtk3:                              [ platforms.darwin ]
-  gi-dbusmenu:                                  [ platforms.darwin ]
-  gi-ggit:                                      [ platforms.darwin ]
-  gi-gtk-layer-shell:                           [ platforms.darwin ] # depends on gtk-layer-shell which is not supported on darwin
-  gi-ibus:                                      [ platforms.darwin ]
-  gi-javascriptcore:                            [ platforms.darwin ] # webkitgtk marked broken on darwin
-  gi-ostree:                                    [ platforms.darwin ]
-  gi-vte:                                       [ platforms.darwin ]
-  gi-webkit2webextension:                       [ platforms.darwin ] # webkitgtk marked broken on darwin
-  gi-webkit2:                                   [ platforms.darwin ] # webkitgtk marked broken on darwin
-  gi-wnck:                                      [ platforms.darwin ]
-  gl:                                           [ platforms.darwin ] # depends on mesa
-  GLHUI:                                        [ platforms.darwin ] # depends on mesa
-  gnome-keyring:                                [ platforms.darwin ]
-  grid-proto:                                   [ platforms.darwin ]
-  gtk-sni-tray:                                 [ platforms.darwin ]
-  h-raylib:                                     [ platforms.darwin ] # depends on mesa
-  haskell-snake:                                [ platforms.darwin ]
-  hcwiid:                                       [ platforms.darwin ]
-  HDRUtils:                                     [ platforms.darwin ]
-  hinotify-bytestring:                          [ platforms.darwin ]
-  honk:                                         [ platforms.darwin ]
-  HSoM:                                         [ platforms.darwin ]
-  intricacy:                                    [ platforms.darwin ] # depends on mesa
-  iwlib:                                        [ platforms.darwin ]
-  Jazzkell:                                     [ platforms.darwin ] # depends on Euterpea
-  jsaddle-webkit2gtk:                           [ platforms.darwin ]
-  Kulitta:                                      [ platforms.darwin ] # depends on Euterpea
-  LambdaHack:                                   [ platforms.darwin ]
-  large-hashable:                               [ aarch64-linux ] # https://github.com/factisresearch/large-hashable/issues/17
-  libmodbus:                                    [ platforms.darwin ]
-  libsystemd-journal:                           [ platforms.darwin ]
-  libtelnet:                                    [ platforms.darwin ]
-  libvirt-hs:                                   [ platforms.darwin ] # spidermonkey is not supported on darwin
-  libzfs:                                       [ platforms.darwin ]
-  linearEqSolver:                               [ aarch64-linux ]
-  lio-fs:                                       [ platforms.darwin ]
-  logging-facade-journald:                      [ platforms.darwin ]
-  longshot:                                     [ aarch64-linux ]
-  mpi-hs:                                       [ aarch64-linux, platforms.darwin ]
-  mpi-hs-binary:                                [ aarch64-linux, platforms.darwin ]
-  mpi-hs-cereal:                                [ aarch64-linux, platforms.darwin ]
-  mpi-hs-store:                                 [ aarch64-linux, platforms.darwin ]
-  mplayer-spot:                                 [ aarch64-linux, platforms.darwin ]
-  mptcp-pm:                                     [ platforms.darwin ]
-  netlink:                                      [ platforms.darwin ]
-  network-unexceptional:                        [ platforms.darwin ] # depends on posix-api
-  notifications-tray-icon:                      [ platforms.darwin ] # depends on gi-dbusmenu
-  oculus:                                       [ platforms.darwin ]
-  ostree-pin:                                   [ platforms.darwin ] # depends on gi-ostree
-  pam:                                          [ platforms.darwin ]
-  parport:                                      [ platforms.darwin ]
-  persist-state:                                [ aarch64-linux, armv7l-linux ] # https://github.com/minad/persist-state/blob/6fd68c0b8b93dec78218f6d5a1f4fa06ced4e896/src/Data/PersistState.hs#L122-L128
-  piyo:                                         [ platforms.darwin ]
-  PortMidi-simple:                              [ platforms.darwin ]
-  PortMidi:                                     [ platforms.darwin ]
-  portmidi-utility:                             [ platforms.darwin ]
-  posix-api:                                    [ platforms.darwin ]
-  Raincat:                                      [ platforms.darwin ]
-  reactive-balsa:                               [ platforms.darwin ] # depends on alsa-core
-  reflex-dom-fragment-shader-canvas:            [ platforms.darwin, aarch64-linux ]
-  reflex-localize-dom:                          [ platforms.darwin, aarch64-linux ]
-  rtlsdr:                                       [ platforms.darwin ]
-  rubberband:                                   [ platforms.darwin ]
-  SDL-mixer:                                    [ platforms.darwin ] # depends on mesa
-  SDL-mpeg:                                     [ platforms.darwin ] # depends on mesa
-  sdl2-mixer:                                   [ platforms.darwin ]
-  sdl2-ttf:                                     [ platforms.darwin ]
-  sdr:                                          [ platforms.darwin ] # depends on rtlsdr
-  sensei:                                       [ platforms.darwin ]
-  sockets:                                      [ platforms.darwin ] # depends on posix-api
-  spade:                                        [ platforms.darwin ] # depends on sdl2-mixer, which doesn't work on darwin
-  synthesizer-alsa:                             [ platforms.darwin ]
-  taffybar:                                     [ platforms.darwin ]
-  twirl:                                        [ platforms.darwin ] # depends on sdl2-mixer
-  emanote:                                      [ x86_64-darwin ] # Depends on stork which is broken on macOS sdk < 10.14
-  termonad:                                     [ platforms.darwin ]
-  tokyotyrant-haskell:                          [ platforms.darwin ]
-  Unixutils-shadow:                             [ platforms.darwin ]
-  verifiable-expressions:                       [ aarch64-linux ]
-  vrpn:                                         [ platforms.darwin ]
-  vulkan:                                       [ i686-linux, armv7l-linux, platforms.darwin ]
-  VulkanMemoryAllocator:                        [ i686-linux, armv7l-linux, platforms.darwin ]
-  vulkan-utils:                                 [ platforms.darwin ]
-  webkit2gtk3-javascriptcore:                   [ platforms.darwin ]
-  wiringPi:                                     [ aarch64-darwin ]
-  xattr:                                        [ platforms.darwin ]
-  xgboost-haskell:                              [ aarch64-linux, armv7l-linux, platforms.darwin ]
-  xmobar:                                       [ platforms.darwin ]
-  xmonad-extras:                                [ platforms.darwin ]
-  xmonad-volume:                                [ platforms.darwin ]
-  xnobar:                                       [ platforms.darwin ]
-  kmonad:                                       [ platforms.darwin ]
 
-supported-platforms:
-  AWin32Console:                                [ platforms.windows ]
+  Allure:                                       [ platforms.darwin ]
   alsa-mixer:                                   [ platforms.linux ]
   alsa-pcm:                                     [ platforms.linux ]
   alsa-seq:                                     [ platforms.linux ]
+  AWin32Console:                                [ platforms.windows ]
   barbly:                                       [ platforms.darwin ]
+  bdcs-api:                                     [ platforms.darwin ]
+  bindings-directfb:                            [ platforms.darwin ]
   bindings-parport:                             [ platforms.linux ] # parport is a linux kernel component
+  bindings-sane:                                [ platforms.darwin ]
   blake3:                                       [ platforms.x86 ] # uses x86 intrinsics
   btrfs:                                        [ platforms.linux ] # depends on linux
+  bustle:                                       [ platforms.darwin ] # uses glibc-specific ptsname_r
+  bytelog:                                      [ platforms.darwin ] # due to posix-api
   bytepatch:                                    [ platforms.x86 ] # due to blake3
+  camfort:                                      [ aarch64-linux ]
+  chalkboard-viewer:                            [ platforms.darwin ] # depends on chalkboard
+  chalkboard:                                   [ platforms.darwin ] # depends on Codec-Image-DevIL
+  charsetdetect:                                [ aarch64-linux ] # not supported by vendored lib / not configured properly https://github.com/batterseapower/libcharsetdetect/issues/3
+  Codec-Image-DevIL:                            [ platforms.darwin ] # depends on mesa
+  coinor-clp:                                   [ aarch64-linux ] # aarch64-linux is not supported by required system dependency clp
   cpuid:                                        [ platforms.x86 ] # needs to be i386 compatible (IA-32)
   cpython:                                      [ platforms.x86 ] # c2hs errors on glibc headers
   crc32c:                                       [ platforms.x86 ] # uses x86 intrinsics
+  cut-the-crap:                                 [ platforms.darwin ]
   d3d11binding:                                 [ platforms.windows ]
   DirectSound:                                  [ platforms.windows ]
   dx9base:                                      [ platforms.windows ]
   dx9d3d:                                       [ platforms.windows ]
   dx9d3dx:                                      [ platforms.windows ]
+  emanote:                                      [ x86_64-darwin ] # Depends on stork which is broken on macOS sdk < 10.14
   erebos-tester:                                [ platforms.linux ] # depends on linux-namespaces
-  evdev:                                        [ platforms.linux ]
+  essence-of-live-coding-PortMidi:              [ platforms.darwin ]
+  Euterpea:                                     [ platforms.darwin ]
   evdev-streamly:                               [ platforms.linux ]
-  geomancy:                                     [ platforms.x86 ] # x86 intrinsics
+  evdev:                                        [ platforms.linux ]
+  follow-file:                                  [ platforms.darwin ]
+  freenect:                                     [ platforms.darwin ]
+  FTGL:                                         [ platforms.darwin ]
+  fuzzytime:                                    [ platforms.darwin ] # https://github.com/kamwitsta/fuzzytime/issues/2
   geomancy-layout:                              [ platforms.x86 ] # x86 intrinsics
-  gi-gtkosxapplication:                         [ platforms.darwin ]
+  geomancy:                                     [ platforms.x86 ] # x86 intrinsics
+  ghc-gc-hook:                                  [ platforms.darwin ] # requires C11 threads which Apple doesn't support
   ghcjs-base:                                   [ javascript-ghcjs ]
   ghcjs-dom-javascript:                         [ javascript-ghcjs ]
+  gi-adwaita:                                   [ platforms.darwin ]
+  gi-dbusmenu:                                  [ platforms.darwin ]
+  gi-dbusmenugtk3:                              [ platforms.darwin ]
+  gi-ggit:                                      [ platforms.darwin ]
+  gi-gtk-layer-shell:                           [ platforms.darwin ] # depends on gtk-layer-shell which is not supported on darwin
+  gi-gtkosxapplication:                         [ platforms.darwin ]
+  gi-ibus:                                      [ platforms.darwin ]
+  gi-javascriptcore:                            [ platforms.darwin ] # webkitgtk marked broken on darwin
+  gi-ostree:                                    [ platforms.darwin ]
+  gi-vte:                                       [ platforms.darwin ]
+  gi-webkit2:                                   [ platforms.darwin ] # webkitgtk marked broken on darwin
+  gi-webkit2webextension:                       [ platforms.darwin ] # webkitgtk marked broken on darwin
+  gi-wnck:                                      [ platforms.darwin ]
+  gl:                                           [ platforms.darwin ] # depends on mesa
+  GLHUI:                                        [ platforms.darwin ] # depends on mesa
+  gnome-keyring:                                [ platforms.darwin ]
+  grid-proto:                                   [ platforms.darwin ]
   gtk-mac-integration:                          [ platforms.darwin ]
+  gtk-sni-tray:                                 [ platforms.darwin ]
   gtk3-mac-integration:                         [ platforms.darwin ]
+  h-raylib:                                     [ platforms.darwin ] # depends on mesa
   halide-haskell:                               [ platforms.linux ]
   halide-JuicyPixels:                           [ platforms.linux ]
+  haskell-snake:                                [ platforms.darwin ]
   hb3sum:                                       [ platforms.x86 ] # due to blake3
-  hommage-ds:                                   [ platforms.windows ]
-  hpapi:                                        [ platforms.linux ] # limited by pkgs.papi
-  hsignal:                                      [ platforms.x86 ] # -msse2
+  hcwiid:                                       [ platforms.darwin ]
+  HDRUtils:                                     [ platforms.darwin ]
   HFuse:                                        [ platforms.linux ]
+  hinotify-bytestring:                          [ platforms.darwin ]
+  hommage-ds:                                   [ platforms.windows ]
+  honk:                                         [ platforms.darwin ]
+  hpapi:                                        [ platforms.linux ] # limited by pkgs.papi
   HQu:                                          [ platforms.x86 ] # vendored C++ library needs i686/x86_64
   hs-swisstable-hashtables-class:               [ platforms.x86_64 ] # depends on swisstable, which Needs AVX2
+  hsignal:                                      [ platforms.x86 ] # -msse2
+  HSoM:                                         [ platforms.darwin ]
   htune:                                        [ platforms.linux ] # depends on alsa-pcm
   hw-prim-bits:                                 [ platforms.x86 ] # x86 assembler
   inline-asm:                                   [ platforms.x86 ] # x86 assembler
+  intricacy:                                    [ platforms.darwin ] # depends on mesa
+  iwlib:                                        [ platforms.darwin ]
+  Jazzkell:                                     [ platforms.darwin ] # depends on Euterpea
+  jsaddle-webkit2gtk:                           [ platforms.darwin ]
   jsaddle-wkwebview:                            [ platforms.darwin ]
   keid-core:                                    [ x86_64-linux ] # geomancy (only x86), vulkan (no i686, no darwin, …)
   keid-frp-banana:                              [ x86_64-linux ] # geomancy (only x86), vulkan (no i686, no darwin, …)
@@ -840,43 +774,109 @@ supported-platforms:
   keid-resource-gltf:                           [ x86_64-linux ] # geomancy (only x86), vulkan (no i686, no darwin, …)
   keid-sound-openal:                            [ x86_64-linux ] # geomancy (only x86), vulkan (no i686, no darwin, …)
   keid-ui-dearimgui:                            [ x86_64-linux ] # geomancy (only x86), vulkan (no i686, no darwin, …)
+  kmonad:                                       [ platforms.darwin ]
   kqueue:                                       [ platforms.netbsd, platforms.freebsd, platforms.openbsd, platforms.darwin ]
+  Kulitta:                                      [ platforms.darwin ] # depends on Euterpea
+  LambdaHack:                                   [ platforms.darwin ]
+  large-hashable:                               [ aarch64-linux ] # https://github.com/factisresearch/large-hashable/issues/17
   libfuse3:                                     [ platforms.linux ]
+  libmodbus:                                    [ platforms.darwin ]
+  libsystemd-journal:                           [ platforms.darwin ]
+  libtelnet:                                    [ platforms.darwin ]
+  libvirt-hs:                                   [ platforms.darwin ] # spidermonkey is not supported on darwin
+  libzfs:                                       [ platforms.darwin ]
+  linearEqSolver:                               [ aarch64-linux ]
   linux-evdev:                                  [ platforms.linux ]
   linux-file-extents:                           [ platforms.linux ]
   linux-inotify:                                [ platforms.linux ]
   linux-mount:                                  [ platforms.linux ]
   linux-namespaces:                             [ platforms.linux ]
+  lio-fs:                                       [ platforms.darwin ]
+  logging-facade-journald:                      [ platforms.darwin ]
+  longshot:                                     [ aarch64-linux ]
   lxc:                                          [ platforms.linux ]
   memfd:                                        [ platforms.linux ]
   midi-alsa:                                    [ platforms.linux ] # alsa-core only supported on linux
   midisurface:                                  [ platforms.linux ] # alsa-core only supported on linux
   miso-action-logger:                           [ javascript-ghcjs ] # https://github.com/Lermex/miso-action-logger/issues/1
   miso-examples:                                [ javascript-ghcjs ]
+  mpi-hs-binary:                                [ aarch64-linux, platforms.darwin ]
+  mpi-hs-cereal:                                [ aarch64-linux, platforms.darwin ]
+  mpi-hs-store:                                 [ aarch64-linux, platforms.darwin ]
+  mpi-hs:                                       [ aarch64-linux, platforms.darwin ]
+  mplayer-spot:                                 [ aarch64-linux, platforms.darwin ]
+  mptcp-pm:                                     [ platforms.darwin ]
+  netlink:                                      [ platforms.darwin ]
+  network-unexceptional:                        [ platforms.darwin ] # depends on posix-api
+  notifications-tray-icon:                      [ platforms.darwin ] # depends on gi-dbusmenu
+  oculus:                                       [ platforms.darwin ]
   OrderedBits:                                  [ platforms.x86 ] # lacks implementations for non-x86: https://github.com/choener/OrderedBits/blob/401cbbe933b1635aa33e8e9b29a4a570b0a8f044/lib/Data/Bits/Ordered.hs#L316
+  ostree-pin:                                   [ platforms.darwin ] # depends on gi-ostree
+  pam:                                          [ platforms.darwin ]
+  parport:                                      [ platforms.darwin ]
+  persist-state:                                [ aarch64-linux, armv7l-linux ] # https://github.com/minad/persist-state/blob/6fd68c0b8b93dec78218f6d5a1f4fa06ced4e896/src/Data/PersistState.hs#L122-L128
+  piyo:                                         [ platforms.darwin ]
+  PortMidi-simple:                              [ platforms.darwin ]
+  portmidi-utility:                             [ platforms.darwin ]
+  PortMidi:                                     [ platforms.darwin ]
+  posix-api:                                    [ platforms.darwin ]
+  Raincat:                                      [ platforms.darwin ]
+  reactive-balsa:                               [ platforms.darwin ] # depends on alsa-core
   reactivity:                                   [ platforms.windows ]
+  reflex-dom-fragment-shader-canvas:            [ platforms.darwin, aarch64-linux ]
   reflex-libtelnet:                             [ platforms.linux ] # pkgs.libtelnet only supports linux
+  reflex-localize-dom:                          [ platforms.darwin, aarch64-linux ]
+  rtlsdr:                                       [ platforms.darwin ]
+  rubberband:                                   [ platforms.darwin ]
   scat:                                         [ platforms.x86 ] # uses scrypt, which requries x86
   scrypt:                                       [ platforms.x86 ] # https://github.com/informatikr/scrypt/issues/8
+  SDL-mixer:                                    [ platforms.darwin ] # depends on mesa
+  SDL-mpeg:                                     [ platforms.darwin ] # depends on mesa
+  sdl2-mixer:                                   [ platforms.darwin ]
+  sdl2-ttf:                                     [ platforms.darwin ]
+  sdr:                                          [ platforms.darwin ] # depends on rtlsdr
+  sensei:                                       [ platforms.darwin ]
   seqalign:                                     [ platforms.x86 ] # x86 intrinsics
+  sockets:                                      [ platforms.darwin ] # depends on posix-api
+  spade:                                        [ platforms.darwin ] # depends on sdl2-mixer, which doesn't work on darwin
   streamed:                                     [ platforms.linux] # alsa-core only supported on linux
+supported-platforms:
   swisstable:                                   [ platforms.x86_64 ] # Needs AVX2
+  synthesizer-alsa:                             [ platforms.darwin ]
   systemd-api:                                  [ platforms.linux ]
+  taffybar:                                     [ platforms.darwin ]
   tasty-papi:                                   [ platforms.linux ] # limited by pkgs.papi
   tcod-haskell:                                 [ platforms.linux ] # limited by pkgs.libtcod
+  termonad:                                     [ platforms.darwin ]
+  tokyotyrant-haskell:                          [ platforms.darwin ]
+  twirl:                                        [ platforms.darwin ] # depends on sdl2-mixer
   udev:                                         [ platforms.linux ]
+  Unixutils-shadow:                             [ platforms.darwin ]
+  verifiable-expressions:                       [ aarch64-linux ]
+  vrpn:                                         [ platforms.darwin ]
   vty-windows:                                  [ platforms.windows ] # depends on Win32
+  vulkan-utils:                                 [ platforms.darwin ]
+  vulkan:                                       [ i686-linux, armv7l-linux, platforms.darwin ]
+  VulkanMemoryAllocator:                        [ i686-linux, armv7l-linux, platforms.darwin ]
+  webkit2gtk3-javascriptcore:                   [ platforms.darwin ]
   Win32-console:                                [ platforms.windows ]
   Win32-dhcp-server:                            [ platforms.windows ]
   Win32-errors:                                 [ platforms.windows ]
   Win32-extras:                                 [ platforms.windows ]
   Win32-junction-point:                         [ platforms.windows ]
   Win32-notify:                                 [ platforms.windows ]
-  Win32:                                        [ platforms.windows ]
   Win32-security:                               [ platforms.windows ]
-  Win32-services:                               [ platforms.windows ]
   Win32-services-wrapper:                       [ platforms.windows ]
+  Win32-services:                               [ platforms.windows ]
+  Win32:                                        [ platforms.windows ]
+  wiringPi:                                     [ aarch64-darwin ]
+  xattr:                                        [ platforms.darwin ]
+  xgboost-haskell:                              [ aarch64-linux, armv7l-linux, platforms.darwin ]
   XInput:                                       [ platforms.windows ]
+  xmobar:                                       [ platforms.darwin ]
+  xmonad-extras:                                [ platforms.darwin ]
+  xmonad-volume:                                [ platforms.darwin ]
+  xnobar:                                       [ platforms.darwin ]
   yesod-auth-simple:                            [ platforms.x86 ] # requires scrypt which only supports x86
 # keep-sorted end
 

--- a/pkgs/development/haskell-modules/configuration-hackage2nix/stackage.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/stackage.yaml
@@ -62,11 +62,11 @@ default-package-overrides:
   - ansi-wl-pprint ==1.0.2
   - ANum ==0.2.0.2
   - aos-signature ==0.1.1
+  - ap-normalize ==0.1.0.1
   - apecs ==0.9.6
   - apecs-gloss ==0.2.4
   - apecs-physics ==0.4.6
   - api-field-json-th ==0.1.0.2
-  - ap-normalize ==0.1.0.1
   - appar ==0.1.8
   - appendful ==0.1.0.0
   - appendful-persistent ==0.1.0.1
@@ -115,6 +115,7 @@ default-package-overrides:
   - audacity ==0.0.2.2
   - authenticate ==1.3.5.2
   - authenticate-oauth ==1.7
+  - auto-update ==0.2.6
   - autodocodec ==0.4.2.2
   - autodocodec-nix ==0.0.1.5
   - autodocodec-openapi3 ==0.2.1.4
@@ -124,7 +125,6 @@ default-package-overrides:
   - autodocodec-yaml ==0.4.0.1
   - autoexporter ==2.0.0.13
   - automaton ==1.5
-  - auto-update ==0.2.6
   - avro ==0.6.2.1
   - aws ==0.24.4
   - aws-lambda-haskell-runtime ==4.3.2
@@ -138,6 +138,11 @@ default-package-overrides:
   - bank-holiday-germany ==1.3.1.0
   - bank-holidays-england ==0.2.0.11
   - barbies ==2.1.1.0
+  - base-compat ==0.13.1
+  - base-compat-batteries ==0.13.1
+  - base-orphans ==0.9.3
+  - base-prelude ==1.6.1.1
+  - base-unicode-symbols ==0.2.4.2
   - base16 ==1.0
   - base16-bytestring ==1.0.2.0
   - base32 ==0.4
@@ -148,12 +153,7 @@ default-package-overrides:
   - base64-bytestring ==1.2.1.0
   - base64-bytestring-type ==1.0.1
   - base64-string ==0.2
-  - base-compat ==0.13.1
-  - base-compat-batteries ==0.13.1
   - basement ==0.0.16
-  - base-orphans ==0.9.3
-  - base-prelude ==1.6.1.1
-  - base-unicode-symbols ==0.2.4.2
   - basic-prelude ==0.7.0
   - battleship-combinatorics ==0.0.1
   - bazel-runfiles ==0.12
@@ -167,8 +167,8 @@ default-package-overrides:
   - beam-sqlite ==0.5.4.0
   - bech32 ==1.1.8
   - bech32-th ==1.1.8
-  - benchpress ==0.2.2.25
   - bench-show ==0.3.2
+  - benchpress ==0.2.2.25
   - bencode ==0.6.1.1
   - bencoding ==0.4.5.6
   - benri-hspec ==0.1.0.3
@@ -182,7 +182,6 @@ default-package-overrides:
   - bin ==0.1.4
   - binance-exports ==0.1.2.0
   - binary-conduit ==1.3.1
-  - binaryen ==0.0.6.0
   - binary-generic-combinators ==0.4.4.0
   - binary-ieee754 ==0.1.0.0
   - binary-instances ==1.0.6
@@ -192,6 +191,7 @@ default-package-overrides:
   - binary-search ==2.0.0
   - binary-shared ==0.8.3
   - binary-tagged ==0.3.1
+  - binaryen ==0.0.6.0
   - bindings-DSL ==1.0.25
   - bindings-GLFW ==3.3.9.2
   - bindings-libzip ==1.0.1
@@ -199,8 +199,8 @@ default-package-overrides:
   - BiobaseNewick ==0.0.0.2
   - bitarray ==0.0.1.1
   - bits ==0.6
-  - bitset-word8 ==0.1.1.2
   - bits-extra ==0.0.2.3
+  - bitset-word8 ==0.1.1.2
   - bitvec ==1.1.5.0
   - bitwise ==1.0.0.1
   - bitwise-enum ==1.0.1.2
@@ -236,13 +236,13 @@ default-package-overrides:
   - bordacount ==0.1.0.0
   - boring ==0.2.2
   - bound ==2.0.7
-  - BoundedChan ==1.0.3.0
   - bounded-qsem ==0.1.0.4
   - bounded-queue ==1.0.0
+  - BoundedChan ==1.0.3.0
   - boundingboxes ==0.2.3
   - box ==0.9.3.2
-  - boxes ==0.1.5
   - box-socket ==0.5.2.0
+  - boxes ==0.1.5
   - breakpoint ==0.1.4.0
   - brick ==2.4
   - brotli ==0.0.0.2
@@ -261,12 +261,12 @@ default-package-overrides:
   - bv ==0.5
   - bv-little ==1.3.2
   - bv-sized ==1.0.6
+  - byte-count-reader ==0.10.1.12
+  - byte-order ==0.1.3.1
   - byteable ==0.1.1
   - bytebuild ==0.3.16.3
-  - byte-count-reader ==0.10.1.12
   - bytedump ==1.0
   - bytehash ==0.1.1.2
-  - byte-order ==0.1.3.1
   - byteorder ==1.0.4
   - bytes ==0.17.4
   - byteset ==0.1.1.2
@@ -284,9 +284,11 @@ default-package-overrides:
   - bzip2-clib ==1.0.8
   - bzlib ==0.5.2.0
   - bzlib-conduit ==0.3.0.4
+  - c-enum ==0.1.1.3
+  - c-struct ==0.1.3.0
   - c14n ==0.1.0.3
   - c2hs ==0.28.8
-  - cabal2spec ==2.7.1
+  - ca-province-codes ==1.0.0.0
   - cabal-add ==0.1
   - cabal-appimage ==0.4.1.0
   - cabal-clean ==0.2.20230609
@@ -300,6 +302,7 @@ default-package-overrides:
   - cabal-plan ==0.7.5.0
   - cabal-rpm ==2.2.1
   - cabal-sort ==0.1.2.1
+  - cabal2spec ==2.7.1
   - cache ==0.1.3.0
   - cached-json-file ==0.1.1
   - cacophony ==0.10.1
@@ -311,13 +314,12 @@ default-package-overrides:
   - call-stack ==0.4.0
   - can-i-haz ==0.3.1.1
   - capability ==0.5.0.1
-  - ca-province-codes ==1.0.0.0
   - cardano-coin-selection ==1.0.1
   - carray ==0.1.6.8
   - casa-client ==0.0.2
   - casa-types ==0.0.2
-  - cased ==0.1.0.0
   - case-insensitive ==1.2.1.0
+  - cased ==0.1.0.0
   - cases ==0.1.4.4
   - casing ==0.1.4.1
   - cassava ==0.5.3.2
@@ -329,7 +331,6 @@ default-package-overrides:
   - cborg ==0.2.10.0
   - cborg-json ==0.2.6.0
   - cdar-mBound ==0.1.0.4
-  - c-enum ==0.1.1.3
   - cereal ==0.5.8.3
   - cereal-conduit ==0.8.0
   - cereal-text ==0.1.0.2
@@ -382,15 +383,15 @@ default-package-overrides:
   - cmark-gfm ==0.2.6
   - cmark-lucid ==0.1.0.0
   - cmdargs ==0.10.22
-  - codec-beam ==0.2.0
-  - code-conjure ==0.5.16
-  - code-page ==0.2.1
-  - coinor-clp ==0.0.0.2
-  - cointracking-imports ==0.1.0.2
-  - collect-errors ==0.1.6.0
   - co-log ==0.6.1.2
   - co-log-core ==0.3.2.5
   - co-log-polysemy ==0.0.1.6
+  - code-conjure ==0.5.16
+  - code-page ==0.2.1
+  - codec-beam ==0.2.0
+  - coinor-clp ==0.0.0.2
+  - cointracking-imports ==0.1.0.2
+  - collect-errors ==0.1.6.0
   - colonnade ==1.2.0.2
   - Color ==0.3.3
   - colorful-monoids ==0.2.1.3
@@ -442,14 +443,14 @@ default-package-overrides:
   - conferer ==1.1.0.0
   - conferer-aeson ==1.1.0.2
   - config-ini ==0.2.7.0
+  - config-value ==0.8.3
   - configuration-tools ==0.7.1
   - configurator ==0.3.0.0
   - configurator-export ==0.1.0.1
   - configurator-pg ==0.2.10
-  - config-value ==0.8.3
+  - constraint-tuples ==0.2
   - constraints ==0.14.2
   - constraints-extras ==0.4.0.2
-  - constraint-tuples ==0.2
   - construct ==0.3.2
   - context ==0.2.1.0
   - context-http-client ==0.2.0.2
@@ -490,10 +491,14 @@ default-package-overrides:
   - criterion ==1.6.4.0
   - criterion-measurement ==0.2.3.0
   - cron ==0.7.2
+  - crypt-sha512 ==0
   - crypto-api ==0.13.3
   - crypto-api-tests ==0.3
   - crypto-cipher-tests ==0.0.11
   - crypto-cipher-types ==0.0.9
+  - crypto-pubkey-types ==0.4.3
+  - crypto-random-api ==0.2.0
+  - crypto-token ==0.1.2
   - cryptocompare ==0.1.2
   - cryptohash ==0.11.9
   - cryptohash-cryptoapi ==0.1.4
@@ -504,20 +509,15 @@ default-package-overrides:
   - crypton ==1.0.4
   - crypton-conduit ==0.2.3
   - crypton-connection ==0.4.4
-  - cryptonite ==0.30
-  - cryptonite-conduit ==0.2.2
-  - cryptonite-openssl ==0.7
   - crypton-x509 ==1.7.7
   - crypton-x509-store ==1.6.10
   - crypton-x509-system ==1.6.7
   - crypton-x509-validation ==1.6.14
-  - crypto-pubkey-types ==0.4.3
-  - crypto-random-api ==0.2.0
-  - crypto-token ==0.1.2
-  - crypt-sha512 ==0
+  - cryptonite ==0.30
+  - cryptonite-conduit ==0.2.2
+  - cryptonite-openssl ==0.7
   - csp ==1.4.0
   - css-text ==0.1.3.0
-  - c-struct ==0.1.3.0
   - csv ==0.1.2
   - csv-conduit ==1.0.1.0
   - ctrie ==0.2
@@ -601,9 +601,9 @@ default-package-overrides:
   - dependent-sum-template ==0.2.0.2
   - depq ==0.4.2
   - deque ==0.4.4.2
-  - deriveJsonNoPrefix ==0.1.0.1
   - derive-storable ==0.3.1.0
   - derive-topdown ==0.1.0.0
+  - deriveJsonNoPrefix ==0.1.0.1
   - deriving-aeson ==0.2.10
   - deriving-compat ==0.6.7
   - deriving-trans ==0.9.1.0
@@ -611,6 +611,10 @@ default-package-overrides:
   - df1 ==0.4.3
   - dhall ==1.42.2
   - di ==1.3
+  - di-core ==1.0.4
+  - di-df1 ==1.2.1
+  - di-handle ==1.0.1
+  - di-monad ==1.3.5
   - diagrams ==1.4.2
   - diagrams-builder ==0.8.0.6
   - diagrams-cairo ==1.4.2.1
@@ -623,19 +627,15 @@ default-package-overrides:
   - diagrams-solve ==0.1.3.1
   - diagrams-svg ==1.4.4
   - dice ==0.1.1
-  - di-core ==1.0.4
   - dictionary-sharing ==0.1.0.0
-  - di-df1 ==1.2.1
   - Diff ==0.5
   - diff-loc ==0.1.0.0
   - digest ==0.0.2.1
   - digits ==0.3.1
-  - di-handle ==1.0.1
   - dimensional ==1.6.1
-  - di-monad ==1.3.5
+  - direct-sqlite ==2.3.29
   - directory-ospath-streaming ==0.1.0.3
   - directory-tree ==0.12.1
-  - direct-sqlite ==2.3.29
   - dirichlet ==0.1.0.7
   - discount ==0.1.1
   - discover-instances ==0.1.0.0
@@ -662,6 +662,8 @@ default-package-overrides:
   - dlist-instances ==0.1.1.1
   - dlist-nonempty ==0.1.3
   - dns ==4.2.0
+  - do-list ==1.0.1
+  - do-notation ==0.1.0.2
   - dockerfile ==0.2.0
   - doclayout ==0.5
   - docopt ==0.7.0.8
@@ -674,13 +676,11 @@ default-package-overrides:
   - doctest-lib ==0.1.1.1
   - doctest-parallel ==0.3.1.1
   - doldol ==0.4.1.2
-  - do-list ==1.0.1
   - domain ==0.1.1.5
   - domain-aeson ==0.1.1.2
   - domain-cereal ==0.1.0.1
   - domain-core ==0.1.0.4
   - domain-optics ==0.1.0.4
-  - do-notation ==0.1.0.2
   - dot ==0.3
   - dotenv ==0.12.0.0
   - dotgen ==0.4.3
@@ -726,12 +726,12 @@ default-package-overrides:
   - elerea ==2.9.0
   - elf ==0.31
   - eliminators ==0.9.4
-  - elm2nix ==0.4.0
   - elm-bridge ==0.8.4
   - elm-core-sources ==1.0.0
   - elm-export ==0.6.0.1
   - elm-street ==0.2.2.1
   - elm-syntax ==0.3.3.0
+  - elm2nix ==0.4.0
   - elynx ==0.8.0.0
   - elynx-markov ==0.8.0.0
   - elynx-nexus ==0.8.0.0
@@ -746,10 +746,10 @@ default-package-overrides:
   - encoding ==0.8.10
   - ENIG ==0.0.1.0
   - entropy ==0.4.1.11
-  - enummapset ==0.7.3.0
-  - enumset ==0.1
   - enum-subset-generate ==0.1.0.3
   - enum-text ==0.5.3.0
+  - enummapset ==0.7.3.0
+  - enumset ==0.1
   - envelope ==0.2.2.0
   - envparse ==0.6.0
   - envy ==2.1.4.0
@@ -761,9 +761,9 @@ default-package-overrides:
   - erf ==2.0.0.0
   - errata ==0.4.0.3
   - error ==1.0.0.0
-  - errorcall-eq-instance ==0.3.0
   - error-or ==0.3.0
   - error-or-utils ==0.2.0
+  - errorcall-eq-instance ==0.3.0
   - errors ==2.3.0
   - errors-ext ==0.4.2
   - ersatz ==0.5
@@ -787,18 +787,18 @@ default-package-overrides:
   - exit-codes ==1.0.0
   - exomizer ==1.0.0
   - exon ==1.7.2.0
+  - exp-pairs ==0.2.1.1
   - expiring-cache-map ==0.0.6.1
   - explainable-predicates ==0.1.2.4
   - explicit-exception ==0.2
-  - exp-pairs ==0.2.1.1
   - express ==1.0.18
   - extended-reals ==0.2.6.0
   - extensible ==0.9.2
   - extensible-effects ==5.0.0.1
   - extensible-exceptions ==0.1.1.4
   - extra ==1.7.16
-  - extractable-singleton ==0.0.1
   - extra-data-yj ==0.1.0.0
+  - extractable-singleton ==0.0.1
   - extrapolate ==0.4.6
   - fail ==4.9.0.0
   - FailT ==0.1.2.0
@@ -826,14 +826,14 @@ default-package-overrides:
   - fgl-arbitrary ==0.2.0.6
   - fields-and-cases ==0.2.0.0
   - fields-json ==0.4.0.0
-  - filecache ==0.5.2
   - file-embed ==0.0.16.0
   - file-embed-lzma ==0.1
   - file-io ==0.1.5
-  - filelock ==0.1.1.7
-  - filemanip ==0.3.6.3
   - file-modules ==0.1.2.4
   - file-path-th ==0.1.0.0
+  - filecache ==0.5.2
+  - filelock ==0.1.1.7
+  - filemanip ==0.3.6.3
   - filepattern ==0.1.3
   - fileplow ==0.1.0.0
   - filter-logger ==0.6.0.0
@@ -845,11 +845,11 @@ default-package-overrides:
   - first-class-families ==0.8.1.0
   - fits-parse ==0.4.2
   - fitspec ==0.4.10
+  - fix-whitespace ==0.1
   - fixed ==0.3
   - fixed-length ==0.2.3.1
   - fixed-vector ==1.2.3.0
   - fixed-vector-hetero ==0.6.2.0
-  - fix-whitespace ==0.1
   - flac ==0.2.1
   - flac-picture ==0.1.3
   - flags-applicative ==0.1.0.3
@@ -866,8 +866,8 @@ default-package-overrides:
   - fn ==0.3.0.2
   - focus ==1.0.3.2
   - focuslist ==0.1.1.0
-  - foldable1-classes-compat ==0.1.1
   - fold-debounce ==0.2.0.16
+  - foldable1-classes-compat ==0.1.1
   - foldl ==1.4.18
   - folds ==0.7.8
   - FontyFruity ==0.5.3.5
@@ -876,8 +876,8 @@ default-package-overrides:
   - ForestStructures ==0.0.1.1
   - forkable-monad ==0.2.0.3
   - forma ==1.2.0
-  - formatn ==0.3.1.0
   - format-numbers ==0.1.0.1
+  - formatn ==0.3.1.0
   - formatting ==7.2.0
   - fortran-src ==0.16.5
   - foundation ==0.0.30
@@ -887,11 +887,11 @@ default-package-overrides:
   - free-alacarte ==1.0.0.9
   - free-categories ==0.2.0.2
   - free-foil ==0.2.0
+  - free-vl ==0.1.4
   - freenect ==1.2.1
   - freer-par-monad ==0.1.0.0
   - freer-simple ==1.2.1.2
   - freetype2 ==0.2.0
-  - free-vl ==0.1.4
   - friendly-time ==0.4.1
   - frisby ==0.2.5
   - from-sum ==0.2.3.0
@@ -909,14 +909,13 @@ default-package-overrides:
   - fuzzcheck ==0.1.1
   - fuzzy ==0.1.1.0
   - fuzzy-dates ==0.1.1.2
-  - fuzzyset ==0.3.2
   - fuzzy-time ==0.3.0.0
+  - fuzzyset ==0.3.2
   - gauge ==0.2.5
   - gd ==3000.7.3
   - gdp ==0.0.3.0
   - gemini-exports ==0.1.0.2
   - general-games ==1.1.1
-  - generically ==0.1.1
   - generic-arbitrary ==1.0.1.2
   - generic-constraints ==1.1.1.1
   - generic-data ==1.1.0.2
@@ -928,13 +927,14 @@ default-package-overrides:
   - generic-lens-core ==2.2.1.0
   - generic-monoid ==0.1.0.1
   - generic-optics ==2.2.1.0
-  - GenericPretty ==1.2.2
   - generic-random ==1.5.0.1
+  - generic-type-asserts ==0.3.0
+  - generic-type-functions ==0.1.0
+  - generically ==0.1.1
+  - GenericPretty ==1.2.2
   - generics-eot ==0.4.0.1
   - generics-sop ==0.5.1.4
   - generics-sop-lens ==0.2.1
-  - generic-type-asserts ==0.3.0
-  - generic-type-functions ==0.1.0
   - geniplate-mirror ==0.7.10
   - genvalidity ==1.1.1.0
   - genvalidity-aeson ==1.0.0.1
@@ -977,12 +977,6 @@ default-package-overrides:
   - ghc-events ==0.20.0.0
   - ghc-exactprint ==1.8.0.0
   - ghc-hs-meta ==0.1.5.0
-  - ghcid ==0.8.9
-  - ghci-hexcalc ==0.1.1.0
-  - ghcjs-codemirror ==0.0.0.2
-  - ghcjs-dom ==0.9.9.2
-  - ghcjs-dom-jsaddle ==0.9.9.0
-  - ghcjs-perch ==0.3.3.3
   - ghc-lib ==9.8.5.20250214
   - ghc-lib-parser ==9.8.5.20250214
   - ghc-lib-parser-ex ==9.8.0.2
@@ -996,6 +990,12 @@ default-package-overrides:
   - ghc-typelits-knownnat ==0.7.13
   - ghc-typelits-natnormalise ==0.7.10
   - ghc-typelits-presburger ==0.7.4.1
+  - ghci-hexcalc ==0.1.1.0
+  - ghcid ==0.8.9
+  - ghcjs-codemirror ==0.0.0.2
+  - ghcjs-dom ==0.9.9.2
+  - ghcjs-dom-jsaddle ==0.9.9.0
+  - ghcjs-perch ==0.3.3.3
   - ghost-buster ==0.1.1.0
   - ghostscript-parallel ==0.0.1
   - gi-atk ==2.0.28
@@ -1019,16 +1019,20 @@ default-package-overrides:
   - gi-graphene ==1.0.8
   - gi-gsk ==4.0.9
   - gi-gtk ==3.0.44
+  - gi-gtk-hs ==0.3.17
   - gi-gtk3 ==3.0.44
   - gi-gtk4 ==4.0.12
-  - gi-gtk-hs ==0.3.17
   - gi-gtksource ==3.0.30
   - gi-gtksource3 ==3.0.30
   - gi-harfbuzz ==0.0.10
-  - gio ==0.13.12.0
   - gi-pango ==1.0.30
-  - gi-soup2 ==2.4.30
   - gi-soup ==2.4.30
+  - gi-soup2 ==2.4.30
+  - gi-vte ==2.91.35
+  - gi-xlib ==2.0.14
+  - gio ==0.13.12.0
+  - git-lfs ==1.2.5
+  - git-mediate ==1.1.0
   - githash ==0.1.7.0
   - github ==0.29
   - github-release ==2.0.0.12
@@ -1036,14 +1040,10 @@ default-package-overrides:
   - github-types ==0.2.1
   - github-webhooks ==0.17.0
   - gitlab-haskell ==1.0.2.2
-  - git-lfs ==1.2.5
   - gitlib ==3.1.3
   - gitlib-libgit2 ==3.1.2.1
   - gitlib-test ==3.1.2
-  - git-mediate ==1.1.0
   - gitrev ==1.3.1
-  - gi-vte ==2.91.35
-  - gi-xlib ==2.0.14
   - gl ==0.9.1
   - glabrous ==2.0.6.3
   - glasso ==0.1.0
@@ -1082,10 +1082,10 @@ default-package-overrides:
   - group-by-date ==0.1.0.5
   - groups ==0.5.3
   - gtk ==0.15.10
-  - gtk2hs-buildtools ==0.13.12.0
-  - gtk3 ==0.15.10
   - gtk-sni-tray ==0.1.8.1
   - gtk-strut ==0.1.3.2
+  - gtk2hs-buildtools ==0.13.12.0
+  - gtk3 ==0.15.10
   - guarded-allocation ==0.0.1
   - hackage-cli ==0.1.0.2
   - hackage-security ==0.6.2.6
@@ -1109,6 +1109,7 @@ default-package-overrides:
   - happy-meta ==0.2.1.0
   - harpie ==0.1.2.0
   - harpie-numhask ==0.1.0.1
+  - has-transformers ==0.1.0.4
   - HasBigDecimal ==0.2.0.0
   - hashable ==1.4.7.0
   - hashids ==1.1.1.0
@@ -1140,7 +1141,6 @@ default-package-overrides:
   - hasql-pool ==1.2.0.3
   - hasql-th ==0.4.0.23
   - hasql-transaction ==1.1.1.2
-  - has-transformers ==0.1.0.4
   - hasty-hamiltonian ==1.3.4
   - HaTeX ==3.22.4.2
   - HaXml ==1.25.14
@@ -1168,19 +1168,19 @@ default-package-overrides:
   - heist ==1.1.1.2
   - here ==1.2.14
   - heredoc ==0.2.0.0
-  - heterocephalus ==1.0.5.7
   - hetero-parameter-list ==0.1.0.21
   - hetero-parameter-list-with-typelevel-tools ==0.1.0.1
+  - heterocephalus ==1.0.5.7
   - hex ==0.2.0
+  - hex-text ==0.1.0.9
   - hexml ==0.3.5
   - hexml-lens ==0.2.2
   - hexpat ==0.20.13
-  - hex-text ==0.1.0.9
   - hformat ==0.3.3.1
   - hfsevents ==0.1.8
   - hgal ==2.0.0.3
-  - hidapi ==0.1.8
   - hi-file-parser ==0.1.7.0
+  - hidapi ==0.1.8
   - hindent ==6.2.1
   - hinfo ==0.0.3.0
   - hinotify ==0.4.2
@@ -1232,17 +1232,18 @@ default-package-overrides:
   - hreader ==1.1.1
   - hreader-lens ==0.1.3.0
   - hruby ==0.5.1.0
-  - hsass ==0.8.0
   - hs-bibutils ==6.10.0.0
-  - hsc2hs ==0.68.10
   - hs-captcha ==1.0
+  - hs-GeoIP ==0.3
+  - hs-php-session ==0.0.9.3
+  - hsass ==0.8.0
+  - hsc2hs ==0.68.10
   - hscolour ==1.25
   - hsdns ==1.8
   - hse-cpp ==0.2
   - hsemail ==2.2.2
   - HSet ==0.0.2
   - hset ==2.2.0
-  - hs-GeoIP ==0.3
   - hsignal ==0.2.7.5
   - hsini ==0.5.2.2
   - hsinstall ==2.8
@@ -1294,7 +1295,6 @@ default-package-overrides:
   - hspec-wai ==0.11.1
   - hspec-wai-json ==0.11.0
   - hspec-webdriver ==1.2.2
-  - hs-php-session ==0.0.9.3
   - hstatistics ==0.3.1
   - HStringTemplate ==0.8.8
   - HSvm ==1.0.3.35
@@ -1309,7 +1309,6 @@ default-package-overrides:
   - html-entities ==1.1.4.7
   - html-entity-map ==0.1.0.0
   - html-parse ==0.2.2.0
-  - http2 ==5.3.9
   - HTTP ==4000.4.1
   - http-api-data ==0.6.2
   - http-api-data-qq ==0.1.0.0
@@ -1323,7 +1322,6 @@ default-package-overrides:
   - http-date ==0.0.11
   - http-directory ==0.1.11
   - http-download ==0.2.1.0
-  - httpd-shed ==0.4.1.2
   - http-io-streams ==0.1.7.0
   - http-link-header ==1.2.3
   - http-media ==0.8.1.1
@@ -1332,6 +1330,8 @@ default-package-overrides:
   - http-semantics ==0.3.0
   - http-streams ==0.8.9.9
   - http-types ==0.12.4
+  - http2 ==5.3.9
+  - httpd-shed ==0.4.1.2
   - human-readable-duration ==0.2.1.4
   - HUnit ==1.6.2.0
   - HUnit-approx ==1.1.1.1
@@ -1341,12 +1341,10 @@ default-package-overrides:
   - hw-bits ==0.7.2.2
   - hw-conduit-merges ==0.2.1.0
   - hw-diagnostics ==0.0.1.0
-  - hweblib ==0.6.3
   - hw-excess ==0.2.3.0
   - hw-hedgehog ==0.1.1.1
   - hw-int ==0.0.2.0
   - hw-json-simd ==0.1.1.2
-  - hwk ==0.6
   - hw-kafka-client ==5.3.0
   - hw-mquery ==0.2.1.2
   - hw-parser ==0.1.1.0
@@ -1354,6 +1352,8 @@ default-package-overrides:
   - hw-rankselect-base ==0.3.4.1
   - hw-streams ==0.0.1.1
   - hw-string-parse ==0.0.0.5
+  - hweblib ==0.6.3
+  - hwk ==0.6
   - hxt ==9.3.1.22
   - hxt-charproperties ==9.5.0.0
   - hxt-css ==0.1.0.3
@@ -1407,6 +1407,7 @@ default-package-overrides:
   - insert-ordered-containers ==0.2.6
   - inspection-testing ==0.5.0.3
   - int-cast ==0.2.0.0
+  - int-supply ==1.0.0
   - integer-conversion ==0.1.1
   - integer-logarithms ==1.0.4
   - integer-roots ==1.0.2.0
@@ -1420,7 +1421,6 @@ default-package-overrides:
   - IntervalMap ==0.6.2.1
   - intervals ==0.9.3
   - intset-imperative ==0.1.0.0
-  - int-supply ==1.0.0
   - invariant ==0.6.4
   - invertible ==0.2.0.8
   - invertible-grammar ==0.1.3.5
@@ -1457,22 +1457,22 @@ default-package-overrides:
   - jose ==0.11
   - jose-jwt ==0.10.0
   - journalctl-stream ==0.6.0.8
-  - jsaddle ==0.9.9.3
-  - jsaddle-dom ==0.9.9.2
   - js-chart ==2.9.4.1
   - js-dgtable ==0.5.2
   - js-flot ==0.8.3
   - js-jquery ==3.3.1
+  - jsaddle ==0.9.9.3
+  - jsaddle-dom ==0.9.9.2
   - json ==0.11
   - json-feed ==2.0.0.13
-  - jsonifier ==0.2.1.3
-  - jsonpath ==0.3.0.0
   - json-rpc ==1.1.1
   - json-spec ==1.1.1.2
   - json-spec-elm ==0.4.0.6
   - json-spec-elm-servant ==0.4.3.0
   - json-spec-openapi ==1.0.1.1
   - json-stream ==0.4.6.0
+  - jsonifier ==0.2.1.3
+  - jsonpath ==0.3.0.0
   - JuicyCairo ==0.1.0.0
   - JuicyPixels ==3.3.9
   - JuicyPixels-extra ==0.6.0
@@ -1496,9 +1496,9 @@ default-package-overrides:
   - keyed-vals-redis ==0.2.3.2
   - keys ==3.12.4
   - ki ==1.0.1.2
+  - ki-unlifted ==1.0.0.2
   - kind-apply ==0.4.0.0
   - kind-generics ==0.5.0.0
-  - ki-unlifted ==1.0.0.2
   - kmeans ==0.1.3
   - knob ==0.2.2
   - koji ==0.0.2
@@ -1509,10 +1509,10 @@ default-package-overrides:
   - lame ==0.2.2
   - language-avro ==0.1.4.0
   - language-c ==0.10.0
+  - language-c-quote ==0.13.0.2
   - language-c99 ==0.2.0
   - language-c99-simple ==0.3.0
   - language-c99-util ==0.2.0
-  - language-c-quote ==0.13.0.2
   - language-docker ==13.0.0
   - language-dot ==0.1.2
   - language-glsl ==0.3.0
@@ -1564,10 +1564,10 @@ default-package-overrides:
   - liboath-hs ==0.0.1.2
   - libyaml ==0.1.4
   - libyaml-clib ==0.2.5
-  - lifted-async ==0.10.2.7
-  - lifted-base ==0.2.3.12
   - lift-generics ==0.3
   - lift-type ==0.1.2.0
+  - lifted-async ==0.10.2.7
+  - lifted-base ==0.2.3.12
   - linear ==1.23.1
   - linear-base ==0.4.0
   - linear-circuit ==0.1.0.4
@@ -1578,14 +1578,14 @@ default-package-overrides:
   - linux-file-extents ==0.2.0.1
   - linux-namespaces ==0.1.3.1
   - List ==0.6.2
-  - ListLike ==4.7.8.3
   - list-predicate ==0.1.0.1
-  - listsafe ==0.1.0.1
   - list-shuffle ==1.0.0.1
   - list-t ==1.0.5.7
   - list-transformer ==1.1.1
-  - ListTree ==0.2.3
   - list-witnesses ==0.1.4.1
+  - ListLike ==4.7.8.3
+  - listsafe ==0.1.0.1
+  - ListTree ==0.2.3
   - ListZipper ==1.2.0.2
   - literatex ==0.3.0.0
   - lmdb ==0.2.5
@@ -1612,10 +1612,10 @@ default-package-overrides:
   - lsql-csv ==0.1.0.6
   - lua ==2.3.3
   - lua-arbitrary ==1.0.1.1
-  - lucid2 ==0.0.20250303
   - lucid ==2.11.20250303
   - lucid-cdn ==0.2.2.0
   - lucid-extras ==0.2.2
+  - lucid2 ==0.0.20250303
   - lukko ==0.1.2
   - lumberjack ==1.0.3.0
   - lz4 ==0.2.3.1
@@ -1625,11 +1625,11 @@ default-package-overrides:
   - magic ==1.1
   - magico ==0.0.2.3
   - mailtrap ==0.1.2.2
-  - mainland-pretty ==0.7.1.1
   - main-tester ==0.2.0.1
+  - mainland-pretty ==0.7.1.1
   - managed ==1.0.10
-  - mappings ==0.3.1.0
   - map-syntax ==0.3
+  - mappings ==0.3.1.0
   - markdown ==0.1.17.5
   - markdown-unlit ==0.6.0
   - markov-chain ==0.0.3.4
@@ -1640,9 +1640,9 @@ default-package-overrides:
   - massiv-serialise ==1.0.0.2
   - massiv-test ==1.1.0.1
   - matchable ==0.1.2.1
-  - mathexpr ==0.3.1.0
   - math-extras ==0.1.1.0
   - math-functions ==0.3.4.4
+  - mathexpr ==0.3.1.0
   - mathlist ==0.2.0.0
   - matplotlib ==0.7.7
   - matrices ==0.5.0
@@ -1655,14 +1655,14 @@ default-package-overrides:
   - mcmc ==0.8.3.1
   - mcmc-types ==1.0.3
   - mealy ==0.5.0.0
-  - median-stream ==0.7.0.0
   - med-module ==0.1.3
+  - median-stream ==0.7.0.0
   - megaparsec ==9.6.1
   - megaparsec-tests ==9.6.1
   - melf ==1.3.1
+  - mem-info ==0.3.1.0
   - membership ==0.0.1
   - memcache ==0.3.0.2
-  - mem-info ==0.3.1.0
   - memory ==0.18.0
   - MemoTrie ==0.6.11
   - mergeful ==0.3.0.0
@@ -1693,12 +1693,12 @@ default-package-overrides:
   - mime-mail ==0.5.1
   - mime-mail-ses ==0.4.3
   - mime-types ==0.1.2.0
+  - min-max-pqueue ==0.1.0.2
   - minimal-configuration ==0.1.4
   - minimorph ==0.3.0.1
   - minisat-solver ==0.1
   - miniterion ==0.1.1.1
   - miniutter ==0.5.1.2
-  - min-max-pqueue ==0.1.0.2
   - mintty ==0.1.4
   - misfortune ==0.1.2.1
   - miso ==1.8.7.0
@@ -1728,7 +1728,6 @@ default-package-overrides:
   - monad-coroutine ==0.9.2
   - monad-extras ==0.6.0
   - monad-interleave ==0.2.0.1
-  - monadlist ==0.0.2
   - monad-logger ==0.3.42
   - monad-logger-aeson ==0.4.1.3
   - monad-logger-json ==0.1.0.0
@@ -1737,29 +1736,30 @@ default-package-overrides:
   - monad-loops ==0.4.3
   - monad-memo ==0.5.4
   - monad-metrics ==0.2.2.2
-  - monadoid ==0.0.3
-  - monadology ==0.3
   - monad-par ==0.3.6
-  - monad-parallel ==0.8
   - monad-par-extras ==0.3.3
+  - monad-parallel ==0.8
   - monad-peel ==0.3
-  - MonadPrompt ==1.0.0.5
-  - MonadRandom ==0.6.2
   - monad-resumption ==0.1.4.0
   - monad-schedule ==0.2.0.2
   - monad-st ==0.2.4.1
-  - monads-tf ==0.3.0.1
   - monad-time ==0.4.0.0
+  - monadlist ==0.0.2
+  - monadoid ==0.0.3
+  - monadology ==0.3
+  - MonadPrompt ==1.0.0.5
+  - MonadRandom ==0.6.2
+  - monads-tf ==0.3.0.1
   - mongoDB ==2.7.1.4
-  - monoidal-containers ==0.6.6.0
-  - monoidal-functors ==0.2.3.0
-  - monoid-extras ==0.6.5
-  - monoidmap ==0.0.4.3
-  - monoid-subclasses ==1.2.6
-  - monoid-transformer ==0.0.4
   - mono-traversable ==1.0.21.0
   - mono-traversable-instances ==0.1.1.0
   - mono-traversable-keys ==0.3.0
+  - monoid-extras ==0.6.5
+  - monoid-subclasses ==1.2.6
+  - monoid-transformer ==0.0.4
+  - monoidal-containers ==0.6.6.0
+  - monoidal-functors ==0.2.3.0
+  - monoidmap ==0.0.4.3
   - more-containers ==0.2.2.2
   - morpheus-graphql ==0.28.1
   - morpheus-graphql-app ==0.28.1
@@ -1779,15 +1779,15 @@ default-package-overrides:
   - mtl-compat ==0.2.2
   - mtl-misc-yj ==0.1.0.4
   - mtl-prelude ==2.0.3.2
-  - multiarg ==0.30.0.10
   - multi-containers ==0.2
+  - multiarg ==0.30.0.10
   - multimap ==1.2.1
   - multipart ==0.2.1
   - MultipletCombiner ==0.0.7
   - multiset ==0.3.4.3
   - multistate ==0.8.0.4
-  - murmur3 ==1.0.5
   - murmur-hash ==0.1.0.11
+  - murmur3 ==1.0.5
   - MusicBrainz ==0.4.1
   - mustache ==2.4.2
   - mutable-containers ==0.3.4.1
@@ -1800,6 +1800,7 @@ default-package-overrides:
   - mysql-haskell-nem ==0.1.0.0
   - mysql-json-table ==0.1.4.1
   - mysql-simple ==0.4.9
+  - n-tuple ==0.0.3
   - n2o ==0.11.1
   - n2o-nitro ==0.11.2
   - nagios-check ==0.3.2
@@ -1851,23 +1852,22 @@ default-package-overrides:
   - NineP ==0.0.2.1
   - nix-derivation ==1.1.3
   - nix-paths ==1.0.1
+  - no-value ==1.0.0.0
   - NoHoed ==0.1.1
-  - nonce ==1.0.7
-  - nondeterminism ==1.5
   - non-empty ==0.3.5
-  - nonempty-containers ==0.3.4.5
   - non-empty-sequence ==0.2.0.4
   - non-empty-text ==0.2.1
+  - non-negative ==0.1.2
+  - nonce ==1.0.7
+  - nondeterminism ==1.5
+  - nonempty-containers ==0.3.4.5
   - nonempty-vector ==0.2.4
   - nonempty-zipper ==1.0.1.1
-  - non-negative ==0.1.2
   - normaldistribution ==1.1.0.3
   - nothunks ==0.3.0.0
-  - no-value ==1.0.0.0
   - nowdoc ==0.1.1.0
   - nqe ==0.6.5
   - nsis ==0.3.3
-  - n-tuple ==0.0.3
   - numbers ==3000.2.0.2
   - numeric-extras ==0.1
   - numeric-limits ==0.1.0.0
@@ -1883,9 +1883,9 @@ default-package-overrides:
   - nvim-hs-contrib ==2.0.0.2
   - nvim-hs-ghcid ==2.0.1.0
   - nvvm ==0.10.0.1
+  - o-clock ==1.4.0.1
   - ObjectName ==1.1.0.2
   - oblivious-transfer ==0.1.0
-  - o-clock ==1.4.0.1
   - odbc ==0.3.0
   - ods2csv ==0.1.0.1
   - oeis2 ==1.0.9
@@ -1903,9 +1903,10 @@ default-package-overrides:
   - oo-prototypes ==0.1.0.0
   - oops ==0.2.0.1
   - opaleye ==0.10.5.0
+  - open-browser ==0.2.1.1
+  - open-witness ==0.6
   - OpenAL ==1.7.0.5
   - openapi3 ==3.2.4
-  - open-browser ==0.2.1.1
   - openexr-write ==0.1.0.2
   - OpenGL ==3.0.3.0
   - OpenGLRaw ==3.3.4.1
@@ -1916,7 +1917,6 @@ default-package-overrides:
   - opentelemetry-extra ==0.8.0
   - opentelemetry-lightstep ==0.8.0
   - opentelemetry-wai ==0.8.0
-  - open-witness ==0.6
   - operational ==0.2.4.2
   - opml-conduit ==0.9.0.0
   - opt-env-conf ==0.8.0.0
@@ -1934,8 +1934,8 @@ default-package-overrides:
   - optparse-generic ==1.5.2
   - optparse-simple ==0.1.1.4
   - optparse-text ==0.1.1.0
-  - OrderedBits ==0.0.2.0
   - ordered-containers ==0.2.4
+  - OrderedBits ==0.0.2.0
   - ormolu ==0.7.4.0
   - os-string ==2.0.7
   - overhang ==1.0.0
@@ -1971,8 +1971,8 @@ default-package-overrides:
   - parsers ==0.12.12
   - partial-handler ==1.0.3
   - partial-isomorphisms ==0.2.4.0
-  - partialord ==0.0.2
   - partial-order ==0.2.0.0
+  - partialord ==0.0.2
   - password ==3.1.0.1
   - password-instances ==3.0.0.0
   - password-types ==1.0.0.0
@@ -1983,17 +1983,17 @@ default-package-overrides:
   - path-io ==1.8.2
   - path-like ==0.2.0.2
   - path-pieces ==0.2.1
-  - pathtype ==0.8.1.3
   - path-utils ==0.1.1.0
+  - pathtype ==0.8.1.3
   - pathwalk ==0.3.1.2
   - patience ==0.3
   - patrol ==1.0.0.9
   - pava ==0.1.1.4
   - pcg-random ==0.1.4.0
-  - pcre2 ==2.2.2
   - pcre-heavy ==1.0.0.3
   - pcre-light ==0.4.1.3
   - pcre-utils ==0.1.9
+  - pcre2 ==2.2.2
   - pdc ==0.1.1
   - pdf-toolbox-content ==0.1.2
   - pdf-toolbox-core ==0.1.3
@@ -2066,11 +2066,12 @@ default-package-overrides:
   - polysemy-plugin ==0.4.5.3
   - polysemy-webserver ==0.2.1.2
   - pooled-io ==0.0.2.3
-  - portable-lines ==0.1
   - port-utils ==0.2.1.0
+  - portable-lines ==0.1
   - posix-paths ==0.3.0.0
   - posix-pty ==0.2.2
   - possibly ==1.0.0.0
+  - post-mess-age ==0.2.1.0
   - postgres-options ==0.2.2.0
   - postgresql-binary ==0.14.0.1
   - postgresql-libpq ==0.11.0.0
@@ -2082,7 +2083,6 @@ default-package-overrides:
   - postgresql-simple-url ==0.2.1.0
   - postgresql-syntax ==0.4.1.2
   - postgresql-typed ==0.6.2.5
-  - post-mess-age ==0.2.1.0
   - pptable ==0.3.0.0
   - pqueue ==1.5.0.0
   - prairie ==0.0.4.0
@@ -2090,10 +2090,15 @@ default-package-overrides:
   - prefix-units ==0.3.0.1
   - prelude-compat ==0.0.0.2
   - prelude-safeenum ==0.1.1.3
-  - prettychart ==0.2.2.0
-  - prettyclass ==1.0.0.0
   - pretty-class ==1.0.1.1
   - pretty-hex ==1.1
+  - pretty-relative-time ==0.3.0.0
+  - pretty-show ==1.10
+  - pretty-simple ==4.1.3.0
+  - pretty-sop ==0.2.0.3
+  - pretty-terminal ==0.1.0.0
+  - prettychart ==0.2.2.0
+  - prettyclass ==1.0.0.0
   - prettyprinter ==1.7.1
   - prettyprinter-ansi-terminal ==1.1.3
   - prettyprinter-combinators ==0.1.3
@@ -2101,11 +2106,7 @@ default-package-overrides:
   - prettyprinter-compat-ansi-wl-pprint ==1.0.2
   - prettyprinter-compat-wl-pprint ==1.0.1
   - prettyprinter-interp ==0.2.0.0
-  - pretty-relative-time ==0.3.0.0
-  - pretty-show ==1.10
-  - pretty-simple ==4.1.3.0
-  - pretty-sop ==0.2.0.3
-  - pretty-terminal ==0.1.0.0
+  - prim-uniq ==0.2
   - primecount ==0.1.0.2
   - primes ==0.2.1.0
   - primitive ==0.9.1.0
@@ -2115,24 +2116,19 @@ default-package-overrides:
   - primitive-serial ==0.1
   - primitive-unaligned ==0.1.1.2
   - primitive-unlifted ==2.1.0.0
-  - prim-uniq ==0.2
   - print-console-colors ==0.1.0.0
   - probability ==0.2.8
   - process-extras ==0.7.4
   - product-isomorphic ==0.0.3.4
   - product-profunctors ==0.11.1.1
   - profunctors ==5.6.2
-  - projectroot ==0.2.0.1
   - project-template ==0.2.1.0
+  - projectroot ==0.2.0.1
   - prometheus ==2.3.0
   - prometheus-client ==1.1.1
   - prometheus-metrics-ghc ==1.0.1.2
   - promises ==0.3
   - prospect ==0.1.0.0
-  - protobuf ==0.2.1.3
-  - protobuf-simple ==0.1.1.1
-  - protocol-radius ==0.0.1.2
-  - protocol-radius-test ==0.1.0.1
   - proto-lens ==0.7.1.5
   - proto-lens-arbitrary ==0.1.2.14
   - proto-lens-optparse ==0.1.1.13
@@ -2140,6 +2136,10 @@ default-package-overrides:
   - proto-lens-protoc ==0.8.0.1
   - proto-lens-runtime ==0.7.0.7
   - proto-lens-setup ==0.4.0.9
+  - protobuf ==0.2.1.3
+  - protobuf-simple ==0.1.1.1
+  - protocol-radius ==0.0.1.2
+  - protocol-radius-test ==0.1.0.1
   - protolude ==0.3.4
   - proxied ==0.3.2
   - psql-helpers ==0.1.0.0
@@ -2194,24 +2194,24 @@ default-package-overrides:
   - random-shuffle ==0.0.4
   - random-tree ==0.6.0.5
   - range ==0.3.0.2
+  - range-set-list ==0.1.4
   - ranged-list ==0.1.2.1
   - Ranged-sets ==0.4.0
   - ranges ==0.2.4
-  - range-set-list ==0.1.4
   - rank1dynamic ==0.4.3
   - rank2classes ==1.5.4
   - Rasterific ==0.7.5.4
   - rasterific-svg ==0.3.3.2
-  - ratel ==2.0.0.13
   - rate-limit ==1.4.3
+  - ratel ==2.0.0.13
   - ratel-wai ==2.0.0.8
   - ratio-int ==0.1.2
   - rattle ==0.2
   - rattletrap ==14.1.1
   - Rattus ==0.5.1.1
+  - raw-strings-qq ==1.1
   - rawfilepath ==1.1.1
   - rawstring-qm ==0.2.3.0
-  - raw-strings-qq ==1.1
   - rcu ==0.2.7
   - rdf ==0.1.0.8
   - rdtsc ==1.3.0.1
@@ -2220,9 +2220,9 @@ default-package-overrides:
   - reactive-banana-bunch ==1.0.0.1
   - reactive-jack ==0.4.1.2
   - reactive-midyim ==0.4.1.1
-  - readable ==0.3.1
   - read-editor ==0.1.0.2
   - read-env-var ==1.0.0.0
+  - readable ==0.3.1
   - real-dice ==0.1.0.5
   - rebase ==1.21.2
   - rec-def ==0.2.2
@@ -2235,12 +2235,12 @@ default-package-overrides:
   - redis-glob ==0.1.0.11
   - redis-resp ==1.0.0
   - reducers ==3.12.5
-  - refact ==0.3.0.2
   - ref-fd ==0.5.0.1
+  - ref-tf ==0.5.0.1
+  - refact ==0.3.0.2
   - refined ==0.8.2
   - reflection ==2.1.9
   - RefSerialize ==0.4.0
-  - ref-tf ==0.5.0.1
   - regex ==1.1.0.2
   - regex-applicative ==0.3.4
   - regex-base ==0.94.0.3
@@ -2307,18 +2307,19 @@ default-package-overrides:
   - rot13 ==0.2.0.1
   - RoundingFiasco ==0.1.0.0
   - row-types ==1.0.1.2
-  - rpmbuild-order ==0.4.12
-  - rpm-nvr ==0.1.2
   - rp-tree ==0.7.1
+  - rpm-nvr ==0.1.2
+  - rpmbuild-order ==0.4.12
   - rrb-vector ==0.2.2.1
   - RSA ==2.4.1
   - rss ==3000.2.0.8
   - rss-conduit ==0.6.0.1
   - run-haskell-module ==0.0.2
-  - runmemo ==1.0.0.1
   - run-st ==0.1.3.3
+  - runmemo ==1.0.0.1
   - rvar ==0.3.0.2
   - rzk ==0.7.5
+  - s-cargot ==0.1.6.0
   - s3-signer ==0.5.0.0
   - safe ==0.3.21
   - safe-coloured-text ==0.3.0.2
@@ -2326,14 +2327,14 @@ default-package-overrides:
   - safe-coloured-text-layout ==0.2.0.1
   - safe-coloured-text-layout-gen ==0.0.0.1
   - safe-coloured-text-terminfo ==0.3.0.0
-  - safecopy ==0.10.4.2
   - safe-decimal ==0.2.1.0
   - safe-exceptions ==0.1.7.4
   - safe-foldable ==0.1.0.0
   - safe-gen ==1.0.1
-  - safeio ==0.0.6.0
   - safe-json ==1.2.1.0
   - safe-money ==0.9.1
+  - safecopy ==0.10.4.2
+  - safeio ==0.0.6.0
   - SafeSemaphore ==0.10.1
   - salve ==2.0.0.6
   - sample-frame ==0.0.4
@@ -2356,7 +2357,6 @@ default-package-overrides:
   - scalpel-core ==0.6.2.2
   - scanf ==0.1.0.0
   - scanner ==0.3.1
-  - s-cargot ==0.1.6.0
   - scheduler ==2.0.1.0
   - SciBaseTypes ==0.1.1.0
   - scientific ==0.3.8.0
@@ -2366,14 +2366,14 @@ default-package-overrides:
   - search-algorithms ==0.3.3
   - secp256k1-haskell ==1.4.2
   - securemem ==0.1.10
+  - select-rpms ==0.2.0
   - selections ==0.3.0.0
   - selective ==0.7.0.1
-  - select-rpms ==0.2.0
   - semialign ==1.3.1
   - semigroupoids ==6.0.1
   - semigroups ==0.20
-  - semirings ==0.7
   - semiring-simple ==1.0.0.1
+  - semirings ==0.7
   - semver ==0.4.0.1
   - sendfile ==0.7.11.6
   - sendgrid-v3 ==1.0.0.1
@@ -2429,9 +2429,9 @@ default-package-overrides:
   - servius ==1.2.3.0
   - ses-html ==0.4.0.0
   - set-cover ==0.1.1.1
+  - set-monad ==0.3.0.0
   - setenv ==0.1.1.3
   - setlocale ==1.0.0.10
-  - set-monad ==0.3.0.0
   - sexp-grammar ==2.3.4.2
   - SHA ==1.6.4.4
   - shake ==0.19.8
@@ -2441,10 +2441,10 @@ default-package-overrides:
   - shared-memory ==0.2.0.1
   - shell-conduit ==5.0.0
   - shell-escape ==0.2.0
+  - shell-utility ==0.1
   - shellify ==0.11.0.4
   - shellmet ==0.0.5.0
   - shelltestrunner ==1.10
-  - shell-utility ==0.1
   - shellwords ==0.1.4.3
   - shelly ==1.12.1
   - should-not-typecheck ==2.1.0
@@ -2517,15 +2517,15 @@ default-package-overrides:
   - Spintax ==0.3.7.0
   - splice ==0.6.1.1
   - split ==0.2.5
+  - split-record ==0.1.1.4
   - splitmix ==0.1.1
   - splitmix-distributions ==1.0.0
-  - split-record ==0.1.1.4
   - Spock-api ==0.14.0.0
   - spoon ==0.3.1
   - spreadsheet ==0.1.3.10
   - sqids ==0.2.2.0
-  - sqlite-simple ==0.4.19.0
   - sql-words ==0.1.6.5
+  - sqlite-simple ==0.4.19.0
   - squeather ==0.8.0.0
   - srcloc ==0.6.0.1
   - srtree ==2.0.0.2
@@ -2552,9 +2552,9 @@ default-package-overrides:
   - stm-delay ==0.1.1.1
   - stm-extras ==0.1.0.3
   - stm-hamt ==1.2.1.1
-  - STMonadTrans ==0.4.8
   - stm-split ==0.0.2.1
   - stm-supply ==0.2.0.0
+  - STMonadTrans ==0.4.8
   - storable-complex ==0.2.3.0
   - storable-endian ==0.2.6.1
   - storable-hetero-list ==0.1.0.4
@@ -2581,18 +2581,18 @@ default-package-overrides:
   - strict-mutable-base ==1.1.0.0
   - strict-tuple ==0.1.5.4
   - strict-wrapper ==0.0.1.0
-  - stringable ==0.1.3
-  - stringbuilder ==0.5.1
   - string-class ==0.1.7.2
   - string-combinators ==0.6.0.5
   - string-conv ==0.2.0
   - string-conversions ==0.4.0.1
   - string-interpolate ==0.3.4.0
-  - stringprep ==1.0.0
   - string-qq ==0.0.6
-  - stringsearch ==0.3.6.6
   - string-transform ==1.1.1
   - string-variants ==0.3.1.1
+  - stringable ==0.1.3
+  - stringbuilder ==0.5.1
+  - stringprep ==1.0.0
+  - stringsearch ==0.3.6.6
   - strive ==6.0.0.12
   - strongweak ==0.11.0
   - structs ==0.1.9
@@ -2601,8 +2601,8 @@ default-package-overrides:
   - subcategories ==0.2.1.1
   - sundown ==0.6
   - svg-builder ==0.1.1
-  - SVGFonts ==1.8.0.1
   - svg-tree ==0.6.2.4
+  - SVGFonts ==1.8.0.1
   - swagger2 ==2.8.9
   - swish ==0.10.10.0
   - syb ==0.7.2.4
@@ -2636,11 +2636,11 @@ default-package-overrides:
   - synthesizer-midi ==0.6.1.2
   - sysinfo ==0.1.1
   - system-argv0 ==0.1.1
-  - systemd ==2.4.0
   - system-fileio ==0.3.16.6
   - system-filepath ==0.4.14.1
   - system-info ==0.5.2
   - system-linux-proc ==0.1.1.1
+  - systemd ==2.4.0
   - tabular ==0.2.2.8
   - tagchup ==0.4.1.2
   - tagged ==0.8.8
@@ -2728,7 +2728,6 @@ default-package-overrides:
   - text-iso8601 ==0.1.1
   - text-latin1 ==0.3.1
   - text-ldap ==0.1.1.14
-  - textlocal ==0.1.0.5
   - text-manipulate ==0.3.1.0
   - text-metrics ==0.3.3
   - text-misc-yj ==0.1.0.2
@@ -2740,8 +2739,9 @@ default-package-overrides:
   - text-show ==3.11.1
   - text-show-instances ==3.9.10
   - text-zipper ==0.13
-  - tfp ==1.0.2
+  - textlocal ==0.1.0.5
   - tf-random ==0.5
+  - tfp ==1.0.2
   - th-abstraction ==0.7.1.0
   - th-bang-compat ==0.0.1.0
   - th-compat ==0.1.6
@@ -2750,10 +2750,6 @@ default-package-overrides:
   - th-deepstrict ==0.1.1.0
   - th-desugar ==1.16
   - th-env ==0.1.1
-  - these ==1.2.1
-  - these-lens ==1.0.2
-  - these-optics ==1.0.2
-  - these-skinny ==0.7.6
   - th-expand-syns ==0.4.12.0
   - th-extras ==0.0.0.8
   - th-lego ==0.3.0.3
@@ -2762,34 +2758,38 @@ default-package-overrides:
   - th-nowq ==0.1.0.5
   - th-orphans ==0.13.16
   - th-printf ==0.8
-  - thread-hierarchy ==0.3.0.2
-  - thread-local-storage ==0.2
-  - threads ==0.5.1.8
-  - threads-extras ==0.1.0.3
-  - thread-supervisor ==0.2.0.0
-  - threepenny-gui ==0.9.4.2
   - th-reify-compat ==0.0.1.5
   - th-reify-many ==0.1.10
   - th-strict-compat ==0.1.0.1
   - th-test-utils ==1.2.2
   - th-utilities ==0.2.5.2
+  - these ==1.2.1
+  - these-lens ==1.0.2
+  - these-optics ==1.0.2
+  - these-skinny ==0.7.6
+  - thread-hierarchy ==0.3.0.2
+  - thread-local-storage ==0.2
+  - thread-supervisor ==0.2.0.0
+  - threads ==0.5.1.8
+  - threads-extras ==0.1.0.3
+  - threepenny-gui ==0.9.4.2
   - tidal ==1.9.5
   - tidal-link ==1.0.3
   - tile ==0.3.0.0
   - time-compat ==1.9.7
   - time-domain ==0.1.0.5
-  - timeit ==2.0
-  - timelens ==0.2.0.2
   - time-lens ==0.4.0.2
   - time-locale-compat ==0.1.1.5
   - time-locale-vietnamese ==1.0.0.0
   - time-manager ==0.2.2
-  - timerep ==2.1.0.0
-  - timers-tick ==0.5.0.4
-  - timer-wheel ==1.0.0.1
-  - timespan ==0.4.0.0
   - time-units ==1.0.0
   - time-units-types ==0.2.0.1
+  - timeit ==2.0
+  - timelens ==0.2.0.2
+  - timer-wheel ==1.0.0.1
+  - timerep ==2.1.0.0
+  - timers-tick ==0.5.0.4
+  - timespan ==0.4.0.0
   - timezone-olson ==0.2.1
   - timezone-olson-th ==0.1.0.11
   - timezone-series ==0.1.13
@@ -2805,10 +2805,10 @@ default-package-overrides:
   - tmp-proc-redis ==0.7.2.4
   - token-bucket ==0.1.0.1
   - tokenize ==0.3.0.1
-  - tomland ==1.3.3.3
   - toml-parser ==2.0.1.2
   - toml-reader ==0.2.2.0
   - toml-reader-parse ==0.1.1.1
+  - tomland ==1.3.3.3
   - tools-yj ==0.1.0.23
   - tophat ==1.0.8.0
   - topograph ==1.0.1
@@ -2832,16 +2832,13 @@ default-package-overrides:
   - ttc ==1.4.0.0
   - ttrie ==0.1.2.2
   - tuple ==0.3.0.2
-  - tuples ==0.1.0.0
-  - tuples-homogenous-h98 ==0.1.1.0
   - tuple-sop ==0.3.1.0
   - tuple-th ==0.2.5
+  - tuples ==0.1.0.0
+  - tuples-homogenous-h98 ==0.1.1.0
   - turtle ==1.6.2
   - twitter-types ==0.11.0
   - twitter-types-lens ==0.11.0
-  - typecheck-plugin-nat-simple ==0.1.0.9
-  - typed-process ==0.2.13.0
-  - typed-uuid ==0.2.0.0
   - type-equality ==1.0.1
   - type-errors ==0.2.0.2
   - type-flip ==0.1.0.0
@@ -2853,16 +2850,19 @@ default-package-overrides:
   - type-level-natural-number ==2.0
   - type-level-numbers ==0.1.1.2
   - type-level-show ==0.3.0
-  - typelevel-tools-yj ==0.1.0.8
-  - typelits-witnesses ==0.4.1.0
   - type-map ==0.1.7.0
   - type-natural ==1.3.0.2
-  - typenums ==0.1.4
   - type-of-html ==1.6.2.0
   - type-of-html-static ==0.1.0.2
   - type-rig ==0.1
   - type-set ==0.1.0.0
   - type-spec ==0.4.0.0
+  - typecheck-plugin-nat-simple ==0.1.0.9
+  - typed-process ==0.2.13.0
+  - typed-uuid ==0.2.0.0
+  - typelevel-tools-yj ==0.1.0.8
+  - typelits-witnesses ==0.4.1.0
+  - typenums ==0.1.4
   - typography-geometry ==1.0.1.0
   - typst ==0.6.1
   - typst-symbols ==0.1.7
@@ -2873,8 +2873,8 @@ default-package-overrides:
   - uglymemo ==0.1.0.1
   - ulid ==0.3.3.0
   - unagi-chan ==0.4.1.4
-  - unbounded-delays ==0.1.1.1
   - unbound-generics ==0.4.4
+  - unbounded-delays ==0.1.1.1
   - unboxed-ref ==0.4.0.0
   - unboxing-vector ==0.2.0.0
   - uncaught-exception ==0.1.0
@@ -3026,6 +3026,10 @@ default-package-overrides:
   - warp-tls ==3.4.9
   - wave ==0.2.1
   - wcwidth ==0.0.2
+  - web-rep ==0.12.3.0
+  - web-routes ==0.27.16
+  - web-routes-boomerang ==0.28.4.5
+  - web-routes-th ==0.22.8.2
   - webdriver ==0.12.0.1
   - webdriver-wrapper ==0.2.0.1
   - webex-teams-api ==0.2.0.1
@@ -3036,10 +3040,6 @@ default-package-overrides:
   - webgear-swagger ==1.3.1
   - webgear-swagger-ui ==1.3.1
   - webpage ==0.0.5.1
-  - web-rep ==0.12.3.0
-  - web-routes ==0.27.16
-  - web-routes-boomerang ==0.28.4.5
-  - web-routes-th ==0.22.8.2
   - webrtc-vad ==0.1.0.3
   - websockets ==0.13.0.0
   - websockets-simple ==0.2.0
@@ -3054,22 +3054,22 @@ default-package-overrides:
   - Win32-notify ==0.3.0.3
   - windns ==0.1.0.1
   - witch ==1.2.4.0
+  - with-location ==0.1.0
+  - with-utf8 ==1.1.0.0
   - withdependencies ==0.3.1
   - witherable ==0.5
   - within ==0.2.0.1
-  - with-location ==0.1.0
-  - with-utf8 ==1.1.0.0
   - witness ==0.6.2
   - wizards ==1.0.3
   - wkt-types ==0.1.0.0
-  - wled-json ==0.0.1.1
   - wl-pprint ==1.2.1
   - wl-pprint-annotated ==0.1.0.1
   - wl-pprint-text ==1.2.0.2
-  - word8 ==0.1.3
+  - wled-json ==0.0.1.1
   - word-compat ==0.0.6
   - word-trie ==0.3.0
   - word-wrap ==0.5
+  - word8 ==0.1.3
   - world-peace ==1.0.2.0
   - wrap ==0.0.0
   - wraxml ==0.5
@@ -3089,20 +3089,20 @@ default-package-overrides:
   - xlsx ==1.1.4
   - xml ==1.3.14
   - xml-basic ==0.1.3.3
-  - xmlbf ==0.7
-  - xmlbf-xeno ==0.2.2
-  - xmlbf-xmlhtml ==0.2.2
   - xml-conduit ==1.9.1.4
   - xml-conduit-writer ==0.1.1.5
-  - xmlgen ==0.6.2.2
   - xml-hamlet ==0.5.0.2
   - xml-helpers ==1.0.0
-  - xmlhtml ==0.2.5.4
   - xml-html-qq ==0.1.0.1
   - xml-indexed-cursor ==0.1.1.0
   - xml-picklers ==0.3.6
   - xml-to-json-fast ==2.0.0
   - xml-types ==0.3.8
+  - xmlbf ==0.7
+  - xmlbf-xeno ==0.2.2
+  - xmlbf-xmlhtml ==0.2.2
+  - xmlgen ==0.6.2.2
+  - xmlhtml ==0.2.5.4
   - xmonad ==0.18.0
   - xmonad-contrib ==0.18.1
   - xor ==0.0.1.3
@@ -3112,6 +3112,7 @@ default-package-overrides:
   - yaml-unscrambler ==0.1.0.19
   - Yampa ==0.14.12
   - yarn-lock ==0.6.5
+  - yes-precure5-command ==5.5.3
   - yeshql-core ==4.2.0.0
   - yesod ==1.6.2.1
   - yesod-auth ==1.6.11.3
@@ -3137,7 +3138,6 @@ default-package-overrides:
   - yesod-static ==1.6.1.0
   - yesod-test ==1.6.16
   - yesod-websockets ==0.3.0.3
-  - yes-precure5-command ==5.5.3
   - yggdrasil-schema ==1.0.0.6
   - yi ==0.19.3
   - yi-core ==0.19.4
@@ -3162,8 +3162,8 @@ default-package-overrides:
   - zim-parser ==0.2.1.0
   - zip ==2.1.0
   - zip-archive ==0.4.3.2
-  - zippers ==0.3.2
   - zip-stream ==0.2.2.0
+  - zippers ==0.3.2
   - zlib ==0.7.1.0
   - zlib-bindings ==0.1.1.5
   - zlib-clib ==1.3.1

--- a/pkgs/development/haskell-modules/configuration-hackage2nix/transitive-broken.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/transitive-broken.yaml
@@ -5,416 +5,10 @@
 dont-distribute-packages:
 
  - 4Blocks
- - ADPfusion
- - ADPfusionForest
- - ADPfusionSet
- - AERN-Net
- - AERN-Real
- - AERN-Real-Double
- - AERN-Real-Interval
- - AERN-RnToRm
- - AERN-RnToRm-Plot
- - ASN1
- - AbortT-monadstf
- - AbortT-mtl
- - Advgame
- - Advise-me
- - AlgoRhythm
- - AlignmentAlgorithms
- - AndroidViewHierarchyImporter
- - Annotations
- - ApplePush
- - AttoJson
- - AutoForms
- - AvlTree
- - BASIC
- - BPS
- - Barracuda
- - BerlekampAlgorithm
- - BesselJ
- - BioHMM
- - Biobase
- - BiobaseBlast
- - BiobaseDotP
- - BiobaseENA
- - BiobaseEnsembl
- - BiobaseFR3D
- - BiobaseFasta
- - BiobaseHTTP
- - BiobaseHTTPTools
- - BiobaseInfernal
- - BiobaseMAF
- - BiobaseTrainingData
- - BiobaseTurner
- - BiobaseTypes
- - BiobaseVienna
- - BiobaseXNA
- - BirdPP
- - Bitly
- - BlastHTTP
- - Blobs
- - BlogLiterately-diagrams
- - Bookshelf
- - CBOR
- - CC-delcont-alt
- - CMCompare
- - CPBrainfuck
- - CSPM-FiringRules
- - CSPM-Interpreter
- - CSPM-ToProlog
- - CSPM-cspm
- - CarneadesIntoDung
- - Chart-fltkhs
- - ClustalParser
- - Coadjute
- - Combinatorrent
- - ComonadSheet
- - Condor
- - Configger
- - Control-Monad-MultiPass
- - CoreFoundation
- - DMuCheck
- - DOM
- - DP
- - DRBG
- - DSA
- - DSH
- - DSTM
- - Dangerous
- - DarcsHelpers
- - DeepArrow
- - DefendTheKing
- - DifferenceLogic
- - DisTract
- - DnaProteinAlignment
- - DocTest
- - DrHylo
- - Dust
- - Dust-crypto
- - Dust-tools
- - Dust-tools-pcap
- - DysFRP-Cairo
- - DysFRP-Craftwerk
- - EditTimeReport
- - EntrezHTTP
- - EsounD
- - EtaMOO
- - Etage-Graph
- - Eternal10Seconds
- - Etherbunny
- - EventSocket
- - FComp
- - FM-SBLEX
- - FTPLine
- - FailureT
- - FermatsLastMargin
- - FieldTrip
- - Fin
- - Finance-Treasury
- - FiniteMap
- - FirstOrderTheory
- - Flint2-Examples
- - Flippi
- - ForSyDe
- - Forestry
- - FormalGrammars
- - Foster
- - Frames-dsv
- - Frames-map-reduce
- - Frank
- - GLFW-OGL
- - GLFW-task
- - GPX
- - GPipe-Collada
- - GPipe-Examples
- - GPipe-GLFW
- - GPipe-GLFW4
- - GPipe-TextureLoad
- - GeBoP
- - GenI
- - Genbank
- - Gene-CluEDO
- - GenussFold
- - GlomeView
- - GoogleDirections
- - GoogleSB
- - GoogleTranslate
- - GrammarProducts
- - GraphHammer
- - GraphHammer-examples
- - Grow
- - GrowlNotify
- - Gtk2hsGenerics
- - GtkGLTV
- - GtkTV
- - GuiHaskell
- - GuiTV
- - H
- - HAppS-Data
- - HAppS-IxSet
- - HAppS-Server
- - HAppS-State
- - HGamer3D-API
- - HGamer3D-Audio
- - HGamer3D-Bullet-Binding
- - HGamer3D-CAudio-Binding
- - HGamer3D-CEGUI-Binding
- - HGamer3D-Common
- - HGamer3D-Enet-Binding
- - HGamer3D-GUI
- - HGamer3D-Graphics3D
- - HGamer3D-InputSystem
- - HGamer3D-Network
- - HGamer3D-OIS-Binding
- - HGamer3D-Ogre-Binding
- - HGamer3D-SDL2-Binding
- - HGamer3D-SFML-Binding
- - HGamer3D-WinEvent
- - HGamer3D-Wire
- - HJScript
- - HLearn-algebra
- - HLearn-approximation
- - HLearn-classification
- - HLearn-datastructures
- - HLearn-distributions
- - HNM
- - HPhone
- - HPlot
- - HPong
- - HQu
- - HROOT
- - HROOT-graf
- - HROOT-hist
- - HROOT-io
- - HROOT-math
- - HROOT-net
- - HROOT-tree
- - HRay
- - HSGEP
- - HSHHelpers
- - HSoundFile
- - HStringTemplateHelpers
- - HTab
- - HXMPP
- - HaRe
- - HaTeX-meta
- - HaTeX-qq
- - HaVSA
- - Hach
- - HarmTrace
- - HasGP
- - Hashell
- - HaskellNet-SSL
- - Hate
- - Hawk
- - Hayoo
- - Hedi
- - Hieroglyph
- - HiggsSet
- - Hipmunk-Utils
- - HipmunkPlayground
- - Hoed
- - Holumbus-Distribution
- - Holumbus-MapReduce
- - Holumbus-Storage
- - HongoDB
- - Hs2lib
- - HsParrot
- - HsWebots
- - Hsed
- - Hungarian-Munkres
- - Hydrogen
- - INblobs
- - IORefCAS
- - IndexedList
- - InfixApplicative
- - JSON-Combinator
- - JSON-Combinator-Examples
- - Javasf
- - JsContracts
- - JsonGrammar
- - JuPyTer-notebook
- - JunkDB-driver-gdbm
- - JunkDB-driver-hashtables
- - KiCS
- - KiCS-debugger
- - KiCS-prophecy
- - LDAPv3
- - LPPaver
- - LambdaINet
- - LambdaPrettyQuote
- - LambdaShell
- - Lattices
- - LinearSplit
- - LinkChecker
- - ListT
- - LogicGrowsOnTrees
- - LogicGrowsOnTrees-MPI
- - LogicGrowsOnTrees-network
- - LogicGrowsOnTrees-processes
- - LslPlus
- - Lucu
- - Lykah
- - MC-Fold-DP
- - MFlow
- - MIP-glpk
- - MSQueue
- - MailchimpSimple
- - Map
- - MetaObject
- - Metrics
- - Mhailist
- - Michelangelo
- - MicrosoftTranslator
- - MissingPy
- - MonadCatchIO-mtl-foreign
- - MonadLab
- - Monaris
- - Monatron-IO
- - Mondrian
- - Monocle
- - MuCheck-HUnit
- - MuCheck-Hspec
- - MuCheck-QuickCheck
- - MuCheck-SmallCheck
- - Munkres-simple
- - MutationOrder
- - NGLess
- - NTRU
- - NaCl
- - NaperianNetCDF
- - NearContextAlgebra
- - Network-NineP
- - Ninjas
- - NoSlow
- - Nomyx
- - Nomyx-Core
- - Nomyx-Language
- - Nomyx-Rules
- - Nomyx-Web
- - NonEmptyList
- - Nussinov78
- - OnRmt
- - OpenAFP-Utils
- - OpenGLCheck
- - OpenSCAD
- - OpenVG
- - PCLT-DB
- - PageIO
- - Paillier
- - Paraiso
- - Parallel-Arrows-BaseSpec
- - Parallel-Arrows-Eden
- - Parallel-Arrows-Multicore
- - Parallel-Arrows-ParMonad
- - PermuteEffects
- - Plot-ho-matic
- - PlslTools
- - Printf-TH
- - ProbabilityMonads
- - Pugs
- - Pup-Events
- - Pup-Events-Demo
- - Quelea
- - RESTng
- - RJson
- - RMP
- - RNAFold
- - RNAFoldProgs
- - RNAdesign
- - RNAdraw
- - RNAlien
- - RNAwolf
- - Raincat
- - Ranka
- - RollingDirectory
- - S3
- - SBench
- - SCRIPTWriter
- - SCalendar
- - SFML-control
- - SFont
- - SGdemo
- - STLinkUSB
- - STM32-Zombie
- - SVG2Q
- - SciFlow-drmaa
- - Scurry
- - SelectSequencesFromMSA
- - Set
- - Shellac-compatline
- - Shellac-editline
- - Shellac-haskeline
- - Shellac-readline
- - ShortestPathProblems
- - Shpadoinkle-backend-pardiff
- - Shpadoinkle-backend-snabbdom
- - Shpadoinkle-backend-static
- - Shpadoinkle-developer-tools
- - Shpadoinkle-disembodied
- - Shpadoinkle-examples
- - Shpadoinkle-html
- - Shpadoinkle-lens
- - Shpadoinkle-router
- - Shpadoinkle-streaming
- - Shpadoinkle-template
- - Shpadoinkle-widgets
- - SimpleGL
- - SimpleLog
- - SimpleServer
- - Smooth
- - Snusmumrik
- - SoccerFun
- - SoccerFunGL
- - SourceGraph
- - SpacePrivateers
- - SpinCounter
- - StockholmAlignment
- - Strafunski-Sdf2Haskell
- - SybWidget
- - Synapse
- - SyntaxMacros
- - TV
- - TastyTLT
- - Taxonomy
- - TaxonomyTools
- - TeaHS
- - TreeCounter
- - Treiber
- - TrieMap
- - TypeClass
- - TypeIlluminator
- - UMM
- - URLT
- - UTFTConverter
- - UrlDisp
- - ViennaRNA-extras
- - WEditorBrick
- - WEditorHyphen
- - WL500gPControl
- - WURFL
- - WXDiffCtrl
- - WashNGo
- - WaveFront
- - WebBits-Html
- - WebBits-multiplate
- - WebCont
- - Wired
- - WordAlignment
- - WringTwistree
- - WxGeneric
- - XML
- - XMPP
- - XSaiga
- - Yablog
- - Yogurt-Standalone
- - Z-Botan
- - Z-IO
- - Z-MessagePack
- - Z-YAML
- - ZipFold
  - a50
  - abcBridge
+ - AbortT-monadstf
+ - AbortT-mtl
  - ac-machine-conduit
  - accelerate-arithmetic
  - accelerate-fourier
@@ -429,6 +23,17 @@ dont-distribute-packages:
  - adhoc-network
  - adict
  - adp-multi-monadiccp
+ - ADPfusion
+ - ADPfusionForest
+ - ADPfusionSet
+ - Advgame
+ - Advise-me
+ - AERN-Net
+ - AERN-Real
+ - AERN-Real-Double
+ - AERN-Real-Interval
+ - AERN-RnToRm
+ - AERN-RnToRm-Plot
  - aeson-native
  - aeson_1_5_6_0
  - affine
@@ -444,11 +49,13 @@ dont-distribute-packages:
  - algebra-driven-design
  - algebra-sql
  - algolia
+ - AlgoRhythm
  - algorithmic-composition-additional
  - algorithmic-composition-basic
  - algorithmic-composition-complex
  - algorithmic-composition-frequency-shift
  - algorithmic-composition-overtones
+ - AlignmentAlgorithms
  - alloy-proxy-fd
  - alms
  - alpha
@@ -462,11 +69,13 @@ dont-distribute-packages:
  - analyze-client
  - anansi-hscolour
  - anatomy
+ - AndroidViewHierarchyImporter
  - animate-example
  - animate-frames
  - animate-preview
  - animate-sdl2
  - annah
+ - Annotations
  - anonymous-sums-tests
  - antagonist
  - anticiv
@@ -497,6 +106,7 @@ dont-distribute-packages:
  - apiary-websockets
  - apis
  - apotiki
+ - ApplePush
  - approx-rand-test
  - arbor-monad-metric-datadog
  - archive-tar-bytestring
@@ -513,6 +123,7 @@ dont-distribute-packages:
  - ascii-cows
  - ascii-table
  - asic
+ - ASN1
  - assert4hs
  - assert4hs-core
  - assert4hs-hspec
@@ -528,6 +139,7 @@ dont-distribute-packages:
  - atomic-primops-foreign
  - atp
  - attenuation-profunctors
+ - AttoJson
  - attoparsec-enumerator
  - attoparsec-iteratee
  - attoparsec-text-enumerator
@@ -535,6 +147,7 @@ dont-distribute-packages:
  - audiovisual
  - aura
  - authoring
+ - AutoForms
  - autonix-deps-kf5
  - avers
  - avers-api
@@ -544,6 +157,7 @@ dont-distribute-packages:
  - aviation-cessna172-weight-balance
  - aviation-navigation
  - aviation-weight-balance
+ - AvlTree
  - awesomium
  - awesomium-glut
  - aws-configuration-tools
@@ -582,9 +196,11 @@ dont-distribute-packages:
  - bamse
  - bamstats
  - barley
+ - Barracuda
  - base32-bytestring
- - base_4_21_0_0
  - baserock-schema
+ - base_4_21_0_0
+ - BASIC
  - basic
  - batchd
  - batchd-core
@@ -604,6 +220,8 @@ dont-distribute-packages:
  - bech32-th
  - bein
  - belka
+ - BerlekampAlgorithm
+ - BesselJ
  - bff
  - bifunctor
  - billboard-parser
@@ -621,8 +239,25 @@ dont-distribute-packages:
  - binembed-example
  - bioace
  - bioalign
+ - Biobase
+ - BiobaseBlast
+ - BiobaseDotP
+ - BiobaseENA
+ - BiobaseEnsembl
+ - BiobaseFasta
+ - BiobaseFR3D
+ - BiobaseHTTP
+ - BiobaseHTTPTools
+ - BiobaseInfernal
+ - BiobaseMAF
+ - BiobaseTrainingData
+ - BiobaseTurner
+ - BiobaseTypes
+ - BiobaseVienna
+ - BiobaseXNA
  - biofasta
  - biofastq
+ - BioHMM
  - bioinformatics-toolkit
  - biophd
  - biopsl
@@ -631,6 +266,7 @@ dont-distribute-packages:
  - bip32
  - birch-beer
  - bird
+ - BirdPP
  - bisc
  - biscuit-servant
  - bishbosh
@@ -642,11 +278,13 @@ dont-distribute-packages:
  - bitcoin-tx
  - bitcoin-types
  - bitcoind-regtest
+ - Bitly
  - bitly-cli
  - bitmaps
  - bittorrent
  - bla
  - blakesum-demo
+ - BlastHTTP
  - blastxml
  - blatex
  - blaze-builder-enumerator
@@ -654,7 +292,9 @@ dont-distribute-packages:
  - ble
  - blink1
  - blip
+ - Blobs
  - blogination
+ - BlogLiterately-diagrams
  - bloxorz
  - blubber
  - bluetile
@@ -667,6 +307,7 @@ dont-distribute-packages:
  - bookkeeper
  - bookkeeper-permissions
  - bookkeeping-jp
+ - Bookshelf
  - boomslang
  - boots-app
  - boots-cloud
@@ -675,6 +316,7 @@ dont-distribute-packages:
  - botan-low
  - both
  - bound-gen
+ - BPS
  - breakout
  - bricks
  - bricks-internal-test
@@ -727,6 +369,7 @@ dont-distribute-packages:
  - car-pool
  - carboncopy
  - cardano-addresses
+ - CarneadesIntoDung
  - cartel
  - cas-hashable-s3
  - cas-store
@@ -749,6 +392,8 @@ dont-distribute-packages:
  - category
  - category-extras
  - cattrap
+ - CBOR
+ - CC-delcont-alt
  - cctools-workqueue
  - cef3-simple
  - ceilometer-common
@@ -768,6 +413,7 @@ dont-distribute-packages:
  - chapelure
  - charade
  - chart-cli
+ - Chart-fltkhs
  - chart-svg-various
  - chart-unit
  - chassis
@@ -828,14 +474,17 @@ dont-distribute-packages:
  - clr-bindings
  - clr-inline
  - clua
+ - ClustalParser
  - clustering
  - clustertools
  - clutterhs
  - cmathml3
+ - CMCompare
  - cmptype
  - cmv
  - cnc-spec-compiler
  - co-feldspar
+ - Coadjute
  - cobot-io
  - codec
  - codec-libevent
@@ -857,10 +506,12 @@ dont-distribute-packages:
  - columnar
  - comark
  - combinat-diagrams
+ - Combinatorrent
  - comic
  - commsec
  - commsec-keyexchange
  - comonad-random
+ - ComonadSheet
  - compact-mutable
  - compdoc
  - compdoc-dhall-decoder
@@ -884,6 +535,7 @@ dont-distribute-packages:
  - concrete-haskell
  - concrete-haskell-autogen
  - concurrency-benchmarks
+ - Condor
  - condor
  - conductive-hsc3
  - conductive-song
@@ -897,6 +549,7 @@ dont-distribute-packages:
  - conffmt
  - confide
  - config-select
+ - Configger
  - configifier
  - configurator-ng
  - conic-graphs
@@ -919,6 +572,7 @@ dont-distribute-packages:
  - control-monad-exception-monadsfd
  - control-monad-exception-monadstf
  - control-monad-exception-mtl
+ - Control-Monad-MultiPass
  - conversion-text
  - conversions
  - convert
@@ -928,10 +582,12 @@ dont-distribute-packages:
  - coordinate
  - copilot-cbmc
  - copilot-sbv
+ - CoreFoundation
  - coroutine-enumerator
  - coroutine-iteratee
  - couch-simple
  - couchdb-enumerator
+ - CPBrainfuck
  - cprng-aes
  - cprng-aes-effect
  - cql-io-tinylog
@@ -963,6 +619,10 @@ dont-distribute-packages:
  - cryptol
  - cryptonite-cd
  - crystalfontz
+ - CSPM-cspm
+ - CSPM-FiringRules
+ - CSPM-Interpreter
+ - CSPM-ToProlog
  - cspmchecker
  - csv-enumerator
  - ctpl
@@ -974,11 +634,13 @@ dont-distribute-packages:
  - dahdit-midi
  - dahdit-test
  - daino
+ - Dangerous
  - dapi
  - darcs-benchmark
  - darcs-beta
  - darcs-fastconvert
  - darcsden
+ - DarcsHelpers
  - darcswatch
  - darkplaces-demo
  - darkplaces-rcon-util
@@ -1023,8 +685,10 @@ dont-distribute-packages:
  - debug
  - decimal-arithmetic
  - dedukti
+ - DeepArrow
  - deepzoom
  - defargs
+ - DefendTheKing
  - definitive-filesystem
  - definitive-graphics
  - definitive-parser
@@ -1063,6 +727,7 @@ dont-distribute-packages:
  - dialog
  - diff
  - difference-monoid
+ - DifferenceLogic
  - differential
  - digestive-foundation-lucid
  - digestive-functors-hsp
@@ -1079,6 +744,7 @@ dont-distribute-packages:
  - discord-haskell-voice
  - discord-hs
  - discord-rest
+ - DisTract
  - distributed-process-azure
  - distribution-plot
  - dixi
@@ -1087,6 +753,8 @@ dont-distribute-packages:
  - dmenu-pkill
  - dmenu-pmount
  - dmenu-search
+ - DMuCheck
+ - DnaProteinAlignment
  - dnf-repo
  - dobutokO-poetry
  - dobutokO-poetry-general
@@ -1094,13 +762,16 @@ dont-distribute-packages:
  - dobutokO3
  - dobutokO4
  - doc-review
+ - DocTest
  - dojang
+ - DOM
  - domaindriven
  - dormouse-client
  - dovetail
  - dovetail-aeson
  - dow
  - download-media-content
+ - DP
  - dph-examples
  - dph-lifted-base
  - dph-lifted-copy
@@ -1108,16 +779,27 @@ dont-distribute-packages:
  - dph-prim-interface
  - dph-prim-par
  - dph-prim-seq
+ - DRBG
+ - DrHylo
  - dropbox-sdk
  - dropsolve
+ - DSA
+ - DSH
  - dsh-sql
  - dsmc-tools
+ - DSTM
  - dtd
+ - Dust
+ - Dust-crypto
+ - Dust-tools
+ - Dust-tools-pcap
  - dvda
  - dynamic-cabal
  - dynamic-plot
  - dynamic-pp
  - dynobud
+ - DysFRP-Cairo
+ - DysFRP-Craftwerk
  - e11y-otel
  - easytensor
  - easytensor-vulkan
@@ -1128,6 +810,7 @@ dont-distribute-packages:
  - edge
  - edges
  - editable
+ - EditTimeReport
  - effect-monad
  - effective-aspects-mzv
  - egison
@@ -1148,6 +831,7 @@ dont-distribute-packages:
  - engine-io-wai
  - engine-io-yesod
  - entangle
+ - EntrezHTTP
  - enum-text-rio
  - enumerate
  - enumerate-function
@@ -1163,12 +847,17 @@ dont-distribute-packages:
  - errors-ext
  - ersatz-toysat
  - esotericbot
+ - EsounD
  - esqueleto-postgis
  - esqueleto-streaming
  - estreps
+ - Etage-Graph
+ - EtaMOO
+ - Eternal10Seconds
  - eternity
  - eternity-timestamped
  - ether
+ - Etherbunny
  - ethereum-analyzer
  - ethereum-analyzer-cli
  - ethereum-analyzer-webui
@@ -1184,6 +873,7 @@ dont-distribute-packages:
  - eventful-sql-common
  - eventful-sqlite
  - eventful-test-helpers
+ - EventSocket
  - eventsource-geteventstore-store
  - eventsource-store-specs
  - eventsource-stub-store
@@ -1209,6 +899,7 @@ dont-distribute-packages:
  - extensible-skeleton
  - extract-dependencies
  - factual-api
+ - FailureT
  - fair
  - fallingblocks
  - family-tree
@@ -1230,6 +921,7 @@ dont-distribute-packages:
  - fay-websockets
  - fbrnch
  - fcd
+ - FComp
  - feature-flipper-postgres
  - fedora-composes
  - fedora-img-dl
@@ -1245,18 +937,24 @@ dont-distribute-packages:
  - fei-nn
  - feldspar-compiler
  - feldspar-language
+ - FermatsLastMargin
  - festung
  - ffmpeg-tutorials
  - ficketed
+ - FieldTrip
  - filepath-crypto
  - filepath-io-access
  - filesystem-enumerator
+ - Fin
  - fin-int
+ - Finance-Treasury
  - find-clumpiness
  - findhttp
  - finitary-derive
  - finite-table
+ - FiniteMap
  - firstify
+ - FirstOrderTheory
  - fishfood
  - fix-parser-simple
  - fixed-generic
@@ -1267,6 +965,8 @@ dont-distribute-packages:
  - flexiwrap
  - flexiwrap-smallcheck
  - flight-kml
+ - Flint2-Examples
+ - Flippi
  - flite
  - flower
  - flowsim
@@ -1279,24 +979,32 @@ dont-distribute-packages:
  - fluent-logger-conduit
  - fluid-idl-http-client
  - fluid-idl-scotty
+ - FM-SBLEX
  - fmt-for-rio
  - foldable1
  - foldl-transduce-attoparsec
  - follower
  - foo
+ - Forestry
+ - FormalGrammars
  - format
  - format-status
  - formlets
  - formlets-hsp
  - forms-data-format
+ - ForSyDe
  - forsyde-deep
  - forth-hll
  - foscam-directory
  - foscam-sort
+ - Foster
  - fpco-api
  - fplll
  - fpnla-examples
  - frame-markdown
+ - Frames-dsv
+ - Frames-map-reduce
+ - Frank
  - freckle-app
  - freckle-ecs
  - freckle-http
@@ -1321,6 +1029,7 @@ dont-distribute-packages:
  - frpnow-vty
  - ftdi
  - ftp-client-conduit
+ - FTPLine
  - ftree
  - ftshell
  - funbot
@@ -1346,6 +1055,7 @@ dont-distribute-packages:
  - gbu
  - gdax
  - gdiff-ig
+ - GeBoP
  - gedcom
  - geek
  - geek-server
@@ -1357,17 +1067,21 @@ dont-distribute-packages:
  - gelatin-shaders
  - gemini-router
  - gemini-textboard
+ - Genbank
  - gencheck
+ - Gene-CluEDO
  - generic-accessors
  - generic-override-aeson
  - generic-xml
  - generics-mrsop-gdiff
  - genesis
  - genesis-test
+ - GenI
  - geni-gui
  - geni-util
  - geniconvert
  - geniserver
+ - GenussFold
  - geodetic
  - geolite-csv
  - getemx
@@ -1403,9 +1117,12 @@ dont-distribute-packages:
  - glazier-react
  - glazier-react-examples
  - glazier-react-widget
+ - GLFW-OGL
+ - GLFW-task
  - global
  - global-config
  - glome-hs
+ - GlomeView
  - gloss-accelerate
  - gloss-devil
  - gloss-raster-accelerate
@@ -1423,7 +1140,10 @@ dont-distribute-packages:
  - goatee-gtk
  - google-drive
  - google-mail-filters
+ - GoogleDirections
  - googleplus
+ - GoogleSB
+ - GoogleTranslate
  - gore-and-ash-actor
  - gore-and-ash-async
  - gore-and-ash-demo
@@ -1433,15 +1153,22 @@ dont-distribute-packages:
  - gore-and-ash-network
  - gore-and-ash-sdl
  - gore-and-ash-sync
+ - GPipe-Collada
+ - GPipe-Examples
+ - GPipe-GLFW
+ - GPipe-GLFW4
+ - GPipe-TextureLoad
  - gps
  - gps2htmlReport
  - gpu-vulkan
  - gpu-vulkan-khr-surface
  - gpu-vulkan-khr-surface-glfw
  - gpu-vulkan-khr-swapchain
+ - GPX
  - grab-form
  - graflog
  - grammar-combinators
+ - GrammarProducts
  - grapefruit-examples
  - grapefruit-frp
  - grapefruit-records
@@ -1458,6 +1185,8 @@ dont-distribute-packages:
  - graph-rewriting-trs
  - graph-rewriting-ww
  - graph-visit
+ - GraphHammer
+ - GraphHammer-examples
  - graphicsFormats
  - graphicstools
  - graphtype
@@ -1476,6 +1205,8 @@ dont-distribute-packages:
  - groundhog-postgresql
  - groundhog-sqlite
  - groundhog-th
+ - Grow
+ - GrowlNotify
  - grpc-etcd-client
  - grpc-haskell
  - gruff
@@ -1493,17 +1224,20 @@ dont-distribute-packages:
  - gtk2hs-cast-gtk
  - gtk2hs-cast-gtkglext
  - gtk2hs-cast-gtksourceview2
+ - Gtk2hsGenerics
+ - GtkGLTV
  - gtkimageview
  - gtkrsync
+ - GtkTV
  - guarded-rewriting
+ - GuiHaskell
+ - GuiTV
+ - H
  - h3spec
- - hOff-display
- - hPDB
- - hPDB-examples
- - hS3
  - habit
  - hablo
  - hablog
+ - Hach
  - hack-contrib
  - hack-contrib-press
  - hack-handler-epoll
@@ -1530,16 +1264,20 @@ dont-distribute-packages:
  - hakyll-ogmarkup
  - hakyll-shortcut-links
  - halberd
- - halide-JuicyPixels
  - halide-arrayfire
+ - halide-JuicyPixels
  - hall-symbols
  - halma-gui
  - halma-telegram-bot
  - hamusic
  - hans-pcap
  - happlets-lib-gtk
+ - HAppS-Data
  - happs-hsp
  - happs-hsp-template
+ - HAppS-IxSet
+ - HAppS-Server
+ - HAppS-State
  - happs-tutorial
  - happstack-auth
  - happstack-authenticate
@@ -1558,8 +1296,10 @@ dont-distribute-packages:
  - happybara-webkit
  - haquil
  - hardware-edsl
+ - HaRe
  - hark
  - harmony
+ - HarmTrace
  - haroonga-httpd
  - has-th
  - hasbolt
@@ -1567,8 +1307,10 @@ dont-distribute-packages:
  - hascat-lib
  - hascat-setup
  - hascat-system
+ - HasGP
  - hash-addressed
  - hash-addressed-cli
+ - Hashell
  - hashflare
  - hask-home
  - haskanoid
@@ -1623,6 +1365,7 @@ dont-distribute-packages:
  - haskelldb-hsql-postgresql
  - haskelldb-hsql-sqlite3
  - haskelldb-th
+ - HaskellNet-SSL
  - haskelm
  - haskey
  - haskey-mtl
@@ -1660,11 +1403,17 @@ dont-distribute-packages:
  - haste-lib
  - haste-markup
  - haste-perch
+ - Hate
+ - HaTeX-meta
+ - HaTeX-qq
  - hatexmpp3
+ - HaVSA
  - hawitter
+ - Hawk
  - haxl-amazonka
  - haxl-facebook
  - haxy
+ - Hayoo
  - hback
  - hbayes
  - hbb
@@ -1693,6 +1442,7 @@ dont-distribute-packages:
  - hecc
  - hedgehog-checkers-lens
  - hedgehog-gen-json
+ - Hedi
  - hedis-pile
  - heist-aeson
  - helic
@@ -1721,6 +1471,23 @@ dont-distribute-packages:
  - hfiar
  - hfractal
  - hgalib
+ - HGamer3D-API
+ - HGamer3D-Audio
+ - HGamer3D-Bullet-Binding
+ - HGamer3D-CAudio-Binding
+ - HGamer3D-CEGUI-Binding
+ - HGamer3D-Common
+ - HGamer3D-Enet-Binding
+ - HGamer3D-Graphics3D
+ - HGamer3D-GUI
+ - HGamer3D-InputSystem
+ - HGamer3D-Network
+ - HGamer3D-Ogre-Binding
+ - HGamer3D-OIS-Binding
+ - HGamer3D-SDL2-Binding
+ - HGamer3D-SFML-Binding
+ - HGamer3D-WinEvent
+ - HGamer3D-Wire
  - hgen
  - hgeometry
  - hgeometry-combinatorial
@@ -1732,6 +1499,8 @@ dont-distribute-packages:
  - hierarchical-clustering-diagrams
  - hierarchical-env
  - hierarchical-spectral-clustering
+ - Hieroglyph
+ - HiggsSet
  - highjson-swagger
  - highjson-th
  - himpy
@@ -1742,6 +1511,8 @@ dont-distribute-packages:
  - hinze-streams
  - hipbot
  - hipe
+ - Hipmunk-Utils
+ - HipmunkPlayground
  - hipsql-client
  - hipsql-server
  - hipsql-tx-simple
@@ -1753,9 +1524,15 @@ dont-distribute-packages:
  - hist-pl-lmf
  - hit
  - hit-graph
+ - HJScript
  - hjsonschema
  - hjugement-cli
  - hlcm
+ - HLearn-algebra
+ - HLearn-approximation
+ - HLearn-classification
+ - HLearn-datastructures
+ - HLearn-distributions
  - hls
  - hls-call-hierarchy-plugin
  - hls-exactprint-utils
@@ -1766,12 +1543,19 @@ dont-distribute-packages:
  - hmeap-utils
  - hmep
  - hmt-diagrams
+ - HNM
  - hnormalise
  - hob
+ - Hoed
+ - hOff-display
  - hogre
  - hogre-examples
+ - Holumbus-Distribution
+ - Holumbus-MapReduce
+ - Holumbus-Storage
  - holy-project
  - hommage
+ - HongoDB
  - hood
  - hoodie
  - hoodle
@@ -1795,7 +1579,12 @@ dont-distribute-packages:
  - hpath-directory
  - hpath-io
  - hpc-tracer
+ - hPDB
+ - hPDB-examples
+ - HPhone
  - hplayground
+ - HPlot
+ - HPong
  - hpqtypes-effectful
  - hpqtypes-extras
  - hpqtypes-extras_1_17_0_1
@@ -1805,10 +1594,19 @@ dont-distribute-packages:
  - hps-cairo
  - hpython
  - hq
+ - HQu
  - hranker
+ - HRay
  - hreq-client
  - hreq-conduit
  - hriemann
+ - HROOT
+ - HROOT-graf
+ - HROOT-hist
+ - HROOT-io
+ - HROOT-math
+ - HROOT-net
+ - HROOT-tree
  - hs
  - hs-blake2
  - hs-ffmpeg
@@ -1820,6 +1618,8 @@ dont-distribute-packages:
  - hs-sdl-term-emulator
  - hs2ats
  - hs2dot
+ - Hs2lib
+ - hS3
  - hsbackup
  - hsbencher-codespeed
  - hsbencher-fusion
@@ -1836,9 +1636,14 @@ dont-distribute-packages:
  - hscope
  - hsdev
  - hsec-core
+ - Hsed
  - hsfacter
+ - HSGEP
+ - HSHHelpers
  - hsinspect-lsp
  - hslogstash
+ - HSoundFile
+ - HsParrot
  - hspec-dirstream
  - hspec-expectations-pretty
  - hspec-pg-transact
@@ -1859,12 +1664,15 @@ dont-distribute-packages:
  - hstar
  - hstox
  - hstradeking
+ - HStringTemplateHelpers
  - hstzaar
  - hsubconvert
+ - HsWebots
  - hswip
  - hsx-jmacro
  - hsx-xhtml
  - hsyslog-tcp
+ - HTab
  - html-kure
  - html2hamlet
  - htoml-parse
@@ -1883,6 +1691,7 @@ dont-distribute-packages:
  - hubris
  - hugs2yc
  - hulk
+ - Hungarian-Munkres
  - hunit-gui
  - hunp
  - hunt-searchengine
@@ -1910,12 +1719,14 @@ dont-distribute-packages:
  - hws
  - hwsl2-bytevector
  - hwsl2-reducers
+ - HXMPP
  - hxournal
  - hxt-binary
  - hxt-filter
  - hxweb
  - hybrid
  - hydra-print
+ - Hydrogen
  - hydrogen-cli
  - hydrogen-cli-args
  - hydrogen-data
@@ -1929,7 +1740,6 @@ dont-distribute-packages:
  - hyloutils
  - hyperbole
  - hyperpublic
- - iException
  - ide-backend
  - ide-backend-server
  - ideas-math
@@ -1937,6 +1747,7 @@ dont-distribute-packages:
  - ideas-statistics
  - identicon-style-squares
  - idna
+ - iException
  - ifscs
  - ige-mac-integration
  - igrf
@@ -1957,6 +1768,7 @@ dont-distribute-packages:
  - importify
  - imprevu-happstack
  - improve
+ - INblobs
  - inch
  - incremental-computing
  - incremental-maps
@@ -1965,12 +1777,14 @@ dont-distribute-packages:
  - indentation-parsec
  - indentation-trifecta
  - indexation
+ - IndexedList
  - indieweb-algorithms
  - indigo
  - inferno-core
  - inferno-lsp
  - inferno-vc
  - infinity
+ - InfixApplicative
  - inline-java
  - inspector-wrecker
  - instant-aeson
@@ -1989,6 +1803,7 @@ dont-distribute-packages:
  - intset
  - io-classes-mtl
  - ion
+ - IORefCAS
  - ipatch
  - ipc
  - ipld-cid
@@ -2008,8 +1823,8 @@ dont-distribute-packages:
  - iteratee-parsec
  - iteratee-stm
  - iterio-server
- - iterm-show-JuicyPixels
  - iterm-show-diagrams
+ - iterm-show-JuicyPixels
  - ival
  - ivor
  - ivory-avr-atmega328p-registers
@@ -2033,6 +1848,7 @@ dont-distribute-packages:
  - java-character
  - java-reflect
  - javaclass
+ - Javasf
  - javasf
  - jespresso
  - jmacro-rpc-happstack
@@ -2046,9 +1862,12 @@ dont-distribute-packages:
  - jordan-servant-openapi
  - jordan-servant-server
  - jsc
+ - JsContracts
  - jsmw
  - json-ast-json-encoder
  - json-b
+ - JSON-Combinator
+ - JSON-Combinator-Examples
  - json-enumerator
  - json-incremental-decoder
  - json-pointer-aeson
@@ -2060,8 +1879,12 @@ dont-distribute-packages:
  - json-togo
  - json2-hdbc
  - json2sg
+ - JsonGrammar
  - jsons-to-schema
  - jspath
+ - JunkDB-driver-gdbm
+ - JunkDB-driver-hashtables
+ - JuPyTer-notebook
  - jvm
  - jvm-batching
  - jvm-streaming
@@ -2107,6 +1930,9 @@ dont-distribute-packages:
  - keyvaluehash
  - keyword-args
  - kicad-data
+ - KiCS
+ - KiCS-debugger
+ - KiCS-prophecy
  - kif-parser
  - kit
  - kmeans-par
@@ -2128,8 +1954,6 @@ dont-distribute-packages:
  - laika
  - lambda-devs
  - lambda-options
- - lambdaFeed
- - lambdaLit
  - lambdabot-zulip
  - lambdacat
  - lambdacms-media
@@ -2140,18 +1964,23 @@ dont-distribute-packages:
  - lambdacube-examples
  - lambdacube-gl
  - lambdacube-samples
+ - lambdaFeed
+ - LambdaINet
+ - lambdaLit
+ - LambdaPrettyQuote
+ - LambdaShell
  - lambdaya-bus
  - lambdiff
  - lame-tester
  - landlock
  - lang
  - langchain-hs
- - language-Modula2
  - language-ats
  - language-boogie
  - language-ecmascript-analysis
  - language-eiffel
  - language-kort
+ - language-Modula2
  - language-ninja
  - language-oberon
  - language-puppet
@@ -2164,6 +1993,7 @@ dont-distribute-packages:
  - latex-formulae-pandoc
  - latex-svg-hakyll
  - latex-svg-pandoc
+ - Lattices
  - launchdarkly-server-sdk-redis-hedis
  - lawful-classes-hedgehog
  - lawful-classes-quickcheck
@@ -2173,6 +2003,7 @@ dont-distribute-packages:
  - lda
  - ldap-scim-bridge
  - ldapply
+ - LDAPv3
  - leaky
  - lean
  - leanpub-wreq
@@ -2212,6 +2043,8 @@ dont-distribute-packages:
  - linear-code
  - linearEqSolver
  - linearscan-hoopl
+ - LinearSplit
+ - LinkChecker
  - linkchk
  - linkcore
  - linnet-aeson
@@ -2233,6 +2066,7 @@ dont-distribute-packages:
  - list-t-html-parser
  - list1
  - listenbrainz-client
+ - ListT
  - liszt
  - lit
  - live-sequencer
@@ -2258,6 +2092,10 @@ dont-distribute-packages:
  - log-utils
  - log4hs
  - logging-effect-extra
+ - LogicGrowsOnTrees
+ - LogicGrowsOnTrees-MPI
+ - LogicGrowsOnTrees-network
+ - LogicGrowsOnTrees-processes
  - lojban
  - lojysamban
  - lol
@@ -2273,18 +2111,21 @@ dont-distribute-packages:
  - lorentz
  - lostcities
  - loup
+ - LPPaver
  - lrucaching-haxl
  - ls-usb
+ - LslPlus
  - lsystem
  - luachunk
  - lucid-colonnade
  - lucienne
+ - Lucu
  - lui
  - luminance-samples
  - lvish
+ - Lykah
  - lz4-conduit
  - lzma-enumerator
- - mDNSResponder-client
  - macbeth-lib
  - machines-amazonka
  - machines-directory
@@ -2295,6 +2136,7 @@ dont-distribute-packages:
  - mahoro
  - maid
  - mail-pool
+ - MailchimpSimple
  - mailgun
  - majordomo
  - majority
@@ -2319,6 +2161,7 @@ dont-distribute-packages:
  - mangopay
  - mangrove
  - manifold-random
+ - Map
  - marionetta
  - markdown-pap
  - markdown2svg
@@ -2340,7 +2183,9 @@ dont-distribute-packages:
  - maxent
  - maxent-learner-hw-gui
  - maxsharing
+ - MC-Fold-DP
  - mcmc-samplers
+ - mDNSResponder-client
  - medea
  - mediabus-fdk-aac
  - mediabus-rtp
@@ -2354,12 +2199,18 @@ dont-distribute-packages:
  - merkle-patricia-db
  - message-db-temp
  - meta-par-accelerate
+ - MetaObject
  - metaplug
  - metar
  - metar-http
+ - Metrics
  - metronome
+ - MFlow
+ - Mhailist
+ - Michelangelo
  - micro-gateway
  - microformats2-types
+ - MicrosoftTranslator
  - midimory
  - mig-server
  - mighttpd
@@ -2372,11 +2223,13 @@ dont-distribute-packages:
  - minimung
  - minioperational
  - minirotate
+ - MIP-glpk
  - mismi-kernel
  - mismi-s3-core
  - miss
  - miss-porcelain
  - missing-py2
+ - MissingPy
  - mixed-strategies
  - mkbndl
  - mlist
@@ -2399,11 +2252,17 @@ dont-distribute-packages:
  - monad-http
  - monad-state
  - monad-stlike-stm
+ - MonadCatchIO-mtl-foreign
  - monadiccp-gecode
+ - MonadLab
  - monarch
+ - Monaris
+ - Monatron-IO
+ - Mondrian
  - monetdb-mapi
  - mongrel2-handler
  - monky
+ - Monocle
  - monoidmap-aeson
  - monoidmap-examples
  - monoidmap-quickcheck
@@ -2436,6 +2295,7 @@ dont-distribute-packages:
  - msgpack-rpc-conduit
  - msgpack-testsuite
  - msi-kb-backlit
+ - MSQueue
  - mstate
  - mtgoxapi
  - mu-avro
@@ -2452,6 +2312,10 @@ dont-distribute-packages:
  - mu-rpc
  - mu-servant-server
  - mu-tracing
+ - MuCheck-Hspec
+ - MuCheck-HUnit
+ - MuCheck-QuickCheck
+ - MuCheck-SmallCheck
  - multi-cabal
  - multibase
  - multifocal
@@ -2464,6 +2328,7 @@ dont-distribute-packages:
  - multirec-alt-deriver
  - multirec-binary
  - multisetrewrite
+ - Munkres-simple
  - murder
  - murmurhash3
  - mushu
@@ -2477,26 +2342,30 @@ dont-distribute-packages:
  - musicbrainz-email
  - musicxml2
  - mutable-iter
+ - MutationOrder
  - mute-unmute
  - mvclient
  - mwc-random-monad
  - mxnet-dataiter
  - mxnet-examples
  - mxnet-nn
- - myTestlll
  - mysnapsession-example
  - mysql-haskell-openssl
  - mysql-simple-typed
+ - myTestlll
  - mywatch
  - mywork
  - n2o-web
+ - NaCl
  - nakadi-client
  - named-servant-client
  - named-servant-server
  - nanq
+ - NaperianNetCDF
  - national-australia-bank
  - nats-queue
  - natural-number
+ - NearContextAlgebra
  - nemesis-titan
  - nerf
  - nero-wai
@@ -2520,6 +2389,7 @@ dont-distribute-packages:
  - network-interfacerequest
  - network-minihttp
  - network-netpacket
+ - Network-NineP
  - network-pgi
  - network-protocol-xmpp
  - network-rpca
@@ -2529,19 +2399,28 @@ dont-distribute-packages:
  - neuron
  - newsletter-mailgun
  - newsynth
+ - NGLess
  - ngx-export-tools-extra
  - nikepub
+ - Ninjas
  - nirum
  - nkjp
  - nlp-scores-scripts
  - nom
+ - Nomyx
  - nomyx-api
+ - Nomyx-Core
  - nomyx-core
+ - Nomyx-Language
  - nomyx-language
  - nomyx-library
+ - Nomyx-Rules
  - nomyx-server
+ - Nomyx-Web
+ - NonEmptyList
  - nonlinear-optimization-ad
  - nonlinear-optimization-backprop
+ - NoSlow
  - not-gloss
  - not-gloss-examples
  - notmuch-web
@@ -2554,6 +2433,7 @@ dont-distribute-packages:
  - nri-prelude
  - nri-redis
  - nri-test-encoding
+ - NTRU
  - numeric-kinds
  - numeric-ode
  - numeric-optimization
@@ -2562,6 +2442,7 @@ dont-distribute-packages:
  - numhask-hedgehog
  - numhask-range
  - numhask-test
+ - Nussinov78
  - nyan
  - nyan-interpolation
  - nyan-interpolation-simple
@@ -2590,17 +2471,22 @@ dont-distribute-packages:
  - om-kubernetes
  - one-time-password
  - online-csv
+ - OnRmt
  - oops-examples
  - opc-xml-da-client
  - open-adt-tutorial
  - open-typerep
+ - OpenAFP-Utils
+ - OpenGLCheck
  - openpgp-Crypto
  - openpgp-crypto-api
+ - OpenSCAD
  - openssh-github-keys
  - opentelemetry-lightstep
  - opentok
  - opentracing-jaeger
  - opentracing-zipkin-v1
+ - OpenVG
  - optimal-blocks
  - optimusprime
  - optparse-enum
@@ -2616,6 +2502,8 @@ dont-distribute-packages:
  - pa-json
  - package-o-tron
  - padKONTROL
+ - PageIO
+ - Paillier
  - pairing
  - panda
  - pandoc-highlighting-extensions
@@ -2630,6 +2518,11 @@ dont-distribute-packages:
  - papa-lens
  - papa-semigroupoids
  - par-dual
+ - Paraiso
+ - Parallel-Arrows-BaseSpec
+ - Parallel-Arrows-Eden
+ - Parallel-Arrows-Multicore
+ - Parallel-Arrows-ParMonad
  - parallel-tree-search
  - parco-attoparsec
  - parco-parsec
@@ -2648,6 +2541,7 @@ dont-distribute-packages:
  - pcap-enumerator
  - pcapng
  - pcf
+ - PCLT-DB
  - pdf-slave
  - pdfname
  - pdfsplit
@@ -2666,6 +2560,7 @@ dont-distribute-packages:
  - periodic-server
  - perm
  - permutations
+ - PermuteEffects
  - persistent-audit
  - persistent-event-source
  - persistent-eventsource
@@ -2721,6 +2616,8 @@ dont-distribute-packages:
  - pkgtreediff
  - planet-mitchell
  - plocketed
+ - Plot-ho-matic
+ - PlslTools
  - plugins-auto
  - png-file
  - pngload
@@ -2730,7 +2627,6 @@ dont-distribute-packages:
  - polh-lexicon
  - poly-rec
  - polydata
- - polysemy-RandomFu
  - polysemy-account
  - polysemy-account-api
  - polysemy-db
@@ -2744,6 +2640,7 @@ dont-distribute-packages:
  - polysemy-methodology-co-log
  - polysemy-methodology-composite
  - polysemy-path
+ - polysemy-RandomFu
  - polysemy-scoped-fs
  - polysemy-uncontrolled
  - polysemy-video
@@ -2794,6 +2691,8 @@ dont-distribute-packages:
  - primal-memory
  - primula-board
  - primula-bot
+ - Printf-TH
+ - ProbabilityMonads
  - proc
  - process-iterio
  - process-progress
@@ -2824,9 +2723,12 @@ dont-distribute-packages:
  - ptera-th
  - publicsuffixlist
  - puffytools
+ - Pugs
  - pugs-compat
  - pugs-hsregex
  - punkt
+ - Pup-Events
+ - Pup-Events-Demo
  - puppetresources
  - pure-cdb
  - pure-priority-queue-tests
@@ -2850,6 +2752,7 @@ dont-distribute-packages:
  - qtah-qt5
  - qtah-qt6
  - quantfin
+ - Quelea
  - queryparser
  - queryparser-demo
  - queryparser-hive
@@ -2884,6 +2787,7 @@ dont-distribute-packages:
  - rail-compiler-editor
  - rails-session
  - rainbow-tests
+ - Raincat
  - raketka
  - rallod
  - randfile
@@ -2894,6 +2798,7 @@ dont-distribute-packages:
  - random-hypergeometric
  - range-space
  - ranged-list_0_1_2_3
+ - Ranka
  - rasa
  - rasa-example-config
  - rasa-ext-bufs
@@ -2930,8 +2835,8 @@ dont-distribute-packages:
  - record-syntax
  - records-th
  - recursion-schemes-ix
- - redHandlers
  - reddit
+ - redHandlers
  - redis-io
  - rediscaching-haxl
  - refh
@@ -2995,6 +2900,7 @@ dont-distribute-packages:
  - rest-types
  - rest-wai
  - restful-snap
+ - RESTng
  - restricted-workers
  - rethinkdb-model
  - rethinkdb-wereHamster
@@ -3022,8 +2928,16 @@ dont-distribute-packages:
  - ripple-federation
  - risc-v
  - rivet
+ - RJson
  - rlwe-challenges
  - rmonad
+ - RMP
+ - RNAdesign
+ - RNAdraw
+ - RNAFold
+ - RNAFoldProgs
+ - RNAlien
+ - RNAwolf
  - rncryptor
  - rob
  - robot
@@ -3035,6 +2949,7 @@ dont-distribute-packages:
  - rollbar-cli
  - rollbar-wai
  - rollbar-yesod
+ - RollingDirectory
  - ron-rdt
  - ron-schema
  - ron-storage
@@ -3056,6 +2971,7 @@ dont-distribute-packages:
  - runtime-arbitrary
  - rv
  - s-expression
+ - S3
  - safe-coupling
  - safe-failure
  - safe-failure-cme
@@ -3088,6 +3004,7 @@ dont-distribute-packages:
  - satchmo-funsat
  - satchmo-toysat
  - sauron
+ - SBench
  - sbv-program
  - sbvPlugin
  - sc2-lowlevel
@@ -3095,6 +3012,7 @@ dont-distribute-packages:
  - sc2hs
  - sc3-rdu
  - scalable-server
+ - SCalendar
  - scalp-webhooks
  - scalpel-search
  - scan-metadata
@@ -3104,6 +3022,7 @@ dont-distribute-packages:
  - scholdoc
  - scholdoc-citeproc
  - scholdoc-texmath
+ - SciFlow-drmaa
  - scion
  - scion-browser
  - scope
@@ -3116,7 +3035,9 @@ dont-distribute-packages:
  - scp-streams
  - scrabble-bot
  - scrapbook
+ - SCRIPTWriter
  - scroll
+ - Scurry
  - sdl2-sprite
  - sdp-binary
  - sdp-deepseq
@@ -3133,6 +3054,7 @@ dont-distribute-packages:
  - secrm
  - sednaDBXML
  - seitz-symbol
+ - SelectSequencesFromMSA
  - selenium-server
  - semantic-source
  - semantic-version
@@ -3187,6 +3109,10 @@ dont-distribute-packages:
  - servant-zeppelin-server
  - servant-zeppelin-swagger
  - sessiontypes-distributed
+ - Set
+ - SFML-control
+ - SFont
+ - SGdemo
  - sgrep
  - shady-gen
  - shady-graphics
@@ -3200,11 +3126,28 @@ dont-distribute-packages:
  - shapes-demo
  - sheets
  - shelduck
+ - Shellac-compatline
+ - Shellac-editline
+ - Shellac-haskeline
+ - Shellac-readline
  - shellmate-extras
  - shine-varying
  - short-vec
  - short-vec-lens
+ - ShortestPathProblems
  - showdown
+ - Shpadoinkle-backend-pardiff
+ - Shpadoinkle-backend-snabbdom
+ - Shpadoinkle-backend-static
+ - Shpadoinkle-developer-tools
+ - Shpadoinkle-disembodied
+ - Shpadoinkle-examples
+ - Shpadoinkle-html
+ - Shpadoinkle-lens
+ - Shpadoinkle-router
+ - Shpadoinkle-streaming
+ - Shpadoinkle-template
+ - Shpadoinkle-widgets
  - shpider
  - shuffle
  - si-clock
@@ -3222,7 +3165,10 @@ dont-distribute-packages:
  - simple-nix
  - simple-pascal
  - simple-postgresql-orm
+ - SimpleGL
  - simpleirc-lens
+ - SimpleLog
+ - SimpleServer
  - simseq
  - singletons-base_3_5
  - siphon
@@ -3245,6 +3191,7 @@ dont-distribute-packages:
  - smcdel
  - smith-cli
  - smith-client
+ - Smooth
  - smt
  - smtlib-backends-z3
  - smtlib2-debug
@@ -3287,8 +3234,11 @@ dont-distribute-packages:
  - snowflake-core
  - snowflake-server
  - snumber
+ - Snusmumrik
  - soap-openssl
  - soap-tls
+ - SoccerFun
+ - SoccerFunGL
  - sock2stream
  - socket-io
  - sockets-and-pipes
@@ -3297,6 +3247,8 @@ dont-distribute-packages:
  - solr
  - souffle-dsl
  - source-code-server
+ - SourceGraph
+ - SpacePrivateers
  - spade
  - sparkle
  - sparrow
@@ -3312,6 +3264,7 @@ dont-distribute-packages:
  - sphero
  - spice
  - spike
+ - SpinCounter
  - splines
  - sprinkles
  - sproxy
@@ -3349,8 +3302,12 @@ dont-distribute-packages:
  - statsdi
  - steeloverseer
  - stern-brocot
+ - STLinkUSB
+ - STM32-Zombie
  - stmcontrol
+ - StockholmAlignment
  - storablevector-streamfusion
+ - Strafunski-Sdf2Haskell
  - stratum-tool
  - stratux
  - stratux-demo
@@ -3392,11 +3349,13 @@ dont-distribute-packages:
  - sv
  - sv-cassava
  - sv-svfactor
+ - SVG2Q
  - svg2q
  - svgone
  - swapper
  - switch
  - syb-with-class-instances-text
+ - SybWidget
  - sydtest-amqp
  - sydtest-webdriver-screenshot
  - sydtest-webdriver-yesod
@@ -3407,6 +3366,7 @@ dont-distribute-packages:
  - symantic-lib
  - symbiote
  - symmetry-operations-symbols
+ - Synapse
  - synapse
  - syncthing-hs
  - syntax
@@ -3415,6 +3375,7 @@ dont-distribute-packages:
  - syntax-example-json
  - syntax-pretty
  - syntax-printer
+ - SyntaxMacros
  - syntaxnet-haskell
  - sys-process
  - systemstats
@@ -3446,10 +3407,14 @@ dont-distribute-packages:
  - tasty-jenkins-xml
  - tasty-laws
  - tasty-lens
+ - TastyTLT
  - tateti-tateti
+ - Taxonomy
+ - TaxonomyTools
  - tbox
  - tccli
  - tdd-util
+ - TeaHS
  - techlab
  - telegram-bot
  - telegram-raw-api
@@ -3530,11 +3495,14 @@ dont-distribute-packages:
  - trasa-server
  - trasa-th
  - traversal-template
+ - TreeCounter
  - treemap-html-tools
  - treersec
+ - Treiber
  - trek-app
  - trek-db
  - triangulation
+ - TrieMap
  - trigger
  - trimpolya
  - trurl
@@ -3545,6 +3513,7 @@ dont-distribute-packages:
  - tuple-gen
  - tuple-ops
  - turingMachine
+ - TV
  - tweet-hs
  - twentefp-eventloop-graphics
  - twentefp-eventloop-trees
@@ -3571,10 +3540,12 @@ dont-distribute-packages:
  - type-structure
  - type-sub-th
  - typecheck-plugin-nat-simple_0_1_0_11
+ - TypeClass
  - typed-encoding-encoding
  - typed-gui
  - typed-streams
  - typedflow
+ - TypeIlluminator
  - typelevel
  - typescript-docs
  - typson-beam
@@ -3588,6 +3559,7 @@ dont-distribute-packages:
  - uhc-light
  - uhc-util
  - ukrainian-phonetics-basic
+ - UMM
  - unagi-bloomfilter
  - unbound
  - unfoldable-restricted
@@ -3622,6 +3594,8 @@ dont-distribute-packages:
  - urembed
  - uri-enumerator
  - uri-enumerator-file
+ - UrlDisp
+ - URLT
  - usb
  - usb-enumerator
  - usb-hid
@@ -3629,6 +3603,7 @@ dont-distribute-packages:
  - usb-iteratee
  - usb-safe
  - utf
+ - UTFTConverter
  - util-exception
  - util-primitive-control
  - util-universe
@@ -3672,6 +3647,7 @@ dont-distribute-packages:
  - vformat-aeson
  - vformat-time
  - vfr-waypoints
+ - ViennaRNA-extras
  - vigilance
  - vimeta
  - vinyl-operational
@@ -3705,6 +3681,8 @@ dont-distribute-packages:
  - warp-grpc
  - warp-quic
  - warped
+ - WashNGo
+ - WaveFront
  - wavesurfer
  - wavy
  - weatherhs
@@ -3721,10 +3699,15 @@ dont-distribute-packages:
  - web3-polkadot
  - web3-provider
  - web3-solidity
+ - WebBits-Html
+ - WebBits-multiplate
+ - WebCont
  - webcrank-wai
  - webdriver-w3c
  - webify
  - webserver
+ - WEditorBrick
+ - WEditorHyphen
  - weekdaze
  - weierstrass-functions
  - weighted
@@ -3744,18 +3727,22 @@ dont-distribute-packages:
  - winery
  - winio
  - wire-streams
+ - Wired
  - wl-pprint-ansiterm
  - wl-pprint-terminfo
+ - WL500gPControl
  - wlc-hs
  - wobsurv
  - wolf
  - word
+ - WordAlignment
  - workflow-extra
  - workflow-pure
  - workflow-types
  - wrecker
  - wrecker-ui
  - wright
+ - WringTwistree
  - write-buffer-stm
  - writer-cps-full
  - wsjtx-udp
@@ -3766,19 +3753,23 @@ dont-distribute-packages:
  - wumpus-drawing
  - wumpus-microprint
  - wumpus-tree
+ - WURFL
  - wx
  - wxAsteroids
- - wxFruit
- - wxSimpleCanvas
  - wxc
  - wxcore
+ - WXDiffCtrl
+ - wxFruit
+ - WxGeneric
  - wxhnotepad
+ - wxSimpleCanvas
  - wxturtle
  - wyvern
  - xdcc
  - xdg-basedir-compliant
  - xhb-atom-cache
  - xhb-ewmh
+ - XML
  - xml-catalog
  - xml-enumerator
  - xml-enumerator-combinators
@@ -3795,13 +3786,16 @@ dont-distribute-packages:
  - xmms2-client-glib
  - xmonad-contrib-bluetilebranch
  - xmpipe
+ - XMPP
  - xournal-builder
  - xournal-convert
  - xournal-parser
  - xournal-render
  - xournal-types
  - xrefcheck
+ - XSaiga
  - xtc
+ - Yablog
  - yajl-enumerator
  - yam
  - yam-datasource
@@ -3842,11 +3836,16 @@ dont-distribute-packages:
  - yesod-worker
  - yjftp
  - yjftp-libs
+ - Yogurt-Standalone
  - yoko
  - york-lava
  - yql
  - yu-launch
  - yuuko
+ - Z-Botan
+ - Z-IO
+ - Z-MessagePack
+ - Z-YAML
  - zasni-gerna
  - zephyr-copilot
  - zeromq3-conduit
@@ -3857,6 +3856,7 @@ dont-distribute-packages:
  - zifter-hindent
  - zifter-hlint
  - zifter-stack
+ - ZipFold
  - zipper
  - zipper-extra
  - zippo

--- a/pkgs/development/haskell-modules/configuration-nix.nix
+++ b/pkgs/development/haskell-modules/configuration-nix.nix
@@ -44,6 +44,8 @@ with haskellLib;
 #
 # To avoid this, we use `intersectAttrs` here so we never add packages that are not present
 # in the parent package set (`super`).
+
+# To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead.
 self: super:
 builtins.intersectAttrs super {
 


### PR DESCRIPTION
I suggested to keep things sorted in main.yaml and was nerd-sniped by https://github.com/NixOS/nixpkgs/pull/400861#discussion_r2055818186.

Commits sorted (!) by potential controversy:
- Fixing the maintainer scripts to consistently sort "-" correctly and case-insensitively is a no-brainer.
- We already have a keep-sorted CI workflow, which we can make use of to keep the manually maintained `main.yaml` in order. I hope we can agree on that.
- The last commits about `configuration-common.nix` are kind of an experiment:
  - How much can keep-sorted do? (quite a lot)
  - Does this actually work? (let's see the number of rebuilds, hoping it to be 0)
  - Do we want something like that? You tell me!

When looking at a file like configuration-common.nix, I am always wondering: "OK, and where do I put my new stuff now?". This makes it 100% clear.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
