### PR TITLE
incus: 6.11.0 -> 6.12.0

### DIFF
--- a/pkgs/by-name/in/incus/1995.diff
+++ b/pkgs/by-name/in/incus/1995.diff
@@ -1,0 +1,93 @@
+diff --git a/internal/server/firewall/drivers/drivers_consts.go b/internal/server/firewall/drivers/drivers_consts.go
+index 2790e07a605..944bca5930e 100644
+--- a/internal/server/firewall/drivers/drivers_consts.go
++++ b/internal/server/firewall/drivers/drivers_consts.go
+@@ -1,8 +1,6 @@
+ package drivers
+ 
+ import (
+-	"encoding/json"
+-	"fmt"
+ 	"net"
+ )
+ 
+@@ -67,62 +65,12 @@ type NftListSetsOutput struct {
+ 
+ // NftListSetsEntry structure to read JSON output of nft set listing.
+ type NftListSetsEntry struct {
+-	Metainfo *NftMetainfo `json:"metainfo,omitempty"`
+-	Set      *NftSet      `json:"set,omitempty"`
+-}
+-
+-// NftMetainfo structure representing metainformation returned by nft.
+-type NftMetainfo struct {
+-	Version           string `json:"version"`
+-	ReleaseName       string `json:"release_name"`
+-	JSONSchemaVersion int    `json:"json_schema_version"`
++	Set *NftSet `json:"set,omitempty"`
+ }
+ 
+ // NftSet structure to parse the JSON of a set returned by nft -j list sets.
+ type NftSet struct {
+-	Family string    `json:"family"`
+-	Name   string    `json:"name"`
+-	Table  string    `json:"table"`
+-	Type   string    `json:"type"`
+-	Handle int       `json:"handle"`
+-	Flags  []string  `json:"flags"`
+-	Elem   ElemField `json:"elem"`
+-}
+-
+-// ElemField supports both string elements (IP, MAC) and dictionary-based CIDR elements.
+-// In order to parse it correctly a custom unsmarshalling is defined in drivers_nftables.go .
+-type ElemField struct {
+-	Addresses []string // Stores plain addresses and CIDR notations as strings.
+-}
+-
+-// UnmarshalJSON handles both plain strings and CIDR dictionaries inside `elem`.
+-func (e *ElemField) UnmarshalJSON(data []byte) error {
+-	var rawElems []any
+-	err := json.Unmarshal(data, &rawElems)
+-	if err != nil {
+-		return err
+-	}
+-
+-	for _, elem := range rawElems {
+-		switch v := elem.(type) {
+-		case string:
+-			// Plain address (IPv4, IPv6, or MAC).
+-			e.Addresses = append(e.Addresses, v)
+-		case map[string]any:
+-			// CIDR notation (prefix dictionary).
+-			prefix, ok := v["prefix"].(map[string]any)
+-			if ok {
+-				addr, addrOk := prefix["addr"].(string)
+-				lenFloat, lenOk := prefix["len"].(float64) // JSON numbers are float64 by default.
+-				if addrOk && lenOk {
+-					e.Addresses = append(e.Addresses, fmt.Sprintf("%s/%d", addr, int(lenFloat)))
+-				}
+-			}
+-
+-		default:
+-			return fmt.Errorf("Unsupported element type in NFTables set: %v", elem)
+-		}
+-	}
+-
+-	return nil
++	Family string `json:"family"`
++	Name   string `json:"name"`
++	Table  string `json:"table"`
+ }
+diff --git a/internal/server/firewall/drivers/drivers_nftables.go b/internal/server/firewall/drivers/drivers_nftables.go
+index fd9be2e2fbb..f803de9dff5 100644
+--- a/internal/server/firewall/drivers/drivers_nftables.go
++++ b/internal/server/firewall/drivers/drivers_nftables.go
+@@ -387,7 +387,7 @@ func (d Nftables) NetworkClear(networkName string, _ bool, _ []uint) error {
+ 		return fmt.Errorf("Failed clearing nftables rules for network %q: %w", networkName, err)
+ 	}
+ 
+-	err = d.RemoveIncusAddressSets("inet")
++	err = d.RemoveIncusAddressSets("bridge")
+ 	if err != nil {
+ 		return fmt.Errorf("Error in deletion of address sets: %w", err)
+ 	}

--- a/pkgs/by-name/in/incus/package.nix
+++ b/pkgs/by-name/in/incus/package.nix
@@ -1,8 +1,11 @@
 import ./generic.nix {
-  hash = "sha256-S6PTtgP4MFV+kiEgV8PBvek1SrVjLaCR9OJy/6jqJGE=";
-  version = "6.11.0";
-  vendorHash = "sha256-wKL+woCMjGJwCBG/JBhFbY4uc97/5K7OWPZRp0J+5DQ=";
-  patches = [ ];
+  hash = "sha256-hgZc30SRnmALTvuD32dNuO0r4pfpXXvN4CtJqn2fGuk=";
+  version = "6.12.0";
+  vendorHash = "sha256-/GwJG6kmjbiUUh0AWQ+IUbeK1kRcuWrwmNdTzH5LT38=";
+  patches = [
+    # fix nft, remove 6.13
+    ./1995.diff
+  ];
   nixUpdateExtraArgs = [
     "--override-filename=pkgs/by-name/in/incus/package.nix"
   ];


### PR DESCRIPTION
https://discuss.linuxcontainers.org/t/incus-6-12-has-been-released/23556
https://github.com/lxc/incus/releases/tag/v6.12.0


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
