### PR TITLE
goose-cli: 1.0.17 -> 1.0.20

### DIFF
--- a/pkgs/by-name/go/goose-cli/package.nix
+++ b/pkgs/by-name/go/goose-cli/package.nix
@@ -26,17 +26,17 @@ let
 in
 rustPlatform.buildRustPackage rec {
   pname = "goose-cli";
-  version = "1.0.17";
+  version = "1.0.20";
 
   src = fetchFromGitHub {
     owner = "block";
     repo = "goose";
     tag = "v${version}";
-    hash = "sha256-l/lcwTNUq2xJHh0MKhnDZjRJ/5cANbdar/Vusf38esQ=";
+    hash = "sha256-lUMqfIVZI+EN/Ys3eNPnPPprB1spanN7RZT6nhuwuHY=";
   };
 
   useFetchCargoVendor = true;
-  cargoHash = "sha256-1xKWzgptnM1ZP0nQXILBoaKVwL2FyXpldTUIa1ITQO0=";
+  cargoHash = "sha256-5Aed0w7VpzPcaFIR0+iA3VCaln/VAU4VDBqDwVBBhR4=";
 
   nativeBuildInputs = [ pkg-config ];
 
@@ -54,20 +54,17 @@ rustPlatform.buildRustPackage rec {
 
   __darwinAllowLocalNetworking = true;
 
-  checkFlags =
-    [
-      # need dbus-daemon
-      "--skip=config::base::tests::test_multiple_secrets"
-      "--skip=config::base::tests::test_secret_management"
-      # Observer should be Some with both init project keys set
-      "--skip=tracing::langfuse_layer::tests::test_create_langfuse_observer"
-      "--skip=providers::gcpauth::tests::test_token_refresh_race_condition"
-    ]
-    ++ lib.optionals stdenv.hostPlatform.isDarwin [
-      # Lazy instance has previously been poisoned
-      "--skip=jetbrains::tests::test_capabilities"
-      "--skip=jetbrains::tests::test_router_creation"
-    ];
+  checkFlags = [
+    # need dbus-daemon
+    "--skip=config::base::tests::test_multiple_secrets"
+    "--skip=config::base::tests::test_secret_management"
+    # Observer should be Some with both init project keys set
+    "--skip=tracing::langfuse_layer::tests::test_create_langfuse_observer"
+    "--skip=providers::gcpauth::tests::test_token_refresh_race_condition"
+    # Lazy instance has previously been poisoned
+    "--skip=jetbrains::tests::test_capabilities"
+    "--skip=jetbrains::tests::test_router_creation"
+  ];
 
   passthru.updateScript = nix-update-script { };
 


### PR DESCRIPTION
The tests that we were skipping on darwin are apparently now also necessary to be skipped on other architectures too.

The update of the hashes was done by using https://github.com/Mic92/nix-update

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
