### PR TITLE
[Backport 401448 to release 24.11] stats: 2.11.21 -> 2.11.41

### DIFF
--- a/pkgs/by-name/st/stats/package.nix
+++ b/pkgs/by-name/st/stats/package.nix
@@ -8,11 +8,11 @@
 
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "stats";
-  version = "2.11.22";
+  version = "2.11.23";
 
   src = fetchurl {
     url = "https://github.com/exelban/stats/releases/download/v${finalAttrs.version}/Stats.dmg";
-    hash = "sha256-b8Yj8YRoiE37cj4NDDdreoPH5BokBBTReFihUnHQ1wU=";
+    hash = "sha256-tlKiRvLTIt0lKc/fOQBj07lFjgOSkKNE4iNlNwxfTCU=";
   };
 
   sourceRoot = ".";

--- a/pkgs/by-name/st/stats/package.nix
+++ b/pkgs/by-name/st/stats/package.nix
@@ -8,11 +8,11 @@
 
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "stats";
-  version = "2.11.26";
+  version = "2.11.30";
 
   src = fetchurl {
     url = "https://github.com/exelban/stats/releases/download/v${finalAttrs.version}/Stats.dmg";
-    hash = "sha256-WRbBqgjNn9W9qRFlbuNAOr8L6lzI1DpTsTCgCQiKSnU=";
+    hash = "sha256-WkNiZZq2PfGp65d82YHupiczojSktDAe4p4WiUj5xWM=";
   };
 
   sourceRoot = ".";

--- a/pkgs/by-name/st/stats/package.nix
+++ b/pkgs/by-name/st/stats/package.nix
@@ -8,11 +8,11 @@
 
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "stats";
-  version = "2.11.31";
+  version = "2.11.32";
 
   src = fetchurl {
     url = "https://github.com/exelban/stats/releases/download/v${finalAttrs.version}/Stats.dmg";
-    hash = "sha256-E+JSN1FKWLt4r2lNjLNNMKnVD+SV8XueRyi8Xj5VUWo=";
+    hash = "sha256-3ObXD4DiJGlZhr+ItoBsF6cXuvecoyfKUDHXtAlBGks=";
   };
 
   sourceRoot = ".";

--- a/pkgs/by-name/st/stats/package.nix
+++ b/pkgs/by-name/st/stats/package.nix
@@ -8,11 +8,11 @@
 
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "stats";
-  version = "2.11.30";
+  version = "2.11.31";
 
   src = fetchurl {
     url = "https://github.com/exelban/stats/releases/download/v${finalAttrs.version}/Stats.dmg";
-    hash = "sha256-WkNiZZq2PfGp65d82YHupiczojSktDAe4p4WiUj5xWM=";
+    hash = "sha256-E+JSN1FKWLt4r2lNjLNNMKnVD+SV8XueRyi8Xj5VUWo=";
   };
 
   sourceRoot = ".";

--- a/pkgs/by-name/st/stats/package.nix
+++ b/pkgs/by-name/st/stats/package.nix
@@ -8,11 +8,11 @@
 
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "stats";
-  version = "2.11.21";
+  version = "2.11.22";
 
   src = fetchurl {
     url = "https://github.com/exelban/stats/releases/download/v${finalAttrs.version}/Stats.dmg";
-    hash = "sha256-EqgWHxiSpMpzxQkogfMX8wTlzIhlfcUIlTARlihjwgw=";
+    hash = "sha256-b8Yj8YRoiE37cj4NDDdreoPH5BokBBTReFihUnHQ1wU=";
   };
 
   sourceRoot = ".";

--- a/pkgs/by-name/st/stats/package.nix
+++ b/pkgs/by-name/st/stats/package.nix
@@ -8,11 +8,11 @@
 
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "stats";
-  version = "2.11.32";
+  version = "2.11.35";
 
   src = fetchurl {
     url = "https://github.com/exelban/stats/releases/download/v${finalAttrs.version}/Stats.dmg";
-    hash = "sha256-3ObXD4DiJGlZhr+ItoBsF6cXuvecoyfKUDHXtAlBGks=";
+    hash = "sha256-A033eMKoQQ7Zz7P/UmndTqWQ8HjUhkW0ysb2M7px6RM=";
   };
 
   sourceRoot = ".";

--- a/pkgs/by-name/st/stats/package.nix
+++ b/pkgs/by-name/st/stats/package.nix
@@ -8,11 +8,11 @@
 
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "stats";
-  version = "2.11.23";
+  version = "2.11.26";
 
   src = fetchurl {
     url = "https://github.com/exelban/stats/releases/download/v${finalAttrs.version}/Stats.dmg";
-    hash = "sha256-tlKiRvLTIt0lKc/fOQBj07lFjgOSkKNE4iNlNwxfTCU=";
+    hash = "sha256-WRbBqgjNn9W9qRFlbuNAOr8L6lzI1DpTsTCgCQiKSnU=";
   };
 
   sourceRoot = ".";

--- a/pkgs/by-name/st/stats/package.nix
+++ b/pkgs/by-name/st/stats/package.nix
@@ -8,11 +8,11 @@
 
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "stats";
-  version = "2.11.35";
+  version = "2.11.36";
 
   src = fetchurl {
     url = "https://github.com/exelban/stats/releases/download/v${finalAttrs.version}/Stats.dmg";
-    hash = "sha256-A033eMKoQQ7Zz7P/UmndTqWQ8HjUhkW0ysb2M7px6RM=";
+    hash = "sha256-ESCZWWJwzkuc+51qSOVj635nADfz2lHRsfn6YQyB69U=";
   };
 
   sourceRoot = ".";

--- a/pkgs/by-name/st/stats/package.nix
+++ b/pkgs/by-name/st/stats/package.nix
@@ -8,11 +8,11 @@
 
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "stats";
-  version = "2.11.36";
+  version = "2.11.41";
 
   src = fetchurl {
     url = "https://github.com/exelban/stats/releases/download/v${finalAttrs.version}/Stats.dmg";
-    hash = "sha256-ESCZWWJwzkuc+51qSOVj635nADfz2lHRsfn6YQyB69U=";
+    hash = "sha256-iW22uCyfx9sCX3GyVmYzyJIHylxIpgJLns2oHVFBwc4=";
   };
 
   sourceRoot = ".";


### PR DESCRIPTION
## Things done

Backports of:
https://github.com/NixOS/nixpkgs/pull/369001
https://github.com/NixOS/nixpkgs/pull/371783
https://github.com/NixOS/nixpkgs/pull/374860
https://github.com/NixOS/nixpkgs/pull/379601
https://github.com/NixOS/nixpkgs/pull/382591
https://github.com/NixOS/nixpkgs/pull/386122
https://github.com/NixOS/nixpkgs/pull/390440
https://github.com/NixOS/nixpkgs/pull/392698
https://github.com/NixOS/nixpkgs/pull/401448

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc