### PR TITLE
firefly-pico: init at 1.9.0/init module

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1571,6 +1571,7 @@
   ./services/web-apps/filesender.nix
   ./services/web-apps/firefly-iii-data-importer.nix
   ./services/web-apps/firefly-iii.nix
+  ./services/web-apps/firefly-pico.nix
   ./services/web-apps/flarum.nix
   ./services/web-apps/fluidd.nix
   ./services/web-apps/freshrss.nix

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1695,6 +1695,7 @@
   ./services/web-apps/filebrowser.nix
   ./services/web-apps/firefly-iii-data-importer.nix
   ./services/web-apps/firefly-iii.nix
+  ./services/web-apps/firefly-pico.nix
   ./services/web-apps/flarum.nix
   ./services/web-apps/fluidd.nix
   ./services/web-apps/freescout.nix

--- a/nixos/modules/services/web-apps/firefly-pico.nix
+++ b/nixos/modules/services/web-apps/firefly-pico.nix
@@ -1,0 +1,421 @@
+{
+  pkgs,
+  config,
+  lib,
+  ...
+}:
+
+let
+  cfg = config.services.firefly-pico;
+
+  user = cfg.user;
+  group = cfg.group;
+
+  defaultUser = "firefly-pico";
+  defaultGroup = "firefly-pico";
+
+  artisan = "${cfg.package}/share/php/firefly-pico/artisan";
+
+  env-file-values = lib.attrsets.mapAttrs' (
+    n: v: lib.attrsets.nameValuePair (lib.strings.removeSuffix "_FILE" n) v
+  ) (lib.attrsets.filterAttrs (n: v: lib.strings.hasSuffix "_FILE" n) cfg.settings);
+  env-nonfile-values = lib.attrsets.filterAttrs (n: v: !lib.strings.hasSuffix "_FILE" n) cfg.settings;
+
+  firefly-pico-maintenance = pkgs.writeShellScript "firefly-pico-maintenance.sh" ''
+    set -a
+    ${lib.strings.toShellVars env-nonfile-values}
+    ${lib.strings.concatLines (
+      lib.attrsets.mapAttrsToList (n: v: "${n}=\"$(< ${v})\"") env-file-values
+    )}
+    set +a
+    ${lib.optionalString (
+      cfg.settings.DB_CONNECTION == "sqlite"
+    ) "touch ${cfg.dataDir}/storage/database/database.sqlite"}
+    ${artisan} migrate --isolated --force
+    ${artisan} config:clear
+    ${artisan} config:cache
+    ${artisan} cache:clear
+  '';
+
+  commonServiceConfig = {
+    Type = "oneshot";
+    User = user;
+    Group = group;
+    StateDirectory = "firefly-pico";
+    ReadWritePaths = [ cfg.dataDir ];
+    WorkingDirectory = cfg.package;
+    PrivateTmp = true;
+    PrivateDevices = true;
+    CapabilityBoundingSet = "";
+    AmbientCapabilities = "";
+    ProtectSystem = "strict";
+    ProtectKernelTunables = true;
+    ProtectKernelModules = true;
+    ProtectControlGroups = true;
+    ProtectClock = true;
+    ProtectHostname = true;
+    ProtectHome = "tmpfs";
+    ProtectKernelLogs = true;
+    ProtectProc = "invisible";
+    ProcSubset = "pid";
+    PrivateNetwork = false;
+    RestrictAddressFamilies = "AF_INET AF_INET6 AF_UNIX";
+    SystemCallArchitectures = "native";
+    SystemCallFilter = [
+      "@system-service @resources"
+      "~@obsolete @privileged"
+    ];
+    RestrictSUIDSGID = true;
+    RemoveIPC = true;
+    NoNewPrivileges = true;
+    RestrictRealtime = true;
+    RestrictNamespaces = true;
+    LockPersonality = true;
+    PrivateUsers = true;
+  };
+
+in
+{
+
+  options.services.firefly-pico = {
+
+    enable = lib.mkEnableOption "Firefly-Pico: A delightful Firefly III companion web app for effortless transaction tracking";
+
+    user = lib.mkOption {
+      type = lib.types.str;
+      default = defaultUser;
+      description = "User account under which firefly-pico runs.";
+    };
+
+    group = lib.mkOption {
+      type = lib.types.str;
+      default = if cfg.enableNginx then "nginx" else defaultGroup;
+      defaultText = "If `services.firefly-pico.enableNginx` is true then `nginx` else ${defaultGroup}";
+      description = ''
+        Group under which firefly-pico runs. It is best to set this to the group
+        of whatever webserver is being used as the frontend.
+      '';
+    };
+
+    dataDir = lib.mkOption {
+      type = lib.types.path;
+      default = "/var/lib/firefly-pico";
+      description = ''
+        The place where firefly-pico stores its state.
+      '';
+    };
+
+    package =
+      lib.mkPackageOption pkgs "firefly-pico" { }
+      // lib.mkOption {
+        apply =
+          firefly-pico:
+          firefly-pico.override (prev: {
+            dataDir = cfg.dataDir;
+          });
+      };
+
+    enableNginx = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = ''
+        Whether to enable nginx or not. If enabled, an nginx virtual host will
+        be created for access to firefly-pico. If not enabled, then you may use
+        `''${config.services.firefly-pico.package}` as your document root in
+        whichever webserver you wish to setup.
+      '';
+    };
+
+    virtualHost = lib.mkOption {
+      type = lib.types.str;
+      default = "localhost";
+      description = ''
+        The hostname at which you wish firefly-pico to be served. If you have
+        enabled nginx using `services.firefly-pico.enableNginx` then this will
+        be used.
+      '';
+    };
+
+    poolConfig = lib.mkOption {
+      type = lib.types.attrsOf (
+        lib.types.oneOf [
+          lib.types.str
+          lib.types.int
+          lib.types.bool
+        ]
+      );
+      default = { };
+      defaultText = ''
+        {
+          "pm" = "dynamic";
+          "pm.max_children" = 32;
+          "pm.start_servers" = 2;
+          "pm.min_spare_servers" = 2;
+          "pm.max_spare_servers" = 4;
+          "pm.max_requests" = 500;
+        }
+      '';
+      description = ''
+        Options for the Firefly-Pico PHP pool. See the documentation on <literal>php-fpm.conf</literal>
+        for details on configuration directives.
+      '';
+    };
+
+    settings = lib.mkOption {
+      default = { };
+      description = ''
+        Options for firefly-Pico configuration. Refer to
+        <https://github.com/cioraneanu/firefly-pico/blob/main/back/.env.example> for
+        details on supported values. All <option>_FILE values supported by
+        upstream are supported here.
+
+        APP_URL will be the same as `services.firefly-pico.virtualHost` if the
+        former is unset in `services.firefly-pico.settings`.
+      '';
+      example = lib.literalExpression ''
+        {
+          APP_ENV = "production";
+          APP_KEY_FILE = "/var/secrets/firefly-pico-app-key.txt";
+          DB_CONNECTION = "mysql";
+          DB_HOST = "db";
+          DB_PORT = 3306;
+          DB_DATABASE = "firefly-pico";
+          DB_USERNAME = "firefly-pico";
+          DB_PASSWORD_FILE = "/var/secrets/firefly-pico-mysql-password.txt";
+        }
+      '';
+      type = lib.types.submodule {
+        freeformType = lib.types.attrsOf (
+          lib.types.oneOf [
+            lib.types.str
+            lib.types.int
+            lib.types.bool
+          ]
+        );
+        options = {
+          LOG_CHANNEL = lib.mkOption {
+            type = lib.types.str;
+            default = "syslog";
+            example = "single";
+            description = ''
+              The output channel for your firefly-pico backend logs.
+              For available drivers see <https://laravel.com/docs/12.x/logging#available-channel-drivers>.
+            '';
+          };
+          DB_CONNECTION = lib.mkOption {
+            type = lib.types.enum [
+              "sqlite"
+              "pgsql"
+              "mysql"
+            ];
+            default = "sqlite";
+            example = "pgsql";
+            description = ''
+              The type of database you wish to use. Can be one of "sqlite",
+              "mysql" or "pgsql".
+            '';
+          };
+          APP_ENV = lib.mkOption {
+            type = lib.types.enum [
+              "local"
+              "production"
+              "testing"
+            ];
+            default = "local";
+            example = "production";
+            description = ''
+              The app environment. It is recommended to keep this at "local".
+              Possible values are "local", "production" and "testing"
+            '';
+          };
+          DB_DATABASE = lib.mkOption {
+            type = lib.types.nullOr lib.types.str;
+            default =
+              if cfg.settings.DB_CONNECTION == "pgsql" then
+                "firefly-pico"
+              else if cfg.settings.DB_CONNECTION == "mysql" then
+                "firefly-pico"
+              else
+                cfg.dataDir + "/storage/database/database.sqlite";
+            defaultText = ''
+              `cfg.dataDir + "/storage/database/database.sqlite` if DB_CONNECTION is "sqlite", `firefly-pico` if "mysql" or "pgsql"
+            '';
+            description = ''
+              The absolute path to, in case of sqlite, or name of your firefly-pico database.
+            '';
+          };
+          DB_PORT = lib.mkOption {
+            type = lib.types.nullOr lib.types.int;
+            default =
+              if cfg.settings.DB_CONNECTION == "pgsql" then
+                5432
+              else if cfg.settings.DB_CONNECTION == "mysql" then
+                3306
+              else
+                null;
+            defaultText = ''
+              `null` if DB_CONNECTION is "sqlite", `3306` if "mysql", `5432` if "pgsql"
+            '';
+            description = ''
+              The port your database is listening at. sqlite does not require
+              this value to be filled.
+            '';
+          };
+          DB_HOST = lib.mkOption {
+            type = lib.types.str;
+            default = if cfg.settings.DB_CONNECTION == "pgsql" then "/run/postgresql" else "localhost";
+            defaultText = ''
+              "localhost" if DB_CONNECTION is "sqlite" or "mysql", "/run/postgresql" if "pgsql".
+            '';
+            description = ''
+              The machine which hosts your database. This is left at the
+              default value for "mysql" because we use the "DB_SOCKET" option
+              to connect to a unix socket instead. "pgsql" requires that the
+              unix socket location be specified here instead of at "DB_SOCKET".
+              This option does not affect "sqlite".
+            '';
+          };
+          APP_KEY_FILE = lib.mkOption {
+            type = lib.types.path;
+            description = ''
+              The path to your appkey. The file should contain a 32 character
+              random app key. This may be set using `echo "base64:$(head -c 32
+              /dev/urandom | base64)" > /path/to/key-file`.
+            '';
+          };
+          APP_URL = lib.mkOption {
+            type = lib.types.str;
+            default =
+              if cfg.virtualHost == "localhost" then
+                "http://${cfg.virtualHost}"
+              else
+                "https://${cfg.virtualHost}";
+            defaultText = ''
+              http(s)://''${config.services.firefly-pico.virtualHost}
+            '';
+            description = ''
+              The APP_URL used by firefly-pico internally. Please make sure this
+              URL matches the external URL of your Firefly pico installation.
+            '';
+          };
+          FIREFLY_URL = lib.mkOption {
+            type = lib.types.str;
+            example = ''
+              https://firefly.example
+            '';
+            description = ''
+              The public URL of your firefly-iii api instance. Has to be reachable by the client
+              opening firefly-pico.
+            '';
+          };
+        };
+      };
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+
+    services.phpfpm.pools.firefly-pico = {
+      inherit user group;
+      phpPackage = cfg.package.phpPackage;
+      phpOptions = ''
+        log_errors = on
+      '';
+      settings = {
+        "listen.mode" = lib.mkDefault "0660";
+        "listen.owner" = lib.mkDefault user;
+        "listen.group" = lib.mkDefault group;
+        "pm" = lib.mkDefault "dynamic";
+        "pm.max_children" = lib.mkDefault 32;
+        "pm.start_servers" = lib.mkDefault 2;
+        "pm.min_spare_servers" = lib.mkDefault 2;
+        "pm.max_spare_servers" = lib.mkDefault 4;
+        "pm.max_requests" = lib.mkDefault 500;
+      }
+      // cfg.poolConfig;
+    };
+
+    systemd.services.firefly-pico-setup = {
+      after = [
+        "postgresql.service"
+        "mysql.service"
+      ];
+      requiredBy = [ "phpfpm-firefly-pico.service" ];
+      before = [ "phpfpm-firefly-pico.service" ];
+      serviceConfig = {
+        ExecStart = firefly-pico-maintenance;
+        RemainAfterExit = true;
+      }
+      // commonServiceConfig;
+      unitConfig.JoinsNamespaceOf = "phpfpm-firefly-pico.service";
+      restartTriggers = [ cfg.package ];
+      partOf = [ "phpfpm-firefly-pico.service" ];
+    };
+
+    services.nginx = lib.mkIf cfg.enableNginx {
+      enable = true;
+      recommendedTlsSettings = lib.mkDefault true;
+      recommendedOptimisation = lib.mkDefault true;
+      recommendedGzipSettings = lib.mkDefault true;
+      virtualHosts.${cfg.virtualHost} = {
+        root = "${cfg.package.frontend}/share/firefly-pico/public";
+        locations = {
+          "/api" = {
+            root = "${cfg.package}/share/php/firefly-pico/public";
+            tryFiles = "$uri $uri/ /index.php?$query_string";
+            index = "index.php";
+          };
+          "~ \\.php$" = {
+            root = "${cfg.package}/share/php/firefly-pico/public";
+            extraConfig = ''
+              include ${config.services.nginx.package}/conf/fastcgi_params ;
+              fastcgi_param SCRIPT_FILENAME $request_filename;
+              fastcgi_param modHeadersAvailable true; #Avoid sending the security headers twice
+              fastcgi_pass unix:${config.services.phpfpm.pools.firefly-pico.socket};
+            '';
+          };
+        };
+      };
+    };
+
+    systemd.tmpfiles.settings."10-firefly-pico" =
+      lib.attrsets.genAttrs
+        [
+          "${cfg.dataDir}/storage"
+          "${cfg.dataDir}/storage/app"
+          "${cfg.dataDir}/storage/database"
+          "${cfg.dataDir}/storage/framework"
+          "${cfg.dataDir}/storage/framework/cache"
+          "${cfg.dataDir}/storage/framework/sessions"
+          "${cfg.dataDir}/storage/framework/views"
+          "${cfg.dataDir}/storage/logs"
+          "${cfg.dataDir}/cache"
+        ]
+        (n: {
+          d = {
+            group = group;
+            mode = "0700";
+            user = user;
+          };
+        })
+      // {
+        "${cfg.dataDir}".d = {
+          group = group;
+          mode = "0710";
+          user = user;
+        };
+      };
+
+    users = {
+      users = lib.mkIf (user == defaultUser) {
+        ${defaultUser} = {
+          description = "Firefly-pico service user";
+          inherit group;
+          isSystemUser = true;
+          home = cfg.dataDir;
+        };
+      };
+      groups = lib.mkIf (group == defaultGroup) { ${defaultGroup} = { }; };
+    };
+  };
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -523,6 +523,7 @@ in
   filesystems-overlayfs = runTest ./filesystems-overlayfs.nix;
   firefly-iii = runTest ./firefly-iii.nix;
   firefly-iii-data-importer = runTest ./firefly-iii-data-importer.nix;
