### PR TITLE
python312Packages.grpc-stubs: init at 1.53.0.5

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4693,6 +4693,12 @@
     github = "CnTeng";
     githubId = 56501688;
   };
+  coastalwhite = {
+    email = "me@gburghoorn.com";
+    name = "Gijs Burghoorn";
+    github = "coastalwhite";
+    githubId = 6944009;
+  };
   coat = {
     email = "kentsmith@gmail.com";
     name = "Kent Smith";

--- a/pkgs/development/python-modules/grpc-stubs/default.nix
+++ b/pkgs/development/python-modules/grpc-stubs/default.nix
@@ -1,0 +1,50 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  grpcio,
+  pythonOlder,
+  pytestCheckHook,
+  pytest-mypy-plugins,
+  types-protobuf,
+  setuptools,
+}:
+
+buildPythonPackage rec {
+  pname = "grpc-stubs";
+  version = "1.53.0.5";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "shabbyrobe";
+    repo = "grpc-stubs";
+    tag = version;
+    hash = "sha256-an7xztaCqxOEmf74Rgb8q9u/WsojFYkBiwtLRa1qqBQ=";
+  };
+
+  disabled = pythonOlder "3.6";
+
+  dependencies = [
+    types-protobuf
+  ];
+
+  build-system = [
+    setuptools
+  ];
+
+  propagatedBuildInputs = [
+    grpcio
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    pytest-mypy-plugins
+  ];
+
+  meta = {
+    description = "gRPC typing stubs for Python";
+    homepage = "https://github.com/shabbyrobe/grpc-stubs";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ coastalwhite ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6007,6 +6007,8 @@ self: super: with self; {
 
   grpc-interceptor = callPackage ../development/python-modules/grpc-interceptor { };
 
+  grpc-stubs = callPackage ../development/python-modules/grpc-stubs { };
+
   grpcio = callPackage ../development/python-modules/grpcio { };
 
   grpcio-channelz = callPackage ../development/python-modules/grpcio-channelz { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This is a python package that adds the type stubs for `grpc`. This is a dependency for many packages, including the dev environment for `polars`. I have been using this iteration of the nix package build for ~1 year now during my dayjob.

## Things done

- Added python package for `grpc-stubs`.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
