### PR TITLE
tests/openssh: write a test for CVE-2025-32728

### DIFF
--- a/nixos/tests/openssh.nix
+++ b/nixos/tests/openssh.nix
@@ -35,6 +35,38 @@ import ./make-test-python.nix (
           ];
         };
 
+      server-x11 =
+        { ... }:
+
+        {
+          environment.systemPackages = [ pkgs.xorg.xauth ];
+          services.openssh = {
+            enable = true;
+            settings.X11Forwarding = true;
+          };
+          users.users.root.openssh.authorizedKeys.keys = [
+            snakeOilPublicKey
+          ];
+        };
+
+      server-x11-disable =
+        { ... }:
+
+        {
+          environment.systemPackages = [ pkgs.xorg.xauth ];
+          services.openssh = {
+            enable = true;
+            settings = {
+              X11Forwarding = true;
+              # CVE-2025-32728: the following line is ineffectual
+              DisableForwarding = true;
+            };
+          };
+          users.users.root.openssh.authorizedKeys.keys = [
+            snakeOilPublicKey
+          ];
+        };
+
       server-allowed-users =
         { ... }:
 
@@ -240,6 +272,8 @@ import ./make-test-python.nix (
       start_all()
 
       server.wait_for_unit("sshd", timeout=30)
+      server_x11.wait_for_unit("sshd", timeout=30)
+      server_x11_disable.wait_for_unit("sshd", timeout=30)
       server_allowed_users.wait_for_unit("sshd", timeout=30)
       server_localhost_only.wait_for_unit("sshd", timeout=30)
       server_match_rule.wait_for_unit("sshd", timeout=30)
@@ -304,6 +338,16 @@ import ./make-test-python.nix (
           )
           client.succeed(
               "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i privkey.snakeoil server-lazy true",
+              timeout=30
+          )
+
+      with subtest("x11-forwarding"):
+          client.succeed(
+              "[ \"$(ssh -Y -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i privkey.snakeoil server-x11 'xauth list' | tee /dev/stderr | wc -l)\" -eq 1 ]",
+              timeout=30
+          )
+          client.succeed(
+              "[ \"$(ssh -Y -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i privkey.snakeoil server-x11-disable 'xauth list' | tee /dev/stderr | wc -l)\" -eq 0 ]",
               timeout=30
           )
 


### PR DESCRIPTION
PR #401506 fixed CVE-2025-32728. We can write a test for it, because NixOS is awesome that way. So, check X11Forwarding and DisableForwarding in the test suite.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
