### PR TITLE
budgie-desktop: Explicitly set overlay-key to Super_L

### DIFF
--- a/pkgs/by-name/bu/budgie-desktop/package.nix
+++ b/pkgs/by-name/bu/budgie-desktop/package.nix
@@ -77,6 +77,13 @@ stdenv.mkDerivation (finalAttrs: {
       url = "https://github.com/BuddiesOfBudgie/budgie-desktop/commit/46c83b1265b4230668da472d9ef6926941678418.patch";
       hash = "sha256-qnA8iBEctZbE86qIPudI1vMbgFy4xDWrxxej517ORws=";
     })
+
+    # Add override for overlay-key to prevent crash with mutter-common v48-rc
+    # https://github.com/BuddiesOfBudgie/budgie-desktop/pull/683
+    (fetchpatch {
+      url = "https://github.com/BuddiesOfBudgie/budgie-desktop/commit/c24091bb424abe99ebcdd33eedd37068f735ad2a.patch";
+      hash = "sha256-4WEkscftOGZmzH7imMTmcTDPH6eHMeEhgto+R5NNlh0=";
+    })
   ];
 
   nativeBuildInputs = [

--- a/pkgs/by-name/bu/budgie-gsettings-overrides/package.nix
+++ b/pkgs/by-name/bu/budgie-gsettings-overrides/package.nix
@@ -35,9 +35,6 @@ let
     [org.gnome.desktop.wm.preferences:Budgie]
     titlebar-font="Noto Sans Bold 10"
 
-    [org.gnome.mutter:Budgie]
-    edge-tiling=true
-
     [com.solus-project.budgie-menu:Budgie]
     use-default-menu-icon=true
 


### PR DESCRIPTION
See the commit messages.

Note that it is easier to test and land this PR against master, this is expected to be a no-op for nixos-unstable users.

Since `Super_L` is already the default in mutter 47, to verify the override actually functions, you can just do e.g.:

```nix
postPatch = ''
  substituteInPlace src/wm/20_solus-project.budgie.wm.gschema.override \
    --replace-fail 'overlay-key = "Super_L"' 'overlay-key = "Super_R"'
'';
```

And check what the default is:

```bash
gsettings reset org.gnome.mutter overlay-key
gsettings reset org.gnome.mutter edge-tiling
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

