### PR TITLE
home-assistant-custom-components: drop skipping of build phase

### DIFF
--- a/pkgs/servers/home-assistant/custom-components/climate_group/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/climate_group/package.nix
@@ -15,8 +15,6 @@ buildHomeAssistantComponent rec {
     hash = "sha256-f/VQUNzRSxmKGNgijaafQ5NbngUUKmcdkafYC3Ol9qM=";
   };
 
-  dontBuild = true;
-
   meta = {
     changelog = "https://github.com/bjrnptrsn/climate_group/blob/${src.rev}/README.md#changelog";
     description = "Group multiple climate devices to a single entity";

--- a/pkgs/servers/home-assistant/custom-components/emporia_vue/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/emporia_vue/package.nix
@@ -25,8 +25,6 @@ buildHomeAssistantComponent rec {
     "pyemvue"
   ];
 
-  dontBuild = true;
-
   meta = with lib; {
     description = "Reads data from the Emporia Vue energy monitor into Home Assistant";
     homepage = "https://github.com/magico13/ha-emporia-vue";

--- a/pkgs/servers/home-assistant/custom-components/epex_spot/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/epex_spot/package.nix
@@ -24,7 +24,6 @@ buildHomeAssistantComponent rec {
   #skip phases without activity
   dontConfigure = true;
   doCheck = false;
-  dontBuild = true;
 
   meta = with lib; {
     changelog = "https://github.com/mampfes/ha_epex_spot/releases/tag/${version}";

--- a/pkgs/servers/home-assistant/custom-components/frigate/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/frigate/package.nix
@@ -29,8 +29,6 @@ buildHomeAssistantComponent rec {
 
   dependencies = [ hass-web-proxy-lib ];
 
-  dontBuild = true;
-
   nativeCheckInputs =
     [
       homeassistant

--- a/pkgs/servers/home-assistant/custom-components/govee-lan/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/govee-lan/package.nix
@@ -28,8 +28,6 @@ buildHomeAssistantComponent {
     })
   ];
 
-  dontBuild = true;
-
   dependencies = [
     govee-led-wez
   ];

--- a/pkgs/servers/home-assistant/custom-components/miele/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/miele/package.nix
@@ -23,9 +23,6 @@ buildHomeAssistantComponent rec {
     pymiele
   ];
 
-  # Makefile only used for bumping the version
-  dontBuild = true;
-
   meta = with lib; {
     changelog = "https://github.com/astrandb/miele/releases/tag/v${version}";
     description = "Modern integration for Miele devices in Home Assistant";

--- a/pkgs/servers/home-assistant/custom-components/moonraker/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/moonraker/package.nix
@@ -23,7 +23,6 @@ buildHomeAssistantComponent rec {
 
   #skip phases with nothing to do
   dontConfigure = true;
-  dontBuild = true;
   doCheck = false;
 
   meta = with lib; {

--- a/pkgs/servers/home-assistant/custom-components/nest_protect/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/nest_protect/package.nix
@@ -15,8 +15,6 @@ buildHomeAssistantComponent rec {
     hash = "sha256-UAVyfI+cHYx0va2P14moyy6BbhNegsdLWtiex5QeFrs=";
   };
 
-  dontBuild = true;
-
   # AttributeError: 'async_generator' object has no attribute 'data'
   doCheck = false;
 

--- a/pkgs/servers/home-assistant/custom-components/prometheus_sensor/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/prometheus_sensor/package.nix
@@ -16,8 +16,6 @@ buildHomeAssistantComponent rec {
     hash = "sha256-+28mMvzNKVInknnDh++YolXR+/b1wsve1VEn4olR7Fs=";
   };
 
-  dontBuild = true;
-
   meta = with lib; {
     changelog = "https://github.com/mweinelt/ha-prometheus-sensor/blob/${version}/CHANGELOG.md";
     description = "Import prometheus query results into Home Assistant";

--- a/pkgs/servers/home-assistant/custom-components/smartir/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/smartir/package.nix
@@ -24,8 +24,6 @@ buildHomeAssistantComponent rec {
     distutils
   ];
 
-  dontBuild = true;
-
   postInstall = ''
     cp -r codes $out/custom_components/smartir/
   '';

--- a/pkgs/servers/home-assistant/custom-components/xiaomi_gateway3/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/xiaomi_gateway3/package.nix
@@ -20,8 +20,6 @@ buildHomeAssistantComponent rec {
 
   dependencies = [ zigpy ];
 
-  dontBuild = true;
-
   passthru.updateScript = nix-update-script { };
 
   meta = with lib; {

--- a/pkgs/servers/home-assistant/custom-components/xiaomi_miot/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/xiaomi_miot/package.nix
@@ -26,8 +26,6 @@ buildHomeAssistantComponent rec {
     python-miio
   ];
 
-  dontBuild = true;
-
   passthru.updateScript = nix-update-script { extraArgs = [ "--version-regex=^v([0-9.]+)$" ]; };
 
   meta = {


### PR DESCRIPTION
Commit 86fff9e3bf8f ("buildHomeAssistantComponent: make build quieter") globally turns the build phase into NOP for custom component packages.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