+  firefly-pico = runTest ./firefly-pico.nix;
   firefox = runTest {
     imports = [ ./firefox.nix ];
     _module.args.firefoxPackage = pkgs.firefox;

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -587,6 +587,7 @@ in
   filesystems-overlayfs = runTest ./filesystems-overlayfs.nix;
   firefly-iii = runTest ./firefly-iii.nix;
   firefly-iii-data-importer = runTest ./firefly-iii-data-importer.nix;
+  firefly-pico = runTest ./firefly-pico.nix;
   firefox = runTest {
     imports = [ ./firefox.nix ];
     _module.args.firefoxPackage = pkgs.firefox;

--- a/nixos/tests/firefly-pico.nix
+++ b/nixos/tests/firefly-pico.nix
@@ -1,0 +1,117 @@
+{ lib, ... }:
+
+let
+  db-pass = "Test2Test2";
+  app-key = "TestTestTestTestTestTestTestTest";
+in
+{
+  name = "firefly-pico";
+  meta.maintainers = [ lib.maintainers.patrickdag ];
+
+  nodes.fireflySqlite =
+    { config, ... }:
+    {
+      environment.etc = {
+        "firefly-pico-appkey".text = app-key;
+      };
+      services.firefly-pico = {
+        enable = true;
+        enableNginx = true;
+        settings = {
+          APP_KEY_FILE = "/etc/firefly-iii-appkey";
+          LOG_CHANNEL = "stdout";
+          FIREFLY_URL = "localhost";
+        };
+      };
+    };
+
+  nodes.fireflyPostgresql =
+    { config, pkgs, ... }:
+    {
+      environment.etc = {
+        "firefly-pico-appkey".text = app-key;
+        "postgres-pass".text = db-pass;
+      };
+      services.firefly-pico = {
+        enable = true;
+        enableNginx = true;
+        settings = {
+          APP_KEY_FILE = "/etc/firefly-pico-appkey";
+          LOG_CHANNEL = "stdout";
+          SITE_OWNER = "mail@example.com";
+          DB_CONNECTION = "pgsql";
+          DB_DATABASE = "firefly";
+          DB_USERNAME = "firefly";
+          DB_PASSWORD_FILE = "/etc/postgres-pass";
+          PGSQL_SCHEMA = "firefly";
+          FIREFLY_URL = "localhost";
+        };
+      };
+
+      services.postgresql = {
+        enable = true;
+        package = pkgs.postgresql_16;
+        authentication = ''
+          local all postgres peer
+          local firefly firefly password
+        '';
+        initialScript = pkgs.writeText "firefly-init.sql" ''
+          CREATE USER "firefly" WITH LOGIN PASSWORD '${db-pass}';
+          CREATE DATABASE "firefly" WITH OWNER "firefly";
+          \c firefly
+          CREATE SCHEMA AUTHORIZATION firefly;
+        '';
+      };
+    };
+
+  nodes.fireflyMysql =
+    { config, pkgs, ... }:
+    {
+      environment.etc = {
+        "firefly-pico-appkey".text = app-key;
+        "mysql-pass".text = db-pass;
+      };
+      services.firefly-pico = {
+        enable = true;
+        enableNginx = true;
+        settings = {
+          APP_KEY_FILE = "/etc/firefly-pico-appkey";
+          LOG_CHANNEL = "stdout";
+          DB_CONNECTION = "mysql";
+          DB_DATABASE = "firefly";
+          DB_USERNAME = "firefly";
+          DB_PASSWORD_FILE = "/etc/mysql-pass";
+          DB_SOCKET = "/run/mysqld/mysqld.sock";
+          FIREFLY_URL = "localhost";
+        };
+      };
+
+      services.mysql = {
+        enable = true;
+        package = pkgs.mariadb;
+        initialScript = pkgs.writeText "firefly-init.sql" ''
+          create database firefly DEFAULT CHARACTER SET utf8mb4;
+          create user 'firefly'@'localhost' identified by '${db-pass}';
+          grant all on firefly.* to 'firefly'@'localhost';
+        '';
+        settings.mysqld.character-set-server = "utf8mb4";
+      };
+    };
+
+  testScript = ''
+    fireflySqlite.wait_for_unit("phpfpm-firefly-pico.service")
+    fireflySqlite.wait_for_unit("nginx.service")
+    fireflySqlite.succeed("curl -fvvv -Ls http://localhost/ | grep 'Pico'")
+    fireflySqlite.succeed("curl -fvvv -Ls http://localhost/api/test | grep 'Test!'")
+    fireflyPostgresql.wait_for_unit("phpfpm-firefly-pico.service")
+    fireflyPostgresql.wait_for_unit("nginx.service")
+    fireflyPostgresql.wait_for_unit("postgresql.service")
+    fireflyPostgresql.succeed("curl -fvvv -Ls http://localhost/ | grep 'Pico'")
+    fireflyPostgresql.succeed("curl -fvvv -Ls http://localhost/api/test | grep 'Test!'")
+    fireflyMysql.wait_for_unit("phpfpm-firefly-pico.service")
+    fireflyMysql.wait_for_unit("nginx.service")
+    fireflyMysql.wait_for_unit("mysql.service")
+    fireflyMysql.succeed("curl -fvvv -Ls http://localhost/ | grep 'Pico'")
+    fireflyMysql.succeed("curl -fvvv -Ls http://localhost/api/test | grep 'Test!'")
+  '';
+}

--- a/pkgs/by-name/fi/firefly-pico/frontend.nix
+++ b/pkgs/by-name/fi/firefly-pico/frontend.nix
@@ -1,0 +1,50 @@
+{
+  src,
+  version,
+  stdenvNoCC,
+  nodejs,
+  fetchNpmDeps,
+  buildPackages,
+  php84,
+  nixosTests,
+  nix-update-script,
+  meta,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "firefly-pico-frontend";
+  inherit version src;
+
+  sourceRoot = "source/front";
+
+  nativeBuildInputs = [
+    nodejs
+    nodejs.python
+    buildPackages.npmHooks.npmConfigHook
+  ];
+
+  npmDeps = fetchNpmDeps {
+    inherit (finalAttrs) src;
+    sourceRoot = "source/front";
+    name = "${finalAttrs.pname}-npm-deps";
+    hash = "sha256-ryxQgnh+Rj5BoSFwKIdhFa99ziVDt4UwVMHvMeIcDSU=";
+  };
+
+  passthru = {
+    phpPackage = php84;
+    tests = nixosTests.firefly-pico;
+    updateScript = nix-update-script { };
+  };
+  env.NUXT_TELEMETRY_DISABLED = 1;
+  buildPhase = ''
+    runHook preBuild
+    npm run generate
+    runHook postBuild
+  '';
+  postInstall = ''
+    mkdir -p $out/share/firefly-pico
+    cp -r .output/public $out/share/firefly-pico/
+  '';
+
+  inherit meta;
+})

--- a/pkgs/by-name/fi/firefly-pico/frontend.nix
+++ b/pkgs/by-name/fi/firefly-pico/frontend.nix
@@ -1,0 +1,52 @@
+{
+  src,
+  version,
+  stdenvNoCC,
+  nodejs,
+  fetchNpmDeps,
+  buildPackages,
+  php84,
+  nixosTests,
+  nix-update-script,
+  meta,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "firefly-pico-frontend";
+  inherit version src;
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  sourceRoot = "source/front";
+
+  nativeBuildInputs = [
+    nodejs
+    nodejs.python
+    buildPackages.npmHooks.npmConfigHook
+  ];
+
+  npmDeps = fetchNpmDeps {
+    inherit (finalAttrs) src;
+    sourceRoot = "source/front";
+    name = "${finalAttrs.pname}-npm-deps";
+    hash = "sha256-9/xJmWIDMAGhWNDA+ne1oVUhvYGTRAjicZwUAO+xFek=";
+  };
+
+  passthru = {
+    phpPackage = php84;
+    tests = nixosTests.firefly-pico;
+    updateScript = nix-update-script { };
+  };
+  env.NUXT_TELEMETRY_DISABLED = 1;
+  buildPhase = ''
+    runHook preBuild
+    npm run generate
+    runHook postBuild
+  '';
+  postInstall = ''
+    mkdir -p $out/share/firefly-pico
+    cp -r .output/public $out/share/firefly-pico/
+  '';
+
+  inherit meta;
+})

