### PR TITLE
vmware-horizon-client: 2406 -> 2503, rename to omnissa-horizon-client

### DIFF
--- a/doc/release-notes/rl-2511.section.md
+++ b/doc/release-notes/rl-2511.section.md
@@ -37,6 +37,8 @@
 
 - `lima` package now only includes the guest agent for the host's architecture by default. If your guest VM's architecture differs from your Lima host's, you'll need to enable the `lima-additional-guestagents` package by setting `withAdditionalGuestAgents = true` when overriding lima with this input.
 
+- `vmware-horizon-client` was renamed to `omnissa-horizon-client`, following [VMware's sale of their end-user business to Omnissa](https://www.omnissa.com/insights/introducing-omnissa-the-former-vmware-end-user-computing-business/). The binary has been renamed from `vmware-view` to `horizon-client`.
+
 - `neovimUtils.makeNeovimConfig` now uses `customLuaRC` parameter instead of accepting `luaRcContent`. The old usage is deprecated but still works with a warning.
 
 - `telegram-desktop` packages now uses `Telegram` for its binary. The previous name was `telegram-desktop`. This is due to [an upstream decision](https://github.com/telegramdesktop/tdesktop/commit/56ff5808a3d766f892bc3c3305afb106b629ef6f) to make the name consistent with other platforms.

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -16308,6 +16308,13 @@
     name = "Martijn Hemeryck";
     keys = [ { fingerprint = "1B47 7ADA 04B4 7A5C E61A  EDE0 1AA3 6833 BC86 F0F1"; } ];
   };
+  mhutter = {
+    email = "manuel@hutter.io";
+    github = "mhutter";
+    githubId = 346819;
+    name = "Manuel Hutter";
+    keys = [ { fingerprint = "BE27 20A9 0C16 C351 31E0  B2FB FC31 B4E5 4C4C F892"; } ];
+  };
   mi-ael = {
     email = "miael.oss.1970@gmail.com";
     name = "mi-ael";

--- a/pkgs/by-name/om/omnissa-horizon-client/package.nix
+++ b/pkgs/by-name/om/omnissa-horizon-client/package.nix
@@ -12,7 +12,7 @@
   configText ? "",
 }:
 let
-  version = "2406";
+  version = "2503";
 
   sysArch =
     if stdenv.hostPlatform.system == "x86_64-linux" then
@@ -21,10 +21,10 @@ let
       throw "Unsupported system: ${stdenv.hostPlatform.system}";
   # The downloaded archive also contains ARM binaries, but these have not been tested.
 
-  # For USB support, ensure that /var/run/vmware/<YOUR-UID>
-  # exists and is owned by you. Then run vmware-usbarbitrator as root.
+  # For USB support, ensure that /var/run/omnissa/<YOUR-UID>
+  # exists and is owned by you. Then run omnissa-usbarbitrator as root.
 
-  mainProgram = "vmware-view";
+  mainProgram = "horizon-client";
 
   # This forces the default GTK theme (Adwaita) because Horizon is prone to
   # UI usability issues when using non-default themes, such as Adwaita-dark.
@@ -32,15 +32,15 @@ let
     makeWrapper "$out/${path}/${name}" "$out/bin/${name}_wrapper" \
     --set GTK_THEME Adwaita \
     --suffix XDG_DATA_DIRS : "${gsettings-desktop-schemas}/share/gsettings-schemas/${gsettings-desktop-schemas.name}" \
-    --suffix LD_LIBRARY_PATH : "$out/lib/vmware/view/crtbora:$out/lib/vmware"
+    --suffix LD_LIBRARY_PATH : "$out/lib/omnissa/horizon/crtbora:$out/lib/omnissa"
   '';
 
-  vmwareHorizonClientFiles = stdenv.mkDerivation {
-    pname = "vmware-horizon-files";
+  omnissaHorizonClientFiles = stdenv.mkDerivation {
+    pname = "omnissa-horizon-files";
     inherit version;
     src = fetchurl {
-      url = "https://download3.omnissa.com/software/CART25FQ2_LIN_2406_TARBALL/VMware-Horizon-Client-Linux-2406-8.13.0-9995429239.tar.gz";
-      sha256 = "d6bae5cea83c418bf3a9cb884a7d8351d8499f1858a1ac282fd79dc0c64e83f6";
+      url = "https://download3.omnissa.com/software/CART26FQ1_LIN_2503_TARBALL/Omnissa-Horizon-Client-Linux-2503-8.15.0-14256322247.tar.gz";
+      sha256 = "c7df084d717dc70ce53eadfbe5a9d0daa06931b640702a8355705fbd93e16bb4";
     };
     nativeBuildInputs = [ makeWrapper ];
     installPhase = ''
@@ -56,27 +56,24 @@ let
       # when it cannot detect a new enough version already present on the system.
       # The checks are distribution-specific and do not function correctly on NixOS.
       # Deleting the bundled library is the simplest way to force it to use our version.
-      rm "$out/lib/vmware/gcc/libstdc++.so.6"
-
-      # This bundled version of libpng causes browser issues, and would prevent web-based sign-on.
-      rm "$out/lib/vmware/libpng16.so.16"
+      rm "$out/lib/omnissa/gcc/libstdc++.so.6"
 
       # This opensc library is required to support smartcard authentication during the
       # initial connection to Horizon.
-      mkdir $out/lib/vmware/view/pkcs11
-      ln -s ${opensc}/lib/pkcs11/opensc-pkcs11.so $out/lib/vmware/view/pkcs11/libopenscpkcs11.so
+      mkdir $out/lib/omnissa/horizon/pkcs11
+      ln -s ${opensc}/lib/pkcs11/opensc-pkcs11.so $out/lib/omnissa/horizon/pkcs11/libopenscpkcs11.so
 
-      ${wrapBinCommands "bin" "vmware-view"}
-      ${wrapBinCommands "lib/vmware/view/usb" "vmware-eucusbarbitrator"}
+      ${wrapBinCommands "bin" "horizon-client"}
+      ${wrapBinCommands "lib/omnissa/horizon/usb" "horizon-eucusbarbitrator"}
     '';
   };
 
-  vmwareFHSUserEnv =
+  omnissaFHSUserEnv =
     pname:
     buildFHSEnv {
       inherit pname version;
 
-      runScript = "${vmwareHorizonClientFiles}/bin/${pname}_wrapper";
+      runScript = "${omnissaHorizonClientFiles}/bin/${pname}_wrapper";
 
       targetPkgs =
         pkgs: with pkgs; [
@@ -105,7 +102,7 @@ let
           pcsclite
           pixman
           udev
-          vmwareHorizonClientFiles
+          omnissaHorizonClientFiles
           xorg.libX11
           xorg.libXau
           xorg.libXcursor
@@ -119,21 +116,24 @@ let
           xorg.libXtst
           zlib
 
-          (writeTextDir "etc/vmware/config" configText)
+          (writeTextDir "etc/omnissa/config" configText)
         ];
     };
 
   desktopItem = makeDesktopItem {
-    name = "vmware-view";
-    desktopName = "VMware Horizon Client";
-    icon = "${vmwareHorizonClientFiles}/share/icons/vmware-view.png";
-    exec = "${vmwareFHSUserEnv mainProgram}/bin/${mainProgram} %u";
-    mimeTypes = [ "x-scheme-handler/vmware-view" ];
+    name = "horizon-client";
+    desktopName = "Omnissa Horizon Client";
+    icon = "${omnissaHorizonClientFiles}/share/icons/horizon-client.png";
+    exec = "${omnissaFHSUserEnv mainProgram}/bin/${mainProgram} %u";
+    mimeTypes = [
+      "x-scheme-handler/horizon-client"
+      "x-scheme-handler/vmware-view"
+    ];
   };
 
 in
 stdenv.mkDerivation {
-  pname = "vmware-horizon-client";
+  pname = "omnissa-horizon-client";
   inherit version;
 
   dontUnpack = true;
@@ -145,21 +145,21 @@ stdenv.mkDerivation {
   installPhase = ''
     runHook preInstall
     mkdir -p $out/bin
-    ln -s ${vmwareFHSUserEnv "vmware-view"}/bin/vmware-view $out/bin/
-    ln -s ${vmwareFHSUserEnv "vmware-usbarbitrator"}/bin/vmware-usbarbitrator $out/bin/
+    ln -s ${omnissaFHSUserEnv "horizon-client"}/bin/horizon-client $out/bin/
+    ln -s ${omnissaFHSUserEnv "omnissa-usbarbitrator"}/bin/omnissa-usbarbitrator $out/bin/
     runHook postInstall
   '';
 
-  unwrapped = vmwareHorizonClientFiles;
+  unwrapped = omnissaHorizonClientFiles;
 
   passthru.updateScript = ./update.sh;
 
   meta = with lib; {
     inherit mainProgram;
-    description = "Allows you to connect to your VMware Horizon virtual desktop";
-    homepage = "https://www.vmware.com/go/viewclients";
+    description = "Allows you to connect to your Omnissa Horizon virtual desktop";
+    homepage = "https://www.omnissa.com/products/horizon-8/";
     license = licenses.unfree;
     platforms = [ "x86_64-linux" ];
-    maintainers = [ ];
+    maintainers = with maintainers; [ mhutter ];
   };
 }

--- a/pkgs/by-name/om/omnissa-horizon-client/package.nix
+++ b/pkgs/by-name/om/omnissa-horizon-client/package.nix
@@ -97,7 +97,6 @@ let
           libudev0-shim
           libuuid
           libv4l
-          libxml2
           pango
           pcsclite
           pixman
@@ -115,6 +114,22 @@ let
           xorg.libXScrnSaver
           xorg.libXtst
           zlib
+
+          # c.f. https://github.com/NixOS/nixpkgs/pull/418543
+          (libxml2.overrideAttrs (oldAttrs: rec {
+            version = "2.13.8";
+            src = fetchurl {
+              url = "mirror://gnome/sources/libxml2/${lib.versions.majorMinor version}/libxml2-${version}.tar.xz";
+              hash = "sha256-J3KUyzMRmrcbK8gfL0Rem8lDW4k60VuyzSsOhZoO6Eo=";
+            };
+            meta = oldAttrs.meta // {
+              knownVulnerabilities = oldAttrs.meta.knownVulnerabilities or [ ] ++ [
+                "CVE-2025-49794"
+                "CVE-2025-49796"
+                "CVE-2025-6021"
+              ];
+            };
+          }))
 
           (writeTextDir "etc/omnissa/config" configText)
         ];

--- a/pkgs/by-name/om/omnissa-horizon-client/update.sh
+++ b/pkgs/by-name/om/omnissa-horizon-client/update.sh
@@ -2,7 +2,7 @@
 #!nix-shell -p curl -p jq -p common-updater-scripts -i bash
 set -e
 
-entryPointURL='https://customerconnect.omnissa.com/channel/public/api/v1.0/products/getRelatedDLGList?locale=en_US&category=desktop_end_user_computing&product=vmware_horizon_clients&version=horizon_8&dlgType=PRODUCT_BINARY'
+entryPointURL='https://customerconnect.omnissa.com/channel/public/api/v1.0/products/getRelatedDLGList?locale=en_US&category=desktop_end_user_computing&product=omnissa_horizon_clients&version=8&dlgType=PRODUCT_BINARY'
 
 function getTarballMetaUrl {
     curl "$entryPointURL" | jq -r '
@@ -23,5 +23,5 @@ echo "version: $ver"
 echo "tar url: $url"
 echo " sha256: $sum"
 
-cd "$(dirname "$0")/../../../../.."
-update-source-version vmware-horizon-client.unwrapped "$ver" "$sum" "$url"
+cd "$(dirname "$0")/../../../.."
+update-source-version omnissa-horizon-client.unwrapped "$ver" "$sum" "$url"

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -2108,6 +2108,7 @@ mapAliases {
   vistafonts-cht = vista-fonts-cht; # Added 2025-02-03
   vkBasalt = vkbasalt; # Added 2022-11-22
   vkdt-wayland = vkdt; # Added 2024-04-19
+  vmware-horizon-client = throw "'vmware-horizon-client' has been renamed to 'omnissa-horizon-client'"; # Added 2025-04-24
   vocal = throw "'vocal' has been archived upstream. Consider using 'gnome-podcasts' or 'kasts' instead."; # Added 2025-04-12
   void = throw "'void' has been removed due to lack of upstream maintenance"; # Added 2025-01-25
   volnoti = throw "'volnoti' has been removed due to lack of maintenance upstream."; # Added 2024-12-04


### PR DESCRIPTION
This PR renames `vmware-horizon-client` to `omnissa-horizon-client` and updates it to the latest Version.

VMware Horizon was sold to Omnissa in 2024, and has since been rebranded as Omnissa Horizon.

Source: https://www.omnissa.com/insights/introducing-omnissa-the-former-vmware-end-user-computing-business/

Release Notes: https://docs.omnissa.com/bundle/horizon-client-linux-rnV2503/page/HorizonClientLinux-ReleaseNotes.html

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] ~aarch64-linux~
  - [ ] ~x86_64-darwin~
  - [ ] ~aarch64-darwin~
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] ~`sandbox = relaxed`~
  - [ ] ~`sandbox = true`~
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
