### PR TITLE
urbit: 3.1 -> 3.2 (and fix the update script)

### DIFF
--- a/pkgs/by-name/ur/urbit/package.nix
+++ b/pkgs/by-name/ur/urbit/package.nix
@@ -11,16 +11,16 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "urbit";
-  version = "3.1";
+  version = "3.2";
 
   src = fetchzip {
     url = "https://github.com/urbit/vere/releases/download/vere-v${version}/${platform}.tgz";
     sha256 =
       {
-        x86_64-linux = "sha256-51Zgv9QANQVMk/dc7/heYmCNfeu4k7mrYNke1/oz/94=";
-        aarch64-linux = "sha256-Tdn/ve9iCjsY/b39TZ7ErHV14mIAHdtmycgUPIzRihQ=";
-        x86_64-darwin = "sha256-y/FQIVcEn6dLWXPztC34+7+5eDMO7Xcx25D2+0p7Mxk=";
-        aarch64-darwin = "sha256-YJGRZlpTdm1x4P+GnZiKC1411tcEX+Jdnm+iyxUlsU0=";
+        x86_64-linux = "sha256-T5d9C2JSmN5y1PSpHLofTKOr32VxLDwjYH9UD0+wAXM=";
+        aarch64-linux = "sha256-wUVqz3VPJ/ZEkS+6MJbbSqqS9vhHPGxTdAty5mIyKgA=";
+        x86_64-darwin = "sha256-uPBTkOCZCpG3mb0D6S710vxaGRAaly5d3UHL1j/+uzo=";
+        aarch64-darwin = "sha256-wfgk3+Z16FThXJdD34vxitXYx/4TdwqboMlXs5IAFDs=";
       }
       .${stdenv.hostPlatform.system} or (throw "unsupported system ${stdenv.hostPlatform.system}");
   };

--- a/pkgs/by-name/ur/urbit/update-bin.sh
+++ b/pkgs/by-name/ur/urbit/update-bin.sh
@@ -4,7 +4,7 @@
 set -euo pipefail
 
 ROOT="$(dirname "$(readlink -f "$0")")"
-NIX_DRV="$ROOT/default.nix"
+NIX_DRV="$ROOT/package.nix"
 if [ ! -f "$NIX_DRV" ]; then
   echo "ERROR: cannot find urbit in $ROOT"
   exit 1


### PR DESCRIPTION
[r-ryantm](https://github.com/NixOS/nixpkgs/commits?author=r-ryantm) should be able to pick future upgrades back up.

https://github.com/urbit/vere/releases/tag/vere-v3.2
