### PR TITLE
linux_xanmod, linux_xanmod_latest: add update script

### DIFF
--- a/pkgs/os-specific/linux/kernel/update-xanmod.sh
+++ b/pkgs/os-specific/linux/kernel/update-xanmod.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p bash nix-prefetch curl jq gawk gnused nixfmt-rfc-style
+
+set -euo pipefail
+
+SCRIPT_DIR="$(dirname "${BASH_SOURCE[0]}")"
+FILE_PATH="$SCRIPT_DIR/xanmod-kernels.nix"
+
+get_old_version() {
+    local file_path="$1"
+    local variant="$2"
+
+    grep -A 2 "$variant = {" "$file_path" | grep "version =" | cut -d '"' -f 2
+}
+
+VARIANT="${1:-lts}"
+OLD_VERSION=${UPDATE_NIX_OLD_VERSION:-$(get_old_version "$FILE_PATH" "$VARIANT")}
+
+RELEASES=$(curl --silent https://gitlab.com/api/v4/projects/xanmod%2Flinux/releases)
+
+# list of URLs. latest first, oldest last
+RELEASE_URLS=$(echo "$RELEASES" | jq '.[].assets.links.[0].name')
+
+while IFS= read -r url; do
+    # Get variant, version and suffix from url fields:
+    #                 8         9       NF
+    #                 |         |       |
+    # https://.../<variant>/<version>-<suffix>
+    release_variant=$(echo "$url" | awk -F'[/-]' '{print $8}')
+    release_version=$(echo "$url" | awk -F'[/-]' '{print $9}')
+
+    # either xanmod1 or xanmod2
+    suffix=$(echo "$url" | awk -F'[/-]' '{print $NF}')
+
+    if [[ "$release_variant" == "$VARIANT" ]]; then
+        if [[ "$release_version" == "$OLD_VERSION" ]]; then
+            echo "Xanmod $VARIANT is up-to-date: ${OLD_VERSION}"
+            exit 0
+        else
+            NEW_VERSION="$release_version"
+            SUFFIX="$suffix"
+            break
+        fi
+    fi
+done < <(echo "$RELEASE_URLS" | jq -r)
+
+echo "Updating Xanmod \"$VARIANT\" from $OLD_VERSION to $NEW_VERSION ($SUFFIX)"
+
+URL="https://gitlab.com/api/v4/projects/xanmod%2Flinux/repository/archive.tar.gz?sha=$NEW_VERSION-$SUFFIX"
+HASH="$(nix-prefetch fetchzip --quiet --url "$URL")"
+
+update_variant() {
+    local file_path="$1"
+    local variant="$2"
+    local new_version="$3"
+    local new_hash="$4"
+    local suffix="$5"
+
+    # ${variant} = {      <- range start
+    #   version = ...
+    #   hash = ...
+    #   suffix = ...
+    # };                  <- range end
+    range_start="^\s*$variant = {"
+    range_end="^\s*};"
+
+    # - Update the version and hash using sed range addresses
+    # - Remove suffix line, if it exists
+    sed -i -e "/$range_start/,/$range_end/ {
+        s|^\s*version = \".*\";|      version = \"$new_version\";|;
+        s|^\s*hash = \".*\";|      hash = \"$new_hash\";|;
+         /^\s*suffix = /d
+    }" "$file_path"
+
+    # Add suffix, if it's different than xanmod1 (the default)
+    if [[ "$suffix" != "xanmod1" ]]; then
+        sed -i -e "/$range_start/,/$range_end/ {
+            s|$range_end|      suffix = \"$suffix\";\n    };|;
+        }" "$file_path"
+    fi
+
+    # Apply proper formatting
+    nixfmt "$file_path"
+}
+
+update_variant "$FILE_PATH" "$VARIANT" "$NEW_VERSION" "$HASH" "$SUFFIX"

--- a/pkgs/os-specific/linux/kernel/xanmod-kernels.nix
+++ b/pkgs/os-specific/linux/kernel/xanmod-kernels.nix
@@ -13,10 +13,12 @@ let
   # NOTE: When updating these, please also take a look at the changes done to
   # kernel config in the xanmod version commit
   variants = {
+    # ./update-xanmod.sh lts
     lts = {
       version = "6.12.40";
       hash = "sha256-L8wL47kD+lrnJsrp0B1MZ2Lg8zs+m1vQ24gPGuvxIA0=";
     };
+    # ./update-xanmod.sh main
     main = {
       version = "6.15.8";
       hash = "sha256-P4DpTS0RhvsgBrNDsZMiA1NvCQucuPmJ4GDyF9mZ7ZU=";
@@ -69,6 +71,11 @@ let
           RCU_BOOST_DELAY = freeform "0";
           RCU_EXP_KTHREAD = yes;
         };
+
+        extraPassthru.updateScript = [
+          ./update-xanmod.sh
+          variant
+        ];
 
         extraMeta = {
           branch = lib.versions.majorMinor version;


### PR DESCRIPTION
To test, run:

```shellSession
nix-shell maintainers/scripts/update.nix --argstr package linux_xanmod
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
