### PR TITLE
perlPackages.NetMQTTSimple: Add IO::Socket::SSL

### DIFF
--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -25708,6 +25708,9 @@ with self;
       url = "mirror://cpan/authors/id/J/JU/JUERD/Net-MQTT-Simple-1.28.tar.gz";
       hash = "sha256-Sp6hB+a8IuJrUzZ4oKPMbEI7N4TsP8ROjjM5t8Vr7gM=";
     };
+    propagatedBuildInputs = [
+      IOSocketSSL
+    ];
     meta = {
       description = "Minimal MQTT version 3 interface";
       license = with lib.licenses; [


### PR DESCRIPTION
The `mqtt-simple` utility requires IO::Socket::SSL when passing --ssl on the command line:

```
$ mqtt-simple --ssl -h mqtt.dataplatform.knmi.nl:443 -s '#'
Can't locate IO/Socket/SSL.pm in @INC (you may need to install the IO::Socket::SSL module) (@INC entries checked: /nix/store/bvnw0icnbilb7zpk36bayq9rd3hbwggw-perl5.40.0-Net-MQTT-Simple-1.28/lib/perl5/site_perl/5.40.0/x86_64-linux-thread-multi /nix/store/bvnw0icnbilb7zpk36bayq9rd3hbwggw-perl5.40.0-Net-MQTT-Simple-1.28/lib/perl5/site_perl/5.40.0 /nix/store/bvnw0icnbilb7zpk36bayq9rd3hbwggw-perl5.40.0-Net-MQTT-Simple-1.28/lib/perl5/site_perl /nix/store/nkn5ylz22hb1069w8q7n76dacm6jkw4k-perl-5.40.0/lib/perl5/site_perl/5.40.0/x86_64-linux-thread-multi /nix/store/nkn5ylz22hb1069w8q7n76dacm6jkw4k-perl-5.40.0/lib/perl5/site_perl/5.40.0 /nix/store/nkn5ylz22hb1069w8q7n76dacm6jkw4k-perl-5.40.0/lib/perl5/site_perl /nix/store/nkn5ylz22hb1069w8q7n76dacm6jkw4k-perl-5.40.0/lib/perl5/site_perl -I/nix/store/bvnw0icnbilb7zpk36bayq9rd3hbwggw-perl5.40.0-Net-MQTT-Simple-1.28/lib/perl5/site_perl /nix/store/nkn5ylz22hb1069w8q7n76dacm6jkw4k-perl-5.40.0/lib/perl5/site_perl/5.40.0/x86_64-linux-thread-multi /nix/store/nkn5ylz22hb1069w8q7n76dacm6jkw4k-perl-5.40.0/lib/perl5/site_perl/5.40.0 /nix/store/nkn5ylz22hb1069w8q7n76dacm6jkw4k-perl-5.40.0/lib/perl5/5.40.0/x86_64-linux-thread-multi /nix/store/nkn5ylz22hb1069w8q7n76dacm6jkw4k-perl-5.40.0/lib/perl5/5.40.0) at /nix/store/bvnw0icnbilb7zpk36bayq9rd3hbwggw-perl5.40.0-Net-MQTT-Simple-1.28/lib/perl5/site_perl/5.40.0/Net/MQTT/Simple/SSL.pm line 5.
```

This patch adds it to the runtime dependencies.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
