### PR TITLE
plink-ng2: init at 2.0.0-a.6.12

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -547,6 +547,13 @@
     githubId = 124545;
     name = "Anthony Cowley";
   };
+  acpuchades = {
+    name = "Alejandro Caravaca Puchades";
+    email = "acaravacapuchades@gmail.com";
+    github = "acpuchades";
+    githubId = 59510094;
+    keys = [ { fingerprint = "D23C FEF0 C257 D999 C80B  1EB6 A158 D219 BD68 B562"; } ];
+  };
   acuteaangle = {
     name = "Summer Tea";
     email = "zestypurple@protonmail.com";

--- a/pkgs/by-name/pl/plink-ng2/package.nix
+++ b/pkgs/by-name/pl/plink-ng2/package.nix
@@ -1,0 +1,64 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  zlib,
+  blas,
+  lapack,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "plink-ng2";
+  version = "2.0.0-a.6.12";
+
+  src = fetchFromGitHub {
+    owner = "chrchang";
+    repo = "plink-ng";
+    tag = "v${version}";
+    hash = "sha256-HtWaZQL+z/28lH+VclRbwiDWJpyDQ47VO6mOqNaFQwI=";
+  };
+
+  buildInputs =
+    [ zlib ]
+    ++ lib.optionals stdenv.hostPlatform.isLinux [
+      blas
+      lapack
+    ];
+
+  preBuild =
+    lib.optionalString stdenv.hostPlatform.isDarwin ''
+      makeFlagsArray+=(
+        CXXFLAGS="-framework Accelerate -Wno-unused-command-line-argument"
+        ZLIB=-lz
+      )
+    ''
+    + lib.optionalString stdenv.hostPlatform.isLinux ''
+      makeFlagsArray+=(
+        BLASFLAGS="-lblas -lcblas -llapack"
+        ZLIB=-lz
+      )
+    '';
+
+  sourceRoot = "${src.name}/2.0/build_dynamic";
+  makefile = "Makefile";
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 plink2 $out/bin/plink2
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Whole genome association analysis toolset";
+    homepage = "https://www.cog-genomics.org/plink2";
+    license = with lib.licenses; [
+      gpl3Plus
+      lgpl3Plus
+    ];
+    mainProgram = "plink2";
+    maintainers = with lib.maintainers; [ acpuchades ];
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

This PR adds a new package: plink2 (PLINK 2.0 whole-genome association analysis toolset).

PLINK 2.0 is under active development and is already widely used in genetics research for GWAS (Genome-Wide Association Studies) and large-scale statistical analysis of genotype/phenotype data.

Homepage: https://www.cog-genomics.org/plink/2.0/

The package builds correctly for Darwin and Linux platforms.
Special handling was added for macOS to link against the Accelerate framework.

**Note on coexistence with existing plink-ng package**

There is already a `plink-ng` package in nixpkgs, which covers PLINK 1.9.

This new package `plink2` provides the PLINK 2.0 version, which is substantially different internally and externally:
- Different binary (plink2 vs. plink).
- Different feature set and performance improvements.
- Different default input and output formats.

Some bioinformatics pipelines still explicitly rely on PLINK 1.9 behavior (plink-ng), while newer workflows require PLINK 2.0 (plink2). Different binary naming ensures that no incompatibility or file conflicts are introduced.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [X] aarch64-linux
  - [ ] x86_64-darwin
  - [X] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [X] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
