### PR TITLE
dcd: init at 0.15.2

### DIFF
--- a/pkgs/by-name/dc/dcd/dub-lock.json
+++ b/pkgs/by-name/dc/dcd/dub-lock.json
@@ -1,0 +1,24 @@
+{
+  "dependencies": {
+    "dsymbol": {
+      "version": "0.14.1",
+      "sha256": "0vh65w6v7am2krc8fhj2snsh7dzqjvfkccvwynsgfbwp9fdxcldq"
+    },
+    "emsi_containers": {
+      "version": "0.9.0",
+      "sha256": "1viz1fjh6jhfvl0d25bb1q7aclm1hrs0d7hhcx1d9c0gg5k6lcpm"
+    },
+    "libdparse": {
+      "version": "0.21.1",
+      "sha256": "0i1lsp9k45pqkksg47ivpj85wb4waz2cfz43hsip7a136pxzaqq0"
+    },
+    "msgpack-d": {
+      "version": "1.0.4",
+      "sha256": "1y2iihxsxpgbwns6r2b4xvw82szakgnv1i61y4d3i6qsakxm7yid"
+    },
+    "stdx-allocator": {
+      "version": "2.77.5",
+      "sha256": "1g8382wr49sjyar0jay8j7y2if7h1i87dhapkgxphnizp24d7kaj"
+    }
+  }
+}

--- a/pkgs/by-name/dc/dcd/package.nix
+++ b/pkgs/by-name/dc/dcd/package.nix
@@ -1,0 +1,46 @@
+{
+  lib,
+  fetchFromGitHub,
+  buildDubPackage,
+}:
+
+buildDubPackage rec {
+  pname = "dcd";
+  version = "0.15.2";
+
+  src = fetchFromGitHub {
+    owner = "dlang-community";
+    repo = "DCD";
+    tag = "v${version}";
+    hash = "sha256-dJ4Ql3P9kPQhQ3ZrNcTAEB5JHSslYn2BN8uqq6vGetY=";
+  };
+
+  dubLock = ./dub-lock.json;
+
+  buildPhase = ''
+    runHook preBuild
+
+    dub build --build=release --config=server
+    dub build --build=release --config=client
+
+    runHook postBuild
+  '';
+
+  doCheck = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 bin/dcd-{client,server} -t "$out/bin"
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Auto-complete program for the D programming language";
+    homepage = "https://github.com/dlang-community/DCD";
+    changelog = "https://github.com/dlang-community/DCD/blob/${src.rev}/CHANGELOG.md";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ tomasajt ];
+  };
+}


### PR DESCRIPTION
https://github.com/dlang-community/DCD

I saw that this was still not packaged.


---

Btw, I have been thinking of deprecating `buildDubPackage`.
I was thinking of having something like `dub.configHook`, and its only job would be to use the specified ./dub-lock file and copy them into the environment.
All other dub-related stuff would be handled by users (or another hook, but that can be decided later)

For this package I didn't use the buildPhase provided by buildDubPackage because it assumes that we only build 1 configuration.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
