### PR TITLE
nixos/test-driver: Allow xwininfo to fail intermittently

### DIFF
--- a/nixos/lib/test-driver/src/test_driver/machine/__init__.py
+++ b/nixos/lib/test-driver/src/test_driver/machine/__init__.py
@@ -1162,9 +1162,17 @@ class Machine:
             retry(check_x, timeout)
 
     def get_window_names(self) -> list[str]:
-        return self.succeed(
+        command = (
             r"xwininfo -root -tree | sed 's/.*0x[0-9a-f]* \"\([^\"]*\)\".*/\1/; t; d'"
-        ).splitlines()
+        )
+        output = ""
+        with self.nested(f"trying: {command}"):
+            (status, out) = self.execute(command)
+            if status != 0:
+                self.log(f"command failed (exit code {status}), output: {out}")
+            else:
+                output += out
+        return output.splitlines()
 
     def wait_for_window(self, regexp: str, timeout: int = 900) -> None:
         """


### PR DESCRIPTION
Untestable for me, as my hardware doesn't run into this issue.

`wait_for_window` can fail due to `xwininfo` running into an X error:

```
error: builder for '/nix/store/lf1nfgxj05919z944gvz39rn68ls3n7y-vm-test-run-lomiri-calculator-app-standalone.drv' failed with exit code 1;
       last 25 log lines:
       > subtest: lomiri calculator launches
       > machine: waiting for a window to appear
       > machine: must succeed: xwininfo -root -tree | sed 's/.*0x[0-9a-f]* \"\([^\"]*\)\".*/\1/; t; d'
       > (finished: must succeed: xwininfo -root -tree | sed 's/.*0x[0-9a-f]* \"\([^\"]*\)\".*/\1/; t; d', in 4.64 seconds)
       > machine: must succeed: xwininfo -root -tree | sed 's/.*0x[0-9a-f]* \"\([^\"]*\)\".*/\1/; t; d'
       > machine # X Error: 9: Bad Drawable
       > machine #   Request Major code: 14
       > machine #   ResourceID in failed request: 0x60005b
       > machine #   Serial number of failed request: 38
       > machine # X Error: 3: Bad Window
       > machine #   Request Major code: 15
       > machine #   ResourceID in failed request: 0x60005b
       > machine #   Serial number of failed request: 40
       > machine # xwininfo: error: Can't query window tree.
       > machine: output: IceDock
       > IceBottom
       > IceTopWin
       > IceWM 3.7.3 (Linux/aarch64)
       >
       > Test "lomiri calculator launches" failed with error: "command `xwininfo -root -tree | sed 's/.*0x[0-9a-f]* \"\([^\"]*\)\".*/\1/; t; d'` failed (exit code 1)"
       > cleanup
       > kill machine (pid 11)
       > qemu-system-aarch64: terminating on signal 15 from pid 8 (/nix/store/ic0fd07z8wg57idmw7q7iy7dc7md6x72-python3-3.12.9/bin/python3.12)
       > kill vlan (pid 9)
       > (finished: cleanup, in 0.01 seconds)
       For full logs, run 'nix log /nix/store/lf1nfgxj05919z944gvz39rn68ls3n7y-vm-test-run-lomiri-calculator-app-standalone.drv'.
```

Under the assumption that this is a temporary failure, rewrite `get_window_names` to not require the `xwininfo | sed` command to succeed at all times.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