--- a/pkgs/by-name/fi/firefly-pico/package.nix
+++ b/pkgs/by-name/fi/firefly-pico/package.nix
@@ -43,6 +43,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
   passthru = {
     phpPackage = php84;
+    tests = nixosTests.firefly-pico;
     updateScript = nix-update-script { };
     frontend = callPackage ./frontend.nix {
       inherit (finalAttrs)

--- a/pkgs/by-name/fi/firefly-pico/package.nix
+++ b/pkgs/by-name/fi/firefly-pico/package.nix
@@ -1,0 +1,72 @@
+{
+  lib,
+  fetchFromGitHub,
+  stdenvNoCC,
+  nodejs,
+  callPackage,
+  php84,
+  nixosTests,
+  nix-update-script,
+  dataDir ? "/var/lib/firefly-pico",
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "firefly-pico";
+  version = "1.9.0";
+
+  src = fetchFromGitHub {
+    owner = "cioraneanu";
+    repo = "firefly-pico";
+    tag = "${finalAttrs.version}";
+    hash = "sha256-5hpvXg6EjjsvKXMXzFQpJCX4FQjnhwu7eQrERN+mZhE=";
+  };
+  sourceRoot = "source/back";
+
+  buildInputs = [ php84 ];
+
+  nativeBuildInputs = [
+    nodejs
+    nodejs.python
+    php84.composerHooks2.composerInstallHook
+  ];
+
+  composerVendor = php84.mkComposerVendor {
+    inherit (finalAttrs) pname src version;
+    sourceRoot = "source/back";
+    composerNoDev = true;
+    composerNoPlugins = true;
+    composerNoScripts = true;
+    composerStrictValidation = true;
+    strictDeps = true;
+    vendorHash = "sha256-eVPMfIpA0PX+jOdgtscKObgi8WPtAh7CsvHsUEzzv8Q=";
+  };
+
+  passthru = {
+    phpPackage = php84;
+    updateScript = nix-update-script { };
+    frontend = callPackage ./frontend.nix {
+      inherit (finalAttrs)
+        src
+        version
+        meta
+        ;
+    };
+  };
+  postInstall = ''
+    chmod +x $out/share/php/firefly-pico/artisan
+    rm -R $out/share/php/firefly-pico/{storage,bootstrap/cache}
+    ln -s ${dataDir}/storage $out/share/php/firefly-pico/storage
+    ln -s ${dataDir}/cache $out/share/php/firefly-pico/bootstrap/cache
+  '';
+
+  meta = {
+    changelog = "https://github.com/cioraneanu/firefly-pico/releases/tag/${finalAttrs.version}";
+    description = "Delightful Firefly III companion web app for effortless transaction tracking";
+    homepage = "https://github.com/cioraneanu/firefly-pico";
+    license = lib.licenses.agpl3Only;
+    maintainers = [
+      lib.maintainers.patrickdag
+    ];
+    hydraPlatforms = lib.platforms.all;
+  };
+})

--- a/pkgs/by-name/fi/firefly-pico/package.nix
+++ b/pkgs/by-name/fi/firefly-pico/package.nix
@@ -5,6 +5,7 @@
   nodejs,
   callPackage,
   php84,
+  nixosTests,
   nix-update-script,
   dataDir ? "/var/lib/firefly-pico",
 }:
