### PR TITLE
firefly-iota-desktop: init at 2.0.12

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -15577,6 +15577,11 @@
     github = "mevatron";
     githubId = 714585;
   };
+  mfcrizz = {
+    github = "MfCrizz";
+    githubId = 56442772;
+    name = "Manuel Fragner";
+  };
   mfossen = {
     email = "msfossen@gmail.com";
     github = "mfossen";

--- a/pkgs/by-name/fi/firefly-iota-desktop/package.nix
+++ b/pkgs/by-name/fi/firefly-iota-desktop/package.nix
@@ -1,0 +1,39 @@
+{
+  lib,
+  fetchurl,
+  appimageTools,
+}:
+
+let
+  pname = "firefly-iota-desktop";
+  version = "2.0.12";
+  src = fetchurl {
+    url = "https://github.com/iotaledger/firefly/releases/download/desktop-iota-${version}/firefly-iota-desktop-${version}.AppImage";
+    hash = "sha256-V+RbrEcZWmbHurNhme1EufYHtECX93wXhlgJNG1E4tU=";
+  };
+  appimageContents = appimageTools.extractType2 { inherit pname version src; };
+
+in
+appimageTools.wrapType2 {
+  inherit pname version src;
+
+  extraPkgs = pkgs: [ pkgs.libsecret ];
+
+  extraInstallCommands = ''
+    install -D -m 444 ${appimageContents}/desktop.desktop $out/share/applications/firefly-iota-desktop.desktop
+    install -D -m 444 ${appimageContents}/desktop.png $out/share/pixmaps/firefly-iota-desktop.png
+    substituteInPlace $out/share/applications/firefly-iota-desktop.desktop \
+      --replace-fail 'Exec=AppRun' 'Exec=firefly-iota-desktop' \
+      --replace-fail 'Icon=desktop' 'Icon=firefly-iota-desktop'
+  '';
+
+  meta = {
+    description = "Firefly IOTA Wallet";
+    homepage = "https://firefly.iota.org";
+    changelog = "https://github.com/iotaledger/firefly/releases/tag/desktop-iota-${version}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ mfcrizz ];
+    platforms = [ "x86_64-linux" ];
+    mainProgram = "firefly-iota-desktop";
+  };
+}


### PR DESCRIPTION
Adds the **IOTA Firefly Wallet** to nixpkgs. 
Firefly is the official wallet for managing your tokens and assets on the IOTA network.

This package wraps the official AppImage.

Homepage: https://firefly.iota.org/
Release: https://github.com/iotaledger/firefly/releases/tag/desktop-iota-2.0.12


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
