### PR TITLE
ipmitool: 1.8.19-unstable-2023-01-12 -> 1.8.19-unstable-2025-02-18

### DIFF
--- a/pkgs/by-name/ip/ipmitool/package.nix
+++ b/pkgs/by-name/ip/ipmitool/package.nix
@@ -1,7 +1,7 @@
 {
   stdenv,
   lib,
-  fetchFromGitHub,
+  fetchFromGitea,
   autoreconfHook,
   pkg-config,
   openssl,
@@ -17,13 +17,14 @@ let
 in
 stdenv.mkDerivation {
   pname = "ipmitool";
-  version = "1.8.19-unstable-2023-01-12";
+  version = "1.8.19-unstable-2025-02-18";
 
-  src = fetchFromGitHub {
-    owner = "ipmitool";
+  src = fetchFromGitea {
+    domain = "codeberg.org";
+    owner = "IPMITool";
     repo = "ipmitool";
-    rev = "be11d948f89b10be094e28d8a0a5e8fb532c7b60";
-    hash = "sha256-5s0F2cTZdmRb/I0rPqX/8KgK/7b5VCl3Hj/ALKpGbMQ=";
+    rev = "3c91e6d91ec6090fe548c55ef301c33ff20c8ed8";
+    hash = "sha256-7R3jmPPd8+yKs7Q1vlU/ZaZusZVB0s+xc1HGeLyLdk0=";
   };
 
   nativeBuildInputs = [
@@ -37,10 +38,6 @@ stdenv.mkDerivation {
   ];
 
   postPatch = ''
-    # Fixes `ipmi_fru.c:1556:41: error: initialization of 'struct fru_multirec_mgmt *' from incompatible pointer type 'struct fru_multirect_mgmt *' []`
-    # Probably fine before GCC14, but this is an error now.
-    substituteInPlace lib/ipmi_fru.c \
-      --replace-fail fru_multirect_mgmt fru_multirec_mgmt
     cp ${iana-enterprise-numbers} enterprise-numbers
   '';
 
@@ -50,7 +47,7 @@ stdenv.mkDerivation {
     description = "Command-line interface to IPMI-enabled devices";
     mainProgram = "ipmitool";
     license = lib.licenses.bsd3;
-    homepage = "https://github.com/ipmitool/ipmitool";
+    homepage = "https://codeberg.org/IPMITool/ipmitool";
     platforms = lib.platforms.unix;
     maintainers = with lib.maintainers; [ fpletz ];
   };


### PR DESCRIPTION
The ipmi_fru.c build failure has been fixed upstream in https://codeberg.org/IPMITool/ipmitool/commit/bf774149ae7f74c12164a5b021b23520c5ca4016

The project has moved to Codeberg, as the author has been banned from GitHub: https://codeberg.org/IPMITool/ipmitool/commit/1f103c7a83684dd4543c15a71532ca1d2e244f38


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
