### PR TITLE
nixos/tests/incus: migrate test suite to runTestOn modules

### DIFF
--- a/nixos/modules/virtualisation/incus-virtual-machine.nix
+++ b/nixos/modules/virtualisation/incus-virtual-machine.nix
@@ -25,7 +25,7 @@ in
 
       partitionTableType = "efi";
       format = "qcow2-compressed";
-      copyChannel = true;
+      copyChannel = config.system.installer.channel.enable;
     };
 
     fileSystems = {

--- a/nixos/modules/virtualisation/lxc-instance-common.nix
+++ b/nixos/modules/virtualisation/lxc-instance-common.nix
@@ -27,7 +27,7 @@
   services.openssh.startWhenNeeded = lib.mkDefault true;
 
   # As this is intended as a standalone image, undo some of the minimal profile stuff
-  documentation.enable = true;
-  documentation.nixos.enable = true;
+  documentation.enable = lib.mkDefault true;
+  documentation.nixos.enable = lib.mkDefault true;
   services.logrotate.enable = true;
 }

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -742,18 +742,14 @@ in
   immich-vectorchord-migration = runTest ./web-apps/immich-vectorchord-migration.nix;
   immich-vectorchord-reindex = runTest ./web-apps/immich-vectorchord-reindex.nix;
   incron = runTest ./incron.nix;
-  incus = recurseIntoAttrs (
-    import ./incus {
-      inherit runTest;
-      lts = false;
-    }
-  );
-  incus-lts = recurseIntoAttrs (
-    import ./incus {
-      inherit runTest;
-      lts = true;
-    }
-  );
+  incus = import ./incus {
+    inherit runTest;
+    lts = false;
+  };
+  incus-lts = import ./incus {
+    inherit runTest;
+    lts = true;
+  };
   influxdb = runTest ./influxdb.nix;
   influxdb2 = runTest ./influxdb2.nix;
   initrd-luks-empty-passphrase = runTest ./initrd-luks-empty-passphrase.nix;

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -744,11 +744,11 @@ in
   incron = runTest ./incron.nix;
   incus = import ./incus {
     inherit runTest;
-    lts = false;
+    package = pkgs.incus;
   };
   incus-lts = import ./incus {
     inherit runTest;
-    lts = true;
+    package = pkgs.incus-lts;
   };
   influxdb = runTest ./influxdb.nix;
   influxdb2 = runTest ./influxdb2.nix;

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -743,11 +743,11 @@ in
   immich-vectorchord-reindex = runTest ./web-apps/immich-vectorchord-reindex.nix;
   incron = runTest ./incron.nix;
   incus = import ./incus {
-    inherit runTest;
+    inherit runTestOn;
     package = pkgs.incus;
   };
   incus-lts = import ./incus {
-    inherit runTest;
+    inherit runTestOn;
     package = pkgs.incus-lts;
   };
   influxdb = runTest ./influxdb.nix;

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -743,12 +743,17 @@ in
   immich-vectorchord-reindex = runTest ./web-apps/immich-vectorchord-reindex.nix;
   incron = runTest ./incron.nix;
   incus = recurseIntoAttrs (
-    handleTest ./incus {
+    import ./incus {
+      inherit runTest;
       lts = false;
-      inherit system pkgs;
     }
   );
-  incus-lts = recurseIntoAttrs (handleTest ./incus { inherit system pkgs; });
+  incus-lts = recurseIntoAttrs (
+    import ./incus {
+      inherit runTest;
+      lts = true;
+    }
+  );
   influxdb = runTest ./influxdb.nix;
   influxdb2 = runTest ./influxdb2.nix;
   initrd-luks-empty-passphrase = runTest ./initrd-luks-empty-passphrase.nix;

--- a/nixos/tests/incus/default.nix
+++ b/nixos/tests/incus/default.nix
@@ -18,6 +18,29 @@ let
     };
 in
 {
+  all = incusRunTest {
+    feature.user = true;
+
+    instances = {
+      c1 = {
+        type = "container";
+      };
+
+      vm1 = {
+        type = "virtual-machine";
+      };
+    };
+
+    network = {
+      ovs = true;
+    };
+
+    storage = {
+      lvm = true;
+      zfs = true;
+    };
+  };
+
   # appArmor = incusRunTest {
   #   all = true;
   #   appArmor = true;
@@ -29,9 +52,9 @@ in
     };
   };
 
-  # lvm = incusRunTest { storage.lvm = true; };
-  #
-  # openvswitch = incusRunTest { network.ovs = true; };
+  lvm = incusRunTest { storage.lvm = true; };
+
+  openvswitch = incusRunTest { network.ovs = true; };
 
   ui = runTest {
     imports = [ ./ui.nix ];
@@ -44,6 +67,14 @@ in
       vm1 = {
         type = "virtual-machine";
       };
+
+      # TODO never becomes available
+      # csm = {
+      #   type = "virtual-machine";
+      #   incusConfig.config = {
+      #     "security.csm" = true;
+      #   };
+      # };
     };
   };
 

--- a/nixos/tests/incus/default.nix
+++ b/nixos/tests/incus/default.nix
@@ -19,6 +19,8 @@ let
 in
 {
   all = incusRunTest {
+    name = "all";
+    appArmor = true;
     feature.user = true;
 
     instances = {
@@ -41,20 +43,25 @@ in
     };
   };
 
-  # appArmor = incusRunTest {
-  #   all = true;
-  #   appArmor = true;
-  # };
-
   container = incusRunTest {
+    name = "container";
+
     instances.c1 = {
       type = "container";
     };
   };
 
-  lvm = incusRunTest { storage.lvm = true; };
+  lvm = incusRunTest {
+    name = "lvm";
 
-  openvswitch = incusRunTest { network.ovs = true; };
+    storage.lvm = true;
+  };
+
+  openvswitch = incusRunTest {
+    name = "openvswitch";
+
+    network.ovs = true;
+  };
 
   ui = runTest {
     imports = [ ./ui.nix ];
@@ -63,12 +70,14 @@ in
   };
 
   virtual-machine = incusRunTest {
+    name = "virtual-machine";
+
     instances = {
       vm1 = {
         type = "virtual-machine";
       };
 
-      # TODO never becomes available
+      # disabled because never becomes available
       # csm = {
       #   type = "virtual-machine";
       #   incusConfig.config = {
@@ -78,5 +87,9 @@ in
     };
   };
 
-  zfs = incusRunTest { storage.zfs = true; };
+  zfs = incusRunTest {
+    name = "zfs";
+
+    storage.zfs = true;
+  };
 }

--- a/nixos/tests/incus/default.nix
+++ b/nixos/tests/incus/default.nix
@@ -1,6 +1,6 @@
 {
+  package,
   runTest,
-  lts ? true,
 }:
 let
   incusRunTest =
