### PR TITLE
gz-utils: correct dependencies, run tests, build docs

### DIFF
--- a/pkgs/by-name/gz/gz-utils/package.nix
+++ b/pkgs/by-name/gz/gz-utils/package.nix
@@ -10,6 +10,12 @@
   # buildInputs
   cli11,
   spdlog,
+
+  # nativeCheckInputs
+  python3,
+
+  # checkInputs
+  gtest,
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "gz-utils";
@@ -21,6 +27,14 @@ stdenv.mkDerivation (finalAttrs: {
     tag = "gz-utils${lib.versions.major finalAttrs.version}_${finalAttrs.version}";
     hash = "sha256-fYzysdB608jfMb/EbqiGD4hXmPxcaVTUrt9Wx0dBlto=";
   };
+
+  # Remove vendored gtest, use nixpkgs' version instead.
+  postPatch = ''
+    rm -r test/gtest_vendor
+
+    substituteInPlace test/CMakeLists.txt --replace-fail \
+      "add_subdirectory(gtest_vendor)" "# add_subdirectory(gtest_vendor)"
+  '';
 
   nativeBuildInputs = [
     cmake
@@ -38,6 +52,12 @@ stdenv.mkDerivation (finalAttrs: {
   cmakeFlags = [
     (lib.cmakeBool "GZ_UTILS_VENDOR_CLI11" false)
   ];
+
+  nativeCheckInputs = [ python3 ];
+
+  checkInputs = [ gtest ];
+
+  doCheck = true;
 
   meta = {
     description = "General purpose utility classes and functions for the Gazebo libraries";

--- a/pkgs/by-name/gz/gz-utils/package.nix
+++ b/pkgs/by-name/gz/gz-utils/package.nix
@@ -2,11 +2,14 @@
   lib,
   stdenv,
   fetchFromGitHub,
+
+  # nativeBuildInputs
   cmake,
   gz-cmake,
+
+  # buildInputs
   spdlog,
 }:
-
 stdenv.mkDerivation (finalAttrs: {
   pname = "gz-utils";
   version = "3.1.1";
@@ -21,8 +24,9 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [
     cmake
     gz-cmake
-    spdlog
   ];
+
+  buildInputs = [ spdlog ];
 
   meta = {
     description = "General purpose utility classes and functions for the Gazebo libraries";

--- a/pkgs/by-name/gz/gz-utils/package.nix
+++ b/pkgs/by-name/gz/gz-utils/package.nix
@@ -8,6 +8,7 @@
   gz-cmake,
 
   # buildInputs
+  cli11,
   spdlog,
 }:
 stdenv.mkDerivation (finalAttrs: {
@@ -26,7 +27,17 @@ stdenv.mkDerivation (finalAttrs: {
     gz-cmake
   ];
 
-  buildInputs = [ spdlog ];
+  buildInputs = [
+    cli11
+    spdlog
+  ];
+
+  # Indicate to CMake that we are not using the vendored CLI11 library.
+  # The integration tests make (unintentional?) unconditional usage of the vendored
+  # CLI11 library, so we can't remove that.
+  cmakeFlags = [
+    (lib.cmakeBool "GZ_UTILS_VENDOR_CLI11" false)
+  ];
 
   meta = {
     description = "General purpose utility classes and functions for the Gazebo libraries";

--- a/pkgs/by-name/gz/gz-utils/package.nix
+++ b/pkgs/by-name/gz/gz-utils/package.nix
@@ -6,6 +6,8 @@
   # nativeBuildInputs
   cmake,
   gz-cmake,
+  doxygen,
+  graphviz,
 
   # buildInputs
   cli11,
@@ -28,6 +30,11 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-fYzysdB608jfMb/EbqiGD4hXmPxcaVTUrt9Wx0dBlto=";
   };
 
+  outputs = [
+    "doc"
+    "out"
+  ];
+
   # Remove vendored gtest, use nixpkgs' version instead.
   postPatch = ''
     rm -r test/gtest_vendor
@@ -39,6 +46,8 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [
     cmake
     gz-cmake
+    doxygen
+    graphviz
   ];
 
   buildInputs = [
@@ -52,6 +61,11 @@ stdenv.mkDerivation (finalAttrs: {
   cmakeFlags = [
     (lib.cmakeBool "GZ_UTILS_VENDOR_CLI11" false)
   ];
+
+  postBuild = ''
+    make doc
+    cp -r doxygen/html $doc
+  '';
 
   nativeCheckInputs = [ python3 ];
 


### PR DESCRIPTION
Incorporates the feedback that was part of #401219 but was missed.
Additionally runs tests and build docs.

Furthermore, I am of the belief that `gz-cmake` should be propagating `doxygen` and `graphviz` via `propagatedNativeBuildInputs`, as it is the [gz_create_docs](https://github.com/gazebosim/gz-cmake/blob/ef0baafb78c7d3a11f96d01a9936497ae0123661/cmake/GzCreateDocs.cmake#L195) directive that is responsible for running them.
This is doable by moving `gz-cmake` to `buildInputs`.

The dependencies on `gtest` and `python3` are similarly afflicted, as they are part of the [gz_create_test](https://github.com/gazebosim/gz-cmake/blob/ef0baafb78c7d3a11f96d01a9936497ae0123661/cmake/GzBuildTests.cmake#L141) routine.
I believe is `python3` should also be made into a `propagatedNativeBuildInputs`, and that `gtest` should be a `checkInput`; is `propagatedBuildInputs` correct here?

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
