### PR TITLE
Iotools: fix werror + add psb_status package

### DIFF
--- a/pkgs/by-name/io/iotools/001-fix-werror-in-sprintf.patch
+++ b/pkgs/by-name/io/iotools/001-fix-werror-in-sprintf.patch
@@ -1,13 +1,27 @@
 diff --git a/commands.c b/commands.c
-index a83f1d5..b3f217a 100644
+index a28e6da..0f76ac7 100644
 --- a/commands.c
 +++ b/commands.c
-@@ -152,1 +152,7 @@ build_symlink_name(const char *path_to_bin, const struct cmd_info *cmd)
+@@ -20,6 +20,7 @@
+ #include <stdlib.h>
+ #include <string.h>
+ #include <unistd.h>
++#include <limits.h>
+ #include <errno.h>
+ #include "commands.h"
+ #include "platform.h"
+@@ -150,7 +151,13 @@ build_symlink_name(const char *path_to_bin, const struct cmd_info *cmd)
+ {
+ 	static char link_name[FILENAME_MAX];
+ 
 -	snprintf(link_name, FILENAME_MAX, "%s/%s", path_to_bin, cmd->name);
-+	int result = snprintf(link_name, FILENAME_MAX, "%s/%s", path_to_bin, cmd->name);
++	int result = snprintf(link_name, PATH_MAX, "%s/%s", path_to_bin, cmd->name);
 +
-+	if (result >= FILENAME_MAX) {
-+		link_name[FILENAME_MAX - 1] = '\0';
-+	} else if (result < 0) {
++	if (result >= PATH_MAX) {
++		link_name[PATH_MAX - 1] = '\0';
++		} else if (result < 0) {
 +		link_name[0] = '\0';
 +	}
+ 
+ 	return link_name;
+ }

--- a/pkgs/by-name/io/iotools/001-fix-werror-in-sprintf.patch
+++ b/pkgs/by-name/io/iotools/001-fix-werror-in-sprintf.patch
@@ -1,0 +1,13 @@
+diff --git a/commands.c b/commands.c
+index a83f1d5..b3f217a 100644
+--- a/commands.c
++++ b/commands.c
+@@ -152,1 +152,7 @@ build_symlink_name(const char *path_to_bin, const struct cmd_info *cmd)
+-	snprintf(link_name, FILENAME_MAX, "%s/%s", path_to_bin, cmd->name);
++	int result = snprintf(link_name, FILENAME_MAX, "%s/%s", path_to_bin, cmd->name);
++
++	if (result >= FILENAME_MAX) {
++		link_name[FILENAME_MAX - 1] = '\0';
++	} else if (result < 0) {
++		link_name[0] = '\0';
++	}

--- a/pkgs/by-name/io/iotools/package.nix
+++ b/pkgs/by-name/io/iotools/package.nix
@@ -4,7 +4,7 @@
   fetchFromGitHub,
 }:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation (finalAttrs: {
   pname = "iotools";
   version = "unstable-2017-12-11";
 
@@ -15,6 +15,8 @@ stdenv.mkDerivation {
     hash = "sha256-tlGXJn3n27mQDupMIVYDd86YaWazVwel/qs0QqCy1W8=";
   };
 
+  patches = [ ./001-fix-werror-in-sprintf.patch ];
+
   makeFlags = [
     "DEBUG=0"
     "STATIC=0"
@@ -24,7 +26,7 @@ stdenv.mkDerivation {
     install -Dm755 iotools -t $out/bin
   '';
 
-  meta = with lib; {
+  meta = {
     description = "Set of simple command line tools which allow access to
       hardware device registers";
     longDescription = ''
@@ -35,12 +37,12 @@ stdenv.mkDerivation {
       operations.
     '';
     homepage = "https://github.com/adurbin/iotools";
-    license = licenses.gpl2Only;
-    maintainers = with maintainers; [ felixsinger ];
+    license = lib.licenses.gpl2Only;
+    maintainers = with lib.maintainers; [ felixsinger ];
     platforms = [
       "x86_64-linux"
       "i686-linux"
     ];
     mainProgram = "iotools";
   };
-}
+})

--- a/pkgs/by-name/ps/psb_status/package.nix
+++ b/pkgs/by-name/ps/psb_status/package.nix
@@ -1,0 +1,44 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchFromGitHub,
+  bash,
+  iotools,
+  makeWrapper,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "psb_status";
+  version = "0-unstable-2024-10-10";
+
+  src = fetchFromGitHub {
+    owner = "mkopec";
+    repo = "psb_status";
+    rev = "be896832c53d6b0b70cf8a87f7ee46ad33deefc2";
+    hash = "sha256-4anPyjO8y3FgnYWa4bGFxI8Glk9srw/XF552tnixc8I=";
+  };
+
+  dontBuild = true;
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+    install -m755 psb_status.sh $out/bin/psb_status
+    wrapProgram $out/bin/psb_status \
+      --prefix PATH : ${lib.makeBinPath [ iotools ]}
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Script to check Platform Secure Boot enablement on Zen based AMD CPUs";
+    homepage = "https://github.com/mkopec/psb_status";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ phodina ];
+    platforms = [ "x86_64-linux" ];
+    mainProgram = "psb_status";
+  };
+})


### PR DESCRIPTION
Hi,
wanted to add `psb_status` but found out the `iotools` is broken.

The point of `psb_status` is to check that your AMD Zen CPU does not have fused keys.
```
# psb_status 
0x00000000
PSB is not enabled on your platform. You may be able to run custom firmware
```


## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
