### PR TITLE
libapparmor: fix cross

### DIFF
--- a/pkgs/by-name/li/libapparmor/package.nix
+++ b/pkgs/by-name/li/libapparmor/package.nix
@@ -58,16 +58,6 @@ stdenv.mkDerivation (finalAttrs: {
     ]
     ++ lib.optionals withPython [
       python3Packages.setuptools
-    ]
-    ++ lib.optionals (!finalAttrs.finalPackage.doCheck) [
-      # TODO FIXME This is a super ugly HACK.
-      # perl is required for podchecker.
-      # It is a native build input on native platform because checks are enabled there.
-      # Checks can't be enabled on cross, but moving perl to
-      # nativeCheckInputs causes rebuilds on native compile.
-      # Thus, hacks!
-      # This should just be made unconditional and removed from nativeCheckInputs.
-      perl
     ];
 
   nativeCheckInputs = [

--- a/pkgs/by-name/li/libapparmor/package.nix
+++ b/pkgs/by-name/li/libapparmor/package.nix
@@ -55,6 +55,7 @@ stdenv.mkDerivation (finalAttrs: {
       ncurses
       which
       dejagnu
+      perl # podchecker
     ]
     ++ lib.optionals withPython [
       python3Packages.setuptools
@@ -62,7 +63,6 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeCheckInputs = [
     python3Packages.pythonImportsCheckHook
-    perl
   ];
 
   buildInputs =


### PR DESCRIPTION
"podchecker" from perl is always required. (`nativeCheckInputs` are ignored for cross builds)

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux (cross)
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).