### PR TITLE
[24.11] open-policy-agent: 1.2.0 -> 1.3.0, skip tests that require network

### DIFF
--- a/pkgs/by-name/op/open-policy-agent/package.nix
+++ b/pkgs/by-name/op/open-policy-agent/package.nix
@@ -14,13 +14,13 @@ assert
 
 buildGoModule rec {
   pname = "open-policy-agent";
-  version = "1.2.0";
+  version = "1.3.0";
 
   src = fetchFromGitHub {
     owner = "open-policy-agent";
     repo = "opa";
     rev = "v${version}";
-    hash = "sha256-9pLySzYfLyRcbhKz+zusBFHNVnhtGyqlsrNr1AzDQx0=";
+    hash = "sha256-wWxWpJSDOaZLJ7ULdAzPFJ9YNXX3FyQRod2roaLsuis=";
   };
 
   vendorHash = null;

--- a/pkgs/by-name/op/open-policy-agent/package.nix
+++ b/pkgs/by-name/op/open-policy-agent/package.nix
@@ -43,9 +43,24 @@ buildGoModule rec {
     ) "opa_wasm"
   );
 
-  checkFlags = lib.optionals (!enableWasmEval) [
-    "-skip=TestRegoTargetWasmAndTargetPluginDisablesIndexingTopdownStages"
-  ];
+  checkFlags =
+    let
+      skippedTests =
+        [
+          # Skip tests that require network, not available in the nix sandbox
+          "TestInterQueryCache_ClientError"
+          "TestIntraQueryCache_ClientError"
+        ]
+        ++ lib.optionals stdenv.hostPlatform.isDarwin [
+          # Skip tests that require network, not available in the darwin sandbox
+          "TestHTTPSClient"
+          "TestHTTPSNoClientCerts"
+        ]
+        ++ lib.optionals (!enableWasmEval) [
+          "TestRegoTargetWasmAndTargetPluginDisablesIndexingTopdownStages"
+        ];
+    in
+    [ "-skip=^${builtins.concatStringsSep "$|^" skippedTests}$" ];
 
   preCheck =
     ''

--- a/pkgs/by-name/op/open-policy-agent/package.nix
+++ b/pkgs/by-name/op/open-policy-agent/package.nix
@@ -99,6 +99,9 @@ buildGoModule rec {
     runHook postInstallCheck
   '';
 
+  # Required for tests that need networking
+  __darwinAllowLocalNetworking = true;
+
   meta = with lib; {
     mainProgram = "opa";
     homepage = "https://www.openpolicyagent.org";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Manual backports of #396858 and https://github.com/NixOS/nixpkgs/pull/394921 (partial).

https://github.com/open-policy-agent/opa/blob/v1.3.0/CHANGELOG.md

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
