### PR TITLE
Adding package `slimjet`

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -16133,6 +16133,12 @@
     github = "mlvzk";
     githubId = 44906333;
   };
+  mmad = {
+    name = "M. MAD";
+    email = "m.mad.official@proton.me";
+    githubId = 96647182;
+    github = "M-MAD-Official";
+  };
   mmahut = {
     email = "marek.mahut@gmail.com";
     github = "mmahut";

--- a/pkgs/by-name/sl/slimjet/package.nix
+++ b/pkgs/by-name/sl/slimjet/package.nix
@@ -1,0 +1,163 @@
+{
+  stdenv,
+  lib,
+  fetchurl,
+  autoPatchelfHook,
+  wrapGAppsHook3,
+  flac,
+  gnome2,
+  harfbuzzFull,
+  nss,
+  snappy,
+  xdg-utils,
+  xorg,
+  alsa-lib,
+  atk,
+  cairo,
+  cups,
+  curl,
+  dbus,
+  expat,
+  fontconfig,
+  freetype,
+  gdk-pixbuf,
+  glib,
+  gtk3,
+  libX11,
+  libxcb,
+  libXScrnSaver,
+  libXcomposite,
+  libXcursor,
+  libXdamage,
+  libXext,
+  libXfixes,
+  libXi,
+  libXrandr,
+  libXrender,
+  libXtst,
+  libdrm,
+  libnotify,
+  libopus,
+  libpulseaudio,
+  libuuid,
+  libxshmfence,
+  mesa,
+  nspr,
+  pango,
+  systemd,
+  at-spi2-atk,
+  at-spi2-core,
+  libqt5pas,
+  qt6,
+  vivaldi-ffmpeg-codecs
+}:
+
+stdenv.mkDerivation rec {
+  pname = "slimjet";
+  version = "45.0.3.0";
+  fullName = "flashpeak-slimjet";
+
+  suffix =
+    if stdenv.isx86_64 then
+      "amd64"
+    else if stdenv.isx86_32 then
+      "i386"
+    else
+      throw "Unsupported system: ${stdenv.hostPlatform.system}";
+  src = fetchurl {
+    url = "http://www.slimjetbrowser.com/release/archive/${version}/slimjet_${suffix}.deb";
+    hash = "sha256-RtDN2NXONfjHbnMC4Mk9fAwA4xrmfq3H9D/eFuazklY=";
+  };
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+    qt6.wrapQtAppsHook
+    wrapGAppsHook3
+  ];
+
+  buildInputs = [
+    flac
+    harfbuzzFull
+    nss
+    snappy
+    xdg-utils
+    xorg.libxkbfile
+    alsa-lib
+    at-spi2-atk
+    at-spi2-core
+    atk
+    cairo
+    cups
+    curl
+    dbus
+    expat
+    fontconfig.lib
+    freetype
+    gdk-pixbuf
+    glib
+    gnome2.GConf
+    gtk3
+    libX11
+    libXScrnSaver
+    libXcomposite
+    libXcursor
+    libXdamage
+    libXext
+    libXfixes
+    libXi
+    libXrandr
+    libXrender
+    libXtst
+    libdrm
+    libnotify
+    libopus
+    libuuid
+    libxcb
+    libxshmfence
+    mesa
+    nspr
+    nss
+    pango
+    stdenv.cc.cc.lib
+    libqt5pas
+    qt6.qtbase
+  ];
+
+  unpackPhase = ''
+    ar vx $src
+    tar -xvf data.tar.xz
+  '';
+
+  dontWrapQtApps = true;
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p "$out"
+    cp {usr/share,opt} $out/ -R
+    mkdir "$out/bin"
+    substituteInPlace "$out"/share/applications/*.desktop --replace-fail /usr/bin/ "$out"/bin/
+    substituteInPlace "$out"/share/menu/${pname}.menu --replace-fail /opt/ $out/opt/ --replace-fail /usr/ $out/usr/
+    substituteInPlace "$out"/share/gnome-control-center/default-apps/${pname}.xml --replace-fail /opt/ $out/opt/
+    ln -sf ${vivaldi-ffmpeg-codecs}/lib/libffmpeg.so "$out"/opt/${pname}/libffmpeg.so
+    for f in ${fullName} ${pname} ${pname}-sandbox; do
+      ln -sf "$out"/opt/${pname}/$f "$out"/bin/$f
+    done
+    runHook postInstall
+  '';
+
+  runtimeDependencies = map lib.getLib [
+    libpulseaudio
+    curl
+    systemd
+    vivaldi-ffmpeg-codecs
+  ] ++ buildInputs;
+
+  meta = with lib; {
+    description = "Flashpeak Slimjet; fastest web browser that automatically blocks ads";
+    homepage = "https://www.slimjet.com/";
+    license = licenses.unfree;
+    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
+    maintainers = with maintainers; [ mmad ];
+    platforms = [ "x86_64-linux" "i686-linux" ];
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

I have packaged Slimjet browser from FlashPeak Inc. as also requested in #180668.

I have tested it, it works (with the sandboxing features of chromium-based browsers as indicated on the internal `chorme://sandbox` page). I used package definition of the Yandex Browser as a basis for packaging a Unfree binary chromium-based browser (and therefor some things may be sub-optimal - like redundant unnecessary dependencies, but I don't know any better).

Also please note that this is my first contribution on nixpkgs so I may have done somethings not using the best practieces. If you find any mistakes, please give me better directions. Thanks in advance!

EDIT: `libqt5pas` dependency is in NixOS 24.11 repo but is absent in the unstable repos. The reference `yandex-browser` itself is also absent in the unstable repos. I can't understand these changes in nixpkgs but my package definition builds successfully on my NixOS 24.11 installation.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
