### PR TITLE
yarn-berry.yarn-berry-fetcher: 1.0.1 -> 1.2.1

### DIFF
--- a/pkgs/by-name/ya/yarn-berry/fetcher/yarn-berry-config-hook.sh
+++ b/pkgs/by-name/ya/yarn-berry/fetcher/yarn-berry-config-hook.sh
@@ -75,7 +75,14 @@ yarnBerryConfigHook() {
     export npm_config_nodedir="@nodeSrc@"
     export npm_config_node_gyp="@nodeGyp@"
 
-    YARN_IGNORE_PATH=1 @yarn_offline@ install --inline-builds
+    YARN_IGNORE_PATH=1 @yarn_offline@ install --mode=skip-build
+    if [[ -z "${dontYarnBerryPatchShebangs-}" ]]; then
+      echo "Running patchShebangs in between the Link and the Build step..."
+      patchShebangs node_modules
+    fi
+    if ! [[ "$YARN_ENABLE_SCRIPTS" == "0" || "$YARN_ENABLE_SCRIPTS" == "false" ]]; then
+      YARN_IGNORE_PATH=1 @yarn_offline@ install --inline-builds
+    fi
 
     echo "finished yarnBerryConfigHook"
 }

--- a/pkgs/by-name/ya/yarn-berry/fetcher/yarn-berry-fetcher.nix
+++ b/pkgs/by-name/ya/yarn-berry/fetcher/yarn-berry-fetcher.nix
@@ -13,18 +13,18 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "yarn-berry-${toString berryVersion}-fetcher";
-  version = "1.0.1";
+  version = "1.2.1";
 
   src = fetchFromGitLab {
     domain = "cyberchaos.dev";
     owner = "yuka";
     repo = "yarn-berry-fetcher";
-    tag = "1.0.1";
-    hash = "sha256-v92+aeGmT151TvcW7FvuooF3g+opdZw7QHY+CcLweJE=";
+    tag = "1.2.1";
+    hash = "sha256-gBre1LGyDVhikigWoWWW5qZyDCHp4lDONPqg1CRtaFM=";
   };
 
   useFetchCargoVendor = true;
-  cargoHash = "sha256-TR9FT95WAaiRvoYBXeT0U6agF94BAdMswNncYysESKo=";
+  cargoHash = "sha256-KNVfwv+qaJEu3TqhCKpiTfuRvFIFcHstcpjre/QXDso=";
 
   env.YARN_ZIP_SUPPORTED_CACHE_VERSION = berryCacheVersion;
   env.LIBZIP_SYS_USE_PKG_CONFIG = 1;


### PR DESCRIPTION
Diff: https://cyberchaos.dev/yuka/yarn-berry-fetcher/-/compare/1.0.1...1.2.1?w=1

- Implemented support for __archiveUrl bindings
- Solved performance issues with many small files
- Improved help output (By @euank)

Also split the "yarn install" in yarnBerryConfigHook in two parts, and added a patchShebangs in between, similar to how npmConfigHook does it.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
