### PR TITLE
comfyui: init at unstable-2025-04-26

### DIFF
--- a/pkgs/by-name/co/comfyui/package.nix
+++ b/pkgs/by-name/co/comfyui/package.nix
@@ -1,0 +1,145 @@
+{
+  lib,
+  python312,
+  linkFarm,
+  writeShellScriptBin,
+  writeTextFile,
+  fetchFromGitHub,
+  stdenv,
+  basePath ? "/var/lib/comfyui",
+  customNodes ? [ ],
+}:
+
+let
+  modelsPath = "${basePath}/models";
+  inputPath = "${basePath}/input";
+  outputPath = "${basePath}/output";
+  tempPath = "${basePath}/temp";
+  userPath = "${basePath}/user";
+  config-data = {
+    comfyui = {
+      base_path = modelsPath;
+      checkpoints = "${modelsPath}/checkpoints";
+      clip = "${modelsPath}/clip";
+      clip_vision = "${modelsPath}/clip_vision";
+      configs = "${modelsPath}/configs";
+      controlnet = "${modelsPath}/controlnet";
+      diffusion_models = "${modelsPath}/diffusion_models";
+      embeddings = "${modelsPath}/embeddings";
+      loras = "${modelsPath}/loras";
+      style_models = "${modelsPath}/style_models";
+      text_encoders = "${modelsPath}/text_encoders";
+      upscale_models = "${modelsPath}/upscale_models";
+      vae = "${modelsPath}/vae";
+      vae_approx = "${modelsPath}/vae_approx";
+    };
+  };
+
+  modelPathsFile = writeTextFile {
+    name = "extra_model_paths.yaml";
+    text = lib.generators.toYAML { } config-data;
+  };
+
+  pythonEnv = (
+    python312.withPackages (
+      ps:
+      with ps;
+      [
+        comfyui-frontend-package
+        comfyui-workflow-templates
+        torch
+        torchsde
+        torchvision
+        torchaudio
+        numpy
+        einops
+        transformers
+        tokenizers
+        sentencepiece
+        safetensors
+        aiohttp
+        yarl
+        pyyaml
+        pillow
+        scipy
+        tqdm
+        psutil
+
+        kornia
+        spandrel
+        av
+        pydantic
+      ]
+      ++ (builtins.concatMap (node: node.dependencies) customNodes)
+    )
+  );
+
+  executable = writeShellScriptBin "comfyui" ''
+    cd $out && \
+    ${pythonEnv}/bin/python comfyui \
+      --input-directory ${inputPath} \
+      --output-directory ${outputPath} \
+      --extra-model-paths-config ${modelPathsFile} \
+      --temp-directory ${tempPath} \
+      "$@"
+  '';
+
+  customNodesCollection = (
+    linkFarm "comfyui-custom-nodes" (
+      builtins.map (pkg: {
+        name = pkg.pname;
+        path = pkg;
+      }) customNodes
+    )
+  );
+in
+stdenv.mkDerivation rec {
+  pname = "comfyui";
+  version = "0-unstable-2025-04-26";
+
+  src = fetchFromGitHub {
+    owner = "comfyanonymous";
+    repo = "ComfyUI";
+    rev = "b685b8a4e098237919adae580eb29e8d861b738f";
+    hash = "sha256-OtTvyqiz2Ba7HViW2MxC1hFulSWPuQaCADeQflr80Ik=";
+  };
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin/
+    # These copies everything over but test/ci/github directories.  But it's not
+    # very future-proof.  This can lead to errors such as "ModuleNotFoundError:
+    # No module named 'app'" when new directories get added (which has happened
+    # at least once).  Investigate if we can just copy everything.
+    cp -r $src/app $out/
+    cp -r $src/api_server $out/
+    cp -r $src/comfy $out/
+    cp -r $src/comfy_api_nodes $out/
+    cp -r $src/comfy_extras $out/
+    cp -r $src/comfy_execution $out/
+    cp -r $src/utils $out/
+    cp $src/*.py $out/
+    mv $out/main.py $out/comfyui
+    cp ${modelPathsFile} $out/extra_model_paths.yaml
+    ln -s ${inputPath} $out/input
+    ln -s ${outputPath} $out/output
+    mkdir -p $out/${tempPath}
+    ln -snf ${customNodesCollection} $out/custom_nodes
+    cp ${executable}/bin/comfyui $out/bin/comfyui
+    substituteInPlace $out/bin/comfyui --replace "\$out" "$out"
+    substituteInPlace $out/folder_paths.py \
+      --replace 'os.path.join(base_path, "temp")' '"${tempPath}"' \
+      --replace 'os.path.join(base_path, "user")' '"${userPath}"'
+
+    runHook postInstall
+  '';
+
+  meta = {
+    homepage = "https://github.com/comfyanonymous/ComfyUI";
+    description = "The most powerful and modular stable diffusion GUI with a graph/nodes interface.";
+    license = lib.licenses.gpl3;
+    platforms = lib.platforms.all;
+    maintainers = with lib.maintainers; [ scd31 ];
+  };
+}

--- a/pkgs/development/python-modules/comfyui-frontend-package/default.nix
+++ b/pkgs/development/python-modules/comfyui-frontend-package/default.nix
@@ -1,0 +1,31 @@
+{
+  lib,
+  fetchPypi,
+  buildPythonPackage,
+  setuptools,
+}:
+buildPythonPackage rec {
+  pname = "comfyui-frontend-package";
+  version = "1.17.11";
+  pyproject = true;
+
+  build-system = [ setuptools ];
+
+  src = fetchPypi {
+    inherit version;
+    pname = "comfyui_frontend_package";
+    hash = "sha256-v2Yfl730hvGEV+kFXva3lAJFDecVplvl+L5XY3PJdNU=";
+  };
+
+  pythonImportsCheck = [ "comfyui_frontend_package" ];
+
+  env.COMFYUI_FRONTEND_VERSION = version;
+
+  meta = {
+    description = "ComfyUI frontend package";
+    homepage = "https://github.com/Comfy-Org/ComfyUI_frontend";
+    changelog = "https://github.com/Comfy-Org/ComfyUI_frontend/releases/tag/v${version}";
+    license = lib.licenses.gpl3;
+    maintainers = with lib.maintainers; [ scd31 ];
+  };
+}

--- a/pkgs/development/python-modules/comfyui-workflow-templates/default.nix
+++ b/pkgs/development/python-modules/comfyui-workflow-templates/default.nix
@@ -1,0 +1,28 @@
+{
+  lib,
+  fetchPypi,
+  buildPythonPackage,
+  setuptools,
+}:
+buildPythonPackage rec {
+  pname = "comfyui-workflow-templates";
+  version = "0.1.3";
+  pyproject = true;
+
+  build-system = [ setuptools ];
+
+  src = fetchPypi {
+    inherit version;
+    pname = "comfyui_workflow_templates";
+    hash = "sha256-Ivnf+xOOGzMJpu68RFH37vFPEsT9g/KxWUlMiE+Hglk=";
+  };
+
+  pythonImportsCheck = [ "comfyui_workflow_templates" ];
+
+  meta = {
+    description = "ComfyUI workflow templates";
+    homepage = "https://github.com/Comfy-Org/workflow_templates";
+    license = lib.licenses.gpl3;
+    maintainers = with lib.maintainers; [ scd31 ];
+  };
+}

--- a/pkgs/development/python-modules/spandrel/default.nix
+++ b/pkgs/development/python-modules/spandrel/default.nix
@@ -1,0 +1,59 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  setuptools,
+  torch,
+  torchWithCuda,
+  torchWithRocm,
+  torchvision,
+  safetensors,
+  einops,
+  config,
+  gpuBackend ? (
+    if config.cudaSupport then
+      "cuda"
+    else if config.rocmSupport then
+      "rocm"
+    else
+      "none"
+  ),
+}:
+let
+  myTorch =
+    if gpuBackend == "cuda" then
+      torchWithCuda
+    else if gpuBackend == "rocm" then
+      torchWithRocm
+    else
+      torch;
+in
+buildPythonPackage rec {
+  pname = "spandrel";
+  version = "0.4.1";
+  pyproject = true;
+
+  build-system = [ setuptools ];
+
+  buildInputs = [
+    myTorch
+    torchvision
+    safetensors
+    einops
+  ];
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-ZG2YFqlC5Z1WqrLckENTlS5X3uSyyz9Z9+pNwPsRofI=";
+  };
+
+  pythonImportsCheck = [ "spandrel" ];
+
+  meta = {
+    description = "Library for loading and running pre-trained PyTorch models";
+    homepage = "https://github.com/chaiNNer-org/spandrel/";
+    changelog = "https://github.com/chaiNNer-org/spandrel/releases/tag/v${version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ scd31 ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -16288,6 +16288,8 @@ self: super: with self; {
 
   spake2 = callPackage ../development/python-modules/spake2 { };
 
+  spandrel = callPackage ../development/python-modules/spandrel { };
+
   spark-parser = callPackage ../development/python-modules/spark-parser { };
 
   sparklines = callPackage ../development/python-modules/sparklines { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2731,6 +2731,8 @@ self: super: with self; {
 
   cometblue-lite = callPackage ../development/python-modules/cometblue-lite { };
 
+  comfyui-frontend-package = callPackage ../development/python-modules/comfyui-frontend-package { };
+
   comicapi = callPackage ../development/python-modules/comicapi { };
 
   comicon = callPackage ../development/python-modules/comicon { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2733,6 +2733,10 @@ self: super: with self; {
 
   comfyui-frontend-package = callPackage ../development/python-modules/comfyui-frontend-package { };
 
+  comfyui-workflow-templates =
+    callPackage ../development/python-modules/comfyui-workflow-templates
+      { };
+
   comicapi = callPackage ../development/python-modules/comicapi { };
 
   comicon = callPackage ../development/python-modules/comicon { };


### PR DESCRIPTION
Continuation of #268378. Fixes #227006

This is just the core package. I'll create a systemd service in another PR once this is merged (or someone else can). Tested on CPU and with CUDA. I don't have the hardware to test on AMD.

Seems to work fine (:

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
