### PR TITLE
nixosTests: fix some eval errors and warnings

### DIFF
--- a/nixos/modules/system/activation/lib-test.nix
+++ b/nixos/modules/system/activation/lib-test.nix
@@ -10,13 +10,7 @@ let
 
   runTests = stdenv.mkDerivation {
     name = "tests-activation-lib";
-    src = fileset.toSource {
-      root = ./.;
-      fileset = fileset.unions [
-        ./lib.sh
-        ./test.sh
-      ];
-    };
+    src = ./lib;
     buildPhase = ":";
     doCheck = true;
     postUnpack = ''

--- a/nixos/modules/system/activation/test.nix
+++ b/nixos/modules/system/activation/test.nix
@@ -6,7 +6,7 @@
 }:
 let
   node-forbiddenDependencies-fail = nixos (
-    { ... }:
+    { config, ... }:
     {
       system.forbiddenDependenciesRegexes = [ "-dev$" ];
       environment.etc."dev-dependency" = {
@@ -15,16 +15,22 @@ let
       documentation.enable = false;
       fileSystems."/".device = "ignore-root-device";
       boot.loader.grub.enable = false;
+
+      # Don't do this in an actual config
+      system.stateVersion = config.system.nixos.release;
     }
   );
   node-forbiddenDependencies-succeed = nixos (
-    { ... }:
+    { config, ... }:
     {
       system.forbiddenDependenciesRegexes = [ "-dev$" ];
       system.extraDependencies = [ expect.dev ];
       documentation.enable = false;
       fileSystems."/".device = "ignore-root-device";
       boot.loader.grub.enable = false;
+
+      # Don't do this in an actual config
+      system.stateVersion = config.system.nixos.release;
     }
   );
 in

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -200,7 +200,7 @@ in
   activation-bashless-image = runTest ./activation/bashless-image.nix;
   activation-etc-overlay-immutable = runTest ./activation/etc-overlay-immutable.nix;
   activation-etc-overlay-mutable = runTest ./activation/etc-overlay-mutable.nix;
-  activation-lib = pkgs.callPackage ../modules/system/activation/lib/test.nix { };
+  activation-lib = pkgs.callPackage ../modules/system/activation/lib-test.nix { };
   activation-nix-channel = runTest ./activation/nix-channel.nix;
   activation-nixos-init = runTest ./activation/nixos-init.nix;
   activation-perlless = runTest ./activation/perlless.nix;

--- a/nixos/tests/kanidm-provisioning.nix
+++ b/nixos/tests/kanidm-provisioning.nix
@@ -18,7 +18,7 @@ in
   name = "kanidm-provisioning-${kanidmPackage.version}";
   meta.maintainers = with pkgs.lib.maintainers; [ oddlama ];
 
-  _module.args.kanidmPackage = pkgs.lib.mkDefault pkgs.kanidmWithSecretProvisioning;
+  _module.args.kanidmPackage = pkgs.lib.mkDefault pkgs.kanidmWithSecretProvisioning_1_7;
 
   nodes.provision =
     { pkgs, lib, ... }:

--- a/nixos/tests/kanidm.nix
+++ b/nixos/tests/kanidm.nix
@@ -21,7 +21,7 @@ in
     oddlama
   ];
 
-  _module.args.kanidmPackage = pkgs.lib.mkDefault pkgs.kanidm;
+  _module.args.kanidmPackage = pkgs.lib.mkDefault pkgs.kanidm_1_7;
 
   nodes.server =
     { pkgs, ... }:

--- a/nixos/tests/vm-variant.nix
+++ b/nixos/tests/vm-variant.nix
@@ -6,12 +6,13 @@ let
   evalConfig = import ../lib/eval-config.nix;
 
   nixos = evalConfig {
+    system = null;
     modules = [
       {
         system.stateVersion = "25.05";
         fileSystems."/".device = "/dev/null";
         boot.loader.grub.device = "nodev";
-        nixpkgs.hostPlatform = pkgs.system;
+        nixpkgs.hostPlatform = pkgs.stdenv.hostPlatform.system;
         virtualisation.vmVariant.networking.hostName = "vm";
         virtualisation.vmVariantWithBootLoader.networking.hostName = "vm-w-bl";
       }


### PR DESCRIPTION
This makes it so that nixosTests no longer fails eval.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
