### PR TITLE
Partially revert: "treewide: support NIX_SSL_CERT_FILE as an impureEnvVar"

### DIFF
--- a/doc/build-helpers/fetchers.chapter.md
+++ b/doc/build-helpers/fetchers.chapter.md
@@ -161,7 +161,7 @@ Here are security considerations for this scenario:
 
 Nixpkgs fetchers can make use of a http(s) proxy. Each fetcher will automatically inherit proxy-related environment variables (`http_proxy`, `https_proxy`, etc) via [impureEnvVars](https://nixos.org/manual/nix/stable/language/advanced-attributes#adv-attr-impureEnvVars).
 
-The environment variable `NIX_SSL_CERT_FILE` is also inherited in fetchers, and can be used to provide a custom certificate bundle to fetchers. This is usually required for a https proxy to work without certificate validation errors.
+TODO: FIGURE OUT WHAT TO WRITE HERE INSTEAD
 
 []{#fetchurl}
 ## `fetchurl` {#sec-pkgs-fetchers-fetchurl}

--- a/lib/fetchers.nix
+++ b/lib/fetchers.nix
@@ -30,8 +30,13 @@ rec {
     "ALL_PROXY"
     "NO_PROXY"
 
-    # https proxies typically need to inject custom root CAs too
-    "NIX_SSL_CERT_FILE"
+    # "NIX_SSL_CERT_FILE" was once added to the list because
+    # usually https proxies need to inject custom root CAs.
+    # However, it was removed because it broke builds for
+    # too many people that had the variable set automatically by the
+    # nix-daemon to an unreadable path.
+    # If you still wish to use it as an impure variable, you could
+    # add it back in your local checkout, or you could apply an overlay
   ];
 
   /**


### PR DESCRIPTION
Partial revert of https://github.com/NixOS/nixpkgs/pull/303307

Possible less-radical alternative: https://github.com/NixOS/nixpkgs/pull/345322 / https://github.com/NixOS/nixpkgs/pull/401942

CC: @timbertson 

The change in question caused too many issues.
(Mostly on Darwin, though some Linux users also encountered issues with it)

Some issues:
- Tracking issue: https://github.com/NixOS/nixpkgs/issues/394972
- https://github.com/NixOS/nixpkgs/issues/345226
- basically anything else that doesn't explicitly set `NIX_SSL_CERT_FILE`, e.g. FOD fetchers that use the `cacert` setup hook


People tried to solve it on the Nix side.
- See Nix issue: https://github.com/NixOS/nix/issues/12698
- See proposed fix for Lix https://gerrit.lix.systems/c/lix/+/2906
  - I don't think Nix's behaviour regarding the `ssl-cert-file` config option is not consistent enough for a perfect Nix-side fix, but it's probably better anyways.
  - related comment https://gerrit.lix.systems/c/lix/+/2906/7#message-26b2c1f961e50d401eb525329288675307a7acdb
    - I may or may not have understood this comment correctly! 

---

Note: this counts as a breaking change, and we have already entered the `25.05` breaking change restriction period.



<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
