### PR TITLE
image/repart: repart.imageFile(BaseName) -> image.baseName, image.extension

### DIFF
--- a/nixos/modules/image/file-options.nix
+++ b/nixos/modules/image/file-options.nix
@@ -9,6 +9,7 @@
     baseName = lib.mkOption {
       type = lib.types.str;
       default = "nixos-image-${config.system.nixos.label}-${pkgs.stdenv.hostPlatform.system}";
+      defaultText = lib.literalExpression "nixos-image-\${config.system.nixos.label}-\${pkgs.stdenv.hostPlatform.system}";
       description = ''
         Basename of the image filename without any extension (e.g. `image_1`).
       '';
@@ -29,6 +30,7 @@
     fileName = lib.mkOption {
       type = lib.types.str;
       default = "${config.image.baseName}.${config.image.extension}";
+      defaultText = lib.literalExpression "\${config.image.baseName}.\${config.image.extension}";
       description = ''
         Filename of the image including all extensions (e.g `image_1.raw` or
         `image_1.raw.zst`).
@@ -38,6 +40,7 @@
     filePath = lib.mkOption {
       type = lib.types.str;
       default = config.image.fileName;
+      defaultText = lib.literalExpression "config.image.fileName";
       description = ''
         Path of the image, relative to `$out` in `system.build.image`.
         While it defaults to `config.image.fileName`, it can be different for builders where

--- a/nixos/modules/image/repart.nix
+++ b/nixos/modules/image/repart.nix
@@ -95,7 +95,7 @@ in
     name = lib.mkOption {
       type = lib.types.str;
       description = ''
-        Name of the image.
+          Name of the image.
 
         If this option is unset but config.system.image.id is set,
         config.system.image.id is used as the default value.
@@ -152,7 +152,7 @@ in
       # Generated with `uuidgen`. Random but fixed to improve reproducibility.
       default = "0867da16-f251-457d-a9e8-c31f9a3c220b";
       description = ''
-        A UUID to use as a seed. You can set this to `null` to explicitly
+          A UUID to use as a seed. You can set this to `null` to explicitly
         randomize the partition UUIDs.
       '';
     };
@@ -161,7 +161,7 @@ in
       type = lib.types.bool;
       default = false;
       description = ''
-        Enables generation of split artifacts from partitions. If enabled, for
+          Enables generation of split artifacts from partitions. If enabled, for
         each partition with SplitName= set, a separate output file containing
         just the contents of that partition is generated.
       '';
@@ -172,7 +172,7 @@ in
       default = 512;
       example = lib.literalExpression "4096";
       description = ''
-        The sector size of the disk image produced by systemd-repart. This
+          The sector size of the disk image produced by systemd-repart. This
         value must be a power of 2 between 512 and 4096.
       '';
     };
@@ -191,7 +191,7 @@ in
       type = with lib.types; attrsOf (submodule partitionOptions);
       default = { };
       example = lib.literalExpression ''
-        {
+          {
           "10-esp" = {
             contents = {
               "/EFI/BOOT/BOOTX64.EFI".source =
@@ -213,7 +213,7 @@ in
         };
       '';
       description = ''
-        Specify partitions as a set of the names of the partitions with their
+          Specify partitions as a set of the names of the partitions with their
         configuration as the key.
       '';
     };
@@ -222,12 +222,12 @@ in
       type = with lib.types; attrsOf (listOf str);
       default = { };
       example = lib.literalExpression ''
-        {
+          {
           vfat = [ "-S 512" "-c" ];
         }
       '';
       description = ''
-        Specify extra options for created file systems. The specified options
+          Specify extra options for created file systems. The specified options
         are converted to individual environment variables of the format
         `SYSTEMD_REPART_MKFS_OPTIONS_<FSTYPE>`.
 


### PR DESCRIPTION
This replaces image-specific options for file name (and basename) with
unified options for basename and extension. This is done to increase
compatibility with `nixos-rebuild build-image` as it uses those options to predict the name of the final image in the built derivation (i.e. for scripting purposes).


With a repart-based image-definition such as https://github.com/NixOS/nixpkgs/pull/351699 and a nixos config such as

```
      {
        nixpkgs.hostPlatform.system = "x86_64-linux";
        system.stateVersion = "25.05";

        image.modules.repart-interactive = (
          {modulesPath, ...}:
          {
            imports = [
              "${modulesPath}/image/interactive.nix"
            ];
            config = {
              boot.loader.systemd-boot.enable = true;
            };
          }
        );
      }
```

I could successfully build an image with

```
nixos-rebuild build-image --image-variant repart-interactive
```

Where the correct path to the full image inside the resulting derivation was displayed on stdout. 


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
