### PR TITLE
file: patch to fix misclassification of some zip files

### DIFF
--- a/pkgs/tools/misc/file/PR-571-jschleus-Some-zip-files-are-misclassified-as-data.patch
+++ b/pkgs/tools/misc/file/PR-571-jschleus-Some-zip-files-are-misclassified-as-data.patch
@@ -1,0 +1,52 @@
+From 60b2032b96fc185b37fb0f2152e834efb2edad6e Mon Sep 17 00:00:00 2001
+From: Christos Zoulas <christos@zoulas.com>
+Date: Thu, 5 Dec 2024 19:41:12 +0000
+Subject: [PATCH] PR/571: jschleus: Some zip files are misclassified as data
+
+---
+ magic/Magdir/archive | 25 +++++++++++++++----------
+ 1 file changed, 15 insertions(+), 10 deletions(-)
+
+diff --git a/magic/Magdir/archive b/magic/Magdir/archive
+index e6ff4570a..e560523cb 100644
+--- a/magic/Magdir/archive
++++ b/magic/Magdir/archive
+@@ -1795,6 +1795,17 @@
+ !:ext zip/cbz
+ 
+ 
++# Generic zip archives (Greg Roelofs, c/o zip-bugs@wkuvx1.wku.edu)
++#   Next line excludes specialized formats:
++0	name	zipgeneric
++>4	beshort		x			Zip archive data, at least
++!:mime	application/zip
++>4	use		zipversion
++>4	beshort		x			to extract
++>8	beshort		x			\b, compression method=
++>8	use		zipcompression
++>0x161	string		WINZIP		\b, WinZIP self-extracting
++
+ 0	string		PK\003\004
+ !:strength +1
+ # IOS/IPadOS IPA file (Zip archive)
+@@ -2132,17 +2143,11 @@
+ >>>>>>(-6.l)	search/9000	kmp.json	Keyman Compiled Package File
+ !:mime	application/vnd.keyman.kmp+zip
+ !:ext kmp
++>>>>>+4	default		x
++>>>>>>0	use		zipgeneric
+ 
+-# Generic zip archives (Greg Roelofs, c/o zip-bugs@wkuvx1.wku.edu)
+-#   Next line excludes specialized formats:
+ >>>>+4	default		x
+->>>>>4	beshort		x			Zip archive data, at least
+-!:mime	application/zip
+->>>>>4	use		zipversion
+->>>>>4	beshort		x			to extract
+->>>>>8	beshort		x			\b, compression method=
+->>>>>8	use		zipcompression
+->>>>>0x161	string		WINZIP		\b, WinZIP self-extracting
++>>>>>0	use		zipgeneric
+ 
+ # Zip archives (Greg Roelofs, c/o zip-bugs@wkuvx1.wku.edu)
+ 0	string		PK\005\006	Zip archive data (empty)

--- a/pkgs/tools/misc/file/default.nix
+++ b/pkgs/tools/misc/file/default.nix
@@ -26,6 +26,12 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-ycx3x8VgxUMTXtxVWvYJ1WGdvvARmX6YjOQKPXXYYIg=";
   };
 
+  patches = [
+    # https://github.com/file/file/commit/60b2032b96fc185b37fb0f2152e834efb2edad6e
+    # Fix for misclassification of some zip files
+    ./PR-571-jschleus-Some-zip-files-are-misclassified-as-data.patch
+  ];
+
   outputs = [
     "out"
     "dev"


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Apply upstream patch to fix misclassification of some zip archives as data.

Upstream commit for fix: https://github.com/file/file/commit/60b2032b96fc185b37fb0f2152e834efb2edad6e.

Upstream bug report: https://bugs.astron.com/view.php?id=571.


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