@@ -45,6 +46,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
   passthru = {
     phpPackage = php84;
+    tests = nixosTests.firefly-pico;
     updateScript = nix-update-script { };
     frontend = callPackage ./frontend.nix {
       inherit (finalAttrs)

--- a/pkgs/by-name/fi/firefly-pico/package.nix
+++ b/pkgs/by-name/fi/firefly-pico/package.nix
@@ -1,0 +1,74 @@
+{
+  lib,
+  fetchFromGitHub,
+  stdenvNoCC,
+  nodejs,
+  callPackage,
+  php84,
+  nix-update-script,
+  dataDir ? "/var/lib/firefly-pico",
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "firefly-pico";
+  version = "1.12.0";
+
+  src = fetchFromGitHub {
+    owner = "cioraneanu";
+    repo = "firefly-pico";
+    tag = "${finalAttrs.version}";
+    hash = "sha256-kRlGEZTE7zEJEVyrFC9cDdGi8HLaPIHX5KLv0KuIBWY=";
+  };
+  sourceRoot = "source/back";
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  buildInputs = [ php84 ];
+
+  nativeBuildInputs = [
+    nodejs
+    nodejs.python
+    php84.packages.composer
+    php84.composerHooks2.composerInstallHook
+  ];
+
+  composerVendor = php84.mkComposerVendor {
+    inherit (finalAttrs) pname src version;
+    sourceRoot = "source/back";
+    composerNoDev = true;
+    composerNoPlugins = true;
+    composerNoScripts = true;
+    composerStrictValidation = true;
+    strictDeps = true;
+    vendorHash = "sha256-AWJNXk8qYiiLuxtCZNsqFEEsYM+j5Yt9p747nNzKWKg=";
+  };
+
+  passthru = {
+    phpPackage = php84;
+    updateScript = nix-update-script { };
+    frontend = callPackage ./frontend.nix {
+      inherit (finalAttrs)
+        src
+        version
+        meta
+        ;
+    };
+  };
+  postInstall = ''
+    chmod +x $out/share/php/firefly-pico/artisan
+    rm -R $out/share/php/firefly-pico/{storage,bootstrap/cache}
+    ln -s ${dataDir}/storage $out/share/php/firefly-pico/storage
+    ln -s ${dataDir}/cache $out/share/php/firefly-pico/bootstrap/cache
+  '';
+
+  meta = {
+    changelog = "https://github.com/cioraneanu/firefly-pico/releases/tag/${finalAttrs.version}";
+    description = "Delightful Firefly III companion web app for effortless transaction tracking";
+    homepage = "https://github.com/cioraneanu/firefly-pico";
+    license = lib.licenses.agpl3Only;
+    maintainers = [
+      lib.maintainers.patrickdag
+    ];
+    hydraPlatforms = lib.platforms.all;
+  };
+})


### PR DESCRIPTION

Package and module for Firefly-pico, a self described "delightful Firefly III companion web app for effortless transaction tracking".

Largely based on the firefly-iii modules already available.

Still missing tests. Will add them before marking ready.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
