### PR TITLE
xfce.xfce4-panel: 4.20.3 -> 4.20.4

### DIFF
--- a/pkgs/desktops/xfce/core/xfce4-panel/default.nix
+++ b/pkgs/desktops/xfce/core/xfce4-panel/default.nix
@@ -2,6 +2,8 @@
   stdenv,
   lib,
   mkXfceDerivation,
+  fetchpatch,
+  python3,
   cairo,
   exo,
   garcon,
@@ -26,14 +28,27 @@
 mkXfceDerivation {
   category = "xfce";
   pname = "xfce4-panel";
-  version = "4.20.3";
+  version = "4.20.4";
 
-  sha256 = "sha256-tLWjU0M7tuE+qqDwaE1CtnOjDiPWno8Mf7hhxYxbvjo=";
+  sha256 = "sha256-P1EZefpGRZ0DQ5S4Okw9pyly23d+UdPp5xMj1wJc44c=";
 
-  nativeBuildInputs = lib.optionals withIntrospection [
-    gobject-introspection
-    vala # vala bindings require GObject introspection
+  patches = [
+    # Fixes panel not shown on external display after reconnecting
+    # https://gitlab.xfce.org/xfce/xfce4-panel/-/issues/925
+    (fetchpatch {
+      url = "https://gitlab.xfce.org/xfce/xfce4-panel/-/commit/e2451cacd950f4b7539efd1e5e36b067515dba9b.patch";
+      hash = "sha256-h2iPlghHJeHD9PJp6RJrRx4MBsaqXuNclAJW6CKHE4A=";
+    })
   ];
+
+  nativeBuildInputs =
+    [
+      python3
+    ]
+    ++ lib.optionals withIntrospection [
+      gobject-introspection
+      vala # vala bindings require GObject introspection
+    ];
 
   buildInputs = [
     cairo
@@ -55,6 +70,8 @@ mkXfceDerivation {
   ];
 
   postPatch = ''
+    patchShebangs xdt-gen-visibility
+
     substituteInPlace plugins/clock/clock.c \
        --replace-fail "/usr/share/zoneinfo" "${tzdata}/share/zoneinfo"
   '';


### PR DESCRIPTION
https://gitlab.xfce.org/xfce/xfce4-panel/-/compare/xfce4-panel-4.20.3...xfce4-panel-4.20.4


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

