### PR TITLE
dvr-scan: init at 1.8.2

### DIFF
--- a/pkgs/by-name/dv/dvr-scan/package.nix
+++ b/pkgs/by-name/dv/dvr-scan/package.nix
@@ -1,0 +1,70 @@
+{
+  lib,
+  python3Packages,
+  fetchFromGitHub,
+  writableTmpDirAsHomeHook,
+}:
+python3Packages.buildPythonApplication rec {
+  pname = "dvr-scan";
+  version = "1.8.2";
+  pyproject = true;
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "Breakthrough";
+    repo = "DVR-Scan";
+    tag = "v${version}-release";
+    hash = "sha256-+1liOZu8360aQlNwWaJXJQS/0POT9bTcIUkDg/v4lxU=";
+  };
+
+  build-system = with python3Packages; [
+    setuptools
+  ];
+
+  dependencies = with python3Packages; [
+    numpy
+    opencv-contrib-python
+    pillow
+    platformdirs
+    scenedetect
+    screeninfo
+    tqdm
+
+    # GUI application
+    tkinter
+  ];
+
+  nativeBuildInputs = with python3Packages; [
+    pytestCheckHook
+    writableTmpDirAsHomeHook
+  ];
+
+  pythonRelaxDeps = [
+    "opencv-contrib-python"
+  ];
+
+  disabledTests = [
+    # frame number mismatches with opencv 4.13+ (upstream issue #257)
+    "test_pre_event_shift_with_frame_skip"
+    "test_start_end_time"
+    "test_start_duration"
+    "test_default"
+    "test_concatenate"
+    "test_scan_only"
+    "test_quiet_mode"
+    "test_config_file"
+  ];
+
+  meta = {
+    description = "Find and extract motion events in videos";
+    longDescription = ''
+      Command-line application that automatically detects motion events in video files (e.g. security camera footage). DVR-Scan looks for areas in footage containing motion, and saves each event to a separate video clip. DVR-Scan is free and open-source software, and works on Windows, Linux, and Mac.
+    '';
+    homepage = "https://www.dvr-scan.com";
+    changelog = "https://github.com/Breakthrough/DVR-Scan/releases/tag/v${version}-release";
+    mainProgram = "dvr-scan";
+    license = lib.licenses.bsd2;
+    maintainers = with lib.maintainers; [ DataHearth ];
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Required PR:
- [x] #401450

Note for testing: this package provides a CLI binary and a GUI binary. GUI is based on `tkinter` which is why it is added as dependency. 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
