### PR TITLE
systemd: Add functions.escapeSystemdExecArg[s]

### DIFF
--- a/nixos/lib/utils.nix
+++ b/nixos/lib/utils.nix
@@ -119,31 +119,7 @@ let
         )
       );
 
-    # Quotes an argument for use in Exec* service lines.
-    # systemd accepts "-quoted strings with escape sequences, toJSON produces
-    # a subset of these.
-    # Additionally we escape % to disallow expansion of % specifiers. Any lone ;
-    # in the input will be turned it ";" and thus lose its special meaning.
-    # Every $ is escaped to $$, this makes it unnecessary to disable environment
-    # substitution for the directive.
-    escapeSystemdExecArg =
-      arg:
-      let
-        s =
-          if isPath arg then
-            "${arg}"
-          else if isString arg then
-            arg
-          else if isInt arg || isFloat arg || isDerivation arg then
-            toString arg
-          else
-            throw "escapeSystemdExecArg only allows strings, paths, numbers and derivations";
-      in
-      replaceStrings [ "%" "$" ] [ "%%" "$$" ] (toJSON s);
-
-    # Quotes a list of arguments into a single string for use in a Exec*
-    # line.
-    escapeSystemdExecArgs = concatMapStringsSep " " escapeSystemdExecArg;
+    inherit (config.systemd.package.functions) escapeSystemdExecArg escapeSystemdExecArgs;
 
     # Returns a system path for a given shell package
     toShellPath =

--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -876,6 +876,11 @@ stdenv.mkDerivation (finalAttrs: {
     # needed - and therefore `interfaceVersion` should be incremented.
     interfaceVersion = 2;
 
+    functions = import ./functions/default.nix {
+      inherit lib;
+      systemd = finalAttrs.finalPackage;
+    };
+
     inherit
       withBootloader
       withCryptsetup
@@ -1001,6 +1006,12 @@ stdenv.mkDerivation (finalAttrs: {
           pkgsCross.${systemString}.systemd;
 
         pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+
+        functions = import ./functions/test.nix {
+          inherit lib;
+          systemd = finalAttrs.finalPackage;
+          ok = buildPackages.emptyFile;
+        };
       };
   };
 

--- a/pkgs/os-specific/linux/systemd/functions/default.nix
+++ b/pkgs/os-specific/linux/systemd/functions/default.nix
@@ -1,0 +1,55 @@
+/**
+  Build the `systemd.functions` library (where `systemd` is the package)
+*/
+{ lib, systemd }:
+let
+  inherit (lib)
+    concatMapStringsSep
+    isDerivation
+    isFloat
+    isInt
+    isPath
+    isString
+    replaceStrings
+    ;
+  inherit (builtins)
+    toJSON
+    ;
+
+  /**
+    Quotes an argument for use in `Exec*` service lines.
+    Additionally we escape `%` to disallow expansion of `%` specifiers. Any lone `;`
+    in the input will be turned into `";"` and thus lose its special meaning.
+    Every `$` is escaped to `$$`, this makes it unnecessary to disable environment
+    substitution for the directive.
+  */
+  escapeSystemdExecArg =
+    arg:
+    let
+      s =
+        if isPath arg then
+          "${arg}"
+        else if isString arg then
+          arg
+        else if isInt arg || isFloat arg || isDerivation arg then
+          toString arg
+        else
+          throw "escapeSystemdExecArg only allows strings, paths, numbers and derivations";
+    in
+    # systemd accepts "-quoted strings with escape sequences, toJSON produces
+    # a subset of these.
+    replaceStrings [ "%" "$" ] [ "%%" "$$" ] (toJSON s);
+
+  /**
+    Quotes a list of arguments into a single string for use in a Exec* line.
+  */
+  escapeSystemdExecArgs = concatMapStringsSep " " escapeSystemdExecArg;
+in
+# Instead of requiring v2, we can make this library conditional on the version as needed.
+assert systemd.interfaceVersion == 2;
+{
+  inherit
+    escapeSystemdExecArg
+    escapeSystemdExecArgs
+    ;
+}

--- a/pkgs/os-specific/linux/systemd/functions/test.nix
+++ b/pkgs/os-specific/linux/systemd/functions/test.nix
@@ -1,0 +1,23 @@
+{
+  lib,
+  systemd,
+  ok,
+}:
+
+# This function is also tested in nixosTests.systemd-escaping
+assert systemd.functions.escapeSystemdExecArg "hi" == ''"hi"'';
+assert systemd.functions.escapeSystemdExecArg "hi there" == ''"hi there"'';
+assert systemd.functions.escapeSystemdExecArg ''"hi there"'' == ''"\"hi there\""'';
+assert systemd.functions.escapeSystemdExecArg ''"%$'' == ''"\"%%$$"'';
+assert
+  systemd.functions.escapeSystemdExecArgs [
+    "hi"
+    "there"
+  ] == ''"hi" "there"'';
+assert
+  systemd.functions.escapeSystemdExecArgs [
+    "hi"
+    "%"
+    "there"
+  ] == ''"hi" "%%" "there"'';
+ok


### PR DESCRIPTION
This makes the functions available outside the NixOS `utils` context.

I'd like to have something like this for [modular services](https://github.com/NixOS/nixpkgs/pull/372170#discussion_r1941876900) in order to avoid creating an unnecessarily broad dependency on NixOS specifics.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
