### PR TITLE
 [Backport release-24.11] home-assistant-custom-components.benqprojector: init at 0.1.3

### DIFF
--- a/nixos/modules/services/home-automation/home-assistant.nix
+++ b/nixos/modules/services/home-automation/home-assistant.nix
@@ -67,7 +67,11 @@ let
     hasAttrByPath (splitString "." component) cfg.config
     || useComponentPlatform component
     || useExplicitComponent component
-    || builtins.elem component (cfg.extraComponents ++ cfg.defaultIntegrations);
+    || builtins.elem component (
+      cfg.extraComponents
+      ++ cfg.defaultIntegrations
+      ++ map (builtins.getAttr "domain") cfg.customComponents
+    );
 
   # Final list of components passed into the package to include required dependencies
   extraComponents = filter useComponent availableComponents;

--- a/nixos/modules/services/home-automation/home-assistant.nix
+++ b/nixos/modules/services/home-automation/home-assistant.nix
@@ -718,6 +718,7 @@ in
 
             # Custom components, maintained manually.
             "amshan"
+            "benqprojector"
           ];
         in
         {

--- a/pkgs/development/python-modules/benqprojector/default.nix
+++ b/pkgs/development/python-modules/benqprojector/default.nix
@@ -1,0 +1,45 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  hatchling,
+  hatch-vcs,
+  pyserial,
+  pyserial-asyncio-fast,
+}:
+
+buildPythonPackage rec {
+  pname = "benqprojector";
+  version = "0.1.6";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "rrooggiieerr";
+    repo = "benqprojector.py";
+    tag = version;
+    hash = "sha256-Ys2C44kr5gd6tXO51OFRx4YVKVRGLfFPCYDFGt+gN0c=";
+  };
+
+  build-system = [
+    hatchling
+    hatch-vcs
+  ];
+
+  dependencies = [
+    pyserial
+    pyserial-asyncio-fast
+  ];
+
+  # Test cases require an actual serial/telnet connection to a projector
+  doCheck = false;
+
+  pythonImportsCheck = [ "benqprojector" ];
+
+  meta = rec {
+    description = "Python library to control BenQ projectors";
+    homepage = "https://github.com/rrooggiieerr/benqprojector.py";
+    changelog = "${homepage}/releases/tag/${version}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ sephalon ];
+  };
+}

--- a/pkgs/servers/home-assistant/custom-components/benqprojector/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/benqprojector/package.nix
@@ -1,0 +1,29 @@
+{
+  lib,
+  buildHomeAssistantComponent,
+  fetchFromGitHub,
+  benqprojector,
+}:
+
+buildHomeAssistantComponent rec {
+  owner = "rrooggiieerr";
+  domain = "benqprojector";
+  version = "0.1.3";
+
+  src = fetchFromGitHub {
+    inherit owner;
+    repo = "homeassistant-benqprojector";
+    tag = version;
+    hash = "sha256-iAFmXL10QqudECsS9u9w7KBETzu9aWCg1EBbFR1ff+o=";
+  };
+
+  dependencies = [ benqprojector ];
+
+  meta = rec {
+    description = "Home Assistant integration for BenQ projectors";
+    homepage = "https://github.com/rrooggiieerr/homeassistant-benqprojector";
+    changelog = "${homepage}/releases/tag/${version}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ sephalon ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1659,6 +1659,8 @@ self: super: with self; {
 
   beniget = callPackage ../development/python-modules/beniget { };
 
+  benqprojector = callPackage ../development/python-modules/benqprojector { };
+
   bentoml = callPackage ../development/python-modules/bentoml { };
 
   berkeleydb = callPackage ../development/python-modules/berkeleydb { };


### PR DESCRIPTION
Bot-based backport to `release-24.11`, triggered by a label in #400094.

* [ ]  Before merging, ensure that this backport is [acceptable for the release](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#changes-acceptable-for-releases).
  * Even as a non-commiter, if you find that it is not acceptable, leave a comment.