### PR TITLE
nixos/syncthing: Add apiKeyFile option (#401745)

### DIFF
--- a/nixos/modules/services/networking/syncthing.nix
+++ b/nixos/modules/services/networking/syncthing.nix
@@ -400,9 +400,8 @@ in
         default = null;
         description = ''
           Path to a text file containing the API key to set in syncthing.
-          Use this instead of
-          [`settings.options.gui.apiKey`](#opt-services.syncthing.settings.options.gui.apiKey)
-          to avoid leaking the plaintext key to the Nix store.
+          Use this instead of `settings.gui.apiKey` to avoid
+          leaking the plaintext key to the Nix store.
         '';
       };
 

--- a/nixos/modules/services/networking/syncthing.nix
+++ b/nixos/modules/services/networking/syncthing.nix
@@ -347,8 +347,9 @@ let
           initial_guiConfig=$(echo ${
             lib.escapeShellArg (builtins.toJSON (if cleanedConfig ? gui then cleanedConfig.gui else { }))
           })
-          updated_guiConfig=$(echo $initial_guiConfig | ${jq} --rawfile data ${lib.escapeShellArg cfg.apiKeyFile} '.apiKey = $data')
-          curl -X PUT -d "$updated_guiConfig" ${curlAddressArgs "/rest/config/gui"}
+          echo $initial_guiConfig \
+            | ${jq} --rawfile data ${lib.escapeShellArg cfg.apiKeyFile} '.apiKey = $data' \
+            | curl --json @- -X PUT ${curlAddressArgs "/rest/config/gui"}
         ''
       )
     )

--- a/nixos/modules/services/networking/syncthing.nix
+++ b/nixos/modules/services/networking/syncthing.nix
@@ -344,11 +344,10 @@ let
         lib.optionalString (cfg.apiKeyFile != null) ''
           # apiKey is part of gui section. We need to merge it because
           # otherwise the other gui options would get cleared.
-          new_apiKey=$(cat ${lib.escapeShellArg cfg.apiKeyFile})
           initial_guiConfig=$(echo ${
             lib.escapeShellArg (builtins.toJSON (if cleanedConfig ? gui then cleanedConfig.gui else { }))
           })
-          updated_guiConfig=$(echo $initial_guiConfig | ${jq} ".apiKey = \"$new_apiKey\"")
+          updated_guiConfig=$(echo $initial_guiConfig | ${jq} --rawfile data ${lib.escapeShellArg cfg.apiKeyFile} '.apiKey = $data')
           curl -X PUT -d "$updated_guiConfig" ${curlAddressArgs "/rest/config/gui"}
         ''
       )

--- a/nixos/modules/services/networking/syncthing.nix
+++ b/nixos/modules/services/networking/syncthing.nix
@@ -348,7 +348,7 @@ let
             lib.escapeShellArg (builtins.toJSON (if cleanedConfig ? gui then cleanedConfig.gui else { }))
           })
           echo $initial_guiConfig \
-            | ${jq} --rawfile data ${lib.escapeShellArg cfg.apiKeyFile} '.apiKey = $data' \
+            | ${jq} --rawfile data ${lib.escapeShellArg cfg.apiKeyFile} '.apiKey = ($data | trim)' \
             | curl --json @- -X PUT ${curlAddressArgs "/rest/config/gui"}
         ''
       )

--- a/nixos/modules/services/networking/syncthing.nix
+++ b/nixos/modules/services/networking/syncthing.nix
@@ -334,6 +334,25 @@ let
         ${pkgs.mkpasswd}/bin/mkpasswd -m bcrypt --stdin <"${cfg.guiPasswordFile}" | tr -d "\n" > "$RUNTIME_DIRECTORY/password_bcrypt"
         curl -X PATCH --variable "pw_bcrypt@$RUNTIME_DIRECTORY/password_bcrypt" --expand-json '{ "password": "{{pw_bcrypt}}" }' ${curlAddressArgs "/rest/config/gui"}
       '')
+    + (lib.throwIf (lib.hasAttrByPath [ "gui" "apiKey" ] cfg.settings)
+      ''
+        The option `services.syncthing.settings.gui.apiKey` should
+        not be used because it leaks the plaintext value to the Nix store.
+        Use `services.syncthing.apiKeyFile` instead.
+      ''
+      (
+        lib.optionalString (cfg.apiKeyFile != null) ''
+          # apiKey is part of gui section. We need to merge it because
+          # otherwise the other gui options would get cleared.
+          new_apiKey=$(cat ${lib.escapeShellArg cfg.apiKeyFile})
+          initial_guiConfig=$(echo ${
+            lib.escapeShellArg (builtins.toJSON (if cleanedConfig ? gui then cleanedConfig.gui else { }))
+          })
+          updated_guiConfig=$(echo $initial_guiConfig | ${jq} ".apiKey = \"$new_apiKey\"")
+          curl -X PUT -d "$updated_guiConfig" ${curlAddressArgs "/rest/config/gui"}
+        ''
+      )
+    )
     + ''
       # restart Syncthing if required
       if curl ${curlAddressArgs "/rest/config/restart-required"} |
@@ -373,6 +392,17 @@ in
         default = null;
         description = ''
           Path to file containing the plaintext password for Syncthing's GUI.
+        '';
+      };
+
+      apiKeyFile = lib.mkOption {
+        type = lib.types.nullOr lib.types.str;
+        default = null;
+        description = ''
+          Path to a text file containing the API key to set in syncthing.
+          Use this instead of
+          [`settings.options.gui.apiKey`](#opt-services.syncthing.settings.options.gui.apiKey)
+          to avoid leaking the plaintext key to the Nix store.
         '';
       };
 

--- a/nixos/tests/syncthing/init.nix
+++ b/nixos/tests/syncthing/init.nix
@@ -11,6 +11,7 @@ in
   nodes.machine = {
     services.syncthing = {
       enable = true;
+      apiKeyFile = "${pkgs.writeText "syncthing-init-test-apiKeyFile" "theNewCustomApiKey"}";
       settings.devices.testDevice = {
         id = testId;
       };
@@ -29,5 +30,6 @@ in
     assert "testFolder" in config
     assert "${testId}" in config
     assert "guiUser" in config
+    assert "theNewCustomApiKey" in config
   '';
 }

--- a/nixos/tests/syncthing/init.nix
+++ b/nixos/tests/syncthing/init.nix
@@ -27,9 +27,9 @@ in
     machine.wait_for_unit("syncthing-init.service")
     config = machine.succeed("cat /var/lib/syncthing/.config/syncthing/config.xml")
 
-    assert "testFolder" in config
-    assert "${testId}" in config
-    assert "guiUser" in config
-    assert "theNewCustomApiKey" in config
+    t.assertIn("testFolder", config, "Test Folder Missing")
+    t.assertIn("${testId}", config, "Test ID Missing")
+    t.assertIn("guiUser", config, "GUI User Missing")
+    t.assertIn("theNewCustomApiKey", config, "Wrong API Key")
   '';
 }


### PR DESCRIPTION
There is currently no way to set syncthing's apiKey without leaking it to the Nix store.
For example, https://github.com/Martchus/syncthingtray requires an API key (but can even access remote instances!).

This PR:
- Adds `services.syncthing.apiKeyFile` to make it possible to securely set api keys for syncthing instances.
- Using the insecure `services.syncthing.settings.gui.apiKey` option now throws an error pointing to the new option.
- Fixes #401745.
- Changes the test `syncthing-init` (maintainer @Lassulus ) to also test the new option.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