@@ -12,32 +12,40 @@ let
       ];
 
       tests.incus = {
-        inherit lts;
+        inherit package;
       }
       // config;
     };
 in
 {
-  all = incusRunTest { all = true; };
+  # appArmor = incusRunTest {
+  #   all = true;
+  #   appArmor = true;
+  # };
 
-  appArmor = incusRunTest {
-    all = true;
-    appArmor = true;
+  container = incusRunTest {
+    instances.c1 = {
+      type = "container";
+    };
   };
 
-  container = incusRunTest { instance.container = true; };
-
-  lvm = incusRunTest { storage.lvm = true; };
-
-  openvswitch = incusRunTest { network.ovs = true; };
+  # lvm = incusRunTest { storage.lvm = true; };
+  #
+  # openvswitch = incusRunTest { network.ovs = true; };
 
   ui = runTest {
     imports = [ ./ui.nix ];
 
-    _module.args = { inherit lts; };
+    _module.args = { inherit package; };
   };
 
-  virtual-machine = incusRunTest { instance.virtual-machine = true; };
+  virtual-machine = incusRunTest {
+    instances = {
+      vm1 = {
+        type = "virtual-machine";
+      };
+    };
+  };
 
   zfs = incusRunTest { storage.zfs = true; };
 }

--- a/nixos/tests/incus/default.nix
+++ b/nixos/tests/incus/default.nix
@@ -1,51 +1,44 @@
 {
-  system ? builtins.currentSystem,
-  config ? { },
-  pkgs ? import ../../.. { inherit system config; },
+  runTest,
   lts ? true,
   ...
 }:
 let
-  incusTest = import ./incus-tests.nix;
+  incusTest =
+    config:
+    runTest {
+      imports = [
+        ./incus-tests-module.nix
+        ./incus-tests.nix
+      ];
+
+      tests.incus = {
+        inherit lts;
+      }
+      // config;
+    };
 in
 {
-  all = incusTest {
-    inherit lts pkgs system;
-    allTests = true;
-  };
-
-  container = incusTest {
-    inherit lts pkgs system;
-    instanceContainer = true;
-  };
-
-  lvm = incusTest {
-    inherit lts pkgs system;
-    storageLvm = true;
-  };
-
-  openvswitch = incusTest {
-    inherit lts pkgs system;
-    networkOvs = true;
-  };
-
-  ui = import ./ui.nix {
-    inherit lts pkgs system;
-  };
-
-  virtual-machine = incusTest {
-    inherit lts pkgs system;
-    instanceVm = true;
-  };
-
-  zfs = incusTest {
-    inherit lts pkgs system;
-    storageZfs = true;
-  };
+  all = incusTest { all = true; };
 
   appArmor = incusTest {
-    inherit lts pkgs system;
+    all = true;
     appArmor = true;
-    allTests = true;
   };
+
+  container = incusTest { instance.container = true; };
+
+  lvm = incusTest { storage.lvm = true; };
+
+  openvswitch = incusTest { network.ovs = true; };
+
+  ui = runTest {
+    imports = [ ./ui.nix ];
+
+    _module.args = { inherit lts; };
+  };
+
+  virtual-machine = incusTest { instance.virtual-machine = true; };
+
+  zfs = incusTest { storage.zfs = true; };
 }

--- a/nixos/tests/incus/default.nix
+++ b/nixos/tests/incus/default.nix
@@ -1,10 +1,9 @@
 {
   runTest,
   lts ? true,
-  ...
 }:
 let
-  incusTest =
+  incusRunTest =
     config:
     runTest {
       imports = [
@@ -19,18 +18,18 @@ let
     };
 in
 {
-  all = incusTest { all = true; };
+  all = incusRunTest { all = true; };
 
-  appArmor = incusTest {
+  appArmor = incusRunTest {
     all = true;
     appArmor = true;
   };
 
-  container = incusTest { instance.container = true; };
+  container = incusRunTest { instance.container = true; };
 
-  lvm = incusTest { storage.lvm = true; };
+  lvm = incusRunTest { storage.lvm = true; };
 
-  openvswitch = incusTest { network.ovs = true; };
+  openvswitch = incusRunTest { network.ovs = true; };
 
   ui = runTest {
     imports = [ ./ui.nix ];
@@ -38,7 +37,7 @@ in
     _module.args = { inherit lts; };
   };
 
-  virtual-machine = incusTest { instance.virtual-machine = true; };
+  virtual-machine = incusRunTest { instance.virtual-machine = true; };
 
-  zfs = incusTest { storage.zfs = true; };
+  zfs = incusRunTest { storage.zfs = true; };
 }

--- a/nixos/tests/incus/default.nix
+++ b/nixos/tests/incus/default.nix
@@ -1,11 +1,11 @@
 {
   package,
-  runTest,
+  runTestOn,
 }:
 let
   incusRunTest =
     config:
-    runTest {
+    runTestOn [ "x86_64-linux" "aarch64-linux" ] {
       imports = [
         ./incus-tests-module.nix
         ./incus-tests.nix
@@ -18,6 +18,8 @@ let
     };
 in
 {
+  # this is the main test which will test as much as possible
+  # run this for testing incus upgrades, also available in incus package tests
   all = incusRunTest {
     name = "all";
     appArmor = true;
@@ -43,6 +45,7 @@ in
     };
   };
 
+  # used in lxc tests to verify container functionality
   container = incusRunTest {
     name = "container";
 
@@ -63,7 +66,7 @@ in
     network.ovs = true;
   };
 
-  ui = runTest {
+  ui = runTestOn [ "x86_64-linux" "aarch64-linux" ] {
     imports = [ ./ui.nix ];
 
     _module.args = { inherit package; };

--- a/nixos/tests/incus/incus-tests-module.nix
+++ b/nixos/tests/incus/incus-tests-module.nix
@@ -1,0 +1,56 @@
+{ config, lib, ... }:
+let
+  cfg = config.tests.incus;
+in
+{
+  options.tests.incus = {
+    lts = lib.mkEnableOption "LTS package testing";
+
+    all = lib.mkEnableOption "All tests";
+    appArmor = lib.mkEnableOption "AppArmor during tests";
+
+    feature.user = lib.mkEnableOption "Validate incus user access feature";
+
+    init = {
+      legacy = lib.mkEnableOption "Validate non-systemd init";
+      systemd = lib.mkEnableOption "Validate systemd init";
+    };
+
+    instance = {
+      container = lib.mkEnableOption "Validate container functionality";
+      virtual-machine = lib.mkEnableOption "Validate virtual machine functionality";
+    };
+
+    network.ovs = lib.mkEnableOption "Validate OVS network integration";
+
+    storage = {
+      lvm = lib.mkEnableOption "Validate LVM storage integration";
+      zfs = lib.mkEnableOption "Validate ZFS storage integration";
+    };
+  };
+
+  config = {
+    tests.incus = {
+      lts = lib.mkDefault true;
+
+      feature.user = lib.mkDefault cfg.all;
+
+      init = {
+        legacy = lib.mkDefault cfg.all;
+        systemd = lib.mkDefault true;
+      };
+
+      instance = {
+        container = lib.mkDefault cfg.all;
+        virtual-machine = lib.mkDefault cfg.all;
+      };
+
+      network.ovs = lib.mkDefault cfg.all;
+
+      storage = {
+        lvm = lib.mkDefault cfg.all;
+        zfs = lib.mkDefault cfg.all;
+      };
+    };
+  };
+}

--- a/nixos/tests/incus/incus-tests-module.nix
+++ b/nixos/tests/incus/incus-tests-module.nix
@@ -1,25 +1,247 @@
-{ config, lib, ... }:
+{
+  lib,
+  pkgs,
+  ...
+}:
 let
-  cfg = config.tests.incus;
+  jsonFormat = pkgs.formats.json { };
 in
 {
   options.tests.incus = {
-    lts = lib.mkEnableOption "LTS package testing";
+    package = lib.mkPackageOption pkgs "incus" { };
 
-    all = lib.mkEnableOption "All tests";
+    preseed = lib.mkOption {
+      description = "configuration provided to incus preseed. https://linuxcontainers.org/incus/docs/main/howto/initialize/#non-interactive-configuration";
+      type = lib.types.submodule {
+        freeformType = jsonFormat.type;
+      };
+    };
+
+    instances = lib.mkOption {
+      type = lib.types.attrsOf (
+        lib.types.submodule (
+          { name, config, ... }:
+          {
+            options = {
+              name = lib.mkOption {
+                type = lib.types.str;
+                default = name;
+              };
+
+              type = lib.mkOption {
+                type = lib.types.enum [
+                  "container"
+                  "virtual-machine"
+                ];
+
+              };
+
+              imageAlias = lib.mkOption {
+                type = lib.types.str;
+                description = "name of image when imported";
+                default = "nixos/${name}/${config.type}";
+              };
+
+              nixosConfig = lib.mkOption {
+                type = lib.types.attrsOf lib.types.anything;
+                default = { };
+              };
+
+              incusConfig = lib.mkOption {
+                type = lib.types.submodule {
+                  freeformType = jsonFormat.type;
+                };
+                description = "incus configuration provided at launch";
+                default = { };
+              };
+
+              testScript = lib.mkOption {
+                type = lib.types.str;
+                description = "final script provided to test runner";
+                readOnly = true;
+              };
+            };
+            config =
+              let
+                releases = import ../../release.nix {
+                  configuration = config.nixosConfig;
+                };
+
+                images = {
+                  container = {
+                    metadata =
+                      releases.incusContainerMeta.${pkgs.stdenv.hostPlatform.system}
+                      + "/tarball/nixos-image-lxc-*-${pkgs.stdenv.hostPlatform.system}.tar.xz";
+
+                    root =
+                      releases.incusContainerImage.${pkgs.stdenv.hostPlatform.system}
+                      + "/nixos-lxc-image-${pkgs.stdenv.hostPlatform.system}.squashfs";
+                  };
+
+                  virtual-machine = {
+                    metadata = releases.incusVirtualMachineImageMeta.${pkgs.stdenv.hostPlatform.system} + "/*/*.tar.xz";
+                    root = releases.incusVirtualMachineImage.${pkgs.stdenv.hostPlatform.system} + "/nixos.qcow2";
+                  };
+                };
+
+                root = images.${config.type}.root;
+                metadata = images.${config.type}.metadata;
+
+                image_id = "${config.type}/${config.name}";
+              in
+              {
+                incusConfig = lib.optionalAttrs (config.type == "virtual-machine") {
+                  config."security.secureboot" = false;
+                };
+
+                nixosConfig = {
+                  # Building documentation makes the test unnecessarily take a longer time:
+                  documentation.enable = lib.mkForce false;
+                  documentation.nixos.enable = lib.mkForce false;
+                  # including a channel forces images to be rebuilt on any changes
+                  system.installer.channel.enable = lib.mkForce false;
+
+                  environment.etc."nix/registry.json".text = lib.mkForce "{}";
+
+                  # Arbitrary sysctl setting changed from nixos default
+                  # used for verifying `distrobuilder.generator` properly allows
+                  # for containers to modify sysctl
+                  boot.kernel.sysctl."net.ipv4.ip_forward" = "1";
+                };
+
+                testScript = # python
+                ''
+                  with subtest("[${image_id}] image can be imported"):
+                      server.succeed("incus image import ${metadata} ${root} --alias ${config.imageAlias}")
+
+                  with subtest("[${image_id}] can be launched and managed"):
+                      instance_name = server.succeed("incus launch ${config.imageAlias}${
+                        lib.optionalString (config.type == "virtual-machine") " --vm"
+                      } --quiet < ${jsonFormat.generate "${config.name}.json" config.incusConfig}").split(":")[1].strip()
+                      server.wait_for_instance(instance_name)
+
+                  with subtest("[${image_id}] can successfully restart"):
+                      server.succeed(f"incus restart {instance_name}")
+                      server.wait_for_instance(instance_name)
+
+                  with subtest("[${image_id}] remains running when softDaemonRestart is enabled and service is stopped"):
+                      pid = server.succeed(f"incus info {instance_name} | grep 'PID'").split(":")[1].strip()
+                      server.succeed(f"ps {pid}")
+                      server.succeed("systemctl stop incus")
+                      server.succeed(f"ps {pid}")
+                      server.succeed("systemctl start incus")
+
+                  with subtest("[${image_id}] CPU limits can be managed"):
+                      server.set_instance_config(instance_name, "limits.cpu 1", restart=True)
+                      server.wait_instance_exec_success(instance_name, "nproc | grep '^1$'", timeout=90)
+
+                  with subtest("[${image_id}] CPU limits can be hotplug changed"):
+                      server.set_instance_config(instance_name, "limits.cpu 2")
+                      server.wait_instance_exec_success(instance_name, "nproc | grep '^2$'", timeout=90)
+
+                  with subtest("[${image_id}] exec has a valid path"):
+                      server.succeed(f"incus exec {instance_name} -- bash -c 'true'")
+
+                  with subtest("[${image_id}] software tpm can be configured"):
+                      # this can be hot added to containers, but stopping for vm
+                      server.succeed(f"incus stop {instance_name}")
+                      server.succeed(f"incus config device add {instance_name} vtpm tpm path=/dev/tpm0 pathrm=/dev/tpmrm0")
+                      server.succeed(f"incus start {instance_name}")
+                      server.wait_for_instance(instance_name)
+
+                      server.succeed(f"incus exec {instance_name} -- test -e /dev/tpm0")
+                      server.succeed(f"incus exec {instance_name} -- test -e /dev/tpmrm0")
+                ''
+                #
+                # container specific
+                #
+                +
+                  lib.optionalString (config.type == "container")
+                    # python
+                    ''
+                      # TODO troubleshoot VM hot memory resizing which was introduced in 6.12
+                      with subtest("[${image_id}] memory limits can be hotplug changed"):
+                          server.set_instance_config(instance_name, "limits.memory 512MB")
+                          # can't use lsmem since it sees the host's memory size
+                          server.wait_instance_exec_success(instance_name, "grep 'MemTotal:[[:space:]]*500000 kB' /proc/meminfo", timeout=1)
+
+                      # verify the patched container systemd generator from `pkgs.distrobuilder.generator`
+                      with subtest("[${image_id}] lxc-generator compatibility"):
+                          with subtest("[${image_id}] lxc-container generator configures plain container"):
+                              # default container is plain
+                              server.succeed(f"incus exec {instance_name} test -- -e /run/systemd/system/service.d/zzz-lxc-service.conf")
+
+                              server.check_instance_sysctl(instance_name)
+
+                          with subtest("[${image_id}] lxc-container generator configures nested container"):
+                              server.set_instance_config(instance_name, "security.nesting=true", restart=True)
+
+                              server.fail(f"incus exec {instance_name} test -- -e /run/systemd/system/service.d/zzz-lxc-service.conf")
+                              target = server.succeed(f"incus exec {instance_name} readlink -- -f /run/systemd/system/systemd-binfmt.service").strip()
+                              assert target == "/dev/null", "lxc generator did not correctly mask /run/systemd/system/systemd-binfmt.service"
+
+                              server.check_instance_sysctl(instance_name)
+
+                      with subtest("[${image_id}] lxcfs"):
+                          with subtest("[${image_id}] mounts lxcfs overlays"):
+                              server.succeed(f"incus exec {instance_name} mount | grep 'lxcfs on /proc/cpuinfo type fuse.lxcfs'")
+                              server.succeed(f"incus exec {instance_name} mount | grep 'lxcfs on /proc/meminfo type fuse.lxcfs'")
+
+                          with subtest("[${image_id}] supports per-instance lxcfs"):
+                              server.succeed(f"incus stop {instance_name}")
+                              server.fail(f"pgrep -a lxcfs | grep 'incus/devices/{instance_name}/lxcfs'")
+
+                              server.succeed("incus config set instances.lxcfs.per_instance=true")
+
+                              server.succeed(f"incus start {instance_name}")
+                              server.wait_for_instance(instance_name)
+                              server.succeed(f"pgrep -a lxcfs | grep 'incus/devices/{instance_name}/lxcfs'")
+                    ''
+
+                #
+                # virtual-machine specific
+                #
+                +
+                  lib.optionalString (config.type == "virtual-machine")
+                    # python
+                    ''
+                      with subtest("[${image_id}] memory limits can be managed"):
+                          server.set_instance_config(instance_name, "limits.memory 384MB", restart=True)
+                          lsmem = json.loads(server.instance_succeed(instance_name, "lsmem --json"))
+                          memsize = lsmem["memory"][0]["size"]
+                          assert memsize == "384M", f"failed to manage memory limit. {memsize} != 384M"
+
+                      with subtest("[${image_id}] incus-agent is started"):
+                          server.succeed(f"incus exec {instance_name} systemctl is-active incus-agent")
+                    ''
+
+                +
+                  #
+                  # finalize
+                  #
+                  # python
+                  ''
+                    # this will leave the instances stopped
+                    with subtest("[${image_id}] stop with incus-startup.service"):
+                        pid = server.succeed(f"incus info {instance_name} | grep 'PID'").split(":")[1].strip()
+                        server.succeed(f"ps {pid}")
+                        server.succeed("systemctl stop incus-startup.service")
+                        server.wait_until_fails(f"ps {pid}", timeout=120)
+                        server.succeed("systemctl start incus-startup.service")
+
+                  '';
+
+              };
+          }
+        )
+      );
+      description = "";
+      default = { };
+    };
+
     appArmor = lib.mkEnableOption "AppArmor during tests";
 
     feature.user = lib.mkEnableOption "Validate incus user access feature";
-
-    init = {
-      legacy = lib.mkEnableOption "Validate non-systemd init";
-      systemd = lib.mkEnableOption "Validate systemd init";
-    };
-
-    instance = {
-      container = lib.mkEnableOption "Validate container functionality";
-      virtual-machine = lib.mkEnableOption "Validate virtual machine functionality";
-    };
 
     network.ovs = lib.mkEnableOption "Validate OVS network integration";
 
@@ -30,27 +252,6 @@ in
   };
 
   config = {
-    tests.incus = {
-      lts = lib.mkDefault true;
-
-      feature.user = lib.mkDefault cfg.all;
-
-      init = {
-        legacy = lib.mkDefault cfg.all;
-        systemd = lib.mkDefault true;
-      };
-
-      instance = {
-        container = lib.mkDefault cfg.all;
-        virtual-machine = lib.mkDefault cfg.all;
-      };
-
-      network.ovs = lib.mkDefault cfg.all;
-
-      storage = {
-        lvm = lib.mkDefault cfg.all;
-        zfs = lib.mkDefault cfg.all;
-      };
-    };
+    tests.incus = { };
   };
 }

--- a/nixos/tests/incus/incus-tests-module.nix
+++ b/nixos/tests/incus/incus-tests-module.nix
@@ -8,6 +8,11 @@ let
 in
 {
   options.tests.incus = {
+    name = lib.mkOption {
+      type = lib.types.str;
+      description = "name appended to test";
+    };
+
     package = lib.mkPackageOption pkgs "incus" { };
 
     preseed = lib.mkOption {

--- a/nixos/tests/incus/incus-tests.nix
+++ b/nixos/tests/incus/incus-tests.nix
@@ -202,8 +202,8 @@ in
               server.succeed("incus project show user-1000")
               # users shouldn't be able to list storage pools
               server.fail("su - testuser bash -c 'incus storage list'")
-
-
+              # user can create an instance
+              server.succeed("su - testuser bash -c 'incus create --empty'")
         ''
     + instanceScript;
 }

--- a/nixos/tests/incus/incus-tests.nix
+++ b/nixos/tests/incus/incus-tests.nix
@@ -6,12 +6,6 @@
 }:
 
 # TODO aarch64 vm filter
-# TODO CSM
-# with subtest("incus-user allows users to create instances"):
-#     server.succeed("su - testuser bash -c 'incus image import ${(images "systemd").container.metadata} ${(images "systemd").container.rootfs} --alias nixos'")
-#     server.succeed("su - testuser bash -c 'incus launch nixos instance2'")
-#     server.wait_for_instance("instance2", "user-1000")
-#
 let
   cfg = config.tests.incus;
 

--- a/nixos/tests/incus/incus-tests.nix
+++ b/nixos/tests/incus/incus-tests.nix
@@ -5,58 +5,33 @@
   ...
 }:
 
+# TODO aarch64 vm filter
+# TODO CSM
+# with subtest("incus-user allows users to create instances"):
+#     server.succeed("su - testuser bash -c 'incus image import ${(images "systemd").container.metadata} ${(images "systemd").container.rootfs} --alias nixos'")
+#     server.succeed("su - testuser bash -c 'incus launch nixos instance2'")
+#     server.wait_for_instance("instance2", "user-1000")
+#
 let
   cfg = config.tests.incus;
 
-  releases =
-    init:
-    import ../../release.nix {
-      configuration = {
-        # Building documentation makes the test unnecessarily take a longer time:
-        documentation.enable = lib.mkForce false;
-
-        boot.initrd.systemd.enable = init == "systemd";
-
-        # Arbitrary sysctl modification to ensure containers can update sysctl
-        boot.kernel.sysctl."net.ipv4.ip_forward" = "1";
-      };
-    };
-
-  images = init: {
-    container = {
-      metadata =
-        (releases init).incusContainerMeta.${pkgs.stdenv.hostPlatform.system}
-        + "/tarball/nixos-image-lxc-*-${pkgs.stdenv.hostPlatform.system}.tar.xz";
-
-      rootfs =
-        (releases init).incusContainerImage.${pkgs.stdenv.hostPlatform.system}
-        + "/nixos-lxc-image-${pkgs.stdenv.hostPlatform.system}.squashfs";
-    };
-
-    virtual-machine = {
-      metadata =
-        (releases init).incusVirtualMachineImageMeta.${pkgs.stdenv.hostPlatform.system} + "/*/*.tar.xz";
-      disk = (releases init).incusVirtualMachineImage.${pkgs.stdenv.hostPlatform.system} + "/nixos.qcow2";
-    };
-  };
-
-  initVariants =
-    lib.optionals cfg.init.legacy [ "legacy" ] ++ lib.optionals cfg.init.systemd [ "systemd" ];
-
-  canTestVm = cfg.instance.virtual-machine && pkgs.stdenv.isLinux && pkgs.stdenv.isx86_64;
+  instanceScript = lib.foldlAttrs (
+    acc: name: instance:
+    acc + instance.testScript
+  ) "" cfg.instances;
 in
 {
-  name = "incus" + lib.optionalString cfg.lts "-lts";
+  name = cfg.package.name;
 
   meta = {
     maintainers = lib.teams.lxc.members;
   };
 
-  nodes.machine = {
+  nodes.server = {
     virtualisation = {
       cores = 2;
       memorySize = 4096;
-      diskSize = 12 * 1024;
+      diskSize = 20 * 1024;
       emptyDiskImages = [
         # vdb for zfs
         2048
@@ -66,7 +41,7 @@ in
 
       incus = {
         enable = true;
-        package = if cfg.lts then pkgs.incus-lts else pkgs.incus;
+        package = cfg.package;
 
         preseed = {
           networks = [
@@ -152,280 +127,83 @@ in
       ''
         server = IncusHost(machine)
       ''
-    + lib.optionalString cfg.appArmor ''
-      with subtest("Verify AppArmor service is started without issue"):
-          # restart AppArmor service since the Incus AppArmor folders are
-          # created after AA service is started
-          machine.systemctl("restart apparmor.service")
-          machine.succeed("systemctl --no-pager -l status apparmor.service")
-          machine.wait_for_unit("apparmor.service")
-    ''
-    + lib.optionalString cfg.instance.container (
-      lib.foldl (
-        acc: variant:
-        acc
-        # python
-        + ''
-          metadata = "${(images variant).container.metadata}"
-          rootfs = "${(images variant).container.rootfs}"
-          alias = "nixos/container/${variant}"
-          variant = "${variant}"
-
-          with subtest("container image can be imported"):
-              machine.succeed(f"incus image import {metadata} {rootfs} --alias {alias}")
-
-
-          with subtest("container can be launched and managed"):
-              machine.succeed(f"incus launch {alias} container-{variant}1")
-              machine.wait_for_instance(f"container-{variant}1")
-
-
-          with subtest("container mounts lxcfs overlays"):
-              machine.succeed(f"incus exec container-{variant}1 mount | grep 'lxcfs on /proc/cpuinfo type fuse.lxcfs'")
-              machine.succeed(f"incus exec container-{variant}1 mount | grep 'lxcfs on /proc/meminfo type fuse.lxcfs'")
-
-
-          with subtest("container CPU limits can be managed"):
-              machine.set_instance_config(f"container-{variant}1", "limits.cpu 1", restart=True)
-              machine.wait_instance_exec_success(f"container-{variant}1", "nproc | grep '^1$'", timeout=90)
-
-
-          with subtest("container CPU limits can be hotplug changed"):
-              machine.set_instance_config(f"container-{variant}1", "limits.cpu 2")
-              machine.wait_instance_exec_success(f"container-{variant}1", "nproc | grep '^2$'", timeout=90)
-
-
-          with subtest("container memory limits can be managed"):
-              machine.set_instance_config(f"container-{variant}1", "limits.memory 128MB", restart=True)
-              machine.wait_instance_exec_success(f"container-{variant}1", "grep 'MemTotal:[[:space:]]*125000 kB' /proc/meminfo", timeout=90)
-
-
-          with subtest("container memory limits can be hotplug changed"):
-              machine.set_instance_config(f"container-{variant}1", "limits.memory 256MB")
-              machine.wait_instance_exec_success(f"container-{variant}1", "grep 'MemTotal:[[:space:]]*250000 kB' /proc/meminfo", timeout=90)
-
-
-          with subtest("container software tpm can be configured"):
-              machine.succeed(f"incus config device add container-{variant}1 vtpm tpm path=/dev/tpm0 pathrm=/dev/tpmrm0")
-              machine.succeed(f"incus exec container-{variant}1 -- test -e /dev/tpm0")
-              machine.succeed(f"incus exec container-{variant}1 -- test -e /dev/tpmrm0")
-              machine.succeed(f"incus config device remove container-{variant}1 vtpm")
-              machine.fail(f"incus exec container-{variant}1 -- test -e /dev/tpm0")
-
-
-          with subtest("container lxc-generator compatibility"):
-              with subtest("lxc-container generator configures plain container"):
-                  # default container is plain
-                  machine.succeed(f"incus exec container-{variant}1 test -- -e /run/systemd/system/service.d/zzz-lxc-service.conf")
-
-                  machine.check_instance_sysctl(f"container-{variant}1")
-
-              with subtest("lxc-container generator configures nested container"):
-                  machine.set_instance_config(f"container-{variant}1", "security.nesting=true", restart=True)
-
-                  machine.fail(f"incus exec container-{variant}1 test -- -e /run/systemd/system/service.d/zzz-lxc-service.conf")
-                  target = machine.succeed(f"incus exec container-{variant}1 readlink -- -f /run/systemd/system/systemd-binfmt.service").strip()
-                  assert target == "/dev/null", "lxc generator did not correctly mask /run/systemd/system/systemd-binfmt.service"
-
-                  machine.check_instance_sysctl(f"container-{variant}1")
-
-              with subtest("lxc-container generator configures privileged container"):
-                  # Create a new instance for a clean state
-                  machine.succeed(f"incus launch {alias} container-{variant}2")
-                  machine.wait_for_instance(f"container-{variant}2")
-
-                  machine.succeed(f"incus exec container-{variant}2 test -- -e /run/systemd/system/service.d/zzz-lxc-service.conf")
-
-                  machine.check_instance_sysctl(f"container-{variant}2")
-
-          with subtest("container supports per-instance lxcfs"):
-              machine.succeed(f"incus stop container-{variant}1")
-              machine.fail(f"pgrep -a lxcfs | grep 'incus/devices/container-{variant}1/lxcfs'")
-
-              machine.succeed("incus config set instances.lxcfs.per_instance=true")
-
-              machine.succeed(f"incus start container-{variant}1")
-              machine.wait_for_instance(f"container-{variant}1")
-              machine.succeed(f"pgrep -a lxcfs | grep 'incus/devices/container-{variant}1/lxcfs'")
-
-
-          with subtest("container can successfully restart"):
-              machine.succeed(f"incus restart container-{variant}1")
-              machine.wait_for_instance(f"container-{variant}1")
-
-
-          with subtest("container remains running when softDaemonRestart is enabled and service is stopped"):
-              pid = machine.succeed(f"incus info container-{variant}1 | grep 'PID'").split(":")[1].strip()
-              machine.succeed(f"ps {pid}")
-              machine.succeed("systemctl stop incus")
-              machine.succeed(f"ps {pid}")
-              machine.succeed("systemctl start incus")
-
-              with subtest("containers stop with incus-startup.service"):
-                  pid = machine.succeed(f"incus info container-{variant}1 | grep 'PID'").split(":")[1].strip()
-                  machine.succeed(f"ps {pid}")
-                  machine.succeed("systemctl stop incus-startup.service")
-                  machine.wait_until_fails(f"ps {pid}", timeout=120)
-                  machine.succeed("systemctl start incus-startup.service")
-
-
-          machine.cleanup()
-        ''
-      ) "" initVariants
-    )
-    + lib.optionalString canTestVm (
-      (lib.foldl (
-        acc: variant:
-        acc
-        # python
-        + ''
-          metadata = "${(images variant).virtual-machine.metadata}"
-          disk = "${(images variant).virtual-machine.disk}"
-          alias = "nixos/virtual-machine/${variant}"
-          variant = "${variant}"
-
-          with subtest("virtual-machine image can be imported"):
-              machine.succeed(f"incus image import {metadata} {disk} --alias {alias}")
-
-
-          with subtest("virtual-machine can be created"):
-              machine.succeed(f"incus create {alias} vm-{variant}1 --vm --config limits.memory=512MB --config security.secureboot=false")
-
-
-          with subtest("virtual-machine software tpm can be configured"):
-              machine.succeed(f"incus config device add vm-{variant}1 vtpm tpm path=/dev/tpm0")
-
-
-          with subtest("virtual-machine can be launched and become available"):
-              machine.succeed(f"incus start vm-{variant}1")
-              machine.wait_for_instance(f"vm-{variant}1")
-
-
-          with subtest("virtual-machine incus-agent is started"):
-              machine.succeed(f"incus exec vm-{variant}1 systemctl is-active incus-agent")
-
-
-          with subtest("virtual-machine incus-agent has a valid path"):
-              machine.succeed(f"incus exec vm-{variant}1 -- bash -c 'true'")
-
-
-          with subtest("virtual-machine CPU limits can be managed"):
-              machine.set_instance_config(f"vm-{variant}1", "limits.cpu 1", restart=True)
-              machine.wait_instance_exec_success(f"vm-{variant}1", "nproc | grep '^1$'", timeout=90)
-
-
-          with subtest("virtual-machine CPU limits can be hotplug changed"):
-              machine.set_instance_config(f"vm-{variant}1", "limits.cpu 2")
-              machine.wait_instance_exec_success(f"vm-{variant}1", "nproc | grep '^2$'", timeout=90)
-
-
-          with subtest("virtual-machine can successfully restart"):
-              machine.succeed(f"incus restart vm-{variant}1")
-              machine.wait_for_instance(f"vm-{variant}1")
-
-
-          with subtest("virtual-machine remains running when softDaemonRestart is enabled and service is stopped"):
-              pid = machine.succeed(f"incus info vm-{variant}1 | grep 'PID'").split(":")[1].strip()
-              machine.succeed(f"ps {pid}")
-              machine.succeed("systemctl stop incus")
-              machine.succeed(f"ps {pid}")
-              machine.succeed("systemctl start incus")
-
-
-              with subtest("virtual-machines stop with incus-startup.service"):
-                  pid = machine.succeed(f"incus info vm-{variant}1 | grep 'PID'").split(":")[1].strip()
-                  machine.succeed(f"ps {pid}")
-                  machine.succeed("systemctl stop incus-startup.service")
-                  machine.wait_until_fails(f"ps {pid}", timeout=120)
-                  machine.succeed("systemctl start incus-startup.service")
-
-
-          machine.cleanup()
-        ''
-      ) "" initVariants)
-      +
-        # python
-        ''
-          with subtest("virtual-machine can launch CSM (BIOS)"):
-              machine.succeed("incus init csm --vm --empty -c security.csm=true -c security.secureboot=false")
-              machine.succeed("incus start csm")
-
-
-          machine.cleanup()
-        ''
-    )
-    +
-      lib.optionalString cfg.feature.user # python
-        ''
-          with subtest("incus-user allows restricted access for users"):
-              machine.fail("incus project show user-1000")
-              machine.succeed("su - testuser bash -c 'incus list'")
-              # a project is created dynamically for the user
-              machine.succeed("incus project show user-1000")
-              # users shouldn't be able to list storage pools
-              machine.fail("su - testuser bash -c 'incus storage list'")
-
-
-          with subtest("incus-user allows users to launch instances"):
-              machine.succeed("su - testuser bash -c 'incus image import ${(images "systemd").container.metadata} ${(images "systemd").container.rootfs} --alias nixos'")
-              machine.succeed("su - testuser bash -c 'incus launch nixos instance2'")
-              machine.wait_for_instance("instance2", "user-1000")
-
-          machine.cleanup()
-        ''
     +
       lib.optionalString cfg.network.ovs # python
         ''
           with subtest("Verify openvswitch bridge"):
-              machine.succeed("incus network info ovsbr0")
+              server.succeed("incus network info ovsbr0")
 
 
           with subtest("Verify openvswitch bridge"):
-              machine.succeed("ovs-vsctl br-exists ovsbr0")
+              server.succeed("ovs-vsctl br-exists ovsbr0")
         ''
 
     +
       lib.optionalString cfg.storage.zfs # python
         ''
           with subtest("Verify zfs pool created and usable"):
-              machine.succeed(
+              server.succeed(
                   "zpool status",
                   "parted --script /dev/vdb mklabel gpt",
                   "zpool create zfs_pool /dev/vdb",
               )
 
-              machine.succeed("incus storage create zfs_pool zfs source=zfs_pool/incus")
-              machine.succeed("zfs list zfs_pool/incus")
+              server.succeed("incus storage create zfs_pool zfs source=zfs_pool/incus")
+              server.succeed("zfs list zfs_pool/incus")
 
-              machine.succeed("incus storage volume create zfs_pool test_fs --type filesystem")
-              machine.succeed("incus storage volume create zfs_pool test_vol --type block")
+              server.succeed("incus storage volume create zfs_pool test_fs --type filesystem")
+              server.succeed("incus storage volume create zfs_pool test_vol --type block")
 
-              machine.succeed("incus storage show zfs_pool")
-              machine.succeed("incus storage volume list zfs_pool")
-              machine.succeed("incus storage volume show zfs_pool test_fs")
-              machine.succeed("incus storage volume show zfs_pool test_vol")
+              server.succeed("incus storage show zfs_pool")
+              server.succeed("incus storage volume list zfs_pool")
+              server.succeed("incus storage volume show zfs_pool test_fs")
+              server.succeed("incus storage volume show zfs_pool test_vol")
 
-              machine.succeed("incus create zfs1 --empty --storage zfs_pool")
-              machine.succeed("incus list zfs1")
+              server.succeed("incus create zfs1 --empty --storage zfs_pool")
+              server.succeed("incus list zfs1")
         ''
 
     +
       lib.optionalString cfg.storage.lvm # python
         ''
           with subtest("Verify lvm pool created and usable"):
-              machine.succeed("incus storage create lvm_pool lvm source=/dev/vdc lvm.vg_name=incus_pool")
-              machine.succeed("vgs incus_pool")
+              server.succeed("incus storage create lvm_pool lvm source=/dev/vdc lvm.vg_name=incus_pool")
+              server.succeed("vgs incus_pool")
 
-              machine.succeed("incus storage volume create lvm_pool test_fs --type filesystem")
-              machine.succeed("incus storage volume create lvm_pool test_vol --type block")
+              server.succeed("incus storage volume create lvm_pool test_fs --type filesystem")
+              server.succeed("incus storage volume create lvm_pool test_vol --type block")
 
-              machine.succeed("incus storage show lvm_pool")
+              server.succeed("incus storage show lvm_pool")
 
-              machine.succeed("incus storage volume list lvm_pool")
-              machine.succeed("incus storage volume show lvm_pool test_fs")
-              machine.succeed("incus storage volume show lvm_pool test_vol")
+              server.succeed("incus storage volume list lvm_pool")
+              server.succeed("incus storage volume show lvm_pool test_fs")
+              server.succeed("incus storage volume show lvm_pool test_vol")
 
-              machine.succeed("incus create lvm1 --empty --storage lvm_pool")
-              machine.succeed("incus list lvm1")
-        '';
+              server.succeed("incus create lvm1 --empty --storage lvm_pool")
+              server.succeed("incus list lvm1")
+        ''
+    +
+      lib.optionalString cfg.appArmor # python
+        ''
+          with subtest("Verify AppArmor service is started without issue"):
+              # restart AppArmor service since the Incus AppArmor folders are
+              # created after AA service is started
+              server.systemctl("restart apparmor.service")
+              server.succeed("systemctl --no-pager -l status apparmor.service")
+              server.wait_for_unit("apparmor.service")
+        ''
+    +
+      lib.optionalString cfg.feature.user # python
+        ''
+          with subtest("incus-user allows restricted access for users"):
+              server.fail("incus project show user-1000")
+              server.succeed("su - testuser bash -c 'incus list'")
+              # a project is created dynamically for the user
+              server.succeed("incus project show user-1000")
+              # users shouldn't be able to list storage pools
+              server.fail("su - testuser bash -c 'incus storage list'")
+
+
+        ''
+    + instanceScript;
 }

--- a/nixos/tests/incus/incus-tests.nix
+++ b/nixos/tests/incus/incus-tests.nix
@@ -1,500 +1,487 @@
-import ../make-test-python.nix (
-  {
-    pkgs,
-    lib,
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}:
 
-    lts ? true,
+let
+  cfg = config.tests.incus;
 
-    allTests ? false,
+  releases =
+    init:
+    import ../../release.nix {
+      configuration = {
+        # Building documentation makes the test unnecessarily take a longer time:
+        documentation.enable = lib.mkForce false;
 
-    appArmor ? false,
-    featureUser ? allTests,
-    initLegacy ? true,
-    initSystemd ? true,
-    instanceContainer ? allTests,
-    instanceVm ? allTests,
-    networkOvs ? allTests,
-    storageLvm ? allTests,
-    storageZfs ? allTests,
-    ...
-  }:
+        boot.initrd.systemd.enable = init == "systemd";
 
-  let
-    releases =
-      init:
-      import ../../release.nix {
-        configuration = {
-          # Building documentation makes the test unnecessarily take a longer time:
-          documentation.enable = lib.mkForce false;
+        # Arbitrary sysctl modification to ensure containers can update sysctl
+        boot.kernel.sysctl."net.ipv4.ip_forward" = "1";
+      };
+    };
 
-          boot.initrd.systemd.enable = init == "systemd";
+  images = init: {
+    container = {
+      metadata =
+        (releases init).incusContainerMeta.${pkgs.stdenv.hostPlatform.system}
+        + "/tarball/nixos-image-lxc-*-${pkgs.stdenv.hostPlatform.system}.tar.xz";
 
-          # Arbitrary sysctl modification to ensure containers can update sysctl
-          boot.kernel.sysctl."net.ipv4.ip_forward" = "1";
+      rootfs =
+        (releases init).incusContainerImage.${pkgs.stdenv.hostPlatform.system}
+        + "/nixos-lxc-image-${pkgs.stdenv.hostPlatform.system}.squashfs";
+    };
+
+    virtual-machine = {
+      metadata =
+        (releases init).incusVirtualMachineImageMeta.${pkgs.stdenv.hostPlatform.system} + "/*/*.tar.xz";
+      disk = (releases init).incusVirtualMachineImage.${pkgs.stdenv.hostPlatform.system} + "/nixos.qcow2";
+    };
+  };
+
+  initVariants =
+    lib.optionals cfg.init.legacy [ "legacy" ] ++ lib.optionals cfg.init.systemd [ "systemd" ];
+
+  canTestVm = cfg.instance.virtual-machine && pkgs.stdenv.isLinux && pkgs.stdenv.isx86_64;
+in
+{
+  name = "incus" + lib.optionalString cfg.lts "-lts";
+
+  meta = {
+    maintainers = lib.teams.lxc.members;
+  };
+
+  nodes.machine = {
+    virtualisation = {
+      cores = 2;
+      memorySize = 4096;
+      diskSize = 12 * 1024;
+      emptyDiskImages = [
+        # vdb for zfs
+        2048
+        # vdc for lvm
+        2048
+      ];
+
+      incus = {
+        enable = true;
+        package = if cfg.lts then pkgs.incus-lts else pkgs.incus;
+
+        preseed = {
+          networks = [
+            {
+              name = "incusbr0";
+              type = "bridge";
+              config = {
+                "ipv4.address" = "10.0.10.1/24";
+                "ipv4.nat" = "true";
+              };
+            }
+          ]
+          ++ lib.optionals cfg.network.ovs [
+            {
+              name = "ovsbr0";
+              type = "bridge";
+              config = {
+                "bridge.driver" = "openvswitch";
+                "ipv4.address" = "10.0.20.1/24";
+                "ipv4.nat" = "true";
+              };
+            }
+          ];
+          profiles = [
+            {
+              name = "default";
+              devices = {
+                eth0 = {
+                  name = "eth0";
+                  network = "incusbr0";
+                  type = "nic";
+                };
+                root = {
+                  path = "/";
+                  pool = "default";
+                  size = "35GiB";
+                  type = "disk";
+                };
+              };
+            }
+          ];
+          storage_pools = [
+            {
+              name = "default";
+              driver = "dir";
+            }
+          ];
         };
       };
 
-    images = init: {
-      container = {
-        metadata =
-          (releases init).incusContainerMeta.${pkgs.stdenv.hostPlatform.system}
-          + "/tarball/nixos-image-lxc-*-${pkgs.stdenv.hostPlatform.system}.tar.xz";
-
-        rootfs =
-          (releases init).incusContainerImage.${pkgs.stdenv.hostPlatform.system}
-          + "/nixos-lxc-image-${pkgs.stdenv.hostPlatform.system}.squashfs";
-      };
-
-      virtual-machine = {
-        metadata =
-          (releases init).incusVirtualMachineImageMeta.${pkgs.stdenv.hostPlatform.system} + "/*/*.tar.xz";
-        disk = (releases init).incusVirtualMachineImage.${pkgs.stdenv.hostPlatform.system} + "/nixos.qcow2";
-      };
+      vswitch.enable = cfg.network.ovs;
     };
 
-    initVariants = lib.optionals initLegacy [ "legacy" ] ++ lib.optionals initSystemd [ "systemd" ];
+    boot.supportedFilesystems = { inherit (cfg.storage) zfs; };
+    boot.zfs.forceImportRoot = false;
 
-    canTestVm = instanceVm && pkgs.stdenv.isLinux && pkgs.stdenv.isx86_64;
-  in
-  {
-    name = "incus" + lib.optionalString lts "-lts";
+    environment.systemPackages = [ pkgs.parted ];
 
-    meta = {
-      maintainers = lib.teams.lxc.members;
+    networking.hostId = "01234567";
+    networking.firewall.trustedInterfaces = [ "incusbr0" ];
+    networking.nftables.enable = true;
+
+    security.apparmor.enable = cfg.appArmor;
+    services.dbus.apparmor = (if cfg.appArmor then "enabled" else "disabled");
+
+    services.lvm = {
+      boot.thin.enable = cfg.storage.lvm;
+      dmeventd.enable = cfg.storage.lvm;
     };
 
-    nodes.machine = {
-      virtualisation = {
-        cores = 2;
-        memorySize = 2048;
-        diskSize = 12 * 1024;
-        emptyDiskImages = [
-          # vdb for zfs
-          2048
-          # vdc for lvm
-          2048
-        ];
-
-        incus = {
-          enable = true;
-          package = if lts then pkgs.incus-lts else pkgs.incus;
-
-          preseed = {
-            networks = [
-              {
-                name = "incusbr0";
-                type = "bridge";
-                config = {
-                  "ipv4.address" = "10.0.10.1/24";
-                  "ipv4.nat" = "true";
-                };
-              }
-            ]
-            ++ lib.optionals networkOvs [
-              {
-                name = "ovsbr0";
-                type = "bridge";
-                config = {
-                  "bridge.driver" = "openvswitch";
-                  "ipv4.address" = "10.0.20.1/24";
-                  "ipv4.nat" = "true";
-                };
-              }
-            ];
-            profiles = [
-              {
-                name = "default";
-                devices = {
-                  eth0 = {
-                    name = "eth0";
-                    network = "incusbr0";
-                    type = "nic";
-                  };
-                  root = {
-                    path = "/";
-                    pool = "default";
-                    size = "35GiB";
-                    type = "disk";
-                  };
-                };
-              }
-            ];
-            storage_pools = [
-              {
-                name = "default";
-                driver = "dir";
-              }
-            ];
-          };
-        };
-
-        vswitch.enable = networkOvs;
-      };
-
-      boot.supportedFilesystems = lib.optionals storageZfs [ "zfs" ];
-      boot.zfs.forceImportRoot = false;
-
-      environment.systemPackages = [ pkgs.parted ];
-
-      networking.hostId = "01234567";
-      networking.firewall.trustedInterfaces = [ "incusbr0" ];
-
-      security.apparmor.enable = appArmor;
-      services.dbus.apparmor = (if appArmor then "enabled" else "disabled");
-
-      services.lvm = {
-        boot.thin.enable = storageLvm;
-        dmeventd.enable = storageLvm;
-      };
-
-      networking.nftables.enable = true;
-
-      users.users.testuser = {
-        isNormalUser = true;
-        shell = pkgs.bashInteractive;
-        group = "incus";
-        uid = 1000;
-      };
+    users.users.testuser = {
+      isNormalUser = true;
+      shell = pkgs.bashInteractive;
+      group = "incus";
+      uid = 1000;
     };
+  };
 
-    testScript = # python
-    ''
-      import json
+  testScript = # python
+  ''
+    import json
 
-      def wait_for_instance(name: str, project: str = "default"):
-          machine.wait_until_succeeds(f"incus exec {name} --disable-stdin --force-interactive --project {project} -- /run/current-system/sw/bin/systemctl is-system-running")
+    def wait_for_instance(name: str, project: str = "default"):
+        machine.wait_until_succeeds(f"incus exec {name} --disable-stdin --force-interactive --project {project} -- /run/current-system/sw/bin/systemctl is-system-running")
 
 
-      def wait_incus_exec_success(name: str, command: str, timeout: int = 900, project: str = "default"):
-          def check_command(_) -> bool:
-              status, _ = machine.execute(f"incus exec {name} --disable-stdin --force-interactive --project {project} -- {command}")
-              return status == 0
+    def wait_incus_exec_success(name: str, command: str, timeout: int = 900, project: str = "default"):
+        def check_command(_) -> bool:
+            status, _ = machine.execute(f"incus exec {name} --disable-stdin --force-interactive --project {project} -- {command}")
+            return status == 0
 
-          with machine.nested(f"Waiting for successful exec: {command}"):
-            retry(check_command, timeout)
+        with machine.nested(f"Waiting for successful exec: {command}"):
+          retry(check_command, timeout)
 
 
-      def set_config(name: str, config: str, restart: bool = False, unset: bool = False):
-          if restart:
-              machine.succeed(f"incus stop {name}")
+    def set_config(name: str, config: str, restart: bool = False, unset: bool = False):
+        if restart:
+            machine.succeed(f"incus stop {name}")
 
-          if unset:
-            machine.succeed(f"incus config unset {name} {config}")
-          else:
-            machine.succeed(f"incus config set {name} {config}")
+        if unset:
+          machine.succeed(f"incus config unset {name} {config}")
+        else:
+          machine.succeed(f"incus config set {name} {config}")
 
-          if restart:
-              machine.succeed(f"incus start {name}")
-              wait_for_instance(name)
-          else:
-              # give a moment to settle
-              machine.sleep(1)
+        if restart:
+            machine.succeed(f"incus start {name}")
+            wait_for_instance(name)
+        else:
+            # give a moment to settle
+            machine.sleep(1)
 
 
-      def cleanup():
-          # avoid conflict between preseed and cleanup operations
-          machine.execute("systemctl kill incus-preseed.service")
+    def cleanup():
+        # avoid conflict between preseed and cleanup operations
+        machine.execute("systemctl kill incus-preseed.service")
 
-          instances = json.loads(machine.succeed("incus list --format json --all-projects"))
-          with subtest("Stopping all running instances"):
-              for instance in [a for a in instances if a['status'] == 'Running']:
-                  machine.execute(f"incus stop --force {instance['name']} --project {instance['project']}")
-                  machine.execute(f"incus delete --force {instance['name']} --project {instance['project']}")
+        instances = json.loads(machine.succeed("incus list --format json --all-projects"))
+        with subtest("Stopping all running instances"):
+            for instance in [a for a in instances if a['status'] == 'Running']:
+                machine.execute(f"incus stop --force {instance['name']} --project {instance['project']}")
+                machine.execute(f"incus delete --force {instance['name']} --project {instance['project']}")
 
 
-      def check_sysctl(name: str):
-          with subtest("systemd sysctl settings are applied"):
-              machine.succeed(f"incus exec {name} -- systemctl status systemd-sysctl")
-              sysctl = machine.succeed(f"incus exec {name} -- sysctl net.ipv4.ip_forward").strip().split(" ")[-1]
-              assert "1" == sysctl, f"systemd-sysctl configuration not correctly applied, {sysctl} != 1"
+    def check_sysctl(name: str):
+        with subtest("systemd sysctl settings are applied"):
+            machine.succeed(f"incus exec {name} -- systemctl status systemd-sysctl")
+            sysctl = machine.succeed(f"incus exec {name} -- sysctl net.ipv4.ip_forward").strip().split(" ")[-1]
+            assert "1" == sysctl, f"systemd-sysctl configuration not correctly applied, {sysctl} != 1"
 
 
-      with subtest("Wait for startup"):
-          machine.wait_for_unit("incus.service")
-          machine.wait_for_unit("incus-preseed.service")
+    with subtest("Wait for startup"):
+        machine.wait_for_unit("incus.service")
+        machine.wait_for_unit("incus-preseed.service")
 
 
-      with subtest("Verify preseed resources created"):
-          machine.succeed("incus profile show default")
-          machine.succeed("incus network info incusbr0")
-          machine.succeed("incus storage show default")
+    with subtest("Verify preseed resources created"):
+        machine.succeed("incus profile show default")
+        machine.succeed("incus network info incusbr0")
+        machine.succeed("incus storage show default")
 
-    ''
-    + lib.optionalString appArmor ''
-      with subtest("Verify AppArmor service is started without issue"):
-          # restart AppArmor service since the Incus AppArmor folders are
-          # created after AA service is started
-          machine.systemctl("restart apparmor.service")
-          machine.succeed("systemctl --no-pager -l status apparmor.service")
-          machine.wait_for_unit("apparmor.service")
-    ''
-    + lib.optionalString instanceContainer (
-      lib.foldl (
-        acc: variant:
-        acc
-        # python
-        + ''
-          metadata = "${(images variant).container.metadata}"
-          rootfs = "${(images variant).container.rootfs}"
-          alias = "nixos/container/${variant}"
-          variant = "${variant}"
+  ''
+  + lib.optionalString cfg.appArmor ''
+    with subtest("Verify AppArmor service is started without issue"):
+        # restart AppArmor service since the Incus AppArmor folders are
+        # created after AA service is started
+        machine.systemctl("restart apparmor.service")
+        machine.succeed("systemctl --no-pager -l status apparmor.service")
+        machine.wait_for_unit("apparmor.service")
+  ''
+  + lib.optionalString cfg.instance.container (
+    lib.foldl (
+      acc: variant:
+      acc
+      # python
+      + ''
+        metadata = "${(images variant).container.metadata}"
+        rootfs = "${(images variant).container.rootfs}"
+        alias = "nixos/container/${variant}"
+        variant = "${variant}"
 
-          with subtest("container image can be imported"):
-              machine.succeed(f"incus image import {metadata} {rootfs} --alias {alias}")
+        with subtest("container image can be imported"):
+            machine.succeed(f"incus image import {metadata} {rootfs} --alias {alias}")
 
 
-          with subtest("container can be launched and managed"):
-              machine.succeed(f"incus launch {alias} container-{variant}1")
-              wait_for_instance(f"container-{variant}1")
+        with subtest("container can be launched and managed"):
+            machine.succeed(f"incus launch {alias} container-{variant}1")
+            wait_for_instance(f"container-{variant}1")
 
 
-          with subtest("container mounts lxcfs overlays"):
-              machine.succeed(f"incus exec container-{variant}1 mount | grep 'lxcfs on /proc/cpuinfo type fuse.lxcfs'")
-              machine.succeed(f"incus exec container-{variant}1 mount | grep 'lxcfs on /proc/meminfo type fuse.lxcfs'")
+        with subtest("container mounts lxcfs overlays"):
+            machine.succeed(f"incus exec container-{variant}1 mount | grep 'lxcfs on /proc/cpuinfo type fuse.lxcfs'")
+            machine.succeed(f"incus exec container-{variant}1 mount | grep 'lxcfs on /proc/meminfo type fuse.lxcfs'")
 
 
-          with subtest("container CPU limits can be managed"):
-              set_config(f"container-{variant}1", "limits.cpu 1", restart=True)
-              wait_incus_exec_success(f"container-{variant}1", "nproc | grep '^1$'", timeout=90)
+        with subtest("container CPU limits can be managed"):
+            set_config(f"container-{variant}1", "limits.cpu 1", restart=True)
+            wait_incus_exec_success(f"container-{variant}1", "nproc | grep '^1$'", timeout=90)
 
 
-          with subtest("container CPU limits can be hotplug changed"):
-              set_config(f"container-{variant}1", "limits.cpu 2")
-              wait_incus_exec_success(f"container-{variant}1", "nproc | grep '^2$'", timeout=90)
+        with subtest("container CPU limits can be hotplug changed"):
+            set_config(f"container-{variant}1", "limits.cpu 2")
+            wait_incus_exec_success(f"container-{variant}1", "nproc | grep '^2$'", timeout=90)
 
 
-          with subtest("container memory limits can be managed"):
-              set_config(f"container-{variant}1", "limits.memory 128MB", restart=True)
-              wait_incus_exec_success(f"container-{variant}1", "grep 'MemTotal:[[:space:]]*125000 kB' /proc/meminfo", timeout=90)
+        with subtest("container memory limits can be managed"):
+            set_config(f"container-{variant}1", "limits.memory 128MB", restart=True)
+            wait_incus_exec_success(f"container-{variant}1", "grep 'MemTotal:[[:space:]]*125000 kB' /proc/meminfo", timeout=90)
 
 
-          with subtest("container memory limits can be hotplug changed"):
-              set_config(f"container-{variant}1", "limits.memory 256MB")
-              wait_incus_exec_success(f"container-{variant}1", "grep 'MemTotal:[[:space:]]*250000 kB' /proc/meminfo", timeout=90)
+        with subtest("container memory limits can be hotplug changed"):
+            set_config(f"container-{variant}1", "limits.memory 256MB")
+            wait_incus_exec_success(f"container-{variant}1", "grep 'MemTotal:[[:space:]]*250000 kB' /proc/meminfo", timeout=90)
 
 
-          with subtest("container software tpm can be configured"):
-              machine.succeed(f"incus config device add container-{variant}1 vtpm tpm path=/dev/tpm0 pathrm=/dev/tpmrm0")
-              machine.succeed(f"incus exec container-{variant}1 -- test -e /dev/tpm0")
-              machine.succeed(f"incus exec container-{variant}1 -- test -e /dev/tpmrm0")
-              machine.succeed(f"incus config device remove container-{variant}1 vtpm")
-              machine.fail(f"incus exec container-{variant}1 -- test -e /dev/tpm0")
+        with subtest("container software tpm can be configured"):
+            machine.succeed(f"incus config device add container-{variant}1 vtpm tpm path=/dev/tpm0 pathrm=/dev/tpmrm0")
+            machine.succeed(f"incus exec container-{variant}1 -- test -e /dev/tpm0")
+            machine.succeed(f"incus exec container-{variant}1 -- test -e /dev/tpmrm0")
+            machine.succeed(f"incus config device remove container-{variant}1 vtpm")
+            machine.fail(f"incus exec container-{variant}1 -- test -e /dev/tpm0")
 
 
-          with subtest("container lxc-generator compatibility"):
-              with subtest("lxc-container generator configures plain container"):
-                  # default container is plain
-                  machine.succeed(f"incus exec container-{variant}1 test -- -e /run/systemd/system/service.d/zzz-lxc-service.conf")
+        with subtest("container lxc-generator compatibility"):
+            with subtest("lxc-container generator configures plain container"):
+                # default container is plain
+                machine.succeed(f"incus exec container-{variant}1 test -- -e /run/systemd/system/service.d/zzz-lxc-service.conf")
 
-                  check_sysctl(f"container-{variant}1")
+                check_sysctl(f"container-{variant}1")
 
-              with subtest("lxc-container generator configures nested container"):
-                  set_config(f"container-{variant}1", "security.nesting=true", restart=True)
+            with subtest("lxc-container generator configures nested container"):
+                set_config(f"container-{variant}1", "security.nesting=true", restart=True)
 
-                  machine.fail(f"incus exec container-{variant}1 test -- -e /run/systemd/system/service.d/zzz-lxc-service.conf")
-                  target = machine.succeed(f"incus exec container-{variant}1 readlink -- -f /run/systemd/system/systemd-binfmt.service").strip()
-                  assert target == "/dev/null", "lxc generator did not correctly mask /run/systemd/system/systemd-binfmt.service"
+                machine.fail(f"incus exec container-{variant}1 test -- -e /run/systemd/system/service.d/zzz-lxc-service.conf")
+                target = machine.succeed(f"incus exec container-{variant}1 readlink -- -f /run/systemd/system/systemd-binfmt.service").strip()
+                assert target == "/dev/null", "lxc generator did not correctly mask /run/systemd/system/systemd-binfmt.service"
 
-                  check_sysctl(f"container-{variant}1")
+                check_sysctl(f"container-{variant}1")
 
-              with subtest("lxc-container generator configures privileged container"):
-                  # Create a new instance for a clean state
-                  machine.succeed(f"incus launch {alias} container-{variant}2")
-                  wait_for_instance(f"container-{variant}2")
+            with subtest("lxc-container generator configures privileged container"):
+                # Create a new instance for a clean state
+                machine.succeed(f"incus launch {alias} container-{variant}2")
+                wait_for_instance(f"container-{variant}2")
 
-                  machine.succeed(f"incus exec container-{variant}2 test -- -e /run/systemd/system/service.d/zzz-lxc-service.conf")
+                machine.succeed(f"incus exec container-{variant}2 test -- -e /run/systemd/system/service.d/zzz-lxc-service.conf")
 
-                  check_sysctl(f"container-{variant}2")
+                check_sysctl(f"container-{variant}2")
 
-          with subtest("container supports per-instance lxcfs"):
-              machine.succeed(f"incus stop container-{variant}1")
-              machine.fail(f"pgrep -a lxcfs | grep 'incus/devices/container-{variant}1/lxcfs'")
+        with subtest("container supports per-instance lxcfs"):
+            machine.succeed(f"incus stop container-{variant}1")
+            machine.fail(f"pgrep -a lxcfs | grep 'incus/devices/container-{variant}1/lxcfs'")
 
-              machine.succeed("incus config set instances.lxcfs.per_instance=true")
+            machine.succeed("incus config set instances.lxcfs.per_instance=true")
 
-              machine.succeed(f"incus start container-{variant}1")
-              wait_for_instance(f"container-{variant}1")
-              machine.succeed(f"pgrep -a lxcfs | grep 'incus/devices/container-{variant}1/lxcfs'")
+            machine.succeed(f"incus start container-{variant}1")
+            wait_for_instance(f"container-{variant}1")
+            machine.succeed(f"pgrep -a lxcfs | grep 'incus/devices/container-{variant}1/lxcfs'")
 
 
-          with subtest("container can successfully restart"):
-              machine.succeed(f"incus restart container-{variant}1")
-              wait_for_instance(f"container-{variant}1")
+        with subtest("container can successfully restart"):
+            machine.succeed(f"incus restart container-{variant}1")
+            wait_for_instance(f"container-{variant}1")
 
 
-          with subtest("container remains running when softDaemonRestart is enabled and service is stopped"):
-              pid = machine.succeed(f"incus info container-{variant}1 | grep 'PID'").split(":")[1].strip()
-              machine.succeed(f"ps {pid}")
-              machine.succeed("systemctl stop incus")
-              machine.succeed(f"ps {pid}")
-              machine.succeed("systemctl start incus")
+        with subtest("container remains running when softDaemonRestart is enabled and service is stopped"):
+            pid = machine.succeed(f"incus info container-{variant}1 | grep 'PID'").split(":")[1].strip()
+            machine.succeed(f"ps {pid}")
+            machine.succeed("systemctl stop incus")
+            machine.succeed(f"ps {pid}")
+            machine.succeed("systemctl start incus")
 
-              with subtest("containers stop with incus-startup.service"):
-                  pid = machine.succeed(f"incus info container-{variant}1 | grep 'PID'").split(":")[1].strip()
-                  machine.succeed(f"ps {pid}")
-                  machine.succeed("systemctl stop incus-startup.service")
-                  machine.wait_until_fails(f"ps {pid}", timeout=120)
-                  machine.succeed("systemctl start incus-startup.service")
+            with subtest("containers stop with incus-startup.service"):
+                pid = machine.succeed(f"incus info container-{variant}1 | grep 'PID'").split(":")[1].strip()
+                machine.succeed(f"ps {pid}")
+                machine.succeed("systemctl stop incus-startup.service")
+                machine.wait_until_fails(f"ps {pid}", timeout=120)
+                machine.succeed("systemctl start incus-startup.service")
 
 
-          cleanup()
-        ''
-      ) "" initVariants
-    )
-    + lib.optionalString canTestVm (
-      (lib.foldl (
-        acc: variant:
-        acc
-        # python
-        + ''
-          metadata = "${(images variant).virtual-machine.metadata}"
-          disk = "${(images variant).virtual-machine.disk}"
-          alias = "nixos/virtual-machine/${variant}"
-          variant = "${variant}"
+        cleanup()
+      ''
+    ) "" initVariants
+  )
+  + lib.optionalString canTestVm (
+    (lib.foldl (
+      acc: variant:
+      acc
+      # python
+      + ''
+        metadata = "${(images variant).virtual-machine.metadata}"
+        disk = "${(images variant).virtual-machine.disk}"
+        alias = "nixos/virtual-machine/${variant}"
+        variant = "${variant}"
 
-          with subtest("virtual-machine image can be imported"):
-              machine.succeed(f"incus image import {metadata} {disk} --alias {alias}")
+        with subtest("virtual-machine image can be imported"):
+            machine.succeed(f"incus image import {metadata} {disk} --alias {alias}")
 
 
-          with subtest("virtual-machine can be created"):
-              machine.succeed(f"incus create {alias} vm-{variant}1 --vm --config limits.memory=512MB --config security.secureboot=false")
+        with subtest("virtual-machine can be created"):
+            machine.succeed(f"incus create {alias} vm-{variant}1 --vm --config limits.memory=512MB --config security.secureboot=false")
 
 
-          with subtest("virtual-machine software tpm can be configured"):
-              machine.succeed(f"incus config device add vm-{variant}1 vtpm tpm path=/dev/tpm0")
+        with subtest("virtual-machine software tpm can be configured"):
+            machine.succeed(f"incus config device add vm-{variant}1 vtpm tpm path=/dev/tpm0")
 
 
-          with subtest("virtual-machine can be launched and become available"):
-              machine.succeed(f"incus start vm-{variant}1")
-              wait_for_instance(f"vm-{variant}1")
+        with subtest("virtual-machine can be launched and become available"):
+            machine.succeed(f"incus start vm-{variant}1")
+            wait_for_instance(f"vm-{variant}1")
 
 
-          with subtest("virtual-machine incus-agent is started"):
-              machine.succeed(f"incus exec vm-{variant}1 systemctl is-active incus-agent")
+        with subtest("virtual-machine incus-agent is started"):
+            machine.succeed(f"incus exec vm-{variant}1 systemctl is-active incus-agent")
 
 
-          with subtest("virtual-machine incus-agent has a valid path"):
-              machine.succeed(f"incus exec vm-{variant}1 -- bash -c 'true'")
+        with subtest("virtual-machine incus-agent has a valid path"):
+            machine.succeed(f"incus exec vm-{variant}1 -- bash -c 'true'")
 
 
-          with subtest("virtual-machine CPU limits can be managed"):
-              set_config(f"vm-{variant}1", "limits.cpu 1", restart=True)
-              wait_incus_exec_success(f"vm-{variant}1", "nproc | grep '^1$'", timeout=90)
+        with subtest("virtual-machine CPU limits can be managed"):
+            set_config(f"vm-{variant}1", "limits.cpu 1", restart=True)
+            wait_incus_exec_success(f"vm-{variant}1", "nproc | grep '^1$'", timeout=90)
 
 
-          with subtest("virtual-machine CPU limits can be hotplug changed"):
-              set_config(f"vm-{variant}1", "limits.cpu 2")
-              wait_incus_exec_success(f"vm-{variant}1", "nproc | grep '^2$'", timeout=90)
+        with subtest("virtual-machine CPU limits can be hotplug changed"):
+            set_config(f"vm-{variant}1", "limits.cpu 2")
+            wait_incus_exec_success(f"vm-{variant}1", "nproc | grep '^2$'", timeout=90)
 
 
-          with subtest("virtual-machine can successfully restart"):
-              machine.succeed(f"incus restart vm-{variant}1")
-              wait_for_instance(f"vm-{variant}1")
+        with subtest("virtual-machine can successfully restart"):
+            machine.succeed(f"incus restart vm-{variant}1")
+            wait_for_instance(f"vm-{variant}1")
 
 
-          with subtest("virtual-machine remains running when softDaemonRestart is enabled and service is stopped"):
-              pid = machine.succeed(f"incus info vm-{variant}1 | grep 'PID'").split(":")[1].strip()
-              machine.succeed(f"ps {pid}")
-              machine.succeed("systemctl stop incus")
-              machine.succeed(f"ps {pid}")
-              machine.succeed("systemctl start incus")
+        with subtest("virtual-machine remains running when softDaemonRestart is enabled and service is stopped"):
+            pid = machine.succeed(f"incus info vm-{variant}1 | grep 'PID'").split(":")[1].strip()
+            machine.succeed(f"ps {pid}")
+            machine.succeed("systemctl stop incus")
+            machine.succeed(f"ps {pid}")
+            machine.succeed("systemctl start incus")
 
 
-              with subtest("virtual-machines stop with incus-startup.service"):
-                  pid = machine.succeed(f"incus info vm-{variant}1 | grep 'PID'").split(":")[1].strip()
-                  machine.succeed(f"ps {pid}")
-                  machine.succeed("systemctl stop incus-startup.service")
-                  machine.wait_until_fails(f"ps {pid}", timeout=120)
-                  machine.succeed("systemctl start incus-startup.service")
+            with subtest("virtual-machines stop with incus-startup.service"):
+                pid = machine.succeed(f"incus info vm-{variant}1 | grep 'PID'").split(":")[1].strip()
+                machine.succeed(f"ps {pid}")
+                machine.succeed("systemctl stop incus-startup.service")
+                machine.wait_until_fails(f"ps {pid}", timeout=120)
+                machine.succeed("systemctl start incus-startup.service")
 
 
-          cleanup()
-        ''
-      ) "" initVariants)
-      +
-        # python
-        ''
-          with subtest("virtual-machine can launch CSM (BIOS)"):
-              machine.succeed("incus init csm --vm --empty -c security.csm=true -c security.secureboot=false")
-              machine.succeed("incus start csm")
-
-
-          cleanup()
-        ''
-    )
+        cleanup()
+      ''
+    ) "" initVariants)
     +
-      lib.optionalString featureUser # python
-        ''
-          with subtest("incus-user allows restricted access for users"):
-              machine.fail("incus project show user-1000")
-              machine.succeed("su - testuser bash -c 'incus list'")
-              # a project is created dynamically for the user
-              machine.succeed("incus project show user-1000")
-              # users shouldn't be able to list storage pools
-              machine.fail("su - testuser bash -c 'incus storage list'")
+      # python
+      ''
+        with subtest("virtual-machine can launch CSM (BIOS)"):
+            machine.succeed("incus init csm --vm --empty -c security.csm=true -c security.secureboot=false")
+            machine.succeed("incus start csm")
 
 
-          with subtest("incus-user allows users to launch instances"):
-              machine.succeed("su - testuser bash -c 'incus image import ${(images "systemd").container.metadata} ${(images "systemd").container.rootfs} --alias nixos'")
-              machine.succeed("su - testuser bash -c 'incus launch nixos instance2'")
-              wait_for_instance("instance2", "user-1000")
+        cleanup()
+      ''
+  )
+  +
+    lib.optionalString cfg.feature.user # python
+      ''
+        with subtest("incus-user allows restricted access for users"):
+            machine.fail("incus project show user-1000")
+            machine.succeed("su - testuser bash -c 'incus list'")
+            # a project is created dynamically for the user
+            machine.succeed("incus project show user-1000")
+            # users shouldn't be able to list storage pools
+            machine.fail("su - testuser bash -c 'incus storage list'")
 
-          cleanup()
-        ''
-    +
-      lib.optionalString networkOvs # python
-        ''
-          with subtest("Verify openvswitch bridge"):
-              machine.succeed("incus network info ovsbr0")
+
+        with subtest("incus-user allows users to launch instances"):
+            machine.succeed("su - testuser bash -c 'incus image import ${(images "systemd").container.metadata} ${(images "systemd").container.rootfs} --alias nixos'")
+            machine.succeed("su - testuser bash -c 'incus launch nixos instance2'")
+            wait_for_instance("instance2", "user-1000")
+
+        cleanup()
+      ''
+  +
+    lib.optionalString cfg.network.ovs # python
+      ''
+        with subtest("Verify openvswitch bridge"):
+            machine.succeed("incus network info ovsbr0")
 
 
-          with subtest("Verify openvswitch bridge"):
-              machine.succeed("ovs-vsctl br-exists ovsbr0")
-        ''
+        with subtest("Verify openvswitch bridge"):
+            machine.succeed("ovs-vsctl br-exists ovsbr0")
+      ''
 
-    +
-      lib.optionalString storageZfs # python
-        ''
-          with subtest("Verify zfs pool created and usable"):
-              machine.succeed(
-                  "zpool status",
-                  "parted --script /dev/vdb mklabel gpt",
-                  "zpool create zfs_pool /dev/vdb",
-              )
+  +
+    lib.optionalString cfg.storage.zfs # python
+      ''
+        with subtest("Verify zfs pool created and usable"):
+            machine.succeed(
+                "zpool status",
+                "parted --script /dev/vdb mklabel gpt",
+                "zpool create zfs_pool /dev/vdb",
+            )
 
-              machine.succeed("incus storage create zfs_pool zfs source=zfs_pool/incus")
-              machine.succeed("zfs list zfs_pool/incus")
+            machine.succeed("incus storage create zfs_pool zfs source=zfs_pool/incus")
+            machine.succeed("zfs list zfs_pool/incus")
 
-              machine.succeed("incus storage volume create zfs_pool test_fs --type filesystem")
-              machine.succeed("incus storage volume create zfs_pool test_vol --type block")
+            machine.succeed("incus storage volume create zfs_pool test_fs --type filesystem")
+            machine.succeed("incus storage volume create zfs_pool test_vol --type block")
 
-              machine.succeed("incus storage show zfs_pool")
-              machine.succeed("incus storage volume list zfs_pool")
-              machine.succeed("incus storage volume show zfs_pool test_fs")
-              machine.succeed("incus storage volume show zfs_pool test_vol")
+            machine.succeed("incus storage show zfs_pool")
+            machine.succeed("incus storage volume list zfs_pool")
+            machine.succeed("incus storage volume show zfs_pool test_fs")
+            machine.succeed("incus storage volume show zfs_pool test_vol")
 
-              machine.succeed("incus create zfs1 --empty --storage zfs_pool")
-              machine.succeed("incus list zfs1")
-        ''
+            machine.succeed("incus create zfs1 --empty --storage zfs_pool")
+            machine.succeed("incus list zfs1")
+      ''
 
-    +
-      lib.optionalString storageLvm # python
-        ''
-          with subtest("Verify lvm pool created and usable"):
-              machine.succeed("incus storage create lvm_pool lvm source=/dev/vdc lvm.vg_name=incus_pool")
-              machine.succeed("vgs incus_pool")
+  +
+    lib.optionalString cfg.storage.lvm # python
+      ''
+        with subtest("Verify lvm pool created and usable"):
+            machine.succeed("incus storage create lvm_pool lvm source=/dev/vdc lvm.vg_name=incus_pool")
+            machine.succeed("vgs incus_pool")
 
-              machine.succeed("incus storage volume create lvm_pool test_fs --type filesystem")
-              machine.succeed("incus storage volume create lvm_pool test_vol --type block")
+            machine.succeed("incus storage volume create lvm_pool test_fs --type filesystem")
+            machine.succeed("incus storage volume create lvm_pool test_vol --type block")
 
-              machine.succeed("incus storage show lvm_pool")
+            machine.succeed("incus storage show lvm_pool")
 
-              machine.succeed("incus storage volume list lvm_pool")
-              machine.succeed("incus storage volume show lvm_pool test_fs")
-              machine.succeed("incus storage volume show lvm_pool test_vol")
+            machine.succeed("incus storage volume list lvm_pool")
+            machine.succeed("incus storage volume show lvm_pool test_fs")
+            machine.succeed("incus storage volume show lvm_pool test_vol")
 
-              machine.succeed("incus create lvm1 --empty --storage lvm_pool")
-              machine.succeed("incus list lvm1")
-        '';
-  }
-)
+            machine.succeed("incus create lvm1 --empty --storage lvm_pool")
+            machine.succeed("incus list lvm1")
+      '';
+}

--- a/nixos/tests/incus/incus-tests.nix
+++ b/nixos/tests/incus/incus-tests.nix
@@ -145,343 +145,287 @@ in
     };
   };
 
-  testScript = # python
-  ''
-    import json
-
-    def wait_for_instance(name: str, project: str = "default"):
-        machine.wait_until_succeeds(f"incus exec {name} --disable-stdin --force-interactive --project {project} -- /run/current-system/sw/bin/systemctl is-system-running")
-
-
-    def wait_incus_exec_success(name: str, command: str, timeout: int = 900, project: str = "default"):
-        def check_command(_) -> bool:
-            status, _ = machine.execute(f"incus exec {name} --disable-stdin --force-interactive --project {project} -- {command}")
-            return status == 0
-
-        with machine.nested(f"Waiting for successful exec: {command}"):
-          retry(check_command, timeout)
-
-
-    def set_config(name: str, config: str, restart: bool = False, unset: bool = False):
-        if restart:
-            machine.succeed(f"incus stop {name}")
-
-        if unset:
-          machine.succeed(f"incus config unset {name} {config}")
-        else:
-          machine.succeed(f"incus config set {name} {config}")
-
-        if restart:
-            machine.succeed(f"incus start {name}")
-            wait_for_instance(name)
-        else:
-            # give a moment to settle
-            machine.sleep(1)
-
-
-    def cleanup():
-        # avoid conflict between preseed and cleanup operations
-        machine.execute("systemctl kill incus-preseed.service")
-
-        instances = json.loads(machine.succeed("incus list --format json --all-projects"))
-        with subtest("Stopping all running instances"):
-            for instance in [a for a in instances if a['status'] == 'Running']:
-                machine.execute(f"incus stop --force {instance['name']} --project {instance['project']}")
-                machine.execute(f"incus delete --force {instance['name']} --project {instance['project']}")
-
-
-    def check_sysctl(name: str):
-        with subtest("systemd sysctl settings are applied"):
-            machine.succeed(f"incus exec {name} -- systemctl status systemd-sysctl")
-            sysctl = machine.succeed(f"incus exec {name} -- sysctl net.ipv4.ip_forward").strip().split(" ")[-1]
-            assert "1" == sysctl, f"systemd-sysctl configuration not correctly applied, {sysctl} != 1"
-
-
-    with subtest("Wait for startup"):
-        machine.wait_for_unit("incus.service")
-        machine.wait_for_unit("incus-preseed.service")
-
-
-    with subtest("Verify preseed resources created"):
-        machine.succeed("incus profile show default")
-        machine.succeed("incus network info incusbr0")
-        machine.succeed("incus storage show default")
-
-  ''
-  + lib.optionalString cfg.appArmor ''
-    with subtest("Verify AppArmor service is started without issue"):
-        # restart AppArmor service since the Incus AppArmor folders are
-        # created after AA service is started
-        machine.systemctl("restart apparmor.service")
-        machine.succeed("systemctl --no-pager -l status apparmor.service")
-        machine.wait_for_unit("apparmor.service")
-  ''
-  + lib.optionalString cfg.instance.container (
-    lib.foldl (
-      acc: variant:
-      acc
-      # python
-      + ''
-        metadata = "${(images variant).container.metadata}"
-        rootfs = "${(images variant).container.rootfs}"
-        alias = "nixos/container/${variant}"
-        variant = "${variant}"
-
-        with subtest("container image can be imported"):
-            machine.succeed(f"incus image import {metadata} {rootfs} --alias {alias}")
-
-
-        with subtest("container can be launched and managed"):
-            machine.succeed(f"incus launch {alias} container-{variant}1")
-            wait_for_instance(f"container-{variant}1")
-
-
-        with subtest("container mounts lxcfs overlays"):
-            machine.succeed(f"incus exec container-{variant}1 mount | grep 'lxcfs on /proc/cpuinfo type fuse.lxcfs'")
-            machine.succeed(f"incus exec container-{variant}1 mount | grep 'lxcfs on /proc/meminfo type fuse.lxcfs'")
-
-
-        with subtest("container CPU limits can be managed"):
-            set_config(f"container-{variant}1", "limits.cpu 1", restart=True)
-            wait_incus_exec_success(f"container-{variant}1", "nproc | grep '^1$'", timeout=90)
-
-
-        with subtest("container CPU limits can be hotplug changed"):
-            set_config(f"container-{variant}1", "limits.cpu 2")
-            wait_incus_exec_success(f"container-{variant}1", "nproc | grep '^2$'", timeout=90)
-
-
-        with subtest("container memory limits can be managed"):
-            set_config(f"container-{variant}1", "limits.memory 128MB", restart=True)
-            wait_incus_exec_success(f"container-{variant}1", "grep 'MemTotal:[[:space:]]*125000 kB' /proc/meminfo", timeout=90)
-
-
-        with subtest("container memory limits can be hotplug changed"):
-            set_config(f"container-{variant}1", "limits.memory 256MB")
-            wait_incus_exec_success(f"container-{variant}1", "grep 'MemTotal:[[:space:]]*250000 kB' /proc/meminfo", timeout=90)
-
-
-        with subtest("container software tpm can be configured"):
-            machine.succeed(f"incus config device add container-{variant}1 vtpm tpm path=/dev/tpm0 pathrm=/dev/tpmrm0")
-            machine.succeed(f"incus exec container-{variant}1 -- test -e /dev/tpm0")
-            machine.succeed(f"incus exec container-{variant}1 -- test -e /dev/tpmrm0")
-            machine.succeed(f"incus config device remove container-{variant}1 vtpm")
-            machine.fail(f"incus exec container-{variant}1 -- test -e /dev/tpm0")
-
-
-        with subtest("container lxc-generator compatibility"):
-            with subtest("lxc-container generator configures plain container"):
-                # default container is plain
-                machine.succeed(f"incus exec container-{variant}1 test -- -e /run/systemd/system/service.d/zzz-lxc-service.conf")
-
-                check_sysctl(f"container-{variant}1")
-
-            with subtest("lxc-container generator configures nested container"):
-                set_config(f"container-{variant}1", "security.nesting=true", restart=True)
-
-                machine.fail(f"incus exec container-{variant}1 test -- -e /run/systemd/system/service.d/zzz-lxc-service.conf")
-                target = machine.succeed(f"incus exec container-{variant}1 readlink -- -f /run/systemd/system/systemd-binfmt.service").strip()
-                assert target == "/dev/null", "lxc generator did not correctly mask /run/systemd/system/systemd-binfmt.service"
-
-                check_sysctl(f"container-{variant}1")
-
-            with subtest("lxc-container generator configures privileged container"):
-                # Create a new instance for a clean state
-                machine.succeed(f"incus launch {alias} container-{variant}2")
-                wait_for_instance(f"container-{variant}2")
-
-                machine.succeed(f"incus exec container-{variant}2 test -- -e /run/systemd/system/service.d/zzz-lxc-service.conf")
-
-                check_sysctl(f"container-{variant}2")
-
-        with subtest("container supports per-instance lxcfs"):
-            machine.succeed(f"incus stop container-{variant}1")
-            machine.fail(f"pgrep -a lxcfs | grep 'incus/devices/container-{variant}1/lxcfs'")
-
-            machine.succeed("incus config set instances.lxcfs.per_instance=true")
-
-            machine.succeed(f"incus start container-{variant}1")
-            wait_for_instance(f"container-{variant}1")
-            machine.succeed(f"pgrep -a lxcfs | grep 'incus/devices/container-{variant}1/lxcfs'")
-
-
-        with subtest("container can successfully restart"):
-            machine.succeed(f"incus restart container-{variant}1")
-            wait_for_instance(f"container-{variant}1")
-
-
-        with subtest("container remains running when softDaemonRestart is enabled and service is stopped"):
-            pid = machine.succeed(f"incus info container-{variant}1 | grep 'PID'").split(":")[1].strip()
-            machine.succeed(f"ps {pid}")
-            machine.succeed("systemctl stop incus")
-            machine.succeed(f"ps {pid}")
-            machine.succeed("systemctl start incus")
-
-            with subtest("containers stop with incus-startup.service"):
-                pid = machine.succeed(f"incus info container-{variant}1 | grep 'PID'").split(":")[1].strip()
-                machine.succeed(f"ps {pid}")
-                machine.succeed("systemctl stop incus-startup.service")
-                machine.wait_until_fails(f"ps {pid}", timeout=120)
-                machine.succeed("systemctl start incus-startup.service")
-
-
-        cleanup()
-      ''
-    ) "" initVariants
-  )
-  + lib.optionalString canTestVm (
-    (lib.foldl (
-      acc: variant:
-      acc
-      # python
-      + ''
-        metadata = "${(images variant).virtual-machine.metadata}"
-        disk = "${(images variant).virtual-machine.disk}"
-        alias = "nixos/virtual-machine/${variant}"
-        variant = "${variant}"
-
-        with subtest("virtual-machine image can be imported"):
-            machine.succeed(f"incus image import {metadata} {disk} --alias {alias}")
-
-
-        with subtest("virtual-machine can be created"):
-            machine.succeed(f"incus create {alias} vm-{variant}1 --vm --config limits.memory=512MB --config security.secureboot=false")
-
-
-        with subtest("virtual-machine software tpm can be configured"):
-            machine.succeed(f"incus config device add vm-{variant}1 vtpm tpm path=/dev/tpm0")
-
-
-        with subtest("virtual-machine can be launched and become available"):
-            machine.succeed(f"incus start vm-{variant}1")
-            wait_for_instance(f"vm-{variant}1")
-
-
-        with subtest("virtual-machine incus-agent is started"):
-            machine.succeed(f"incus exec vm-{variant}1 systemctl is-active incus-agent")
-
-
-        with subtest("virtual-machine incus-agent has a valid path"):
-            machine.succeed(f"incus exec vm-{variant}1 -- bash -c 'true'")
-
-
-        with subtest("virtual-machine CPU limits can be managed"):
-            set_config(f"vm-{variant}1", "limits.cpu 1", restart=True)
-            wait_incus_exec_success(f"vm-{variant}1", "nproc | grep '^1$'", timeout=90)
-
-
-        with subtest("virtual-machine CPU limits can be hotplug changed"):
-            set_config(f"vm-{variant}1", "limits.cpu 2")
-            wait_incus_exec_success(f"vm-{variant}1", "nproc | grep '^2$'", timeout=90)
-
-
-        with subtest("virtual-machine can successfully restart"):
-            machine.succeed(f"incus restart vm-{variant}1")
-            wait_for_instance(f"vm-{variant}1")
-
-
-        with subtest("virtual-machine remains running when softDaemonRestart is enabled and service is stopped"):
-            pid = machine.succeed(f"incus info vm-{variant}1 | grep 'PID'").split(":")[1].strip()
-            machine.succeed(f"ps {pid}")
-            machine.succeed("systemctl stop incus")
-            machine.succeed(f"ps {pid}")
-            machine.succeed("systemctl start incus")
-
-
-            with subtest("virtual-machines stop with incus-startup.service"):
-                pid = machine.succeed(f"incus info vm-{variant}1 | grep 'PID'").split(":")[1].strip()
-                machine.succeed(f"ps {pid}")
-                machine.succeed("systemctl stop incus-startup.service")
-                machine.wait_until_fails(f"ps {pid}", timeout=120)
-                machine.succeed("systemctl start incus-startup.service")
-
-
-        cleanup()
-      ''
-    ) "" initVariants)
+  testScript =
+    lib.readFile ./incus_machine.py
     +
       # python
       ''
-        with subtest("virtual-machine can launch CSM (BIOS)"):
-            machine.succeed("incus init csm --vm --empty -c security.csm=true -c security.secureboot=false")
-            machine.succeed("incus start csm")
-
-
-        cleanup()
+        server = IncusHost(machine)
       ''
-  )
-  +
-    lib.optionalString cfg.feature.user # python
-      ''
-        with subtest("incus-user allows restricted access for users"):
-            machine.fail("incus project show user-1000")
-            machine.succeed("su - testuser bash -c 'incus list'")
-            # a project is created dynamically for the user
-            machine.succeed("incus project show user-1000")
-            # users shouldn't be able to list storage pools
-            machine.fail("su - testuser bash -c 'incus storage list'")
+    + lib.optionalString cfg.appArmor ''
+      with subtest("Verify AppArmor service is started without issue"):
+          # restart AppArmor service since the Incus AppArmor folders are
+          # created after AA service is started
+          machine.systemctl("restart apparmor.service")
+          machine.succeed("systemctl --no-pager -l status apparmor.service")
+          machine.wait_for_unit("apparmor.service")
+    ''
+    + lib.optionalString cfg.instance.container (
+      lib.foldl (
+        acc: variant:
+        acc
+        # python
+        + ''
+          metadata = "${(images variant).container.metadata}"
+          rootfs = "${(images variant).container.rootfs}"
+          alias = "nixos/container/${variant}"
+          variant = "${variant}"
+
+          with subtest("container image can be imported"):
+              machine.succeed(f"incus image import {metadata} {rootfs} --alias {alias}")
 
 
-        with subtest("incus-user allows users to launch instances"):
-            machine.succeed("su - testuser bash -c 'incus image import ${(images "systemd").container.metadata} ${(images "systemd").container.rootfs} --alias nixos'")
-            machine.succeed("su - testuser bash -c 'incus launch nixos instance2'")
-            wait_for_instance("instance2", "user-1000")
-
-        cleanup()
-      ''
-  +
-    lib.optionalString cfg.network.ovs # python
-      ''
-        with subtest("Verify openvswitch bridge"):
-            machine.succeed("incus network info ovsbr0")
+          with subtest("container can be launched and managed"):
+              machine.succeed(f"incus launch {alias} container-{variant}1")
+              machine.wait_for_instance(f"container-{variant}1")
 
 
-        with subtest("Verify openvswitch bridge"):
-            machine.succeed("ovs-vsctl br-exists ovsbr0")
-      ''
+          with subtest("container mounts lxcfs overlays"):
+              machine.succeed(f"incus exec container-{variant}1 mount | grep 'lxcfs on /proc/cpuinfo type fuse.lxcfs'")
+              machine.succeed(f"incus exec container-{variant}1 mount | grep 'lxcfs on /proc/meminfo type fuse.lxcfs'")
 
-  +
-    lib.optionalString cfg.storage.zfs # python
-      ''
-        with subtest("Verify zfs pool created and usable"):
-            machine.succeed(
-                "zpool status",
-                "parted --script /dev/vdb mklabel gpt",
-                "zpool create zfs_pool /dev/vdb",
-            )
 
-            machine.succeed("incus storage create zfs_pool zfs source=zfs_pool/incus")
-            machine.succeed("zfs list zfs_pool/incus")
+          with subtest("container CPU limits can be managed"):
+              machine.set_instance_config(f"container-{variant}1", "limits.cpu 1", restart=True)
+              machine.wait_instance_exec_success(f"container-{variant}1", "nproc | grep '^1$'", timeout=90)
 
-            machine.succeed("incus storage volume create zfs_pool test_fs --type filesystem")
-            machine.succeed("incus storage volume create zfs_pool test_vol --type block")
 
-            machine.succeed("incus storage show zfs_pool")
-            machine.succeed("incus storage volume list zfs_pool")
-            machine.succeed("incus storage volume show zfs_pool test_fs")
-            machine.succeed("incus storage volume show zfs_pool test_vol")
+          with subtest("container CPU limits can be hotplug changed"):
+              machine.set_instance_config(f"container-{variant}1", "limits.cpu 2")
+              machine.wait_instance_exec_success(f"container-{variant}1", "nproc | grep '^2$'", timeout=90)
 
-            machine.succeed("incus create zfs1 --empty --storage zfs_pool")
-            machine.succeed("incus list zfs1")
-      ''
 
-  +
-    lib.optionalString cfg.storage.lvm # python
-      ''
-        with subtest("Verify lvm pool created and usable"):
-            machine.succeed("incus storage create lvm_pool lvm source=/dev/vdc lvm.vg_name=incus_pool")
-            machine.succeed("vgs incus_pool")
+          with subtest("container memory limits can be managed"):
+              machine.set_instance_config(f"container-{variant}1", "limits.memory 128MB", restart=True)
+              machine.wait_instance_exec_success(f"container-{variant}1", "grep 'MemTotal:[[:space:]]*125000 kB' /proc/meminfo", timeout=90)
 
-            machine.succeed("incus storage volume create lvm_pool test_fs --type filesystem")
-            machine.succeed("incus storage volume create lvm_pool test_vol --type block")
 
-            machine.succeed("incus storage show lvm_pool")
+          with subtest("container memory limits can be hotplug changed"):
+              machine.set_instance_config(f"container-{variant}1", "limits.memory 256MB")
+              machine.wait_instance_exec_success(f"container-{variant}1", "grep 'MemTotal:[[:space:]]*250000 kB' /proc/meminfo", timeout=90)
 
-            machine.succeed("incus storage volume list lvm_pool")
-            machine.succeed("incus storage volume show lvm_pool test_fs")
-            machine.succeed("incus storage volume show lvm_pool test_vol")
 
-            machine.succeed("incus create lvm1 --empty --storage lvm_pool")
-            machine.succeed("incus list lvm1")
-      '';
+          with subtest("container software tpm can be configured"):
+              machine.succeed(f"incus config device add container-{variant}1 vtpm tpm path=/dev/tpm0 pathrm=/dev/tpmrm0")
+              machine.succeed(f"incus exec container-{variant}1 -- test -e /dev/tpm0")
+              machine.succeed(f"incus exec container-{variant}1 -- test -e /dev/tpmrm0")
+              machine.succeed(f"incus config device remove container-{variant}1 vtpm")
+              machine.fail(f"incus exec container-{variant}1 -- test -e /dev/tpm0")
+
+
+          with subtest("container lxc-generator compatibility"):
+              with subtest("lxc-container generator configures plain container"):
+                  # default container is plain
+                  machine.succeed(f"incus exec container-{variant}1 test -- -e /run/systemd/system/service.d/zzz-lxc-service.conf")
+
+                  machine.check_instance_sysctl(f"container-{variant}1")
+
+              with subtest("lxc-container generator configures nested container"):
+                  machine.set_instance_config(f"container-{variant}1", "security.nesting=true", restart=True)
+
+                  machine.fail(f"incus exec container-{variant}1 test -- -e /run/systemd/system/service.d/zzz-lxc-service.conf")
+                  target = machine.succeed(f"incus exec container-{variant}1 readlink -- -f /run/systemd/system/systemd-binfmt.service").strip()
+                  assert target == "/dev/null", "lxc generator did not correctly mask /run/systemd/system/systemd-binfmt.service"
+
+                  machine.check_instance_sysctl(f"container-{variant}1")
+
+              with subtest("lxc-container generator configures privileged container"):
+                  # Create a new instance for a clean state
+                  machine.succeed(f"incus launch {alias} container-{variant}2")
+                  machine.wait_for_instance(f"container-{variant}2")
+
+                  machine.succeed(f"incus exec container-{variant}2 test -- -e /run/systemd/system/service.d/zzz-lxc-service.conf")
+
+                  machine.check_instance_sysctl(f"container-{variant}2")
+
+          with subtest("container supports per-instance lxcfs"):
+              machine.succeed(f"incus stop container-{variant}1")
+              machine.fail(f"pgrep -a lxcfs | grep 'incus/devices/container-{variant}1/lxcfs'")
+
+              machine.succeed("incus config set instances.lxcfs.per_instance=true")
+
+              machine.succeed(f"incus start container-{variant}1")
+              machine.wait_for_instance(f"container-{variant}1")
+              machine.succeed(f"pgrep -a lxcfs | grep 'incus/devices/container-{variant}1/lxcfs'")
+
+
+          with subtest("container can successfully restart"):
+              machine.succeed(f"incus restart container-{variant}1")
+              machine.wait_for_instance(f"container-{variant}1")
+
+
+          with subtest("container remains running when softDaemonRestart is enabled and service is stopped"):
+              pid = machine.succeed(f"incus info container-{variant}1 | grep 'PID'").split(":")[1].strip()
+              machine.succeed(f"ps {pid}")
+              machine.succeed("systemctl stop incus")
+              machine.succeed(f"ps {pid}")
+              machine.succeed("systemctl start incus")
+
+              with subtest("containers stop with incus-startup.service"):
+                  pid = machine.succeed(f"incus info container-{variant}1 | grep 'PID'").split(":")[1].strip()
+                  machine.succeed(f"ps {pid}")
+                  machine.succeed("systemctl stop incus-startup.service")
+                  machine.wait_until_fails(f"ps {pid}", timeout=120)
+                  machine.succeed("systemctl start incus-startup.service")
+
+
+          machine.cleanup()
+        ''
+      ) "" initVariants
+    )
+    + lib.optionalString canTestVm (
+      (lib.foldl (
+        acc: variant:
+        acc
+        # python
+        + ''
+          metadata = "${(images variant).virtual-machine.metadata}"
+          disk = "${(images variant).virtual-machine.disk}"
+          alias = "nixos/virtual-machine/${variant}"
+          variant = "${variant}"
+
+          with subtest("virtual-machine image can be imported"):
+              machine.succeed(f"incus image import {metadata} {disk} --alias {alias}")
+
+
+          with subtest("virtual-machine can be created"):
+              machine.succeed(f"incus create {alias} vm-{variant}1 --vm --config limits.memory=512MB --config security.secureboot=false")
+
+
+          with subtest("virtual-machine software tpm can be configured"):
+              machine.succeed(f"incus config device add vm-{variant}1 vtpm tpm path=/dev/tpm0")
+
+
+          with subtest("virtual-machine can be launched and become available"):
+              machine.succeed(f"incus start vm-{variant}1")
+              machine.wait_for_instance(f"vm-{variant}1")
+
+
+          with subtest("virtual-machine incus-agent is started"):
+              machine.succeed(f"incus exec vm-{variant}1 systemctl is-active incus-agent")
+
+
+          with subtest("virtual-machine incus-agent has a valid path"):
+              machine.succeed(f"incus exec vm-{variant}1 -- bash -c 'true'")
+
+
+          with subtest("virtual-machine CPU limits can be managed"):
+              machine.set_instance_config(f"vm-{variant}1", "limits.cpu 1", restart=True)
+              machine.wait_instance_exec_success(f"vm-{variant}1", "nproc | grep '^1$'", timeout=90)
+
+
+          with subtest("virtual-machine CPU limits can be hotplug changed"):
+              machine.set_instance_config(f"vm-{variant}1", "limits.cpu 2")
+              machine.wait_instance_exec_success(f"vm-{variant}1", "nproc | grep '^2$'", timeout=90)
+
+
+          with subtest("virtual-machine can successfully restart"):
+              machine.succeed(f"incus restart vm-{variant}1")
+              machine.wait_for_instance(f"vm-{variant}1")
+
+
+          with subtest("virtual-machine remains running when softDaemonRestart is enabled and service is stopped"):
+              pid = machine.succeed(f"incus info vm-{variant}1 | grep 'PID'").split(":")[1].strip()
+              machine.succeed(f"ps {pid}")
+              machine.succeed("systemctl stop incus")
+              machine.succeed(f"ps {pid}")
+              machine.succeed("systemctl start incus")
+
+
+              with subtest("virtual-machines stop with incus-startup.service"):
+                  pid = machine.succeed(f"incus info vm-{variant}1 | grep 'PID'").split(":")[1].strip()
+                  machine.succeed(f"ps {pid}")
+                  machine.succeed("systemctl stop incus-startup.service")
+                  machine.wait_until_fails(f"ps {pid}", timeout=120)
+                  machine.succeed("systemctl start incus-startup.service")
+
+
+          machine.cleanup()
+        ''
+      ) "" initVariants)
+      +
+        # python
+        ''
+          with subtest("virtual-machine can launch CSM (BIOS)"):
+              machine.succeed("incus init csm --vm --empty -c security.csm=true -c security.secureboot=false")
+              machine.succeed("incus start csm")
+
+
+          machine.cleanup()
+        ''
+    )
+    +
+      lib.optionalString cfg.feature.user # python
+        ''
+          with subtest("incus-user allows restricted access for users"):
+              machine.fail("incus project show user-1000")
+              machine.succeed("su - testuser bash -c 'incus list'")
+              # a project is created dynamically for the user
+              machine.succeed("incus project show user-1000")
+              # users shouldn't be able to list storage pools
+              machine.fail("su - testuser bash -c 'incus storage list'")
+
+
+          with subtest("incus-user allows users to launch instances"):
+              machine.succeed("su - testuser bash -c 'incus image import ${(images "systemd").container.metadata} ${(images "systemd").container.rootfs} --alias nixos'")
+              machine.succeed("su - testuser bash -c 'incus launch nixos instance2'")
+              machine.wait_for_instance("instance2", "user-1000")
+
+          machine.cleanup()
+        ''
+    +
+      lib.optionalString cfg.network.ovs # python
+        ''
+          with subtest("Verify openvswitch bridge"):
+              machine.succeed("incus network info ovsbr0")
+
+
+          with subtest("Verify openvswitch bridge"):
+              machine.succeed("ovs-vsctl br-exists ovsbr0")
+        ''
+
+    +
+      lib.optionalString cfg.storage.zfs # python
+        ''
+          with subtest("Verify zfs pool created and usable"):
+              machine.succeed(
+                  "zpool status",
+                  "parted --script /dev/vdb mklabel gpt",
+                  "zpool create zfs_pool /dev/vdb",
+              )
+
+              machine.succeed("incus storage create zfs_pool zfs source=zfs_pool/incus")
+              machine.succeed("zfs list zfs_pool/incus")
+
+              machine.succeed("incus storage volume create zfs_pool test_fs --type filesystem")
+              machine.succeed("incus storage volume create zfs_pool test_vol --type block")
+
+              machine.succeed("incus storage show zfs_pool")
+              machine.succeed("incus storage volume list zfs_pool")
+              machine.succeed("incus storage volume show zfs_pool test_fs")
+              machine.succeed("incus storage volume show zfs_pool test_vol")
+
+              machine.succeed("incus create zfs1 --empty --storage zfs_pool")
+              machine.succeed("incus list zfs1")
+        ''
+
+    +
+      lib.optionalString cfg.storage.lvm # python
+        ''
+          with subtest("Verify lvm pool created and usable"):
+              machine.succeed("incus storage create lvm_pool lvm source=/dev/vdc lvm.vg_name=incus_pool")
+              machine.succeed("vgs incus_pool")
+
+              machine.succeed("incus storage volume create lvm_pool test_fs --type filesystem")
+              machine.succeed("incus storage volume create lvm_pool test_vol --type block")
+
+              machine.succeed("incus storage show lvm_pool")
+
+              machine.succeed("incus storage volume list lvm_pool")
+              machine.succeed("incus storage volume show lvm_pool test_fs")
+              machine.succeed("incus storage volume show lvm_pool test_vol")
+
+              machine.succeed("incus create lvm1 --empty --storage lvm_pool")
+              machine.succeed("incus list lvm1")
+        '';
 }

--- a/nixos/tests/incus/incus-tests.nix
+++ b/nixos/tests/incus/incus-tests.nix
@@ -15,11 +15,14 @@ let
   ) "" cfg.instances;
 in
 {
-  name = cfg.package.name;
+  name = "${cfg.package.name}-${cfg.name}";
 
   meta = {
     maintainers = lib.teams.lxc.members;
   };
+
+  # sshBackdoor.enable = true;
+  # enableDebugHook = true;
 
   nodes.server = {
     virtualisation = {

--- a/nixos/tests/incus/incus_machine.py
+++ b/nixos/tests/incus/incus_machine.py
@@ -1,0 +1,92 @@
+import json
+
+
+class IncusHost(Machine):
+    def __init__(self, base):
+        with subtest("Wait for startup"):
+            base.wait_for_unit("incus.service")
+            base.wait_for_unit("incus-preseed.service")
+
+        with subtest("Verify preseed resources created"):
+            base.succeed("incus profile show default")
+            base.succeed("incus network info incusbr0")
+            base.succeed("incus storage show default")
+
+        self._parent = base
+
+    # delegate attribute access to the parent
+    def __getattr__(self, name):
+        return getattr(self._parent, name)
+
+    def instance_exec(self, name: str, command: str, project: str = "default"):
+        return super().execute(
+            f"incus exec {name} --disable-stdin --force-interactive --project {project} -- {command}"
+        )
+
+    def instance_succeed(self, name: str, command: str, project: str = "default"):
+        return super().succeed(
+            f"incus exec {name} --disable-stdin --force-interactive --project {project} -- {command}"
+        )
+
+    def wait_for_instance(self, name: str, project: str = "default"):
+        self.wait_instance_exec_success(
+            name,
+            "/run/current-system/sw/bin/systemctl is-system-running",
+            project=project,
+        )
+
+    def wait_instance_exec_success(
+        self, name: str, command: str, timeout: int = 900, project: str = "default"
+    ):
+        def check_command(_) -> bool:
+            status, _ = self.instance_exec(name, command, project)
+            return status == 0
+
+        with super().nested(
+            f"Waiting for successful instance exec, instance={name}, project={project}, command={command}"
+        ):
+            retry(check_command, timeout)
+
+    def set_instance_config(
+        self, name: str, config: str, restart: bool = False, unset: bool = False
+    ):
+        if restart:
+            super().succeed(f"incus stop {name}")
+
+        if unset:
+            super().succeed(f"incus config unset {name} {config}")
+        else:
+            super().succeed(f"incus config set {name} {config}")
+
+        if restart:
+            super().succeed(f"incus start {name}")
+            self.wait_for_instance(name)
+        else:
+            # give a moment to settle
+            super().sleep(1)
+
+    def cleanup(self):
+        # avoid conflict between preseed and cleanup operations
+        super().execute("systemctl kill incus-preseed.service")
+
+        instances = json.loads(
+            super().succeed("incus list --format json --all-projects")
+        )
+        for instance in [a for a in instances if a["status"] == "Running"]:
+            super().execute(
+                f"incus stop --force {instance['name']} --project {instance['project']}"
+            )
+            super().execute(
+                f"incus delete --force {instance['name']} --project {instance['project']}"
+            )
+
+    def check_instance_sysctl(self, name: str, project: str = "default"):
+        self.instance_succeed(name, "systemctl status systemd-sysctl", project)
+        sysctl = (
+            self.instance_succeed(name, "sysctl net.ipv4.ip_forward", project)
+            .strip()
+            .split(" ")[-1]
+        )
+        assert (
+            "1" == sysctl
+        ), f"systemd-sysctl configuration not correctly applied, {sysctl} != 1"

--- a/nixos/tests/incus/incus_machine.py
+++ b/nixos/tests/incus/incus_machine.py
@@ -87,6 +87,6 @@ class IncusHost(Machine):
             .strip()
             .split(" ")[-1]
         )
-        assert (
-            "1" == sysctl
-        ), f"systemd-sysctl configuration not correctly applied, {sysctl} != 1"
+        assert "1" == sysctl, (
+            f"systemd-sysctl configuration not correctly applied, {sysctl} != 1"
+        )

--- a/nixos/tests/incus/ui.nix
+++ b/nixos/tests/incus/ui.nix
@@ -1,84 +1,82 @@
-import ../make-test-python.nix (
-  {
-    pkgs,
-    lib,
-    lts ? true,
-    ...
-  }:
-  {
-    name = "incus-ui";
+{
+  pkgs,
+  lib,
+  lts ? true,
+  ...
+}:
+{
+  name = "incus-ui";
 
-    meta = {
-      maintainers = lib.teams.lxc.members;
-    };
+  meta = {
+    maintainers = lib.teams.lxc.members;
+  };
 
-    nodes.machine =
-      { lib, ... }:
-      {
+  nodes.machine =
+    { lib, ... }:
+    {
 
-        virtualisation.incus = {
-          enable = true;
-          package = if lts then pkgs.incus-lts else pkgs.incus;
+      virtualisation.incus = {
+        enable = true;
+        package = if lts then pkgs.incus-lts else pkgs.incus;
 
-          preseed.config."core.https_address" = ":8443";
-          ui.enable = true;
-        };
-
-        networking.nftables.enable = true;
-
-        environment.systemPackages =
-          let
-            seleniumScript =
-              pkgs.writers.writePython3Bin "selenium-script"
-                {
-                  libraries = with pkgs.python3Packages; [ selenium ];
-                }
-                ''
-                  from selenium import webdriver
-                  from selenium.webdriver.common.by import By
-                  from selenium.webdriver.firefox.options import Options
-                  from selenium.webdriver.support.ui import WebDriverWait
-
-                  options = Options()
-                  options.add_argument("--headless")
-                  service = webdriver.FirefoxService(executable_path="${lib.getExe pkgs.geckodriver}")  # noqa: E501
-
-                  driver = webdriver.Firefox(options=options, service=service)
-                  driver.implicitly_wait(10)
-                  driver.get("https://localhost:8443/ui")
-
-                  wait = WebDriverWait(driver, 60)
-
-                  assert len(driver.find_elements(By.CLASS_NAME, "l-application")) > 0
-                  assert len(driver.find_elements(By.CLASS_NAME, "l-navigation__drawer")) > 0
-
-                  driver.close()
-                '';
-          in
-          with pkgs;
-          [
-            curl
-            firefox-unwrapped
-            geckodriver
-            seleniumScript
-          ];
+        preseed.config."core.https_address" = ":8443";
+        ui.enable = true;
       };
 
-    testScript = ''
-      machine.wait_for_unit("incus.service")
-      machine.wait_for_unit("incus-preseed.service")
+      networking.nftables.enable = true;
 
-      # Check that the INCUS_UI environment variable is populated in the systemd unit
-      machine.succeed("systemctl cat incus.service | grep 'INCUS_UI'")
+      environment.systemPackages =
+        let
+          seleniumScript =
+            pkgs.writers.writePython3Bin "selenium-script"
+              {
+                libraries = with pkgs.python3Packages; [ selenium ];
+              }
+              ''
+                from selenium import webdriver
+                from selenium.webdriver.common.by import By
+                from selenium.webdriver.firefox.options import Options
+                from selenium.webdriver.support.ui import WebDriverWait
 
-      # Ensure the endpoint returns an HTML page with 'Incus UI' in the title
-      machine.succeed("curl -kLs https://localhost:8443/ui | grep '<title>Incus UI</title>'")
+                options = Options()
+                options.add_argument("--headless")
+                service = webdriver.FirefoxService(executable_path="${lib.getExe pkgs.geckodriver}")  # noqa: E501
 
-      # Ensure the documentation is rendering correctly
-      machine.succeed("curl -kLs https://localhost:8443/documentation/ | grep '<title>Incus documentation</title>'")
+                driver = webdriver.Firefox(options=options, service=service)
+                driver.implicitly_wait(10)
+                driver.get("https://localhost:8443/ui")
 
-      # Ensure the application is actually rendered by the Javascript
-      machine.succeed("PYTHONUNBUFFERED=1 selenium-script")
-    '';
-  }
-)
+                wait = WebDriverWait(driver, 60)
+
+                assert len(driver.find_elements(By.CLASS_NAME, "l-application")) > 0
+                assert len(driver.find_elements(By.CLASS_NAME, "l-navigation__drawer")) > 0
+
+                driver.close()
+              '';
+        in
+        with pkgs;
+        [
+          curl
+          firefox-unwrapped
+          geckodriver
+          seleniumScript
+        ];
+    };
+
+  testScript = ''
+    machine.wait_for_unit("incus.service")
+    machine.wait_for_unit("incus-preseed.service")
+
+    # Check that the INCUS_UI environment variable is populated in the systemd unit
+    machine.succeed("systemctl cat incus.service | grep 'INCUS_UI'")
+
+    # Ensure the endpoint returns an HTML page with 'Incus UI' in the title
+    machine.succeed("curl -kLs https://localhost:8443/ui | grep '<title>Incus UI</title>'")
+
+    # Ensure the documentation is rendering correctly
+    machine.succeed("curl -kLs https://localhost:8443/documentation/ | grep '<title>Incus documentation</title>'")
+
+    # Ensure the application is actually rendered by the Javascript
+    machine.succeed("PYTHONUNBUFFERED=1 selenium-script")
+  '';
+}

--- a/nixos/tests/incus/ui.nix
+++ b/nixos/tests/incus/ui.nix
@@ -1,7 +1,7 @@
 {
   pkgs,
   lib,
-  lts ? true,
+  package,
   ...
 }:
 {
@@ -17,7 +17,7 @@
 
       virtualisation.incus = {
         enable = true;
-        package = if lts then pkgs.incus-lts else pkgs.incus;
+        inherit package;
 
         preseed.config."core.https_address" = ":8443";
         ui.enable = true;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
This is a complete refactor of the incus tests to use runTestOn and the module system. 

Some highlights:
- An initial example of declarative incus instances is included, which could be the groundwork for moving into the nixos module system
- Fast. I can run the "all" test suite in <4min on my desktop, and <6min on rpi4.
- Test instance images no longer import channels. This saves a *lot* of time when changing the tests. Should we offer channel-less as a separate image from releases?
- Only test default boot.initrd. Containers already don't use initrd, and it adds minutes for building and testing extra VM instances.

Some more time could probably be saved by removing unnecessary duplicates from instance scripts, but this is enough of an improvement that it can be iterated on.

Reviewers would likely be better off just reading the new code and not the diff.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
