### PR TITLE
ungoogled-chromium: 135.0.7049.95-1 -> 135.0.7049.114-1

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/info.json
+++ b/pkgs/applications/networking/browsers/chromium/info.json
@@ -787,7 +787,7 @@
     }
   },
   "ungoogled-chromium": {
-    "version": "135.0.7049.95",
+    "version": "135.0.7049.114",
     "deps": {
       "depot_tools": {
         "rev": "85ec2718b5a29990c7eb67778348c9f76a00f392",
@@ -798,16 +798,16 @@
         "hash": "sha256-8NynNvLNCHxy8EYmsnPovKhXu9DcDcYBhg4A6d2QIfY="
       },
       "ungoogled-patches": {
-        "rev": "135.0.7049.95-1",
-        "hash": "sha256-kLLtJti5GIF9TT0cH8zvsxywJzD22X8u2bB/tqENSjo="
+        "rev": "135.0.7049.114-1",
+        "hash": "sha256-frUL7b+4CyrzBa5T1HzFseWHwFa2MPgkpkrFeASWyLA="
       },
       "npmHash": "sha256-wNrZaugdKJCyV1WchkKXzr/I1OW1AtjiC2p7qTZZOqU="
     },
     "DEPS": {
       "src": {
         "url": "https://chromium.googlesource.com/chromium/src.git",
-        "rev": "de2eb485a1951079e63bdb57ce25544d2dc79c15",
-        "hash": "sha256-6ydyJWsDawt0bfYAFHotTB9ujmIYsqUUpNwB6q6RNQE=",
+        "rev": "63fd8a7d9d09e41ba37b84386c85d5f249f848f7",
+        "hash": "sha256-U6OJHocA6vI36QCU8UITUsVlentm210CwdThCwlDw5E=",
         "recompress": true
       },
       "src/third_party/clang-format/script": {


### PR DESCRIPTION
Same underlying changes as #401195

https://chromereleases.googleblog.com/2025/04/stable-channel-update-for-desktop_22.html

This update includes 1 security fix.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
