### PR TITLE
libx{dmcp,au,cb,11,ext}: refactor and move to pkgs/by-name from xorg namespace

### DIFF
--- a/lib/licenses.nix
+++ b/lib/licenses.nix
@@ -719,6 +719,16 @@ lib.mapAttrs mkLicense (
       spdxId = "HPND-sell-variant";
     };
 
+    hpndDoc = {
+      fullName = "Historical Permission Notice and Disclaimer - documentation variant";
+      spdxId = "HPND-doc";
+    };
+
+    hpndDocSell = {
+      fullName = "Historical Permission Notice and Disclaimer - documentation sell variant";
+      spdxId = "HPND-doc-sell";
+    };
+
     hpndUc = {
       spdxId = "HPND-UC";
       fullName = "Historical Permission Notice and Disclaimer - University of California variant";
@@ -1309,6 +1319,14 @@ lib.mapAttrs mkLicense (
       #
       # Sincerly
       # Marc Weber (small nix contributor)
+    };
+
+    tekHvcLicense = {
+      fullName = "TekHVC License";
+      url = "https://gitlab.freedesktop.org/xorg/lib/libx11/-/blob/7f8305c779ac6948d7261764f5ffb8ae9aa975b1/COPYING#L138-171";
+      # TODO: add spdxId when it gets accepted to spdx
+      # https://tools.spdx.org/app/license_requests/458
+      # https://github.com/spdx/license-list-XML/issues/2757
     };
 
     tsl = {

--- a/pkgs/by-name/li/libx11/package.nix
+++ b/pkgs/by-name/li/libx11/package.nix
@@ -1,0 +1,93 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  buildPackages,
+  pkg-config,
+  xorgproto,
+  libpthread-stubs,
+  libxcb,
+  xtrans,
+  writeScript,
+  testers,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "libx11";
+  version = "1.8.12";
+
+  outputs = [
+    "out"
+    "dev"
+    "man"
+  ];
+
+  src = fetchurl {
+    url = "mirror://xorg/individual/lib/libX11-${finalAttrs.version}.tar.xz";
+    hash = "sha256-+gJvm7AST01sgI+a70BXqtZeezXY/0OVHO8Kvga7mpo=";
+  };
+
+  strictDeps = true;
+
+  depsBuildBuild = [ buildPackages.stdenv.cc ];
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [
+    xorgproto
+    libpthread-stubs
+    libxcb
+    xtrans
+  ];
+
+  propagatedBuildInputs = [ xorgproto ];
+
+  configureFlags =
+    lib.optional (stdenv.hostPlatform != stdenv.buildPlatform) "--enable-malloc0returnsnull"
+    ++ lib.optional (stdenv.targetPlatform.useLLVM or false) "ac_cv_path_RAWCPP=cpp";
+
+  env = lib.optionalAttrs stdenv.hostPlatform.isDarwin { CPP = "clang -E -"; };
+
+  postInstall = ''
+    # Remove useless DocBook XML files.
+    rm -r $out/share/doc
+  '';
+
+  passthru = {
+    updateScript = writeScript "update-${finalAttrs.pname}" ''
+      #!/usr/bin/env nix-shell
+      #!nix-shell -i bash -p common-updater-scripts
+      version="$(list-directory-versions --pname libX11 \
+        --url https://xorg.freedesktop.org/releases/individual/lib/ \
+        | sort -V | tail -n1)"
+      update-source-version ${finalAttrs.pname} "$version"
+    '';
+    tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+  };
+
+  meta = {
+    description = "Core X11 protocol client library (aka \"Xlib\")";
+    homepage = "https://gitlab.freedesktop.org/xorg/lib/libx11";
+    license = with lib.licenses; [
+      mit
+      mitOpenGroup
+      x11
+      hpndDoc
+      hpndSellVariant
+      tekHvcLicense
+      hpndDocSell
+      hpnd
+      bsd1
+      isc
+      # The "source code modified by FUJITSU LIMITED under the Joint Development Agreement for the
+      # CDE/Motif PST" is possibly unfree.
+      # upstream issue: https://gitlab.freedesktop.org/xorg/lib/libx11/-/issues/217
+      # unfree
+    ];
+    maintainers = [ ];
+    pkgConfigModules = [
+      "x11"
+      "x11-xcb"
+    ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/by-name/li/libxau/package.nix
+++ b/pkgs/by-name/li/libxau/package.nix
@@ -1,0 +1,48 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  pkg-config,
+  xorgproto,
+  writeScript,
+  testers,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "libxau";
+  version = "1.0.12";
+
+  outputs = [
+    "out"
+    "dev"
+  ];
+
+  src = fetchurl {
+    url = "mirror://xorg/individual/lib/libXau-${finalAttrs.version}.tar.xz";
+    hash = "sha256-dNDk36PTmtiTnpm9o39ZZ6ulKCEQdoKEZNJ3fUd/wPs=";
+  };
+
+  strictDeps = true;
+  nativeBuildInputs = [ pkg-config ];
+  propagatedBuildInputs = [ xorgproto ];
+
+  passthru = {
+    updateScript = writeScript "update-${finalAttrs.pname}" ''
+      #!/usr/bin/env nix-shell
+      #!nix-shell -i bash -p common-updater-scripts
+      version="$(list-directory-versions --pname libXau \
+        --url https://xorg.freedesktop.org/releases/individual/lib/ \
+        | sort -V | tail -n1)"
+      update-source-version ${finalAttrs.pname} "$version"
+    '';
+    tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+  };
+
+  meta = {
+    description = "Functions for handling Xauthority files and entries.";
+    homepage = "https://gitlab.freedesktop.org/xorg/lib/libxau";
+    license = lib.licenses.mitOpenGroup;
+    maintainers = [ ];
+    pkgConfigModules = [ "xau" ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/by-name/li/libxcb/package.nix
+++ b/pkgs/by-name/li/libxcb/package.nix
@@ -1,0 +1,94 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  pkg-config,
+  python3,
+  libpthread-stubs,
+  libxau,
+  libxdmcp,
+  xcb-proto,
+  windows,
+  writeScript,
+  testers,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "libxcb";
+  version = "1.17.0";
+
+  outputs = [
+    "out"
+    "dev"
+    "man"
+    "doc"
+  ];
+
+  src = fetchurl {
+    url = "mirror://xorg/individual/lib/libxcb-${finalAttrs.version}.tar.xz";
+    hash = "sha256-WZ6/mZZxD+pxYi5uGE86itW0PQ5fqMTkBxI8iKWabVU=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    pkg-config
+    python3
+  ];
+
+  buildInputs = [
+    libpthread-stubs
+    libxau
+    libxdmcp
+    xcb-proto
+  ];
+
+  # $dev/include/xcb/xcb.h includes pthread.h
+  propagatedBuildInputs = lib.optional stdenv.hostPlatform.isMinGW windows.mingw_w64_pthreads;
+
+  passthru = {
+    updateScript = writeScript "update-${finalAttrs.pname}" ''
+      #!/usr/bin/env nix-shell
+      #!nix-shell -i bash -p common-updater-scripts
+      version="$(list-directory-versions --pname ${finalAttrs.pname} \
+        --url https://xorg.freedesktop.org/releases/individual/lib/ \
+        | sort -V | tail -n1)"
+      update-source-version ${finalAttrs.pname} "$version"
+    '';
+    tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+  };
+
+  meta = {
+    description = "C interface to the X Window System protocol";
+    homepage = "https://gitlab.freedesktop.org/xorg/lib/libxcb";
+    # gitlab wrongly says X11 Distribute Modifications
+    license = lib.licenses.x11;
+    maintainers = [ ];
+    pkgConfigModules = [
+      "xcb"
+      "xcb-composite"
+      "xcb-damage"
+      "xcb-dpms"
+      "xcb-dri2"
+      "xcb-dri3"
+      "xcb-glx"
+      "xcb-present"
+      "xcb-randr"
+      "xcb-record"
+      "xcb-render"
+      "xcb-res"
+      "xcb-screensaver"
+      "xcb-shape"
+      "xcb-shm"
+      "xcb-sync"
+      "xcb-xf86dri"
+      "xcb-xfixes"
+      "xcb-xinerama"
+      "xcb-xinput"
+      "xcb-xkb"
+      "xcb-xtest"
+      "xcb-xv"
+      "xcb-xvmc"
+    ];
+    platforms = lib.platforms.unix ++ lib.platforms.windows;
+  };
+})

--- a/pkgs/by-name/li/libxdmcp/package.nix
+++ b/pkgs/by-name/li/libxdmcp/package.nix
@@ -1,0 +1,50 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  pkg-config,
+  xorgproto,
+  writeScript,
+  testers,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "libxdmcp";
+  version = "1.1.5";
+
+  outputs = [
+    "out"
+    "dev"
+    "doc"
+  ];
+
+  src = fetchurl {
+    url = "mirror://xorg/individual/lib/libXdmcp-${finalAttrs.version}.tar.xz";
+    hash = "sha256-2KUiKCjDratwrfaaVYPx0y617OBDBPf4OStqNTqiIow=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [ xorgproto ];
+
+  passthru = {
+    updateScript = writeScript "update-${finalAttrs.pname}" ''
+      #!/usr/bin/env nix-shell
+      #!nix-shell -i bash -p common-updater-scripts
+      version="$(list-directory-versions --pname libXdmcp \
+        --url https://xorg.freedesktop.org/releases/individual/lib/ \
+        | sort -V | tail -n1)"
+      update-source-version ${finalAttrs.pname} "$version"
+    '';
+    tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+  };
+
+  meta = {
+    description = "X Display Manager Control Protocol library";
+    homepage = "https://gitlab.freedesktop.org/xorg/lib/libxdmcp";
+    license = lib.licenses.mitOpenGroup;
+    maintainers = [ ];
+    pkgConfigModules = [ "xdmcp" ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/by-name/li/libxext/package.nix
+++ b/pkgs/by-name/li/libxext/package.nix
@@ -1,0 +1,74 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  pkg-config,
+  libX11,
+  xorgproto,
+  libxau,
+  writeScript,
+  testers,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "libxext";
+  version = "1.3.6";
+
+  outputs = [
+    "out"
+    "dev"
+    "man"
+    "doc"
+  ];
+
+  src = fetchurl {
+    url = "mirror://xorg/individual/lib/libXext-${finalAttrs.version}.tar.xz";
+    hash = "sha256-7bWfojmU5AX9xbQAr99YIK5hYLlPNePcPaRFehbol1M=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [
+    libX11
+    xorgproto
+  ];
+  propagatedBuildInputs = [
+    xorgproto
+    libxau
+  ];
+
+  configureFlags = lib.optional (
+    stdenv.hostPlatform != stdenv.buildPlatform
+  ) "--enable-malloc0returnsnull";
+
+  passthru = {
+    updateScript = writeScript "update-${finalAttrs.pname}" ''
+      #!/usr/bin/env nix-shell
+      #!nix-shell -i bash -p common-updater-scripts
+      version="$(list-directory-versions --pname libXext \
+        --url https://xorg.freedesktop.org/releases/individual/lib/ \
+        | sort -V | tail -n1)"
+      update-source-version ${finalAttrs.pname} "$version"
+    '';
+    tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+  };
+
+  meta = {
+    description = "Xlib-based library for common extensions to the X11 protocol";
+    homepage = "https://gitlab.freedesktop.org/xorg/lib/libxext";
+    license = with lib.licenses; [
+      mitOpenGroup
+      x11
+      hpnd
+      hpndSellVariant
+      hpndDocSell
+      hpndDoc
+      mit
+      isc
+    ];
+    maintainers = [ ];
+    pkgConfigModules = [ "xext" ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -13,6 +13,7 @@
   libxcb,
   libxcvt,
   libxdmcp,
+  libxext,
   lndir,
   luit,
   makedepend,
@@ -53,6 +54,7 @@ self: with self; {
   libX11 = libx11;
   libXau = libxau;
   libXdmcp = libxdmcp;
+  libXext = libxext;
   utilmacros = util-macros;
   xcbproto = xcb-proto;
   xkeyboardconfig = xkeyboard-config;
@@ -2153,42 +2155,6 @@ self: with self; {
       passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
       meta = {
         pkgConfigModules = [ "xdamage" ];
-        platforms = lib.platforms.unix;
-      };
-    })
-  ) { };
-
-  # THIS IS A GENERATED FILE.  DO NOT EDIT!
-  libXext = callPackage (
-    {
-      stdenv,
-      pkg-config,
-      fetchurl,
-      libX11,
-      xorgproto,
-      testers,
-    }:
-    stdenv.mkDerivation (finalAttrs: {
-      pname = "libXext";
-      version = "1.3.6";
-      builder = ./builder.sh;
-      src = fetchurl {
-        url = "mirror://xorg/individual/lib/libXext-1.3.6.tar.xz";
-        sha256 = "0lwpx0b7lid47pff6dagp5h63bi0b3gsy05lqpyhbr4l76i9zdgd";
-      };
-      hardeningDisable = [
-        "bindnow"
-        "relro"
-      ];
-      strictDeps = true;
-      nativeBuildInputs = [ pkg-config ];
-      buildInputs = [
-        libX11
-        xorgproto
-      ];
-      passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-      meta = {
-        pkgConfigModules = [ "xext" ];
         platforms = lib.platforms.unix;
       };
     })

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -8,6 +8,7 @@
   imake,
   libpciaccess,
   libpthread-stubs,
+  libxau,
   libxcvt,
   libxdmcp,
   lndir,
@@ -46,6 +47,7 @@ self: with self; {
   fontalias = font-alias;
   fontutil = font-util;
   libpthreadstubs = libpthread-stubs;
+  libXau = libxau;
   libXdmcp = libxdmcp;
   utilmacros = util-macros;
   xcbproto = xcb-proto;
@@ -2027,38 +2029,6 @@ self: with self; {
       passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
       meta = {
         pkgConfigModules = [ "xtrap" ];
-        platforms = lib.platforms.unix;
-      };
-    })
-  ) { };
-
-  # THIS IS A GENERATED FILE.  DO NOT EDIT!
-  libXau = callPackage (
-    {
-      stdenv,
-      pkg-config,
-      fetchurl,
-      xorgproto,
-      testers,
-    }:
-    stdenv.mkDerivation (finalAttrs: {
-      pname = "libXau";
-      version = "1.0.12";
-      builder = ./builder.sh;
-      src = fetchurl {
-        url = "mirror://xorg/individual/lib/libXau-1.0.12.tar.xz";
-        sha256 = "1yy0gx3psxyjcj284xhh44labav7b5zs7gcrks9xi6nklggy9l3l";
-      };
-      hardeningDisable = [
-        "bindnow"
-        "relro"
-      ];
-      strictDeps = true;
-      nativeBuildInputs = [ pkg-config ];
-      buildInputs = [ xorgproto ];
-      passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-      meta = {
-        pkgConfigModules = [ "xau" ];
         platforms = lib.platforms.unix;
       };
     })

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -8,6 +8,7 @@
   imake,
   libpciaccess,
   libpthread-stubs,
+  libx11,
   libxau,
   libxcb,
   libxcvt,
@@ -49,6 +50,7 @@ self: with self; {
   fontalias = font-alias;
   fontutil = font-util;
   libpthreadstubs = libpthread-stubs;
+  libX11 = libx11;
   libXau = libxau;
   libXdmcp = libxdmcp;
   utilmacros = util-macros;
@@ -1910,49 +1912,6 @@ self: with self; {
       passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
       meta = {
         pkgConfigModules = [ "windowswm" ];
-        platforms = lib.platforms.unix;
-      };
-    })
-  ) { };
-
-  # THIS IS A GENERATED FILE.  DO NOT EDIT!
-  libX11 = callPackage (
-    {
-      stdenv,
-      pkg-config,
-      fetchurl,
-      xorgproto,
-      libpthreadstubs,
-      libxcb,
-      xtrans,
-      testers,
-    }:
-    stdenv.mkDerivation (finalAttrs: {
-      pname = "libX11";
-      version = "1.8.12";
-      builder = ./builder.sh;
-      src = fetchurl {
-        url = "mirror://xorg/individual/lib/libX11-1.8.12.tar.xz";
-        sha256 = "16lspc3bw2pg3jal7zyq6mxmxmmaax0fz6lgh1n4skqjn2dny0ps";
-      };
-      hardeningDisable = [
-        "bindnow"
-        "relro"
-      ];
-      strictDeps = true;
-      nativeBuildInputs = [ pkg-config ];
-      buildInputs = [
-        xorgproto
-        libpthreadstubs
-        libxcb
-        xtrans
-      ];
-      passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-      meta = {
-        pkgConfigModules = [
-          "x11"
-          "x11-xcb"
-        ];
         platforms = lib.platforms.unix;
       };
     })

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -9,6 +9,7 @@
   libpciaccess,
   libpthread-stubs,
   libxcvt,
+  libxdmcp,
   lndir,
   luit,
   makedepend,
@@ -45,6 +46,7 @@ self: with self; {
   fontalias = font-alias;
   fontutil = font-util;
   libpthreadstubs = libpthread-stubs;
+  libXdmcp = libxdmcp;
   utilmacros = util-macros;
   xcbproto = xcb-proto;
   xkeyboardconfig = xkeyboard-config;
@@ -2220,38 +2222,6 @@ self: with self; {
       passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
       meta = {
         pkgConfigModules = [ "xdamage" ];
-        platforms = lib.platforms.unix;
-      };
-    })
-  ) { };
-
-  # THIS IS A GENERATED FILE.  DO NOT EDIT!
-  libXdmcp = callPackage (
-    {
-      stdenv,
-      pkg-config,
-      fetchurl,
-      xorgproto,
-      testers,
-    }:
-    stdenv.mkDerivation (finalAttrs: {
-      pname = "libXdmcp";
-      version = "1.1.5";
-      builder = ./builder.sh;
-      src = fetchurl {
-        url = "mirror://xorg/individual/lib/libXdmcp-1.1.5.tar.xz";
-        sha256 = "1312l8x3asib77wgf123w3nbabnky61mb6pnmmqapbf350l259fq";
-      };
-      hardeningDisable = [
-        "bindnow"
-        "relro"
-      ];
-      strictDeps = true;
-      nativeBuildInputs = [ pkg-config ];
-      buildInputs = [ xorgproto ];
-      passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-      meta = {
-        pkgConfigModules = [ "xdmcp" ];
         platforms = lib.platforms.unix;
       };
     })

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -9,6 +9,7 @@
   libpciaccess,
   libpthread-stubs,
   libxau,
+  libxcb,
   libxcvt,
   libxdmcp,
   lndir,
@@ -34,6 +35,7 @@ self: with self; {
     gccmakedep
     imake
     libpciaccess
+    libxcb
     libxcvt
     lndir
     luit
@@ -3100,82 +3102,6 @@ self: with self; {
       passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
       meta = {
         pkgConfigModules = [ "fontenc" ];
-        platforms = lib.platforms.unix;
-      };
-    })
-  ) { };
-
-  # THIS IS A GENERATED FILE.  DO NOT EDIT!
-  libxcb = callPackage (
-    {
-      stdenv,
-      pkg-config,
-      fetchurl,
-      libxslt,
-      libpthreadstubs,
-      libXau,
-      xcbproto,
-      libXdmcp,
-      python3,
-      testers,
-    }:
-    stdenv.mkDerivation (finalAttrs: {
-      pname = "libxcb";
-      version = "1.17.0";
-      builder = ./builder.sh;
-      src = fetchurl {
-        url = "mirror://xorg/individual/lib/libxcb-1.17.0.tar.xz";
-        sha256 = "0mbdkajqhg0j0zjc9a2z1qyv9mca797ihvifc9qyl3vijscvz7jr";
-      };
-      hardeningDisable = [
-        "bindnow"
-        "relro"
-      ];
-      strictDeps = true;
-      nativeBuildInputs = [
-        pkg-config
-        python3
-      ];
-      buildInputs = [
-        libxslt
-        libpthreadstubs
-        libXau
-        xcbproto
-        libXdmcp
-      ];
-      passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-      meta = {
-        pkgConfigModules = [
-          "xcb"
-          "xcb-composite"
-          "xcb-damage"
-          "xcb-dbe"
-          "xcb-dpms"
-          "xcb-dri2"
-          "xcb-dri3"
-          "xcb-ge"
-          "xcb-glx"
-          "xcb-present"
-          "xcb-randr"
-          "xcb-record"
-          "xcb-render"
-          "xcb-res"
-          "xcb-screensaver"
-          "xcb-shape"
-          "xcb-shm"
-          "xcb-sync"
-          "xcb-xevie"
-          "xcb-xf86dri"
-          "xcb-xfixes"
-          "xcb-xinerama"
-          "xcb-xinput"
-          "xcb-xkb"
-          "xcb-xprint"
-          "xcb-xselinux"
-          "xcb-xtest"
-          "xcb-xv"
-          "xcb-xvmc"
-        ];
         platforms = lib.platforms.unix;
       };
     })

--- a/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
+++ b/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
@@ -41,6 +41,7 @@ $pcMap{"pciaccess"} = "libpciaccess";
 $pcMap{"pthread-stubs"} = "libpthreadstubs";
 $pcMap{"xbitmaps"} = "xbitmaps";
 $pcMap{"xcb-proto"} = "xcbproto";
+$pcMap{"xdmcp"} = "libXdmcp";
 $pcMap{"xtrans"} = "xtrans";
 $pcMap{"\$PIXMAN"} = "pixman";
 $pcMap{"\$RENDERPROTO"} = "xorgproto";
@@ -283,6 +284,7 @@ print OUT <<EOF;
   libpciaccess,
   libpthread-stubs,
   libxcvt,
+  libxdmcp,
   lndir,
   luit,
   makedepend,
@@ -319,6 +321,7 @@ self: with self; {
   fontalias = font-alias;
   fontutil = font-util;
   libpthreadstubs = libpthread-stubs;
+  libXdmcp = libxdmcp;
   utilmacros = util-macros;
   xcbproto = xcb-proto;
   xkeyboardconfig = xkeyboard-config;

--- a/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
+++ b/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
@@ -39,6 +39,7 @@ $pcMap{"hwdata"} = "hwdata";
 $pcMap{"fontutil"} = "fontutil";
 $pcMap{"pciaccess"} = "libpciaccess";
 $pcMap{"pthread-stubs"} = "libpthreadstubs";
+$pcMap{"xau"} = "libXau";
 $pcMap{"xbitmaps"} = "xbitmaps";
 $pcMap{"xcb-proto"} = "xcbproto";
 $pcMap{"xdmcp"} = "libXdmcp";
@@ -283,6 +284,7 @@ print OUT <<EOF;
   imake,
   libpciaccess,
   libpthread-stubs,
+  libxau,
   libxcvt,
   libxdmcp,
   lndir,
@@ -321,6 +323,7 @@ self: with self; {
   fontalias = font-alias;
   fontutil = font-util;
   libpthreadstubs = libpthread-stubs;
+  libXau = libxau;
   libXdmcp = libxdmcp;
   utilmacros = util-macros;
   xcbproto = xcb-proto;

--- a/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
+++ b/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
@@ -49,6 +49,12 @@ $pcMap{"\$RENDERPROTO"} = "xorgproto";
 $pcMap{"\$DRI3PROTO"} = "xorgproto";
 $pcMap{"\$DRI2PROTO"} = "xorgproto";
 $pcMap{"\${XKBMODULE}"} = "libxkbfile";
+foreach my $mod ("xcb", "xcb-composite", "xcb-damage", "xcb-dpms", "xcb-dri2", "xcb-dri3",
+    "xcb-glx", "xcb-present", "xcb-randr", "xcb-record", "xcb-render", "xcb-res", "xcb-screensaver",
+    "xcb-shape", "xcb-shm", "xcb-sync", "xcb-xf86dri", "xcb-xfixes", "xcb-xinerama", "xcb-xinput",
+    "xcb-xkb", "xcb-xtest", "xcb-xv", "xcb-xvmc") {
+    $pcMap{$mod} = "libxcb";
+}
 foreach my $mod ("applewmproto", "bigreqsproto", "compositeproto", "damageproto", "dmxproto",
     "dpmsproto", "dri2proto", "dri3proto", "evieproto", "fixesproto", "fontcacheproto",
     "fontsproto", "glproto", "inputproto", "kbproto", "lg3dproto", "presentproto",
@@ -285,6 +291,7 @@ print OUT <<EOF;
   libpciaccess,
   libpthread-stubs,
   libxau,
+  libxcb,
   libxcvt,
   libxdmcp,
   lndir,
@@ -310,6 +317,7 @@ self: with self; {
     gccmakedep
     imake
     libpciaccess
+    libxcb
     libxcvt
     lndir
     luit

--- a/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
+++ b/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
@@ -39,6 +39,8 @@ $pcMap{"hwdata"} = "hwdata";
 $pcMap{"fontutil"} = "fontutil";
 $pcMap{"pciaccess"} = "libpciaccess";
 $pcMap{"pthread-stubs"} = "libpthreadstubs";
+$pcMap{"x11"} = "libX11";
+$pcMap{"x11-xcb"} = "libX11";
 $pcMap{"xau"} = "libXau";
 $pcMap{"xbitmaps"} = "xbitmaps";
 $pcMap{"xcb-proto"} = "xcbproto";
@@ -290,6 +292,7 @@ print OUT <<EOF;
   imake,
   libpciaccess,
   libpthread-stubs,
+  libx11,
   libxau,
   libxcb,
   libxcvt,
@@ -331,6 +334,7 @@ self: with self; {
   fontalias = font-alias;
   fontutil = font-util;
   libpthreadstubs = libpthread-stubs;
+  libX11 = libx11;
   libXau = libxau;
   libXdmcp = libxdmcp;
   utilmacros = util-macros;

--- a/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
+++ b/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
@@ -45,6 +45,7 @@ $pcMap{"xau"} = "libXau";
 $pcMap{"xbitmaps"} = "xbitmaps";
 $pcMap{"xcb-proto"} = "xcbproto";
 $pcMap{"xdmcp"} = "libXdmcp";
+$pcMap{"xext"} = "libXext";
 $pcMap{"xtrans"} = "xtrans";
 $pcMap{"\$PIXMAN"} = "pixman";
 $pcMap{"\$RENDERPROTO"} = "xorgproto";
@@ -297,6 +298,7 @@ print OUT <<EOF;
   libxcb,
   libxcvt,
   libxdmcp,
+  libxext,
   lndir,
   luit,
   makedepend,
@@ -337,6 +339,7 @@ self: with self; {
   libX11 = libx11;
   libXau = libxau;
   libXdmcp = libxdmcp;
+  libXext = libxext;
   utilmacros = util-macros;
   xcbproto = xcb-proto;
   xkeyboardconfig = xkeyboard-config;

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -243,17 +243,6 @@ self: super:
     propagatedBuildInputs = attrs.propagatedBuildInputs or [ ] ++ [ xorg.xorgproto ];
   });
 
-  libXdmcp = super.libXdmcp.overrideAttrs (attrs: {
-    outputs = [
-      "out"
-      "dev"
-      "doc"
-    ];
-    meta = attrs.meta // {
-      pkgConfigModules = [ "xdmcp" ];
-    };
-  });
-
   libXtst = super.libXtst.overrideAttrs (attrs: {
     meta = attrs.meta // {
       pkgConfigModules = [ "xtst" ];

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -235,14 +235,6 @@ self: super:
     };
   });
 
-  libXau = super.libXau.overrideAttrs (attrs: {
-    outputs = [
-      "out"
-      "dev"
-    ];
-    propagatedBuildInputs = attrs.propagatedBuildInputs or [ ] ++ [ xorg.xorgproto ];
-  });
-
   libXtst = super.libXtst.overrideAttrs (attrs: {
     meta = attrs.meta // {
       pkgConfigModules = [ "xtst" ];

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -316,20 +316,6 @@ self: super:
     };
   });
 
-  libXext = super.libXext.overrideAttrs (attrs: {
-    outputs = [
-      "out"
-      "dev"
-      "man"
-      "doc"
-    ];
-    propagatedBuildInputs = attrs.propagatedBuildInputs or [ ] ++ [
-      xorg.xorgproto
-      xorg.libXau
-    ];
-    configureFlags = attrs.configureFlags or [ ] ++ malloc0ReturnsNullCrossFlag;
-  });
-
   libXfixes = super.libXfixes.overrideAttrs (attrs: {
     outputs = [
       "out"

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -151,33 +151,6 @@ self: super:
 
   mkfontdir = xorg.mkfontscale;
 
-  libX11 = super.libX11.overrideAttrs (attrs: {
-    outputs = [
-      "out"
-      "dev"
-      "man"
-    ];
-    configureFlags =
-      attrs.configureFlags or [ ]
-      ++ malloc0ReturnsNullCrossFlag
-      ++ lib.optional (stdenv.targetPlatform.useLLVM or false) "ac_cv_path_RAWCPP=cpp";
-    depsBuildBuild = [
-      buildPackages.stdenv.cc
-    ]
-    ++ lib.optionals stdenv.hostPlatform.isStatic [
-      (xorg.buildPackages.libc.static or null)
-    ];
-    preConfigure = ''
-      sed 's,^as_dummy.*,as_dummy="\$PATH",' -i configure
-    '';
-    postInstall = ''
-      # Remove useless DocBook XML files.
-      rm -rf $out/share/doc
-    '';
-    CPP = lib.optionalString stdenv.hostPlatform.isDarwin "clang -E -";
-    propagatedBuildInputs = attrs.propagatedBuildInputs or [ ] ++ [ xorg.xorgproto ];
-  });
-
   libAppleWM = super.libAppleWM.overrideAttrs (attrs: {
     nativeBuildInputs = attrs.nativeBuildInputs ++ [
       autoreconfHook

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -151,53 +151,6 @@ self: super:
 
   mkfontdir = xorg.mkfontscale;
 
-  libxcb = super.libxcb.overrideAttrs (attrs: {
-    # $dev/include/xcb/xcb.h includes pthread.h
-    propagatedBuildInputs =
-      attrs.propagatedBuildInputs or [ ]
-      ++ lib.optional stdenv.hostPlatform.isMinGW windows.mingw_w64_pthreads;
-    configureFlags = [
-      "--enable-xkb"
-      "--enable-xinput"
-    ]
-    ++ lib.optional stdenv.hostPlatform.isStatic "--disable-shared";
-    outputs = [
-      "out"
-      "dev"
-      "man"
-      "doc"
-    ];
-    meta = attrs.meta // {
-      pkgConfigModules = [
-        "xcb-composite"
-        "xcb-damage"
-        "xcb-dpms"
-        "xcb-dri2"
-        "xcb-dri3"
-        "xcb-glx"
-        "xcb-present"
-        "xcb-randr"
-        "xcb-record"
-        "xcb-render"
-        "xcb-res"
-        "xcb-screensaver"
-        "xcb-shape"
-        "xcb-shm"
-        "xcb-sync"
-        "xcb-xf86dri"
-        "xcb-xfixes"
-        "xcb-xinerama"
-        "xcb-xinput"
-        "xcb-xkb"
-        "xcb-xtest"
-        "xcb-xv"
-        "xcb-xvmc"
-        "xcb"
-      ];
-      platforms = lib.platforms.unix ++ lib.platforms.windows;
-    };
-  });
-
   libX11 = super.libX11.overrideAttrs (attrs: {
     outputs = [
       "out"

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -168,7 +168,6 @@ mirror://xorg/individual/lib/libxcb-1.17.0.tar.xz
 mirror://xorg/individual/lib/libXcomposite-0.4.6.tar.xz
 mirror://xorg/individual/lib/libXcursor-1.2.3.tar.xz
 mirror://xorg/individual/lib/libXdamage-1.1.6.tar.xz
-mirror://xorg/individual/lib/libXdmcp-1.1.5.tar.xz
 mirror://xorg/individual/lib/libXext-1.3.6.tar.xz
 mirror://xorg/individual/lib/libXfixes-6.0.1.tar.xz
 mirror://xorg/individual/lib/libXfont-1.5.4.tar.bz2

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -165,7 +165,6 @@ mirror://xorg/individual/lib/libXaw-1.0.16.tar.xz
 mirror://xorg/individual/lib/libXcomposite-0.4.6.tar.xz
 mirror://xorg/individual/lib/libXcursor-1.2.3.tar.xz
 mirror://xorg/individual/lib/libXdamage-1.1.6.tar.xz
-mirror://xorg/individual/lib/libXext-1.3.6.tar.xz
 mirror://xorg/individual/lib/libXfixes-6.0.1.tar.xz
 mirror://xorg/individual/lib/libXfont-1.5.4.tar.bz2
 mirror://xorg/individual/lib/libXfont2-2.0.7.tar.xz

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -163,7 +163,6 @@ mirror://xorg/individual/lib/libSM-1.2.6.tar.xz
 mirror://xorg/individual/lib/libWindowsWM-1.0.1.tar.bz2
 mirror://xorg/individual/lib/libX11-1.8.12.tar.xz
 mirror://xorg/individual/lib/libXaw-1.0.16.tar.xz
-mirror://xorg/individual/lib/libxcb-1.17.0.tar.xz
 mirror://xorg/individual/lib/libXcomposite-0.4.6.tar.xz
 mirror://xorg/individual/lib/libXcursor-1.2.3.tar.xz
 mirror://xorg/individual/lib/libXdamage-1.1.6.tar.xz

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -162,7 +162,6 @@ mirror://xorg/individual/lib/libICE-1.1.2.tar.xz
 mirror://xorg/individual/lib/libSM-1.2.6.tar.xz
 mirror://xorg/individual/lib/libWindowsWM-1.0.1.tar.bz2
 mirror://xorg/individual/lib/libX11-1.8.12.tar.xz
-mirror://xorg/individual/lib/libXau-1.0.12.tar.xz
 mirror://xorg/individual/lib/libXaw-1.0.16.tar.xz
 mirror://xorg/individual/lib/libxcb-1.17.0.tar.xz
 mirror://xorg/individual/lib/libXcomposite-0.4.6.tar.xz

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -161,7 +161,6 @@ mirror://xorg/individual/lib/libFS-1.0.10.tar.xz
 mirror://xorg/individual/lib/libICE-1.1.2.tar.xz
 mirror://xorg/individual/lib/libSM-1.2.6.tar.xz
 mirror://xorg/individual/lib/libWindowsWM-1.0.1.tar.bz2
-mirror://xorg/individual/lib/libX11-1.8.12.tar.xz
 mirror://xorg/individual/lib/libXaw-1.0.16.tar.xz
 mirror://xorg/individual/lib/libXcomposite-0.4.6.tar.xz
 mirror://xorg/individual/lib/libXcursor-1.2.3.tar.xz


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

After this pr is merged i will be able to make several small chunk PRs that can be merged independently without merge conflicts.

my plan is to migrate all packages from xorg to pkgs/by-name
it looks like chunks of 5 packages seem ok small chunks

this is the script i use to get the packages that don't depend on other xorg packages:

```nix
let
  inherit (import <nixpkgs> { }) lib;

  done = import ./pkgs/servers/x11/xorg/default.nix |> lib.functionArgs |> lib.attrNames;

  pkgs =
    (import ./default.nix { }).xorg
    |> lib.filterAttrs (
      n: v:
      lib.isAttrs v
      && v ? pname
      && !lib.elem n done
      && !lib.elem n (map (lib.replaceStrings [ "-" ] [ "" ]) done)
      && !lib.elem v.pname done
      && !lib.elem v.pname (map (lib.replaceStrings [ "-" ] [ "" ]) done)
      && !lib.elem (lib.toLower n) done
      && !lib.elem (lib.toLower n) (map (lib.replaceStrings [ "-" ] [ "" ]) done)
      && !v.meta.unfree
      && !v.meta.broken
      && !v.meta.unsupported
    );

  pnames = lib.mapAttrsToList (_: v: v.pname) pkgs;
in
pkgs
# get deps
|> lib.mapAttrs (
  _: v:
  v.buildInputs ++ v.nativeBuildInputs ++ v.propagatedBuildInputs ++ v.propagatedNativeBuildInputs
)
# filter deps for xorg packages
|> lib.mapAttrs (_: v: lib.filter (x: x ? pname && lib.elem x.pname pnames) v)
# map deps to list and count
|> lib.mapAttrsToList (
  name: value: {
    inherit name;
    deps = map (x: x.pname or "error") value |> lib.unique;
    count = lib.length value;
  }
)
# sort
|> lib.sort (x: y: x.count > y.count)
# represent as string
|> map (x: "${toString x.count} - ${toString x.name}: ${lib.concatStringsSep " " x.deps}")
```
you can call it like this to get a nice output:
```sh
nix eval --json --file ./xorg-nodepends.nix | jq .[] --raw-output
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
