### PR TITLE
apery: init at 2.1.0-unstable-2024-06-23

### DIFF
--- a/pkgs/by-name/ap/apery/package.nix
+++ b/pkgs/by-name/ap/apery/package.nix
@@ -1,0 +1,56 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  unstableGitUpdater,
+}:
+
+rustPlatform.buildRustPackage {
+  pname = "apery";
+  version = "2.1.0-unstable-2024-06-23";
+
+  src = fetchFromGitHub {
+    owner = "HiraokaTakuya";
+    # Successor of C++ implementation
+    # https://github.com/HiraokaTakuya/apery/blob/d14471fc879062bfabbd181eaa91e90c7cc28a71/Readme.txt#L3-L4
+    repo = "apery_rust";
+    rev = "8e64bc427bff033a38f1b60b9013ad2d62f88db7";
+    hash = "sha256-Y8IBZISutXNgbuc7/qhNoiwYDCP6M9ukhu48t3oZM18=";
+    # The submodule includes evaluation files for the installCheckPhase
+    fetchSubmodules = true;
+  };
+
+  cargoHash = "sha256-xaQ83WKXKSAFRSKzaTFnM2lklGLCJG+i7wa8a+KNR/I=";
+
+  checkFlags = [
+    "--skip=movegen"
+  ];
+
+  doInstallCheck = true;
+  installCheckPhase = ''
+    runHook preInstallCheck
+
+    usi_command='isready
+    go byoyomi 1000
+    wait'
+    usi_output="$("$out/bin/apery" <<< "$usi_command")"
+    [[ "$usi_output" == *'bestmove'* ]]
+
+    runHook postInstallCheck
+  '';
+
+  passthru.updateScript = unstableGitUpdater {
+    tagPrefix = "v";
+    branch = "master";
+  };
+
+  meta = {
+    description = "USI shogi engine";
+    homepage = "https://github.com/HiraokaTakuya/apery_rust";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [
+      kachick
+    ];
+    mainProgram = "apery";
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This PR introduces https://github.com/HiraokaTakuya/apery_rust, it is an USI shogi engine.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [x] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
