### PR TITLE
xastir: fix cross, enable strictDeps, update meta, modernize

### DIFF
--- a/pkgs/by-name/xa/xastir/package.nix
+++ b/pkgs/by-name/xa/xastir/package.nix
@@ -4,9 +4,12 @@
   fetchFromGitHub,
   autoreconfHook,
   pkg-config,
+  bashNonInteractive,
   curl,
   db,
+  gnused,
   libgeotiff,
+  libtiff,
   xorg,
   motif,
   pcre2,
@@ -24,19 +27,22 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "xastir";
     repo = "xastir";
-    rev = "Release-${version}";
+    tag = "Release-${version}";
     hash = "sha256-EQXSfH4b5vMiprFcMXCUDNl+R1cHSj9CyhZnUPAMoCw=";
   };
 
   nativeBuildInputs = [
     autoreconfHook
     pkg-config
+    perl
   ];
 
   buildInputs = [
+    bashNonInteractive
     curl
     db
     libgeotiff
+    libtiff
     xorg.libXpm
     xorg.libXt
     motif
@@ -48,15 +54,41 @@ stdenv.mkDerivation rec {
     libax25
   ];
 
-  configureFlags = [ "--with-motif-includes=${motif}/include" ];
+  strictDeps = true;
 
-  postPatch = "patchShebangs .";
+  configureFlags = [
+    "--with-motif-includes=${lib.getDev motif}/include"
+    "ac_cv_path_gm=${lib.getExe' graphicsmagick "gm"}"
+    "ac_cv_path_convert=${lib.getExe' graphicsmagick "convert"}"
+    "ac_cv_header_xtiffio_h=yes"
+    "ac_cv_path_GMAGIC_BIN=${lib.getExe' (lib.getDev graphicsmagick) "GraphicsMagick-config"}"
+  ];
 
-  meta = with lib; {
+  makeFlags = [
+    "AR=${stdenv.cc.targetPrefix}ar"
+  ];
+
+  postPatch = ''
+    patchShebangs --build scripts/lang*.pl
+
+    # checks for files in /usr/bin/
+    substituteInPlace acinclude.m4 \
+      --replace-fail "AC_CHECK_FILE" "# AC_CHECK_FILE"
+    # would pick up builder sed from $PATH
+    substituteInPlace configure.ac \
+      --replace-fail 'AC_DEFINE_UNQUOTED(SED_PATH, "''${sed}", [Path to sed])' \
+                     'AC_DEFINE_UNQUOTED(SED_PATH, "${lib.getExe gnused}", [Path to sed])'
+  '';
+
+  preInstall = ''
+    patchShebangs --host --update .
+  '';
+
+  meta = {
     description = "Graphical APRS client";
-    homepage = "https://xastir.org";
-    license = licenses.gpl2;
-    maintainers = [ maintainers.ehmry ];
-    platforms = platforms.linux;
+    homepage = "https://github.com/xastir/xastir";
+    license = lib.licenses.gpl2Plus;
+    maintainers = [ lib.maintainers.ehmry ];
+    platforms = lib.platforms.linux;
   };
 }


### PR DESCRIPTION
This also fixes geotiff support which was previously not configured correctly.

For strictDeps, see #178468

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux (cross)
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).