### PR TITLE
mapcache: fix darwin build

### DIFF
--- a/pkgs/by-name/ma/mapcache/package.nix
+++ b/pkgs/by-name/ma/mapcache/package.nix
@@ -12,6 +12,7 @@
   fcgi,
   gdal,
   geos,
+  gfortran,
   libgeotiff,
   libjpeg,
   libpng,
@@ -23,21 +24,26 @@
   zlib,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "mapcache";
   version = "1.14.1";
 
   src = fetchFromGitHub {
     owner = "MapServer";
     repo = "mapcache";
-    rev = "rel-${lib.replaceStrings [ "." ] [ "-" ] version}";
+    tag = "rel-${lib.replaceStrings [ "." ] [ "-" ] finalAttrs.version}";
     hash = "sha256-AwdZdOEq9SZ5VzuBllg4U1gdVxZ9IVdqiDrn3QuRdCk=";
   };
 
-  nativeBuildInputs = [
-    cmake
-    pkg-config
-  ];
+  nativeBuildInputs =
+    [
+      cmake
+      pkg-config
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [
+      # work around for `ld: file not found: @rpath/libquadmath.0.dylib`
+      gfortran.cc
+    ];
 
   buildInputs = [
     apacheHttpd
@@ -70,6 +76,12 @@ stdenv.mkDerivation rec {
 
   env.NIX_CFLAGS_COMPILE = lib.optionalString stdenv.hostPlatform.isDarwin "-std=c99";
 
+  prePatch = lib.optionalString stdenv.hostPlatform.isDarwin ''
+    substituteInPlace CMakeLists.txt \
+      --replace-fail "include_directories(\''${TIFF_INCLUDE_DIR})" "" \
+      --replace-fail "target_link_libraries(mapcache \''${TIFF_LIBRARY})" "target_link_libraries(mapcache TIFF::TIFF)"
+  '';
+
   meta = {
     description = "Server that implements tile caching to speed up access to WMS layers";
     homepage = "https://mapserver.org/mapcache/";
@@ -78,4 +90,4 @@ stdenv.mkDerivation rec {
     maintainers = lib.teams.geospatial.members;
     platforms = lib.platforms.unix;
   };
-}
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

`mapcache` build failed on darwin for a while caused by:

1. `libtiff` linking issue

```
[ 87%] Linking C shared library libmapcache.dylib
Undefined symbols for architecture arm64:
  "_TIFFErrorExt", referenced from:
      __tiffSeekProc in cache_tiff.c.o
  "_TIFFGetField", referenced from:
      __mapcache_cache_tiff_get in cache_tiff.c.o
      __mapcache_cache_tiff_has_tile in cache_tiff.c.o
  "_TIFFReadDirectory", referenced from:
      __mapcache_cache_tiff_get in cache_tiff.c.o
      __mapcache_cache_tiff_has_tile in cache_tiff.c.o
  "_TIFFSetErrorHandler", referenced from:
      _mapcache_cache_tiff_create in cache_tiff.c.o
  "_TIFFSetWarningHandler", referenced from:
      _mapcache_cache_tiff_create in cache_tiff.c.o
ld: symbol(s) not found for architecture arm64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
make[2]: *** [CMakeFiles/mapcache.dir/build.make:1008: libmapcache.1.14.1.dylib] Error 1
make[1]: *** [CMakeFiles/Makefile2:201: CMakeFiles/mapcache.dir/all] Error 2
make: *** [Makefile:136: all] Error 2
```

2. `libquadmath` linking issue

```
[100%] Built target mapcache_detail
ld: file not found: @rpath/libquadmath.0.dylib for architecture arm64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

This PR fixes the above issues.

cc: @NixOS/geospatial 

close #401474

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [x] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
