### PR TITLE
haskellPackages.accelerate: overrideCabal from GH

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -20,6 +20,30 @@ with haskellLib;
 
 self: super:
 {
+  # Hackage's accelerate is from 2020 and incomptible with our GHC.
+  # The existing derivation also has missing dependencies
+  # compared to the source from github.
+  # https://github.com/AccelerateHS/accelerate/issues/553
+  accelerate =
+    assert super.accelerate.version == "1.3.0.0";
+    lib.pipe super.accelerate [
+      (addBuildDepends [
+        self.double-conversion
+        self.formatting
+        self.microlens
+      ])
+
+      (overrideCabal (drv: {
+        version = "1.3.0.0-unstable-2025-04-25";
+        src = pkgs.fetchFromGitHub {
+          owner = "AccelerateHS";
+          repo = "accelerate";
+          rev = "3f681a5091eddf5a3b97f4cd0de32adc830e1117";
+          sha256 = "sha256-tCcl7wAls+5cBSrqbxfEAJngbV43OJcLJdaC4qqkBxc=";
+        };
+      }))
+    ];
+
   # https://github.com/ivanperez-keera/dunai/issues/427
   dunai = addBuildDepend self.list-transformer (enableCabalFlag "list-transformer" super.dunai);
 

--- a/pkgs/development/haskell-modules/configuration-hackage2nix/broken.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/broken.yaml
@@ -13,7 +13,6 @@ broken-packages:
   - AbortT-transformers # failure in job https://hydra.nixos.org/build/233210345 at 2023-09-02
   - abt # failure in job https://hydra.nixos.org/build/233201301 at 2023-09-02
   - AC-BuildPlatform # failure in job https://hydra.nixos.org/build/233219130 at 2023-09-02
-  - accelerate # failure in job https://hydra.nixos.org/build/233198907 at 2023-09-02
   - accentuateus # failure in job https://hydra.nixos.org/build/233253627 at 2023-09-02
   - access-time # failure in job https://hydra.nixos.org/build/233246051 at 2023-09-02
   - accuerr # failure in job https://hydra.nixos.org/build/233220965 at 2023-09-02


### PR DESCRIPTION
I was trying to get a flake working for https://github.com/simonmar/parconc-examples, and noticed `haskellPackages.accelerate` was marked as broken. It appears that there hasn't been a new version pushed to the `stable` or `1.3.0.0` (latest version) branch in a number of years, but the `master` branch builds on up to GHC 9.10. 

This PR pulls the source from [the repo](https://github.com/AccelerateHS/accelerate) and adds missing dependencies. There's a [changelog](https://github.com/AccelerateHS/accelerate/blob/master/CHANGELOG.md), but it hasn't been updated in 4 years.

I'm not familiar with the library, but as far as I can tell, the build succeeds and the tests pass.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
