### PR TITLE
python3Packages.benchopt: init at 1.6.0

### DIFF
--- a/pkgs/development/python-modules/benchopt/default.nix
+++ b/pkgs/development/python-modules/benchopt/default.nix
@@ -1,0 +1,96 @@
+{
+  buildPythonPackage,
+  fetchFromGitHub,
+  lib,
+
+  # build system
+  setuptools,
+  setuptools-scm,
+
+  # python package dependencies
+  click,
+  joblib,
+  line-profiler,
+  mako,
+  matplotlib,
+  numpy,
+  pandas,
+  plotly,
+  psutil,
+  pyarrow,
+  pygithub,
+  pytest,
+  pyyaml,
+  scipy,
+
+  # optional dependencies
+  submitit,
+  rich,
+
+  # hooks
+  pytestCheckHook,
+}:
+
+buildPythonPackage {
+  pname = "benchopt";
+  version = "1.6.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "benchopt";
+    repo = "benchopt";
+    rev = "5d2a17399beac44775807c59ec8c16d9996997d2";
+    hash = "sha256-WfvVdgTFrbwdZy7f451GtnEHo0K7KFaxXrCkcahuDpw=";
+  };
+
+  build-system = [
+    setuptools
+    setuptools-scm
+  ];
+
+  dependencies = [
+    click
+    joblib
+    line-profiler
+    mako
+    matplotlib
+    numpy
+    pandas
+    plotly
+    psutil
+    pyarrow
+    pygithub
+    pytest
+    pyyaml
+    scipy
+  ];
+
+  optional-dependencies = {
+    slurm = [
+      rich
+      submitit
+    ];
+  };
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "benchopt" ];
+
+  disabledTests = [
+    # Skip tests requiring installations via conda or pip
+    "InstallCmd"
+    "RunCmd"
+    "invalid_install_cmd"
+    "solver_install"
+  ];
+
+  meta = {
+    description = "Making your ML and optimization benchmarks simple and open";
+    changelog = "https://benchopt.github.io/whats_new.html";
+    homepage = "https://benchopt.github.io/";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ jolars ];
+  };
+}

--- a/pkgs/development/python-modules/ubelt/default.nix
+++ b/pkgs/development/python-modules/ubelt/default.nix
@@ -51,11 +51,16 @@ buildPythonPackage rec {
     export HOME=$TMPDIR
   '';
 
-  disabledTests = lib.optionals stdenv.hostPlatform.isDarwin [
-    # fail due to sandbox environment
-    "CacheStamp.expired"
-    "userhome"
-  ];
+  disabledTests =
+    [
+      # fails on python 3.13, see https://github.com/Erotemic/ubelt/issues/157
+      "import_module_from_name"
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [
+      # fail due to sandbox environment
+      "CacheStamp.expired"
+      "userhome"
+    ];
 
   pythonImportsCheck = [ "ubelt" ];
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1758,6 +1758,8 @@ self: super: with self; {
 
   bellows = callPackage ../development/python-modules/bellows { };
 
+  benchopt = callPackage ../development/python-modules/benchopt { };
+
   bencode-py = callPackage ../development/python-modules/bencode-py { };
 
   bencoder = callPackage ../development/python-modules/bencoder { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Adds benchopt (https://benchopt.github.io/), a cli tool and python library for benchmarking ML algorithms.

This PR also disables a test in ubelt, which was failing for unrelated reasons (https://github.com/Erotemic/ubelt/issues/157).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
