### PR TITLE
analyzeMFT: init at 3.0.7.1

### DIFF
--- a/pkgs/by-name/an/analyzeMFT/package.nix
+++ b/pkgs/by-name/an/analyzeMFT/package.nix
@@ -1,0 +1,27 @@
+{
+  lib,
+  python3,
+  fetchFromGitHub,
+}:
+
+python3.pkgs.buildPythonApplication rec {
+  pname = "analyzeMFT";
+  version = "3.0.7.1";
+
+  src = fetchFromGitHub {
+    owner = "rowingdude";
+    repo = "analyzeMFT";
+    tag = "v${version}";
+    hash = "sha256-tPGLV+hzNf76sra21TB6AqkhjZIc9w5l1yLEdfE9vE4=";
+  };
+
+  meta = {
+    description = "Tool to parse the MFT file from an NTFS filesystem";
+    homepage = "https://github.com/rowingdude/analyzeMFT";
+    changelog = "https://github.com/rowingdude/analyzeMFT/releases/tag/v${version}";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.all;
+    maintainers = with lib.maintainers; [ mikehorn ];
+    mainProgram = "analyzeMFT";
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Add [analyzeMFT](https://github.com/rowingdude/analyzeMFT). A tool to parse the MFT file from an NTFS filesystem.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

Result of ```nixpkgs-review rev analyzemft```:

```bash
$ git -c fetch.prune=false fetch --no-tags --force https://github.com/NixOS/nixpkgs master:refs/nixpkgs-review/0
$ git worktree add /home/archlinux/.cache/nixpkgs-review/rev-cfa9997faeb82fb3384eee7d0f94d82cf8a109e5-1/nixpkgs c335c9cc621e011c8407943c6134cf3b78f6e4a5
Preparing worktree (detached HEAD c335c9cc621e)
Updating files: 100% (47501/47501), done.
HEAD is now at c335c9cc621e x265: fix build for armv7l & add neon support (#396472)
Local evaluation for computing rebuilds
$ nix-env --extra-experimental-features no-url-literals --option system x86_64-linux -f <nixpkgs> --nix-path nixpkgs=/home/archlinux/.cache/nixpkgs-review/rev-cfa9997faeb82fb3384eee7d0f94d82cf8a109e5-1/nixpkgs nixpkgs-overlays=/tmp/tmp17ror2wu -qaP --xml --out-path --show-trace --no-allow-import-from-derivation
$ git merge --no-commit --no-ff cfa9997faeb82fb3384eee7d0f94d82cf8a109e5
Auto-merging maintainers/maintainer-list.nix
Automatic merge went well; stopped before committing as requested
$ nix-env --extra-experimental-features no-url-literals --option system x86_64-linux -f <nixpkgs> --nix-path nixpkgs=/home/archlinux/.cache/nixpkgs-review/rev-cfa9997faeb82fb3384eee7d0f94d82cf8a109e5-1/nixpkgs nixpkgs-overlays=/tmp/tmp17ror2wu -qaP --xml --out-path --show-trace --no-allow-import-from-derivation --meta
--------- Impacted packages on 'x86_64-linux' ---------
1 package added:
analyzeMFT (init at 3.0.7.1)

warning: ignoring the client-specified setting 'system', because it is a restricted setting and you are not a trusted user

$ nix build --file /nix/store/f4vh27bjszvwdnb0z7kw4vcb5c926fyq-nixpkgs-review-3.2.0/lib/python3.12/site-packages/nixpkgs_review/nix/review-shell.nix --nix-path 'nixpkgs=/home/archlinux/.cache/nixpkgs-review/rev-cfa9997faeb82fb3384eee7d0f94d82cf8a109e5-1/nixpkgs nixpkgs-overlays=/tmp/tmp17ror2wu' --extra-experimental-features 'nix-command no-url-literals' --no-link --keep-going --no-allow-import-from-derivation --option build-use-sandbox relaxed --argstr local-system x86_64-linux --argstr nixpkgs-path /home/archlinux/.cache/nixpkgs-review/rev-cfa9997faeb82fb3384eee7d0f94d82cf8a109e5-1/nixpkgs --argstr nixpkgs-config-path /tmp/tmpcj7swuk9.nix --argstr attrs-path /home/archlinux/.cache/nixpkgs-review/rev-cfa9997faeb82fb3384eee7d0f94d82cf8a109e5-1/attrs.nix
warning: ignoring the client-specified setting 'sandbox', because it is a restricted setting and you are not a trusted user
--------- Report for 'x86_64-linux' ---------
2 packages built:
analyzeMFT analyzeMFT.dist
```

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
