### PR TITLE
lxqt-admin: fix ability to set timezone

### DIFF
--- a/pkgs/desktops/lxqt/lxqt-admin/default.nix
+++ b/pkgs/desktops/lxqt/lxqt-admin/default.nix
@@ -11,6 +11,7 @@
   qtsvg,
   qttools,
   qtwayland,
+  tzdata,
   wrapQtAppsHook,
   gitUpdater,
 }:
@@ -42,12 +43,22 @@ stdenv.mkDerivation rec {
     qtwayland
   ];
 
+  cmakeFlags = [
+    # fake finding of libsystemd; used to check if we are a systemd-based
+    # distro rather than actually being linked to
+    "-DLIBSYSTEMD_FOUND=TRUE"
+  ];
+
   postPatch = ''
     for f in lxqt-admin-{time,user}/CMakeLists.txt; do
       substituteInPlace $f --replace-fail \
         "\''${POLKITQT-1_POLICY_FILES_INSTALL_DIR}" \
         "$out/share/polkit-1/actions"
     done
+
+    # patch timezone database file location
+    substituteInPlace lxqt-admin-time/timeadmindialog.cpp \
+      --replace-fail "/usr/share/zoneinfo/zone.tab" "${tzdata}/share/zoneinfo/zone.tab"
   '';
 
   passthru.updateScript = gitUpdater { };


### PR DESCRIPTION
* The timezone database file was not searched for in the correct location, giving an empty timezone list. Patch in the correct path.

* The time utility believed it was built on a non-systemd-based distro, and so used an incorrect method to manipulate the timezone. Tell it that it should use systemd.

The timezone list, and using the list to set the timezone, now work properly. Note that the taskbar clock will only update to the correct timezone on the next minute.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---
@NixOS/lxqt 
Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
