### PR TITLE
haskellPackages: remove non-applying patches

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -885,16 +885,6 @@ self: super:
   # "base" dependency.
   haddock-cheatsheet = doJailbreak super.haddock-cheatsheet;
 
-  # https://github.com/Gabriella439/Haskell-MVC-Updates-Library/pull/1
-  mvc-updates = appendPatches [
-    (pkgs.fetchpatch {
-      name = "rename-pretraverse.patch";
-      url = "https://github.com/Gabriella439/Haskell-MVC-Updates-Library/commit/47b31202b761439947ffbc89ec1c6854c1520819.patch";
-      sha256 = "sha256-a6k3lWtXNYUIjWXR+vRAHz2bANq/2eM0F5FLL8Qt2lA=";
-      includes = [ "src/MVC/Updates.hs" ];
-    })
-  ] (doJailbreak super.mvc-updates);
-
   # Too strict bounds on bytestring < 0.12
   # https://github.com/Gabriella439/Haskell-Pipes-HTTP-Library/issues/18
   pipes-http = doJailbreak super.pipes-http;

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -248,20 +248,6 @@ self: super:
     sha256 = "10zkvclyir3zf21v41zdsvg68vrkq89n64kv9k54742am2i4aygf";
   }) super.weeder;
 
-  # Allow aeson == 2.1.*
-  # https://github.com/hdgarrood/aeson-better-errors/issues/23
-  aeson-better-errors = lib.pipe super.aeson-better-errors [
-    doJailbreak
-    (appendPatches [
-      # https://github.com/hdgarrood/aeson-better-errors/pull/25
-      (fetchpatch {
-        name = "mtl-2-3.patch";
-        url = "https://github.com/hdgarrood/aeson-better-errors/commit/1ec49ab7d1472046b680b5a64ae2930515b47714.patch";
-        hash = "sha256-xuuocWxSoBDclVp0bJ9UrDamVcDVOAFgJIi/un1xBvk=";
-      })
-    ])
-  ];
-
   # Version 2.1.1 is deprecated, but part of Stackage LTS at the moment.
   # https://github.com/commercialhaskell/stackage/issues/7500
   # https://github.com/yesodweb/shakespeare/issues/280

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -2881,14 +2881,6 @@ self: super:
     }
   ) super.feedback;
 
-  # https://github.com/maralorn/haskell-taskwarrior/pull/12
-  taskwarrior = appendPatches [
-    (fetchpatch {
-      url = "https://github.com/maralorn/haskell-taskwarrior/commit/b846c6ae64e716dca2d44488f60fee3697b5322d.patch";
-      sha256 = "sha256-fwBYBmw9Jva2UEPQ6E/5/HBA8ZDiM7/QQQDBp3diveU=";
-    })
-  ] super.taskwarrior;
-
   testcontainers = lib.pipe super.testcontainers [
     dontCheck # Tests require docker
     doJailbreak # https://github.com/testcontainers/testcontainers-hs/pull/58

--- a/pkgs/development/haskell-modules/configuration-ghc-9.12.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.12.x.nix
@@ -147,17 +147,6 @@ with haskellLib;
     ];
   }) super.doctest_0_24_0;
 
-  # https://github.com/typeable/generic-arbitrary/issues/18
-  generic-arbitrary = overrideCabal (drv: {
-    patches = drv.patches or [ ] ++ [
-      (pkgs.fetchpatch {
-        name = "hellwolf:fix-recursive-test-hidding-unit";
-        url = "https://github.com/typeable/generic-arbitrary/commit/133b80be93e6744f21e0e5ed4180a24c589f92e4.patch";
-        sha256 = "sha256-z9EVcD1uNAYUOVTwmCCnrEFFOvFB7lD94Y6BwGVwVRQ=";
-      })
-    ];
-  }) super.generic-arbitrary;
-
   # https://gitlab.haskell.org/ghc/ghc/-/issues/25930
   generic-lens = dontCheck super.generic-lens;
 

--- a/pkgs/development/haskell-modules/configuration-ghc-9.8.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.8.x.nix
@@ -7,8 +7,7 @@ let
   inherit (pkgs) lib;
 in
 
-self: super:
-{
+self: super: {
 
   llvmPackages = pkgs.lib.dontRecurseIntoAttrs self.ghc.llvmPackages;
 
@@ -98,9 +97,4 @@ self: super:
           --replace-fail "HsWord64 u = atomic_inc64" "HsWord64 u = atomic_inc"
       '';
     } super.ghc-lib-parser;
-}
-// lib.optionalAttrs (lib.versionAtLeast super.ghc.version "9.8.3") {
-  # Breakage related to GHC 9.8.3 / deepseq 1.5.1.0
-  # https://github.com/typeable/generic-arbitrary/issues/18
-  generic-arbitrary = dontCheck super.generic-arbitrary;
 }


### PR DESCRIPTION
Removes some patches which don't apply anymore.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
