### PR TITLE
movim: 0.30 → 0.30.1; {movim,nixos.movim}: mysql → mariadb

### DIFF
--- a/nixos/modules/services/web-apps/movim.nix
+++ b/nixos/modules/services/web-apps/movim.nix
@@ -58,7 +58,7 @@ let
         // lib.optionalAttrs (cfg.database.type == "postgresql") {
           withPostgreSQL = true;
         }
-        // lib.optionalAttrs (cfg.database.type == "mysql") {
+        // lib.optionalAttrs (cfg.database.type == "mariadb") {
           withMySQL = true;
         }
       );
@@ -168,7 +168,7 @@ let
   dbService =
     {
       "postgresql" = "postgresql.service";
-      "mysql" = "mysql.service";
+      "mariadb" = "mysql.service";
     }
     .${cfg.database.type};
 
@@ -475,10 +475,10 @@ in
       database = {
         type = mkOption {
           type = types.enum [
-            "mysql"
+            "mariadb"
             "postgresql"
           ];
-          example = "mysql";
+          example = "mariadb";
           default = "postgresql";
           description = "Database engine to use.";
         };
@@ -621,7 +621,7 @@ in
             DB_DRIVER =
               {
                 "postgresql" = "pgsql";
-                "mysql" = "mysql";
+                "mariadb" = "mysql";
               }
               .${cfg.database.type};
             DB_HOST = "localhost";
@@ -791,7 +791,7 @@ in
         }
       );
 
-      mysql = mkIf (cfg.database.createLocally && cfg.database.type == "mysql") {
+      mysql = mkIf (cfg.database.createLocally && cfg.database.type == "mariadb") {
         enable = mkDefault true;
         package = mkDefault pkgs.mariadb;
         ensureDatabases = [ cfg.database.name ];

--- a/pkgs/by-name/mo/movim/package.nix
+++ b/pkgs/by-name/mo/movim/package.nix
@@ -44,13 +44,13 @@ let
 in
 php.buildComposerProject2 (finalAttrs: {
   pname = "movim";
-  version = "0.30";
+  version = "0.30.1";
 
   src = fetchFromGitHub {
     owner = "movim";
     repo = "movim";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-rW751UhDBhakOrAT4BOiRDPpGldf1EwNZY8iavXlpLk=";
+    hash = "sha256-MjP1rLyWJWrUAHrOKAwGN3A0wIq4iPaXlaUbtPs3F6U=";
   };
 
   php = php.buildEnv (
@@ -88,7 +88,7 @@ php.buildComposerProject2 (finalAttrs: {
     ++ lib.optional minify.style.enable lightningcss
     ++ lib.optional minify.svg.enable scour;
 
-  vendorHash = "sha256-NuX6CX2QXea8BcL0nzFOdxIBs36igD8lvixna+vsviM=";
+  vendorHash = "sha256-7jb4/UgnMcXtLCihwk4rr0HLw99FgiYeYJVATGxM/D4=";
 
   postPatch = ''
     # Our modules are already wrapped, removes missing *.so warnings;

--- a/pkgs/by-name/mo/movim/package.nix
+++ b/pkgs/by-name/mo/movim/package.nix
@@ -6,7 +6,7 @@
   php,
   phpCfg ? null,
   withPostgreSQL ? true, # “strongly recommended” according to docs
-  withMySQL ? false,
+  withMariaDB ? false,
   minifyStaticFiles ? false, # default files are often not minified
   esbuild,
   lightningcss,
@@ -71,7 +71,7 @@ php.buildComposerProject2 (finalAttrs: {
           all.pdo_pgsql
           all.pgsql
         ]
-        ++ lib.optionals withMySQL [
+        ++ lib.optionals withMariaDB [
           all.mysqli
           all.mysqlnd
           all.pdo_mysql


### PR DESCRIPTION
https://mov.im/community/pubsub.movim.eu/Movim/here-comes-the-new-movim-release-encke-0-30-1-ckTLY4

Change naming in Nix to reflect that MySQL is no longer supported—even if a lot of the tooling behind the scenes still uses the MySQL name (such as `mysqli` or `mysql.service`).

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

[^1]

[^1]: Please consider [giving up MS GitHub](https://sfconservancy.org/GiveUpGitHub/) or offering a non-proprietary, non-US-corporate-controlled mirror for this free software project. I wish to delete this Microsoft account in the future, but I need more projects like this to support alternative methods to send patches & contribute.
