### PR TITLE
[Backport release-24.11] qt6.qtdeclarative: fix code-signing on Darwin

### DIFF
--- a/pkgs/development/libraries/qt-6/modules/qtdeclarative/default.nix
+++ b/pkgs/development/libraries/qt-6/modules/qtdeclarative/default.nix
@@ -7,6 +7,7 @@
   stdenv,
   lib,
   pkgsBuildBuild,
+  fetchpatch2,
 }:
 
 qtModule {
@@ -25,7 +26,14 @@ qtModule {
     ./disable-disk-cache.patch
     # add version specific QML import path
     ./use-versioned-import-path.patch
-  ];
+  ]
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [
+      # The build attempts to sign qmltestrunner, which may already be signed, causing it to fail unless forced.
+      (fetchpatch2 {
+        url = "https://invent.kde.org/qt/qt/qtdeclarative/-/commit/8effbbcefd8cae27cd5da07b4ffe3aa86dad83bf.diff";
+        hash = "sha256-wKrKXdr1ddshpRVIZZ/dsn87wjPXSaoUvXT9edlPtzA=";
+      })
+    ];
 
   cmakeFlags =
     [


### PR DESCRIPTION
The build tries to sign qmltestrunner, but sometimes it’s already signed, causing the signing to fail due to an existing signature. Cherry-pick this patch from upstream to force sign it regardless.

(cherry picked from commit b403bd0b59f14a166a43e7ffda334dac7ac17305 from #398849)
Blocking channel via wireshark: https://hydra.nixos.org/build/295474305

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
