### PR TITLE
rockbox-utility: 1.4.1 -> 1.5.1

### DIFF
--- a/pkgs/by-name/ro/rockbox-utility/package.nix
+++ b/pkgs/by-name/ro/rockbox-utility/package.nix
@@ -7,23 +7,24 @@
   makeWrapper,
   pkg-config,
   qt5,
+  cmake,
   withEspeak ? false,
   espeak ? null,
 }:
 
 stdenv.mkDerivation rec {
   pname = "rockbox-utility";
-  version = "1.4.1";
+  version = "1.5.1";
 
   src = fetchurl {
     url = "https://download.rockbox.org/rbutil/source/RockboxUtility-v${version}-src.tar.bz2";
-    hash = "sha256-PhlJ+fNY4/Qjoc72zV9WO+kNqF5bZQuwOh4EpAJwqX4=";
+    hash = "sha256-guNO11a0d30RexPEAAQGIgV9W17zgTjZ/LNz/oUn4HM=";
   };
 
   nativeBuildInputs = [
     makeWrapper
     pkg-config
-    qt5.qmake
+    cmake
     qt5.wrapQtAppsHook
   ];
 
@@ -31,30 +32,20 @@ stdenv.mkDerivation rec {
     cryptopp
     libusb1
     qt5.qtbase
+    qt5.qtmultimedia
     qt5.qttools
   ] ++ lib.optional withEspeak espeak;
 
-  postPatch = ''
-    sed -i rbutil/rbutilqt/rbutilqt.pro \
-        -e '/^lrelease.commands =/ s|$$\[QT_INSTALL_BINS\]/lrelease -silent|${lib.getDev qt5.qttools}/bin/lrelease|'
-  '';
+  cmakeDir = "../utils";
 
-  preConfigure = ''
-    cd rbutil/rbutilqt
-    lrelease rbutilqt.pro
-  '';
-
-  # Workaround build failure on -fno-common toolchains like upstream
-  # gcc-10. Otherwise build fails as:
-  #   ld: libmkimxboot.a(elf.c.o):utils/imxtools/sbtools/misc.h:43: multiple definition of `g_nr_keys';
-  #     libmkimxboot.a(mkimxboot.c.o):utils/imxtools/sbtools/misc.h:43: first defined here
-  # TODO: try to remove with 1.5.1 update.
-  env.NIX_CFLAGS_COMPILE = "-fcommon";
+  patches = [
+    ./rockbox-utility-fix-cmake.patch
+  ];
 
   installPhase = ''
     runHook preInstall
 
-    install -Dm755 RockboxUtility $out/bin/rockboxutility
+    install -Dm755 rbutilqt/RockboxUtility $out/bin/rockboxutility
     ln -s $out/bin/rockboxutility $out/bin/RockboxUtility
     wrapProgram $out/bin/rockboxutility \
     ${lib.optionalString withEspeak ''
@@ -64,17 +55,11 @@ stdenv.mkDerivation rec {
     runHook postInstall
   '';
 
-  # `make build/rcc/qrc_rbutilqt-lang.cpp` fails with
-  #      RCC: Error in 'rbutilqt-lang.qrc': Cannot find file 'lang/rbutil_cs.qm'
-  # Do not add `lrelease rbutilqt.pro` into preConfigure, otherwise `make lrelease`
-  # may clobber the files read by the parallel `make build/rcc/qrc_rbutilqt-lang.cpp`.
-  enableParallelBuilding = false;
-
   meta = with lib; {
     homepage = "https://www.rockbox.org";
     description = "Open source firmware for digital music players";
     license = licenses.gpl2Plus;
-    maintainers = with maintainers; [ ];
+    maintainers = with maintainers; [ ozkutuk ];
     mainProgram = "RockboxUtility";
     platforms = platforms.linux;
   };

--- a/pkgs/by-name/ro/rockbox-utility/rockbox-utility-fix-cmake.patch
+++ b/pkgs/by-name/ro/rockbox-utility/rockbox-utility-fix-cmake.patch
@@ -1,0 +1,33 @@
+diff --git a/utils/CMakeLists.txt b/utils/CMakeLists.txt
+index 55e5b79..0934905 100644
+--- a/utils/CMakeLists.txt
++++ b/utils/CMakeLists.txt
+@@ -358,22 +358,6 @@ add_library(rbtomcrypt
+     )
+ target_include_directories(rbtomcrypt PUBLIC ${CMAKE_CURRENT_LIST_DIR}/tomcrypt/src/headers)
+ 
+-add_library(skin_parser
+-    ${CMAKE_CURRENT_LIST_DIR}/../lib/skin_parser/skin_buffer.c
+-    ${CMAKE_CURRENT_LIST_DIR}/../lib/skin_parser/skin_buffer.h
+-    ${CMAKE_CURRENT_LIST_DIR}/../lib/skin_parser/skin_debug.c
+-    ${CMAKE_CURRENT_LIST_DIR}/../lib/skin_parser/skin_debug.h
+-    ${CMAKE_CURRENT_LIST_DIR}/../lib/skin_parser/skin_parser.c
+-    ${CMAKE_CURRENT_LIST_DIR}/../lib/skin_parser/skin_parser.h
+-    ${CMAKE_CURRENT_LIST_DIR}/../lib/skin_parser/skin_scan.c
+-    ${CMAKE_CURRENT_LIST_DIR}/../lib/skin_parser/skin_scan.h
+-    ${CMAKE_CURRENT_LIST_DIR}/../lib/skin_parser/symbols.h
+-    ${CMAKE_CURRENT_LIST_DIR}/../lib/skin_parser/tag_table.c
+-    ${CMAKE_CURRENT_LIST_DIR}/../lib/skin_parser/tag_table.h
+-    )
+-target_include_directories(skin_parser PUBLIC ${CMAKE_CURRENT_LIST_DIR}/../lib/skin_parser)
+-target_compile_definitions(skin_parser PUBLIC __PCTOOL__)
+-
+ # target will always be build. File is only updated when contents change.
+ add_custom_target(gitversion.h
+     COMMENT "Updating gitversion.h"
+@@ -391,5 +375,3 @@ target_include_directories(gitversion INTERFACE ${CMAKE_CURRENT_BINARY_DIR}/gitv
+ include(${CMAKE_CURRENT_LIST_DIR}/cmake/deploy.cmake)
+ include(${CMAKE_CURRENT_LIST_DIR}/cmake/QtTest.cmake)
+ add_subdirectory(rbutilqt)
+-add_subdirectory(themeeditor)
+-


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
