### PR TITLE
SDL2_mixer: fix configure warnings

### DIFF
--- a/pkgs/by-name/sd/SDL2_mixer/package.nix
+++ b/pkgs/by-name/sd/SDL2_mixer/package.nix
@@ -14,9 +14,11 @@
   smpeg2,
   stdenv,
   timidity,
+  wavpack,
+  libxmp,
+  game-music-emu,
   # Boolean flags
   enableSdltest ? (!stdenv.hostPlatform.isDarwin),
-  enableSmpegtest ? (!stdenv.hostPlatform.isDarwin),
 }:
 
 let
@@ -54,6 +56,9 @@ stdenv.mkDerivation (finalAttrs: {
     mpg123
     opusfile
     smpeg2
+    wavpack
+    libxmp
+    game-music-emu
     # MIDI patterns
     timidity
   ];
@@ -66,14 +71,11 @@ stdenv.mkDerivation (finalAttrs: {
   strictDeps = true;
 
   configureFlags = [
-    (lib.enableFeature false "music-ogg-shared")
-    (lib.enableFeature false "music-flac-shared")
     (lib.enableFeature false "music-mod-modplug-shared")
     (lib.enableFeature false "music-mp3-mpg123-shared")
     (lib.enableFeature false "music-opus-shared")
     (lib.enableFeature false "music-midi-fluidsynth-shared")
     (lib.enableFeature enableSdltest "sdltest")
-    (lib.enableFeature enableSmpegtest "smpegtest")
     # override default path to allow MIDI files to be played
     (lib.withFeatureAs true "timidity-cfg" "${timidity}/share/timidity/timidity.cfg")
   ];

--- a/pkgs/by-name/sd/SDL2_mixer/package.nix
+++ b/pkgs/by-name/sd/SDL2_mixer/package.nix
@@ -1,7 +1,6 @@
 {
   lib,
   SDL2,
-  darwin,
   fetchFromGitHub,
   flac,
   fluidsynth,
@@ -20,10 +19,6 @@
   # Boolean flags
   enableSdltest ? (!stdenv.hostPlatform.isDarwin),
 }:
-
-let
-  inherit (darwin.apple_sdk.frameworks) CoreServices AudioUnit AudioToolbox;
-in
 stdenv.mkDerivation (finalAttrs: {
   pname = "SDL2_mixer";
   version = "2.8.1";
@@ -38,12 +33,6 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [
     SDL2
     pkg-config
-  ];
-
-  buildInputs = lib.optionals stdenv.hostPlatform.isDarwin [
-    AudioToolbox
-    AudioUnit
-    CoreServices
   ];
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/pygame-ce/default.nix
+++ b/pkgs/development/python-modules/pygame-ce/default.nix
@@ -21,7 +21,7 @@
   portmidi,
   SDL2_classic,
   SDL2_classic_image,
-  SDL2_classic_mixer_2_0,
+  SDL2_classic_mixer,
   SDL2_classic_ttf,
   numpy,
 
@@ -101,7 +101,7 @@ buildPythonPackage rec {
     portmidi
     SDL2_classic
     (SDL2_classic_image.override { enableSTB = false; })
-    SDL2_classic_mixer_2_0
+    SDL2_classic_mixer
     SDL2_classic_ttf
   ] ++ lib.optionals stdenv.hostPlatform.isDarwin [ AppKit ];
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
During configure phase of SDL2_mixer several warnings are reported:
```
configure: WARNING: *** Unable to find xmp library (http://xmp.sourceforge.net/)
configure: WARNING: MOD support disabled
...
configure: WARNING: *** Unable to find GME library (https://github.com/libgme/game-music-emu)
configure: WARNING: Game Music Emu support disabled.
...
configure: WARNING: *** Unable to find WavPack library (http://www.wavpack.com)
configure: WARNING: WavPack support disabled
...
configure: WARNING: unrecognized options: --disable-music-ogg-shared, --disable-music-flac-shared, --enable-smpegtest
```

This results in reduced functionality and in particular `python3Packages.pygame-ce` relies on MOD and WavPack support.

This allows us to drop `SDL2_mixer_2_0` and `SDL2_classic_mixer_2_0` but it will be done in a separate MR since breaking changes are restricted.
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
