### PR TITLE
Fix hype r

### DIFF
--- a/pkgs/applications/science/math/R/default.nix
+++ b/pkgs/applications/science/math/R/default.nix
@@ -51,7 +51,7 @@ assert (!blas.isILP64) && (!lapack.isILP64);
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "R";
-  version = "4.4.3";
+  version = "4.5.0";
 
   src =
     let
@@ -59,7 +59,7 @@ stdenv.mkDerivation (finalAttrs: {
     in
     fetchurl {
       url = "https://cran.r-project.org/src/base/R-${lib.versions.major version}/${pname}-${version}.tar.gz";
-      sha256 = "sha256-DZPSJEQt6iU8KwhvCI220NPP2bWSzVSW6MshQ+kPyeg=";
+      sha256 = "sha256-OzPqET4NHdyXk4dNWUnOwsc4b2bkq/sc75rsIoRsPOE=";
     };
 
   outputs = [

--- a/pkgs/development/r-modules/bioc-annotation-packages.json
+++ b/pkgs/development/r-modules/bioc-annotation-packages.json
@@ -1,6 +1,6 @@
 {
   "extraArgs": {
-    "biocVersion": "3.20"
+    "biocVersion": "3.21"
   },
   "packages": {
     "AHCytoBands": {
@@ -11,8 +11,8 @@
     },
     "AHEnsDbs": {
       "name": "AHEnsDbs",
-      "version": "1.6.0",
-      "sha256": "1l62703d0czlysvxggvzsqfn1cgjgim7vd0wgzav70vj572z2bs5",
+      "version": "1.7.0",
+      "sha256": "0a4gddq5w0bn0z8msbq0qsk47rm91nmxhfnk29vq07xsvmz5cz21",
       "depends": ["AnnotationHubData", "ensembldb"]
     },
     "AHLRBaseDbs": {
@@ -881,8 +881,8 @@
     },
     "GO_db": {
       "name": "GO.db",
-      "version": "3.20.0",
-      "sha256": "1p0hw5j6a7q7pgp7l40rs27ci16n6jpyd39irhrpys94hqrqx5pz",
+      "version": "3.21.0",
+      "sha256": "0m50szqp044wbxdjq1n3jywv49fdqhrlisbd165fwkwja19y7sbp",
       "depends": ["AnnotationDbi"]
     },
     "GeneSummary": {
@@ -893,15 +893,15 @@
     },
     "GenomeInfoDbData": {
       "name": "GenomeInfoDbData",
-      "version": "1.2.13",
-      "sha256": "0kh7yxk8aqadv9xdnvrp2ysa1xxxgjqkj83w3bw1w9k55r1kr8si",
+      "version": "1.2.14",
+      "sha256": "1nahp2ali234fsac8dndl1a222b9z8j9jrzb75anqa2dkp2zxqi3",
       "depends": []
     },
     "GenomicState": {
       "name": "GenomicState",
-      "version": "0.99.15",
-      "sha256": "1r7z3n6wyrd2cclj5b7sg15wpmjdh9k5b1hjlw7jjx8j384l7l1h",
-      "depends": ["AnnotationDbi", "AnnotationHub", "GenomeInfoDb", "GenomicFeatures", "IRanges", "bumphunter", "derfinder", "org_Hs_eg_db", "rtracklayer"]
+      "version": "0.99.16",
+      "sha256": "0x4m8096ra57xs6b60ws0k1wq91yrhfr6q7jbdw8m686qzd159p1",
+      "depends": ["AnnotationDbi", "AnnotationHub", "GenomeInfoDb", "GenomicFeatures", "IRanges", "bumphunter", "derfinder", "org_Hs_eg_db", "rtracklayer", "txdbmaker"]
     },
     "HDO_db": {
       "name": "HDO.db",
@@ -1067,8 +1067,8 @@
     },
     "JASPAR2024": {
       "name": "JASPAR2024",
-      "version": "0.99.6",
-      "sha256": "1l169kwymylqz67fz182fgq22nvg3cg12p2r8drgibs2d72khcpf",
+      "version": "0.99.7",
+      "sha256": "1zrbymy9r278znsrmy11m2akdlhyz4i4jq2px3vfxj98bw4msv6f",
       "depends": ["BiocFileCache"]
     },
     "JazaeriMetaData_db": {
@@ -1235,8 +1235,8 @@
     },
     "Orthology_eg_db": {
       "name": "Orthology.eg.db",
-      "version": "3.20.0",
-      "sha256": "0876srbhjg872v46373p4bjy9kxpyqncbysc577bn2zf7miaxsal",
+      "version": "3.21.0",
+      "sha256": "0zhxvmh370ixzxxhqqxjvvk2x6ln5pcr4bblnjhhw91gvrd76mra",
       "depends": ["AnnotationDbi"]
     },
     "PANTHER_db": {
@@ -1247,8 +1247,8 @@
     },
     "PFAM_db": {
       "name": "PFAM.db",
-      "version": "3.20.0",
-      "sha256": "0ibhdvb7vc2s70n6dq13357y9fgvkg0bdjxcq13n9rqajk6bmaw6",
+      "version": "3.21.0",
+      "sha256": "06qv66if25isw677gqlfsff7rr77vgdncrlf7jk3xh4r3406hwxa",
       "depends": ["AnnotationDbi"]
     },
     "POCRCannotation_db": {
@@ -1337,14 +1337,14 @@
     },
     "SNPlocs_Hsapiens_dbSNP149_GRCh38": {
       "name": "SNPlocs.Hsapiens.dbSNP149.GRCh38",
-      "version": "0.99.20",
-      "sha256": "17bv25p1261hn9d7mxfp6pvivj15pxyvr92gms8a8msfqg9y0xkb",
+      "version": "0.99.21",
+      "sha256": "03qjbsazd9i804z5lg3ywkm2gj5md8qjflz72yqb7xvwjnn3l3x2",
       "depends": ["BSgenome", "BiocGenerics", "GenomeInfoDb", "GenomicRanges", "IRanges", "S4Vectors"]
     },
     "SNPlocs_Hsapiens_dbSNP150_GRCh38": {
       "name": "SNPlocs.Hsapiens.dbSNP150.GRCh38",
-      "version": "0.99.20",
-      "sha256": "0jkwwgxxpm9ry8kizq8hs70sky41pks1ag40y5aqq91yjbpqlckj",
+      "version": "0.99.21",
+      "sha256": "0zsfbp31lzbg3zlhw9qgvj3h5lhvys8fd71hyi620vfp2i6a4h4f",
       "depends": ["BSgenome", "BiocGenerics", "GenomeInfoDb", "GenomicRanges", "IRanges", "S4Vectors"]
     },
     "SNPlocs_Hsapiens_dbSNP155_GRCh37": {
@@ -1367,8 +1367,8 @@
     },
     "TENET_AnnotationHub": {
       "name": "TENET.AnnotationHub",
-      "version": "0.99.4",
-      "sha256": "0kfdwxbxi4y773nknpd712wz3zcqbigkycnsrrd40jp04my91mpm",
+      "version": "1.0.0",
+      "sha256": "072jzxmr3a2b2947nyga98p36dl9lq1qm2bh848mk8pla9sjd3jy",
       "depends": ["AnnotationHub", "GenomicRanges"]
     },
     "TxDb_Athaliana_BioMart_plantsmart22": {
@@ -1517,8 +1517,8 @@
     },
     "TxDb_Hsapiens_UCSC_hg38_knownGene": {
       "name": "TxDb.Hsapiens.UCSC.hg38.knownGene",
-      "version": "3.20.0",
-      "sha256": "15qmd51wcjhwzg3w1s13ky39km0waypwzipvr4cisvhvkbr7sqn4",
+      "version": "3.21.0",
+      "sha256": "0rb2pycx3b7mhmdx9k3f3nyjd9aa7dppxivyridp159y1pxsybfv",
       "depends": ["AnnotationDbi", "GenomicFeatures"]
     },
     "TxDb_Hsapiens_UCSC_hg38_refGene": {
@@ -1559,8 +1559,8 @@
     },
     "TxDb_Mmusculus_UCSC_mm39_knownGene": {
       "name": "TxDb.Mmusculus.UCSC.mm39.knownGene",
-      "version": "3.20.0",
-      "sha256": "1bvq9msb9z7j82gf37lfgxjl24qbvs7ydndil3c110jzaja2yn00",
+      "version": "3.21.0",
+      "sha256": "18ckr0sn8ff6ga2rzaxicbbfynvbpx56kl4949fnrgaygxgnlf9p",
       "depends": ["AnnotationDbi", "GenomicFeatures"]
     },
     "TxDb_Mmusculus_UCSC_mm39_refGene": {
@@ -1715,14 +1715,14 @@
     },
     "anopheles_db0": {
       "name": "anopheles.db0",
-      "version": "3.20.0",
-      "sha256": "07vfxbvw41w7600xv70bnh37wxxwsbkkhihypmibprxmwibf7dvp",
+      "version": "3.21.0",
+      "sha256": "1c2s1qwr27mizrdpscsg3nc2sr7k3ysbg72dcs8hwkr0c515a15l",
       "depends": ["AnnotationDbi"]
     },
     "arabidopsis_db0": {
       "name": "arabidopsis.db0",
-      "version": "3.20.0",
-      "sha256": "15rcqa844plk5hg1pagry4ybhbcq41n3lccqprmvvlxw5xsrhkv4",
+      "version": "3.21.0",
+      "sha256": "18gcn21z4pkzzgqzf3nfhd7rg626s3d2jbdzcid3wpw8fbz1bh17",
       "depends": ["AnnotationDbi"]
     },
     "ath1121501_db": {
@@ -1769,8 +1769,8 @@
     },
     "bovine_db0": {
       "name": "bovine.db0",
-      "version": "3.20.0",
-      "sha256": "0z6g9kn85v88mm94qm4j0m6081qjqqrdwnxgz8j0i85cyw2l730q",
+      "version": "3.21.0",
+      "sha256": "1499b0gfy5bp0sa04hra8vfhn5n7lm0lbg5l6nvsclvy6hcbzn24",
       "depends": ["AnnotationDbi"]
     },
     "bovinecdf": {
@@ -1823,8 +1823,8 @@
     },
     "canine_db0": {
       "name": "canine.db0",
-      "version": "3.20.0",
-      "sha256": "1lllajhmmics9jvdympy8fx54wdan9ipcmwpq5sfm3ncm5bh10bj",
+      "version": "3.21.0",
+      "sha256": "1iciz5p8z9sf6l4rr5n55b9hl2nl7x3fayn2cpnwm2qm3vqf4lp1",
       "depends": ["AnnotationDbi"]
     },
     "canine2_db": {
@@ -1883,8 +1883,8 @@
     },
     "chicken_db0": {
       "name": "chicken.db0",
-      "version": "3.20.0",
-      "sha256": "0s8ag58f5xfcyvhx6cgg95dmkgdllvmz4s5vd24g4rn1l4ikvrw9",
+      "version": "3.21.0",
+      "sha256": "007grjh856j8wy4hcylx6f276zhn3jbyqm1pdzxhcb2xfy8qsh7k",
       "depends": ["AnnotationDbi"]
     },
     "chickencdf": {
@@ -1901,8 +1901,8 @@
     },
     "chimp_db0": {
       "name": "chimp.db0",
-      "version": "3.20.0",
-      "sha256": "1jx6cl4l226yp3fjd1md034bdmif8yg0f1bjivsqbb6mxrvdypa1",
+      "version": "3.21.0",
+      "sha256": "04bfz79dyv6isslxn5i9z023k244mfpmykfzz2aqhxjj56fmyqdp",
       "depends": ["AnnotationDbi"]
     },
     "chromhmmData": {
@@ -2045,14 +2045,14 @@
     },
     "ecoliK12_db0": {
       "name": "ecoliK12.db0",
-      "version": "3.20.0",
-      "sha256": "168byg9z4chby69cxkgmih3q5bad9shcmhmcn5b27qqyg737r29f",
+      "version": "3.21.0",
+      "sha256": "1xn0259khanwnj5s2py0spcgmrgshavvv73k6wmcmnaxqlsw4icc",
       "depends": ["AnnotationDbi"]
     },
     "ecoliSakai_db0": {
       "name": "ecoliSakai.db0",
-      "version": "3.20.0",
-      "sha256": "0nmjqxmic1crpy2rhjn86ls68j2w1x67sbc8q5j42zm75crb752k",
+      "version": "3.21.0",
+      "sha256": "02lxbvd1b2132lv7lc48spyah36pdz5y2f0m8rmpvsc1f89wlhr6",
       "depends": ["AnnotationDbi"]
     },
     "ecoliasv2cdf": {
@@ -2093,8 +2093,8 @@
     },
     "fly_db0": {
       "name": "fly.db0",
-      "version": "3.20.0",
-      "sha256": "0nsxzbxg284jg9gd9fnn55qhsw7lbsnywwyh5dp9ssmmhwf746ix",
+      "version": "3.21.0",
+      "sha256": "0394llii7pcxpkjjjp42m5himqwggmp6ap1d2lcsswkb1csmv9c0",
       "depends": ["AnnotationDbi"]
     },
     "geneplast_data": {
@@ -2891,8 +2891,8 @@
     },
     "human_db0": {
       "name": "human.db0",
-      "version": "3.20.0",
-      "sha256": "0l4nlgnwwxrizbywzd1n3nq0p98l32hm93kk250l6hwh9jacmi6b",
+      "version": "3.21.0",
+      "sha256": "0p5h54bz1qkc9812mfsmbxkj9m4xrb7nb17z1xi69vny03pxzw3v",
       "depends": ["AnnotationDbi"]
     },
     "human1mduov3bCrlmm": {
@@ -3119,8 +3119,8 @@
     },
     "malaria_db0": {
       "name": "malaria.db0",
-      "version": "3.20.0",
-      "sha256": "1m2s9pa0xhcgvxxz240chl3qscdy7bsk8f6wf27svws6h4d0zvrc",
+      "version": "3.21.0",
+      "sha256": "18lyczz2049sqgsqip7d40fhs5vzd1d1bb4hjl26gzgkh7b983vi",
       "depends": ["AnnotationDbi"]
     },
     "medicagocdf": {
@@ -3299,8 +3299,8 @@
     },
     "mirbase_db": {
       "name": "mirbase.db",
-      "version": "1.2.0",
-      "sha256": "0l7ah1ia7q1h16av2v1qa9nqpr0604z5dlrq37kd0aiz8dcxyddk",
+      "version": "1.2.1",
+      "sha256": "06dgj82jlggb272b0nvx0y4q9w4kkq7lbn9i0z4m8h6z23qlw7d9",
       "depends": ["AnnotationDbi"]
     },
     "mirna102xgaincdf": {
@@ -3449,8 +3449,8 @@
     },
     "mouse_db0": {
       "name": "mouse.db0",
-      "version": "3.20.0",
-      "sha256": "1xx66q0mgylyapflczrnmci933byb24b6psiqybx2a8zd2mw9i87",
+      "version": "3.21.0",
+      "sha256": "0fc50cnn62f3043f8jm1r0x4v1zj8xjcvnrgiqz474kf558wchbr",
       "depends": ["AnnotationDbi"]
     },
     "mouse4302_db": {
@@ -3677,80 +3677,80 @@
     },
     "org_Ag_eg_db": {
       "name": "org.Ag.eg.db",
-      "version": "3.20.0",
-      "sha256": "0r5flj8h3w0hxacwdk4hq54r0dvjnj6fyv31m22x7ld7c466awf0",
+      "version": "3.21.0",
+      "sha256": "07zx94qpnh0s3fxv7wcpxnpzpmvy087m4qwdhbn86s1r6qnhjbfh",
       "depends": ["AnnotationDbi"]
     },
     "org_At_tair_db": {
       "name": "org.At.tair.db",
-      "version": "3.20.0",
-      "sha256": "01cchwj03hq8jng0xaxwc96ibbmrrai26hnp61g8bxlfgnn5zh4k",
+      "version": "3.21.0",
+      "sha256": "1gwi1xmb39lz879dmln127x8iky10q35sw7ij7b6cp3w9wdj601j",
       "depends": ["AnnotationDbi"]
     },
     "org_Bt_eg_db": {
       "name": "org.Bt.eg.db",
-      "version": "3.20.0",
-      "sha256": "0ryfpblhpqzkww1xb63k2c5ki8xh73as8fwl8f8kvsy4x7axfr5g",
+      "version": "3.21.0",
+      "sha256": "1k7cv7jc16v9px6cz59ssllnjd52z3p5hhk99jaznzmfjb4nv9rs",
       "depends": ["AnnotationDbi"]
     },
     "org_Ce_eg_db": {
       "name": "org.Ce.eg.db",
-      "version": "3.20.0",
-      "sha256": "1r7fzzrqcas23bxcd55ppflx0ls1biifis3qj36iv5gwhhwimq3i",
+      "version": "3.21.0",
+      "sha256": "0lqsna178pyy8fslkx4n9z5mmxd95m50w1b2gm96ikjsldgng75k",
       "depends": ["AnnotationDbi"]
     },
     "org_Cf_eg_db": {
       "name": "org.Cf.eg.db",
-      "version": "3.20.0",
-      "sha256": "0sf7lyh16mbh1h986dkbdci5rmkvg1rj80far1grcd2hwpdgaq7s",
+      "version": "3.21.0",
+      "sha256": "0wb342h9a5jr95azqy2scys1zaskarl9iamlci730a2irncwbi2l",
       "depends": ["AnnotationDbi"]
     },
     "org_Dm_eg_db": {
       "name": "org.Dm.eg.db",
-      "version": "3.20.0",
-      "sha256": "1v21rx7kpdi30898jbnvg1cd3xgghvqhkiipkasn5wjz22z1lqna",
+      "version": "3.21.0",
+      "sha256": "1wavkwq73isi6clj26m6j4rhshllkbvxdm95iv7kxca1xrdhd4f3",
       "depends": ["AnnotationDbi"]
     },
     "org_Dr_eg_db": {
       "name": "org.Dr.eg.db",
-      "version": "3.20.0",
-      "sha256": "0ayva6p2qav16s4nvngxqi8zwl4ylrl5riww3lwc2dql0kkgbvrs",
+      "version": "3.21.0",
+      "sha256": "18vznfmlmygwpwkm7kzavripjg7vppcs4p6b771nmwx62i73s0sc",
       "depends": ["AnnotationDbi"]
     },
     "org_EcK12_eg_db": {
       "name": "org.EcK12.eg.db",
-      "version": "3.20.0",
-      "sha256": "0qd6ppvcpsprbw8c9rp3fx5i8cs6gv0n4mqwxwjs1421p19m1bqd",
+      "version": "3.21.0",
+      "sha256": "0ng6nf3gfwiajbjsb3q19livi9drlx6flacv97igfwylhq0w2nin",
       "depends": ["AnnotationDbi"]
     },
     "org_EcSakai_eg_db": {
       "name": "org.EcSakai.eg.db",
-      "version": "3.20.0",
-      "sha256": "1dqs6lkjlyy32pg3qiv6ll1mqbs4h0j0wkkn1zwdnban6migv1y2",
+      "version": "3.21.0",
+      "sha256": "1n8zl0rvqpflwcvyfkzdcbd9iri434syxfd97fwlw88jbaj6l9qp",
       "depends": ["AnnotationDbi"]
     },
     "org_Gg_eg_db": {
       "name": "org.Gg.eg.db",
-      "version": "3.20.0",
-      "sha256": "1v22p36gxjs4fjc4zamaj4h10qvhknvz22chlnjqn4lisifpg325",
+      "version": "3.21.0",
+      "sha256": "1854hwpdxzy02c1ips2ipxyqi2j556yv405gzhq4qmgcf10q6fbk",
       "depends": ["AnnotationDbi"]
     },
     "org_Hs_eg_db": {
       "name": "org.Hs.eg.db",
-      "version": "3.20.0",
-      "sha256": "1gykdrfkzvx83bkpbggsnk8gd0w9xh5g071r3ngykjh5x36w6dlc",
+      "version": "3.21.0",
+      "sha256": "1i9ipx4anzj795y2y4rihqhpdcr5i3awabd3lxipzxcw0zndv51l",
       "depends": ["AnnotationDbi"]
     },
     "org_Mm_eg_db": {
       "name": "org.Mm.eg.db",
-      "version": "3.20.0",
-      "sha256": "1wlc34qq0hv9fmdw810jc26gyf7ibicy8rsbll4is7bp2i1hxk47",
+      "version": "3.21.0",
+      "sha256": "01rfqack61rnqq1i6w9bkj4a42gyig17af2fdrc89yrpbw87b3hb",
       "depends": ["AnnotationDbi"]
     },
     "org_Mmu_eg_db": {
       "name": "org.Mmu.eg.db",
-      "version": "3.20.0",
-      "sha256": "0qpzslrjd77s4zgv68pmkm2kbbrb0h8ginzp9wppsnb58qvbz4nv",
+      "version": "3.21.0",
+      "sha256": "1al3x1d23r6prkfw0312n937g3625hrnaf3gkhdwrgaj0nvsplsm",
       "depends": ["AnnotationDbi"]
     },
     "org_Mxanthus_db": {
@@ -3761,38 +3761,38 @@
     },
     "org_Pf_plasmo_db": {
       "name": "org.Pf.plasmo.db",
-      "version": "3.20.0",
-      "sha256": "1n8xs8l9ggg18x8gkhf6pr0ic6sgdf63gbfrm6w5ixzmwdfazq90",
+      "version": "3.21.0",
+      "sha256": "0p286jk22h87flf4byjma013bzd5b8c77nxb0kiyvaiqr16cgx2x",
       "depends": ["AnnotationDbi"]
     },
     "org_Pt_eg_db": {
       "name": "org.Pt.eg.db",
-      "version": "3.20.0",
-      "sha256": "05hkhwjh5r18wpk60vwk06bfra6fwrnrr0jshc71hzr6cc15jqfk",
+      "version": "3.21.0",
+      "sha256": "1w4zg790mrr95b2wda76dwcqgf7wr2pahdjnan0nzz2ym0wv4w7y",
       "depends": ["AnnotationDbi"]
     },
     "org_Rn_eg_db": {
       "name": "org.Rn.eg.db",
-      "version": "3.20.0",
-      "sha256": "009c22ry5nnklzdc5dywnf8lq41cj3141yr5vw1kgifys6lanj01",
+      "version": "3.21.0",
+      "sha256": "05285al4g41x0pyfg7y14hbg9ghf2qxkxqdjwzzlb0mnbzwyqfwp",
       "depends": ["AnnotationDbi"]
     },
     "org_Sc_sgd_db": {
       "name": "org.Sc.sgd.db",
-      "version": "3.20.0",
-      "sha256": "0p7mvra93l21pb14qbvqjg7pwl6n572d8a3k15v9fsafikd07v8a",
+      "version": "3.21.0",
+      "sha256": "190v4l6dar3a2vdycmb9dvlp3w9rjg3h425i74lqb8y5y4w4sdl9",
       "depends": ["AnnotationDbi"]
     },
     "org_Ss_eg_db": {
       "name": "org.Ss.eg.db",
-      "version": "3.20.0",
-      "sha256": "0ls2w86r06rwdvmgsv54fksp0wk9nk0a88xaljx85d2x0x5vfkwj",
+      "version": "3.21.0",
+      "sha256": "0mvvq8gyydnhl0q6vf5jpwyhhn385k6gg1088xkv7m282721m47i",
       "depends": ["AnnotationDbi"]
     },
     "org_Xl_eg_db": {
       "name": "org.Xl.eg.db",
-      "version": "3.20.0",
-      "sha256": "0g20n9c1rrh82w809sisrwm05jzldzqyzvmjj5rfv23i158rjhc2",
+      "version": "3.21.0",
+      "sha256": "1knbk8nm87wiv1d7jy7xp2hjin5661lsdgvyvdkvlw85is9ixhm5",
       "depends": ["AnnotationDbi"]
     },
     "paeg1acdf": {
@@ -4871,8 +4871,8 @@
     },
     "pig_db0": {
       "name": "pig.db0",
-      "version": "3.20.0",
-      "sha256": "0mlc62dj7im85czy9idqfld510d3dfygqm03sx9s8lksb0ib0g7n",
+      "version": "3.21.0",
+      "sha256": "16p7bz9p9z5w2xr7j8iciqwmvk8m3ir21lrd1spbnnhqj38l8cmp",
       "depends": ["AnnotationDbi"]
     },
     "plasmodiumanophelescdf": {
@@ -5051,8 +5051,8 @@
     },
     "rat_db0": {
       "name": "rat.db0",
-      "version": "3.20.0",
-      "sha256": "0515r25qj1gca0rr2cydn3rzwxrifbfpx354chj94rl0xz2ppk3n",
+      "version": "3.21.0",
+      "sha256": "1n72pvrsyc4a3wb9zwa58l730s3mkwhzm93bznjlcydihhq0r0ry",
       "depends": ["AnnotationDbi"]
     },
     "rat2302_db": {
@@ -5099,8 +5099,8 @@
     },
     "reactome_db": {
       "name": "reactome.db",
-      "version": "1.89.0",
-      "sha256": "1r4h9wdm3h99b9w18kihma8n9hprxqp1il5k43cfrf191l6wic38",
+      "version": "1.92.0",
+      "sha256": "0kg4awcnq4v7dr2n4dwdlrdjx0ysza5fb41pfrfbscz1d9gsfsip",
       "depends": ["AnnotationDbi"]
     },
     "rgu34a_db": {
@@ -5183,8 +5183,8 @@
     },
     "rhesus_db0": {
       "name": "rhesus.db0",
-      "version": "3.20.0",
-      "sha256": "09b8lqna4vp92dwjs6cqw71kfb7w31zaph6x47l2aq0phn0zr0q4",
+      "version": "3.21.0",
+      "sha256": "1vlgzyi9lkykaxp9dx3rrib629v0l35y9qdpby742xgi53xvn08k",
       "depends": ["AnnotationDbi"]
     },
     "rhesuscdf": {
@@ -5327,14 +5327,14 @@
     },
     "targetscan_Hs_eg_db": {
       "name": "targetscan.Hs.eg.db",
-      "version": "0.6.1",
-      "sha256": "1p14jyhn1d2m6kww9vsb96263g8crnrff7qgyiz46pp9ww8mvxf4",
+      "version": "0.6.2",
+      "sha256": "1blq6nllipp4ar4gcw0fay5rfc1rrfq9dj9fh7ghpyf490vk5d04",
       "depends": ["AnnotationDbi"]
     },
     "targetscan_Mm_eg_db": {
       "name": "targetscan.Mm.eg.db",
-      "version": "0.6.1",
-      "sha256": "0ad6vxpwn9x82qcrpwcy1lwg0q3ik4vabxn01k6gwmbpvydz9cf5",
+      "version": "0.6.2",
+      "sha256": "1ph6kgzkrzjfhfk0iqiw45i7rxa29mynqyj19y2ik76ychc15r8p",
       "depends": ["AnnotationDbi"]
     },
     "test1cdf": {
@@ -5423,14 +5423,14 @@
     },
     "worm_db0": {
       "name": "worm.db0",
-      "version": "3.20.0",
-      "sha256": "1r5man0ad7gkl0444ys7r60jiandb93i6d23g4vx5p31a2ih07jj",
+      "version": "3.21.0",
+      "sha256": "1kkd92pfqsa37ld0nbap19648w10qv7734qw98bgk67vqv523wxr",
       "depends": ["AnnotationDbi"]
     },
     "xenopus_db0": {
       "name": "xenopus.db0",
-      "version": "3.20.0",
-      "sha256": "1pk2i3rl421hs79s6rzaxlha6x41ggq2k3salm73p3f4xymzrpc6",
+      "version": "3.21.0",
+      "sha256": "1439r2f9iz5mrjdr4fssybbjld4ll8wz6rvwa19466cbdln3a74a",
       "depends": ["AnnotationDbi"]
     },
     "xenopuslaeviscdf": {
@@ -5501,8 +5501,8 @@
     },
     "yeast_db0": {
       "name": "yeast.db0",
-      "version": "3.20.0",
-      "sha256": "0wvk457jlw05g28f158bd49ymri13x0mbbr6gif8msrj78zkdi3j",
+      "version": "3.21.0",
+      "sha256": "0vh15i4nnyl2g2l22hib3j8gscll57vgyr2hyq971pbpz6s7iv48",
       "depends": ["AnnotationDbi"]
     },
     "yeast2_db": {
@@ -5555,8 +5555,8 @@
     },
     "zebrafish_db0": {
       "name": "zebrafish.db0",
-      "version": "3.20.0",
-      "sha256": "08w5hcpq71gfwzai0niyxd27pay2755nywqxjh5kxb8l050kpjnf",
+      "version": "3.21.0",
+      "sha256": "1b0pn4cvcn2hphklavxlqg6wzh7dl78l4nr7fhxv3b980qvi56p0",
       "depends": ["AnnotationDbi"]
     },
     "zebrafishcdf": {

--- a/pkgs/development/r-modules/bioc-experiment-packages.json
+++ b/pkgs/development/r-modules/bioc-experiment-packages.json
@@ -1,2376 +1,2382 @@
 {
   "extraArgs": {
-    "biocVersion": "3.20"
+    "biocVersion": "3.21"
   },
   "packages": {
     "ALL": {
       "name": "ALL",
-      "version": "1.48.0",
-      "sha256": "0bj7hd0k7rlyh1y68w09s5wpwi68fiw7hsdh0lwmald7x1asbjax",
+      "version": "1.49.0",
+      "sha256": "1l34qmqv1wq35vp2pxipzd2v5fxdnp5d9csbi0pbfzx4gq4g6288",
       "depends": ["Biobase"]
     },
     "ALLMLL": {
       "name": "ALLMLL",
-      "version": "1.46.0",
-      "sha256": "1ipp8ykdfldyxza2g8g8lj1yrwaynky0fwhmksym7pgn39gl910l",
+      "version": "1.47.0",
+      "sha256": "1dr890x9h94mqq733n1llwkppz6xxvms2nwnqpq735ihl7iv4h39",
       "depends": ["affy"]
     },
     "ARRmData": {
       "name": "ARRmData",
-      "version": "1.42.0",
-      "sha256": "0hic3rm9z1z98dqg6g7nvs4mdq7xn0xvkpraqv95zw1izs0zvndi",
+      "version": "1.43.0",
+      "sha256": "1pvs77rh9bgfl74br9r77klrpihryfh6yisq72cqik932cxiw8k7",
       "depends": []
     },
     "ASICSdata": {
       "name": "ASICSdata",
-      "version": "1.26.0",
-      "sha256": "1vhhvdpnayxf33mq50hdg9ypfpbvxlnjk1h4p73k462517dzxpn0",
+      "version": "1.27.0",
+      "sha256": "0jghrvgjf28lh6wbbw9708v96c98vs8p475qpmzy3fdik3hxmxda",
       "depends": []
     },
     "Affyhgu133A2Expr": {
       "name": "Affyhgu133A2Expr",
-      "version": "1.42.0",
-      "sha256": "1asq4vv6lh6yixnnkh12rrlpqckyw3j53vb107mfrwzq99vngmpa",
+      "version": "1.43.0",
+      "sha256": "1jsgd8zk78zqd5krx6320almsx0swwpyaqv8526jblchir4x944l",
       "depends": []
     },
     "Affyhgu133Plus2Expr": {
       "name": "Affyhgu133Plus2Expr",
-      "version": "1.40.0",
-      "sha256": "0dy7bx5nncc90xfcmgy1gaf3bs29wkb0s2g2pjnf475xgvrjf07c",
+      "version": "1.41.0",
+      "sha256": "1xw6pyni4961z29vkl4kxfhm62j55w8w9jnv50lz6ypy0d8lphg7",
       "depends": []
     },
     "Affyhgu133aExpr": {
       "name": "Affyhgu133aExpr",
-      "version": "1.44.0",
-      "sha256": "17bq293nyzb8rxn8ywgr2ypk72n5jrcgmyzjsmz9f9dp53icfgzk",
+      "version": "1.45.0",
+      "sha256": "0j41z5s7di7qn229n83479vckrazrdvripwidkrki37icxgfa44k",
       "depends": []
     },
     "AffymetrixDataTestFiles": {
       "name": "AffymetrixDataTestFiles",
-      "version": "0.44.0",
-      "sha256": "055msffzbv9ga74krp2hrxjlfxw57p7ldwb9bqp3rcji834d5nmb",
+      "version": "0.45.0",
+      "sha256": "1dnlqfczcykqvpf7sa9j7xi7qc1y3s8lxy8k3l93sci97zwf7gsf",
       "depends": []
     },
     "Affymoe4302Expr": {
       "name": "Affymoe4302Expr",
-      "version": "1.44.0",
-      "sha256": "1vnilic1lkx8s0gllrfznd03p49m05426fbjhgxmqznd45s7rjaw",
+      "version": "1.45.0",
+      "sha256": "0b7y9ygvlqwdiibnjk7k71krnhyahqrlij2xc5jkln99g0yvphf7",
       "depends": []
     },
     "AmpAffyExample": {
       "name": "AmpAffyExample",
-      "version": "1.46.0",
-      "sha256": "0hh3j161whmnw0crcrypv77sdkkcbjrzpfzvgvjvad9m9qkkgfb9",
+      "version": "1.47.0",
+      "sha256": "1wgcldxq0cg7zbxgcl6cmwa70xdznjdpq554a6a76y48gldb0xbz",
       "depends": ["affy"]
     },
     "AneuFinderData": {
       "name": "AneuFinderData",
-      "version": "1.34.0",
-      "sha256": "039ymqwxr66hmkzig333gwjxczzxlc6jl1x27jw7agriynjbqmgx",
+      "version": "1.35.0",
+      "sha256": "0jc2zd5wbk2ydbl6npkfm64gyxvfshlw4p7rvzm3kc9ddwdrcdxh",
       "depends": []
     },
     "AshkenazimSonChr21": {
       "name": "AshkenazimSonChr21",
-      "version": "1.36.0",
-      "sha256": "0chcr50wa1lwcl1y9sgp2759i6hlwbqald5x5l0y4dldjsqfsr3s",
+      "version": "1.37.0",
+      "sha256": "1b7zb1kqzfl9cgla6jdm2227kvlw0sb5wz0p2mkxav6z0bijzwkv",
       "depends": []
+    },
+    "AssessORFData": {
+      "name": "AssessORFData",
+      "version": "1.25.1",
+      "sha256": "07jni8dw97sajr1y28dkm7bhbwkdqd12vkkpr86gyl4g6xya7fn8",
+      "depends": ["DECIPHER", "RSQLite"]
     },
     "BeadArrayUseCases": {
       "name": "BeadArrayUseCases",
-      "version": "1.44.1",
-      "sha256": "0p7y8b75wf6628cig8mj87srp87c978mbyb3fzifxnr72m1wjg73",
+      "version": "1.45.1",
+      "sha256": "055iilzwci6rqghdwag2p1ajkkb28wl36pbdk80lb7mb1ssac211",
       "depends": ["GEOquery", "beadarray", "limma"]
     },
     "BeadSorted_Saliva_EPIC": {
       "name": "BeadSorted.Saliva.EPIC",
-      "version": "1.14.0",
-      "sha256": "0pdm4vvic78zaxr4r9lp00m0jaj4617pmpcxbxxy1xn83qgbd2hc",
+      "version": "1.15.0",
+      "sha256": "0nc3gf80w5ngvknn3cmakx9kl8gbbjypx8992r1q0bcprrqc0dya",
       "depends": ["ExperimentHub", "minfi"]
     },
     "BioImageDbs": {
       "name": "BioImageDbs",
-      "version": "1.14.0",
-      "sha256": "128kzcn1v4qp3d4yyr5qkqgqzdjf37c0i07wz94zw883snbigqra",
+      "version": "1.15.0",
+      "sha256": "1n55x2l3q8pl2n7md5c5j0rmqn07py5ywwl55fwjlm0ablp0hcla",
       "depends": ["AnnotationHub", "EBImage", "ExperimentHub", "animation", "einsum", "filesstrings", "magick", "magrittr", "markdown", "rmarkdown"]
     },
     "BioPlex": {
       "name": "BioPlex",
-      "version": "1.12.0",
-      "sha256": "0yjsfmj06jsrivj70y2c95kghicmq5m5jqacy6sqzk9gbg7sr594",
+      "version": "1.13.0",
+      "sha256": "0vsbbkn7j7kl5yqi161fk592701c5dpqc63nai8g7xx8s8yzg60c",
       "depends": ["BiocFileCache", "GEOquery", "GenomeInfoDb", "GenomicRanges", "SummarizedExperiment", "graph"]
     },
     "BloodCancerMultiOmics2017": {
       "name": "BloodCancerMultiOmics2017",
-      "version": "1.26.0",
-      "sha256": "1nr4jb85qlg2i11i6p1x6xg7klffpy8wk7801z3gawkby1zywfs0",
+      "version": "1.27.1",
+      "sha256": "14kmnbrq9xkjlc5346n4ydgpfi6qh45dr2xk6rwc2p0sym6yzngp",
       "depends": ["Biobase", "DESeq2", "RColorBrewer", "SummarizedExperiment", "beeswarm", "devtools", "dplyr", "ggdendro", "ggplot2", "glmnet", "gtable", "ipflasso", "reshape2", "scales", "survival", "tibble"]
     },
     "CCl4": {
       "name": "CCl4",
-      "version": "1.44.0",
-      "sha256": "15z8x1f9m94v44m2w6pzqqcvm0q8vavda2w9m44chlsppmzsfl9j",
+      "version": "1.45.0",
+      "sha256": "0nplbfmszg33wkdfb02rj1jhrwrg0l6hqik642s4dchf607gv44h",
       "depends": ["Biobase", "limma"]
     },
     "CLL": {
       "name": "CLL",
-      "version": "1.46.0",
-      "sha256": "0c893wrfbbwbpd2lv1y0f5m61dvs94s51b9gdbgyv6ihwqn858lf",
+      "version": "1.47.0",
+      "sha256": "1ynpjcdyiyvxd1m64034japw91rxqfx5yfn1y2ikiy38b04kabkv",
       "depends": ["Biobase", "affy"]
     },
     "CLLmethylation": {
       "name": "CLLmethylation",
-      "version": "1.26.0",
-      "sha256": "111z7lwk1lic3j41cy6j1cq0ks5fi2gyj859laf4x4qahrkzap1b",
+      "version": "1.27.0",
+      "sha256": "106371x9pn24zjjbkmspgjb8s49yz30x7hpd7ybr521mzvqdj0dz",
       "depends": ["ExperimentHub", "SummarizedExperiment"]
     },
     "COHCAPanno": {
       "name": "COHCAPanno",
-      "version": "1.42.0",
-      "sha256": "068k6p4bl4w0fa81517bfsrv2p1yd915zl2qjjsnlyczb77c4gkm",
+      "version": "1.43.0",
+      "sha256": "17iqrh1lmichlzdq09rhrprwgaf80dbg96vsphy8g7bp8jwwf5xp",
       "depends": []
     },
     "CONFESSdata": {
       "name": "CONFESSdata",
-      "version": "1.34.0",
-      "sha256": "1qrnvd1c9jfjyn9k283x6g3z50zfvh4ryd5mig1w57a2hi714ars",
+      "version": "1.35.0",
+      "sha256": "1k8xc1wadgq8yqx97a0qsbsfz38g5hm8j0ky80a718r21m72708g",
       "depends": []
     },
     "COPDSexualDimorphism_data": {
       "name": "COPDSexualDimorphism.data",
-      "version": "1.42.0",
-      "sha256": "08nrc8r21p1nvzfiahrbxigbyipzi82d6q7r064jq92qyc2fd8jh",
+      "version": "1.43.0",
+      "sha256": "1nipz4f55znfg4v9f8jygdshpjzzfaar17a6zfazj0dhw3cmlyd3",
       "depends": []
     },
     "COSMIC_67": {
       "name": "COSMIC.67",
-      "version": "1.42.0",
-      "sha256": "0kb78j7wdjzcl6dygj18kq6lmnga67l6h9v6an9bvw97vdlwijkj",
+      "version": "1.43.0",
+      "sha256": "0g2k4632rl1j2g2vbj8cncgz09a60bdaym2hakff5wsfr649w2s2",
       "depends": ["GenomicRanges", "SummarizedExperiment", "VariantAnnotation"]
     },
     "CRCL18": {
       "name": "CRCL18",
-      "version": "1.26.0",
-      "sha256": "03a0haskz3jpccgbb4r9jzgzrrxabprwh3h3j1r5mpjasq7yrwdv",
+      "version": "1.27.0",
+      "sha256": "1yb8s8lpvv5ix3y8g97zmgwdq6mdpvhpgc73fqwx600af5l2qwkz",
       "depends": ["Biobase"]
     },
     "CardinalWorkflows": {
       "name": "CardinalWorkflows",
-      "version": "1.38.0",
-      "sha256": "1wk1yrxbb22xablwy0blahj89y434607zpqap1d2sx71qgj64vwc",
+      "version": "1.39.0",
+      "sha256": "0gr7z1xcd92mqxwiid1bs9annp0rjkh8rc5s6l952k7w0nm8sch8",
       "depends": ["Cardinal"]
     },
     "CellMapperData": {
       "name": "CellMapperData",
-      "version": "1.32.0",
-      "sha256": "07ikbz8vfqmvqw6dpjvirlgvhldn4lc7cy8zjkiqv9a428hfgvb5",
+      "version": "1.33.0",
+      "sha256": "1yjc6mp543rfyvnd8z7li5k5f8wfxhq2xhrw4izsxvvh5ckyw3rd",
       "depends": ["CellMapper", "ExperimentHub"]
     },
     "ChAMPdata": {
       "name": "ChAMPdata",
-      "version": "2.38.0",
-      "sha256": "0gcd58ad61niknq1dqn8ydr4v31i718jcg75q1hklbn78xlj2m3f",
+      "version": "2.39.0",
+      "sha256": "0bybz4k1fgipididfzai54z1gpq69abpfmmb02ban9p9b84xrx8i",
       "depends": ["BiocGenerics", "GenomicRanges"]
     },
     "ChIPXpressData": {
       "name": "ChIPXpressData",
-      "version": "1.44.0",
-      "sha256": "0jf5357dw09dl8xf94jaipymz32qyi7zqm3yc0k4gxws42yw3xy8",
+      "version": "1.45.0",
+      "sha256": "0qj67plizhxd2w9ybz73zv6ssf5h174gz3ycrabr8ivkih61p92l",
       "depends": ["bigmemory"]
     },
     "ChIPexoQualExample": {
       "name": "ChIPexoQualExample",
-      "version": "1.30.0",
-      "sha256": "0c6lxl79j65pqy6sgnwaqz83r9fwh0m10xmnj9zcp8s0j1cxn5xq",
+      "version": "1.31.0",
+      "sha256": "0dzy7g6frl6jgadz5ahvcmwm4iv1k5sgfsmfkvd7flrvkslwrimz",
       "depends": []
     },
     "ChimpHumanBrainData": {
       "name": "ChimpHumanBrainData",
-      "version": "1.44.0",
-      "sha256": "1797yccghjn4ajrrs2gz1dkbg4bp4vilxs2nhj657rqqap0gxwpy",
+      "version": "1.45.0",
+      "sha256": "1jskpickyd7789h2srzlhn7jw83zcpmbb55brrmjwb28hr3ignq4",
       "depends": ["affy", "hexbin", "limma", "qvalue", "statmod"]
     },
     "CluMSIDdata": {
       "name": "CluMSIDdata",
-      "version": "1.22.0",
-      "sha256": "07q2qzky019f1vbnbhgb2vkqfgqwi1h2y0vssbw3z14ff5drx126",
+      "version": "1.23.0",
+      "sha256": "1xg9rxdwifzbrsa1czydgcawp7h6fnk2z49krbqixjwm43icwx6j",
       "depends": []
     },
     "CoSIAdata": {
       "name": "CoSIAdata",
-      "version": "1.6.0",
-      "sha256": "1pd0k8gnn7s798qkvjvgvaschjpn72fvaf28ly1qvdg6mx1xfb2p",
+      "version": "1.7.0",
+      "sha256": "0mbicvcn5p6jjd2n522hx6zcib2achay5c4f0k101blsv8v0bilc",
       "depends": ["ExperimentHub"]
     },
     "ConnectivityMap": {
       "name": "ConnectivityMap",
-      "version": "1.42.0",
-      "sha256": "0lq9yjz104426dn8y2q7a51433x4zfv5y7rrlavy7hkwlqr4jm5j",
+      "version": "1.43.0",
+      "sha256": "16j4jhqlibipms2pq52g0lkpj2ardlc46i4ka6mz1fay8791mi5w",
       "depends": []
     },
     "CopyNeutralIMA": {
       "name": "CopyNeutralIMA",
-      "version": "1.24.0",
-      "sha256": "1zls7gj8y5pav5gw0lxdi89p38b6idywryqppqfq7zn4mhdz198m",
+      "version": "1.25.0",
+      "sha256": "1r6vnqwk48kn4jfr9c820zy1637v16daifdxc3c3s861n4m6i5fb",
       "depends": ["ExperimentHub", "Rdpack"]
     },
     "CopyhelpeR": {
       "name": "CopyhelpeR",
-      "version": "1.38.0",
-      "sha256": "1zg2cp7rff6yc1lk70gipy0q3z6ndizipay3102psv1q2916x8ln",
+      "version": "1.39.0",
+      "sha256": "1a9ckxn36c677d6vb0a6c2j2ibivi9clwsbkcn8z4cw8r2gihns0",
       "depends": []
     },
     "CytoMethIC": {
       "name": "CytoMethIC",
-      "version": "1.2.0",
-      "sha256": "1dmkqd3hk1nfd07j0bq4ljdrbh72kcjlb1xddazpfvsf3wm7ijkq",
-      "depends": ["BiocManager", "BiocParallel", "ExperimentHub", "sesame", "sesameData", "tibble"]
+      "version": "1.3.3",
+      "sha256": "0l9x6i47b9m2d6xyi8is8s2myhzb5y20i37xlpx24b8a2ddwqmc0",
+      "depends": ["BiocManager", "BiocParallel", "ExperimentHub", "sesame", "sesameData"]
     },
     "DAPARdata": {
       "name": "DAPARdata",
-      "version": "1.36.0",
-      "sha256": "0q7ql1971nls7wpvzgc2nk1h890zl2y6p1zdniwf42azahpvhcka",
+      "version": "1.37.0",
+      "sha256": "0wckivznvlpb79rmra7ws92649lkjfwnv6c92qkqa8r6f750k0lk",
       "depends": ["MSnbase"]
     },
     "DExMAdata": {
       "name": "DExMAdata",
-      "version": "1.14.0",
-      "sha256": "0i7d5cswh0gpyl0dj0ww34xy1m0gjzzssll5xjch9n4i4gq0kzs9",
+      "version": "1.15.0",
+      "sha256": "0pr4nd6f9n1wv5njp7zxd6g53qqdbdahyrm3bz4v1v4ijnb12bif",
       "depends": ["Biobase"]
     },
     "DLBCL": {
       "name": "DLBCL",
-      "version": "1.46.0",
-      "sha256": "0lw6554la5ihfp93idxy4pcp3iack03ng7f6pik109mijwnd68rq",
+      "version": "1.47.0",
+      "sha256": "1ragqxlpq79vvpi2m7fqj6qkyvgn0wrv98ga6qirbcxawjfx1w4x",
       "depends": ["Biobase", "graph"]
     },
     "DMRcatedata": {
       "name": "DMRcatedata",
-      "version": "2.24.0",
-      "sha256": "0w6mv0zclrnr897xjrsgbm3bki3mmvbafzdhj9bl55v07438wh7i",
+      "version": "2.25.0",
+      "sha256": "1rxab8n4095rp3jglbpb9w4k1g8rvb4j6a9ac1dbz76dlwjb1ag9",
       "depends": ["ExperimentHub", "GenomicFeatures", "Gviz", "IlluminaHumanMethylation450kanno_ilmn12_hg19", "IlluminaHumanMethylationEPICanno_ilm10b4_hg19", "plyr", "readxl", "rtracklayer"]
     },
     "DNAZooData": {
       "name": "DNAZooData",
-      "version": "1.6.0",
-      "sha256": "042wk00vhc98p847fsja3hc8bp0076yn8b3nfi6khrgjr2cfrfns",
+      "version": "1.7.0",
+      "sha256": "1kl2ki8s8qi6lhbsyldbi4z57yf26ajvq1ivd32bm03s4c0hhqr3",
       "depends": ["BiocFileCache", "HiCExperiment", "S4Vectors", "rjson"]
     },
     "DeSousa2013": {
       "name": "DeSousa2013",
-      "version": "1.42.0",
-      "sha256": "0kyaycn5i1dxllzakc8m837apd4fj57d2ddsx01wb4zqk7dpsk2k",
+      "version": "1.43.0",
+      "sha256": "0mhrkyk12qrxgmb2zp67ysacn4f1yplaw62087r7wj8y8pz2v0nx",
       "depends": ["AnnotationDbi", "Biobase", "ConsensusClusterPlus", "ROCR", "affy", "cluster", "frma", "frmaTools", "gplots", "hgu133plus2_db", "hgu133plus2frmavecs", "pamr", "rgl", "siggenes", "survival", "sva"]
-    },
-    "DmelSGI": {
-      "name": "DmelSGI",
-      "version": "1.37.0",
-      "sha256": "023ynaky11cc33ksmq8s77m17rlr45mp33bzrzaqija64z01rgih",
-      "depends": ["TSP", "abind", "gplots", "igraph", "knitr", "limma", "rhdf5"]
     },
     "DonaPLLP2013": {
       "name": "DonaPLLP2013",
-      "version": "1.44.0",
-      "sha256": "0swc6a2pfk4rmd4am3y34xifmrcys4wyz8x6rmdncbzq6v78vjcm",
+      "version": "1.45.0",
+      "sha256": "10lmzs4fq0jhmjnwbv9clmssz3pcs4n5219y5a61v1z2zjn87hma",
       "depends": ["EBImage"]
     },
     "DropletTestFiles": {
       "name": "DropletTestFiles",
-      "version": "1.16.0",
-      "sha256": "18js640mf07yx0hxswbyqpdq2iaf7rzpmz1alazx9yayzwlk7fhm",
+      "version": "1.17.0",
+      "sha256": "1r36pbwqh53xybphq9p637zpkpz3h00i6gfy1n1hriz3k1m0fni5",
       "depends": ["AnnotationHub", "ExperimentHub", "S4Vectors"]
     },
     "DrugVsDiseasedata": {
       "name": "DrugVsDiseasedata",
-      "version": "1.42.0",
-      "sha256": "18qgs1r86v35jm4d3m8cb81cz92m3rghx7wwvlshflfw581r5anb",
+      "version": "1.43.0",
+      "sha256": "06v8cyhj7f9nqclz8a3150718q7lmg9ccys40v40ivqgdvkgzsg5",
       "depends": []
     },
     "DuoClustering2018": {
       "name": "DuoClustering2018",
-      "version": "1.24.0",
-      "sha256": "1cf08ydsg8hj4klbl9wga0dmjabqq77rg22jms1dimpmf15a1vjk",
+      "version": "1.25.0",
+      "sha256": "1gs714ddcysrcmchb3m4xsk7v08pjb93x21az04k9chavmbnjh9b",
       "depends": ["ExperimentHub", "dplyr", "ggplot2", "ggthemes", "magrittr", "mclust", "purrr", "reshape2", "tidyr", "viridis"]
     },
     "DvDdata": {
       "name": "DvDdata",
-      "version": "1.42.0",
-      "sha256": "034dj6z8drk45w3v2izivrn6q5gwbyy3dc515ayj4irf756r5555",
+      "version": "1.43.0",
+      "sha256": "1z8lq3nwsf6dhbb1s2r7rw2c4dg1raxd0gnn9wvms8mw4yd64hcs",
       "depends": []
     },
     "EGSEAdata": {
       "name": "EGSEAdata",
-      "version": "1.34.0",
-      "sha256": "120csmjcr3zgskqdxzfy37j5kid58fd9fcwvk9p8fzmybz4x9lcw",
+      "version": "1.35.0",
+      "sha256": "0lyixfp44l29v1rmjpl5vls92zmjwkfx55mr7rf6hlslvapj7w01",
       "depends": []
     },
     "ELMER_data": {
       "name": "ELMER.data",
-      "version": "2.30.0",
-      "sha256": "02vz6n7dnc0jgszj9h9ym861jbhlp6z8w5dl8h3x3m0d8ka5jlw2",
+      "version": "2.31.0",
+      "sha256": "1c2wbnsdm924723xax2nmx7ym3bc9y8bwyk1x5264y7dwhmaywxc",
       "depends": ["GenomicRanges"]
     },
     "EatonEtAlChIPseq": {
       "name": "EatonEtAlChIPseq",
-      "version": "0.44.0",
-      "sha256": "1zss730sqmbbn2hs9rqd5gnx86crjmgwbrwl90yybrya9ijfa7k4",
+      "version": "0.45.0",
+      "sha256": "0aaxbhda27fknpyl4c5i5i6r8b9is2ljajkdkqmimf7mqa86vsii",
       "depends": ["GenomicRanges", "ShortRead", "rtracklayer"]
     },
     "EpiMix_data": {
       "name": "EpiMix.data",
-      "version": "1.8.0",
-      "sha256": "0qahz20cz3q31l2m9g3lyy52gdkccqj4xgsqqq76r4nqylgrqg2w",
+      "version": "1.9.0",
+      "sha256": "17lsb6mkhghgp2v9pi5qvq9d7j9zx73dq9y3ksz7d2d2bgdxmgd6",
       "depends": ["ExperimentHub"]
     },
     "EpipwR_data": {
       "name": "EpipwR.data",
-      "version": "1.0.0",
-      "sha256": "0m784qygmzn9drcfx73vgvc0fgz76iajnhh3wpiqsqfdpkyix59f",
+      "version": "1.1.0",
+      "sha256": "1kh88ybzyqjkcgiyzs7jb03snfbjygf7flbd83h2qh58x614yvxk",
       "depends": ["ExperimentHub"]
     },
     "FANTOM3and4CAGE": {
       "name": "FANTOM3and4CAGE",
-      "version": "1.42.0",
-      "sha256": "0kz91pajy3y2xsg88jinghx973190ncxsmg179mbqjimqkyzjfyv",
+      "version": "1.43.0",
+      "sha256": "1g7qjp43xhsydcdyi9ibllxna7wlmrl6sqn1qxkdb0b0h6bv3qqn",
       "depends": []
     },
     "FIs": {
       "name": "FIs",
-      "version": "1.34.0",
-      "sha256": "1fgga7vm6mrq622drx8lhp7i9bql16sd0843w2dp0scq3w80qyhz",
+      "version": "1.35.0",
+      "sha256": "0d6lz07a6a4sfl7mal7aa00r8lkf0dfrgjdryjzpv5z75kbchc0m",
       "depends": []
     },
     "FieldEffectCrc": {
       "name": "FieldEffectCrc",
-      "version": "1.16.0",
-      "sha256": "0gbj5qgxwilkbdab9q3i47dxj3ah3hfji4knvlvdxsa1sf4f8bhh",
+      "version": "1.17.0",
+      "sha256": "18ic344w2wdz8mish7scbkl1g991ldijh9ls8zwgv6n72d689ra8",
       "depends": ["AnnotationHub", "BiocStyle", "DESeq2", "ExperimentHub", "RUnit", "SummarizedExperiment"]
     },
     "Fletcher2013a": {
       "name": "Fletcher2013a",
-      "version": "1.42.0",
-      "sha256": "02wb3d2dw29bdnapy25znvs1mrpifwfax13ngv07g3jbm64sfcbr",
+      "version": "1.43.0",
+      "sha256": "05fg9kyyap6xvmb624sgkwjnxylk3hkfp37ybxyzai93qnyl19da",
       "depends": ["Biobase", "VennDiagram", "gplots", "limma"]
     },
     "Fletcher2013b": {
       "name": "Fletcher2013b",
-      "version": "1.42.0",
-      "sha256": "081l3af001i2z7zzhgjdlm02lwaw9g65bc9hkb393rrfxix974aq",
+      "version": "1.43.0",
+      "sha256": "09z45sdhqklxix9ffwkjnrw5q0sc9isjf1kz9cywnyfmaz0sq8fc",
       "depends": ["Fletcher2013a", "RColorBrewer", "RTN", "RedeR", "igraph"]
     },
     "FlowSorted_Blood_450k": {
       "name": "FlowSorted.Blood.450k",
-      "version": "1.44.0",
-      "sha256": "1afjwjddx9nwg01png223zr9vcb3xq8i71wx8mj2cxdwsb0lyqsq",
+      "version": "1.45.0",
+      "sha256": "12mxyqqk8z2alpyr6z30brvyj477ax06qb4jdm1fymg5q478pxv0",
       "depends": ["minfi"]
     },
     "FlowSorted_Blood_EPIC": {
       "name": "FlowSorted.Blood.EPIC",
-      "version": "2.10.0",
-      "sha256": "1zq5xbgr4r68mmzsszb16w11axkmgrxcrpl56dy33szs0ahk10xs",
+      "version": "2.11.0",
+      "sha256": "18kfd15yacill0d86kb5vb9rs197h2m80w3zw9azl72m8s99xm81",
       "depends": ["AnnotationHub", "ExperimentHub", "S4Vectors", "SummarizedExperiment", "genefilter", "minfi", "nlme", "quadprog"]
     },
     "FlowSorted_CordBlood_450k": {
       "name": "FlowSorted.CordBlood.450k",
-      "version": "1.34.0",
-      "sha256": "0cxdhysyj1s5wrj1779km6gfyk6n8yz94sysg9w6cw7n561b2q5i",
+      "version": "1.35.0",
+      "sha256": "1dhnm74alxlbnpvijq8n1g08401w144vz2611kmk7484awmx5whm",
       "depends": ["minfi"]
     },
     "FlowSorted_CordBloodCombined_450k": {
       "name": "FlowSorted.CordBloodCombined.450k",
-      "version": "1.22.0",
-      "sha256": "15phn2kikaap2yzv9pn1206iiv4lg87hrh1yn4ks45f30prryp9x",
+      "version": "1.23.0",
+      "sha256": "05ks4v11dwh3y2jacdk183hcqljhxpks3aqs8y893gp7gxysb9mj",
       "depends": ["AnnotationHub", "ExperimentHub", "IlluminaHumanMethylation450kanno_ilmn12_hg19", "IlluminaHumanMethylationEPICanno_ilm10b4_hg19", "SummarizedExperiment", "minfi"]
     },
     "FlowSorted_CordBloodNorway_450k": {
       "name": "FlowSorted.CordBloodNorway.450k",
-      "version": "1.32.0",
-      "sha256": "11w600kbk7gkm1pafqm513kv7y5cfrny589gw18z6magnkscffna",
+      "version": "1.33.0",
+      "sha256": "1ffvms0l6cl6i4yipz2i06bb3zmmqv8fwbw8n49gfxixvbqqbjni",
       "depends": ["minfi"]
     },
     "FlowSorted_DLPFC_450k": {
       "name": "FlowSorted.DLPFC.450k",
-      "version": "1.42.0",
-      "sha256": "1338vkd2fjirmbydlz8ma2pxpln243fsj68a004bxp47gkvxpjnd",
+      "version": "1.43.0",
+      "sha256": "0wcgi004fp7cn6r62s72hvvx7kfqzjababikaqamzv3q6gg1sf8g",
       "depends": ["minfi"]
     },
     "GIGSEAdata": {
       "name": "GIGSEAdata",
-      "version": "1.24.0",
-      "sha256": "13ggd156s67asa0afpahazzi6xbk2yfb4rpnf71vak6bfvgpalim",
+      "version": "1.25.0",
+      "sha256": "171q8rlvkb66dwi9vzyip6cjxjjrvwq08qp9nrglzzjxq6qcs7px",
       "depends": []
     },
     "GSBenchMark": {
       "name": "GSBenchMark",
-      "version": "1.26.0",
-      "sha256": "0dyc1611nzg2hmm4gw71pdh5v6k6jpqcqmnc4p6hbgnbmmckijik",
+      "version": "1.27.0",
+      "sha256": "179gcqplp243zqy96w4bz6sbzh685a3brckg7gjfzwym7x8xglc8",
       "depends": []
     },
     "GSE103322": {
       "name": "GSE103322",
-      "version": "1.12.0",
-      "sha256": "00v4hjw0mv1i2b3gy32dhgvh0np6lqm0pgr3ck9kymisjnj8q05k",
+      "version": "1.13.0",
+      "sha256": "0j2ma53m5p4md68bnw74wl9xa4j20a4hazwwm21g4f0gydr9zn6m",
       "depends": ["Biobase", "GEOquery"]
     },
     "GSE13015": {
       "name": "GSE13015",
-      "version": "1.14.0",
-      "sha256": "143aails9r04z86n5j5dlr6bq6jq95br0gwg5iwg4cxv2xghrqqd",
+      "version": "1.15.0",
+      "sha256": "0n2zp0g4msarjr79b233mg9gw9f0nhvxrr9m3iivq44ychciiy2n",
       "depends": ["Biobase", "GEOquery", "SummarizedExperiment", "preprocessCore"]
     },
     "GSE159526": {
       "name": "GSE159526",
-      "version": "1.12.0",
-      "sha256": "0dqnbp4xpafvqg4490jw2l3g8ki7ghdzfypa40l74i76shlfp8sb",
+      "version": "1.13.0",
+      "sha256": "03xi37q8wq7wapjkrf5gv29wgvs0knll60mcdrsjjckbc3mrdx5g",
       "depends": []
     },
     "GSE62944": {
       "name": "GSE62944",
-      "version": "1.34.0",
-      "sha256": "015jp3kmdwpvmv38wa3r4qy5yfbyxjzy9mgynfkwpapzswgpgf6f",
+      "version": "1.35.0",
+      "sha256": "08p1vv2xfpk9n4f7nkm3g9x3sawa09pzvdlwg1zlki9jas1lf78z",
       "depends": ["Biobase", "GEOquery"]
     },
     "GSVAdata": {
       "name": "GSVAdata",
-      "version": "1.42.0",
-      "sha256": "160k1vsxcbjqwpfkdkhd7dsvnaasjbs270gnfdwdbnl0c6d24348",
+      "version": "1.43.1",
+      "sha256": "189sbvvr8jpxxv1jrz4fx2xgskq952b94asrjxxr2axz38aqrhbd",
       "depends": ["Biobase", "GSEABase", "SummarizedExperiment", "hgu95a_db"]
     },
     "GWASdata": {
       "name": "GWASdata",
-      "version": "1.44.0",
-      "sha256": "1rvl7mp5jimzsff2i1qlkx92ljk1fgqycrwhq21p03p9nakbpbs8",
+      "version": "1.45.0",
+      "sha256": "1pphgyd5n5dq2gw5khnxxbfvwsir2558fj2qz9x38c9r24idfs7x",
       "depends": ["GWASTools"]
     },
     "GenomicDistributionsData": {
       "name": "GenomicDistributionsData",
-      "version": "1.14.0",
-      "sha256": "1k2agyxndlmn20lxraidmb63sx530736qmi5wx1dlgp8bj5ghaw5",
+      "version": "1.15.0",
+      "sha256": "0r4q2dgq07sv7w2pabbcqmzc671y24jxj0jrqjchr86l2iwjw39d",
       "depends": ["AnnotationFilter", "AnnotationHub", "BSgenome", "ExperimentHub", "GenomeInfoDb", "GenomicFeatures", "GenomicRanges", "data_table", "ensembldb"]
     },
     "GeuvadisTranscriptExpr": {
       "name": "GeuvadisTranscriptExpr",
-      "version": "1.34.0",
-      "sha256": "02pm49hljlhabv6j5ryzrdj5kh69xzrpdz0sc7jk9c1ky0cb9f82",
+      "version": "1.35.0",
+      "sha256": "190i627mhlz7sv2awc2irqjy5adyvrv0h2pnxbrcnpxmnxdb1lns",
       "depends": []
     },
     "HCAData": {
       "name": "HCAData",
-      "version": "1.22.0",
-      "sha256": "0gqh065bfdndvxmksg3m86kpb1l91qijpyva2mx4azng85fc5bm7",
+      "version": "1.23.1",
+      "sha256": "10fgb6f4lqmxbn970mjwr68l108hhlyizh4gm98nahj58499kcgk",
       "depends": ["AnnotationHub", "ExperimentHub", "HDF5Array", "SingleCellExperiment"]
     },
     "HCATonsilData": {
       "name": "HCATonsilData",
-      "version": "1.4.0",
-      "sha256": "0g3wfgkj09gx4knn2sw9kx09mxxdj3bdcg7951ba5ak6f99c3f5b",
+      "version": "1.5.0",
+      "sha256": "0bnfdsg658pcnryig60gc4775bl15fmhdafbx6w4arlr941y4y50",
       "depends": ["ExperimentHub", "HDF5Array", "S4Vectors", "SingleCellExperiment", "SpatialExperiment", "SummarizedExperiment", "base64enc", "htmltools", "rmarkdown"]
     },
     "HD2013SGI": {
       "name": "HD2013SGI",
-      "version": "1.46.0",
-      "sha256": "05q5xq1q2bvnm1y420gw4z8acpx6cgpqa4zcqhgydgn3af2q0ya9",
+      "version": "1.47.0",
+      "sha256": "17n7yjpmjpcyibc8ln3qyyfjs0dhjccjpr4lhib16767w6d6cs5l",
       "depends": ["EBImage", "LSD", "RColorBrewer", "geneplotter", "gplots", "limma", "splots", "vcd"]
     },
     "HDCytoData": {
       "name": "HDCytoData",
-      "version": "1.26.0",
-      "sha256": "10b5fjhyrz5rm08xrniv6pnnay0h96bhs838napxsmjgvmhqbibn",
+      "version": "1.27.0",
+      "sha256": "09a7dn1lnrryrdh40gdyqd1axqdwq2kh11zwk8xg2sip0r33vrdl",
       "depends": ["ExperimentHub", "SummarizedExperiment", "flowCore"]
     },
     "HEEBOdata": {
       "name": "HEEBOdata",
-      "version": "1.44.0",
-      "sha256": "0alndr9qzhdhibik5wlzf87m58jyvaiqp410cxi5ymqdg6vajc6z",
+      "version": "1.45.0",
+      "sha256": "176bxzwpvpi0907crkpxqla7vrfyc3lghp93wdhk21hjyaaifryi",
       "depends": []
     },
     "HIVcDNAvantWout03": {
       "name": "HIVcDNAvantWout03",
-      "version": "1.46.0",
-      "sha256": "046faa4gjnajcqszxha16xqvn31kdb8b015zd3vkg88w2p0i1s13",
+      "version": "1.47.0",
+      "sha256": "1cw262vk57pk8i4wc9caz9alqk4lcja220gz2kbipsfb6bxwxhrw",
       "depends": []
     },
     "HMP16SData": {
       "name": "HMP16SData",
-      "version": "1.26.0",
-      "sha256": "1km40658svlz6byv8bdm6ngmgpdpfrg80gk25g1i9dd860zqhy30",
+      "version": "1.27.0",
+      "sha256": "0cvm1pmx44pf0c51ld3xs30s4377jirn9mhhnwlsghjhvd4vn295",
       "depends": ["AnnotationHub", "ExperimentHub", "S4Vectors", "SummarizedExperiment", "assertthat", "dplyr", "kableExtra", "knitr", "magrittr", "readr", "stringr", "tibble"]
     },
     "HMP2Data": {
       "name": "HMP2Data",
-      "version": "1.20.0",
-      "sha256": "07gh52z9xjlpkw36gil5xnv4ykym8s83rnvvgmhqr4zynnzspwdb",
+      "version": "1.21.0",
+      "sha256": "0dp966jsr0bg3x8vlr8ghrf08rlm9yx905qfcrkbg7sys9kfr1py",
       "depends": ["AnnotationHub", "ExperimentHub", "MultiAssayExperiment", "S4Vectors", "SummarizedExperiment", "assertthat", "data_table", "dplyr", "kableExtra", "knitr", "magrittr", "phyloseq", "readr"]
     },
     "HSMMSingleCell": {
       "name": "HSMMSingleCell",
-      "version": "1.26.0",
-      "sha256": "1mcckdpz4i6azm2dmjrkbn6py4c7bhq1dqzpb3h9am49s1jhzgiw",
+      "version": "1.27.0",
+      "sha256": "09jz6a4gjh2dwiff5qz59y6x5fc82jdqhjc43bldrc1hqvs4g39s",
       "depends": []
     },
     "HarmanData": {
       "name": "HarmanData",
-      "version": "1.34.0",
-      "sha256": "1xqlpvyw54dq2xmdqsvx7salph246wpq5vz38sv1k544vigzmkxy",
+      "version": "1.35.0",
+      "sha256": "1lkhz7f9m5kbzp40w9sb2kfcidz92y5w4q04rdan5n6v7hkavlwb",
       "depends": []
     },
     "HarmonizedTCGAData": {
       "name": "HarmonizedTCGAData",
-      "version": "1.28.0",
-      "sha256": "1v12rnlwcy8xz2qsqba829ybrny7hqs7zw8p52z3sa98l7s4i0qp",
+      "version": "1.29.0",
+      "sha256": "04hva46ynwjxdm14dnbx8gng5z8h00zkgksj0piabxg5kd62fbib",
       "depends": ["ExperimentHub"]
     },
     "HelloRangesData": {
       "name": "HelloRangesData",
-      "version": "1.32.0",
-      "sha256": "0a6bjiyq8y505lcl4nn2jz7x5zkbspnw5l4zaar3p3hql981268a",
+      "version": "1.33.0",
+      "sha256": "0ahkx7wcmydahxrxxcpqc0cpmjx4vxdk1mqv5i211brxjc8c19yy",
       "depends": []
     },
     "HiBED": {
       "name": "HiBED",
-      "version": "1.4.0",
-      "sha256": "11kqh3dj00gabyy8frvd5ac0h7ryh53sl97l6n2f19a5hkwcwqh2",
+      "version": "1.5.0",
+      "sha256": "0qadddqf56dp4n2bf8a900rc6yh0wn6mb91xgykp2j9xwgwl2fc2",
       "depends": ["AnnotationHub", "FlowSorted_Blood_EPIC", "FlowSorted_DLPFC_450k", "SummarizedExperiment", "dplyr", "minfi", "tibble"]
     },
     "HiCDataHumanIMR90": {
       "name": "HiCDataHumanIMR90",
-      "version": "1.26.0",
-      "sha256": "1l5as56kra8dnvgdynwhmpd4nlj91mrx8qal0mqanxzhdw6w0bzb",
+      "version": "1.27.0",
+      "sha256": "15dpzhxlcwgq07a8sc867shjz854njnc2a57lzvrx4niyc3g0nha",
       "depends": []
     },
     "HiCDataLymphoblast": {
       "name": "HiCDataLymphoblast",
-      "version": "1.42.0",
-      "sha256": "1i47am8j3ygzczl3hqjymnrpsjc1w5q41gcwl24j9h82qa80plrx",
+      "version": "1.43.0",
+      "sha256": "19dhdg8yhmldrlzlyxg0rwwbg4sj47pgn21d3f92cy9l349iqbaz",
       "depends": []
     },
     "HiContactsData": {
       "name": "HiContactsData",
-      "version": "1.8.0",
-      "sha256": "0lrgqri557l7iflsljj18vz5z8b3z1dyrcchxf5g798fvrb5jk0q",
+      "version": "1.9.0",
+      "sha256": "0srvk7vdijk1z3ir3yrqisnn2rswpnfkp02rxrkprkqi1qn82kl0",
       "depends": ["AnnotationHub", "BiocFileCache", "ExperimentHub"]
     },
     "HighlyReplicatedRNASeq": {
       "name": "HighlyReplicatedRNASeq",
-      "version": "1.18.0",
-      "sha256": "08r930wyrmf23aiaipid766ckjal4f4q3fr7gxqk1vy21bhq2h70",
+      "version": "1.19.0",
+      "sha256": "0db5sfrmlczdk9nhg1zkn7pfm993wncaf5c4120yprmdkmnlz6is",
       "depends": ["ExperimentHub", "S4Vectors", "SummarizedExperiment"]
-    },
-    "Hiiragi2013": {
-      "name": "Hiiragi2013",
-      "version": "1.41.0",
-      "sha256": "0z8ns2qsnng3kvzcris3hxggy1jmzrl8jwy0ndf6sbn1cqj1pnkl",
-      "depends": ["Biobase", "KEGGREST", "MASS", "RColorBrewer", "affy", "boot", "clue", "cluster", "genefilter", "geneplotter", "gplots", "gtools", "lattice", "latticeExtra", "mouse4302_db", "xtable"]
     },
     "HumanAffyData": {
       "name": "HumanAffyData",
-      "version": "1.32.0",
-      "sha256": "1vdiwdivxxsz4r3505bqqv4mly6q11mzll0pq1g7dhjmdmy6xxzf",
+      "version": "1.33.0",
+      "sha256": "1k52gy3d5f7a64zdaa861shg97lcg9xb3lpjhf2sdckxdbc68v48",
       "depends": ["Biobase", "ExperimentHub"]
     },
     "IHWpaper": {
       "name": "IHWpaper",
-      "version": "1.34.0",
-      "sha256": "0vg5vj91k0pv80rh1l8x4psd4km9ds3yy4mlpw8qwgd1sqwj1h3x",
+      "version": "1.35.0",
+      "sha256": "0kb9xl7v77r1rzkaadmqzmc920g7gc0k5sxwrdikvqf0fykcq07a",
       "depends": ["Biobase", "BiocGenerics", "BiocParallel", "DESeq2", "IHW", "Rcpp", "SummarizedExperiment", "cowplot", "dplyr", "fdrtool", "genefilter", "ggplot2", "qvalue"]
     },
     "ITALICSData": {
       "name": "ITALICSData",
-      "version": "2.44.0",
-      "sha256": "0gdr3r7ivyyfawrx5bmlqf617z3s3hcv4la58bd0wq9xdw79fw74",
+      "version": "2.45.0",
+      "sha256": "08db6j85izwcbai4jwddvh02ynf1qmb5rm3x4am4z4gn9cm04pc5",
       "depends": []
     },
     "Illumina450ProbeVariants_db": {
       "name": "Illumina450ProbeVariants.db",
-      "version": "1.42.0",
-      "sha256": "0sp9znznmqhf0h4g5gbz34hn3frki6nfqvfs7v1w6kin3y9k2gr5",
+      "version": "1.43.0",
+      "sha256": "1hwqwj7b7rw7fyhpgqlbmsqcs0m0mvy8dx8zymckksiia6iamxwr",
       "depends": []
     },
     "IlluminaDataTestFiles": {
       "name": "IlluminaDataTestFiles",
-      "version": "1.44.0",
-      "sha256": "0xwck8i2r2866kaimwy9klg85fs81f6h4i9zw20zxxd0qmqkpzwi",
+      "version": "1.45.0",
+      "sha256": "04np112xpam819xyzbcrna6w5bjps4bsmhrrqyzjbbj35plsk9ys",
       "depends": []
     },
     "Iyer517": {
       "name": "Iyer517",
-      "version": "1.48.0",
-      "sha256": "1849ni75zk72mzpnmd5q9c6rxc2s7d0kx61fk5hkl0pilm9y9zy8",
+      "version": "1.49.0",
+      "sha256": "022y8cydi05fwyd40vpgzfnmp55ahd0lw29xxx77y9akx15hmc9p",
       "depends": ["Biobase"]
     },
     "JASPAR2014": {
       "name": "JASPAR2014",
-      "version": "1.42.0",
-      "sha256": "0487bxyc24saxy0r3hdxapqcrh20qgr8rdwkskc1w8l4qgi01rj8",
+      "version": "1.43.0",
+      "sha256": "1kbq8vg3isx2fql17k7c169nsff17035rpr47da0dvaxjpxr1wcd",
       "depends": ["Biostrings"]
     },
     "JASPAR2016": {
       "name": "JASPAR2016",
-      "version": "1.34.0",
-      "sha256": "0vg47zvpb20vhk177d1hj959cj1srfql10ywakzkhw7h4hmc8jnl",
+      "version": "1.35.0",
+      "sha256": "1vnbj0ff94d7wrgf76m74jjp8l6hrh7k5nwj3d5l3rmzarlac03g",
       "depends": []
     },
     "JohnsonKinaseData": {
       "name": "JohnsonKinaseData",
-      "version": "1.2.0",
-      "sha256": "0i9l1bdbdvv7npb8bviyl0y8fpmhg6wj3ysr8z6d9a8ycplsm3jr",
+      "version": "1.3.0",
+      "sha256": "0m95w9aqrgsvxzjyas8rc5p8zvcvn590cp3l6rh984ypl8wapdl6",
       "depends": ["BiocParallel", "ExperimentHub", "checkmate", "dplyr", "purrr", "stringr", "tidyr"]
     },
     "KEGGandMetacoreDzPathwaysGEO": {
       "name": "KEGGandMetacoreDzPathwaysGEO",
-      "version": "1.26.0",
-      "sha256": "0gpvw6hgn0xis0zkqx0i05hy2ijsda0kwsxddh9758r1ablzd0rl",
+      "version": "1.27.0",
+      "sha256": "1l8zxflwbfcdbdynb21rry8mhqjbms9vkklchdjgsgs108an93c7",
       "depends": ["Biobase", "BiocGenerics"]
     },
     "KEGGdzPathwaysGEO": {
       "name": "KEGGdzPathwaysGEO",
-      "version": "1.44.0",
-      "sha256": "15xvh2vm2mzwfqq2jw667k33y9kayjnpligz34yczjhv59559xs8",
+      "version": "1.45.0",
+      "sha256": "0grwv6zagkclwla3qgxxaib953iybbk6bybhp67xkb9z0y64jhja",
       "depends": ["Biobase", "BiocGenerics"]
     },
     "KOdata": {
       "name": "KOdata",
-      "version": "1.32.0",
-      "sha256": "1iwjl8w5gbw190z40m4rani4kql2na4sil1wpdvbs5d4pnw5n2qa",
+      "version": "1.33.0",
+      "sha256": "0hz1nbdbrv8dmcv7506bnmcikz455mpqzb309jidiz2v5w1prign",
       "depends": []
     },
     "LRcellTypeMarkers": {
       "name": "LRcellTypeMarkers",
-      "version": "1.14.0",
-      "sha256": "0q5mw2fdz3hlnxx3k7qca7wr50s49jymgqyr8ydq4dfqqcvmzxyr",
+      "version": "1.15.0",
+      "sha256": "1slx2kbgkqdj1h6wvn9ik3xjs683v212vfp1v0q1vszww1pk90mp",
       "depends": ["ExperimentHub"]
     },
     "LegATo": {
       "name": "LegATo",
-      "version": "1.0.0",
-      "sha256": "1lprd2g3qd0r3vqqzfaf3h25gyi4c0bbinqyvadvw3m68n55lcx0",
+      "version": "1.1.3",
+      "sha256": "0gh5jyj7jxgvh22za3g27kwihdf00qfhq1md525lcyswp9j5mvd4",
       "depends": ["MultiAssayExperiment", "S4Vectors", "SummarizedExperiment", "animalcules", "data_table", "dplyr", "ggplot2", "magrittr", "plyr", "rlang", "stringr", "tibble", "tidyr", "tidyselect"]
     },
     "LiebermanAidenHiC2009": {
       "name": "LiebermanAidenHiC2009",
-      "version": "0.44.0",
-      "sha256": "0xa0j53i121r9yscklwcaibhm5826l878w2ys4hwn03kv1jbxm14",
+      "version": "0.45.0",
+      "sha256": "0c69nhvn2rca1bj3iviagq2vzih4as7l8l8y06b2qha264j3q0ib",
       "depends": ["IRanges", "KernSmooth"]
     },
     "ListerEtAlBSseq": {
       "name": "ListerEtAlBSseq",
-      "version": "1.38.0",
-      "sha256": "0i3ql1pyyw53n8q3q2wwhqndhyb960l0j5616vx5777dfybm4j9n",
+      "version": "1.39.0",
+      "sha256": "0dzz0m1fmb8ia1p819zk89wk81zdj3wxma94l2zszkjfvhzbyxkm",
       "depends": ["methylPipe"]
     },
     "LungCancerACvsSCCGEO": {
       "name": "LungCancerACvsSCCGEO",
-      "version": "1.42.0",
-      "sha256": "0xnikck5idln235chn2lyrh7yaaihpwi3dm8d70i0hps9rg7ibix",
+      "version": "1.43.0",
+      "sha256": "0890bbw8hw171vi87fgzywjn9s9bzb8p9ml4wm74sb3pkwn0f1mw",
       "depends": []
     },
     "LungCancerLines": {
       "name": "LungCancerLines",
-      "version": "0.44.0",
-      "sha256": "1g6h8b94hrn8wp6fhjwx1mkrdmqmpmp1y22979apf4fn2al10y17",
+      "version": "0.45.0",
+      "sha256": "12b22615fmfhm0m2vvmzjll1xf6d4h9y6xa4wjj4001pp15gbxwk",
       "depends": ["Rsamtools"]
     },
     "M3DExampleData": {
       "name": "M3DExampleData",
-      "version": "1.32.0",
-      "sha256": "08nid6lqbxf6jjqkp945wg5wr3pv33ljy499563rnvnnadi3gncm",
+      "version": "1.33.0",
+      "sha256": "0vii72qk9hanfhdx61vy98gank0md5wxhhvr2pa8a6crcx2r3l6r",
       "depends": []
     },
     "MACSdata": {
       "name": "MACSdata",
-      "version": "1.14.0",
-      "sha256": "15cs7096hyfqrw1b3lhnfzkirn3g9ryzymdypqdijjgp2l88j419",
+      "version": "1.15.0",
+      "sha256": "1f78p16by0fjlxddsfly0gd70va6rnil87nq8m2mlal097c0hi21",
       "depends": []
     },
     "MAQCsubset": {
       "name": "MAQCsubset",
-      "version": "1.44.0",
-      "sha256": "114sk6yxcz8v7wx2dh661y7nazn8dfik045r2m6zfm0zdkqljd6w",
+      "version": "1.45.0",
+      "sha256": "11hgh8hb8wb0hyjnm08r71pax0jrk7wmykxmxy4bcl0glkr0kqir",
       "depends": ["Biobase", "affy", "lumi"]
     },
     "MEDIPSData": {
       "name": "MEDIPSData",
-      "version": "1.42.0",
-      "sha256": "0vrnyjsdags72fk6ipy3jiw9kq46yrmv4inzff8hrc20rcq74yav",
+      "version": "1.43.0",
+      "sha256": "07xvfa4wzy1yf53a4ymvc8bnjbzfqr0sbz4ya4r8d8kghp1cg5k0",
       "depends": []
     },
     "MEEBOdata": {
       "name": "MEEBOdata",
-      "version": "1.44.0",
-      "sha256": "0imyssybgcl54capbh0bcppky0a8yb109gbsfh7g11j2af9nb0ps",
+      "version": "1.45.0",
+      "sha256": "1y48m5nyv9f6xnry5zgdpcmbchvny4fs8490qvmrj5x3yv26rq21",
       "depends": []
     },
     "MMDiffBamSubset": {
       "name": "MMDiffBamSubset",
-      "version": "1.42.0",
-      "sha256": "0kyyz9fw03gfnpving4swjihz8wi0603l91f1qda5gqj692dg0rs",
+      "version": "1.43.0",
+      "sha256": "0i812gzibqxwq73r4mv9pcymxb5hddp9df6f336q3g8sshjav3s5",
       "depends": []
     },
     "MOFAdata": {
       "name": "MOFAdata",
-      "version": "1.22.0",
-      "sha256": "007rmp37qwrsfm02g1xwzr3az9rv43hz58j41f982z0ikzz8hl2q",
+      "version": "1.23.0",
+      "sha256": "0pp43cjr663rzna508m8i46x70004m6a38b16cc2kqp9fgs1fi9x",
       "depends": []
     },
     "MSMB": {
       "name": "MSMB",
-      "version": "1.24.0",
-      "sha256": "0vshdk1axyvccfixzd3bsgxf6gxpissakg1zk8pqnd87zfznkh8z",
+      "version": "1.25.0",
+      "sha256": "19cxyvl682v4cmwyn1w8imscgwzzy51y69vfb3lphziircwryxn3",
       "depends": ["tibble"]
     },
     "MUGAExampleData": {
       "name": "MUGAExampleData",
-      "version": "1.26.0",
-      "sha256": "1i2pck7nyq8g0vi61cqah570fcsmsx4wdif2siwi37vr17s9fvf7",
+      "version": "1.27.0",
+      "sha256": "1nl173l6cg85lhi2xc5mi9lkzjnirr94x0xzrpdx7famxgbdgv7l",
       "depends": []
     },
     "MerfishData": {
       "name": "MerfishData",
-      "version": "1.8.0",
-      "sha256": "0dnkvmbjpzk0xv8xzpy3qs6yqlrc7ac78n63h21vn7f7zmq7cpmf",
+      "version": "1.9.0",
+      "sha256": "19j6ydap8p9jmlla62np47jx2fsyxrmvlarmv7php3bkmi1jppzx",
       "depends": ["AnnotationHub", "BumpyMatrix", "EBImage", "ExperimentHub", "HDF5Array", "S4Vectors", "SingleCellExperiment", "SpatialExperiment", "SummarizedExperiment"]
     },
     "MetaGxBreast": {
       "name": "MetaGxBreast",
-      "version": "1.26.0",
-      "sha256": "02bhrm1ancachq9yx1nkl1yzvcji8qnqx7v306gx9z5rahr53n15",
+      "version": "1.27.0",
+      "sha256": "1zmi83890d1mx90r75brdwd66hs0kh3zcsy1drxy0vr974vyy0q3",
       "depends": ["AnnotationHub", "Biobase", "ExperimentHub", "SummarizedExperiment", "impute", "lattice"]
     },
     "MetaGxOvarian": {
       "name": "MetaGxOvarian",
-      "version": "1.26.0",
-      "sha256": "00wnfhj5bdq5gps26c3z0kv981wwy7qcradcjcc75v7la75wm8xw",
+      "version": "1.27.0",
+      "sha256": "0p748si4axvdslb487y240y2c4ap7mpyvr9z1s5849fn3zi05pgj",
       "depends": ["AnnotationHub", "Biobase", "ExperimentHub", "SummarizedExperiment", "impute", "lattice"]
     },
     "MetaGxPancreas": {
       "name": "MetaGxPancreas",
-      "version": "1.26.0",
-      "sha256": "11fbrva5yhjqw29vyl823k8g1gy8a476d3d1754x2a8yj5aw7n80",
+      "version": "1.27.0",
+      "sha256": "0ymi13ry25rq61i657ci96b07wqgqkcfzfw9hcz0iq10sr01qj11",
       "depends": ["AnnotationHub", "ExperimentHub", "S4Vectors", "SummarizedExperiment", "impute"]
     },
     "MetaScope": {
       "name": "MetaScope",
-      "version": "1.6.0",
-      "sha256": "1f7w4dfv6sizpp97vjwm034ha4pcq93b3j0gg1l75s6ans8s89aw",
-      "depends": ["BiocFileCache", "Biostrings", "Matrix", "MultiAssayExperiment", "Rbowtie2", "Rsamtools", "S4Vectors", "SummarizedExperiment", "data_table", "dplyr", "ggplot2", "magrittr", "readr", "rlang", "stringr", "taxize", "tibble", "tidyr"]
+      "version": "1.7.6",
+      "sha256": "0chwah5smj607mpvczxsq5fl37bz5gxjh960vb2k58286lgycikp",
+      "depends": ["BiocFileCache", "Biostrings", "Matrix", "MultiAssayExperiment", "Rbowtie2", "Rsamtools", "S4Vectors", "SummarizedExperiment", "data_table", "dplyr", "ggplot2", "magrittr", "readr", "rlang", "stringr", "taxonomizr", "tibble", "tidyr"]
     },
     "MethylAidData": {
       "name": "MethylAidData",
-      "version": "1.38.0",
-      "sha256": "1y8kcbbi76cfw379g2wlml2adkf0vn1bmyhqq8vp70vdc23n9vr1",
+      "version": "1.39.0",
+      "sha256": "0sb18f6051nyhi2q5fikh5zz8n6fdx22bpkjrxzpi9z6khsip708",
       "depends": ["MethylAid"]
     },
     "MethylSeqData": {
       "name": "MethylSeqData",
-      "version": "1.16.0",
-      "sha256": "0qflbqkslp2fhprhhjagskd91833lxsxydfq12an57v5ww25ix4r",
+      "version": "1.17.0",
+      "sha256": "04cv0vvaw2gacqlyrkng58cz526x6m2v0d1nja4qbazy3s30mjip",
       "depends": ["ExperimentHub", "GenomeInfoDb", "GenomicRanges", "HDF5Array", "IRanges", "S4Vectors", "SummarizedExperiment", "rhdf5"]
     },
     "MicrobiomeBenchmarkData": {
       "name": "MicrobiomeBenchmarkData",
-      "version": "1.8.0",
-      "sha256": "0ca79ss8a31diykqpy323dd4sb7iky4gqyvil2wagy6hq25mdqp7",
+      "version": "1.9.0",
+      "sha256": "1dmavlsks49l8mp1q7nrqdzpd0jssj6i7h5bj0p96l53v8q47syp",
       "depends": ["BiocFileCache", "S4Vectors", "SummarizedExperiment", "TreeSummarizedExperiment", "ape"]
     },
     "MouseAgingData": {
       "name": "MouseAgingData",
-      "version": "1.2.0",
-      "sha256": "0cw03p2xk8amgswjzvka5l23crhd9f8p2ggr7rdib4wy3cidvhmg",
+      "version": "1.3.0",
+      "sha256": "09lp7wd6y53sjvhb6yvn1i097czfkq65wzx4yg2k7m7l68kikpv4",
       "depends": ["AnnotationHub", "ExperimentHub", "SingleCellExperiment"]
     },
     "MouseGastrulationData": {
       "name": "MouseGastrulationData",
-      "version": "1.20.0",
-      "sha256": "1w2907hcja7rkdrizh0rmdf75liy2zx4v9kxp4xx12x222q9ngz6",
+      "version": "1.21.0",
+      "sha256": "1rb4b9vzdj2b5bxmnvsqvij7c2j6zn4y0ajiicplkkr6sn1xfv5h",
       "depends": ["BiocGenerics", "BumpyMatrix", "ExperimentHub", "S4Vectors", "SingleCellExperiment", "SpatialExperiment", "SummarizedExperiment"]
     },
     "MouseThymusAgeing": {
       "name": "MouseThymusAgeing",
-      "version": "1.14.0",
-      "sha256": "0sbb4vr4gs2sbkn35cwhysx6gqp25l4ifx4pqvll7nywq9hr28if",
+      "version": "1.15.0",
+      "sha256": "0c40apr15k5h24fv4czy87jaax7inq9mgfwyh8011gsfalsshpdn",
       "depends": ["BiocGenerics", "ExperimentHub", "S4Vectors", "SingleCellExperiment", "SummarizedExperiment"]
     },
     "NCIgraphData": {
       "name": "NCIgraphData",
-      "version": "1.42.0",
-      "sha256": "15bvrqyvd3lg9y5qy749dc7giq4hx9ixlk342gbf7n2jhnjhh0gz",
+      "version": "1.43.0",
+      "sha256": "0xczl54bkv7gd41brhvhx5dn43am46vqzci22mr40kj7r6kkapss",
       "depends": []
     },
     "NGScopyData": {
       "name": "NGScopyData",
-      "version": "1.26.0",
-      "sha256": "123gla377dck6vvki3dxv7absscp73229i2sl1p1kfzmy0bvf4lk",
+      "version": "1.27.0",
+      "sha256": "0s14zq4z1mxmixsynm2mjr5rrhdvs0r2zz0lwby9kg2x557mk49a",
       "depends": []
     },
     "NanoporeRNASeq": {
       "name": "NanoporeRNASeq",
-      "version": "1.16.0",
-      "sha256": "0z0aa9nd0f3l1ncl8gbm50x779lgpazi6fwzxl7p1xnrikwa7lzp",
+      "version": "1.17.0",
+      "sha256": "0m56p7xkij1rf2pg40qan8clfid232xk8fdz5q1ml9mcbw40hscz",
       "depends": ["ExperimentHub"]
     },
     "NestLink": {
       "name": "NestLink",
-      "version": "1.22.0",
-      "sha256": "0fgl07gqipxmj0yqqa97inqdv8fma2n8lm20irpj825798f0iq6z",
+      "version": "1.23.0",
+      "sha256": "0051r71dhnvridvcifccm7038jbddwfcaw4qk8f4p5c51ggc5n4z",
       "depends": ["AnnotationHub", "Biostrings", "ExperimentHub", "ShortRead", "gplots", "protViz"]
     },
     "NetActivityData": {
       "name": "NetActivityData",
-      "version": "1.8.0",
-      "sha256": "0b6f07467l448dw2nrv243gf7mhhyq59w4by54iwdb9zk1gyvwlm",
+      "version": "1.9.0",
+      "sha256": "1dynvwsk3pfapm061i1m6n5vdl14niwpi0brahzw5lhpw10mfjpd",
       "depends": []
     },
     "Neve2006": {
       "name": "Neve2006",
-      "version": "0.44.0",
-      "sha256": "0qbqd501scsdx0d7s1pxfjdy2r7nj9d0dgfs368cpbf28wab51jw",
+      "version": "0.45.0",
+      "sha256": "0yi8526k27c3mslx6a81y9ipz3hvjqi5cmyj0sssyafvvxpf35zc",
       "depends": ["Biobase", "annotate", "hgu133a_db"]
     },
     "NxtIRFdata": {
       "name": "NxtIRFdata",
-      "version": "1.12.0",
-      "sha256": "1i2s3mpv057qb543rs4dyqfr9h75w3v1rswrix5lbkp2654n323b",
+      "version": "1.13.0",
+      "sha256": "0ycx3d6ayzhdqk7zsl0gpx6z6hz4y96fp2n32z6mzmglwblg2xra",
       "depends": ["BiocFileCache", "ExperimentHub", "R_utils", "rtracklayer"]
     },
     "OMICsPCAdata": {
       "name": "OMICsPCAdata",
-      "version": "1.24.0",
-      "sha256": "0dqjx33flfcx54qwag5767gqxq09imvy6rgc1qw5d07ms9idv20l",
+      "version": "1.25.0",
+      "sha256": "1pz7vxwqk2hckzslryi2bkmac01zx8rcc8xbfv17wxjnrsyj8912",
       "depends": ["MultiAssayExperiment"]
     },
     "ObMiTi": {
       "name": "ObMiTi",
-      "version": "1.14.0",
-      "sha256": "194m049axyprmvxfc3f40p8vkkwqnh2kjc47ayqiplfhdihr94n5",
+      "version": "1.15.0",
+      "sha256": "1pls427hylmjfd7ym9xypb4y25mr76qfw5zn902mzarq2702wj66",
       "depends": ["ExperimentHub", "SummarizedExperiment"]
     },
     "OnassisJavaLibs": {
       "name": "OnassisJavaLibs",
-      "version": "1.28.0",
-      "sha256": "00pryisrs1cy6xw9lmwxqd87ybmmjasch764d8kfbn0dhzn5s2h1",
+      "version": "1.29.0",
+      "sha256": "13rwq5ly74phqhflqpg6v24n2wdqd69mf894nbiy6kzi63d4fbn6",
       "depends": ["rJava"]
     },
     "PCHiCdata": {
       "name": "PCHiCdata",
-      "version": "1.34.0",
-      "sha256": "110b8ss4mfh9gvhbkvkwxhsjx82wzdk159b76643id9gwrhvick6",
+      "version": "1.35.0",
+      "sha256": "1pxa1232dv5fx5s5xjfg5i9gyvpb2a92mp1s4w3k1161f7ln091y",
       "depends": ["Chicago"]
     },
     "PREDAsampledata": {
       "name": "PREDAsampledata",
-      "version": "0.46.0",
-      "sha256": "1hif80a3w16c8da04bh1jw0n7yyp7msjshasni6k858ygw0q3wwh",
+      "version": "0.47.0",
+      "sha256": "1ywcma4zfqffbycc9d6pa283gcl62gqf6gfaplykjbpfb7ckld1j",
       "depends": ["Biobase", "PREDA", "affy", "annotate"]
     },
     "PWMEnrich_Dmelanogaster_background": {
       "name": "PWMEnrich.Dmelanogaster.background",
-      "version": "4.40.0",
-      "sha256": "13l0dylava0d7gmiqkn1wpqnkkixqcv3njlwr1v73hmmzi382sjs",
+      "version": "4.41.0",
+      "sha256": "02jhbw4gwjlqkc1jrl6apdp3lfkz9fl6br5fl9kp3kdfm9kvc4jb",
       "depends": ["PWMEnrich"]
     },
     "PWMEnrich_Hsapiens_background": {
       "name": "PWMEnrich.Hsapiens.background",
-      "version": "4.40.0",
-      "sha256": "0d0dz3w0c88xx9hw1pvaz3p2pxrfwdsmfwlf5ffy0xw9vn3mglhs",
+      "version": "4.41.0",
+      "sha256": "01vqbdsa4krgcfv8q1lpn9wsvkyf10ij5jl9iqvyizavfyli2zcv",
       "depends": ["PWMEnrich"]
     },
     "PWMEnrich_Mmusculus_background": {
       "name": "PWMEnrich.Mmusculus.background",
-      "version": "4.40.0",
-      "sha256": "1jijn2kp5n3ng11bf9vj6mfi422zz1bzs2jb8rp9sdlzqf1n89kr",
+      "version": "4.41.0",
+      "sha256": "1l855sbsxbkgvp474hcdvrjl8c6ii8vp0cvdkxmmfb1583h04ppr",
       "depends": ["PWMEnrich"]
     },
     "PasillaTranscriptExpr": {
       "name": "PasillaTranscriptExpr",
-      "version": "1.34.0",
-      "sha256": "0bjxqnkybdcj6g4q88kiq2mpvap9qwayq99whl634fjawibpipk8",
+      "version": "1.35.0",
+      "sha256": "0inly11ixfks2n678pa3p6bbjijk3pcmd0jx02jfjz1iln5079gh",
       "depends": []
     },
     "PathNetData": {
       "name": "PathNetData",
-      "version": "1.42.0",
-      "sha256": "1wix226lja5mhxzqargmpa3vnyjxs54jvia71jq438pp4ssrsjzq",
+      "version": "1.43.0",
+      "sha256": "1h3blcjxdaq7labv123wjf05v8vdz6a5k45i18csmxxlly6k8i3x",
       "depends": []
     },
     "PepsNMRData": {
       "name": "PepsNMRData",
-      "version": "1.24.0",
-      "sha256": "1rvmkyi9y6ny1xyz9xlblp99ddjx1s4wzp1wghdk53rc8qn3fm1v",
+      "version": "1.25.0",
+      "sha256": "1b4d1rwlyxlihzzdrv1r4fbn6i2l4cwjnnim5x3vy11ljpfpn9np",
       "depends": []
     },
     "PhyloProfileData": {
       "name": "PhyloProfileData",
-      "version": "1.20.0",
-      "sha256": "1b1qf8s7il8cyjfmp5z3zrq21apzc8jyr9hyq2vb6y48gycjjs8k",
+      "version": "1.21.0",
+      "sha256": "0hjv7v1cqp02793nrlhcd8105pz8q20zgcrqvnhj0ccssfszhk2l",
       "depends": ["BiocStyle", "Biostrings", "ExperimentHub"]
     },
     "ProData": {
       "name": "ProData",
-      "version": "1.44.0",
-      "sha256": "0hbglrqlqn6c5y8bhl88djid7bjvnd7m43n346qzqv1baba7rdcd",
+      "version": "1.45.0",
+      "sha256": "0hdcaipsj9nlnkq02dk6633lf6xrgl0y138f4bhvb63fhaipzxdj",
       "depends": ["Biobase"]
     },
     "ProteinGymR": {
       "name": "ProteinGymR",
-      "version": "1.0.0",
-      "sha256": "0p260mha4492dv526sx6kc7dbniy5rmfh209kqi06mq3y5jv28j5",
-      "depends": ["ExperimentHub", "dplyr", "forcats", "ggdist", "gghalves", "ggplot2", "purrr", "queryup", "spdl", "tidyr", "tidyselect"]
+      "version": "1.1.3",
+      "sha256": "0nh0xnb4xks7xnwnl6a923k84g8g6cfw1k8d0ydkc6g2s6w9f5p8",
+      "depends": ["ComplexHeatmap", "ExperimentHub", "circlize", "dplyr", "forcats", "ggdist", "gghalves", "ggplot2", "purrr", "queryup", "spdl", "stringr", "tidyr", "tidyselect"]
     },
     "PtH2O2lipids": {
       "name": "PtH2O2lipids",
-      "version": "1.32.0",
-      "sha256": "1rk9qk6d921lplj8q110kpnipndq576lxn59wpjmpzbzz1qz3946",
+      "version": "1.33.0",
+      "sha256": "06r93w77imam6py2zpqivh4z4mm3dvhhffl581mamlkhxzslg4k6",
       "depends": ["CAMERA", "LOBSTAHS", "xcms"]
     },
     "QDNAseq_hg19": {
       "name": "QDNAseq.hg19",
-      "version": "1.36.0",
-      "sha256": "1k80df803nzbaqvbhnj6d973dzqcjsps3gaxhw1w1x6hm231qnjc",
+      "version": "1.37.0",
+      "sha256": "1a2xpwnvpfdya3zz3x3h5yy1289razyawpbf794qd6pzf163cw5i",
       "depends": ["QDNAseq"]
     },
     "QDNAseq_mm10": {
       "name": "QDNAseq.mm10",
-      "version": "1.36.0",
-      "sha256": "0dy776lham0n7hjdy3xf34bs9a9bzqf70xsaxv4mc94x807bicfs",
+      "version": "1.37.0",
+      "sha256": "1a325lk5ihyl12pgy80fahg13j4qc3mwbcsx77csxg3d9x75sg28",
       "depends": ["QDNAseq"]
     },
     "QUBICdata": {
       "name": "QUBICdata",
-      "version": "1.34.0",
-      "sha256": "1wyi0x64f7gvj2sxg0l01dpwx09h2ga14kiybjfbrhzsp54288w2",
+      "version": "1.35.0",
+      "sha256": "0qazkslrwv3blbsmfilksv76z0k4d72v5pnasfw1y4d228k440ya",
       "depends": []
     },
     "RGMQLlib": {
       "name": "RGMQLlib",
-      "version": "1.26.0",
-      "sha256": "1j6n8nvkfcdyh39d70nscm6xmkvyahmq16znc1ya12azkp0n3fpg",
+      "version": "1.27.0",
+      "sha256": "0hbrkwfx9vj1wp5cjkhi049fk058b7jwa3s4anjqwxj25xm377yn",
       "depends": []
     },
     "RITANdata": {
       "name": "RITANdata",
-      "version": "1.30.0",
-      "sha256": "1azrkw0zxplmzlb3vs58mw9nka23p13xblrq9pqdfvv7cpcpq4la",
+      "version": "1.31.0",
+      "sha256": "1drdw2mhc2wbylip8qd2izahgvm2w2xp38x5xbwfp8q2168am20k",
       "depends": []
     },
     "RMassBankData": {
       "name": "RMassBankData",
-      "version": "1.44.0",
-      "sha256": "196n2qq63gkcjqlill2wc3v0hiq1zxqw75c2r4y9z6j6ac11ryz9",
+      "version": "1.45.0",
+      "sha256": "10f9rsbgblgl52df5r8xzq8la4y5z3i5dlacnpmcl3wsjzk859cv",
       "depends": []
-    },
-    "RNAinteractMAPK": {
-      "name": "RNAinteractMAPK",
-      "version": "1.41.0",
-      "sha256": "0dfxy6hhcwx8xd4c2a02v41dnrrj97lg7ddl4pfn492rk4qvd4s6",
-      "depends": ["Biobase", "MASS", "fields", "gdata", "genefilter", "lattice", "sparseLDA"]
     },
     "RNAmodR_Data": {
       "name": "RNAmodR.Data",
-      "version": "1.20.0",
-      "sha256": "0msav01jgpv1vhf9p4q5zs50kgg6f1r8lrfad377zbflhf1pf2aw",
+      "version": "1.21.0",
+      "sha256": "0fag8jlzk7fl9sk3sks114wnv109dq5k0k1b7aygd7m072chgp46",
       "depends": ["ExperimentHub", "ExperimentHubData"]
     },
     "RNAseqData_HNRNPC_bam_chr14": {
       "name": "RNAseqData.HNRNPC.bam.chr14",
-      "version": "0.44.0",
-      "sha256": "1yhr798bbv3mc8wnalz4wag1np6kyq6akb0mbpvj47130ifi0wbx",
+      "version": "0.45.0",
+      "sha256": "0bv1k52y28vajdlywrmqgkr3vckf80vrccvf10sj0szcjky0lmlj",
       "depends": []
     },
     "RRBSdata": {
       "name": "RRBSdata",
-      "version": "1.26.0",
-      "sha256": "1yxx7ssm831bph0qhzl9qv9mm4l4hgj9j1x7mn4kf2qqacpkvgjz",
+      "version": "1.27.0",
+      "sha256": "1nrbzdyb06pfahff3ip88dzpbmcr3jz35jsfmy1mpxzxcplw9ign",
       "depends": ["BiSeq"]
     },
     "RTCGA_CNV": {
       "name": "RTCGA.CNV",
-      "version": "1.34.0",
-      "sha256": "0g41nvnp3h35l4yvidbfcmdfx891vfh1h1iqg0fnyhammj6kkf3j",
+      "version": "1.35.0",
+      "sha256": "1dhawv77plavaf5sgi9iwj1pnfwf5q50kr4323gqb61xcnrva75q",
       "depends": ["RTCGA"]
     },
     "RTCGA_PANCAN12": {
       "name": "RTCGA.PANCAN12",
-      "version": "1.34.0",
-      "sha256": "0qkkzrqhyixbrlib6k4918mv66kdvjrz95a6mlcybp1vfscj65p2",
+      "version": "1.35.0",
+      "sha256": "0zrz9g6f5h8w9pskqbywzzmvd2fgdx74gbs3gmg3b91hb6hc5ncg",
       "depends": ["RTCGA"]
     },
     "RTCGA_RPPA": {
       "name": "RTCGA.RPPA",
-      "version": "1.34.0",
-      "sha256": "0n0gsijswgphpp6grjq8j7rgjml1zqcfkns48535v5pjgdz07qyk",
+      "version": "1.35.0",
+      "sha256": "0yl7wfv6x7xgxw0zy6nas9rphzcysbh3svpvlhzkhs3mpjlmgrv0",
       "depends": ["RTCGA"]
     },
     "RTCGA_clinical": {
       "name": "RTCGA.clinical",
-      "version": "20151101.36.0",
-      "sha256": "1ax41ngjrngvnsgysffgh9wyixn2izbjyb4s494vkmhqrrsww055",
+      "version": "20151101.37.0",
+      "sha256": "0nhwwmfkz0yyl70z9v96nq2mridi1ca9i6wr43ysqy3cjsr1s8zr",
       "depends": ["RTCGA"]
     },
     "RTCGA_mRNA": {
       "name": "RTCGA.mRNA",
-      "version": "1.34.0",
-      "sha256": "1cmak5japs4afq3i2xh33dcxhj2h5qws2s33qkd8hy8rvk09x2vk",
+      "version": "1.35.0",
+      "sha256": "0am2q12rgl7km9v8g98nmag7f711xwlwk1qgzf8lggl6m12d7ph3",
       "depends": ["RTCGA"]
     },
     "RTCGA_methylation": {
       "name": "RTCGA.methylation",
-      "version": "1.34.0",
-      "sha256": "19k0c8q1xmzgjh59wv3c9p1wxkpssp072vpwnpyrgi0zrigxdz4q",
+      "version": "1.35.0",
+      "sha256": "0lgzh4lsa4csa7c7hr6lj3n4qqpdqvk0f5fba2xaaw6xmshr8kvs",
       "depends": ["RTCGA"]
     },
     "RTCGA_miRNASeq": {
       "name": "RTCGA.miRNASeq",
-      "version": "1.34.0",
-      "sha256": "1p2350rw2dwzpw5wa1cq1yijrhym2vwlf3khmvbjjlm4khgwznzq",
+      "version": "1.35.0",
+      "sha256": "1f1wgmrv8ayd25l69bg575jjfpidxs0k2lfwxw6n6pyvwl831cj7",
       "depends": ["RTCGA"]
     },
     "RTCGA_mutations": {
       "name": "RTCGA.mutations",
-      "version": "20151101.36.0",
-      "sha256": "1bklbf6rywgd5azig861iqg4x0czrx0rbf1s16x54g5ww8aci2bz",
+      "version": "20151101.37.0",
+      "sha256": "11kd88gpyzkk4lywxcn4zwj103ryyhkj9gln4q5j420q6dbr57ap",
       "depends": ["RTCGA"]
     },
     "RTCGA_rnaseq": {
       "name": "RTCGA.rnaseq",
-      "version": "20151101.36.0",
-      "sha256": "0yn89m988gvq4y5nv56581dlh6ydyhd6dkcx1clwalb453v390dz",
+      "version": "20151101.37.0",
+      "sha256": "11sxrwzf43xp0hh8nxpzsd9ylg2bbs1ygd501iijlv9iap4ax9p2",
       "depends": ["RTCGA"]
     },
     "RUVnormalizeData": {
       "name": "RUVnormalizeData",
-      "version": "1.26.0",
-      "sha256": "1rbyrni2bfsm377vlmaw02wy0gz8llls7ad9h1mjiz0jw1jnql8i",
+      "version": "1.27.0",
+      "sha256": "07sx8986x3xqjhd2v1rxijn2z5njywv450vx6hb0wbya3bi0fxzq",
       "depends": ["Biobase"]
     },
     "RcisTarget_hg19_motifDBs_cisbpOnly_500bp": {
       "name": "RcisTarget.hg19.motifDBs.cisbpOnly.500bp",
-      "version": "1.26.0",
-      "sha256": "1c3gsk4jvbwyj7s18hms29liha52820p5mmnpfnhxdhh8g6ll4sc",
+      "version": "1.27.0",
+      "sha256": "0nlinq6a6i0xlqsyx3z75rimjqcpsy1k1kg0nb30zqcwkcwx7vqp",
       "depends": ["data_table"]
     },
     "ReactomeGSA_data": {
       "name": "ReactomeGSA.data",
-      "version": "1.20.0",
-      "sha256": "0j1z4qaqvahjfd4ac5fy2q40f7fiac2jz358h7gdb157d0c7wx9x",
+      "version": "1.21.0",
+      "sha256": "0kf951yzcf8s0661i5r81lvpb5s26w61zxvqxf5vfclma5dykcb2",
       "depends": ["ReactomeGSA", "Seurat", "edgeR", "limma"]
     },
     "RegParallel": {
       "name": "RegParallel",
-      "version": "1.24.0",
-      "sha256": "0611wimhjm3ylv1gasrzjl9dalcbd2vzyxvqn03pybi2hjyp5l52",
+      "version": "1.25.0",
+      "sha256": "0hsnh1qd72npap0w0z1wdwxvfprhxqi5lsffk5bfrp8clmy21xj1",
       "depends": ["arm", "data_table", "doParallel", "foreach", "iterators", "stringr", "survival"]
     },
     "RforProteomics": {
       "name": "RforProteomics",
-      "version": "1.44.0",
-      "sha256": "0rdx13pdqhfq6pijq9a5fn9j5vdihy95pymcidj5cymni6h3a4dd",
+      "version": "1.45.0",
+      "sha256": "0piinyrlp9x3471pzsb1avykpc5j9sii47hw76w6sbs1vl9kz5j8",
       "depends": ["BiocManager", "MSnbase", "R_utils", "biocViews"]
     },
     "RnBeads_hg19": {
       "name": "RnBeads.hg19",
-      "version": "1.38.0",
-      "sha256": "0hvsf3nvyl72rqrwvx54vpca1c445vfchz9h74kd90fgh8crydcm",
+      "version": "1.39.0",
+      "sha256": "0hlh5bc566vhzxdjiabj0jz9p6ic9wgjgd19lv0q88dxiq7b43ni",
       "depends": ["GenomicRanges"]
     },
     "RnBeads_hg38": {
       "name": "RnBeads.hg38",
-      "version": "1.38.0",
-      "sha256": "1wpnkh1rsirnvbbl7y89lmr9q5r6hr331n20qjav92j3g41r3bqp",
+      "version": "1.39.1",
+      "sha256": "154sgmz97g08064dbjbw6gr7swjmlizv1rprb79lhdif3v7665f7",
       "depends": ["GenomicRanges"]
     },
     "RnBeads_mm10": {
       "name": "RnBeads.mm10",
-      "version": "2.14.0",
-      "sha256": "1yb22lkklsjs62vj6l5hhp80z5zgil4n93bc1yavixzf81hd7msq",
+      "version": "2.15.0",
+      "sha256": "0z1d8lqqvfasg7z0jzrxpvq0q8a4ndxdg27j4acy50bxzzxgjv76",
       "depends": ["GenomicRanges"]
     },
     "RnBeads_mm9": {
       "name": "RnBeads.mm9",
-      "version": "1.38.0",
-      "sha256": "0s6fq6zqrfm4ixchhqm21imar1hrcn8wmk0dp9wsi4wpc9rffn07",
+      "version": "1.39.0",
+      "sha256": "0dngdh087p3dzfvhxzn481xjqrwlzwzqlalma0hb91ldw61zvb8q",
       "depends": ["GenomicRanges"]
     },
     "RnBeads_rn5": {
       "name": "RnBeads.rn5",
-      "version": "1.38.0",
-      "sha256": "12vbjjw70l0fgx45bf66mpvxifck1sqpnkn6xdf3i8gdijj06jzp",
+      "version": "1.39.0",
+      "sha256": "1a08dkkzsdqxfya7mq5f45bkd9fv51ib6584s3iap71i3bgfy57x",
       "depends": ["GenomicRanges"]
     },
     "RnaSeqSampleSizeData": {
       "name": "RnaSeqSampleSizeData",
-      "version": "1.38.0",
-      "sha256": "094m8n0r4imwy9mqj1qqrn3wxbqazvbk6vj5b189sh3ll42xqddq",
+      "version": "1.39.0",
+      "sha256": "04d0ajln6j2r3niib8kkwyqdhxfprmqx8z8fir7ydnvgh1qzjicz",
       "depends": ["edgeR"]
     },
     "SBGNview_data": {
       "name": "SBGNview.data",
-      "version": "1.20.0",
-      "sha256": "1n76ggmsh5h7gdn22jlhy7vs81qmijgdx63nmalm4bmrm4m9jzgb",
+      "version": "1.21.0",
+      "sha256": "1y8x6hm9d2b1bz8s391g4kb3fxyniqj7qx2fx5gy19w24s3j05qi",
       "depends": ["bookdown", "knitr", "rmarkdown"]
     },
     "SCLCBam": {
       "name": "SCLCBam",
-      "version": "1.38.0",
-      "sha256": "0fp2jrx2dpzipgkgzsvr2pasnhmwyms4p1mis9389bwxivni6giw",
+      "version": "1.39.0",
+      "sha256": "0lyqa5rkpi570643wmfpqp6yahi67ggyxglp9b8hrfc9ngmhylbv",
       "depends": []
     },
     "SFEData": {
       "name": "SFEData",
-      "version": "1.8.1",
-      "sha256": "19wclzk4pd9lms64wfjpy8yd8iq6lv2a563lqdqcbk072i3c7m24",
+      "version": "1.9.1",
+      "sha256": "04k3ax5b7wrgkm5wa2jlh6g362cka7jwyd2rkcj74h59nn3qaqj8",
       "depends": ["AnnotationHub", "BiocFileCache", "ExperimentHub"]
     },
     "SNAData": {
       "name": "SNAData",
-      "version": "1.52.0",
-      "sha256": "0fjypgshp6xsqgqz55mcc0iwmz0i8zf9zgankpw0lbiganrnbmgv",
+      "version": "1.53.0",
+      "sha256": "12nf92gd86fqhi4rmijan647b83vhaa00nnl90jw1wf7k20ih05w",
       "depends": ["graph"]
     },
     "SNAGEEdata": {
       "name": "SNAGEEdata",
-      "version": "1.42.0",
-      "sha256": "1n0akijkyq0rngcjalgz9srrqribpj605q7ph9wwf0yv9xnzq972",
+      "version": "1.43.0",
+      "sha256": "1qp8pajdg72dqpbb8k91s3d94q96iriziknzq6mn18b739mf8v88",
       "depends": []
     },
     "SNPhoodData": {
       "name": "SNPhoodData",
-      "version": "1.36.0",
-      "sha256": "15kh75sk4025ixjp7c706923j719qbq6hk93sc87yl06w9yhq24w",
+      "version": "1.37.0",
+      "sha256": "1y5zx4y3c96rd63zhlqzby2644nnv53dsxlnxyh1srf0d2b535ki",
       "depends": []
     },
     "STexampleData": {
       "name": "STexampleData",
-      "version": "1.14.1",
-      "sha256": "14xdinp0ix55lgs0adcxwnjascrpx4s39kghrhbcpjl0ainrdhk3",
+      "version": "1.15.3",
+      "sha256": "0f70lvgkrh604sxl3gg1qpa5225750malyd1dmdlnljmvklbmmb7",
       "depends": ["ExperimentHub", "SingleCellExperiment", "SpatialExperiment"]
     },
     "SVM2CRMdata": {
       "name": "SVM2CRMdata",
-      "version": "1.38.0",
-      "sha256": "15p33gwbwa41qm1hcs1a8aywqmmnd1ndaxl3fqbz92qfm0lcp9ml",
+      "version": "1.39.0",
+      "sha256": "1sqyd5na8p5lmhj60z1psq6yis9hjhgxkfn1qc698kpmk5qhisl3",
       "depends": []
     },
     "SimBenchData": {
       "name": "SimBenchData",
-      "version": "1.14.0",
-      "sha256": "1zcbdygmnpmphbmf6rly6vz9v4cq0gcv2rm9yq0yzs323290f8fr",
+      "version": "1.15.0",
+      "sha256": "1b3d7pf7frln85yvra3wgs5992034n5l3bmpd22aqkg03vbbx778",
       "depends": ["ExperimentHub", "S4Vectors"]
     },
     "Single_mTEC_Transcriptomes": {
       "name": "Single.mTEC.Transcriptomes",
-      "version": "1.34.0",
-      "sha256": "1mqqpdf5b4rznm0bsm1pdiday6qxgav1622jpakp4av233ipswrn",
+      "version": "1.35.0",
+      "sha256": "0lb14q8k200qxsxni9i4g76zq2wlgr7s50mrs004irf64802s139",
       "depends": []
     },
     "SingleCellMultiModal": {
       "name": "SingleCellMultiModal",
-      "version": "1.18.0",
-      "sha256": "14ph8yd82xsjlihidn39dqmll2cq00gxpqpj605fqz61i317vs23",
+      "version": "1.19.2",
+      "sha256": "18vmjnlcjgqcmhsvlv4db5fzyimnlsdldjm906njyjir7kbv0jri",
       "depends": ["AnnotationHub", "BiocBaseUtils", "BiocFileCache", "ExperimentHub", "HDF5Array", "Matrix", "MultiAssayExperiment", "S4Vectors", "SingleCellExperiment", "SpatialExperiment", "SummarizedExperiment"]
     },
     "SingleMoleculeFootprintingData": {
       "name": "SingleMoleculeFootprintingData",
-      "version": "1.14.0",
-      "sha256": "02ndxsbif4bnklwb8llxf8jkinnqcyfjb04x0qpcyyn3b0m43w5v",
+      "version": "1.15.0",
+      "sha256": "1nwhlg0adw355xyxr2hb49d9r6r29zr79fdyk50kqjvcbdnb7qn5",
       "depends": ["ExperimentHub"]
     },
     "SomatiCAData": {
       "name": "SomatiCAData",
-      "version": "1.44.0",
-      "sha256": "1ahh6hjsifg65x09miq2ilc85j58drxg9xajjd521kj75z4argag",
+      "version": "1.45.0",
+      "sha256": "08s45h068hc8zqa03jyj603byb7rnsmnb16hladwvzr7a4pazq7h",
       "depends": []
     },
     "SomaticCancerAlterations": {
       "name": "SomaticCancerAlterations",
-      "version": "1.42.0",
-      "sha256": "1j7gdbw0n41f44l66xfw8m0q84rbx7c2lcwpdbpssb7k4mnkl9bf",
+      "version": "1.43.0",
+      "sha256": "1zbf8q7k1jgnycq60kzli8pcvgkd65pr7myd0h5b7shaq2rssqkg",
       "depends": ["GenomicRanges", "IRanges", "S4Vectors"]
     },
     "SpatialDatasets": {
       "name": "SpatialDatasets",
-      "version": "1.4.0",
-      "sha256": "0pl53dmcymlj819lplynxidk8vjfq5w46g5hwgyllc83mqjgc5rq",
+      "version": "1.5.0",
+      "sha256": "17mxzzp569mcs5fmcqqjbv2j35whnxqs1qfahkpn9bq19gcqbnk9",
       "depends": ["ExperimentHub", "SpatialExperiment"]
     },
     "SpikeIn": {
       "name": "SpikeIn",
-      "version": "1.48.0",
-      "sha256": "0rv0szm3izqldg7hpbq1b501l6mk7c27h7a1vf8vd0y68zcri8ck",
+      "version": "1.49.0",
+      "sha256": "0v11h2jzyy4104mngl22rc1lb6rbxx42idq44890w9mf19xpzbnh",
       "depends": ["affy"]
     },
     "SpikeInSubset": {
       "name": "SpikeInSubset",
-      "version": "1.46.0",
-      "sha256": "1xkhmy2jjdy50mqr3zpsqqk49slzvk89swqcxnp4nvcz5qhk6zgg",
+      "version": "1.47.0",
+      "sha256": "0lksw5xbjp2l52c03h8ibmg6lb1clkxrxhyi1l83m2panhdbis8j",
       "depends": ["Biobase", "affy"]
     },
     "SubcellularSpatialData": {
       "name": "SubcellularSpatialData",
-      "version": "1.2.0",
-      "sha256": "0ivsn1s35vhfmwkn9y3q1pmcjlpyfplfqnsnz08jnknijkbyfmy4",
+      "version": "1.3.0",
+      "sha256": "1c2rqwjrs4k6pj0y705yqy1qchm09vdjf1fp5s66hxjc81c7fi46",
       "depends": ["Matrix", "SpatialExperiment", "dplyr", "hexbin"]
     },
     "TBX20BamSubset": {
       "name": "TBX20BamSubset",
-      "version": "1.42.0",
-      "sha256": "107pj3y40rr740mv7sphd67dh360ld8lbrlwknxp6kwwg08wyaj3",
+      "version": "1.43.0",
+      "sha256": "18qc0gy6mllcgdip1xxnz9dzm7hyai460vpr3h90rrwiwrn1czjj",
       "depends": ["Rsamtools", "xtable"]
     },
     "TCGAMethylation450k": {
       "name": "TCGAMethylation450k",
-      "version": "1.42.0",
-      "sha256": "1lfxs3lva03pdxdx09llm2wirc367fdp30bia8lw0kb59c6d0s72",
+      "version": "1.43.0",
+      "sha256": "0j19jl4qdb6m8k63234gn59ibcsn88kyfhk6s4vs9pxkvhqjsmhz",
       "depends": []
     },
     "TCGAWorkflowData": {
       "name": "TCGAWorkflowData",
-      "version": "1.30.0",
-      "sha256": "1g3xslb14xkygv6i6wlsna014aqqz052wz2c44afqffqrd8szm5d",
+      "version": "1.31.0",
+      "sha256": "1xsqbkj9s5k8hl2pyh1liql5l0g0l4g4bm9yy8zi7yiqkzwa0ylr",
       "depends": ["SummarizedExperiment"]
     },
     "TCGAbiolinksGUI_data": {
       "name": "TCGAbiolinksGUI.data",
-      "version": "1.26.0",
-      "sha256": "16ki2mwippf7mk6xrr90m243njvdkdi74yq6lfbklnxsscwcw556",
+      "version": "1.27.0",
+      "sha256": "01yg2diyf8q0zwnrk7pdiyxsx9w9v9vmyax7yscp9i4hsjrr0wws",
       "depends": []
     },
     "TCGAcrcmRNA": {
       "name": "TCGAcrcmRNA",
-      "version": "1.26.0",
-      "sha256": "0cjbjzbnzhlzpc6p7v6z0x82igdsnyz1xjm5whlpf8d4x5q9xjjd",
+      "version": "1.27.0",
+      "sha256": "0z4gklsa1gixc9m2waxz1da36pky5frrs1mvk0hyx0zp0gn1asmm",
       "depends": ["Biobase"]
     },
     "TCGAcrcmiRNA": {
       "name": "TCGAcrcmiRNA",
-      "version": "1.26.0",
-      "sha256": "1iwvzfncg4jy6fxqfwzhcbks8vlf1ynifhawd42g73cawgpbjlv5",
+      "version": "1.27.0",
+      "sha256": "1vb7x1k7iiii1if70qbrcvxa5chnrnsnj0gn1fqaxhvr2sdr9xvr",
       "depends": ["Biobase"]
+    },
+    "TENET_ExperimentHub": {
+      "name": "TENET.ExperimentHub",
+      "version": "0.99.3",
+      "sha256": "192kcfq5czww5ip9xz5nzfkg7cxgphzsg6rijzi7i7kla08bsa9s",
+      "depends": ["ExperimentHub", "GenomicRanges", "MultiAssayExperiment", "SummarizedExperiment"]
     },
     "TENxBUSData": {
       "name": "TENxBUSData",
-      "version": "1.20.0",
-      "sha256": "1xyb4cmndqkq5frg5ias5d6c4bgyx5g7pyhakm19v4rkwm6sjmf7",
+      "version": "1.21.0",
+      "sha256": "133g54bbjgx9gskpkgw01gz9adjbqmi8vlchdijih8hpn9bwm5j4",
       "depends": ["AnnotationHub", "BiocGenerics", "ExperimentHub"]
     },
     "TENxBrainData": {
       "name": "TENxBrainData",
-      "version": "1.26.0",
-      "sha256": "1xdi1x5kn6xb8ds6awvlm5rjv78lggci7fd6jw26f1kngfs1fgdm",
+      "version": "1.27.0",
+      "sha256": "16rl4gv93yba9kph6dd1gjh8n2j9fmcw6lrnyp8x07qr3mmbcmxh",
       "depends": ["AnnotationHub", "ExperimentHub", "HDF5Array", "SingleCellExperiment"]
     },
     "TENxPBMCData": {
       "name": "TENxPBMCData",
-      "version": "1.24.0",
-      "sha256": "1a4sqag9wwn31mlbvm2whdcgxkqbzjia6bhrfvxs03b658xk8pv9",
+      "version": "1.25.0",
+      "sha256": "1lsdyqy9cbdhdswd1x4sf5pykkz9kabgvqmrxgyfnwsv4jb6a5df",
       "depends": ["AnnotationHub", "ExperimentHub", "HDF5Array", "SingleCellExperiment"]
     },
     "TENxVisiumData": {
       "name": "TENxVisiumData",
-      "version": "1.14.0",
-      "sha256": "19lc3z5w5icibyg62n6my42gxf7iwy4ic0mymdvbj4ili8ckpd4s",
+      "version": "1.15.0",
+      "sha256": "0n4j02cdfh2y8pa1p2s5887d89j1g4zv6j2nkv0lgxrp6j45fq3x",
       "depends": ["ExperimentHub", "SpatialExperiment"]
     },
     "TENxXeniumData": {
       "name": "TENxXeniumData",
-      "version": "1.2.0",
-      "sha256": "098dyr2h8f2zkmhadczgjpx3mnli1gb0pm6kvfgk21cdb0nwypf6",
+      "version": "1.3.0",
+      "sha256": "11c0yhyfm0x63fq207j2x3mvihnx8wpcvkgnm7xd64q5hnyi15p8",
       "depends": ["BumpyMatrix", "ExperimentHub", "SpatialExperiment", "SpatialFeatureExperiment", "SummarizedExperiment"]
     },
     "TMExplorer": {
       "name": "TMExplorer",
-      "version": "1.16.0",
-      "sha256": "0qsq54hac0j5lq3lh7lama2sqydjs298f5w073nvvdgpikyp3fc3",
+      "version": "1.17.0",
+      "sha256": "0mzhbhjdwlbx4apvdkhglsmzd0rlymywxgnl89a3hnrnpbf8n0ad",
       "depends": ["BiocFileCache", "Matrix", "SingleCellExperiment"]
     },
     "TabulaMurisData": {
       "name": "TabulaMurisData",
-      "version": "1.24.0",
-      "sha256": "0yzp36yyvxsll35d9l5fb0vmihhdj95g8j30k49zx2f3hixyqk25",
+      "version": "1.25.0",
+      "sha256": "1w6r58vgkpp4adqy6n6nq1cy6gm3f7y3rxiilnjk20bi63l1lqzq",
       "depends": ["ExperimentHub"]
     },
     "TabulaMurisSenisData": {
       "name": "TabulaMurisSenisData",
-      "version": "1.12.0",
-      "sha256": "0lgk1ihdwjc1q1b1izbsvnzdm589np45308jmql03d0wcy9vra83",
+      "version": "1.13.0",
+      "sha256": "15yzqz2rv4a88nj2q3d9chl7rwpx9hnmv8ylf4lsp2979yd31n62",
       "depends": ["AnnotationHub", "ExperimentHub", "HDF5Array", "SingleCellExperiment", "SummarizedExperiment", "gdata"]
     },
     "TargetScoreData": {
       "name": "TargetScoreData",
-      "version": "1.42.0",
-      "sha256": "03pv722rjs086f545i1b8q55gc3g3d5lihhj779xy3l28lb98725",
+      "version": "1.43.0",
+      "sha256": "1680743qh69217dvcjr4jr2mmsly6nnnv7rm1f1cnarwzhiwbsf5",
       "depends": []
     },
     "TargetSearchData": {
       "name": "TargetSearchData",
-      "version": "1.44.0",
-      "sha256": "0k3nf4qan4d16myk5dc27wqjgz6s060zhp9ndqs5k961ll89a0x2",
+      "version": "1.45.0",
+      "sha256": "1121gfgrar06zj577zwirpddkav33dwdimfavcpcln1rg0h5jaa0",
       "depends": []
     },
     "TimerQuant": {
       "name": "TimerQuant",
-      "version": "1.36.0",
-      "sha256": "1mchffpddyl29x5yih6g3w1033pvshq9fcgh8jh8h7r258smrjij",
+      "version": "1.37.0",
+      "sha256": "0mmx1xd7ccjykij0hg8qbxh7z4nyzg3z6m2ffyqpmznmcgb6yf93",
       "depends": ["deSolve", "dplyr", "ggplot2", "gridExtra", "locfit", "shiny"]
     },
     "TransOmicsData": {
       "name": "TransOmicsData",
-      "version": "1.2.0",
-      "sha256": "04jkip71ydq669l5nz9jaxx8g127lskdx4lqxh6n32rcqw3f061y",
+      "version": "1.3.0",
+      "sha256": "1m3llywai1fwj4wvmcybzi2qf0jyx7mafy60pmkx2dsvm25rsh9b",
       "depends": ["S4Vectors"]
     },
     "TumourMethData": {
       "name": "TumourMethData",
-      "version": "1.4.0",
-      "sha256": "14y58qa4khi4jdymilxrb6x57br1gjclw2q3n9mivjrj6z3r3nmw",
-      "depends": ["BSgenome_Hsapiens_UCSC_hg19", "ExperimentHub", "ExperimentHubData", "GenomicRanges", "HDF5Array", "R_utils", "SummarizedExperiment", "TCGAutils", "dplyr", "knitr", "methrix", "openxlsx", "readr", "rhdf5", "rmarkdown", "stringr", "tibble", "usethis", "xlsx"]
+      "version": "1.5.0",
+      "sha256": "143mgxgzjlv86bqbn2dnyjlp9sg5p1gb3qv4q8izbxv9v15qnxxi",
+      "depends": ["ExperimentHub", "GenomicRanges", "HDF5Array", "R_utils", "SummarizedExperiment", "rhdf5"]
     },
     "VariantToolsData": {
       "name": "VariantToolsData",
-      "version": "1.30.0",
-      "sha256": "1ms6abm0ymxv69kqdp14kay0lvga3b3bfhli0408wss3sjmhs50r",
+      "version": "1.31.0",
+      "sha256": "1dwq9rzh878hzh2diymggbp8mnrlrpgc3q09lviq0gvg5jpnmxki",
       "depends": ["BiocGenerics", "GenomicRanges", "VariantAnnotation"]
     },
     "VectraPolarisData": {
       "name": "VectraPolarisData",
-      "version": "1.10.0",
-      "sha256": "06ax2dgkjd5p9lb24bhjrf05nq0bz9x0z2ydi1iv5lbl0ncc7hvc",
+      "version": "1.11.0",
+      "sha256": "03lxgg1dv5r5crwg4m6vvs8l0h2iwsiva4mm45pw11iq142d72g8",
       "depends": ["ExperimentHub", "SpatialExperiment"]
     },
     "WES_1KG_WUGSC": {
       "name": "WES.1KG.WUGSC",
-      "version": "1.38.0",
-      "sha256": "17iyj3klw9c7pwv4g8895k2mkzgjymzp518ra77b25l0lfm6k2fc",
+      "version": "1.39.0",
+      "sha256": "1mmhajbyivif3lqd1wbx6jrphdpff1mv4lszdvz2bspq0c4imrsf",
       "depends": []
     },
     "WGSmapp": {
       "name": "WGSmapp",
-      "version": "1.18.0",
-      "sha256": "1x96sq82qfsrbzijb8f9yyk8d60acar6wz5v0afc9rcavkina941",
+      "version": "1.19.0",
+      "sha256": "1d6y5n3j4387fj32zyxxz7x4zc2wcnm2i67nkjp6540pxb2zyvmz",
       "depends": ["GenomicRanges"]
     },
     "WeberDivechaLCdata": {
       "name": "WeberDivechaLCdata",
-      "version": "1.8.0",
-      "sha256": "0chvnnn5ihmq24safy45fdh22h12d7ihbxsj7zwd9af0nb15g9z3",
+      "version": "1.9.0",
+      "sha256": "0vd231wimlv1cy3s2js8b2yc76w2z6cw2y81d472hm966a2717wl",
       "depends": ["ExperimentHub", "SingleCellExperiment", "SpatialExperiment"]
     },
     "XhybCasneuf": {
       "name": "XhybCasneuf",
-      "version": "1.44.0",
-      "sha256": "1pg3bwi3aprn4f9y43agd25sjhmxj619k61is7zgrkm2ljg4mj00",
+      "version": "1.45.0",
+      "sha256": "0y9bwf9jnhjgnv95fd50x28afj2687dw3l5cpd322ihrbc3rh754",
       "depends": ["RColorBrewer", "affy", "ath1121501cdf", "tinesath1cdf"]
     },
     "adductData": {
       "name": "adductData",
-      "version": "1.22.0",
-      "sha256": "1s9vflcvsi1136ax0isc1zskbz64cis6mlhhd458jrsx34cf5hff",
+      "version": "1.23.0",
+      "sha256": "0nb9b09r7gamn4llb74jygjcry39m2bpvylkz8bjswkmpnigb132",
       "depends": ["AnnotationHub", "ExperimentHub"]
     },
     "affycompData": {
       "name": "affycompData",
-      "version": "1.44.0",
-      "sha256": "01x4qj2sc1b6z3221af2acpniaar97jhfdgg21lkb6429mm6g42r",
+      "version": "1.45.0",
+      "sha256": "1mdrri2l5bi2pnxrhly05x2d4c01k1j5a5dl8sp4mk7j189kapv3",
       "depends": ["Biobase", "affycomp"]
     },
     "affydata": {
       "name": "affydata",
-      "version": "1.54.0",
-      "sha256": "1yk3kgyl58wg48004h8249iwbr4g05rkk78rfcdcw4c5r4asfjng",
+      "version": "1.55.0",
+      "sha256": "1c7vign64byn1iklc4xir4z10p7jsdkbya903wgnk4miczalldyl",
       "depends": ["affy"]
     },
     "airway": {
       "name": "airway",
-      "version": "1.26.0",
-      "sha256": "0cj8s2pxydq7n644lf07vb9g89gqbd91s3m0d0x1qvbp1sskp536",
+      "version": "1.27.0",
+      "sha256": "1qc9q169gw13d5hm59vh6n1saxyrlz3mw475mm2lwxaws4laf984",
       "depends": ["SummarizedExperiment"]
     },
     "antiProfilesData": {
       "name": "antiProfilesData",
-      "version": "1.42.0",
-      "sha256": "0590iff9pf7nc34w0llg2jk8gc8004vl5fxg93nb91n0jm86crdp",
+      "version": "1.43.0",
+      "sha256": "0mwql2j5jhkm3ma975al8ih80ziyxnak17hm3aqn3s0cxxi6z60z",
       "depends": ["Biobase"]
     },
     "aracne_networks": {
       "name": "aracne.networks",
-      "version": "1.32.0",
-      "sha256": "10zp8nqb0xsxc5xbhlc3la34kcrk7f9m0yqrp45c3qaffzr63jki",
+      "version": "1.33.0",
+      "sha256": "14b2zq4760zw2vkfvsxg9q1msa8abc42lyn5i36wi7n5cbcgwrn6",
       "depends": ["viper"]
     },
     "bcellViper": {
       "name": "bcellViper",
-      "version": "1.42.0",
-      "sha256": "140wwk0d3lds60x7b0w2612ss0bdlbjza351j1w576bda47a48rg",
+      "version": "1.43.0",
+      "sha256": "0yimwbm2b9i2m0aj7ayz9y3pbyw252yaakzpj4cp15vvyakghmfn",
       "depends": ["Biobase"]
     },
     "beadarrayExampleData": {
       "name": "beadarrayExampleData",
-      "version": "1.44.0",
-      "sha256": "1nii7320r2mhnis67gg8ckj3rcm5x878hzanb0rqmjki36n6yxsb",
+      "version": "1.45.0",
+      "sha256": "00rxcb0a2yxmxycg79m4cl3nfmrm5fl0pfisv8nxg8nsgf9ab1kn",
       "depends": ["Biobase", "beadarray"]
     },
     "benchmarkfdrData2019": {
       "name": "benchmarkfdrData2019",
-      "version": "1.20.0",
-      "sha256": "08wa4k2i4s92gfqcfh2fs7g7360dpbyz62qrkrs8xa7gfy3n3zfw",
+      "version": "1.21.0",
+      "sha256": "1dpf3d3rdxvadd6mccw0s6v973ip34ljaj3s22p9ns732pwx43wq",
       "depends": ["ExperimentHub", "SummarizedExperiment"]
     },
     "beta7": {
       "name": "beta7",
-      "version": "1.44.0",
-      "sha256": "16r77mvfajwvp59a40ffq23ryhx343l9zambyql29ba22g7jg653",
+      "version": "1.45.0",
+      "sha256": "04rk5814cjrpfry34avpy003lw5f6is3nizsp0676sv2w5mh8rqn",
       "depends": ["marray"]
     },
     "biotmleData": {
       "name": "biotmleData",
-      "version": "1.30.0",
-      "sha256": "0bnjhn0xirv81lw83ymd4mcmllkrd19gya7fr4j7xq77hjrx1kl7",
+      "version": "1.31.0",
+      "sha256": "000cs5gbpc3l45wgmwqcp3fjj7gpmixbqvq4lv4i8pahm659yh80",
       "depends": []
     },
     "biscuiteerData": {
       "name": "biscuiteerData",
-      "version": "1.20.0",
-      "sha256": "0x80ccnlh6wdknxfrkj8y6lxx2b369ma7hc9znhzw2xgr9fj6qpm",
+      "version": "1.21.0",
+      "sha256": "1q7hfyyq5rhjah19jkxkbcya006ph00sk3hsy5n4yqcj5c3ckzrl",
       "depends": ["AnnotationHub", "ExperimentHub", "GenomicRanges", "curl"]
     },
     "bladderbatch": {
       "name": "bladderbatch",
-      "version": "1.44.0",
-      "sha256": "14lik0n2b3fnvggrcash3kcd03vgzqimzhv9w3vagz0cbvdr0s01",
+      "version": "1.45.0",
+      "sha256": "1mamari26pn6yrn2azyn44rdv5pw8361r76vm7raah5v4zwxz59s",
       "depends": ["Biobase"]
     },
     "blimaTestingData": {
       "name": "blimaTestingData",
-      "version": "1.26.0",
-      "sha256": "1q7z4wdpmrd33hh8gj5cavxiiaxflygzssrzy6nm5p240vya6wi3",
+      "version": "1.27.0",
+      "sha256": "11asl28hziq1zmv1wh6zqr1kfzlikdx24z9sr703fliwqa2222zj",
       "depends": []
     },
     "bodymapRat": {
       "name": "bodymapRat",
-      "version": "1.22.0",
-      "sha256": "06rqhnri8nwy1p8srzmhi0z81q9nwdk1q413if7n3760gp0qfgbn",
+      "version": "1.23.0",
+      "sha256": "1qznz8va78k4fj9jnncig6hix2y39kjrf0dqkvn58b61b43v73zk",
       "depends": ["ExperimentHub", "SummarizedExperiment"]
     },
     "breakpointRdata": {
       "name": "breakpointRdata",
-      "version": "1.24.0",
-      "sha256": "08kwslm55w0vmcdjndsaq51pwm8gvlrxqy9cjz87dmwxd42giv46",
+      "version": "1.25.0",
+      "sha256": "0z890byfq0lbxvi9d5sy81c3461gyippwfa26pq9wxjbkykny5gk",
       "depends": []
     },
     "breastCancerMAINZ": {
       "name": "breastCancerMAINZ",
-      "version": "1.44.0",
-      "sha256": "03q5mq0rg4kv5nk9vk4lhyj2zbz3gc4x9b795v9i39lmab3qb9w6",
+      "version": "1.45.0",
+      "sha256": "1ka95zlb380b7bxw5sshf8ik54w2kmficq7mbb45dp03zs1j97bx",
       "depends": []
     },
     "breastCancerNKI": {
       "name": "breastCancerNKI",
-      "version": "1.44.0",
-      "sha256": "05bs2rmsj5ca15rhc8q1670knsns7lgcvxzd0i5ak39vs4mj60l4",
+      "version": "1.45.0",
+      "sha256": "1skqicgm54p59yskjgfw5jb25zpbqci1mpm6znjgqxw1vk6305g2",
       "depends": []
     },
     "breastCancerTRANSBIG": {
       "name": "breastCancerTRANSBIG",
-      "version": "1.44.0",
-      "sha256": "1qhpmabn814p3k7my0r0423f8wxz0fsvb7rzql8fhrr057ngg341",
+      "version": "1.45.0",
+      "sha256": "0qjyzbs4lqvd9883njz4dgvd7ljbq07lsml3k614psn4wsckdw19",
       "depends": []
     },
     "breastCancerUNT": {
       "name": "breastCancerUNT",
-      "version": "1.44.0",
-      "sha256": "0bix9n9s6jpxw61vbh3prj1xd12h6b03sf8r9fc9zvjagh0yr1wh",
+      "version": "1.45.0",
+      "sha256": "0j83xl0rksib8yqp8nk2pvrlasxihrzfj2vaiml6r05iw0agvc11",
       "depends": []
     },
     "breastCancerUPP": {
       "name": "breastCancerUPP",
-      "version": "1.44.0",
-      "sha256": "1h76j3y2pwhgnayry539xgflq7hy0z61bgb7q9j7c90i1sv0d6h4",
+      "version": "1.45.0",
+      "sha256": "07wp0l4vli4qqmqa8phrvcg7sdphdlc3j7n7i9w3cpa534cf9n9h",
       "depends": []
     },
     "breastCancerVDX": {
       "name": "breastCancerVDX",
-      "version": "1.44.0",
-      "sha256": "1q248675kn2r0q7spw6wa8fhcihsk98diys3zfr36xba1pr3f8yy",
+      "version": "1.45.0",
+      "sha256": "1risf3l9xcd34sm8rbibd3h7z3a0v37nf5vfviw7n0szwq7i91q4",
       "depends": []
     },
     "brgedata": {
       "name": "brgedata",
-      "version": "1.28.0",
-      "sha256": "1ddcj8izlnzsn6chvyabha5qyigagqr2xa5paqi0h83kmmvpahkm",
+      "version": "1.29.0",
+      "sha256": "1qcykmk98dvf8naa97nnsd50qmlmynqrmv6xkv8fd4i1a1j4zf9d",
       "depends": ["Biobase", "SummarizedExperiment"]
     },
     "bronchialIL13": {
       "name": "bronchialIL13",
-      "version": "1.44.0",
-      "sha256": "0fcin64vfvmdda664s1q5m9la8gxwsiqng1gwp2gr58kgr4ywyxy",
+      "version": "1.45.0",
+      "sha256": "0h9nf9ig6wm07nrp6rv0bafyr61vr92wadwg5412afki1kqq027w",
       "depends": ["affy"]
     },
     "bsseqData": {
       "name": "bsseqData",
-      "version": "0.44.0",
-      "sha256": "08vzvr6gqcgk1d3rhg5zcwg2lxsmj33phr37hy5hrpxn0syma018",
+      "version": "0.45.0",
+      "sha256": "0jaj3vlfgrd0g1b8zw7b5xn1kh466yddawlp3ak236jzscim1lh0",
       "depends": ["bsseq"]
     },
     "bugphyzz": {
       "name": "bugphyzz",
-      "version": "1.0.0",
-      "sha256": "018rm85jyfp2gw4gnpaj1q7v97br1vhkf5zsdw4b4ahn0qx9haf5",
+      "version": "1.1.0",
+      "sha256": "03s8lqlhvw07f3zlwvqg339cz20viwk7bna0wvvdqd9b4jz609hh",
       "depends": ["BiocFileCache", "S4Vectors", "dplyr", "httr2", "purrr", "stringr", "tidyr", "tidyselect"]
     },
     "cMap2data": {
       "name": "cMap2data",
-      "version": "1.42.0",
-      "sha256": "0a584zh6ykxbym6ns5v9ws3grndn49m6d5ah89qybrwmv6cxqgdy",
+      "version": "1.43.0",
+      "sha256": "1v7ga4js6ccbg2q38xny520gzhw18wpk8dkza65gcy4cncrijj4j",
       "depends": []
     },
     "cancerdata": {
       "name": "cancerdata",
-      "version": "1.44.0",
-      "sha256": "1kjra8im5wgjyfp1h2s62b5hqwc5440v0bjwwby8hdbmqz78549i",
+      "version": "1.45.0",
+      "sha256": "0sw9h5601cnqvpwdl2v5gy9vcwwnb7w2wv7gk38dgm64v7rr7pbz",
       "depends": ["Biobase"]
     },
     "ccdata": {
       "name": "ccdata",
-      "version": "1.32.0",
-      "sha256": "19khzj5pfm8ysi4ra5pc255z9vxywlf0yjfy4myip6w70ba865nx",
+      "version": "1.33.0",
+      "sha256": "0gff2yrsmnajamygwxgc1zd144crwckiv5n1y52s8ndcmqw9wfr5",
       "depends": []
     },
     "celarefData": {
       "name": "celarefData",
-      "version": "1.24.0",
-      "sha256": "1szj7x00lsjf8751ni9azwds5w53gfg9028chv4vj6a4kj00blr5",
+      "version": "1.25.0",
+      "sha256": "1f1b8i3ax6mr3dzqwi9chwnrkvwiik576br51dkcskj4xlasvhdh",
       "depends": []
     },
     "celldex": {
       "name": "celldex",
-      "version": "1.16.0",
-      "sha256": "0kn1mdnbiiag29n52gar2ymihx5q9hrjfjc6qssxm0m7ns9gm4hm",
+      "version": "1.17.0",
+      "sha256": "16dg342dlf3d9aj8ms2q0njzm5gqqhy6fffj0pv1jfl2plggjpfs",
       "depends": ["AnnotationDbi", "AnnotationHub", "DBI", "DelayedArray", "DelayedMatrixStats", "ExperimentHub", "Matrix", "RSQLite", "S4Vectors", "SummarizedExperiment", "alabaster_base", "alabaster_matrix", "alabaster_se", "gypsum", "jsonlite"]
     },
     "cfToolsData": {
       "name": "cfToolsData",
-      "version": "1.4.0",
-      "sha256": "1bxzihqz7miyriw8zvxc3ac6wgkqwa3h141x49y50mamhhcy8qy8",
+      "version": "1.5.0",
+      "sha256": "0d57xmvcxchrn0xh7ll2lnkci0naa20x9qv7hzmxpx7g766vwsgl",
       "depends": ["ExperimentHub"]
     },
     "chipenrich_data": {
       "name": "chipenrich.data",
-      "version": "2.30.0",
-      "sha256": "03jbpp8qxj9j3jglmcnmkp5b5ah96770g7qq7qij8hw222gw8wcg",
+      "version": "2.31.0",
+      "sha256": "0mbm3r6vhw8yjkgik122p9axj1nns6gxnbyiy96r0vy87q1p2jln",
       "depends": ["AnnotationDbi", "BiocGenerics", "GenomeInfoDb", "GenomicRanges", "IRanges", "S4Vectors", "readr", "rtracklayer"]
     },
     "chipseqDBData": {
       "name": "chipseqDBData",
-      "version": "1.22.0",
-      "sha256": "1ygym612j46qgb3a16lnlldgriqqng9mws707h0yqh1r2szxqc34",
+      "version": "1.23.0",
+      "sha256": "1b6y8yk49y89gwj1i4gbq8m83v2zida8y7g595lng092ak246w0i",
       "depends": ["AnnotationHub", "ExperimentHub", "Rsamtools", "S4Vectors"]
     },
     "chromstaRData": {
       "name": "chromstaRData",
-      "version": "1.32.0",
-      "sha256": "19kb4ya8p5shhm2zcdf8y172w8fsg409fjmkqlyagpncvcak0b04",
+      "version": "1.33.0",
+      "sha256": "1piz7jihay3zh3ynabyifvqp9v89fwaw19p6dgf6piqpzbj3k7zg",
       "depends": []
     },
     "clustifyrdatahub": {
       "name": "clustifyrdatahub",
-      "version": "1.16.0",
-      "sha256": "1k2ihpw496zliycpa0wblcx9f53nx87ircf975p6dm7w54i0anqx",
+      "version": "1.17.0",
+      "sha256": "1yljk3qxi8fa1bxkhg4wl798j35np86vxivnikj5r36kbrljkl4s",
       "depends": ["ExperimentHub"]
     },
     "cnvGSAdata": {
       "name": "cnvGSAdata",
-      "version": "1.42.0",
-      "sha256": "1irzc1irq93bfjcdh12q80k9fyl3rpmg28flb0kzs8b39scsm3v0",
+      "version": "1.43.0",
+      "sha256": "1h04lpa2lr5qlkdkdzj4v3qws2056pp61bf8isn6rgpgsqz2ld96",
       "depends": ["cnvGSA"]
     },
     "colonCA": {
       "name": "colonCA",
-      "version": "1.48.0",
-      "sha256": "1j4k0jnmcaabk568apk0yicy3k4ky1l0bxsm9pll1i6h7hxqy0pg",
+      "version": "1.49.0",
+      "sha256": "02b4rvl4p063240vimjilwak07jhmvqdb66lw131fazci3nhz1wg",
       "depends": ["Biobase"]
     },
     "crisprScoreData": {
       "name": "crisprScoreData",
-      "version": "1.10.0",
-      "sha256": "1107c7fa5pjjjf4q6jf9xv1sbwdx9q1p2dalfwbjr9z2fhp6waw8",
+      "version": "1.11.0",
+      "sha256": "12nn966nr793hw8l9w3c8rp8fxxl5jnpnjq7q87vjis7k6d9fjr4",
       "depends": ["AnnotationHub", "ExperimentHub"]
     },
     "curatedAdipoArray": {
       "name": "curatedAdipoArray",
-      "version": "1.18.0",
-      "sha256": "0rzsaf48vfkf9kx6m1fbd900qc5hwhflz2yz84yxip4yic617hx7",
+      "version": "1.19.0",
+      "sha256": "185qnd1f4s4hvf80wijnbrs9qdws4vw12wnlna07zadzpn9rf6v1",
       "depends": []
     },
     "curatedAdipoChIP": {
       "name": "curatedAdipoChIP",
-      "version": "1.22.0",
-      "sha256": "1dy3sswxs0w8dhdw5zx38mbd32ich3v283sijina1yb0gdah66i1",
+      "version": "1.23.0",
+      "sha256": "01r4gqz92bicbm15c5dfj18yrci9h0dcjiczk12vj7xg47c2m8fw",
       "depends": ["ExperimentHub", "SummarizedExperiment"]
     },
     "curatedAdipoRNA": {
       "name": "curatedAdipoRNA",
-      "version": "1.22.0",
-      "sha256": "0k48x18z6pdrphknjz0v210fg8143a1dj2qiznrc421rznwy60lc",
+      "version": "1.23.0",
+      "sha256": "1kb5pn514rdiw0ghwdprmpywazqklxja8ll0s5wnk0a28rccyl9d",
       "depends": ["SummarizedExperiment"]
     },
     "curatedBladderData": {
       "name": "curatedBladderData",
-      "version": "1.42.0",
-      "sha256": "0s6wb14c2dyrd2pl9sq6dzylcg5500sbcki25qfyf9g7dgpabj6h",
+      "version": "1.43.0",
+      "sha256": "1y0vca7f383wrnph2nkmb84q3px6j36k5161r2hmj0zjbq4gmwvw",
       "depends": ["affy"]
     },
     "curatedBreastData": {
       "name": "curatedBreastData",
-      "version": "2.34.0",
-      "sha256": "1c5mw9yy27mqp0zk1llirzmk95j7k7fl3jr98is15l5a6f6rwh0x",
+      "version": "2.35.0",
+      "sha256": "09ga8d30v11dpa8byamqrrah7rinqsfx5wnfm31mln07nx3zvh74",
       "depends": ["Biobase", "BiocStyle", "XML", "ggplot2", "impute"]
     },
     "curatedMetagenomicData": {
       "name": "curatedMetagenomicData",
-      "version": "3.14.0",
-      "sha256": "1zpjkijhig7yg7asmnmb6ivvah9pbiifnfglrs7g9zb23wi2iymm",
+      "version": "3.15.0",
+      "sha256": "0h88wz357ln7b2jpjckrg3gv6372lqlgd5lcgk1xchfm7s3878x2",
       "depends": ["AnnotationHub", "ExperimentHub", "S4Vectors", "SummarizedExperiment", "TreeSummarizedExperiment", "dplyr", "magrittr", "mia", "purrr", "rlang", "stringr", "tibble", "tidyr", "tidyselect"]
     },
     "curatedOvarianData": {
       "name": "curatedOvarianData",
-      "version": "1.44.0",
-      "sha256": "0dl0v1v1imk5gy0glzllx32x19p4akma3scccwq0c6shdp3988v9",
+      "version": "1.45.0",
+      "sha256": "1zpxpdr6c69430dh9dlmqd3q24p2gy43xyfrdipk6ixrndkbjqsw",
       "depends": ["Biobase", "BiocGenerics"]
     },
     "curatedPCaData": {
       "name": "curatedPCaData",
-      "version": "1.2.0",
-      "sha256": "0l6wdc1h7pzap5zfpc11dl1y3jdfr75iq7ly3927bqq94nkp6wcq",
+      "version": "1.3.0",
+      "sha256": "0q262nv152c0xxg1qdix76nljy269plfink5kp3iz04a5k13g7qi",
       "depends": ["AnnotationHub", "ExperimentHub", "MultiAssayExperiment", "RaggedExperiment", "S4Vectors", "reshape2", "rlang"]
     },
     "curatedTBData": {
       "name": "curatedTBData",
-      "version": "2.2.0",
-      "sha256": "01s69cdd67l589r9vzl8qgkb00a5y8gqy8ijz73bw2nj2bsmrymr",
+      "version": "2.3.0",
+      "sha256": "0n0rbbjigzmlrl60drnlfphnny9x0bnxxhzxbwdpfim5drr3yj66",
       "depends": ["AnnotationHub", "ExperimentHub", "MultiAssayExperiment", "rlang"]
     },
     "curatedTCGAData": {
       "name": "curatedTCGAData",
-      "version": "1.28.1",
-      "sha256": "1g8hyi9b2423y3lbg52dxqqnaljj2jnnaybnb2a9x5h4sm4gbqw4",
+      "version": "1.29.2",
+      "sha256": "1g5psdxdnmr1lihsnbp83s1cwcy31w5kmdln5mlhq6q3wrini0rk",
       "depends": ["AnnotationHub", "ExperimentHub", "HDF5Array", "MultiAssayExperiment", "S4Vectors", "SummarizedExperiment"]
     },
     "davidTiling": {
       "name": "davidTiling",
-      "version": "1.46.0",
-      "sha256": "0hw0j96a9zkd413114z69j17hdrpshnm47qijzcplna05js2djx9",
+      "version": "1.47.0",
+      "sha256": "1sh8p0wdkhvi9yb9m9vky6j59bkb9d34xz7pizcp91a2j37sxag8",
       "depends": ["Biobase", "GO_db", "tilingArray"]
     },
     "depmap": {
       "name": "depmap",
-      "version": "1.20.0",
-      "sha256": "1mjx8jx4n36hjgw4nf6cc84bm868qfxgrb9knpxvvildzq1a04g1",
+      "version": "1.21.0",
+      "sha256": "0sxlxszvmi4pxdqnrpliw523k10s6dfdicy4bi46dy1yg34yjk40",
       "depends": ["AnnotationHub", "BiocFileCache", "ExperimentHub", "curl", "dplyr", "httr2", "tibble"]
     },
     "derfinderData": {
       "name": "derfinderData",
-      "version": "2.24.0",
-      "sha256": "0rkc54gh3yasms4nrayi58ly2raad0ksid3wmzbmhy22zib4n9hy",
+      "version": "2.25.0",
+      "sha256": "0yay5q9gl0a1hr37k97maqfnpv3n02qgzapx3w7aghsyqk1pxr67",
       "depends": []
     },
     "diffloopdata": {
       "name": "diffloopdata",
-      "version": "1.34.0",
-      "sha256": "000zmrcic50mbx3byxpjn66ancpd3mp4dp7zn2dqd1g5d17j7xxg",
+      "version": "1.35.0",
+      "sha256": "0yhfcv0fl4dzlgid7iqvyza96w68611dc9cr79906vmi414h0xk0",
       "depends": []
     },
     "diggitdata": {
       "name": "diggitdata",
-      "version": "1.38.0",
-      "sha256": "0ar99whdbnq13cqxcsmvj64iqr1p8d9vrb3gbm4f26w1chm2crl0",
+      "version": "1.39.0",
+      "sha256": "105w6ybj0az8aifbhcya3liypwiwssj2l1nwgh9ym6hwl17capkx",
       "depends": ["Biobase", "viper"]
     },
     "dorothea": {
       "name": "dorothea",
-      "version": "1.18.0",
-      "sha256": "1s2kj3x1206cq61ncivizq8shscsdjwmc2g2493d6cqip0am47rw",
+      "version": "1.19.0",
+      "sha256": "0gw2aj19j6ck0a9xjj1hxj04asjf6x6il2h7bq079prq8c5hcfjm",
       "depends": ["bcellViper", "decoupleR", "dplyr", "magrittr"]
     },
     "dressCheck": {
       "name": "dressCheck",
-      "version": "0.44.0",
-      "sha256": "0k9lyibpnf87rcna233fjmr0gmw4dbrsa8ddbv37a2xy8clsli3j",
+      "version": "0.45.0",
+      "sha256": "0ww4xfj5wl26zjjminid2hzwc1vp38q77qf3drws7xrlf0fqbwss",
       "depends": ["Biobase"]
     },
     "dyebiasexamples": {
       "name": "dyebiasexamples",
-      "version": "1.46.0",
-      "sha256": "10vqaqdzs0c24slx2qnjbzah0rf69x76i7qssarcpgqpv35qm6vl",
+      "version": "1.47.0",
+      "sha256": "1wcimlsqsp307rxd9v9b71ir37xl541ihdx69k67310x9svz7xa8",
       "depends": ["GEOquery", "marray"]
     },
     "easierData": {
       "name": "easierData",
-      "version": "1.12.0",
-      "sha256": "0lpgankpw7yrzmh5sfd05f0srhgf031rvqg7r2ap6fx3d6j53hrn",
+      "version": "1.13.0",
+      "sha256": "0g2phlp0idqcj1hrabdqzxg7x4mgc7jhbah5wv3kqfz9ggxi11zd",
       "depends": ["AnnotationHub", "ExperimentHub", "SummarizedExperiment"]
     },
     "ecoliLeucine": {
       "name": "ecoliLeucine",
-      "version": "1.46.0",
-      "sha256": "1w6fz8dnafqf47n16jh7p6j6fig31vigkygdkv14kric3xr4vf1k",
+      "version": "1.47.0",
+      "sha256": "18bsdl1z5g1rvr673i9cxvakx0avkw1la353ardyyd46y86ggmyp",
       "depends": ["affy", "ecolicdf"]
     },
     "emtdata": {
       "name": "emtdata",
-      "version": "1.14.0",
-      "sha256": "1g6im42wzkjr5xxrh21q2kh50m3igqjz6srp1zshjx2hg27gdd72",
+      "version": "1.15.0",
+      "sha256": "0hlq79gm1g8z5j85wmvsmrxf0rcbfhi4pzzll12q1r89wqi27ak3",
       "depends": ["ExperimentHub", "SummarizedExperiment", "edgeR"]
     },
     "eoPredData": {
       "name": "eoPredData",
-      "version": "1.0.0",
-      "sha256": "1bmxqa6gsj3hkw9znpa13lc0fpi0yp1psqx1jpmy01bkk36y6ikw",
+      "version": "1.1.0",
+      "sha256": "0jiyj7ld65jkhapvv64x571yjrykrvg7c26vr1ir50g9wl7i0dzp",
       "depends": ["ExperimentHub"]
     },
     "epimutacionsData": {
       "name": "epimutacionsData",
-      "version": "1.10.0",
-      "sha256": "18gmc4x7q5ff53gy4d7vmjyjjsg9spj4kgmkdf9yg34mc3laryfv",
+      "version": "1.11.0",
+      "sha256": "0f1bhp16qihlrfjk8sw09kyyjn281cqpzr94zz8z18hxjqy9d47p",
       "depends": []
     },
     "estrogen": {
       "name": "estrogen",
-      "version": "1.52.0",
-      "sha256": "0bm7xxjbkcyd8b4pifqmhfz1ncdvrr5lq52mf4xniy873k7460jx",
+      "version": "1.53.0",
+      "sha256": "01rg4wiywqcb1chm4acnbplqkqv6s670vhn1sg3d0jacfxgsywc2",
       "depends": []
     },
     "etec16s": {
       "name": "etec16s",
-      "version": "1.34.0",
-      "sha256": "114jmrnjm2xpfzx1m10bn73fy1am209c70ws4jwfggrbavg6xp8j",
+      "version": "1.35.0",
+      "sha256": "1kx4cb4ck9mc7xlgj7n9c329qx7yicnwapgz8khd9bgpf9jv2c6n",
       "depends": ["Biobase", "metagenomeSeq"]
     },
     "ewceData": {
       "name": "ewceData",
-      "version": "1.14.0",
-      "sha256": "1vcdyvdwklr3icz6i9015721ixxsjsgz4i4y0yabbrbwpxl6wcqp",
+      "version": "1.15.0",
+      "sha256": "0dv38j196nzb15krfh3jhd0njgcsc8520q5rl4nrdhxikvyf60hx",
       "depends": ["ExperimentHub"]
     },
     "faahKO": {
       "name": "faahKO",
-      "version": "1.46.0",
-      "sha256": "1i52f5anjvag3n6hn1w6wyjc81h81rfb5a7w1lcnkg4q87g149nm",
+      "version": "1.47.1",
+      "sha256": "0ihqq0xg2q2fhsszn18fm89j7avz8rychbykgmps0fkd8q04ja7r",
       "depends": ["xcms"]
     },
     "fabiaData": {
       "name": "fabiaData",
-      "version": "1.44.0",
-      "sha256": "005hxja8g1608gkhgl5bi6xg5pkswvdh4400yzjp8ph8irsdcd4d",
+      "version": "1.45.0",
+      "sha256": "0f0ykj7aahwval4yr8bwgfvcrxvgancfrpi9pwnfw3my1hwack53",
       "depends": ["Biobase"]
     },
     "ffpeExampleData": {
       "name": "ffpeExampleData",
-      "version": "1.44.0",
-      "sha256": "096400prmh23jd5q3dab6vgh19vbkwar4hx4l57n8klrx8dxq7q4",
+      "version": "1.45.0",
+      "sha256": "15k0pcgzwg2mpbq7wj788p1pl1pdmvnz96p1ngz4blw7q82wvfkh",
       "depends": ["lumi"]
     },
     "fibroEset": {
       "name": "fibroEset",
-      "version": "1.48.0",
-      "sha256": "050dmfl2v1z48kzr03nlxsp4xzshs0046bkd0lcdylzvk8gdwpyf",
+      "version": "1.49.0",
+      "sha256": "1fsdk1rlnz9hyg5avzb4ll5x2p4h2a4jxmbmv052bs7h6hby2ihv",
       "depends": ["Biobase"]
     },
     "fission": {
       "name": "fission",
-      "version": "1.26.0",
-      "sha256": "07xg2j46jxx6g01wa6m774y1x9cawpq6njk61il08fxhxmv9zv0q",
+      "version": "1.27.0",
+      "sha256": "00ldnmpm7rn5jixqb18l4n2zhn4jwiryliwrydfscnwdx4kghpg2",
       "depends": ["SummarizedExperiment"]
     },
     "flowPloidyData": {
       "name": "flowPloidyData",
-      "version": "1.32.0",
-      "sha256": "17a7cabqgfj4f6l7p2fxvf2z1lafhkl01wcklyhjycfb1803plsl",
+      "version": "1.33.0",
+      "sha256": "0f9jb1z3f9a3r7k7ar50i2jbdnnxxww2ricsplsyfs96kcpjac8k",
       "depends": []
     },
     "flowWorkspaceData": {
       "name": "flowWorkspaceData",
-      "version": "3.18.0",
-      "sha256": "1bwykpv1y76iq0qhnn24snwymy0wirip7xwq1wqj1flbainzmv6g",
+      "version": "3.19.0",
+      "sha256": "0lsf6miqqd7qzgjgr8kq6m84ax528hy54fxbjlfhnfw4wyqghsvq",
       "depends": []
     },
     "fourDNData": {
       "name": "fourDNData",
-      "version": "1.6.0",
-      "sha256": "1ippkbavwhwbhf7j6r2k50jnbdrzxzb6qv2ff5dab86wr59804x1",
+      "version": "1.7.0",
+      "sha256": "1lk8l5vvlqkk9xrqpvh7qyl305yprpqdrn4gbkgywhdwjl26a363",
       "depends": ["BiocFileCache", "GenomicRanges", "HiCExperiment", "IRanges", "S4Vectors"]
     },
     "frmaExampleData": {
       "name": "frmaExampleData",
-      "version": "1.42.0",
-      "sha256": "1sazkzs2nr0kbmc1ilb1rhwkjd2lwkjf8lx89id8qxra62wdc19f",
+      "version": "1.43.0",
+      "sha256": "19dmr2piyygvv20zmy00nzr8rv20wsqw1l5wgcc8xx12h86wizps",
       "depends": []
     },
     "furrowSeg": {
       "name": "furrowSeg",
-      "version": "1.34.0",
-      "sha256": "052531x1fb47mx7p77y61amkxhdga6xsgcq98a55vxm3pg2jsf49",
+      "version": "1.35.0",
+      "sha256": "0aih9f2j38aza04r52xx4z4ccxgz9dzng6rgdglx4kgxa093fz02",
       "depends": ["EBImage", "abind", "dplyr", "locfit", "tiff"]
     },
     "gDNAinRNAseqData": {
       "name": "gDNAinRNAseqData",
-      "version": "1.6.0",
-      "sha256": "1m05c19pqzaax9k9jmc6fja86867d38328i7gz8wcdhavgjlif5c",
+      "version": "1.7.0",
+      "sha256": "03dm0h7vmdbnb2a6da3xswrzp94fzbn6n6rv4nifrnjdaxyn2k2m",
       "depends": ["BiocGenerics", "ExperimentHub", "RCurl", "Rsamtools", "XML"]
     },
     "gDRtestData": {
       "name": "gDRtestData",
-      "version": "1.4.1",
-      "sha256": "0ybp2zrkjivrfl62zz7jljs1inlnx3iybwazyh0rxb255r9cg9ns",
+      "version": "1.5.1",
+      "sha256": "1bzqj5q5bfswip8iagxjr7nbls3wfh8gm1p6vi9iynk9fgr28xzi",
       "depends": ["checkmate", "data_table"]
     },
     "gageData": {
       "name": "gageData",
-      "version": "2.44.0",
-      "sha256": "0nbmm17ysyn7sar29sagdhbp2b8zi20ka8l56y9kznaxha7jfk7p",
+      "version": "2.45.0",
+      "sha256": "1mx72mwvdwc05l2qp6a99sn28y0vckdgjjvg3lmvppixhrg89jc1",
       "depends": []
     },
     "gaschYHS": {
       "name": "gaschYHS",
-      "version": "1.44.0",
-      "sha256": "1c407h406giaq092mzmxdxz7b8y7r1yfjncwzz1yrgxn8z53pq71",
+      "version": "1.45.0",
+      "sha256": "0pk5yzxhi90wfrahbsh3dhl2xf9x1lkbc2qghbc6jzccm4bq9a7m",
       "depends": ["Biobase"]
     },
     "gcspikelite": {
       "name": "gcspikelite",
-      "version": "1.44.0",
-      "sha256": "101y42f1pspgcxn2x8qnjzyyvybvwal9sqy6a3d6jf6hibayhlhh",
+      "version": "1.45.0",
+      "sha256": "15ad3ncd63bqmz3s1kjw0qwgqcxaw1zx6lhrfpi14qyr231r88a0",
       "depends": []
     },
     "geneLenDataBase": {
       "name": "geneLenDataBase",
-      "version": "1.42.0",
-      "sha256": "1v23v859w75svl2vl0758h8i41mjy5vq6xq4w6z8v8w3zyhwycgp",
+      "version": "1.43.0",
+      "sha256": "08k6mh6w8f3vj0x0f94dqq4lqjxn7rcysh9c5bwmxm8ihmypbkia",
       "depends": ["GenomicFeatures", "rtracklayer", "txdbmaker"]
     },
     "genomationData": {
       "name": "genomationData",
-      "version": "1.38.0",
-      "sha256": "1ml8p99y4lba2gzphf0hsy840yqvfsanqscjh7sww5gk06yx9c4p",
+      "version": "1.39.0",
+      "sha256": "0pn0rgmx8lk5vz2s4pd6y43sj1ybrvy5adjk8hsx8cpc1ab8jx45",
       "depends": []
     },
     "golubEsets": {
       "name": "golubEsets",
-      "version": "1.48.0",
-      "sha256": "0f0lk9qp6d5frvgs5c34jm7fhnjw4v76wi45pdjbh0sr0fhzxf9z",
+      "version": "1.49.0",
+      "sha256": "0mchxhzaymrhvgim2ghanq6s29366pi5aljszwa1lkkkky0vpwip",
       "depends": ["Biobase"]
     },
     "gpaExample": {
       "name": "gpaExample",
-      "version": "1.18.0",
-      "sha256": "1f3llr6bfpc7qijsd7735077a7gwyyyrzsnngpfpl8rrricw2sd3",
+      "version": "1.19.0",
+      "sha256": "1j1jm3a3wb2z0yjx8msmjvsb57r6w3q39jiawainq7fi533256ch",
       "depends": []
     },
     "grndata": {
       "name": "grndata",
-      "version": "1.38.0",
-      "sha256": "1d33wzrd1dvwqfaaqvkahmnn2dvcsdqwvrxglihr0ljj7aq693ip",
+      "version": "1.39.0",
+      "sha256": "0krvxj66vnh2l88cn6jdlygnqwbkyy37acpnz064c7ka3mp663rw",
       "depends": []
     },
     "h5vcData": {
       "name": "h5vcData",
-      "version": "2.26.0",
-      "sha256": "048baw95mdq7y3d8b2m48d2g5zm6x9l722lh1zp14yqipv4ms8gi",
+      "version": "2.27.0",
+      "sha256": "1778f8h4f3caw7xcndk5h211vf9n5lgdvjl22jdx44z3ivrvkdkw",
       "depends": []
     },
     "hapmap100khind": {
       "name": "hapmap100khind",
-      "version": "1.48.0",
-      "sha256": "0pmsrbl8s1n73pcix3r4rcssaqz9xd8znaifv72pzqbmcp0x755r",
+      "version": "1.49.0",
+      "sha256": "19wkiq9l2wq7mq4mjjx7nvl9bmndyjfw67rla5g2ggsq4ybzxgvz",
       "depends": []
     },
     "hapmap100kxba": {
       "name": "hapmap100kxba",
-      "version": "1.48.0",
-      "sha256": "0bah2q34mkcc15s6hh21mlfd52qxjn93ip4mnfaq10m9q5imgp6i",
+      "version": "1.49.0",
+      "sha256": "0l2m7rsks9iry1dkba970jr0j7sn7sj2bcrpcbxbf84nkkgqimj8",
       "depends": []
     },
     "hapmap500knsp": {
       "name": "hapmap500knsp",
-      "version": "1.48.0",
-      "sha256": "0wk5p4r3ccklg7hss3kgs82k4chk1wyi1f9md8ygckghy6sap894",
+      "version": "1.49.0",
+      "sha256": "0dxf9kx32q5inb42i97bn7d65w9f9aw4gmqwrspsbms8fnzq50nb",
       "depends": []
     },
     "hapmap500ksty": {
       "name": "hapmap500ksty",
-      "version": "1.48.0",
-      "sha256": "0r0i2xcg9bmm9y4hls21zhp8g10bg2x4rf81xb9v0fj3yqv1i5w0",
+      "version": "1.49.0",
+      "sha256": "0lpajxf4bi0np8cn70wd4klwwhy4hf326djhk5sqdszh1xqskwyx",
       "depends": []
     },
     "hapmapsnp5": {
       "name": "hapmapsnp5",
-      "version": "1.48.0",
-      "sha256": "1cy5hf9crbw06gdpwhhrndjbk3id70xhws6y18k72x4va8mxmzv7",
+      "version": "1.49.0",
+      "sha256": "1pjdpr8rw0cb22psxn6w6qlm6g4h38m7j9v2hl7r7x70mgs6mw26",
       "depends": []
     },
     "hapmapsnp6": {
       "name": "hapmapsnp6",
-      "version": "1.48.0",
-      "sha256": "0gcmrp3spglrzpx9x7xvb7hw0rqw5nk4mc5rwwhdjvppa4vma5h9",
+      "version": "1.49.0",
+      "sha256": "0vi3vxj72d5x5gr1shgkxsr01k7jclyr5gnzkqcyp6izwqqpa2ab",
       "depends": []
     },
     "harbChIP": {
       "name": "harbChIP",
-      "version": "1.44.0",
-      "sha256": "13awr28aaylkvbjxpw9l4wwghyxa6jmaxcrsjijk0chk0qnmnsig",
+      "version": "1.45.0",
+      "sha256": "0xzzq1j5rdj5q3h0laavksc43zmxn964v5wkaqkbc4ycha64h11l",
       "depends": ["Biobase", "Biostrings", "IRanges"]
     },
     "healthyControlsPresenceChecker": {
       "name": "healthyControlsPresenceChecker",
-      "version": "1.10.0",
-      "sha256": "1pzladgwl9453bfhbzldlyyx40n7lpnxnsmmzaib3ff8p2hbkfcc",
+      "version": "1.11.0",
+      "sha256": "084yjf1cr6lsk6fn3cf9d15bp555ldimyrzakvkmd63fw3j8dwpz",
       "depends": ["GEOquery", "geneExpressionFromGEO", "magrittr", "xml2"]
     },
     "healthyFlowData": {
       "name": "healthyFlowData",
-      "version": "1.44.0",
-      "sha256": "0pwnhbdp1nnniqkzhf3hy9ikar05aflcv27rhx3627sgpaxy1z7y",
+      "version": "1.45.0",
+      "sha256": "05ilvfvza7h6hx2m6g3zllpm8q9nc21h9g7myccfbzvrhgcvg3d5",
       "depends": ["flowCore"]
     },
     "hgu133abarcodevecs": {
       "name": "hgu133abarcodevecs",
-      "version": "1.44.0",
-      "sha256": "0nmfki6jljnan53xhykhxc754k0dpxilw1c9xy3kwdqnh1bpjh99",
+      "version": "1.45.0",
+      "sha256": "0az3h0pmh9fzdndy9kiyr0kiqw7rf1szfqw94bq1qpdfdbxcp3d2",
       "depends": []
     },
     "hgu133plus2CellScore": {
       "name": "hgu133plus2CellScore",
-      "version": "1.26.0",
-      "sha256": "0rh6hqf8azrn65qx1h57flrq62hmj19w4bidwyrrx2aga31ycyd5",
+      "version": "1.27.0",
+      "sha256": "0ll5qgvynjv96wivry4a0lnbfwc44z25jjndjw6zgcczd7hfsfyc",
       "depends": ["Biobase"]
     },
     "hgu133plus2barcodevecs": {
       "name": "hgu133plus2barcodevecs",
-      "version": "1.44.0",
-      "sha256": "1pqxszdmqf50pmgdqkvn78blzrqm54x24zfl1pjk8cgb87npi7kf",
+      "version": "1.45.0",
+      "sha256": "1za9x3jgr3q285yf38vlwm53pl9iy28ibfbgin4gnkn61d9225h9",
       "depends": []
     },
     "hgu2beta7": {
       "name": "hgu2beta7",
-      "version": "1.46.0",
-      "sha256": "1warfbqli331l4cbvja9b91qzqw9521b06nal5x5jx66bnnnqv9y",
+      "version": "1.47.0",
+      "sha256": "1fzy0v2q1313z7czbbmbrcd1jyka0a4lzlfkcgxacabc3x8143rp",
       "depends": []
     },
     "homosapienDEE2CellScore": {
       "name": "homosapienDEE2CellScore",
-      "version": "1.2.0",
-      "sha256": "0acpl7kslv7gn22gbqkyysp3fhh5rkmcq32rl8cikf854f2nkf6k",
+      "version": "1.3.0",
+      "sha256": "15y1khwx9gklvkszfd4ld8rnbldma1gphghzbyz2hk8i922b9ic4",
       "depends": ["BiocGenerics", "DESeq2", "ExperimentHub", "MatrixGenerics", "Rtsne", "S4Vectors", "SummarizedExperiment", "getDEE2"]
+    },
+    "humanHippocampus2024": {
+      "name": "humanHippocampus2024",
+      "version": "0.99.8",
+      "sha256": "0k0km931n3x2md9h3a6d3h8yxxq18pic7dbwmf9g637ril9j3xpy",
+      "depends": ["ExperimentHub", "SpatialExperiment", "SummarizedExperiment"]
     },
     "humanStemCell": {
       "name": "humanStemCell",
-      "version": "0.46.0",
-      "sha256": "02ml1vbcm3nbhxkgzxm62ag970d8pabn4gj9ll2d1xpglvkcam9v",
+      "version": "0.47.0",
+      "sha256": "1rpin11gg4g683cc8v1z97imr0kp3ixdbh9yllw0vskfgk0m0m01",
       "depends": ["Biobase", "hgu133plus2_db"]
     },
     "imcdatasets": {
       "name": "imcdatasets",
-      "version": "1.14.0",
-      "sha256": "1mck9r0w1n56ri21xwj0w0c5b6nf21fws7qinml9psiszrxhh763",
+      "version": "1.15.0",
+      "sha256": "1292zg2was67sx8qlq468ls341rndrf5ai76wmyqiaqavw57ibq4",
       "depends": ["DelayedArray", "ExperimentHub", "HDF5Array", "S4Vectors", "SingleCellExperiment", "SpatialExperiment", "cytomapper"]
     },
     "kidpack": {
       "name": "kidpack",
-      "version": "1.48.0",
-      "sha256": "0ggps36p3bb303yfv81zlcsix04xyfaiflmb2sjkdz170zzzvpam",
+      "version": "1.49.0",
+      "sha256": "1dkirznpws0h5sg4yknh4yhbgiq2g3mf2n7pd9djb741c5w0ajid",
       "depends": ["Biobase"]
     },
     "leeBamViews": {
       "name": "leeBamViews",
-      "version": "1.42.0",
-      "sha256": "1fqcjmhki1am8b2kw0cymnih3wii8v5a7mbk1imvkl858chh3npz",
+      "version": "1.43.0",
+      "sha256": "0nc7irfb44s0hzax6ng78460v461zr8xv8cxzkaw2j1kbafs1v46",
       "depends": ["BSgenome", "Biobase", "GenomicAlignments", "GenomicRanges", "IRanges", "Rsamtools", "S4Vectors"]
     },
     "leukemiasEset": {
       "name": "leukemiasEset",
-      "version": "1.42.0",
-      "sha256": "1zgzg38l24vf27hhyywiv5gan6n25idziwxva09nc5qw4hyy8ikr",
+      "version": "1.43.0",
+      "sha256": "0rh4p3vkyh238mhg3xhp6pw0qsd32ciybk79c5h091iypifnjl2v",
       "depends": ["Biobase"]
     },
     "lumiBarnes": {
       "name": "lumiBarnes",
-      "version": "1.46.0",
-      "sha256": "1d1xpxjh6shynsj3ngv3nryrkjkzqx3d1f14sjr93qlwsbvhypfm",
+      "version": "1.47.0",
+      "sha256": "1bzychb6wwy5aqm2pyp95ixxvdrqm1dhr7dfx67z81b2zi7wfcc5",
       "depends": ["Biobase", "lumi"]
     },
     "lungExpression": {
       "name": "lungExpression",
-      "version": "0.44.0",
-      "sha256": "1wmxg0655i59rdf5h5p6fxah4vdmgkrcqrbpl5rgzi3kixrdpvqx",
+      "version": "0.45.0",
+      "sha256": "1psl42h6crzlaij7ppg8ddw9zycr4c3iizs1qasxd3j97hhacwpf",
       "depends": ["Biobase"]
     },
     "lydata": {
       "name": "lydata",
-      "version": "1.32.0",
-      "sha256": "1ag3bbjf3x3g3f3ivyyc7nrhny1562p27b8m2hs01krc1a80m1ym",
+      "version": "1.33.0",
+      "sha256": "1bpm86m22pvsmbg8fy3bvi4z20sxx6vd1mrvj43lipill2mrasbr",
       "depends": []
     },
     "mCSEAdata": {
       "name": "mCSEAdata",
-      "version": "1.26.1",
-      "sha256": "1qynhnpw7ap3k9imfpjccm0bkhrggjspwjnawq3i9mz4ahm6i4gk",
+      "version": "1.27.1",
+      "sha256": "1919hwlc7r5yp7jqghh428m6fmmm95ja33brx7lqkn3dqgw6zbhf",
       "depends": ["GenomicRanges"]
     },
     "macrophage": {
       "name": "macrophage",
-      "version": "1.22.0",
-      "sha256": "0dw15l1zs1byk9afhf7rlh9pifvn356slm5l4pagcfhn867qd5d6",
+      "version": "1.23.0",
+      "sha256": "041w6vdm38qy6c5z2qzakbm11l37rr1qfwml4f8h7mbgs43n9l5h",
       "depends": []
     },
     "mammaPrintData": {
       "name": "mammaPrintData",
-      "version": "1.42.0",
-      "sha256": "0limslpziil158drx8g783n425wnzvqr61h35hbv199nmrqc31in",
+      "version": "1.43.0",
+      "sha256": "01k8rm628bc15lshpb39j3pdj298vk80f50c0cwfblzqi3fy0k9j",
       "depends": []
     },
     "maqcExpression4plex": {
       "name": "maqcExpression4plex",
-      "version": "1.50.0",
-      "sha256": "059k1nsjc1c745vcpj3xnkfxymqpalmd8dn4drcj3z8f19gk76n4",
+      "version": "1.51.0",
+      "sha256": "0cyfaw9gv6n41yhxf4dpdm0372xqbymfqhicv3p4i7w30bnfhr4y",
       "depends": []
     },
     "marinerData": {
       "name": "marinerData",
-      "version": "1.6.0",
-      "sha256": "0p5xphaw0061yc84cjpcmqhq7qvjfz623imxv4zx1sz1nmavbai7",
+      "version": "1.7.0",
+      "sha256": "1icl7i9nix1kxhicy99hfvqlwa91q7dcrkb8zlnb7sfmn0i76j3n",
       "depends": ["ExperimentHub"]
     },
     "mcsurvdata": {
       "name": "mcsurvdata",
-      "version": "1.24.0",
-      "sha256": "165yychw6c1008nmaiac20zrk9ampmp7r3g1y3j9hv4lxjdczma6",
+      "version": "1.25.0",
+      "sha256": "0dbid6pfxwhh9ywqkza7cdr8sql5cwm7n15fmkp0d4x56kx2lriv",
       "depends": ["AnnotationHub", "Biobase", "ExperimentHub"]
     },
     "metaMSdata": {
       "name": "metaMSdata",
-      "version": "1.42.0",
-      "sha256": "16a7ff9dc157gjiq6zk1ig3ql0g7yh22ccxjnw2hfk66s3idqfpc",
+      "version": "1.43.0",
+      "sha256": "1ycfasldkgiygq8xf72c9wfhkfcw1jjnjcnk59dydvf70ppzf4sv",
       "depends": []
     },
     "methylclockData": {
       "name": "methylclockData",
-      "version": "1.14.0",
-      "sha256": "1ivl919xlrdqi1y1y4i5793925vd2ysj582wr9r4kwnird2dwbmw",
+      "version": "1.15.0",
+      "sha256": "0apvvidw6cwr2mfglysad5sfam5wj9ipjns5jsspmhwbg7wz1kxp",
       "depends": ["ExperimentHub", "ExperimentHubData"]
     },
     "miRNATarget": {
       "name": "miRNATarget",
-      "version": "1.44.0",
-      "sha256": "0arv3h8b3va3kcrpn8kj819mkqssjxi01322d3ijqy59ygbm91a3",
+      "version": "1.45.0",
+      "sha256": "0xcrxjnf6xyj8mfxz59v69vb18ffgyz616wj919g666mw2syc43p",
       "depends": ["Biobase"]
     },
     "miRcompData": {
       "name": "miRcompData",
-      "version": "1.36.0",
-      "sha256": "1wkr3i5pq9iwr2mrar9jky2z1qc7byxcfy9japidxfxsk287iapl",
+      "version": "1.37.0",
+      "sha256": "0a9wi0hy5mnqqwgfsi4pl748454is4q7mvf2c7pbjadwpx3dv4ha",
       "depends": []
     },
     "microRNAome": {
       "name": "microRNAome",
-      "version": "1.28.0",
-      "sha256": "1mfdaahi4ww5j7bzzwwflqs7h2hx565dynm1r4w4csgki0vr0j4l",
+      "version": "1.29.0",
+      "sha256": "0phw5pp0v2405s4p9xfn9jxiwq17v2c2dzyxdz1xi697vjabr74g",
       "depends": ["SummarizedExperiment"]
     },
     "microbiomeDataSets": {
       "name": "microbiomeDataSets",
-      "version": "1.14.0",
-      "sha256": "1mvdspp0kdv0x41z66iljr8x7cfyhsvp616h888sfiy7wh2jcmwc",
+      "version": "1.15.0",
+      "sha256": "0p8smyqv10nvjsz2nniwm7pmnzbxibvv5k0snxibdvdmnamjnbhr",
       "depends": ["BiocGenerics", "Biostrings", "ExperimentHub", "MultiAssayExperiment", "SummarizedExperiment", "TreeSummarizedExperiment", "ape"]
     },
     "minfiData": {
       "name": "minfiData",
-      "version": "0.52.0",
-      "sha256": "0vhf8hknls4dw49jgbgxqd8znx474g7x3imzvsh43cb7cs89xj3i",
+      "version": "0.53.0",
+      "sha256": "0cvhi0nfdfgx1g0799hn27xha8kgi3bfaa56bm3i2ygkbl0hkflr",
       "depends": ["IlluminaHumanMethylation450kanno_ilmn12_hg19", "IlluminaHumanMethylation450kmanifest", "minfi"]
     },
     "minfiDataEPIC": {
       "name": "minfiDataEPIC",
-      "version": "1.32.0",
-      "sha256": "0xqciawmlfxcb0s60d0dk9mc9jga12dmm7qx3dqs1i6p69lmdbiy",
+      "version": "1.33.0",
+      "sha256": "1ig3vi1182c70msfkjmh0fk8697zw5cymm5ikk1zhjkwdr7d5l9b",
       "depends": ["IlluminaHumanMethylationEPICanno_ilm10b2_hg19", "IlluminaHumanMethylationEPICmanifest", "minfi"]
     },
     "minionSummaryData": {
       "name": "minionSummaryData",
-      "version": "1.36.0",
-      "sha256": "0x5d0wrl6ck12g5xq8flyngvwi2wvij9pb6km34g7rz1c34wjj1n",
+      "version": "1.37.0",
+      "sha256": "1n62qzlcfsy9shqxv0ykhpg45cabbl4m7df0lg7664wn7vaah1xx",
       "depends": []
     },
     "mosaicsExample": {
       "name": "mosaicsExample",
-      "version": "1.44.0",
-      "sha256": "0zr5xpm3znscr5bl2l22nsgikfbhap0f0zc6sh8vxjjj8scq4mma",
+      "version": "1.45.0",
+      "sha256": "1cvc6sgsh9sb2j1y0xsh71sym2cyqcbk9nng5x6kc6vbxmyhrkh1",
       "depends": []
     },
     "mouse4302barcodevecs": {
       "name": "mouse4302barcodevecs",
-      "version": "1.44.0",
-      "sha256": "108hilxnvywqy3m1iks6d1nlivxgpxjlgcn203nh9mpyzk98d0m3",
+      "version": "1.45.0",
+      "sha256": "056vvpqpnwszvqqgb7brs2qpf4ykabzfr905fvqnz4pgz90kz1mm",
       "depends": []
     },
     "msPurityData": {
       "name": "msPurityData",
-      "version": "1.34.0",
-      "sha256": "16j10ncisvqfhyqkwqin4vclw87slgn9v2zq62rq437wjh9y0iqx",
+      "version": "1.35.0",
+      "sha256": "0h35q8sggh55rlka13rr7aknqijl1ic8ba82k58im3gm96qfrkbi",
       "depends": []
     },
     "msd16s": {
       "name": "msd16s",
-      "version": "1.26.0",
-      "sha256": "0wg705d0232d4916d3b84q62pdrzmf8v3k9apyh4fsmg4pk2xw6p",
+      "version": "1.27.0",
+      "sha256": "1j5kkkbsgwckjavjlxgzfrvrxs25n76kd182sviggdfq3fmj6nxp",
       "depends": ["Biobase", "metagenomeSeq"]
     },
     "msdata": {
       "name": "msdata",
-      "version": "0.46.0",
-      "sha256": "10b8anw0ygbsq95p89agjhs3qvgj9xrlrblg75cdbgmlzks2jhdl",
+      "version": "0.47.0",
+      "sha256": "136dddva2cyd14y39vqwbyryrllla00xkrg2w7fqz3xnin9wsw2m",
       "depends": []
     },
     "msigdb": {
       "name": "msigdb",
-      "version": "1.14.0",
-      "sha256": "1bla3jj5vdvb956pz07fxsihiwqlkpm409rdhljbdnld438q3kpp",
+      "version": "1.15.0",
+      "sha256": "1kw0dc7mpz1a01q804s6m22yk8a86i4hxk94gnyw815d69izzzkf",
       "depends": ["AnnotationDbi", "AnnotationHub", "ExperimentHub", "GSEABase", "org_Hs_eg_db", "org_Mm_eg_db"]
     },
     "msqc1": {
       "name": "msqc1",
-      "version": "1.34.0",
-      "sha256": "0qa0ki201miccd0pbcpc00wdpl3yxmwfjzwzk1jd816p10bn3qal",
+      "version": "1.35.0",
+      "sha256": "0bprdnzz86hvw0394lcskpx79zrb26q44s6rrx9fvl797l1hkgmp",
       "depends": ["lattice"]
     },
     "mtbls2": {
       "name": "mtbls2",
-      "version": "1.36.0",
-      "sha256": "1n1vz29y2yx1hbaxl1xl2lfvbd0f8knbngk07ibgi3dcfyjii6rz",
+      "version": "1.37.0",
+      "sha256": "17wrlvh14nxqvxgqljh7d01n1df6q8xj9p5pv5nr09r4bllmqhfk",
       "depends": []
+    },
+    "muSpaData": {
+      "name": "muSpaData",
+      "version": "0.99.5",
+      "sha256": "16jii5zfk98ipyfi91pa2gjbrnhl5nxnmi8svgbnfgnw95zn3j80",
+      "depends": ["ExperimentHub"]
     },
     "muleaData": {
       "name": "muleaData",
-      "version": "1.2.0",
-      "sha256": "1zw62kqr429g4nqhvgjjmxir25g0wh0490gpmcfc0vg72a00gyhf",
+      "version": "1.3.0",
+      "sha256": "0l7xzircjpl7svg5997qabwqg5b8qw2k3skkzy988hg7jl6s3rp5",
       "depends": []
     },
     "multiWGCNAdata": {
       "name": "multiWGCNAdata",
-      "version": "1.4.0",
-      "sha256": "1l2pqrxk6yab39ghgyicdchkkahaa57xhjglnjq15k4ss447cy01",
+      "version": "1.5.0",
+      "sha256": "0j2wg2f9dblc5jpb105fr9fz45qlsqv26r6mq8i7c6cp5b5m8z7q",
       "depends": ["ExperimentHub"]
     },
     "muscData": {
       "name": "muscData",
-      "version": "1.20.0",
-      "sha256": "1y2aqhbj3v8z2rzibay6q5d3505vx6c5qmybj147k8nyvffc8w9r",
+      "version": "1.21.0",
+      "sha256": "0c1p2nyssjzlhs3nay65d65ic3rdahsk8zsz43vaqjx0x548nvvh",
       "depends": ["ExperimentHub", "SingleCellExperiment"]
     },
     "mvoutData": {
       "name": "mvoutData",
-      "version": "1.42.0",
-      "sha256": "0w2fmzdfprk9kri8wmkr27p4gdps72i5gb9jj82pn7jlx3vqflkv",
+      "version": "1.43.0",
+      "sha256": "0062bimszsgylkxmpqpibs9a0fx333xxciczpqmqaxqic2hqaqp2",
       "depends": ["Biobase", "affy", "lumi"]
     },
     "nanotubes": {
       "name": "nanotubes",
-      "version": "1.22.0",
-      "sha256": "0ah9f2arylvvg0ndbn65qc79f573lv8pl5mzv8mpcm3xdh0gcf7v",
+      "version": "1.23.0",
+      "sha256": "0hznf4mrcbjkj7w79bpinbz4bm80knlc47lri1nivq7m428v093k",
       "depends": []
     },
     "nullrangesData": {
       "name": "nullrangesData",
-      "version": "1.12.0",
-      "sha256": "0mi1h40aagfxh79hpcd0bvbp7g4fwzggsnagny9i58sixbjj4kf8",
+      "version": "1.13.0",
+      "sha256": "1v2slrxqnf5irkrlqhcgsvx57qmkr71xwfrq7scqnbj337gvh79w",
       "depends": ["ExperimentHub", "GenomicRanges", "InteractionSet"]
     },
     "oct4": {
       "name": "oct4",
-      "version": "1.22.0",
-      "sha256": "1lh7cw5rjiv8l7f6g3nkk4h2390l8j5id1r42qw3b9mgz2dhhkc0",
+      "version": "1.23.0",
+      "sha256": "1w4hqiph1jvjyffmvab5niqyr5hdfk9xxzqax6n949ncmiwhpz7v",
       "depends": []
     },
     "octad_db": {
       "name": "octad.db",
-      "version": "1.8.0",
-      "sha256": "0n39hiwyrzpc7qmdak6s49fp7vypgixyh0li64gwgvqn7xawds29",
+      "version": "1.9.0",
+      "sha256": "1i4hv213fij0ym790nyy07wd5y23m2fk2r1smyq4ys37p28203p6",
       "depends": ["ExperimentHub"]
     },
     "optimalFlowData": {
       "name": "optimalFlowData",
-      "version": "1.18.0",
-      "sha256": "0rmx15jxp6qqi8vi9y5n419bb6dph5m75r71p9i11q01lqbk0i5b",
+      "version": "1.19.0",
+      "sha256": "1qmcfdp8fgijcxv5v4dvnhnaa8as8j4rk1rxbyvlzglsg9kv7a97",
       "depends": []
     },
     "orthosData": {
       "name": "orthosData",
-      "version": "1.4.0",
-      "sha256": "0iv8r0rnbix06kfrwcnrxvn31l0p0mlzciwsbxi7cyz8ar9h85j2",
+      "version": "1.5.0",
+      "sha256": "0591gbvns984ik7h5wqbm76rv3h7pa8gih1iybjl2qlwk4dkx0dj",
       "depends": ["AnnotationHub", "BiocFileCache", "ExperimentHub", "HDF5Array", "SummarizedExperiment", "stringr"]
     },
     "pRolocdata": {
       "name": "pRolocdata",
-      "version": "1.44.1",
-      "sha256": "01n9p4a02lq96rhz97skzs79mvnki3vqyn3b4b89vhrp8idgmli0",
+      "version": "1.45.1",
+      "sha256": "0r4frr4qh0vxj5vpnm18sfwwcjap3qhq8icrrbjmxvmgq4qrlzma",
       "depends": ["Biobase", "MSnbase"]
     },
     "parathyroidSE": {
       "name": "parathyroidSE",
-      "version": "1.44.0",
-      "sha256": "0lg52jn0bw5qavlw00wv8lx5g0lqx63p1k85bg7p3nx335v3ddrm",
+      "version": "1.45.1",
+      "sha256": "0ak4m518515mmsxqg9ch0vcr5dnnsl05804g2xyl7nwawj6cn3k5",
       "depends": ["SummarizedExperiment"]
     },
     "pasilla": {
       "name": "pasilla",
-      "version": "1.34.0",
-      "sha256": "1pa8s19q1n22nwjwdsdj9sla1x766wr87llxk5jywgfgl49317i7",
+      "version": "1.35.0",
+      "sha256": "0zl8v3s07zc93nzi0jz13ykka46cx3fgd9ls0kyvvp3wxnr5gx1x",
       "depends": ["DEXSeq"]
     },
     "pasillaBamSubset": {
       "name": "pasillaBamSubset",
-      "version": "0.44.0",
-      "sha256": "1i1z5vh0clvwrh2dlq0vw61k6nqvm9x7gzqxhm9wx4fxsgry6ncc",
+      "version": "0.45.0",
+      "sha256": "0sv219hr99dpa0alq9v57qzyzcrzr373cwnkqmigsi77xppigadr",
       "depends": []
     },
     "pd_atdschip_tiling": {
       "name": "pd.atdschip.tiling",
-      "version": "0.44.0",
-      "sha256": "1h92qkdbhk11qh8286zczrk00158yxjny4ya053dxcbg7wrzyv1s",
+      "version": "0.45.0",
+      "sha256": "16yirj2w2rgq0b1cij5ajw8ya0q95i77gryxmbs97qprq7g1cx1c",
       "depends": ["Biostrings", "DBI", "IRanges", "RSQLite", "S4Vectors", "oligo", "oligoClasses"]
     },
     "pepDat": {
       "name": "pepDat",
-      "version": "1.26.0",
-      "sha256": "114dx8nlx0hdi5kc5sjddsa1fbcjkx754ayfxxbdb1zl1zqxmbpi",
+      "version": "1.27.0",
+      "sha256": "174lq7rxc9cmns80k4r69n3zm4bmpl68spl1d55cyhfng6a7ww7l",
       "depends": ["GenomicRanges"]
     },
     "plotgardenerData": {
       "name": "plotgardenerData",
-      "version": "1.12.0",
-      "sha256": "0fi7ymf6kbgrr934xw0dj4skar8xvaan0s52j63rbzbvzsdvibz8",
+      "version": "1.13.0",
+      "sha256": "0vrsic758gr6cagxf0zbcxd2kiikj2sc9dp13bsjk3yl0iciqqdn",
       "depends": []
     },
     "prebsdata": {
       "name": "prebsdata",
-      "version": "1.42.0",
-      "sha256": "0q0dcd440ddq9jmjva3if4553shqydx5m11pqivirjjfbfdgjidn",
+      "version": "1.43.0",
+      "sha256": "0xdajinw9zk92ka2id2kj9cd9hl8wwgpxiy6vxi85sidi13q2l3w",
       "depends": []
     },
     "preciseTADhub": {
       "name": "preciseTADhub",
-      "version": "1.14.0",
-      "sha256": "05kia0l07qknpad8rb3afyfwin78gjs5b423afb7r9saj5yba041",
+      "version": "1.15.0",
+      "sha256": "0fkyknvc83kfcxwgklplrjfyavh6ypjr3l0jh7qcfisr746rn9qw",
       "depends": ["ExperimentHub"]
     },
     "prostateCancerCamcap": {
       "name": "prostateCancerCamcap",
-      "version": "1.34.0",
-      "sha256": "0wfaivl8f9g4dpgjmcj34md9yq9gdi31761lys70i9bpbq9p5mgy",
+      "version": "1.35.0",
+      "sha256": "0jdlnz0ip52h72zarv1bfqvcq1j903q6mmvsjz0h6wlw5fkr236r",
       "depends": ["Biobase"]
     },
     "prostateCancerGrasso": {
       "name": "prostateCancerGrasso",
-      "version": "1.34.0",
-      "sha256": "1q9a5jijr0pi7yh6aw6ygd9plczfj52rv7vs5gbl68rmhy63374r",
+      "version": "1.35.0",
+      "sha256": "17idxfllkpqrzygakchya59vgsks0rjj77arbah4pd51bcscjg9j",
       "depends": ["Biobase"]
     },
     "prostateCancerStockholm": {
       "name": "prostateCancerStockholm",
-      "version": "1.34.0",
-      "sha256": "1168mpfzx16qnwpvnlibaspi0v5zcncwa99cbv0prg7radp3wrzm",
+      "version": "1.35.0",
+      "sha256": "03rwhfy4ndm5nalyvb890v2x56kx1rwnz0qvfykpxvhz3mlbg6qh",
       "depends": ["Biobase"]
     },
     "prostateCancerTaylor": {
       "name": "prostateCancerTaylor",
-      "version": "1.34.0",
-      "sha256": "0qn2lysb70scvw52kq2qz5hzivl9yhsbisb5x68f375yns9s40h9",
+      "version": "1.35.0",
+      "sha256": "1v2xi60xhwzgb85ha6v46fyfi78vwn2n3zr8ah8bis9nl1k6v827",
       "depends": ["Biobase"]
     },
     "prostateCancerVarambally": {
       "name": "prostateCancerVarambally",
-      "version": "1.34.0",
-      "sha256": "0akyyjbg6mh4j53h6lf6m2mr0c9p667cmj94mflcp3b64a0n2y9r",
+      "version": "1.35.0",
+      "sha256": "15ypkmvky9kb7siymsrbgj8p0q6i5ydk5rxvjhdfx69sj8fzbqlv",
       "depends": ["Biobase"]
     },
     "ptairData": {
       "name": "ptairData",
-      "version": "1.14.0",
-      "sha256": "0kmqzzgpy3kbi8w462wwb8c8gviiyk0w2v7k5w9zi3zxdrmw7ccm",
+      "version": "1.15.0",
+      "sha256": "0i03k4srgy9s034i9h38drvhm240rs3c7la276zcjm8mcj95jcz8",
       "depends": ["rhdf5", "signal"]
     },
     "pumadata": {
       "name": "pumadata",
-      "version": "2.42.0",
-      "sha256": "1ha92bc24qxdzjp1m98a0261snp44i293ryl0vkwgafdq4q9w320",
+      "version": "2.43.0",
+      "sha256": "11895s03vlnq1cypkh8n65w1lb863v5zyaqg2yc6r0qcm4lafnnx",
       "depends": ["Biobase", "oligo", "puma"]
     },
     "qPLEXdata": {
       "name": "qPLEXdata",
-      "version": "1.24.0",
-      "sha256": "08cji317gf0di58hx30faan8hii69acd70d6z903pf4m4mcx8q98",
+      "version": "1.25.0",
+      "sha256": "1m1m16wqfyg9rs5ilmyxdv3ly73ijr983m29rcl2shc1aq8q45s6",
       "depends": ["MSnbase", "dplyr", "knitr", "qPLEXanalyzer"]
     },
     "rRDPData": {
       "name": "rRDPData",
-      "version": "1.26.0",
-      "sha256": "0f662rxavvzrfmg275h4fs12v36dlm5vagjxdwfrslpayw10mjf9",
+      "version": "1.27.0",
+      "sha256": "0cww8wcf976xdc4qi0ijbwnvxc1ydz4g3q9idpph1iljdr1ck90y",
       "depends": ["rRDP"]
     },
     "raerdata": {
       "name": "raerdata",
-      "version": "1.4.0",
-      "sha256": "01zvkzqiw2m6nvr2z45i6aqzwgp3ck7rrxdkx1ycqdc2xg2jm36c",
+      "version": "1.5.0",
+      "sha256": "1vrmx5gwb9a77la83hajfbwbqw0jh2mzymcxv8brm2ijpi338vjy",
       "depends": ["BiocGenerics", "ExperimentHub", "Rsamtools", "SingleCellExperiment", "rtracklayer"]
     },
     "rcellminerData": {
       "name": "rcellminerData",
-      "version": "2.28.0",
-      "sha256": "15jx4nnn6zqi6agq7ddcbdqng4pzikl6dckig4phv2zblfq7jvhv",
+      "version": "2.29.0",
+      "sha256": "01rpzsplwjz4y3s57cidj6bbxnh7ghnq1816n0ivk2n90wdb127s",
       "depends": ["Biobase"]
     },
     "rheumaticConditionWOLLBOLD": {
       "name": "rheumaticConditionWOLLBOLD",
-      "version": "1.44.0",
-      "sha256": "0749nv3qspwqvaqwd0mssyvqcz8nyircrn87bmmd9pdwsw1i4p18",
+      "version": "1.45.0",
+      "sha256": "1qip8wxn4v1mb6wdc8asvmsrv634rdkvsjx34wdxh23g5bvqibsl",
       "depends": []
     },
     "sampleClassifierData": {
       "name": "sampleClassifierData",
-      "version": "1.30.0",
-      "sha256": "0q46jri2x8wi2b2xgp17fqpjp3grn6vn9gs16nfvdfcbr19lhfj9",
+      "version": "1.31.0",
+      "sha256": "02lzjnz6zi7xhgihz8sdpylsxaw25lhlajjmwgcllgmv7cyhkykx",
       "depends": ["SummarizedExperiment"]
     },
     "scATAC_Explorer": {
       "name": "scATAC.Explorer",
-      "version": "1.12.1",
-      "sha256": "0zafzrvdll5w0kig13nzfvcykz0m4a12vfzzdgxnjsyyffsf1szv",
+      "version": "1.13.0",
+      "sha256": "0a81hd49mzqbg3v24ljyzd1aqn3c0w9zm0iy3v015rh94l2mig2a",
       "depends": ["BiocFileCache", "Matrix", "S4Vectors", "SingleCellExperiment", "data_table", "zellkonverter"]
     },
     "scMultiome": {
       "name": "scMultiome",
-      "version": "1.6.0",
-      "sha256": "1wfjk5vq1apy9s2hn86b379kd2zbi0r3wxcvw6dz599pgsxly35y",
+      "version": "1.7.3",
+      "sha256": "1d4rpl26qbbrknpd21pjyd666y945098q2z6wk7cpwspvq7nih38",
       "depends": ["AnnotationHub", "AzureStor", "ExperimentHub", "GenomicRanges", "HDF5Array", "MultiAssayExperiment", "S4Vectors", "SingleCellExperiment", "SummarizedExperiment", "alabaster_matrix", "checkmate", "rhdf5"]
     },
     "scRNAseq": {
       "name": "scRNAseq",
-      "version": "2.20.0",
-      "sha256": "1vjww44d3w2rvvj1b2fdbcv0pwpsspqdhzbykwvsqmw559k9viz1",
+      "version": "2.21.1",
+      "sha256": "0sgr8cqzmsx1fl386qh6bs8minagjhxmfdp2kjhiwlrz7fysy0q3",
       "depends": ["AnnotationDbi", "AnnotationHub", "BiocGenerics", "DBI", "DelayedArray", "ExperimentHub", "GenomicFeatures", "GenomicRanges", "Matrix", "RSQLite", "S4Vectors", "SingleCellExperiment", "SparseArray", "SummarizedExperiment", "alabaster_base", "alabaster_matrix", "alabaster_sce", "ensembldb", "gypsum", "jsonlite"]
     },
     "scTHI_data": {
       "name": "scTHI.data",
-      "version": "1.18.0",
-      "sha256": "17m8f5jg184cg95wh24ya63imaxcb71k4rsw95kfv0dsnv6203ls",
+      "version": "1.19.0",
+      "sha256": "03ix5d6mra5a6fn87grk6i45ia0x6p8ypkk11wq9fm42qj80v5yl",
       "depends": []
     },
     "scaeData": {
       "name": "scaeData",
-      "version": "1.2.0",
-      "sha256": "0pjk97akkn5i83z6n63hzgwpw6rdl6d6xrx95hbxvk2srij4jx4l",
+      "version": "1.3.0",
+      "sha256": "0p964m8fvh3gm53hmjvimyizspaay1agd80aka3ijmww2dy8nrbb",
       "depends": ["ExperimentHub"]
     },
     "scanMiRData": {
       "name": "scanMiRData",
-      "version": "1.12.0",
-      "sha256": "1rw4mfqx86j2ln637lwk2z4cn5bwfc3icrp4w2yvq8ll7jlgzazm",
+      "version": "1.13.0",
+      "sha256": "1x8hpdfnnd4ag1xssxyrvvr1x6pz1i46dj772jh5jh6ya3d3b74q",
       "depends": ["scanMiR"]
     },
     "scpdata": {
@@ -2381,200 +2387,200 @@
     },
     "seq2pathway_data": {
       "name": "seq2pathway.data",
-      "version": "1.38.0",
-      "sha256": "0ad7g1m4dca0dqhri4g6gm6332r890ba0pvxbnajk8ahjlhzs0j3",
+      "version": "1.39.0",
+      "sha256": "0mly7d53g0clms18qkya98bmxkxda0kib0viqfh469gj6d1d6h5a",
       "depends": []
     },
     "seqc": {
       "name": "seqc",
-      "version": "1.40.0",
-      "sha256": "1cpfb3xml4bmvhlnprw5kg7k1rk8r5p88i4n11g23n3ban4ynbah",
+      "version": "1.41.0",
+      "sha256": "0c708lrynn4xfj10ifwj0vdda1vzcry4gqmsnw66d22hzi0l8bmk",
       "depends": ["Biobase"]
     },
     "serumStimulation": {
       "name": "serumStimulation",
-      "version": "1.42.0",
-      "sha256": "1g2v40x150j4v467wns6b5z7blrz9xf5wqi7jm52dwgh6fp145hp",
+      "version": "1.43.0",
+      "sha256": "159rb4sq4ny4h3cgk2lra4n59jdmp8fd7i4w2s9j0hi39cgm7fqk",
       "depends": []
     },
     "sesameData": {
       "name": "sesameData",
-      "version": "1.24.0",
-      "sha256": "1dgf9qi27rc98mwlyax0v86h7fmwbnp0xna1c0ppsj0fpwbmj50y",
+      "version": "1.25.0",
+      "sha256": "1j174casrqd1wnk0v082ln37m1kbzm4x0ggis5ypg5267k94vlzr",
       "depends": ["AnnotationHub", "ExperimentHub", "GenomeInfoDb", "GenomicRanges", "IRanges", "S4Vectors", "readr", "stringr"]
     },
     "seventyGeneData": {
       "name": "seventyGeneData",
-      "version": "1.42.0",
-      "sha256": "1g7qfjgljm8945rjm371f2677aks0v5hbb84hxj3572bp3jqi7z7",
+      "version": "1.43.0",
+      "sha256": "0x15fvy4vgsr9hwgfn79xg252lv7cqdmwkcl7k15naw07h0bsvvk",
       "depends": []
     },
     "shinyMethylData": {
       "name": "shinyMethylData",
-      "version": "1.26.0",
-      "sha256": "09ddyzfxf8pihma6fadxsvil00ikx9xivdpybb5gm6ij9g9vsksl",
+      "version": "1.27.0",
+      "sha256": "0czglfj1vi2p2allvl3g5bzkix15k8x8sx0kxyny9cxs2rrr1j4v",
       "depends": []
     },
     "signatureSearchData": {
       "name": "signatureSearchData",
-      "version": "1.20.0",
-      "sha256": "14q30cbym19p3k6d5052c6h05vqkdzkhqh230v91nmjwa2qkvw0b",
+      "version": "1.21.0",
+      "sha256": "04jiri95v8q3x6kmfsdni5fmg3f559wsv3p21k2a6wphc79d3j1x",
       "depends": ["Biobase", "ExperimentHub", "R_utils", "affy", "dplyr", "limma", "magrittr", "rhdf5"]
     },
     "simpIntLists": {
       "name": "simpIntLists",
-      "version": "1.42.0",
-      "sha256": "0b6z5ya7bbf6j4blc3f2l705k19fxq02sk9by3dg3qx63vishra4",
+      "version": "1.43.0",
+      "sha256": "0bksnpwmhnrlrf2jxh772n62rmn2jg3zcpzd05wjxkyyr5n9lxww",
       "depends": []
     },
     "smokingMouse": {
       "name": "smokingMouse",
-      "version": "1.4.0",
-      "sha256": "0nzadqpsxshic7kprvdfjxvd4hhb531902fjh7r3n4mn34r2v8c5",
+      "version": "1.5.1",
+      "sha256": "1ripqq7xcd8x1i9azyc8ha4hsf2b84wv65qyrd21r5s923p9sfd7",
       "depends": []
     },
     "spatialDmelxsim": {
       "name": "spatialDmelxsim",
-      "version": "1.12.0",
-      "sha256": "0qdjm8pvvxggwb4s0202mnyy68zpmx8c31zvg3cddkyf9cw9lynb",
+      "version": "1.13.0",
+      "sha256": "1q2hw2n6xjp170i8mb0x6rnfb2jz1s92b0srvhxfad722fzagrf4",
       "depends": ["ExperimentHub", "SummarizedExperiment"]
     },
     "spatialLIBD": {
       "name": "spatialLIBD",
-      "version": "1.18.0",
-      "sha256": "0n1gywjhz72m196frw2p3zhxwxhkyd22m1gsby42w2myms939mj4",
-      "depends": ["AnnotationHub", "BiocFileCache", "BiocGenerics", "DT", "ExperimentHub", "GenomicRanges", "IRanges", "Matrix", "MatrixGenerics", "RColorBrewer", "S4Vectors", "SingleCellExperiment", "SpatialExperiment", "SummarizedExperiment", "benchmarkme", "cowplot", "dplyr", "edgeR", "fields", "ggplot2", "golem", "jsonlite", "limma", "magick", "paletteer", "plotly", "png", "rlang", "rtracklayer", "scater", "scuttle", "sessioninfo", "shiny", "shinyWidgets", "statmod", "tibble", "viridisLite"]
+      "version": "1.19.12",
+      "sha256": "0ivwn1rphaip61f8b9gp4lr35wdn0iq773mdlhdk7kcq4jxx9aad",
+      "depends": ["AnnotationHub", "BiocFileCache", "BiocGenerics", "ComplexHeatmap", "DT", "ExperimentHub", "GenomicRanges", "IRanges", "Matrix", "MatrixGenerics", "S4Vectors", "SingleCellExperiment", "SpatialExperiment", "SummarizedExperiment", "benchmarkme", "circlize", "cowplot", "dplyr", "edgeR", "ggplot2", "golem", "jsonlite", "limma", "magick", "paletteer", "plotly", "png", "rlang", "rtracklayer", "scater", "scuttle", "sessioninfo", "shiny", "shinyWidgets", "statmod", "tibble", "viridisLite"]
     },
     "spqnData": {
       "name": "spqnData",
-      "version": "1.18.0",
-      "sha256": "1r94c4p4cjwjwv9wsfvf90a6i3c4a3n31248yi29bly1v56hpwff",
+      "version": "1.19.0",
+      "sha256": "1822pm0lb8irf9in47qaf34s1kxyvj4wgiaclvzp1fc22i602dvn",
       "depends": ["SummarizedExperiment"]
     },
     "stemHypoxia": {
       "name": "stemHypoxia",
-      "version": "1.42.0",
-      "sha256": "1kxnqgn52a07iy8770k7wd72p1chjbcb11qhzb4s9c5ydhmb9vyw",
+      "version": "1.43.0",
+      "sha256": "0dn6iay0z5f0psrs2mqd3rs12xqhc4nza848yyh1hh3n9llgy864",
       "depends": []
     },
     "synapterdata": {
       "name": "synapterdata",
-      "version": "1.44.0",
-      "sha256": "1csrkpyjmp54a8wdahwdm2kqjraff0hg91jzrz209pqv88ymf1jm",
+      "version": "1.45.1",
+      "sha256": "1587sl3msak2xd7bljn2mqkhl3jyxgan15vyjlihp8p52bq3agai",
       "depends": ["synapter"]
     },
     "systemPipeRdata": {
       "name": "systemPipeRdata",
-      "version": "2.10.0",
-      "sha256": "0276cyzcd9pzma9s4f300snlkyq2xlnavbwm8rwvn22dpgzapskd",
+      "version": "2.11.0",
+      "sha256": "02dbhq138asfwmxd573jwsrshkncc7801l3xdcb3gcr5x8za08lf",
       "depends": ["BiocGenerics", "Biostrings", "jsonlite", "remotes"]
     },
     "tartare": {
       "name": "tartare",
-      "version": "1.20.0",
-      "sha256": "1ay9mglinp92c2rhac1yrvhc86pa4inn7fhifzi3scrblwwz0fyx",
+      "version": "1.21.0",
+      "sha256": "1iaag1p01hnzk64dyfsj6g85m5wrp6lc4y17z5sfd3mx7v41r7ai",
       "depends": ["AnnotationHub", "ExperimentHub"]
     },
     "timecoursedata": {
       "name": "timecoursedata",
-      "version": "1.16.0",
-      "sha256": "1frz3ya65qhb6pr7iysmm1ijvzvhgmr5hfhldrq69xmdin2vfzk5",
+      "version": "1.17.0",
+      "sha256": "026avbzn7p5yhm7fh4qwq0xilgx42qhyplmfzcpzx13kq08jp25w",
       "depends": ["SummarizedExperiment"]
     },
     "tinesath1cdf": {
       "name": "tinesath1cdf",
-      "version": "1.44.0",
-      "sha256": "1977lhsjhp1r2abaaz1yqj8wgkjc3jxw0kpvwqwv49g2dkrrajgh",
+      "version": "1.45.0",
+      "sha256": "0zq4r0qfdrwh0a8hk4pkav8abs112dhszf2n1n51zlwvysvkz7w4",
       "depends": []
     },
     "tinesath1probe": {
       "name": "tinesath1probe",
-      "version": "1.44.0",
-      "sha256": "0rvqal11clfisj9srraw2fmw401264l1lbzcb8l4rssqspvfabi1",
+      "version": "1.45.0",
+      "sha256": "00cmv0dgwhszir2ljmbxzr6fkrv0xqk6i7jkjkjqsgjzbxwf78c3",
       "depends": ["AnnotationDbi"]
     },
     "tissueTreg": {
       "name": "tissueTreg",
-      "version": "1.26.0",
-      "sha256": "0l2dq57dmavqyp22rn0rvhcir7xagxn981rynpi7yjadhs2vx9yb",
+      "version": "1.27.0",
+      "sha256": "1wsiwd8f9njpl6jpxbx9y52vd8012pg975xxbh4jyv47sck3b90f",
       "depends": []
     },
     "tofsimsData": {
       "name": "tofsimsData",
-      "version": "1.34.0",
-      "sha256": "1y72masgz7l9g29n9r2p09b02spr19pxkzwxid5sckivrfacr581",
+      "version": "1.35.0",
+      "sha256": "1pqv30v9i3br6x8cj3605pcds1a5a6xnibcmqh8w7bsdgwka8scj",
       "depends": []
     },
     "topdownrdata": {
       "name": "topdownrdata",
-      "version": "1.28.0",
-      "sha256": "1192ws4a062a5xwqzpnavy9kby1vj4acgkfy39yxxawl4vk1snzj",
+      "version": "1.29.0",
+      "sha256": "0d7wqn1k1izk6b3pc5gqcaghwnsfwczb4aidxllykbx366pkc2aq",
       "depends": ["topdownr"]
     },
     "tuberculosis": {
       "name": "tuberculosis",
-      "version": "1.12.0",
-      "sha256": "03vh5rarggydia75pzz37jqbpf6jwl2mzsrrp5sww331274djbyl",
+      "version": "1.13.0",
+      "sha256": "067089k6jvdrp7jjclfwwvxfg3zmqf8bj52x60m3w5pdk8wqj144",
       "depends": ["AnnotationHub", "ExperimentHub", "S4Vectors", "SummarizedExperiment", "dplyr", "magrittr", "purrr", "rlang", "stringr", "tibble", "tidyr"]
     },
     "tweeDEseqCountData": {
       "name": "tweeDEseqCountData",
-      "version": "1.44.0",
-      "sha256": "1xgqfx9mnqa1xgxyayijl1873philc24cr91r5wm25y56hp2c6yb",
+      "version": "1.45.0",
+      "sha256": "1ga0iz05a25ffbmwns5ffgrxdhzhvaksp7rdl79840h00751f4r8",
       "depends": ["Biobase"]
     },
     "tximportData": {
       "name": "tximportData",
-      "version": "1.34.0",
-      "sha256": "1x4c4pd4yyfd8z5gyv7kqiip25bi9mdzl5qix1rb27ljvnyz9405",
+      "version": "1.35.0",
+      "sha256": "0ah5c6qkca7gb8g02d8yc2rc9kcvcmprs8pv81vqdbrwgyssg9kq",
       "depends": []
     },
     "vulcandata": {
       "name": "vulcandata",
-      "version": "1.28.0",
-      "sha256": "10742vjwrf9b5vgqgy8girpxczgcl6jybsmf0pa6y5dlf81lkkby",
+      "version": "1.29.0",
+      "sha256": "0hirplqv2di1b6jq7cyzn2szmhhrmyf7550qirxbbirqarrp5l3l",
       "depends": []
     },
     "xcoredata": {
       "name": "xcoredata",
-      "version": "1.10.0",
-      "sha256": "0y8z0gfkcacl82s6j5g3fjg7a5k8hyz4w4xfx6lyjsp7fxdbmc9f",
+      "version": "1.11.0",
+      "sha256": "192jiad9dfxrixyw1z23s5r7r5a2hdmb4c9n2jq3mgxvrb64j59y",
       "depends": ["ExperimentHub"]
     },
     "yeastCC": {
       "name": "yeastCC",
-      "version": "1.46.0",
-      "sha256": "12nfq7dndl3snmqg3zcpbgk93dlnqlkvccadhipmdqb1j7l0k686",
+      "version": "1.47.0",
+      "sha256": "1qf2daamqk1qg802878f3bmlwsbs8072dnpja4579dzcr2r47f39",
       "depends": ["Biobase"]
     },
     "yeastExpData": {
       "name": "yeastExpData",
-      "version": "0.52.0",
-      "sha256": "0dqg5im7k31l217qg6sv8bzw83ix6zd9p0c28gx9hzarvh3hr5vl",
+      "version": "0.53.0",
+      "sha256": "0935764p7msqmkdz0ihnxqbpdpd5qrhj6bp9qx37v492hh26qay8",
       "depends": ["graph"]
     },
     "yeastGSData": {
       "name": "yeastGSData",
-      "version": "0.44.0",
-      "sha256": "1i7z5pf4ci4rzv8ns42j9kw4y5rdq4lw18basdxg3syhiiqd21pd",
+      "version": "0.45.0",
+      "sha256": "0xqdcpnih9y3677v1i14h3r5dx353366gi9lh1m5b72ikdq80p1f",
       "depends": []
     },
     "yeastNagalakshmi": {
       "name": "yeastNagalakshmi",
-      "version": "1.42.0",
-      "sha256": "0j6by8n9cdfnfzapn2985zsmb3861p59xhmzyxbpyhxz465m6d5x",
+      "version": "1.43.0",
+      "sha256": "0dgm0zl07iic2mhifncdfspqhfr5ir2rwqffibp09v6482jclqmw",
       "depends": []
     },
     "yeastRNASeq": {
       "name": "yeastRNASeq",
-      "version": "0.44.0",
-      "sha256": "08pk3p21m3ida96psy7a2shffhz2qx5kz9arhhgk3vm7c1ai25l6",
+      "version": "0.45.0",
+      "sha256": "1cg65l4ghdqr43698829v13dpddqnzrz5ybnp54sr2jh52sp16pa",
       "depends": []
     },
     "zebrafishRNASeq": {
       "name": "zebrafishRNASeq",
-      "version": "1.26.0",
-      "sha256": "0h9bgqbyrakpmp15fvwpygmf0yrf8wqyfg3fnr30k46xvn265axh",
+      "version": "1.27.0",
+      "sha256": "1iz3p4klv54s6r2y4wafxzzriyzrlqhkrfy3gm21bmiq6aisx7xl",
       "depends": []
     },
     "ABAData": {
@@ -2582,13 +2588,6 @@
       "version": "1.0.0",
       "sha256": "1p2q03c87ilwfz7gbypkfi0n3m9m3c4z6ci9b5v4pr46q4ppl7s9",
       "depends": [],
-      "broken": true
-    },
-    "AssessORFData": {
-      "name": "AssessORFData",
-      "version": "1.21.0",
-      "sha256": "10rbwdcjqfhq9ramrzfxd3bl2q2nqminsj3pigid6fmvyg0ykfhk",
-      "depends": ["DECIPHER"],
       "broken": true
     },
     "ChIC_data": {
@@ -2612,6 +2611,13 @@
       "depends": ["SummarizedExperiment"],
       "broken": true
     },
+    "DmelSGI": {
+      "name": "DmelSGI",
+      "version": "1.37.0",
+      "sha256": "023ynaky11cc33ksmq8s77m17rlr45mp33bzrzaqija64z01rgih",
+      "depends": ["TSP", "abind", "gplots", "igraph", "knitr", "limma", "rhdf5"],
+      "broken": true
+    },
     "FunciSNP_data": {
       "name": "FunciSNP.data",
       "version": "1.6.0",
@@ -2624,6 +2630,13 @@
       "version": "1.8.0",
       "sha256": "1r2kshwi8iajk0rwzkccdw389ffvkzivg82f4bri3xw0sq57fm50",
       "depends": ["AnnotationDbi", "Biobase", "GGBase", "illuminaHumanv1_db", "snpStats"],
+      "broken": true
+    },
+    "Hiiragi2013": {
+      "name": "Hiiragi2013",
+      "version": "1.41.0",
+      "sha256": "0z8ns2qsnng3kvzcris3hxggy1jmzrl8jwy0ndf6sbn1cqj1pnkl",
+      "depends": ["Biobase", "KEGGREST", "MASS", "RColorBrewer", "affy", "boot", "clue", "cluster", "genefilter", "geneplotter", "gplots", "gtools", "lattice", "latticeExtra", "mouse4302_db", "xtable"],
       "broken": true
     },
     "MAQCsubsetAFX": {
@@ -2701,6 +2714,13 @@
       "version": "1.16.0",
       "sha256": "17c5fvyqxdsg7wl0hy0i28z0kf2lmjg36lfrmsv51kzklsc6ykrp",
       "depends": [],
+      "broken": true
+    },
+    "RNAinteractMAPK": {
+      "name": "RNAinteractMAPK",
+      "version": "1.41.0",
+      "sha256": "0dfxy6hhcwx8xd4c2a02v41dnrrj97lg7ddl4pfn492rk4qvd4s6",
+      "depends": ["Biobase", "MASS", "fields", "gdata", "genefilter", "lattice", "sparseLDA"],
       "broken": true
     },
     "RnaSeqTutorial": {

--- a/pkgs/development/r-modules/bioc-packages.json
+++ b/pkgs/development/r-modules/bioc-packages.json
@@ -1,7872 +1,8172 @@
 {
   "extraArgs": {
-    "biocVersion": "3.20"
+    "biocVersion": "3.21"
   },
   "packages": {
     "ABSSeq": {
       "name": "ABSSeq",
-      "version": "1.60.0",
-      "sha256": "02yypkrvd2gbclcddjvw5zdl4crh286ifddxj5cix1d4hhas1gc4",
+      "version": "1.62.0",
+      "sha256": "11fkdzgm480qmyi9hscc99d0agdjvija01226np2s8k45iy4j0r8",
       "depends": ["limma", "locfit"]
     },
     "ABarray": {
       "name": "ABarray",
-      "version": "1.74.0",
-      "sha256": "0iay7aai5ijg0ai42mz4sks6qvndy69hdwavy5qvbhgfsgbdpmxv",
+      "version": "1.76.0",
+      "sha256": "0rs6x9ccw3i5xzsinajqq300jxwp9v69s96wp1xdgpdx24azmq03",
       "depends": ["Biobase", "multtest"]
     },
     "ACE": {
       "name": "ACE",
-      "version": "1.24.0",
-      "sha256": "0ky6l0x5wbwil0lqnclgfpdhn94954k62xpv0z3mhy4lvqf07h4j",
+      "version": "1.26.0",
+      "sha256": "0v78djw83b253gsjxs3m5ihxyz82gzvsqhbiblxcryvghzv1c7x3",
       "depends": ["Biobase", "GenomicRanges", "QDNAseq", "ggplot2"]
     },
     "ACME": {
       "name": "ACME",
-      "version": "2.62.0",
-      "sha256": "05lvljiq3wgn0xqax8nhrsfwfxkslch9fyzk8v7qdvi72j0j3g9b",
+      "version": "2.64.0",
+      "sha256": "1s1s00b6mrv710x14vnscs99iinqq5pml684vpgbshlvszzyw71h",
       "depends": ["Biobase", "BiocGenerics"]
     },
     "ADAM": {
       "name": "ADAM",
-      "version": "1.22.0",
-      "sha256": "044r6ykd3kv1zswmnw82q961mxywcmxxyj9x55z6qbykww5868lz",
+      "version": "1.24.0",
+      "sha256": "03258gs13spyg807ky217y4mv265cklykb8a6qvn2b9shyjss8qb",
       "depends": ["DT", "GO_db", "KEGGREST", "Rcpp", "SummarizedExperiment", "dplyr", "knitr", "pbapply", "stringr"]
     },
     "ADAMgui": {
       "name": "ADAMgui",
-      "version": "1.22.0",
-      "sha256": "1gpc5gzrwlji7a0vlr1jidn1c2nkzdv8qb82jhrg5yfglaxf1ddd",
+      "version": "1.24.0",
+      "sha256": "008ak7x5ph841ls60jzhycyyqkbqzvdj5px8nn1ig2if72krhhdw",
       "depends": ["ADAM", "DT", "GO_db", "RColorBrewer", "colorRamps", "data_table", "dplyr", "ggplot2", "ggpubr", "ggrepel", "ggsignif", "gridExtra", "knitr", "reshape2", "shiny", "shinyjs", "stringi", "stringr", "testthat", "varhandle"]
     },
     "ADAPT": {
       "name": "ADAPT",
-      "version": "1.0.0",
-      "sha256": "111k0q40znpjacqkgcswjdp5iqbxxx60d1bjkziazgk3kgz6ly44",
+      "version": "1.2.0",
+      "sha256": "0v4vivxvsfwxs1sds3lawsbjb7ajv769i3xqiqir29ifn6lsjlw1",
       "depends": ["Rcpp", "RcppArmadillo", "RcppParallel", "ggplot2", "ggrepel", "phyloseq"]
     },
     "ADImpute": {
       "name": "ADImpute",
-      "version": "1.16.0",
-      "sha256": "1738j07hk2kj7w29vba1xhxnjj5w2zxcf59d3r4mwrxbhc771sqy",
+      "version": "1.18.0",
+      "sha256": "0fa03prsxbwhqhhglr0c4fjgasa9g32i5fh73lc82axd86nk2vk3",
       "depends": ["BiocParallel", "DrImpute", "MASS", "Matrix", "S4Vectors", "SAVER", "SingleCellExperiment", "SummarizedExperiment", "checkmate", "data_table", "kernlab", "rsvd"]
     },
     "ADaCGH2": {
       "name": "ADaCGH2",
-      "version": "2.46.0",
-      "sha256": "1pzzbqh5wflhn9zqpdggx80y6zhdzg6i4xwgzjrh89bq90ibck04",
-      "depends": ["DNAcopy", "GLAD", "aCGH", "bit", "cluster", "ff", "tilingArray", "waveslim"]
+      "version": "2.48.0",
+      "sha256": "1wxqwd8grmn900qib8xxfvmfb2g2r8ic6rmc6nbqlpzgfq0aa325",
+      "depends": ["DNAcopy", "aCGH", "bit", "cluster", "ff", "tilingArray", "waveslim"]
     },
     "AGDEX": {
       "name": "AGDEX",
-      "version": "1.54.0",
-      "sha256": "02kldgslgyx5xr5zn45vndai37j66wp4xdjpvasdv46b7rm7drx2",
+      "version": "1.56.0",
+      "sha256": "14ykvs8rgf8c6gar5xacypsk2m30w4a8r3jmkdx1v3wxl510pbzk",
       "depends": ["Biobase", "GSEABase"]
     },
     "AHMassBank": {
       "name": "AHMassBank",
-      "version": "1.6.0",
-      "sha256": "1z9sd8rkzq4bgx3abrm2d31kmxq3q8b2lrkp45gw46026nvz8217",
+      "version": "1.8.0",
+      "sha256": "0iqf86vfff3rnxxchha5dp1fglnw13awpy703adlwasr7dx61sf4",
       "depends": ["AnnotationHubData"]
     },
     "AIMS": {
       "name": "AIMS",
-      "version": "1.38.0",
-      "sha256": "04xch3ld6f9bwsp3v8m1klxppr52flaj0svk2fjak5m9dar5lg0b",
+      "version": "1.40.0",
+      "sha256": "0414w398wlr8rzcc9nyz3nq2xni5582p99i4d0bqydg35zdmzxr5",
       "depends": ["Biobase", "e1071"]
     },
     "ALDEx2": {
       "name": "ALDEx2",
-      "version": "1.38.0",
-      "sha256": "1c22h27w852b5mbniw6266r8pxf28ii5czi8iki6ik9k3l4n6xzd",
+      "version": "1.40.0",
+      "sha256": "1dblf8cabwy2jwi70v6l5n2fjjfpnxy6qdszs4klq152g2wnx3sg",
       "depends": ["BiocParallel", "GenomicRanges", "IRanges", "Rfast", "S4Vectors", "SummarizedExperiment", "directlabels", "lattice", "latticeExtra", "multtest", "zCompositions"]
     },
     "AMARETTO": {
       "name": "AMARETTO",
-      "version": "1.22.0",
-      "sha256": "0lk7rd4ipwgx2mzwwy9kc4ngd9849p804499xdwy2j4ygq01zrkq",
+      "version": "1.24.0",
+      "sha256": "0njf8xm4z4s9gyyv8zybi9w4hzvv52i6wkspd7pd71k4m0xnpd33",
       "depends": ["BiocFileCache", "ComplexHeatmap", "DT", "Matrix", "MultiAssayExperiment", "Rcpp", "callr", "circlize", "curatedTCGAData", "doParallel", "dplyr", "foreach", "ggplot2", "glmnet", "gridExtra", "httr", "impute", "knitr", "limma", "matrixStats", "readr", "reshape2", "rmarkdown", "tibble"]
     },
     "AMOUNTAIN": {
       "name": "AMOUNTAIN",
-      "version": "1.32.0",
-      "sha256": "0w1m0y9q7vksxnhxa8gz3fl47niss7zcbvvrjsdrf82yx6x8vp6j",
+      "version": "1.34.0",
+      "sha256": "1kqlbjzcp3hgp2v54v5jp34q19cb46s4g0cya7pkgk729b8wglz3",
       "depends": []
     },
     "ANCOMBC": {
       "name": "ANCOMBC",
-      "version": "2.8.1",
-      "sha256": "13sd32f55zyzbxs5sbb96smgzkh4y45lh8291w35bgxc41vqxdjx",
+      "version": "2.10.0",
+      "sha256": "00ywqww9vhsxsx2y4ji8k3b9202f187a54nkafl6wa10yqqnvqcq",
       "depends": ["CVXR", "DescTools", "Hmisc", "MASS", "Matrix", "Rdpack", "doParallel", "doRNG", "energy", "foreach", "gtools", "lme4", "lmerTest", "multcomp", "nloptr"]
     },
     "ANF": {
       "name": "ANF",
-      "version": "1.28.0",
-      "sha256": "1v1lzd0lbg21z1gyca1p45p50akznjlq0b3999sny7hfh20954fr",
+      "version": "1.30.0",
+      "sha256": "17rw1sb6fvan37hvsiv21zbldq7ajkxaxaswynjp33klycqkxvaf",
       "depends": ["Biobase", "MASS", "RColorBrewer", "igraph", "survival"]
     },
     "APAlyzer": {
       "name": "APAlyzer",
-      "version": "1.20.0",
-      "sha256": "06zalaf2lqw0ba3wa47mfdj4nidqs4i0arcqnpdrgdnjw1b679mv",
+      "version": "1.22.0",
+      "sha256": "00a3barcm8yr4q7c9irpmg5v6v8ybzb2ww9mb1r7fdkg0kpj6dj9",
       "depends": ["DESeq2", "GenomicAlignments", "GenomicFeatures", "GenomicRanges", "HybridMTest", "Rsamtools", "Rsubread", "SummarizedExperiment", "VariantAnnotation", "dplyr", "ggplot2", "ggrepel", "repmis", "rtracklayer", "tidyr"]
     },
     "APL": {
       "name": "APL",
-      "version": "1.10.2",
-      "sha256": "0z3djj3sdr10i8virdp21fn7vv8jg99v6868234rvzkghyij3i68",
+      "version": "1.12.0",
+      "sha256": "03s5aw0ij06rih2yqwp2flv1f943lkz0i0n00vr6maw6bpbzf19p",
       "depends": ["Matrix", "RSpectra", "SeuratObject", "SingleCellExperiment", "SummarizedExperiment", "ggplot2", "ggrepel", "magrittr", "org_Hs_eg_db", "org_Mm_eg_db", "plotly", "rlang", "topGO", "viridisLite"]
     },
     "ARRmNormalization": {
       "name": "ARRmNormalization",
-      "version": "1.46.0",
-      "sha256": "0v6b86gaqszbbp8dx9i8bkz95lxkb4ci20w1l596b3vzqs2a8fb2",
+      "version": "1.48.0",
+      "sha256": "0rgmi5rxv1qlgsdgbixcyabx8qpaai3f8pcv99pbnhby99m20ns4",
       "depends": ["ARRmData"]
     },
     "ASAFE": {
       "name": "ASAFE",
-      "version": "1.32.0",
-      "sha256": "0q7rv3aasc8xdl0mamggncgs2cdyqyagq4rnskc0c3qccb7mvakg",
+      "version": "1.34.0",
+      "sha256": "1hx8zxsbva755y5kj5s9jvwjjf84w27m2p0798r1byi69c1rqigd",
       "depends": []
     },
     "ASEB": {
       "name": "ASEB",
-      "version": "1.50.0",
-      "sha256": "0ks9h4gzsjpjjwifscid9y175kdshqng22rqc129fq4ch17pd0bs",
+      "version": "1.52.0",
+      "sha256": "19cvciadpjn0zjlh2bcrhsvwn1vzfm0rcxx89z6rw29hk0j98xgk",
       "depends": []
     },
     "ASGSCA": {
       "name": "ASGSCA",
-      "version": "1.40.0",
-      "sha256": "1c004m9n7z7xg15pd212gjxsawir68xvqrhsxgsm5vz7viwmyqqr",
+      "version": "1.42.0",
+      "sha256": "0d45hlz7445c1dxxbxlmjak87i8l33pxiyzjdpw78rshy9dz7910",
       "depends": ["MASS", "Matrix"]
     },
     "ASICS": {
       "name": "ASICS",
-      "version": "2.22.0",
-      "sha256": "1ab8j2rmqig1c25z70ys5ip9818idy0md2a755lz0jcy0srk425j",
+      "version": "2.24.0",
+      "sha256": "173v75sl33saf5ghmq610l6138p5wqy58xlzdlin7w6p8jl13yqc",
       "depends": ["BiocParallel", "Matrix", "PepsNMR", "SummarizedExperiment", "ggplot2", "glmnet", "gridExtra", "mvtnorm", "plyr", "quadprog", "ropls", "zoo"]
     },
     "ASSET": {
       "name": "ASSET",
-      "version": "2.24.0",
-      "sha256": "0lq07mq7ai51c1dkjkmjrafq3caw6wpzrpbfsbqa3dyjn3vp3c04",
+      "version": "2.26.0",
+      "sha256": "04xnggnfvi5v9mcc3sbjq8prwz4acnvzg44fc3a9sa1fv51y5v7b",
       "depends": ["MASS", "msm", "rmeta"]
     },
     "ASSIGN": {
       "name": "ASSIGN",
-      "version": "1.42.0",
-      "sha256": "0avr3zn9nyamcdkr5b9qklcl9gzk36w9w7ky6qwhm7innqhmfapp",
+      "version": "1.44.0",
+      "sha256": "1sfy9bqq4b7yljihn4kgc46rx5shy4lwyf0wxrjlcndrc29myhk9",
       "depends": ["Rlab", "ggplot2", "gplots", "msm", "sva", "yaml"]
     },
     "ASURAT": {
       "name": "ASURAT",
-      "version": "1.10.0",
-      "sha256": "0dak5kx8fwmz9kx2a2r7dgzg5d8jhbf5qx6014p4g54lxns0zxj5",
+      "version": "1.12.0",
+      "sha256": "0wx54jf44i6qy7q46dki7pjdkmddq9zvzjj1v0s2izhr73xgrrfw",
       "depends": ["ComplexHeatmap", "Rcpp", "S4Vectors", "SingleCellExperiment", "SummarizedExperiment", "circlize", "cluster", "plot3D"]
     },
     "ASpli": {
       "name": "ASpli",
-      "version": "2.16.0",
-      "sha256": "160cdm2f8mi3smnx5svaw0mhwnvcmqrl8hikhwj69fygh0razfix",
+      "version": "2.18.0",
+      "sha256": "1v2a3kspr4xl7rr94jy7ldmdhh6px0817di6i7rq07vjpwsy29fx",
       "depends": ["AnnotationDbi", "BiocGenerics", "BiocStyle", "DT", "GenomicAlignments", "GenomicFeatures", "GenomicRanges", "Gviz", "IRanges", "MASS", "Rsamtools", "S4Vectors", "UpSetR", "data_table", "edgeR", "htmltools", "igraph", "limma", "pbmcapply", "tidyr", "txdbmaker"]
     },
     "ATACseqQC": {
       "name": "ATACseqQC",
-      "version": "1.30.0",
-      "sha256": "128ka9fzj8zy6mlccszi5xnq25ivhpgq08q9jsiazm65kzxpvqfb",
+      "version": "1.32.0",
+      "sha256": "04dnvjwxq64ax9d6mg5j30285wv1kc0yq7ms3m1bj6654v1vvpcq",
       "depends": ["BSgenome", "BiocGenerics", "BiocParallel", "Biostrings", "ChIPpeakAnno", "GenomeInfoDb", "GenomicAlignments", "GenomicRanges", "GenomicScores", "IRanges", "KernSmooth", "Rsamtools", "S4Vectors", "edgeR", "limma", "motifStack", "preseqR", "randomForest", "rtracklayer"]
     },
     "ATACseqTFEA": {
       "name": "ATACseqTFEA",
-      "version": "1.8.0",
-      "sha256": "08s06npspgggfg5vpw4iwmlx2ygbc19nwfp97pphc7lml0d3dhmb",
+      "version": "1.10.0",
+      "sha256": "1q7skafrkqwbkr8prkgglli18f0h76x4z0bqmmq1hcaw1l5zl4b2",
       "depends": ["BiocGenerics", "GenomeInfoDb", "GenomicAlignments", "GenomicRanges", "IRanges", "Matrix", "Rsamtools", "S4Vectors", "SummarizedExperiment", "TFBSTools", "dplyr", "ggplot2", "ggrepel", "limma", "motifmatchr", "pracma", "rtracklayer"]
     },
     "AUCell": {
       "name": "AUCell",
-      "version": "1.28.0",
-      "sha256": "1n5xb6qymfywglnnh1klxlqzhry78kwn8zlpvz7z06w6ixfc9q80",
+      "version": "1.30.0",
+      "sha256": "1ryjd1y547ai63dcknhh88adw0f1igzlrhv561p3jjwx1gi4vnnd",
       "depends": ["BiocGenerics", "DelayedArray", "DelayedMatrixStats", "GSEABase", "Matrix", "R_utils", "SummarizedExperiment", "data_table", "mixtools"]
     },
     "AWFisher": {
       "name": "AWFisher",
-      "version": "1.20.0",
-      "sha256": "040x6millcnii58q441zh99zkskl0v1s9g9cx54srhca25qywfnr",
+      "version": "1.22.0",
+      "sha256": "181zy3kzx2kwirlk7kv3c4xph7frxs5z1imj76sbzgc13nsbf668",
       "depends": ["edgeR", "limma"]
     },
     "AffiXcan": {
       "name": "AffiXcan",
-      "version": "1.24.0",
-      "sha256": "1a76l58hl78f0cn602mxxisq7rbgm3ywb45nd20d5h01wmgv3bci",
+      "version": "1.26.0",
+      "sha256": "19h4cd2j9sv9nlj9d46sgd6rbi92vr3kp3qr6pd016rdj8an7inm",
       "depends": ["BiocParallel", "MultiAssayExperiment", "SummarizedExperiment", "crayon"]
     },
     "AffyRNADegradation": {
       "name": "AffyRNADegradation",
-      "version": "1.52.0",
-      "sha256": "1k7d2w377w9ab7f9j71mc92lx3w851mxbm7lrrbzv63zbv7cynbk",
+      "version": "1.54.0",
+      "sha256": "1sq5mawmykd14vvw6854mdpdc8qqn52l3z131by79j1sklbjah0d",
       "depends": ["affy"]
     },
     "AgiMicroRna": {
       "name": "AgiMicroRna",
-      "version": "2.56.0",
-      "sha256": "1w1x1pzas8vq4x93700j4slkpq3xmwrm3w9zk3nf2366fxrjp65i",
+      "version": "2.58.0",
+      "sha256": "1fqslyiwl3d9i2qvvhispf5g340vsl7wd2z61lfjw43p0azjlr1m",
       "depends": ["Biobase", "affy", "affycoretools", "limma", "preprocessCore"]
     },
     "AllelicImbalance": {
       "name": "AllelicImbalance",
-      "version": "1.44.0",
-      "sha256": "1grjrbq15xd05m819j7804v3hzrjnmqj7jmdypc2wn53jxnbpqf5",
+      "version": "1.46.0",
+      "sha256": "0cfk0n33p0lv8i0i6nvwv8afv6i3p5xgr6qsmngafacql8klw2p5",
       "depends": ["AnnotationDbi", "BSgenome", "BiocGenerics", "Biostrings", "GenomeInfoDb", "GenomicAlignments", "GenomicFeatures", "GenomicRanges", "Gviz", "IRanges", "Rsamtools", "S4Vectors", "SummarizedExperiment", "VariantAnnotation", "gridExtra", "lattice", "latticeExtra", "nlme", "seqinr"]
     },
     "AlphaBeta": {
       "name": "AlphaBeta",
-      "version": "1.20.0",
-      "sha256": "0zyf38xa5dbk8n71l1bgk1d49ic0f009nggajggyhgsrgf5j14gr",
+      "version": "1.22.0",
+      "sha256": "04420pnxgnsba1jd1ma6cg889mmh2vs2c5p8570r3hxsgppzk6pj",
       "depends": ["BiocParallel", "data_table", "dplyr", "expm", "ggplot2", "gtools", "igraph", "optimx", "plotly", "stringr"]
     },
     "AlphaMissenseR": {
       "name": "AlphaMissenseR",
-      "version": "1.2.0",
-      "sha256": "0lmpij9k36hi8adp0mnbjagh6mfyykhvsyzyk1vabvbnqi9d3zxk",
+      "version": "1.4.0",
+      "sha256": "0zxdq9afill3dkfvc0ykdr3vxz568siigxdb30n9va8kdf34iqwm",
       "depends": ["BiocBaseUtils", "BiocFileCache", "DBI", "curl", "dplyr", "duckdb", "ggplot2", "memoise", "rjsoncons", "rlang", "spdl", "whisker"]
     },
     "AlpsNMR": {
       "name": "AlpsNMR",
-      "version": "4.8.0",
-      "sha256": "0aqf87i96fgbjkwkpa86k6kika0xz5f1jw6zs1sjq56q63xnd4bx",
+      "version": "4.10.0",
+      "sha256": "10d7q245crfvnx4rlsg879vchia35wnv9swsjbyqfbq3cvix4n0v",
       "depends": ["BiocParallel", "baseline", "cli", "dplyr", "fs", "generics", "ggplot2", "glue", "htmltools", "magrittr", "matrixStats", "mixOmics", "pcaPP", "purrr", "readxl", "reshape2", "rlang", "rmarkdown", "scales", "signal", "speaq", "stringr", "tibble", "tidyr", "tidyselect", "vctrs"]
     },
     "AnVIL": {
       "name": "AnVIL",
-      "version": "1.18.5",
-      "sha256": "07ar2ahc41mfrg2abrfxcgc74n2cx03zy60qp0rrmij3hwvf94v2",
-      "depends": ["AnVILBase", "BiocBaseUtils", "BiocManager", "DT", "dplyr", "futile_logger", "htmltools", "httr", "jsonlite", "miniUI", "rapiclient", "rlang", "shiny", "tibble", "tidyr", "tidyselect", "yaml"]
+      "version": "1.20.0",
+      "sha256": "1rwfp8hw7dziqlg3fj93kgdm96xirba0sv5cvjhfnnwx09ghpsmy",
+      "depends": ["AnVILBase", "BiocBaseUtils", "DT", "dplyr", "futile_logger", "htmltools", "httr", "jsonlite", "miniUI", "rapiclient", "rlang", "shiny", "tibble", "tidyr", "tidyselect", "yaml"]
     },
     "AnVILAz": {
       "name": "AnVILAz",
-      "version": "1.0.0",
-      "sha256": "0b0rpq5f394y50djiwq1ldjr7wfvd4c4vw1nfdqzgizx6cybii7a",
+      "version": "1.2.0",
+      "sha256": "02v9qn6nfc7gb1iqcwpaxnp66gqq0fyxm74a905xadnsp1c8z60j",
       "depends": ["AnVILBase", "BiocBaseUtils", "curl", "httr2", "jsonlite", "rjsoncons", "tibble"]
     },
     "AnVILBase": {
       "name": "AnVILBase",
-      "version": "1.0.0",
-      "sha256": "0cjik5yvbbpryyawkqb6y38h92in0jkkm46a4kisbsif42hwa2i5",
+      "version": "1.2.0",
+      "sha256": "1mia9qji8x8zs4h7m2vf3x4dhyarpxydn42zdfs0qmfiaq5lsrwk",
       "depends": ["dplyr", "httr", "httr2", "jsonlite", "tibble"]
     },
     "AnVILBilling": {
       "name": "AnVILBilling",
-      "version": "1.16.0",
-      "sha256": "1g7j9q1n11nnyjkz68wrpavinchwfpshcs2bridag45n6l42zd16",
+      "version": "1.18.0",
+      "sha256": "0xxkm92vxk8gq8hn4vjnmivxnxcfnybrls4wqwci7y6yn01s9vq0",
       "depends": ["DBI", "DT", "bigrquery", "dplyr", "ggplot2", "lubridate", "magrittr", "plotly", "shiny", "shinytoastr"]
     },
     "AnVILGCP": {
       "name": "AnVILGCP",
-      "version": "1.0.0",
-      "sha256": "0m0assxfq65smzqif7rqsqzlw0y8zjdnyq0nxij0snqzjd9a0iih",
+      "version": "1.2.0",
+      "sha256": "16msp62ifvazaz5c8vlr80fz2ds9rgf5rmng4phbv7isamh3h9sj",
       "depends": ["AnVILBase", "BiocBaseUtils", "dplyr", "httr", "jsonlite", "rlang", "tibble", "tidyr"]
     },
     "AnVILPublish": {
       "name": "AnVILPublish",
-      "version": "1.16.0",
-      "sha256": "1fyz9xaycm9skaisa0v8mr6bp57an29482sbj7yfqz8p421dydkp",
+      "version": "1.18.0",
+      "sha256": "1rdabz5mxvsz8yqj39r4fskv201qm0dm1n984h9q4qwykj18w2xa",
       "depends": ["AnVIL", "AnVILGCP", "BiocBaseUtils", "BiocManager", "httr", "jsonlite", "readr", "rmarkdown", "whisker", "yaml"]
     },
     "AnVILWorkflow": {
       "name": "AnVILWorkflow",
-      "version": "1.6.0",
-      "sha256": "0yix1ilxw3wz5x195bqj6n333kdqb4pqckpdar32sl28zx9ymhzr",
+      "version": "1.8.0",
+      "sha256": "0k31j6dlfkk7a8kdcvffb54rk0q19p6gicjmaxld9nlmr4527iid",
       "depends": ["AnVIL", "AnVILBase", "AnVILGCP", "dplyr", "httr", "jsonlite", "plyr", "rlang", "stringr", "tibble", "tidyr"]
     },
     "Anaquin": {
       "name": "Anaquin",
-      "version": "2.30.0",
-      "sha256": "0krfyb0bcc4vpna7ygyd9rqsdpnqmizlmf8sgpcyfk722dbavvdn",
+      "version": "2.32.0",
+      "sha256": "09f1pfy06jzhwbxjvh126yxnahk3y6hmcy5793wxnpgsy6wmmabl",
       "depends": ["DESeq2", "ROCR", "ggplot2", "knitr", "locfit", "plyr", "qvalue"]
     },
     "AneuFinder": {
       "name": "AneuFinder",
-      "version": "1.34.0",
-      "sha256": "0zqbpip172w02d9iw3n10b0c3pcnk63fp28m886333wcsm7j84b0",
+      "version": "1.35.0",
+      "sha256": "0zx0brvcyi9id7xli9h5nk9an7j46p7zgjj3qmwr3jm4b95qahpl",
       "depends": ["AneuFinderData", "BiocGenerics", "Biostrings", "DNAcopy", "GenomeInfoDb", "GenomicAlignments", "GenomicRanges", "IRanges", "Rsamtools", "S4Vectors", "bamsignals", "cowplot", "doParallel", "ecp", "foreach", "ggdendro", "ggplot2", "ggrepel", "mclust", "reshape2"]
     },
     "AnnotationDbi": {
       "name": "AnnotationDbi",
-      "version": "1.68.0",
-      "sha256": "13gqbmx7pqnl6g087kz1isnw61jbljq8pizzn5wf4hv9c76dlvpf",
+      "version": "1.70.0",
+      "sha256": "1nx9yrj76gwxqi2v7ynp8z6p4zm8gc3dqqpn62akflcymc213ppq",
       "depends": ["Biobase", "BiocGenerics", "DBI", "IRanges", "KEGGREST", "RSQLite", "S4Vectors"]
     },
     "AnnotationFilter": {
       "name": "AnnotationFilter",
-      "version": "1.30.0",
-      "sha256": "1a7ffcxdx95irbcr2sh7sph6x5lf7spnyq084pvx9qd18i6cif5n",
+      "version": "1.32.0",
+      "sha256": "1r642f9qh8gxj5fypkkdav738s875minsyaz1qw4gi2ckv2j8jks",
       "depends": ["GenomicRanges", "lazyeval"]
     },
     "AnnotationForge": {
       "name": "AnnotationForge",
-      "version": "1.48.0",
-      "sha256": "1m3s3jkq43w94mr4g3cqfgndan7ihhhnx84ag4xm1rzmvdpsd0pp",
+      "version": "1.50.0",
+      "sha256": "1h0h9axlq9knw8hiyhay7d9wbxvlgg8378pd6zygbj74qvy60pp3",
       "depends": ["AnnotationDbi", "Biobase", "BiocGenerics", "DBI", "RCurl", "RSQLite", "S4Vectors", "XML"]
     },
     "AnnotationHub": {
       "name": "AnnotationHub",
-      "version": "3.14.0",
-      "sha256": "1l0wjc6kapkvj047g11755ardsg12jmlmvb6bq3jvp34ida7j8in",
+      "version": "3.16.0",
+      "sha256": "02cbx21lnbayyi282f71z2rdcarcxghfmvy7hjw4jm7kyybxzzxd",
       "depends": ["AnnotationDbi", "BiocFileCache", "BiocGenerics", "BiocManager", "BiocVersion", "RSQLite", "S4Vectors", "curl", "dplyr", "httr", "rappdirs", "yaml"]
     },
     "AnnotationHubData": {
       "name": "AnnotationHubData",
-      "version": "1.36.0",
-      "sha256": "0b279vpqyq4a88w543yj9hwlifl0c1qxjvz1msrxxxibz21fk3r8",
+      "version": "1.38.0",
+      "sha256": "17ajnm8ynd8v7n0fb99317kd5s80pzrjzcf1xhhmnqxf5hk8rk2m",
       "depends": ["AnnotationDbi", "AnnotationForge", "AnnotationHub", "Biobase", "BiocCheck", "BiocGenerics", "BiocManager", "Biostrings", "DBI", "GenomeInfoDb", "GenomicFeatures", "GenomicRanges", "IRanges", "OrganismDbi", "RCurl", "RSQLite", "Rsamtools", "S4Vectors", "XML", "biocViews", "futile_logger", "graph", "jsonlite", "rtracklayer"]
     },
     "ArrayExpress": {
       "name": "ArrayExpress",
-      "version": "1.66.0",
-      "sha256": "1ngmgf05zxdhgg15c8qplc04j5azr4kjw0x4s0hcvrjay6kimvlw",
+      "version": "1.67.1",
+      "sha256": "1cnlr2xnah4cw66xn5ww3ci1flfhrwwd0k3z5l1fbh8h9msnbr3w",
       "depends": ["Biobase", "httr", "jsonlite", "limma", "oligo", "rlang"]
     },
     "AssessORF": {
       "name": "AssessORF",
-      "version": "1.24.0",
-      "sha256": "1q0m5a9wqqn1mm8mkqyqs85g33a6pccgxbzlgwimihdbxhddg9qd",
+      "version": "1.26.0",
+      "sha256": "1wd1xr2f25l418klvr7dwjvv9n8x51qg4la3i354q5vrjj0y5hrp",
       "depends": ["Biostrings", "DECIPHER", "GenomicRanges", "IRanges"]
     },
     "BADER": {
       "name": "BADER",
-      "version": "1.44.0",
-      "sha256": "1bksx6a0xg7hd3nd32d5pjfwb9iy64asvdp6drwlkyxv9fys976y",
+      "version": "1.46.0",
+      "sha256": "00ma4zx6nha1x0iwcpzq0a4ajw2gm9k5zvq5n6ambdy5cf22z0nx",
       "depends": []
     },
     "BAGS": {
       "name": "BAGS",
-      "version": "2.46.0",
-      "sha256": "0wv55pmn0435wn4as4r1ihf8w82v2a95n59wq94n25lx46gzjih7",
+      "version": "2.48.0",
+      "sha256": "1s0fqs4chr8ixxlq3a5scnncrq3bma6vz1s1isdwwxf57vp6d1v2",
       "depends": ["Biobase", "breastCancerVDX"]
     },
     "BANDITS": {
       "name": "BANDITS",
-      "version": "1.22.0",
-      "sha256": "01ksk9wqzmg14pn0x0dch1fcrdwxw9qrfc592gkx9cy4sh8kdf3n",
+      "version": "1.24.0",
+      "sha256": "1xqi3gpsshnb6h1yyvxh4dqafzw691zmpy4mc40nd6skz3hqwls0",
       "depends": ["BiocParallel", "DRIMSeq", "MASS", "R_utils", "Rcpp", "RcppArmadillo", "data_table", "doParallel", "doRNG", "foreach", "ggplot2"]
     },
     "BASiCS": {
       "name": "BASiCS",
-      "version": "2.18.0",
-      "sha256": "1pdbkxamzcpgiqycp3dzmakj3laclgj3r9q9garz3q86m59fkrzb",
+      "version": "2.20.0",
+      "sha256": "0wlsamynz8230h4yp8vqdmdh5n8ky1bnp6dr906cswfj89zn4yiv",
       "depends": ["Biobase", "BiocGenerics", "BiocParallel", "MASS", "Matrix", "Rcpp", "RcppArmadillo", "S4Vectors", "SingleCellExperiment", "SummarizedExperiment", "assertthat", "coda", "cowplot", "ggExtra", "ggplot2", "hexbin", "matrixStats", "posterior", "reshape2", "scran", "scuttle", "viridis"]
     },
     "BASiCStan": {
       "name": "BASiCStan",
-      "version": "1.8.0",
-      "sha256": "1ss9bc2vnr7637rhmljijlr87rqx956br0ghrnsf80s6qvz01rzh",
+      "version": "1.10.0",
+      "sha256": "0i4m777lfy5v8j6mzh3sj0g411q1n89kdf8hqaaznblx73r1af9f",
       "depends": ["BASiCS", "BH", "Rcpp", "RcppEigen", "RcppParallel", "SingleCellExperiment", "StanHeaders", "SummarizedExperiment", "glmGamPoi", "rstan", "rstantools", "scran", "scuttle"]
     },
     "BBCAnalyzer": {
       "name": "BBCAnalyzer",
-      "version": "1.36.0",
-      "sha256": "1021srhg6j3p0lwkn3d777iylrjqm8rvspfvj73hphk8l828cd53",
+      "version": "1.38.0",
+      "sha256": "1qs25p1cj7k8j88w193c35fidgz3hfprsd8bsrk9nfvsg399g0py",
       "depends": ["Biostrings", "GenomicRanges", "IRanges", "Rsamtools", "SummarizedExperiment", "VariantAnnotation"]
     },
     "BCRANK": {
       "name": "BCRANK",
-      "version": "1.68.0",
-      "sha256": "1fjnxv3i8mi3l5gl1c6wpph4fsn8ax08h2b25m9ihs1nxp97x682",
+      "version": "1.70.0",
+      "sha256": "0jgryr10fyivrj5yhqdnikbkif2g53v4mhyfczb9z0c7p1vipcc6",
       "depends": ["Biostrings"]
     },
     "BEAT": {
       "name": "BEAT",
-      "version": "1.44.0",
-      "sha256": "0vsq1184n4nqjih31y1mkyzf3g38ajm26590g10d4ri63rqkdd5y",
+      "version": "1.46.0",
+      "sha256": "0fd1yd1pl4zvxnmq10w6fl6a0xzgghhl4by00dxiiqrwfsqnh7sv",
       "depends": ["BSgenome", "Biostrings", "GenomicRanges", "ShortRead"]
     },
     "BERT": {
       "name": "BERT",
-      "version": "1.2.0",
-      "sha256": "1h4sx9bnvxhz7sxzw4nklfzirkc2ris3y4485jssf5np7k1si8j2",
+      "version": "1.4.0",
+      "sha256": "1y1knq38fp3frw7c1j45xps1pvqfa5909hdj5v5n58vzxb4qxnnq",
       "depends": ["BiocParallel", "SummarizedExperiment", "cluster", "comprehenr", "foreach", "invgamma", "iterators", "janitor", "limma", "logging", "sva"]
     },
     "BEclear": {
       "name": "BEclear",
-      "version": "2.22.0",
-      "sha256": "06kz8433vazx7dkxysh8z9lp098irayxh23hra17bf0dih9xjcjp",
+      "version": "2.24.0",
+      "sha256": "158ca135lsxjj523gv31cqdc6321fpyjvc652dpyfbva0xbz7qw7",
       "depends": ["BiocParallel", "Matrix", "Rcpp", "Rdpack", "abind", "data_table", "dixonTest", "futile_logger", "ids"]
     },
     "BG2": {
       "name": "BG2",
-      "version": "1.6.0",
-      "sha256": "1hhqij5k8pw3gply0x75lyz1ggzgbkw5rczcl14cwcv01js0j7h2",
+      "version": "1.8.0",
+      "sha256": "0d6ck2x60nw5zqplalgvqm2093lqirin1lp91ihdj1hmhfbpy1zz",
       "depends": ["GA", "MASS", "Matrix", "caret", "memoise"]
     },
     "BLMA": {
       "name": "BLMA",
-      "version": "1.30.0",
-      "sha256": "0mcmzc4siiv8k6dqq3w6f3p29fqg0ls0m8whbnr8gx6bswrmhhnq",
+      "version": "1.32.0",
+      "sha256": "1lqfim34rci17hl27hi3cmp40wikfxq5vkjvqrrzh9cs7nvi0kns",
       "depends": ["Biobase", "GSA", "PADOG", "ROntoTools", "graph", "limma", "metafor"]
     },
     "BOBaFIT": {
       "name": "BOBaFIT",
-      "version": "1.10.0",
-      "sha256": "0gvldzwzcdrl609678fnjr4afh2lwlg9zcc1g2rf3kps33g17wj5",
+      "version": "1.12.0",
+      "sha256": "0pfkdcsl6bwvaad0dwina5k7ajchpknkfp6v6ircic5yxvi6yd25",
       "depends": ["GenomicRanges", "NbClust", "dplyr", "ggbio", "ggforce", "ggplot2", "magrittr", "plyranges", "stringr", "tidyr"]
     },
     "BPRMeth": {
       "name": "BPRMeth",
-      "version": "1.32.0",
-      "sha256": "0mp30pcmvgvckxbay843srcq0c3808lz7k7b82nk8xdb1zvbmixd",
+      "version": "1.34.0",
+      "sha256": "0p06wjxmhfq3nyz1cwj0ghl3rnwd9lkhgzrndzgxb2a9l6v74w2h",
       "depends": ["BiocStyle", "GenomicRanges", "IRanges", "MASS", "Rcpp", "RcppArmadillo", "S4Vectors", "assertthat", "cowplot", "data_table", "doParallel", "e1071", "earth", "foreach", "ggplot2", "kernlab", "magrittr", "matrixcalc", "mvtnorm", "randomForest", "truncnorm"]
     },
     "BRAIN": {
       "name": "BRAIN",
-      "version": "1.52.0",
-      "sha256": "1hvxfkxa2hrin416qkia343iijq4iam2sbvxqfjsy1n8j2s1sz85",
+      "version": "1.54.0",
+      "sha256": "11zd5z9xd9564cqh6lzl3wgi15170w4cbi0np18v2fmc3hkm2gzh",
       "depends": ["Biostrings", "PolynomF", "lattice"]
     },
     "BREW3R_r": {
       "name": "BREW3R.r",
-      "version": "1.2.0",
-      "sha256": "19qvwv6papinrqcn98a7j06rckv3yjqba971ya7y8vzgmw9sf74p",
+      "version": "1.4.0",
+      "sha256": "0m8ivr5wx7z7ymwzk5kjhczrhr81i92lf2ph6qz58yg1xzqvmxmi",
       "depends": ["GenomicRanges", "S4Vectors", "rlang"]
     },
     "BSgenome": {
       "name": "BSgenome",
-      "version": "1.74.0",
-      "sha256": "0abcz2rpw9af2cfyssz6adbx36issjlwzf7ipj1vkcmia6j5f1ji",
+      "version": "1.76.0",
+      "sha256": "0xlfznvccvk6ymnk41bsdif4pgkh90xpsq9c67rsjrza71cl31f0",
       "depends": ["BiocGenerics", "BiocIO", "Biostrings", "GenomeInfoDb", "GenomicRanges", "IRanges", "Rsamtools", "S4Vectors", "XVector", "matrixStats", "rtracklayer"]
     },
     "BSgenomeForge": {
       "name": "BSgenomeForge",
-      "version": "1.6.0",
-      "sha256": "0zjr1wm274l3c5bkf030mvif5pnsb8hclsyzxjfsghs7c1z3wdas",
+      "version": "1.8.0",
+      "sha256": "0118mxyg8xxkwkfg6k1zw2xnx4b6zacf3bn9jy0kfks555cfbjsy",
       "depends": ["BSgenome", "Biobase", "BiocGenerics", "BiocIO", "Biostrings", "GenomeInfoDb", "GenomicRanges", "IRanges", "S4Vectors", "rtracklayer"]
     },
     "BUMHMM": {
       "name": "BUMHMM",
-      "version": "1.30.0",
-      "sha256": "0xsz9hsp7pxigjhk05srnlncnhfa2zzrqw4d9jbg9xl7xv7jnkh0",
+      "version": "1.32.0",
+      "sha256": "0anmnwbpcrz0n5zwf80cb4zxmybhxf94ayzyxpilfb04xg1j77dm",
       "depends": ["Biostrings", "IRanges", "SummarizedExperiment", "devtools", "gtools", "stringi"]
     },
     "BUS": {
       "name": "BUS",
-      "version": "1.62.0",
-      "sha256": "0hrxx8gsfjyppwiwfhvdprq64v290gcbwm9bx67vviawig1dj364",
+      "version": "1.64.0",
+      "sha256": "1x017881b1zw3hnfj45llmrkn76qrzqirfyv1ldif7lkg2a00qkz",
       "depends": ["infotheo", "minet"]
     },
     "BUScorrect": {
       "name": "BUScorrect",
-      "version": "1.24.0",
-      "sha256": "0iq8cz42pp3n1mg657n4pnsp5g9h5g201zpqndssdki9ahhyqppv",
+      "version": "1.26.0",
+      "sha256": "13l3x9jdfcdh8aswvqkhk1gjbz8y6nl3v4lbhw57w1smxlj9gz3g",
       "depends": ["SummarizedExperiment", "gplots"]
     },
     "BUSpaRse": {
       "name": "BUSpaRse",
-      "version": "1.20.0",
-      "sha256": "1i1jdn93w6cli6idfvll64pgskwjqap183vpaqcs60vpw1cdbsd0",
+      "version": "1.22.0",
+      "sha256": "16gim1zvifj9b82c4cy0px568w73zsbfffmnjnxf1474savadll4",
       "depends": ["AnnotationDbi", "AnnotationFilter", "BH", "BSgenome", "BiocGenerics", "Biostrings", "GenomeInfoDb", "GenomicFeatures", "GenomicRanges", "IRanges", "Matrix", "Rcpp", "RcppArmadillo", "RcppProgress", "S4Vectors", "biomaRt", "dplyr", "ensembldb", "ggplot2", "magrittr", "plyranges", "stringr", "tibble", "tidyr", "zeallot"]
     },
     "BUSseq": {
       "name": "BUSseq",
-      "version": "1.12.0",
-      "sha256": "0as429r1y5vm5230xk5bd980l6fa8p2vw40qrxb9law6fd9kp0w7",
+      "version": "1.14.0",
+      "sha256": "0sxjwrh3vcpi5sf80mkcnx3jsl53xla9qrhpq6mxfg61gx9psdwh",
       "depends": ["S4Vectors", "SingleCellExperiment", "SummarizedExperiment", "gplots"]
     },
     "BaalChIP": {
       "name": "BaalChIP",
-      "version": "1.32.0",
-      "sha256": "0zhxsw1sbk6kmxm9ypw211ybdn29lid5r2cjz7j855822afgg0l4",
+      "version": "1.34.0",
+      "sha256": "05l8n7yff1gkfcbv6d4j4sa4fyx8d99j87k0hdi9mi903l0kwidi",
       "depends": ["GenomeInfoDb", "GenomicAlignments", "GenomicRanges", "IRanges", "Rsamtools", "coda", "doBy", "doParallel", "foreach", "ggplot2", "reshape2", "scales"]
     },
     "BadRegionFinder": {
       "name": "BadRegionFinder",
-      "version": "1.34.0",
-      "sha256": "1xnzg4vaadh46dyqrrk1srzxkm57bkwm942xrsvlf46vibd4l9iw",
+      "version": "1.36.0",
+      "sha256": "1b6chw8h8vv38gifnn51zmdbgqkfkamq761hvmsqm8vhbfm6sgm9",
       "depends": ["GenomicRanges", "Rsamtools", "S4Vectors", "VariantAnnotation", "biomaRt"]
     },
     "Banksy": {
       "name": "Banksy",
-      "version": "1.2.0",
-      "sha256": "0irm6jfqw1fnzqhqrgpdvq7gkgzbd172fz6xc7bmdhcdrz380xzx",
+      "version": "1.4.0",
+      "sha256": "0s01d9wli074970qpbb235vpb2s1ni0b4ay6gl4blcp4g5q3327c",
       "depends": ["RcppHungarian", "S4Vectors", "SingleCellExperiment", "SpatialExperiment", "SummarizedExperiment", "aricode", "data_table", "dbscan", "igraph", "irlba", "leidenAlg", "matrixStats", "mclust", "uwot"]
     },
     "BaseSpaceR": {
       "name": "BaseSpaceR",
-      "version": "1.50.0",
-      "sha256": "1fbj41m9rqg1x6lmklk5zkq2hn5vvv2w693i5xv7nw0rprbjq5x3",
+      "version": "1.52.0",
+      "sha256": "10h6wq1b8lyh7dnxxwsjxy06y32r16k0r4knaj6zrij9d1in6yw0",
       "depends": ["RCurl", "RJSONIO"]
     },
     "Basic4Cseq": {
       "name": "Basic4Cseq",
-      "version": "1.42.0",
-      "sha256": "0yv1j494kjkp7qgyv67j1shd0lmxsr67dsibj27ldp43p2ipyr1h",
+      "version": "1.44.0",
+      "sha256": "1b27061iznhajcdis6r86cwid4y35m8j6si7h0winw1j87rhdg14",
       "depends": ["BSgenome_Ecoli_NCBI_20080805", "Biostrings", "GenomicAlignments", "GenomicRanges", "RCircos", "caTools"]
     },
     "BasicSTARRseq": {
       "name": "BasicSTARRseq",
-      "version": "1.34.0",
-      "sha256": "0mnvrnk2p5qnrmncrkyv2ajx8wff5ax15p0z0wh8rhi3n8bhja4f",
+      "version": "1.36.0",
+      "sha256": "195cpbmnz2hl1yxjq86qjdk2ns96bhvjq89kv379pq8xiais3mmz",
       "depends": ["GenomeInfoDb", "GenomicAlignments", "GenomicRanges", "IRanges", "S4Vectors"]
     },
     "BatchQC": {
       "name": "BatchQC",
-      "version": "2.2.0",
-      "sha256": "0jyxfyw2c1q930y2hi6xydpq98fwih3pyivv1dm51a901378cy7h",
-      "depends": ["DESeq2", "EBSeq", "RColorBrewer", "S4Vectors", "SummarizedExperiment", "data_table", "dplyr", "ggdendro", "ggnewscale", "ggplot2", "limma", "matrixStats", "pheatmap", "reader", "reshape2", "scran", "shiny", "shinyjs", "shinythemes", "sva", "tibble", "tidyr", "tidyverse"]
+      "version": "2.4.0",
+      "sha256": "1bqi8ypwdz6mlk6k4h8spw49qmq70ln8s6jx6rdizgv136b8q3ls",
+      "depends": ["DESeq2", "EBSeq", "RColorBrewer", "S4Vectors", "SummarizedExperiment", "data_table", "dplyr", "ggdendro", "ggnewscale", "ggplot2", "limma", "matrixStats", "pheatmap", "reader", "reshape2", "scran", "shiny", "shinyjs", "shinythemes", "sva", "tibble", "tidyr", "tidyverse", "umap"]
+    },
+    "BatchSVG": {
+      "name": "BatchSVG",
+      "version": "1.0.0",
+      "sha256": "1bwvziwl8wxkn26fiz76sr06w3j2ldwin88s49iqaq27wlr19b75",
+      "depends": ["RColorBrewer", "SummarizedExperiment", "cowplot", "dplyr", "ggplot2", "ggrepel", "rlang", "scales", "scry"]
     },
     "BayesKnockdown": {
       "name": "BayesKnockdown",
-      "version": "1.32.0",
-      "sha256": "149ksni85zcms0kiz0as30jji9w55djzv7isnc69nd0xxp54gnyj",
+      "version": "1.34.0",
+      "sha256": "18jmsgdyvg5m3kndzcszjgfwfh0bwmi3nvfyg4nl9l0skp478cld",
       "depends": ["Biobase"]
     },
     "BayesSpace": {
       "name": "BayesSpace",
-      "version": "1.16.0",
-      "sha256": "08q2k2l90rjw95khlvnyz1jjlq1qyn3y5qc635nsvdlkf75fc7rz",
+      "version": "1.17.0",
+      "sha256": "1ybf17zggvl7s1k6bgxskyna42fylnggv4wy7xvkglnfmv8rz5lp",
       "depends": ["BiocFileCache", "BiocParallel", "BiocSingular", "DirichletReg", "Matrix", "RCurl", "Rcpp", "RcppArmadillo", "RcppDist", "RcppProgress", "S4Vectors", "SingleCellExperiment", "SummarizedExperiment", "arrow", "assertthat", "coda", "dplyr", "ggplot2", "magrittr", "mclust", "microbenchmark", "purrr", "rhdf5", "rjson", "rlang", "scales", "scater", "scran", "tibble", "tidyr", "xgboost"]
     },
     "BeadDataPackR": {
       "name": "BeadDataPackR",
-      "version": "1.58.0",
-      "sha256": "0qzgn3kj7137yp8crj4d8ir597c5k0qscg7n7fdzhi7540jjnpsb",
+      "version": "1.60.0",
+      "sha256": "066cjf2ir95xzc97a7ir2lhnpgzzhdgylv6ly0xvybjfbimq99a7",
       "depends": []
     },
     "BgeeCall": {
       "name": "BgeeCall",
-      "version": "1.22.0",
-      "sha256": "13lhps2dswd29rxr08yhpd9aqbdcvcgq5kfbymmrgr5ampl9dk29",
+      "version": "1.24.0",
+      "sha256": "0fjqwnaq26dzca4n3d7nsq8psim2k8vq6l6gdz11psf805k60hdl",
       "depends": ["Biostrings", "GenomicFeatures", "biomaRt", "data_table", "dplyr", "jsonlite", "rhdf5", "rslurm", "rtracklayer", "sjmisc", "txdbmaker", "tximport"]
     },
     "BgeeDB": {
       "name": "BgeeDB",
-      "version": "2.32.0",
-      "sha256": "15hnn6rk9hv623zzjsg1axydvlj3vjpwyhvhw0xpmk9q7zm6g79h",
+      "version": "2.34.0",
+      "sha256": "0haf6khbm695dyi2f6npm7yx2gbz29kvi62qln1h1nj0k3qw0afi",
       "depends": ["Biobase", "HDF5Array", "RCurl", "RSQLite", "R_utils", "anndata", "bread", "curl", "data_table", "digest", "dplyr", "graph", "tidyr", "topGO", "zellkonverter"]
     },
     "BiFET": {
       "name": "BiFET",
-      "version": "1.26.0",
-      "sha256": "0p5ziib0k8clv8jk99k1z6izk63fpklb6nkf40ar4i63ri4yp776",
+      "version": "1.28.0",
+      "sha256": "0qc715kqiky0r9kn1hhnmqd987im9v4awg0jg7nlp3yv5isl0m90",
       "depends": ["GenomicRanges", "poibin"]
     },
     "BiGGR": {
       "name": "BiGGR",
-      "version": "1.42.0",
-      "sha256": "0zvazxkyllalb2j3k6hwh1g1p0jbm2kcn0yf9ypi8v5wfw71c5dc",
+      "version": "1.44.0",
+      "sha256": "1awdwwg54cfnsn8kp0lw6a7c3mgix024ry7mxn9vb5xq4hp1gflb",
       "depends": ["LIM", "hyperdraw", "hypergraph", "limSolve", "rsbml", "stringr"]
     },
     "BiRewire": {
       "name": "BiRewire",
-      "version": "3.38.0",
-      "sha256": "0503vd2alhpda2brqgg0cqw6w9bad3yz92gsm4fbmyf1lklwlhg8",
+      "version": "3.40.0",
+      "sha256": "0amv3ralspzj1s5md7maxdr2abysnjrizlvcfjvdnb68ryv86wwa",
       "depends": ["Matrix", "Rtsne", "igraph", "slam"]
     },
     "BiSeq": {
       "name": "BiSeq",
-      "version": "1.46.0",
-      "sha256": "0izla8shaqjyjv25sjqs1c1410s8fph2dq11n27r94gx21l8x8xf",
+      "version": "1.48.0",
+      "sha256": "13wgy0a442pc1f440v4wgda2wzcbd5n5gpgw6z98xfvvp5yr42am",
       "depends": ["Biobase", "BiocGenerics", "Formula", "GenomeInfoDb", "GenomicRanges", "IRanges", "S4Vectors", "SummarizedExperiment", "betareg", "globaltest", "lokern", "rtracklayer"]
     },
     "BicARE": {
       "name": "BicARE",
-      "version": "1.64.0",
-      "sha256": "1x8fxcv8lvclb3ynj16gld6l07jdqlarrk1j26g5bsqy0zd0v7gm",
+      "version": "1.66.0",
+      "sha256": "17nbww1fnqnq5jzl54pszva6sf9ic730ph9klcsyay01z54lk7j0",
       "depends": ["Biobase", "GO_db", "GSEABase", "multtest"]
     },
     "BindingSiteFinder": {
       "name": "BindingSiteFinder",
-      "version": "2.4.0",
-      "sha256": "057f0yd7kjgwjkgbndpwqhsky9wkwbam5wqsrz2y1yici9w1q1cq",
+      "version": "2.6.0",
+      "sha256": "1m3bli4jpjqcaif28pbd7d06q2q354h5adf8l3kk4m4v2dvjqh8v",
       "depends": ["ComplexHeatmap", "GenomeInfoDb", "GenomicFeatures", "GenomicRanges", "IRanges", "RColorBrewer", "S4Vectors", "dplyr", "forcats", "ggdist", "ggforce", "ggplot2", "kableExtra", "lifecycle", "matrixStats", "plyr", "rlang", "rtracklayer", "tibble", "tidyr"]
     },
     "BioCartaImage": {
       "name": "BioCartaImage",
-      "version": "1.4.0",
-      "sha256": "0mni5hf5ir8h0bx3d3d4xf35q0f8lajgzlgpjwz90ki4n099rv1h",
+      "version": "1.6.0",
+      "sha256": "1xzjvn39hnw5fjkm71c7lv6k2wzyxsxnkkhxwj7xhs723m8pfxxb",
       "depends": ["magick"]
     },
     "BioCor": {
       "name": "BioCor",
-      "version": "1.30.0",
-      "sha256": "0f282cfs326xj0dib57wqclqj0gnllqxm8zcy0s23qx5kb4jzq08",
+      "version": "1.32.0",
+      "sha256": "0kb970wqdj1csgprfr4wdiz90vk1ibqc684kpnhlja8zh0s2p92n",
       "depends": ["BiocParallel", "GSEABase", "Matrix"]
     },
     "BioGA": {
       "name": "BioGA",
-      "version": "1.0.0",
-      "sha256": "1g3409z332cg9sbqs4ld9w7mlf9pilwmdwwbc1y5cpjs1xhms7pg",
+      "version": "1.2.0",
+      "sha256": "18ralrpz8cfk6ab5hmz4zn3nz6dcvl8kkhiqj30qw8pk6c2pdkjn",
       "depends": ["BiocStyle", "Rcpp", "SummarizedExperiment", "animation", "biocViews", "ggplot2", "rlang", "sessioninfo"]
     },
     "BioMVCClass": {
       "name": "BioMVCClass",
-      "version": "1.74.0",
-      "sha256": "0jsnycykbf2vgqfjnd7fff6k2hly7n50mavcj940vsg3gy2hfady",
+      "version": "1.76.0",
+      "sha256": "03w97bix5xlb6v06ffmlj1nbyl11j6qrb1a54m7wdrvranmr7msl",
       "depends": ["Biobase", "MVCClass", "Rgraphviz", "graph"]
     },
     "BioNAR": {
       "name": "BioNAR",
-      "version": "1.8.1",
-      "sha256": "014bidfkpxvrnnda4yky9q3n2hgi7z1ywnhp0n1cl3aqy671ix3q",
+      "version": "1.10.0",
+      "sha256": "0l675wbsvjh0p91fs17p47ldhmlllkvvdp8n84ch2j1mfqmxz39n",
       "depends": ["AnnotationDbi", "GO_db", "Matrix", "RSpectra", "Rdpack", "WGCNA", "cowplot", "data_table", "dplyr", "fgsea", "ggplot2", "ggrepel", "igraph", "latex2exp", "minpack_lm", "org_Hs_eg_db", "poweRlaw", "rSpectral", "scales", "stringr", "viridis"]
     },
     "BioNERO": {
       "name": "BioNERO",
-      "version": "1.14.0",
-      "sha256": "08mhr9ichh2kynnwchmcqf4l0sn38v5sww6995jwqfyxy5vqvx4x",
+      "version": "1.16.0",
+      "sha256": "1cih9d9a0ncn65gylw6bi49n25s8v6scglsmka0fv9fncypaqc7h",
       "depends": ["BiocParallel", "ComplexHeatmap", "GENIE3", "NetRep", "RColorBrewer", "SummarizedExperiment", "WGCNA", "dynamicTreeCut", "ggdendro", "ggnetwork", "ggplot2", "ggrepel", "igraph", "intergraph", "matrixStats", "minet", "patchwork", "reshape2", "rlang", "sva"]
     },
     "BioNet": {
       "name": "BioNet",
-      "version": "1.66.0",
-      "sha256": "0s1mi4sjbhjs548a2bjqlj5bhslf7wzqkag80g9f2m86hxnmkxwc",
+      "version": "1.68.0",
+      "sha256": "0a0pd7bhmgxa8yl9qfk4ns1vbvfxvclb2gblslfwmp7blqayhva3",
       "depends": ["AnnotationDbi", "Biobase", "RBGL", "graph", "igraph"]
     },
     "BioQC": {
       "name": "BioQC",
-      "version": "1.34.0",
-      "sha256": "10m1ch170d1frq6qcryiqbhb0m1nk921frw04qrxf3b4xfmgiq8c",
+      "version": "1.36.0",
+      "sha256": "0waw9hkf879hmyb2s1bhnia0sygr4z46815frbxdir5q9m6w7zhc",
       "depends": ["Biobase", "Rcpp", "edgeR"]
     },
     "BioTIP": {
       "name": "BioTIP",
-      "version": "1.20.0",
-      "sha256": "0p9f9i4snkc4xgb00nwd7cky4n8s7z99lkv2lahmggk2a53bzx13",
+      "version": "1.22.0",
+      "sha256": "0xrsni2gnzis5ids5c2xlm2qzhplr9ny54jc65a798r072v1yilc",
       "depends": ["GenomicRanges", "MASS", "cluster", "igraph", "psych", "scran", "stringr"]
     },
     "Biobase": {
       "name": "Biobase",
-      "version": "2.66.0",
-      "sha256": "1ndkvl44pxdsw39gka1ivlb8l89m1ix58nkji7b65qq9mj6dw31k",
+      "version": "2.68.0",
+      "sha256": "03vzsm6m8wbmrg997k3qczr6jfwin9qxfxmq3lal6l1yk9vk0fwr",
       "depends": ["BiocGenerics"]
     },
     "BiocBaseUtils": {
       "name": "BiocBaseUtils",
-      "version": "1.8.0",
-      "sha256": "10xzfxyl12zkcx8l0b5hnmcnq6bdr1gg1dp64indvrnwwqpdjqjp",
+      "version": "1.10.0",
+      "sha256": "1ssva33zg6n6j8k6v3cnl6nrllm371jp7l20wh00mj70garaizkw",
       "depends": []
     },
     "BiocBook": {
       "name": "BiocBook",
-      "version": "1.4.0",
-      "sha256": "03kvqrj91jh9sg5dfga1jgqh0qhaz4853d7ysfy9mkhxdagxqljc",
+      "version": "1.6.0",
+      "sha256": "1kc4n2mrny4zmdg2lhf4b9gcnhmx34wn8h55ladnkkx2llgjb89v",
       "depends": ["BiocGenerics", "available", "cli", "dplyr", "gert", "gh", "gitcreds", "glue", "httr", "purrr", "quarto", "renv", "rlang", "rprojroot", "stringr", "tibble", "usethis", "yaml"]
     },
     "BiocCheck": {
       "name": "BiocCheck",
-      "version": "1.42.1",
-      "sha256": "108kic1bsycq7pkbbv6881w7w7vfb2wy8n06vvzmbmvfh5jg5nv2",
+      "version": "1.44.0",
+      "sha256": "0bbp1srcrls1x3b9a2q0xvsrfig0sridx8lp2mrm2sc97mzlzw38",
       "depends": ["BiocBaseUtils", "BiocFileCache", "BiocManager", "biocViews", "callr", "cli", "codetools", "graph", "httr2", "knitr", "rvest", "stringdist"]
     },
     "BiocFHIR": {
       "name": "BiocFHIR",
-      "version": "1.8.0",
-      "sha256": "1rcvlbqszis0hf4s5skagljxjy8bwyzi4xyy8yigp3x3jjfm2dhn",
+      "version": "1.10.0",
+      "sha256": "0569szdaz94k2vaz1jjwybnc49i8izdvx0agzh38356xjsv05d79",
       "depends": ["BiocBaseUtils", "DT", "dplyr", "graph", "jsonlite", "shiny", "tidyr", "visNetwork"]
     },
     "BiocFileCache": {
       "name": "BiocFileCache",
-      "version": "2.14.0",
-      "sha256": "08j0589rwylirna6r4bwk5vb965fp4zpj0msk0mlhppngqzlc2kc",
+      "version": "2.16.0",
+      "sha256": "182liy633q2aln2578saxhr83f5c64v3140g89yzblbyh4hnvql4",
       "depends": ["DBI", "RSQLite", "curl", "dbplyr", "dplyr", "filelock", "httr"]
     },
     "BiocGenerics": {
       "name": "BiocGenerics",
-      "version": "0.52.0",
-      "sha256": "1nbzbrb07v7wx19qhm65py9bl7ij4bpiqw87ixd00b6w6j6nmx8l",
-      "depends": []
+      "version": "0.54.0",
+      "sha256": "1fa11kh0d4sxjac22p2kjxj5v0dg32vldz7fcdzi8wf6rds6yga1",
+      "depends": ["generics"]
+    },
+    "BiocHail": {
+      "name": "BiocHail",
+      "version": "1.7.1",
+      "sha256": "1ik7yqjvwk3nyqsq39y888d0fd1rbrnlana6sj2r73xppm8ic3iw",
+      "depends": ["BiocFileCache", "BiocGenerics", "basilisk", "dplyr", "reticulate"]
     },
     "BiocHubsShiny": {
       "name": "BiocHubsShiny",
-      "version": "1.6.2",
-      "sha256": "0fpp49zqsc96wlhbalqhdc5jldh96knmx9zi9rn2jgwvlvd15ql4",
-      "depends": ["AnnotationHub", "DT", "ExperimentHub", "S4Vectors", "htmlwidgets", "shiny", "shinyAce", "shinyjs", "shinythemes", "shinytoastr"]
+      "version": "1.8.0",
+      "sha256": "0vwmq3vci10l7ypih3mixns57c0nplnqw95blsmbnjv095nqlpqi",
+      "depends": ["AnnotationHub", "DT", "ExperimentHub", "S4Vectors", "htmlwidgets", "rclipboard", "shiny", "shinyAce", "shinyjs", "shinythemes", "shinytoastr"]
     },
     "BiocIO": {
       "name": "BiocIO",
-      "version": "1.16.0",
-      "sha256": "1dqsilhlw5xwbmy04bcf6fqgnlkmzszr5xgfzhlgywdbh0pqm1lr",
+      "version": "1.18.0",
+      "sha256": "0sjvxzw110qrigfnhzmbzi16nhvfhqa7lj1yly5r4pqkpj77sdrs",
       "depends": ["BiocGenerics", "S4Vectors"]
     },
     "BiocNeighbors": {
       "name": "BiocNeighbors",
-      "version": "2.0.1",
-      "sha256": "0dzk92ixhgnhrqkmw9fgap0yvmrml5a4cw1r3wbgf5vgq2ccx2yq",
+      "version": "2.2.0",
+      "sha256": "01fnlbh57y989cdcki5zpbva7q7fj5sw9vrx3pjh51riqy8nnniw",
       "depends": ["Rcpp", "assorthead"]
     },
     "BiocParallel": {
       "name": "BiocParallel",
-      "version": "1.40.0",
-      "sha256": "1avnn7xpcabw73w75x66fxlx8wmlmv69p1zmr493gbgvy85plv1z",
+      "version": "1.42.0",
+      "sha256": "0f9jvx1z1qxa3z17x1a3jgf8rfcslqqk24absw9iw9hfs3b84z5d",
       "depends": ["BH", "codetools", "cpp11", "futile_logger", "snow"]
     },
     "BiocPkgTools": {
       "name": "BiocPkgTools",
-      "version": "1.24.0",
-      "sha256": "0d0acbhqm7x7813jmm90hw9fmv559zrahxnlm6smaw3jz74kb2q4",
-      "depends": ["BiocFileCache", "BiocManager", "DT", "RBGL", "biocViews", "dplyr", "gh", "graph", "htmltools", "htmlwidgets", "httr", "igraph", "jsonlite", "magrittr", "readr", "rlang", "rorcid", "rvest", "stringr", "tibble", "xml2"]
+      "version": "1.26.0",
+      "sha256": "19h0yq9q4gjwsa6b44187ifl1v5m3r5828i5gqgggnlnl37z6q1a",
+      "depends": ["BiocFileCache", "BiocManager", "DT", "RBGL", "biocViews", "curl", "dplyr", "gh", "glue", "graph", "htmltools", "htmlwidgets", "httr", "igraph", "jsonlite", "lubridate", "purrr", "readr", "rlang", "rorcid", "rvest", "stringr", "tibble", "tidyr", "xml2", "yaml"]
     },
     "BiocSet": {
       "name": "BiocSet",
-      "version": "1.20.0",
-      "sha256": "1jl4q3r6zcn837kd627wfki6z42bxdfklrj97c4r3cr3bnbyxvk0",
+      "version": "1.22.0",
+      "sha256": "1lnk8j22v75vr5wq501976i2ny43jqd3ixwk4yfrb531acvz2yd7",
       "depends": ["AnnotationDbi", "BiocIO", "KEGGREST", "S4Vectors", "dplyr", "ontologyIndex", "plyr", "rlang", "tibble", "tidyr"]
     },
     "BiocSingular": {
       "name": "BiocSingular",
-      "version": "1.22.0",
-      "sha256": "17flxapf8jw44rsbfz0iifhn6kdb2248lppbq0iz9c021wxlk28h",
+      "version": "1.24.0",
+      "sha256": "0dmlx6jshwh1iwmwjz9p8iykv34jskl9z6kxdxcbrl38wzsjhjfy",
       "depends": ["BiocGenerics", "BiocParallel", "DelayedArray", "Matrix", "Rcpp", "S4Vectors", "ScaledMatrix", "assorthead", "beachmat", "irlba", "rsvd"]
     },
     "BiocSklearn": {
       "name": "BiocSklearn",
-      "version": "1.28.0",
-      "sha256": "0ic17zcw4110rdk83p00ddq1lz2cm7vr5xpsb6y9ibf1hnk7s2al",
+      "version": "1.30.0",
+      "sha256": "15fyjg2pf77cnqzbb5hcbg3wc9kqn6hnklivhb3797v1za9y283x",
       "depends": ["SummarizedExperiment", "basilisk", "reticulate"]
     },
     "BiocStyle": {
       "name": "BiocStyle",
-      "version": "2.34.0",
-      "sha256": "1n6dg53sx1vmz2xzfj040l26znp3664wcam92nxm7hsi0l5lbqyx",
+      "version": "2.36.0",
+      "sha256": "1q186nrib86gicgv54h3snyah8kq8vc1vrzn81l5ly1hkgrn7fnl",
       "depends": ["BiocManager", "bookdown", "knitr", "rmarkdown", "yaml"]
     },
     "BiocVersion": {
       "name": "BiocVersion",
-      "version": "3.20.0",
-      "sha256": "1ixn9pwzm15z79da90iqniv8c6x8w7k5wdwzpj9dm1ghwd04xqcx",
+      "version": "3.21.1",
+      "sha256": "1xvfcvlg8984mfb99nml8p8liyb7w6myznhp2kvr8cy8x7g60p4q",
       "depends": []
     },
     "BiocWorkflowTools": {
       "name": "BiocWorkflowTools",
-      "version": "1.32.0",
-      "sha256": "195n6va4y1caj9g5dzdimzdi7ygkapmiq0cxd1lzk8sf2skg5dwb",
+      "version": "1.34.0",
+      "sha256": "07g8snhhjwl7vcsm2k9kim8b167awr94axalr0hzq81w5k6ajs1d",
       "depends": ["BiocStyle", "bookdown", "git2r", "httr", "knitr", "rmarkdown", "rstudioapi", "stringr", "usethis"]
     },
     "Biostrings": {
       "name": "Biostrings",
-      "version": "2.74.1",
-      "sha256": "1kyyrkcnpblyl37x5ncbhz412l5jm1l0ci7r7d1z60dhikysbpxl",
+      "version": "2.76.0",
+      "sha256": "1fwkpqf3m6hq305fiw371hmkldwvbcgdbhsc3vf477xighyhqh85",
       "depends": ["BiocGenerics", "GenomeInfoDb", "IRanges", "S4Vectors", "XVector", "crayon"]
     },
     "BloodGen3Module": {
       "name": "BloodGen3Module",
-      "version": "1.14.0",
-      "sha256": "1lhjhy07ly81gj6dbs9i25lbr3vzygrv0nghwabkq0ypklzppg24",
+      "version": "1.16.0",
+      "sha256": "011k9jl84gg5m9j1qg818wq3bixzy1hqzlz8an3h6w9rm3gcsfwb",
       "depends": ["ComplexHeatmap", "ExperimentHub", "SummarizedExperiment", "V8", "circlize", "ggplot2", "gtools", "limma", "matrixStats", "preprocessCore", "randomcoloR", "reshape2", "testthat"]
+    },
+    "BreastSubtypeR": {
+      "name": "BreastSubtypeR",
+      "version": "1.0.0",
+      "sha256": "1r5fmks5x4al3wldmy5lspcbpiwvp93glfc1r95arx011462kx92",
+      "depends": ["Biobase", "ComplexHeatmap", "RColorBrewer", "SummarizedExperiment", "circlize", "data_table", "dplyr", "e1071", "ggplot2", "ggrepel", "impute", "magrittr", "rlang", "stringr", "tidyselect", "withr"]
     },
     "BridgeDbR": {
       "name": "BridgeDbR",
-      "version": "2.16.0",
-      "sha256": "1gqnmq3669rw39b1jizcq2f2vw5a3ca6b4m2m7zhi7gxz8mf27zr",
+      "version": "2.18.0",
+      "sha256": "08p4d1z65pkqk78zp6sg9zimzbqzr91xci9crr4mkn3nh7ncnyhh",
       "depends": ["curl", "rJava"]
     },
     "BrowserViz": {
       "name": "BrowserViz",
-      "version": "2.28.0",
-      "sha256": "1sgj7193rqvj0f5z64krkvs45k939xj4lrq7h2c6zdpvl01g37dc",
+      "version": "2.30.0",
+      "sha256": "18cqkq9yc9n0wiiihrr2lggp3s848x391yxb1m5gfkwk0cpyzv6h",
       "depends": ["BiocGenerics", "httpuv", "jsonlite"]
     },
     "BubbleTree": {
       "name": "BubbleTree",
-      "version": "2.36.0",
-      "sha256": "1f0ikkwyrjmbxdxbyqjf90j8q7dn4kd00lbxiv0b9qhabczp2dcb",
+      "version": "2.38.0",
+      "sha256": "1h3wyp9f554zlf4ah6dqgb1c26bkx1ks2q709hz3krchgzv3pinn",
       "depends": ["Biobase", "BiocGenerics", "BiocStyle", "GenomicRanges", "IRanges", "RColorBrewer", "WriteXLS", "biovizBase", "dplyr", "e1071", "ggplot2", "gridExtra", "gtable", "gtools", "limma", "magrittr", "plyr"]
     },
     "BufferedMatrix": {
       "name": "BufferedMatrix",
-      "version": "1.70.0",
-      "sha256": "14wd9chwhagy2m12fvn5s0z27dh2hirqbzk188sch9myg2jndhjf",
+      "version": "1.72.0",
+      "sha256": "1186mmiw7pca05llgzq3lqycr0kcyb94fbrjyvvxaa7cjlzhrlni",
       "depends": []
     },
     "BufferedMatrixMethods": {
       "name": "BufferedMatrixMethods",
-      "version": "1.70.0",
-      "sha256": "0bdgxjz6bk094znrs6w6h3z3nx6gk4nfz6c3r6l7n3v4b93vqgzp",
+      "version": "1.72.0",
+      "sha256": "0inxq1ahx57y5g2kd1spp64v4rqja8y8zich3rj8887nw6j47jiw",
       "depends": ["BufferedMatrix"]
+    },
+    "BulkSignalR": {
+      "name": "BulkSignalR",
+      "version": "1.0.0",
+      "sha256": "10fr2p5vpzvbydydvjskrymij6s8g1lwp2g0yvvlvzhpjabdkmn6",
+      "depends": ["BiocFileCache", "ComplexHeatmap", "DBI", "RANN", "RSQLite", "Rtsne", "SpatialExperiment", "SummarizedExperiment", "circlize", "cli", "curl", "doParallel", "dplyr", "foreach", "ggalluvial", "ggplot2", "ggrepel", "glmnet", "gridExtra", "httr", "igraph", "jsonlite", "matrixStats", "multtest", "orthogene", "rlang", "scales", "stabledist"]
     },
     "BumpyMatrix": {
       "name": "BumpyMatrix",
-      "version": "1.14.0",
-      "sha256": "1ffg36b35li50nx1gs0knjl32k0jlqyhcw6j7zqw651apfknvd4i",
+      "version": "1.16.0",
+      "sha256": "1frai0sf94igvd078pnkdvhwmrwihpdqvc0rcxislpjjjl697jhp",
       "depends": ["IRanges", "Matrix", "S4Vectors"]
     },
     "CAEN": {
       "name": "CAEN",
-      "version": "1.14.0",
-      "sha256": "1azfpxvsgcr0yvap9l76hwjyl90fg0xkpkll4ykbgyn1bprl8vcw",
+      "version": "1.16.0",
+      "sha256": "1s7gmcnc3d9xzx8zhfqpch6brz84g4b8j2wjl27bs60bx6fwpbwa",
       "depends": ["PoiClaClu", "SummarizedExperiment"]
     },
     "CAFE": {
       "name": "CAFE",
-      "version": "1.42.0",
-      "sha256": "0dfjdyb2vzy87mgw3aq0jyfm448mk3k3zsjcyfwa4z8lcn3dr7z9",
+      "version": "1.44.0",
+      "sha256": "049idq4iz68rvrdajwwcf6g2fl3wh4bwrnaflap9pivdwkm14i8s",
       "depends": ["Biobase", "GenomicRanges", "IRanges", "affy", "annotate", "biovizBase", "ggbio", "ggplot2", "gridExtra"]
     },
     "CAGEfightR": {
       "name": "CAGEfightR",
-      "version": "1.26.0",
-      "sha256": "1lpci0dnblrchhbpbc3f31c3i98hsmik94m1jvc53av15v2fkxdc",
+      "version": "1.28.0",
+      "sha256": "1rdnr780lbh61zyd976w64zyzvxyqz720dq80d9d2d39axym8jb9",
       "depends": ["BiocGenerics", "BiocParallel", "GenomeInfoDb", "GenomicAlignments", "GenomicFeatures", "GenomicFiles", "GenomicInteractions", "GenomicRanges", "Gviz", "IRanges", "InteractionSet", "Matrix", "S4Vectors", "SummarizedExperiment", "assertthat", "pryr", "rtracklayer"]
     },
     "CAGEr": {
       "name": "CAGEr",
-      "version": "2.12.0",
-      "sha256": "17hxhpsh6cvifrkzfz4l643kvphbahn9w54dc3xfal6f135cyal7",
+      "version": "2.14.0",
+      "sha256": "05aaw9lcdabn4zgi2f10s9inw1b9inwxcg05d4mj5d5jwrhs9ysc",
       "depends": ["BSgenome", "BiocGenerics", "BiocParallel", "Biostrings", "CAGEfightR", "GenomeInfoDb", "GenomicAlignments", "GenomicFeatures", "GenomicRanges", "IRanges", "KernSmooth", "MultiAssayExperiment", "Rsamtools", "S4Vectors", "SummarizedExperiment", "VGAM", "data_table", "formula_tools", "ggplot2", "gtools", "memoise", "plyr", "reshape2", "rlang", "rtracklayer", "scales", "som", "stringdist", "stringi", "vegan"]
     },
     "CAMERA": {
       "name": "CAMERA",
-      "version": "1.62.0",
-      "sha256": "0b6k1k6qaapp17cqjjzz11bcg98q41b2llyyj12vz9ngy3qn570a",
+      "version": "1.64.0",
+      "sha256": "08483nkygysgvnn9acdwgibj2b8l0lrxzlwabm3jr091rhnzpazp",
       "depends": ["Biobase", "Hmisc", "RBGL", "graph", "igraph", "xcms"]
+    },
+    "CARDspa": {
+      "name": "CARDspa",
+      "version": "1.0.0",
+      "sha256": "1gsdlf6asxli78yx50pxj4yg8s2rd5msi3vq9b3brqm0bakaid6n",
+      "depends": ["BiocParallel", "MCMCpack", "Matrix", "NMF", "RANN", "RColorBrewer", "Rcpp", "RcppArmadillo", "RcppML", "S4Vectors", "SingleCellExperiment", "SpatialExperiment", "SummarizedExperiment", "concaveman", "dplyr", "fields", "ggcorrplot", "ggplot2", "gtools", "nnls", "reshape2", "scatterpie", "sf", "sp", "spatstat_random", "wrMisc"]
     },
     "CARNIVAL": {
       "name": "CARNIVAL",
-      "version": "2.16.0",
-      "sha256": "05sx2p8i0gxxki26nbb76xm2i2m8fdabi6k5li5yncg3p28gw3q2",
+      "version": "2.18.0",
+      "sha256": "1f4b8459lc8qirzdw2pn1jszipklif12wscpc9ll99pgmb65h37f",
       "depends": ["dplyr", "igraph", "lpSolve", "readr", "rjson", "rmarkdown", "stringr", "tibble", "tidyr"]
     },
     "CATALYST": {
       "name": "CATALYST",
-      "version": "1.30.2",
-      "sha256": "0i6rf1z1m4v43aw7mh4j44a7mscz5xnbnbmpbgzksw74zjg17604",
+      "version": "1.32.0",
+      "sha256": "17m2446z61mxxfcalimq47z3phla0z1zs11rkbpsc3zq8590pj83",
       "depends": ["ComplexHeatmap", "ConsensusClusterPlus", "FlowSOM", "Matrix", "RColorBrewer", "Rtsne", "S4Vectors", "SingleCellExperiment", "SummarizedExperiment", "circlize", "cowplot", "data_table", "dplyr", "drc", "flowCore", "ggplot2", "ggrepel", "ggridges", "gridExtra", "matrixStats", "nnls", "purrr", "reshape2", "scales", "scater"]
-    },
-    "CBEA": {
-      "name": "CBEA",
-      "version": "1.6.0",
-      "sha256": "1mbd62wakjn9pwhy2q2hfxkx09ny577a4j6lssnjj65jb3s7gjr6",
-      "depends": ["BiocParallel", "BiocSet", "Rcpp", "SummarizedExperiment", "TreeSummarizedExperiment", "dplyr", "fitdistrplus", "generics", "glue", "goftest", "lmom", "magrittr", "mixtools", "rlang", "tibble", "tidyr"]
     },
     "CBNplot": {
       "name": "CBNplot",
-      "version": "1.6.0",
-      "sha256": "1xg1d3p64h9pqfk9kb889c3vnnvcvzn3dncr3v76zxmlfr6vn215",
+      "version": "1.8.0",
+      "sha256": "13w72kjdyrk6zmb9aq0y63q166smndhvzyx0cwgcbfpl3nz18w3r",
       "depends": ["BiocFileCache", "ExperimentHub", "Rmpfr", "bnlearn", "clusterProfiler", "depmap", "dplyr", "enrichplot", "ggdist", "ggforce", "ggplot2", "ggraph", "graphite", "graphlayouts", "igraph", "magrittr", "org_Hs_eg_db", "patchwork", "purrr", "pvclust", "reshape2", "rlang", "stringr", "tidyr"]
+    },
+    "CCAFE": {
+      "name": "CCAFE",
+      "version": "1.0.0",
+      "sha256": "11j26rgg87wdcg6figpdg0s4944s575drz1k17wwgc9xa6vg6wv1",
+      "depends": ["VariantAnnotation", "dplyr"]
     },
     "CCPROMISE": {
       "name": "CCPROMISE",
-      "version": "1.32.0",
-      "sha256": "0596j63169n0gsn24j52l0ph8ryynklsv26akfy514d96vm52nwg",
+      "version": "1.34.0",
+      "sha256": "1wbcpksxw917jggm15z6bzbgrkqavb6rd64j7yj3wr3fhbyq3b0b",
       "depends": ["Biobase", "CCP", "GSEABase", "PROMISE"]
     },
     "CCPlotR": {
       "name": "CCPlotR",
-      "version": "1.4.0",
-      "sha256": "0iyrg8ibah5lny59y8496k6v6gpgpyc8vw0kszmryb6sf63n5ks9",
+      "version": "1.6.0",
+      "sha256": "1jbfqffavawp48ljc6pnfn5n68yrasp68jwr8v8gf4d7bcig590q",
       "depends": ["ComplexHeatmap", "RColorBrewer", "circlize", "dplyr", "forcats", "ggbump", "ggh4x", "ggplot2", "ggraph", "ggtext", "igraph", "patchwork", "plyr", "scales", "scatterpie", "stringr", "tibble", "tidyr", "viridis"]
     },
     "CDI": {
       "name": "CDI",
-      "version": "1.4.0",
-      "sha256": "18m3m39hqhl225f1cm8hgf8xldgj23c8ywlq83s4csdwagqigxbm",
+      "version": "1.6.0",
+      "sha256": "1lr5h0wh4ib7nzbcfsgn51iwz31rqfljk5wk937hvgh2p0in19gg",
       "depends": ["BiocParallel", "Seurat", "SeuratObject", "SingleCellExperiment", "SummarizedExperiment", "ggplot2", "ggsci", "matrixStats", "reshape2"]
     },
     "CEMiTool": {
       "name": "CEMiTool",
-      "version": "1.30.0",
-      "sha256": "00ycl82cnphnzxmyli7fxs2wlgyx64131s4gvkigi5rbbaiij24k",
+      "version": "1.32.0",
+      "sha256": "1havqmgai0vdm0w1mwajflkqn8hilrsa4hgchwbq13rfhrb5ykjm",
       "depends": ["DT", "WGCNA", "clusterProfiler", "data_table", "dplyr", "fastcluster", "fgsea", "ggdendro", "ggplot2", "ggpmisc", "ggrepel", "ggthemes", "gridExtra", "gtable", "htmltools", "igraph", "intergraph", "knitr", "matrixStats", "network", "pracma", "rmarkdown", "scales", "sna", "stringr"]
     },
     "CFAssay": {
       "name": "CFAssay",
-      "version": "1.40.0",
-      "sha256": "0ssph2s9cqzfccd628q4zqvra7lrlnbdq4bbk9vzdx3ahri5m4r9",
+      "version": "1.42.0",
+      "sha256": "0qbn86fhv35kqxnnb5g1nkd3767r2f5j9fqbqgw3h660q84qxi02",
       "depends": []
     },
     "CGEN": {
       "name": "CGEN",
-      "version": "3.42.0",
-      "sha256": "1skk62ziygjlx23b4nl5nc9ryjq133w76cnhnv9hq9b09mj4g9nj",
+      "version": "3.44.0",
+      "sha256": "03iysky09hfm348350mhx199frdr766b1ln4ppp1ja5qx3gw8r78",
       "depends": ["mvtnorm", "survival"]
     },
     "CGHbase": {
       "name": "CGHbase",
-      "version": "1.66.0",
-      "sha256": "0gcw2765ljqnhvnmawxhcz8xrfrjvh9slsaqhy8ggzhr47g7xnb6",
+      "version": "1.68.0",
+      "sha256": "1kp2isq47x6z0wysx0jbxqjr4zsr118bw9jx4r2k6jqf6ikpsbdj",
       "depends": ["Biobase", "marray"]
     },
     "CGHcall": {
       "name": "CGHcall",
-      "version": "2.68.0",
-      "sha256": "178gi1d0mdm201ay1srikndd6dsbi41rmn8h3rvmv3q2ngzk70hm",
+      "version": "2.70.0",
+      "sha256": "1ygfzla36h3bgj9j480xlgczn473r894d0yy10wvfi01rcpgmccn",
       "depends": ["Biobase", "CGHbase", "DNAcopy", "impute", "snowfall"]
     },
     "CGHnormaliter": {
       "name": "CGHnormaliter",
-      "version": "1.60.0",
-      "sha256": "0zi9yj3clqaf7gz3y8b1zg6x5v7py77j73b31dy3kg370mw4qc95",
+      "version": "1.62.0",
+      "sha256": "0d1g24xglli0zgkysk95827rwylpv0w0sz2zhh7cnzqcbdyplwch",
       "depends": ["Biobase", "CGHbase", "CGHcall"]
     },
     "CGHregions": {
       "name": "CGHregions",
-      "version": "1.64.0",
-      "sha256": "1zd41040m8k91c0gwqjivl8r8371f2rkhrlyaq61z0yx9qd0prig",
+      "version": "1.66.0",
+      "sha256": "016g4wzb4c3wacpp7f684l0ncqb70s7w29fcvxk4vgr9b6mh70id",
       "depends": ["Biobase", "CGHbase"]
     },
     "CHETAH": {
       "name": "CHETAH",
-      "version": "1.22.0",
-      "sha256": "1s4i9xmfksq1zb2r2jdmila0qc04f80pvwkzi9zxygsidx6d2n9g",
+      "version": "1.24.0",
+      "sha256": "1zwxkzfqgdc3qyb2pxr5z7azly1z91pcl0zlfk2qlxdi9p6a0xbj",
       "depends": ["S4Vectors", "SingleCellExperiment", "SummarizedExperiment", "bioDist", "corrplot", "cowplot", "dendextend", "ggplot2", "pheatmap", "plotly", "reshape2", "shiny"]
     },
     "CHRONOS": {
       "name": "CHRONOS",
-      "version": "1.34.0",
-      "sha256": "0q9r5xlk9ng85z3lyr3sk7fz31yzphakm70qh29n0qkn4hinnghr",
+      "version": "1.36.0",
+      "sha256": "1lvski7p05zv8zziimhfacpq8y3nay6awngm1dgs8r494a8k0kax",
       "depends": ["RBGL", "RCurl", "XML", "biomaRt", "circlize", "doParallel", "foreach", "graph", "igraph", "openxlsx", "rJava"]
     },
     "CIMICE": {
       "name": "CIMICE",
-      "version": "1.14.0",
-      "sha256": "00c07gs5syzhq7nh288vmx2bbcl6qk5db5b4ianysdp7x4794jg2",
+      "version": "1.16.0",
+      "sha256": "1xvbrqs5m19dhnqkpadqqcxjizc6g55v66lbqljqi1l1rzqhsq00",
       "depends": ["Matrix", "assertthat", "dplyr", "expm", "ggcorrplot", "ggplot2", "ggraph", "glue", "igraph", "maftools", "networkD3", "purrr", "tidygraph", "tidyr", "visNetwork"]
     },
     "CINdex": {
       "name": "CINdex",
-      "version": "1.34.0",
-      "sha256": "0ks867899b912gxqdvyiwnvikiikfmfrd2d52ps5430avjhkipvp",
+      "version": "1.36.0",
+      "sha256": "1cdmmnyxsrzlnsp15i8b072dfdsglql89ss1ddcwh4jyg8svwakl",
       "depends": ["GenomeInfoDb", "GenomicRanges", "IRanges", "S4Vectors", "bitops", "dplyr", "gplots", "gridExtra", "png", "som", "stringr"]
     },
     "CMA": {
       "name": "CMA",
-      "version": "1.64.0",
-      "sha256": "0v7yzm8vfb2i2irg55rbhcm66ila2lcwkgxxcqqfpw2h4hqwx0v9",
+      "version": "1.66.0",
+      "sha256": "152g2w3nvva6z637j3l1g1v0kpfs2pqzcdkhphkbahjii9svxl8s",
       "depends": ["Biobase"]
     },
     "CNAnorm": {
       "name": "CNAnorm",
-      "version": "1.52.0",
-      "sha256": "18w48lxif8xzfmi3kxi2diq80498kd3jjk0ckf5fz1cp8n82fslg",
+      "version": "1.54.0",
+      "sha256": "1c54y6cswl6vfk222p22qszqina3m4ppc7m2g9a3d82ipi7gcxl4",
       "depends": ["DNAcopy"]
     },
     "CNEr": {
       "name": "CNEr",
-      "version": "1.42.0",
-      "sha256": "0f4hbg5vprsygpd3d79vrvz2d35rbicv5wgllnk5cyvyrgsp15c7",
+      "version": "1.43.0",
+      "sha256": "129092mvpfiglf63z00himz39m5xw4dizrq70zg1l4s357cbbi9h",
       "depends": ["BiocGenerics", "Biostrings", "DBI", "GO_db", "GenomeInfoDb", "GenomicAlignments", "GenomicRanges", "IRanges", "KEGGREST", "RSQLite", "R_utils", "S4Vectors", "XVector", "annotate", "ggplot2", "poweRlaw", "pwalign", "readr", "reshape2", "rtracklayer"]
     },
     "CNORdt": {
       "name": "CNORdt",
-      "version": "1.48.0",
-      "sha256": "0dv9vq2qcmjwacxjwisrnm95khqf9p6idrycwgr3zm0d1ci5rzd9",
+      "version": "1.50.0",
+      "sha256": "01dcgbyb656yw23ihnsbwwid1zz11s9f75zh5fp0w5lg1bmxpmmv",
       "depends": ["CellNOptR", "abind"]
     },
     "CNORfeeder": {
       "name": "CNORfeeder",
-      "version": "1.46.0",
-      "sha256": "0l47748si5fvlga8wxzxk4j47354k3y87b9y2br1f1njqz8z2ij0",
+      "version": "1.48.0",
+      "sha256": "0lihig0j3x4nf5y1m8f12d1iwd5v6svh7754j71111il85kdgjcs",
       "depends": ["CellNOptR", "graph"]
     },
     "CNORfuzzy": {
       "name": "CNORfuzzy",
-      "version": "1.48.0",
-      "sha256": "1bsr5bqqs5ymjlb46g9f3v1kd8smfk6qwspr4g94swl1hxswx6dv",
+      "version": "1.50.0",
+      "sha256": "1zxvl98k2w308l29h16h2gn16r880n7nqw5z9rx8fsncv1g6k4s8",
       "depends": ["CellNOptR", "nloptr"]
     },
     "CNORode": {
       "name": "CNORode",
-      "version": "1.48.0",
-      "sha256": "1daxx83yli5qbf91yxlji6abb7v70s1fn0axh15w0ys9n57w7j93",
+      "version": "1.50.0",
+      "sha256": "0ax75f1xsnxgnxpvlwiw1idng7l6dcx25jqgsv9i2jpjzhvypm97",
       "depends": ["CellNOptR", "genalg"]
     },
     "CNTools": {
       "name": "CNTools",
-      "version": "1.62.0",
-      "sha256": "0w4zyacyr8zbqi26qkrv7gk5ih0r1f4w5qmma1z0scwa1sxfgqcj",
+      "version": "1.64.0",
+      "sha256": "0pysvvk826aj9x017jbma92p55w52sb57imsx5pzdiqvjx4ip47x",
       "depends": ["genefilter"]
     },
     "CNVMetrics": {
       "name": "CNVMetrics",
-      "version": "1.10.0",
-      "sha256": "1mjjmwgi6zcfly3xgivpk94kigvhpv61kwp0ybm1qkbnw871p4nb",
+      "version": "1.12.0",
+      "sha256": "16h04vba4x8xwisghgnmwy95hy24hgbhhrlpq1ncxgglr7vrgq58",
       "depends": ["BiocParallel", "GenomicRanges", "IRanges", "S4Vectors", "gridExtra", "magrittr", "pheatmap", "rBeta2009"]
     },
     "CNVPanelizer": {
       "name": "CNVPanelizer",
-      "version": "1.38.0",
-      "sha256": "0115ifqr5n9wx4f8kzsih9m6g9zgm8c8mzjfvikv0nfhzr8b28z4",
+      "version": "1.40.0",
+      "sha256": "0b5iil4pivcr5j1xfv5ix9p570f6m1aalibrzcj81s2a044rk4rv",
       "depends": ["BiocGenerics", "GenomeInfoDb", "GenomicRanges", "IRanges", "NOISeq", "Rsamtools", "S4Vectors", "foreach", "ggplot2", "gplots", "openxlsx", "plyr", "reshape2", "shiny", "shinyFiles", "shinyjs", "stringr", "testthat"]
     },
     "CNVRanger": {
       "name": "CNVRanger",
-      "version": "1.22.0",
-      "sha256": "0gf8fsjizh7c0d9b44gri95nw4yv56lk5kqd6wspy09h0agjaymx",
+      "version": "1.23.0",
+      "sha256": "1h0p4w9gak1kag37g12spfdiimbigy73kx18pnrsb3ijg12p9f7n",
       "depends": ["BiocGenerics", "BiocParallel", "GDSArray", "GenomeInfoDb", "GenomicRanges", "IRanges", "RaggedExperiment", "S4Vectors", "SNPRelate", "SummarizedExperiment", "data_table", "edgeR", "gdsfmt", "lattice", "limma", "plyr", "qqman", "rappdirs", "reshape2"]
     },
     "CNVfilteR": {
       "name": "CNVfilteR",
-      "version": "1.20.0",
-      "sha256": "1aibk5fcp2vxkw9ihrglfafk0pvnsg8r1prpdca806n5j52r2zfb",
+      "version": "1.21.0",
+      "sha256": "1jcdqcz83q3c5c78qm2jf7kgm7hrrjfb45byryfp5jazv7rkfkz9",
       "depends": ["Biostrings", "CopyNumberPlots", "GenomeInfoDb", "GenomicRanges", "IRanges", "Rsamtools", "SummarizedExperiment", "VariantAnnotation", "assertthat", "karyoploteR", "pracma", "regioneR"]
     },
     "CNViz": {
       "name": "CNViz",
-      "version": "1.14.0",
-      "sha256": "1clfk49abjq1vyyd0ab803jl9gd7ws9j6fydx8d1pxk85lksm7jl",
+      "version": "1.16.0",
+      "sha256": "167a7v3r7ngfnsf7j1sblb7h2myqz9rfi17syp1v5g4w3k0p6nv7",
       "depends": ["CopyNumberPlots", "DT", "GenomicRanges", "dplyr", "karyoploteR", "magrittr", "plotly", "scales", "shiny"]
     },
     "CNVrd2": {
       "name": "CNVrd2",
-      "version": "1.44.0",
-      "sha256": "192vdqq2zd58z7mq5izp3ga268q4a1a6ibszr34m54r836wscl2x",
+      "version": "1.46.0",
+      "sha256": "05ljlfbrvy8h9piwn3vjw3b24nrqz3xmngygak3zz7v2iwrw8iy1",
       "depends": ["DNAcopy", "IRanges", "Rsamtools", "VariantAnnotation", "ggplot2", "gridExtra", "rjags"]
     },
     "COCOA": {
       "name": "COCOA",
-      "version": "2.20.0",
-      "sha256": "0ifjr7xkrilhyckm2xpq35565rznag05nripl7kb446vbqn5lc8s",
+      "version": "2.22.0",
+      "sha256": "0ppfwrv447rsb7583m22s54s9ha0iq8vvjc25xj99sgbbm2q5zs0",
       "depends": ["Biobase", "BiocGenerics", "ComplexHeatmap", "GenomicRanges", "IRanges", "MIRA", "S4Vectors", "data_table", "fitdistrplus", "ggplot2", "simpleCache", "tidyr"]
     },
     "CODEX": {
       "name": "CODEX",
-      "version": "1.38.0",
-      "sha256": "0zqpgiqhcjr04kff1qg0gihwds3kjdy3f2gj14yynfbnmxklrmz2",
+      "version": "1.40.0",
+      "sha256": "0lf8rqp0m2bk93s1kg5zdz2lxipkm5lgp3y15h6bmm6f90d18caz",
       "depends": ["BSgenome_Hsapiens_UCSC_hg19", "Biostrings", "GenomeInfoDb", "IRanges", "Rsamtools", "S4Vectors"]
     },
     "COMPASS": {
       "name": "COMPASS",
-      "version": "1.44.0",
-      "sha256": "1pnfyyfjrsalc4ilaxbi566rni6yjhgz1ha5n15vz485rwblvp8j",
+      "version": "1.46.0",
+      "sha256": "09dj3m3fcqzc32i3kw4azfp4jn1v43z32vgp9n7j9jav5k7lh5ji",
       "depends": ["BiocStyle", "RColorBrewer", "Rcpp", "abind", "clue", "coda", "data_table", "dplyr", "foreach", "knitr", "magrittr", "pdist", "plyr", "reshape2", "rlang", "rmarkdown", "scales", "tidyr"]
     },
     "CONFESS": {
       "name": "CONFESS",
-      "version": "1.34.0",
-      "sha256": "0hd90fkbq2m40ql6cmkfklwnnjgmgv0fw1j9ddasc1326n85qn8i",
+      "version": "1.36.0",
+      "sha256": "16szf3jgrxp391b1syjjp39q2c0hxy7f0mqaqzl6lx6bf995wigc",
       "depends": ["EBImage", "MASS", "SamSPECTRAL", "changepoint", "cluster", "contrast", "data_table", "ecp", "flexmix", "flowClust", "flowCore", "flowMeans", "flowMerge", "flowPeaks", "foreach", "ggplot2", "limma", "moments", "outliers", "plotrix", "raster", "readbitmap", "reshape2", "waveslim", "wavethresh", "zoo"]
     },
     "CONSTANd": {
       "name": "CONSTANd",
-      "version": "1.14.0",
-      "sha256": "1jzl6krqy51fsk9l9jn1gqh1lviwsq98n0rnkh4z8d968s7mrzyy",
+      "version": "1.16.0",
+      "sha256": "1cgis1zdsm445hmjw8bwqzqxmdb7rw0j4alxswfnnvm1vca7qba7",
       "depends": []
     },
     "COSNet": {
       "name": "COSNet",
-      "version": "1.40.0",
-      "sha256": "1jp7l3chnyshva82f7qaz59gvwhz855x6257bq250nljwbv62x54",
+      "version": "1.42.0",
+      "sha256": "0b3ajdax3873x172fzvp22g6i9ckdznsw8njy74afc8kajm3aw8l",
       "depends": []
     },
     "COTAN": {
       "name": "COTAN",
-      "version": "2.6.2",
-      "sha256": "12qh5jrch349fd0kqx3nn79x1h7k0sjzvggaym1a2xjcmd6fq7sr",
-      "depends": ["BiocSingular", "ComplexHeatmap", "Matrix", "PCAtools", "RColorBrewer", "Rfast", "S4Vectors", "Seurat", "SingleCellExperiment", "SummarizedExperiment", "assertthat", "circlize", "dendextend", "dplyr", "ggplot2", "ggrepel", "ggthemes", "parallelDist", "parallelly", "plyr", "rlang", "scales", "stringr", "tibble", "tidyr", "umap", "withr", "zeallot"]
+      "version": "2.8.0",
+      "sha256": "0smicvq8qr00kmwahf28fq2047445844va8m12ql1fm5hl1gb5jv",
+      "depends": ["BiocSingular", "ComplexHeatmap", "Matrix", "RColorBrewer", "Rfast", "S4Vectors", "Seurat", "SingleCellExperiment", "SummarizedExperiment", "assertthat", "circlize", "dendextend", "dplyr", "ggplot2", "ggrepel", "ggthemes", "parallelDist", "parallelly", "plyr", "rlang", "scales", "stringr", "tibble", "tidyr", "umap", "withr", "zeallot"]
+    },
+    "CPSM": {
+      "name": "CPSM",
+      "version": "1.0.0",
+      "sha256": "0bhn6lp0z8pnjs42fcx5ybadj3c95ijx2i8bp5vsjj2jgqwmb3mz",
+      "depends": ["Hmisc", "MASS", "MTLR", "Matrix", "ROCR", "SummarizedExperiment", "ggfortify", "ggplot2", "glmnet", "pec", "preprocessCore", "reshape2", "rms", "survival", "survivalROC", "survminer", "svglite"]
     },
     "CRISPRball": {
       "name": "CRISPRball",
-      "version": "1.2.0",
-      "sha256": "04gma48r31sirl33r74xfh884gpx06aydm1vdqissmsli0kqnxd3",
-      "depends": ["ComplexHeatmap", "DT", "InteractiveComplexHeatmap", "MAGeCKFlute", "PCAtools", "circlize", "colourpicker", "dittoSeq", "ggplot2", "htmlwidgets", "matrixStats", "plotly", "shiny", "shinyBS", "shinyWidgets", "shinycssloaders", "shinyjqui", "shinyjs"]
+      "version": "1.4.0",
+      "sha256": "0y1hqb6jb356qff3jclab47jkf8i65qdva3idixi20y9m009q5s8",
+      "depends": ["ComplexHeatmap", "DT", "InteractiveComplexHeatmap", "PCAtools", "circlize", "colourpicker", "dittoSeq", "ggplot2", "htmlwidgets", "matrixStats", "plotly", "shiny", "shinyBS", "shinyWidgets", "shinycssloaders", "shinyjqui", "shinyjs"]
     },
     "CRISPRseek": {
       "name": "CRISPRseek",
-      "version": "1.46.0",
-      "sha256": "1p5983v1w4rj2i5ch2g3ygzxqssqvgv222anf3060s9zsyiycm9a",
-      "depends": ["BSgenome", "BiocGenerics", "Biostrings", "DelayedArray", "GenomeInfoDb", "GenomicRanges", "IRanges", "S4Vectors", "XVector", "data_table", "dplyr", "hash", "keras", "mltools", "reticulate", "rhdf5", "seqinr"]
+      "version": "1.48.0",
+      "sha256": "1sr15nrf3nfrm2cvm8nkmshvlfrm9sabarymmlqf5pf7f6wq9pjh",
+      "depends": ["BSgenome", "BiocGenerics", "Biostrings", "DelayedArray", "GenomeInfoDb", "GenomicFeatures", "GenomicRanges", "IRanges", "S4Vectors", "XVector", "data_table", "dplyr", "gtools", "hash", "keras", "mltools", "openxlsx", "reticulate", "rhdf5", "rio", "rlang", "seqinr", "stringr"]
     },
     "CRImage": {
       "name": "CRImage",
-      "version": "1.54.0",
-      "sha256": "08gh04dslr08dw5cb954v0p9p65g88yqdrlbwz4qyysva4yali0f",
+      "version": "1.56.0",
+      "sha256": "0a98fhw16xy32raqi9p4h4xby3zpgbz1936lpcb2yx3g9l4mh96c",
       "depends": ["DNAcopy", "EBImage", "MASS", "aCGH", "e1071", "foreach", "sgeostat"]
     },
     "CSAR": {
       "name": "CSAR",
-      "version": "1.58.0",
-      "sha256": "1baqklp2pa7nam2vcjanpy4hip9dgmx9bxi1czdb92rrjgr6vk2l",
+      "version": "1.60.0",
+      "sha256": "0qfwqayxg11zjwp0br21782a5l0a6qdyn18d4780gfpx0az34hf5",
       "depends": ["GenomeInfoDb", "GenomicRanges", "IRanges", "S4Vectors"]
     },
     "CSSQ": {
       "name": "CSSQ",
-      "version": "1.18.0",
-      "sha256": "049lh3qypngcgz0a1yvmddighfyc81fm76amvmf4b9zgirdgf16p",
+      "version": "1.20.0",
+      "sha256": "1sc5y26j34g5i3s6001dv2a0rxpiiv1f59w3xawj2n9h1ydi93pv",
       "depends": ["GenomicAlignments", "GenomicFeatures", "GenomicRanges", "IRanges", "Rsamtools", "S4Vectors", "SummarizedExperiment", "ggplot2", "rtracklayer"]
     },
     "CTDquerier": {
       "name": "CTDquerier",
-      "version": "2.14.0",
-      "sha256": "0kgnvsw13hmnkjy7ka23p6n5ixnyxim994q200jxcbnp7as0fh0b",
+      "version": "2.16.0",
+      "sha256": "1lkab41xz6md3bwma5lnmy2ypk8s01nqzwh9xap8nmn1q95rinmq",
       "depends": ["BiocFileCache", "RCurl", "S4Vectors", "ggplot2", "gridExtra", "igraph", "stringdist", "stringr"]
     },
     "CTSV": {
       "name": "CTSV",
-      "version": "1.8.0",
-      "sha256": "1i5zlcjyxs8y8wfhn9jfxgkfbz0r05if7hshvacx33c64drpj8jc",
+      "version": "1.10.0",
+      "sha256": "1v2chhbk48jcq4yknc3rpk05pbhb9cci761fr4586ablvjksf7j5",
       "depends": ["BiocParallel", "SpatialExperiment", "SummarizedExperiment", "knitr", "pscl", "qvalue"]
     },
     "CTdata": {
       "name": "CTdata",
-      "version": "1.6.0",
-      "sha256": "1wyxhwhix4cpj02y0pvqa7l6lfqffwvsnk8sy36xp9fazxp962dy",
+      "version": "1.8.0",
+      "sha256": "0w89npf2ygli3m7g692rjy13hi5ga07l0shf4wdbws0wk90rysvz",
       "depends": ["ExperimentHub"]
     },
     "CTexploreR": {
       "name": "CTexploreR",
-      "version": "1.2.0",
-      "sha256": "1k5c7zp5ks53n46gzay1dpax7018082mn70blzxy7vhdmwigisjl",
+      "version": "1.4.0",
+      "sha256": "0krkgl8iqz8vhvn8rcah4y1pddyjmihq3fql9wkj9s6fn2zpig4a",
       "depends": ["BiocGenerics", "CTdata", "ComplexHeatmap", "GenomicRanges", "IRanges", "MatrixGenerics", "SingleCellExperiment", "SummarizedExperiment", "circlize", "dplyr", "ggplot2", "ggrepel", "rlang", "tibble", "tidyr"]
     },
     "CaDrA": {
       "name": "CaDrA",
-      "version": "1.4.0",
-      "sha256": "1vb1rq4bs24swcswxvsid1bhc1lpivrynqsy39lb362d0bmgr211",
+      "version": "1.6.0",
+      "sha256": "1kw197picmwaa03m9rx55x18pn5xdjj9xsk5f1w2lxpmq1bkrl5w",
       "depends": ["MASS", "R_cache", "SummarizedExperiment", "doParallel", "ggplot2", "gplots", "gtable", "knnmi", "misc3d", "plyr", "ppcor", "reshape2"]
     },
     "CaMutQC": {
       "name": "CaMutQC",
-      "version": "1.2.0",
-      "sha256": "1b1i3nkqb31rdlaznwwcwn8ksvlw9wmi2xmhi07cq7zkh4mrpgjb",
+      "version": "1.4.0",
+      "sha256": "1r1c454h3jssr5pzl2vp0sgkgdybpdnkcvjr2qjsqq55mn7129m8",
       "depends": ["DT", "MesKit", "clusterProfiler", "data_table", "dplyr", "ggplot2", "maftools", "org_Hs_eg_db", "stringr", "tidyr", "vcfR"]
     },
     "Cardinal": {
       "name": "Cardinal",
-      "version": "3.8.3",
-      "sha256": "1nza7j7y22f16pwdgzplx8bacqdp4i2rmsr6zfa874ivr0mf5grj",
+      "version": "3.10.0",
+      "sha256": "1rik9cyw7h8gw2d8pwr0b74pj4clh9m915sj4fazfcb2d8sj6k3z",
       "depends": ["Biobase", "BiocGenerics", "BiocParallel", "CardinalIO", "EBImage", "Matrix", "ProtGenerics", "S4Vectors", "irlba", "matter", "nlme"]
     },
     "CardinalIO": {
       "name": "CardinalIO",
-      "version": "1.4.0",
-      "sha256": "1b773hvdk5dqkrzpb5yyb85xszpkn9pdkyzdsid406zfhsqwwn97",
+      "version": "1.6.0",
+      "sha256": "067ykhkdbwiws98b8dy8prhd7v5zw23vlj2nm5j1nyhpv06p7kk9",
       "depends": ["BiocParallel", "S4Vectors", "matter", "ontologyIndex"]
     },
     "Category": {
       "name": "Category",
-      "version": "2.72.0",
-      "sha256": "0s65rfk9sw02qdqk7jhbkjybx1sm0hq0impdcxyypxbg77db5wk2",
+      "version": "2.74.0",
+      "sha256": "1faffkhi86gmnh0capmxh0gzw7vc3xy4gxnwnidz4fj3dbvcxahn",
       "depends": ["AnnotationDbi", "Biobase", "BiocGenerics", "DBI", "GSEABase", "Matrix", "RBGL", "annotate", "genefilter", "graph"]
     },
     "CatsCradle": {
       "name": "CatsCradle",
-      "version": "1.0.1",
-      "sha256": "1g0wdzrca148bb7vjac183vxxng30d0hgh0vbv4xravzcpqfnzzy",
+      "version": "1.2.0",
+      "sha256": "16cx1blp0vh4bcf57j16wq0ny2fydmimpbhwsky8vnjzqg6wwar3",
       "depends": ["EBImage", "Matrix", "Rfast", "S4Vectors", "Seurat", "SeuratObject", "SingleCellExperiment", "SpatialExperiment", "SummarizedExperiment", "abind", "data_table", "geometry", "ggplot2", "igraph", "msigdbr", "networkD3", "pheatmap", "pracma", "rdist", "reshape2", "stringr"]
     },
     "CausalR": {
       "name": "CausalR",
-      "version": "1.38.0",
-      "sha256": "089fhrl4n621pp7sba6hfbzv2wbiz3sqnb9yg6cwzlh0dw4wjy1k",
+      "version": "1.40.0",
+      "sha256": "0wjc657lpi17zkb9fnp8x8mysgpp7mz5r8l5ambsqn99wnfpz0hp",
       "depends": ["igraph"]
     },
     "CeTF": {
       "name": "CeTF",
-      "version": "1.18.0",
-      "sha256": "13n7ym57fzzdx6d1b5g3b1mj02k6pfwns5sqlnvhxfl4s5drm80d",
+      "version": "1.20.0",
+      "sha256": "1dlrppsiw03qm7lzdfnax1zahvcmly1w5h2815jp3zp6mpnkk074",
       "depends": ["ComplexHeatmap", "DESeq2", "GGally", "GenomicTools_fileHandler", "Matrix", "RCy3", "Rcpp", "RcppArmadillo", "S4Vectors", "SummarizedExperiment", "circlize", "clusterProfiler", "dplyr", "ggnetwork", "ggplot2", "ggpubr", "ggrepel", "igraph", "network"]
     },
     "CellBarcode": {
       "name": "CellBarcode",
-      "version": "1.12.0",
-      "sha256": "1c9gbqjwa8kabiwsy5yc99pspc78isfy8867kpklzfwbvsf0c641",
-      "depends": ["BH", "Biostrings", "Ckmeans_1d_dp", "Rcpp", "Rsamtools", "S4Vectors", "ShortRead", "data_table", "egg", "ggplot2", "magrittr", "plyr", "seqinr", "stringr", "zlibbioc"]
+      "version": "1.14.0",
+      "sha256": "034p8vsxsarhyafgrqxv35c8wdm5qb2c1ddg541x4v1sba9aqjf3",
+      "depends": ["BH", "Biostrings", "Ckmeans_1d_dp", "Rcpp", "Rsamtools", "S4Vectors", "ShortRead", "data_table", "egg", "ggplot2", "magrittr", "plyr", "seqinr", "stringr"]
     },
     "CellBench": {
       "name": "CellBench",
-      "version": "1.22.0",
-      "sha256": "0c9qaqql1bcm4r1lhxlmbbw1v0l6z9g3dwaq3cm863fhi4822xl4",
+      "version": "1.24.0",
+      "sha256": "0pr1dj9c9f0gd4i7h8shwy40pzva2ncih786fs072akb83gwg7j4",
       "depends": ["BiocFileCache", "BiocGenerics", "BiocParallel", "SingleCellExperiment", "assertthat", "dplyr", "glue", "lubridate", "magrittr", "memoise", "purrr", "rappdirs", "rlang", "tibble", "tidyr", "tidyselect"]
     },
     "CellMapper": {
       "name": "CellMapper",
-      "version": "1.32.0",
-      "sha256": "1jbdpclya852yv9z2qb807spwrvs5yw8vnq2i238pbc4a7qngjvh",
+      "version": "1.34.0",
+      "sha256": "08fvq6qsah0a6sxgpf962027q010hvy61sjffc6s00al04awk6wf",
       "depends": ["S4Vectors"]
     },
     "CellMixS": {
       "name": "CellMixS",
-      "version": "1.22.0",
-      "sha256": "1xg099xjbm6p4b36yvgckcirc4n0bm5md66gk9vyb9azka56x83r",
+      "version": "1.24.0",
+      "sha256": "053wpmv5m6m1iw5rmpsv2qm8da1r375pc65d5s2s9xcflrawdgg0",
       "depends": ["BiocGenerics", "BiocNeighbors", "BiocParallel", "SingleCellExperiment", "SummarizedExperiment", "cowplot", "dplyr", "ggplot2", "ggridges", "kSamples", "magrittr", "purrr", "scater", "tidyr", "viridis"]
     },
     "CellNOptR": {
       "name": "CellNOptR",
-      "version": "1.52.0",
-      "sha256": "1gzjmxycgxd8zvjksfyp08sasgv532vk3864pg7ilmch96q8sw9r",
+      "version": "1.54.0",
+      "sha256": "11bl03dpr4xlr5ja6a7j3zrvcmwrvr9l2jhfzkbd41v2qrxl67dw",
       "depends": ["RBGL", "RCurl", "Rgraphviz", "XML", "ggplot2", "graph", "igraph", "rmarkdown", "stringi", "stringr"]
     },
     "CellScore": {
       "name": "CellScore",
-      "version": "1.26.0",
-      "sha256": "084bnxd132lfjk66lrx30qx33d7i37n6h8vzrqj0a7acag6w0mni",
+      "version": "1.27.0",
+      "sha256": "11lhb46d5w3fq8qhlmap7wfirkpdnr6bqdpdarwxirrp076znvi2",
       "depends": ["Biobase", "RColorBrewer", "SummarizedExperiment", "gplots", "lsa", "squash"]
     },
     "CellTrails": {
       "name": "CellTrails",
-      "version": "1.24.0",
-      "sha256": "11wbq43jrmh9g3p55hc2z4q9kvqpivmrzn58c5b47wrggayi66na",
+      "version": "1.26.0",
+      "sha256": "0y9kp9995gry4vsk0jhp8baxbdiqhs5i5qmbx1hwb660gjdb454l",
       "depends": ["Biobase", "BiocGenerics", "EnvStats", "Rtsne", "SingleCellExperiment", "SummarizedExperiment", "cba", "dendextend", "dtw", "ggplot2", "ggrepel", "igraph", "maptree", "mgcv", "reshape2"]
     },
     "CelliD": {
       "name": "CelliD",
-      "version": "1.14.0",
-      "sha256": "0qgkyl57ggkx9577a6lvpxb3vcqhjgi5r1l56xbxniphjcq41cpy",
+      "version": "1.16.0",
+      "sha256": "169cvjjbzqn6q1v3m5kg1k40klwdrv7jbsmsabmqjf30xd2wjlrr",
       "depends": ["BiocParallel", "Matrix", "Rcpp", "RcppArmadillo", "Rtsne", "Seurat", "SingleCellExperiment", "SummarizedExperiment", "data_table", "fastmatch", "fgsea", "ggplot2", "glue", "irlba", "matrixStats", "pbapply", "reticulate", "scater", "stringr", "tictoc", "umap"]
     },
     "Cepo": {
       "name": "Cepo",
-      "version": "1.12.0",
-      "sha256": "1qwz3y80sy6yjc3mc024pi76q019rs9vbpqwdi8fijmci6xgbyx2",
+      "version": "1.14.0",
+      "sha256": "0mpp3sgsrh7q65956cdlbxjrb6nfsfd67aml5qim37idakpkyhg7",
       "depends": ["BiocParallel", "DelayedArray", "DelayedMatrixStats", "GSEABase", "HDF5Array", "S4Vectors", "SingleCellExperiment", "SummarizedExperiment", "dplyr", "ggplot2", "patchwork", "purrr", "reshape2", "rlang"]
     },
     "CexoR": {
       "name": "CexoR",
-      "version": "1.44.0",
-      "sha256": "17w7mnrcv3kv5wnnaxs9nnb00wr7dbkpsdgwhp0n6jh4qbq2dzqb",
+      "version": "1.46.0",
+      "sha256": "06hmlxiv027x6fvz4pcwkn6n2s9a4crj1q81mpdqshx0wpasky3x",
       "depends": ["GenomeInfoDb", "GenomicRanges", "IRanges", "RColorBrewer", "Rsamtools", "S4Vectors", "genomation", "idr", "rtracklayer"]
     },
     "ChAMP": {
       "name": "ChAMP",
-      "version": "2.36.0",
-      "sha256": "0cbgzkza1gqrqyk32i9vy1s3qvvr0wx2j0fjwg1cqy42qdy24rax",
+      "version": "2.38.0",
+      "sha256": "1dza1kv7s7zjw56shr6bi79vqziabihad6qjrf92p24p0yzzfwsl",
       "depends": ["ChAMPdata", "DMRcate", "DNAcopy", "DT", "GenomicRanges", "Hmisc", "Illumina450ProbeVariants_db", "IlluminaHumanMethylation450kmanifest", "IlluminaHumanMethylationEPICanno_ilm10b4_hg19", "IlluminaHumanMethylationEPICmanifest", "RColorBrewer", "RPMM", "bumphunter", "combinat", "dendextend", "doParallel", "ggplot2", "globaltest", "goseq", "illuminaio", "impute", "isva", "kpmt", "limma", "marray", "matrixStats", "minfi", "missMethyl", "plotly", "plyr", "preprocessCore", "prettydoc", "quadprog", "qvalue", "rmarkdown", "shiny", "shinythemes", "sva", "wateRmelon"]
     },
     "ChIPComp": {
       "name": "ChIPComp",
-      "version": "1.36.0",
-      "sha256": "1pbzqldavg21zds4v9yvhfdf0knli7z66xldsmdz646v6f1q1579",
+      "version": "1.38.0",
+      "sha256": "0j5pq8l1azr9abfmnnycy1nkqxy19r4q5pjda45xwsmiz94b543l",
       "depends": ["BSgenome_Hsapiens_UCSC_hg19", "BSgenome_Mmusculus_UCSC_mm9", "BiocGenerics", "GenomeInfoDb", "GenomicRanges", "IRanges", "Rsamtools", "S4Vectors", "limma", "rtracklayer"]
     },
     "ChIPQC": {
       "name": "ChIPQC",
-      "version": "1.42.0",
-      "sha256": "01p2iahschwm3fy0sf1p79cm7f6z59a4y7akg99cmx44zwlzbj2x",
+      "version": "1.44.0",
+      "sha256": "1zmxyh9a26niix1rch1xl8imc4fwzjbdbbfbcq14hqhdjha0g95p",
       "depends": ["Biobase", "BiocGenerics", "BiocParallel", "DiffBind", "GenomicAlignments", "GenomicFeatures", "GenomicRanges", "IRanges", "Nozzle_R1", "Rsamtools", "S4Vectors", "TxDb_Celegans_UCSC_ce6_ensGene", "TxDb_Dmelanogaster_UCSC_dm3_ensGene", "TxDb_Hsapiens_UCSC_hg18_knownGene", "TxDb_Hsapiens_UCSC_hg19_knownGene", "TxDb_Mmusculus_UCSC_mm10_knownGene", "TxDb_Mmusculus_UCSC_mm9_knownGene", "TxDb_Rnorvegicus_UCSC_rn4_ensGene", "chipseq", "ggplot2", "gtools", "reshape2"]
     },
     "ChIPXpress": {
       "name": "ChIPXpress",
-      "version": "1.50.0",
-      "sha256": "1whym24hvzaz0j60iblgwayw20lz5362mqxn2n1kmikrn4whz5gv",
+      "version": "1.52.0",
+      "sha256": "1qf6pbbypg9889p3lpbmackb0saisq6v4d0vp7l8ngc47rfwzaba",
       "depends": ["Biobase", "ChIPXpressData", "GEOquery", "affy", "biganalytics", "bigmemory", "frma"]
     },
     "ChIPanalyser": {
       "name": "ChIPanalyser",
-      "version": "1.28.0",
-      "sha256": "15xm5xap4vws1ah0iidb8529x53kw5k3hvli7xlz5gfpicdfg3hh",
+      "version": "1.30.0",
+      "sha256": "1v3wb8v54vj2q3dqr5xgma6l93qq2b20vfgh0q5r61vgzkzr9j28",
       "depends": ["BSgenome", "BiocManager", "Biostrings", "GenomeInfoDb", "GenomicRanges", "IRanges", "RColorBrewer", "ROCR", "RcppRoll", "S4Vectors", "rtracklayer"]
     },
     "ChIPexoQual": {
       "name": "ChIPexoQual",
-      "version": "1.30.0",
-      "sha256": "0xmznc8cc6nphzr5gkc4cccix80d5397qnqwx6q7imdfbm0ygy8i",
+      "version": "1.32.0",
+      "sha256": "1i5ribbhamszq0nllgjqvlii4psypp2qrn81ln8q55ilysv76myv",
       "depends": ["BiocParallel", "GenomeInfoDb", "GenomicAlignments", "GenomicRanges", "IRanges", "RColorBrewer", "Rsamtools", "S4Vectors", "biovizBase", "broom", "data_table", "dplyr", "ggplot2", "hexbin", "rmarkdown", "scales", "viridis"]
     },
     "ChIPpeakAnno": {
       "name": "ChIPpeakAnno",
-      "version": "3.40.0",
-      "sha256": "0zzpmrni4la6d2zws8wxak51lnn9g2i9xbwj1f3micpyn1bxlsc9",
+      "version": "3.42.0",
+      "sha256": "0a2f36bwg287jif8yjhy9q6mr6ilwzm5r425g22sdhghfba8i2gh",
       "depends": ["AnnotationDbi", "BiocGenerics", "Biostrings", "DBI", "GenomeInfoDb", "GenomicAlignments", "GenomicFeatures", "GenomicRanges", "IRanges", "InteractionSet", "KEGGREST", "RBGL", "Rsamtools", "S4Vectors", "SummarizedExperiment", "VennDiagram", "biomaRt", "data_table", "dplyr", "ensembldb", "ggplot2", "graph", "matrixStats", "multtest", "pwalign", "regioneR", "rtracklayer", "scales", "stringr", "tibble", "tidyr", "universalmotif"]
     },
     "ChIPseeker": {
       "name": "ChIPseeker",
-      "version": "1.42.1",
-      "sha256": "18abjm59z9isxy3dj3cpf1xbg4gyz0mm1cfxn78g5m17jkkyr7b7",
+      "version": "1.44.0",
+      "sha256": "1agxgvm78wvsirvgk3azqgdqa18k6li78h0zki2fzvmzw7qfzswm",
       "depends": ["AnnotationDbi", "BiocGenerics", "GenomeInfoDb", "GenomicFeatures", "GenomicRanges", "IRanges", "RColorBrewer", "S4Vectors", "TxDb_Hsapiens_UCSC_hg19_knownGene", "aplot", "boot", "dplyr", "enrichplot", "ggplot2", "gplots", "gtools", "magrittr", "plotrix", "rlang", "rtracklayer", "scales", "tibble", "yulab_utils"]
     },
     "ChIPseqR": {
       "name": "ChIPseqR",
-      "version": "1.60.0",
-      "sha256": "1zflq6b863iiixgrvrj68g6kfkfvl2aki2ivr4151wqf7yxr00i0",
+      "version": "1.61.0",
+      "sha256": "1bv6cflygkx59aqwjggw8r3dkh5sj8gid5i3r7rp72xbc4h4bq81",
       "depends": ["BiocGenerics", "Biostrings", "GenomicRanges", "HilbertVis", "IRanges", "S4Vectors", "ShortRead", "fBasics", "timsac"]
     },
     "ChIPsim": {
       "name": "ChIPsim",
-      "version": "1.60.0",
-      "sha256": "1sj4d87y1pj56mhb4v0snk5pqd79pxb42d5kg10ijvmpygbz68nq",
+      "version": "1.62.0",
+      "sha256": "10iz3sxc2qhwjwm2hbnxdzg5ppp6frccfi7m95mg3cpwdwwicm6q",
       "depends": ["Biostrings", "IRanges", "ShortRead", "XVector"]
     },
     "ChemmineOB": {
       "name": "ChemmineOB",
-      "version": "1.44.0",
-      "sha256": "0nvlc2s5s9w7zqalay6dz73mqrcalbkyv43jx52pcgnl842r4g95",
+      "version": "1.46.0",
+      "sha256": "0z156k7anzl0xcbch6lcg8z3dkkfy6901x8hl3wsshf6rl9ibahz",
       "depends": ["BH", "BiocGenerics", "Rcpp", "zlibbioc"]
     },
     "ChemmineR": {
       "name": "ChemmineR",
-      "version": "3.58.0",
-      "sha256": "0gydxqchyhgx1jq4p3658dvhiqpmwhynngcmpkac9sim9ym968db",
+      "version": "3.60.0",
+      "sha256": "0kvg14g4mj8dsyw1ksmgqf5a0dx791px0vf61fmbi5sx67ncirf6",
       "depends": ["BH", "BiocGenerics", "DBI", "DT", "RCurl", "Rcpp", "base64enc", "digest", "ggplot2", "gridExtra", "jsonlite", "png", "rjson", "rsvg", "stringi"]
     },
     "Chicago": {
       "name": "Chicago",
-      "version": "1.34.0",
-      "sha256": "1g86hffd0j3zyz654h0pn2pviykskkh40pcglf4bq99cxslnzww2",
+      "version": "1.36.0",
+      "sha256": "0hq96svbcx98gss5wf068rmpz4x85n4k5vf9pd4ips2yzy9454vf",
       "depends": ["Delaporte", "Hmisc", "MASS", "data_table", "matrixStats"]
     },
     "ChromHeatMap": {
       "name": "ChromHeatMap",
-      "version": "1.60.0",
-      "sha256": "0zmm3s4in1dswh82xhabaivcyn1lj5b0n0hric50mgws34z261bh",
+      "version": "1.62.0",
+      "sha256": "0d7iwwdvvlfkmpk74vrhw7yh713sd7v01aa7hjq984y071dl4sai",
       "depends": ["AnnotationDbi", "Biobase", "BiocGenerics", "GenomicRanges", "IRanges", "annotate", "rtracklayer"]
     },
     "ChromSCape": {
       "name": "ChromSCape",
-      "version": "1.16.0",
-      "sha256": "1x4zkpm84hg6shim0s8jpp060g4dm4fvicpx9nf5p66ydwy1q0nm",
+      "version": "1.17.0",
+      "sha256": "1nvm20qh3mzgimp175ykx0z50vzc0wsnb16lwpk5pik8r8yaks7z",
       "depends": ["BiocParallel", "ConsensusClusterPlus", "DT", "DelayedArray", "GenomicRanges", "IRanges", "Matrix", "Rcpp", "Rsamtools", "Rtsne", "S4Vectors", "SingleCellExperiment", "SummarizedExperiment", "batchelor", "colorRamps", "colourpicker", "coop", "dplyr", "edgeR", "forcats", "fs", "gggenes", "ggplot2", "ggrepel", "gridExtra", "irlba", "jsonlite", "kableExtra", "matrixTests", "msigdbr", "plotly", "qs", "qualV", "rlist", "rtracklayer", "scater", "scran", "shiny", "shinyFiles", "shinyWidgets", "shinycssloaders", "shinydashboard", "shinydashboardPlus", "shinyhelper", "shinyjs", "stringdist", "stringr", "tibble", "tidyr", "umap", "viridis"]
     },
     "CircSeqAlignTk": {
       "name": "CircSeqAlignTk",
-      "version": "1.8.0",
-      "sha256": "1iivgzlbq63f7f77c5j7ffr4s23qnq3rp37qsmdyysqkh6v46nc3",
+      "version": "1.10.0",
+      "sha256": "12cqzc5l8i3jx6g8b6l9ijrr4xym7ahzk3y4yhg6km2mw84b4rh3",
       "depends": ["BiocGenerics", "Biostrings", "IRanges", "R_utils", "Rbowtie2", "Rhisat2", "Rsamtools", "S4Vectors", "ShortRead", "dplyr", "ggplot2", "htmltools", "magrittr", "plotly", "rlang", "shiny", "shinyFiles", "shinyjs", "tidyr"]
     },
     "CiteFuse": {
       "name": "CiteFuse",
-      "version": "1.18.0",
-      "sha256": "0w12i1bshc1nflmc8d36skc9phkxiql7vg2r27c88z4bc85qpzz3",
+      "version": "1.20.0",
+      "sha256": "07ssm67i9dqw40gj2pr3n7k3rfp7g18h8ym6dyqy84zs0bnhh1rk",
       "depends": ["Matrix", "Rcpp", "Rtsne", "S4Vectors", "SingleCellExperiment", "SummarizedExperiment", "compositions", "cowplot", "dbscan", "ggplot2", "ggraph", "ggridges", "gridExtra", "igraph", "mixtools", "pheatmap", "randomForest", "reshape2", "rhdf5", "rlang", "scales", "scran", "uwot"]
     },
     "ClassifyR": {
       "name": "ClassifyR",
-      "version": "3.10.6",
-      "sha256": "1s8q2mn537jx0dy7ylcnlyb8nhy86g40f5qkrqh2d8d0l3jhqzq0",
+      "version": "3.12.0",
+      "sha256": "1v3df03k0wpq38mvzj77mv8pprsnrg5750h8prfyy1rhdpkg33f1",
       "depends": ["BiocParallel", "MultiAssayExperiment", "S4Vectors", "broom", "dcanr", "dplyr", "genefilter", "generics", "ggplot2", "ggpubr", "ggupset", "ranger", "reshape2", "rlang", "survival", "tidyr"]
     },
     "CleanUpRNAseq": {
       "name": "CleanUpRNAseq",
-      "version": "1.0.0",
-      "sha256": "1ddqx7pzna1iqvl89n28pqgl3wbz3hailagj26iqcgwyirx46n4h",
+      "version": "1.2.0",
+      "sha256": "1bkyl0q140hpg1rq5dqgcrg4xdkm1g1sla3cq0g75qj5ggx1n2hj",
       "depends": ["AnnotationFilter", "BSgenome", "BiocGenerics", "Biostrings", "DESeq2", "GenomeInfoDb", "GenomicRanges", "KernSmooth", "R6", "RColorBrewer", "Rsamtools", "Rsubread", "SummarizedExperiment", "edgeR", "ensembldb", "ggplot2", "ggrepel", "limma", "pheatmap", "qsmooth", "reshape2", "tximport"]
     },
     "Clomial": {
       "name": "Clomial",
-      "version": "1.42.0",
-      "sha256": "1rcqdhrgdqlqg2g04nfbmc5r107v1k4vzfg58vlkad10a2cvvmj7",
+      "version": "1.44.0",
+      "sha256": "05i8dfbn110ywaqd3d2f6xbl1ra2bax3j0in3fyi360ra3kq62rw",
       "depends": ["matrixStats", "permute"]
     },
     "CluMSID": {
       "name": "CluMSID",
-      "version": "1.22.0",
-      "sha256": "0xsxcl6ck60v8lyh1kdrqrp1wcdnd4yhqyi8jky7ba23a3nl9ql4",
+      "version": "1.24.0",
+      "sha256": "0vzam72cqn4mnxvikwazy4gmf3dyygwc5p2gchqc8sn0py4nxmy2",
       "depends": ["Biobase", "GGally", "MSnbase", "RColorBrewer", "S4Vectors", "ape", "dbscan", "ggplot2", "gplots", "mzR", "network", "plotly", "sna"]
     },
     "ClustAll": {
       "name": "ClustAll",
-      "version": "1.2.0",
-      "sha256": "0nysladvhcdbvdchv09zn59r7ngiq1r2490wnxmd58swhmlfm48g",
+      "version": "1.4.0",
+      "sha256": "059cagw9i9789lqnfz3zr3lz54l95gfjpndzxwsmp2gxdh7b5l7b",
       "depends": ["ComplexHeatmap", "FactoMineR", "RColorBrewer", "bigstatsr", "circlize", "clValid", "cluster", "doSNOW", "dplyr", "flock", "foreach", "fpc", "ggplot2", "mice", "modeest", "networkD3", "pbapply"]
     },
     "ClustIRR": {
       "name": "ClustIRR",
-      "version": "1.4.0",
-      "sha256": "04jhi80zjq7km5nhbs6931bsc366a096mccyk1v4yyqs7m9xwiqx",
-      "depends": ["BH", "Rcpp", "RcppEigen", "RcppParallel", "StanHeaders", "blaster", "future", "future_apply", "igraph", "pwalign", "reshape2", "rstan", "rstantools", "stringdist", "visNetwork"]
+      "version": "1.6.0",
+      "sha256": "0gbafvcbya0g6prnrcz6xpb92f1ykaqfyyal07jwm8cf0ivqmb3c",
+      "depends": ["BH", "Rcpp", "RcppEigen", "RcppParallel", "StanHeaders", "blaster", "dplyr", "future", "future_apply", "ggforce", "ggplot2", "igraph", "posterior", "reshape2", "rstan", "rstantools", "scales", "stringdist", "tidyr", "visNetwork"]
     },
     "ClusterFoldSimilarity": {
       "name": "ClusterFoldSimilarity",
-      "version": "1.2.0",
-      "sha256": "1wm7gdf56igi3xv8wk4cvjkgq7y2rm31bnlw115yg6gnw3qvj16z",
+      "version": "1.4.0",
+      "sha256": "0479rfz74d5vb299f51vprjd1cjppggi4xss2wh51i3ln9qznj86",
       "depends": ["BiocParallel", "Matrix", "Seurat", "SeuratObject", "SingleCellExperiment", "cowplot", "dplyr", "ggdendro", "ggplot2", "igraph", "reshape2", "scales"]
     },
     "ClusterJudge": {
       "name": "ClusterJudge",
-      "version": "1.28.0",
-      "sha256": "1544p82qyp2h380qsd490dbdk2lzbpla0khk4fd6pknfvsba4ljh",
+      "version": "1.30.0",
+      "sha256": "1hqlvf253chqalc1vzrfv295g8f2z3qnx7yhxx8pnkm5q2xjc4bb",
       "depends": ["httr", "infotheo", "jsonlite", "lattice", "latticeExtra"]
     },
     "ClusterSignificance": {
       "name": "ClusterSignificance",
-      "version": "1.34.0",
-      "sha256": "0fjxr3pd5wh1k1agrnnl6gwmwqzs4qfncvflf0k2ivrzzcc8ys0a",
+      "version": "1.36.0",
+      "sha256": "1pp8g2l6kq4rvki0v895b0q36disasrmwmw8m8pk6k0qwidh1mi0",
       "depends": ["RColorBrewer", "pracma", "princurve", "scatterplot3d"]
     },
     "CoCiteStats": {
       "name": "CoCiteStats",
-      "version": "1.78.0",
-      "sha256": "0xjrwmjhpfp4nvcqrrzn14pars12argni9923l8v8jyrxwwhczkp",
+      "version": "1.80.0",
+      "sha256": "1j67wy8rcwv6z32wkkm0cxr0iqji0hpbrxfzydd9dvb5rf7lbg6c",
       "depends": ["AnnotationDbi", "org_Hs_eg_db"]
     },
     "CoGAPS": {
       "name": "CoGAPS",
-      "version": "3.26.0",
-      "sha256": "07p8cqqk10mkmkb4s5c1a53wc1d1ncjvwlbmjpbabmb8an71al7i",
-      "depends": ["BH", "BiocParallel", "RColorBrewer", "Rcpp", "S4Vectors", "SingleCellExperiment", "SummarizedExperiment", "cluster", "dplyr", "fgsea", "forcats", "ggplot2", "gplots", "rhdf5"]
+      "version": "3.28.0",
+      "sha256": "0i9pj6pwgkb5i3h367hprb8qdi6a0fmd450sij5naw5nbb1j5hks",
+      "depends": ["BH", "BiocParallel", "RColorBrewer", "Rcpp", "S4Vectors", "SingleCellExperiment", "SummarizedExperiment", "cluster", "dplyr", "fgsea", "forcats", "ggplot2", "gplots", "rhdf5", "testthat"]
     },
     "CoSIA": {
       "name": "CoSIA",
-      "version": "1.6.0",
-      "sha256": "1rnd5y1vlcf330zvpl1njzknnima2zcsn9hsdsi8lvprj6llws6l",
+      "version": "1.8.0",
+      "sha256": "1xkh2nms6pynpaaw1ckkp2d5vgi93m27jxac9js02cxixg1qmc3l",
       "depends": ["AnnotationDbi", "ExperimentHub", "RColorBrewer", "annotationTools", "biomaRt", "dplyr", "ggplot2", "homologene", "magrittr", "org_Ce_eg_db", "org_Dm_eg_db", "org_Dr_eg_db", "org_Hs_eg_db", "org_Mm_eg_db", "org_Rn_eg_db", "plotly", "readr", "stringr", "tibble", "tidyr", "tidyselect"]
     },
     "Cogito": {
       "name": "Cogito",
-      "version": "1.12.0",
-      "sha256": "0q0572aiy1pma4sdpi1dbh0gd4dqqh7jfk5vlw89rkcvv5qvr9ks",
+      "version": "1.14.0",
+      "sha256": "1lv1lckrkydxp6670d7i138v9vhcsprrg56hp98jwab91l4lbgp3",
       "depends": ["AnnotationDbi", "BiocManager", "GenomeInfoDb", "GenomicFeatures", "GenomicRanges", "S4Vectors", "TxDb_Mmusculus_UCSC_mm9_knownGene", "entropy", "ggplot2", "jsonlite", "magrittr", "rmarkdown"]
     },
     "ComPrAn": {
       "name": "ComPrAn",
-      "version": "1.14.0",
-      "sha256": "1xd9jdzvs7gz04daw9gl9dw0k8kcb2k90p7i3azwqgia0j7zp4hj",
+      "version": "1.16.0",
+      "sha256": "0pcm5hsjcv87avjpsb0cvybs44042grjwj7vzfscaj9j7iv4cixq",
       "depends": ["DT", "RColorBrewer", "VennDiagram", "data_table", "dplyr", "forcats", "ggplot2", "magrittr", "purrr", "rio", "rlang", "scales", "shiny", "shinydashboard", "shinyjs", "stringr", "tibble", "tidyr"]
     },
     "ComplexHeatmap": {
       "name": "ComplexHeatmap",
-      "version": "2.22.0",
-      "sha256": "1hab197h1d01p8960zqmb0vnhgw9bk68ibmappryhv1jb4ibmx60",
+      "version": "2.24.0",
+      "sha256": "0l1613dzggm15l8cxdrdrwdld9gfsg47rmq3w8z00pssdk95l09a",
       "depends": ["GetoptLong", "GlobalOptions", "IRanges", "RColorBrewer", "circlize", "clue", "codetools", "colorspace", "digest", "doParallel", "foreach", "matrixStats", "png"]
     },
     "CompoundDb": {
       "name": "CompoundDb",
-      "version": "1.10.0",
-      "sha256": "1yzqcqww4mysxaxlqiwcyvv18qwfnfig59jrv7x6p7dls5s8r88d",
-      "depends": ["AnnotationFilter", "Biobase", "BiocGenerics", "BiocParallel", "ChemmineR", "DBI", "IRanges", "MetaboCoreUtils", "MsCoreUtils", "ProtGenerics", "RSQLite", "S4Vectors", "Spectra", "dbplyr", "dplyr", "jsonlite", "tibble", "xml2"]
+      "version": "1.12.0",
+      "sha256": "0r14ni8qqymw83dchz9xhp2hy8bmrz0n9xlsmwlgqpsrjpv1khjw",
+      "depends": ["AnnotationFilter", "Biobase", "BiocGenerics", "BiocParallel", "ChemmineR", "DBI", "IRanges", "MetaboCoreUtils", "MsCoreUtils", "ProtGenerics", "RSQLite", "S4Vectors", "Spectra", "dbplyr", "dplyr", "jsonlite", "stringi", "tibble", "xml2"]
     },
     "ConsensusClusterPlus": {
       "name": "ConsensusClusterPlus",
-      "version": "1.70.0",
-      "sha256": "06lrjjl7h9d3xyi1j9ciikrqjmpqxvw2d0z1yifwd1lwx6b6zsgb",
+      "version": "1.72.0",
+      "sha256": "0mxz03nyhprahlsban3l6k5wlgsrhg1z8a25y0ndwqfd6w2gvf2a",
       "depends": ["ALL", "Biobase", "cluster"]
     },
     "CopyNumberPlots": {
       "name": "CopyNumberPlots",
-      "version": "1.22.0",
-      "sha256": "03pg348h88d55kd9cg0svlhvyjv5fb7vmgrx32l2345zg1j0m0g1",
+      "version": "1.23.0",
+      "sha256": "09d9njacl5f363r397xb7k4596c7zj11lywh36m2vrvg88vy057c",
       "depends": ["GenomeInfoDb", "GenomicRanges", "IRanges", "Rsamtools", "SummarizedExperiment", "VariantAnnotation", "cn_mops", "karyoploteR", "regioneR", "rhdf5"]
     },
     "CoreGx": {
       "name": "CoreGx",
-      "version": "2.10.0",
-      "sha256": "0lw1fby6jxkz6bcbvlz8yqa8p00k85bay59lsr2qk5qlbsgz894a",
+      "version": "2.12.0",
+      "sha256": "1lqqk19vi8332qrg1iwr5zalhqba5inlgdmywgql3hahak4qhwxx",
       "depends": ["Biobase", "BiocGenerics", "BiocParallel", "BumpyMatrix", "MatrixGenerics", "MultiAssayExperiment", "S4Vectors", "SummarizedExperiment", "bench", "checkmate", "crayon", "data_table", "glue", "lsa", "piano", "rlang"]
     },
     "Cormotif": {
       "name": "Cormotif",
-      "version": "1.52.0",
-      "sha256": "192kqzyqxrwf6dcjzffmqvs0hiizl6bcmqv1hn02ikji0p5g9kbv",
+      "version": "1.54.0",
+      "sha256": "0mirma6qy7ha1yf1gl0fpdndw1v4s3is1yr3ibm3fyw3s7gxanij",
       "depends": ["affy", "limma"]
     },
     "CoverageView": {
       "name": "CoverageView",
-      "version": "1.44.0",
-      "sha256": "0r9g6iwbgf1dfi606cgzi32bjp57f7dfzpjx1fa3y3z6ikffjykb",
+      "version": "1.46.0",
+      "sha256": "1x6gsslsvfab75p8pcbbffgzzqh94q1awa31mv34j25a5hz59r38",
       "depends": ["GenomicAlignments", "GenomicRanges", "IRanges", "Rsamtools", "S4Vectors", "rtracklayer"]
     },
     "CrispRVariants": {
       "name": "CrispRVariants",
-      "version": "1.34.0",
-      "sha256": "15dx4bzvn2b44lbjyb4h2g76kqychsqhmv5vrb8pn97fg6pmfsgy",
+      "version": "1.36.0",
+      "sha256": "0f8fbzl6hllac57ydlxns56aqcrla1pd5rkpdvxpy45294f79vm2",
       "depends": ["AnnotationDbi", "BiocParallel", "Biostrings", "GenomeInfoDb", "GenomicAlignments", "GenomicRanges", "IRanges", "Rsamtools", "S4Vectors", "ggplot2", "gridExtra", "reshape2"]
     },
     "CuratedAtlasQueryR": {
       "name": "CuratedAtlasQueryR",
-      "version": "1.4.0",
-      "sha256": "1bm06ykfzjxrrzs8rcs73r1812c6ckah2cy744lc8pdsl3xnha39",
+      "version": "1.6.0",
+      "sha256": "1sjxd132r7l9p56yiakkcyysbbvw5hy0j4l3kg6liskyp6cridxx",
       "depends": ["BiocGenerics", "DBI", "HDF5Array", "S4Vectors", "Seurat", "SeuratObject", "SingleCellExperiment", "SummarizedExperiment", "assertthat", "cli", "dbplyr", "dplyr", "duckdb", "glue", "httr", "purrr", "rlang", "stringr", "tibble"]
     },
     "CytoDx": {
       "name": "CytoDx",
-      "version": "1.26.0",
-      "sha256": "03yihxbai0y02k0d1nlr37snvgaficrqlw1ylnl938mzcqza28f6",
+      "version": "1.28.0",
+      "sha256": "0h6vghvai24g1nd0v50pm7avd3lgi9kld0j1iqb49acv8f7kj7cs",
       "depends": ["doParallel", "dplyr", "flowCore", "glmnet", "rpart", "rpart_plot"]
     },
     "CytoGLMM": {
       "name": "CytoGLMM",
-      "version": "1.14.0",
-      "sha256": "1sdiz3mcl66gyrj0hs99w0vnmlgzz6jz1m9cib1x3bjfr11kr4ri",
-      "depends": ["BiocParallel", "MASS", "Matrix", "RColorBrewer", "caret", "cowplot", "doParallel", "dplyr", "factoextra", "flexmix", "ggplot2", "ggrepel", "logging", "magrittr", "mbest", "pheatmap", "rlang", "stringr", "strucchange", "tibble", "tidyr"]
+      "version": "1.16.0",
+      "sha256": "1wp2vgvpyx5kdrdzv6mz83lwbgfi44abnjpwnh82dwzr9dz8yykg",
+      "depends": ["BiocParallel", "MASS", "Matrix", "RColorBrewer", "caret", "cowplot", "dplyr", "factoextra", "flexmix", "ggplot2", "ggrepel", "magrittr", "pheatmap", "rlang", "stringr", "strucchange", "tibble", "tidyr"]
     },
     "CytoMDS": {
       "name": "CytoMDS",
-      "version": "1.2.0",
-      "sha256": "014hfak9la8fgdq42id62qjbq3byvdgxg90a4c0hj7m2b07s4r5l",
-      "depends": ["BiocParallel", "CytoPipeline", "flowCore", "ggforce", "ggplot2", "ggrepel", "patchwork", "pracma", "reshape2", "rlang", "smacof", "transport", "withr"]
+      "version": "1.4.0",
+      "sha256": "0a3lzb875395brq1xrpm8kl24arzhaqjn5bj2v23ls8pzr2mbgby",
+      "depends": ["Biobase", "BiocParallel", "CytoPipeline", "flowCore", "ggforce", "ggplot2", "ggrepel", "patchwork", "pracma", "reshape2", "rlang", "smacof", "transport", "withr"]
     },
     "CytoML": {
       "name": "CytoML",
-      "version": "2.18.1",
-      "sha256": "05kla1q8296jxxvbgg9chdlcm20i9iqgzwgqdn4by4y3ap8zg318",
+      "version": "2.20.0",
+      "sha256": "0xrwpxn7zbcvj6ng56wp8vw74jr50nz6qab0z8fb0hlzfa0dnpdw",
       "depends": ["BH", "Biobase", "RBGL", "RProtoBufLib", "Rgraphviz", "Rhdf5lib", "XML", "cpp11", "cytolib", "data_table", "dplyr", "flowCore", "flowWorkspace", "ggcyto", "graph", "jsonlite", "openCyto", "tibble", "yaml"]
     },
     "CytoPipeline": {
       "name": "CytoPipeline",
-      "version": "1.6.0",
-      "sha256": "0ja1w7xhqga1kkabx714jli21xwnq3i7bi3h41gbpcy60g65y32l",
+      "version": "1.8.0",
+      "sha256": "1rr9s6l9m4w165gjsz3k131q9pl9sc8jm30cznm7vignf8aq6g2v",
       "depends": ["BiocFileCache", "BiocParallel", "PeacoQC", "diagram", "flowAI", "flowCore", "ggcyto", "ggplot2", "jsonlite", "rlang", "scales", "withr"]
     },
     "CytoPipelineGUI": {
       "name": "CytoPipelineGUI",
-      "version": "1.4.0",
-      "sha256": "03zcr3393kyws8p1wqd13bwyphz1z4r507s6jwcd7q6nz03v1vqh",
+      "version": "1.6.0",
+      "sha256": "1icvjw517f4pip67liihad9vnfhzq5p8n21vsfcxlypys78lpc2x",
       "depends": ["CytoPipeline", "flowCore", "ggplot2", "plotly", "shiny"]
     },
     "DAMEfinder": {
       "name": "DAMEfinder",
-      "version": "1.18.0",
-      "sha256": "03lk5i1sc0jfzw4qkhbkzjl86xqnv9v1398z5ykiajw8cama0lkq",
+      "version": "1.20.0",
+      "sha256": "17yb21gs9124ii65m95s6v6irmlfhqzd81sq03vzgl5k7ajkl7dc",
       "depends": ["BiocGenerics", "Biostrings", "GenomeInfoDb", "GenomicAlignments", "GenomicRanges", "IRanges", "Rsamtools", "S4Vectors", "SummarizedExperiment", "VariantAnnotation", "bumphunter", "cowplot", "ggplot2", "limma", "plyr", "readr", "reshape2", "stringr"]
     },
     "DAPAR": {
       "name": "DAPAR",
-      "version": "1.38.0",
-      "sha256": "0328lvwvwjlws2bh2aafbvgn605z4nql1khjf6xv2jdgnl1v8c1i",
+      "version": "1.40.0",
+      "sha256": "1v1bv7q161rd52ynp9xv333li41c3pxzm09wafpbg4hf98knnpbl",
       "depends": ["Biobase", "DAPARdata", "MSnbase", "foreach", "highcharter"]
     },
     "DART": {
       "name": "DART",
-      "version": "1.54.0",
-      "sha256": "01vk7bs9cj9g2wimhwn0mn1d4c73pzck1x86zb4dd4jgx32hyc8n",
+      "version": "1.56.0",
+      "sha256": "0qkdh3112j04vpxyqv8k1sznrmx34nayg8qdrz0b43kix9my6ffn",
       "depends": ["igraph"]
     },
     "DCATS": {
       "name": "DCATS",
-      "version": "1.4.0",
-      "sha256": "0hg76kcr9sdqmqs7mbr9cbbay8p15jvd0k9h03yay5zwsn98nnb5",
+      "version": "1.6.0",
+      "sha256": "0pia4rbg4mvxv2p175vg23hrclcnzxjfbiq3xs41r50xb1wq175x",
       "depends": ["MCMCpack", "aod", "e1071", "matrixStats", "robustbase"]
     },
     "DECIPHER": {
       "name": "DECIPHER",
-      "version": "3.2.0",
-      "sha256": "18fvmlxch10pgl9lnyww2506r7jbjigx6h2agjsm9wn5bga4mqzm",
+      "version": "3.4.0",
+      "sha256": "1llz1p0sikdqdc1505whnsbr68k4r3lq6sc7fgjaa5dybycrmkwy",
       "depends": ["Biostrings", "DBI", "IRanges", "S4Vectors", "XVector"]
     },
     "DEFormats": {
       "name": "DEFormats",
-      "version": "1.34.0",
-      "sha256": "13zybgyr91c4007nyqjqli6hhvzzfjmzaqacbnx16dxcq7kp2307",
+      "version": "1.36.0",
+      "sha256": "011mbkvfmrdgrahp046yd1a5cc0hqpicfjg4hwak5nnliai7i9yh",
       "depends": ["DESeq2", "GenomicRanges", "S4Vectors", "SummarizedExperiment", "checkmate", "data_table", "edgeR"]
     },
     "DEGraph": {
       "name": "DEGraph",
-      "version": "1.58.0",
-      "sha256": "0dgfad4rjx3q47012533ilcpi5b5f7968l418jaxh318rnnpssm0",
+      "version": "1.60.0",
+      "sha256": "0qaxw5kb7qp11dlyb8rdajvhx04qnai16w6qckq64abn7g21lm5h",
       "depends": ["KEGGgraph", "NCIgraph", "RBGL", "R_methodsS3", "R_utils", "Rgraphviz", "graph", "lattice", "mvtnorm", "rrcov"]
     },
     "DEGreport": {
       "name": "DEGreport",
-      "version": "1.42.0",
-      "sha256": "01dhsr5lycr0mrcjgc3g4gb7sjpk6fdww3bl8w4fabqfpwkzz3d1",
+      "version": "1.44.0",
+      "sha256": "142h3kswqr8v5mcsj35v094cq3vgx2p0019v3nmycmsxidfw7p59",
       "depends": ["Biobase", "BiocGenerics", "ComplexHeatmap", "ConsensusClusterPlus", "DESeq2", "RColorBrewer", "S4Vectors", "SummarizedExperiment", "broom", "circlize", "cluster", "cowplot", "dendextend", "dplyr", "edgeR", "ggdendro", "ggplot2", "ggrepel", "knitr", "logging", "magrittr", "psych", "reshape", "rlang", "scales", "stringi", "stringr", "tibble", "tidyr"]
     },
     "DEGseq": {
       "name": "DEGseq",
-      "version": "1.60.0",
-      "sha256": "0gkpz4xij7as8l9kylzl60ic1pwnc6fl4k3a3q1yyvw6zpidbwwh",
+      "version": "1.62.0",
+      "sha256": "1903v9bfbaadr24g1c65qvb98qv1222lmmx6x3hni19cpsi233nz",
       "depends": ["qvalue"]
     },
     "DELocal": {
       "name": "DELocal",
-      "version": "1.6.0",
-      "sha256": "1kgw6vlkrilchxv98gir977cx2m6b9jihqlz814m65y6hgn9hqp7",
+      "version": "1.8.0",
+      "sha256": "0hinzs1220hs7qfjv5na9cn7929wbrnvr409ay0vgphzkh92w30z",
       "depends": ["DESeq2", "SummarizedExperiment", "dplyr", "ggplot2", "limma", "matrixStats", "reshape2"]
     },
     "DEP": {
       "name": "DEP",
-      "version": "1.28.0",
-      "sha256": "001k86lqc810lscpnfnmvkmxylgh4wzckhj1slm671ikwxkf0w68",
+      "version": "1.30.0",
+      "sha256": "1cf30pf5j51rhgp1i56w5j83yqpblk5pnigw1qxzm6d70277a8yg",
       "depends": ["ComplexHeatmap", "DT", "MSnbase", "RColorBrewer", "SummarizedExperiment", "assertthat", "circlize", "cluster", "dplyr", "fdrtool", "ggplot2", "ggrepel", "gridExtra", "imputeLCMD", "limma", "purrr", "readr", "rmarkdown", "shiny", "shinydashboard", "tibble", "tidyr", "vsn"]
     },
     "DEScan2": {
       "name": "DEScan2",
-      "version": "1.26.0",
-      "sha256": "1j6rizkwwynkl06fvrff0dbba5wpyhkg3pnh13f9ldqgd2nycy8n",
+      "version": "1.28.0",
+      "sha256": "1ci8bwpgwk71kcgy1sqabapxbr5fj6nyn8wr2kyzn9lc1v387qkb",
       "depends": ["BiocGenerics", "BiocParallel", "ChIPpeakAnno", "DelayedArray", "GenomeInfoDb", "GenomicAlignments", "GenomicRanges", "IRanges", "Rcpp", "RcppArmadillo", "S4Vectors", "SummarizedExperiment", "data_table", "glue", "plyr", "rtracklayer"]
     },
     "DESeq2": {
       "name": "DESeq2",
-      "version": "1.46.0",
-      "sha256": "0n0cq388rds9x8nxy13srzhm3sc0x539xb26nn1bz05c177kmwxb",
+      "version": "1.48.0",
+      "sha256": "1qcp16dhvwv41jg1497ibcznimminc9rfaf2halqiaakmhf3rw95",
       "depends": ["Biobase", "BiocGenerics", "BiocParallel", "GenomicRanges", "IRanges", "MatrixGenerics", "Rcpp", "RcppArmadillo", "S4Vectors", "SummarizedExperiment", "ggplot2", "locfit", "matrixStats"]
     },
     "DESpace": {
       "name": "DESpace",
-      "version": "1.6.0",
-      "sha256": "0568npl5a7hmzvxma5vds5mmqh2yrjbzpbbaxisvx79ax6qi45vk",
-      "depends": ["BiocGenerics", "BiocParallel", "Matrix", "S4Vectors", "SpatialExperiment", "SummarizedExperiment", "assertthat", "cowplot", "data_table", "dplyr", "edgeR", "ggforce", "ggnewscale", "ggplot2", "ggpubr", "limma", "patchwork", "scales"]
+      "version": "2.0.0",
+      "sha256": "195by5l6iiga8xcvry11x9x0303f3h47i5qf4a32f2n3hzb9m8k7",
+      "depends": ["BiocGenerics", "BiocParallel", "Matrix", "S4Vectors", "SpatialExperiment", "SummarizedExperiment", "assertthat", "data_table", "dplyr", "edgeR", "ggforce", "ggnewscale", "ggplot2", "limma", "patchwork", "scales", "scuttle", "sf", "spatstat_explore", "spatstat_geom", "terra"]
     },
     "DEWSeq": {
       "name": "DEWSeq",
-      "version": "1.20.0",
-      "sha256": "1rsw08v510mx17lsw9913arwznifphdxa5vcq51v8z0pp7lvvdvw",
+      "version": "1.22.0",
+      "sha256": "042534cn0hczfzsh7dk5g3rsskkqf2mbs217j2gqlvblj84vnl35",
       "depends": ["BiocGenerics", "BiocParallel", "DESeq2", "GenomeInfoDb", "GenomicRanges", "R_utils", "S4Vectors", "SummarizedExperiment", "data_table"]
     },
     "DEXSeq": {
       "name": "DEXSeq",
-      "version": "1.52.0",
-      "sha256": "05sjxxv5299m0i9hnhz037dz6f5q8qdb70vbvr28jjzc1jcv7ym8",
+      "version": "1.54.0",
+      "sha256": "18r880s9xzs22dpicj7cghzi4041n1izbdqfnmp7hfly2a4a0z71",
       "depends": ["AnnotationDbi", "Biobase", "BiocGenerics", "BiocParallel", "DESeq2", "GenomicRanges", "IRanges", "RColorBrewer", "Rsamtools", "S4Vectors", "SummarizedExperiment", "biomaRt", "genefilter", "geneplotter", "hwriter", "statmod", "stringr"]
     },
     "DEqMS": {
       "name": "DEqMS",
-      "version": "1.24.0",
-      "sha256": "1y0vjm7a64iwwsgd4pgvrlgrqwbd03p4sss4ggg4k29bgyjv36xi",
+      "version": "1.25.0",
+      "sha256": "0wnfkr82rw4aw0afwlvp7yb7fyg3sv2h7skn2ff3xd7wa7mmgqb3",
       "depends": ["ggplot2", "limma", "matrixStats"]
     },
     "DEsingle": {
       "name": "DEsingle",
-      "version": "1.26.0",
-      "sha256": "1kb3sm43l7jhf253r1091pypksnhzp3jgi4ddapjhmkgh6p32xy5",
+      "version": "1.28.0",
+      "sha256": "1djicbxx4j0nm5rydfn1yxcimvnldzxffpavcyw25f9fxlb05yb2",
       "depends": ["BiocParallel", "MASS", "Matrix", "VGAM", "bbmle", "gamlss", "maxLik", "pscl"]
     },
     "DEsubs": {
       "name": "DEsubs",
-      "version": "1.32.0",
-      "sha256": "106304xck9qs463lay2j9ncv7x7w4bg79phmbqcy0y888apia9nd",
+      "version": "1.34.0",
+      "sha256": "03y7pc094s9y36x6mm0xph6xj0z7ivzzs8awwc44pjs24p0776ic",
       "depends": ["DESeq2", "EBSeq", "Matrix", "NBPSeq", "RBGL", "circlize", "edgeR", "ggplot2", "graph", "igraph", "jsonlite", "limma", "locfit", "pheatmap"]
     },
     "DExMA": {
       "name": "DExMA",
-      "version": "1.14.0",
-      "sha256": "0kyjwwh6f4bpa9vpl4jbm629570q7mlfvyw8cv8c0jmbnx54rksz",
+      "version": "1.16.0",
+      "sha256": "077y1vb8rnakqbgjhfb2brj3vx8m3hv1wqyxv60dz0dhxx7b2nvz",
       "depends": ["Biobase", "DExMAdata", "GEOquery", "RColorBrewer", "bnstruct", "impute", "limma", "pheatmap", "plyr", "scales", "snpStats", "sva", "swamp"]
     },
     "DFP": {
       "name": "DFP",
-      "version": "1.64.0",
-      "sha256": "0vq2pswzd3b47ld8scgbbi53yj06928d79pqk2lyscz8lz4mxqhq",
+      "version": "1.66.0",
+      "sha256": "155v02mi40d81hddiv9750md91gb3y6qyjaif97vxahcr8f8lx8w",
       "depends": ["Biobase"]
     },
     "DFplyr": {
       "name": "DFplyr",
-      "version": "1.0.0",
-      "sha256": "1vmk7zvcb11397r1x92vgc827azrm4dz1qcl255nvmpc4cxdl8xw",
+      "version": "1.2.0",
+      "sha256": "1n39rnvmr4hvhq4fpwisvib7xkzb1gdrv84jm4ccwzm4yrxdpb7y",
       "depends": ["BiocGenerics", "S4Vectors", "dplyr", "rlang", "tidyselect"]
     },
     "DMCFB": {
       "name": "DMCFB",
-      "version": "1.20.0",
-      "sha256": "1sm2gixy4jf4aiycd5nbfmfdr9qzm6qasaak9cc7q2jd86q3ciaz",
+      "version": "1.22.0",
+      "sha256": "1s5kwzl28gkpyp7haxr5z62iyag4n2yn3mnj27z4jk92xzgf5iby",
       "depends": ["BiocParallel", "GenomicRanges", "IRanges", "MASS", "S4Vectors", "SummarizedExperiment", "arm", "benchmarkme", "data_table", "fastDummies", "matrixStats", "rtracklayer", "speedglm", "tibble"]
     },
     "DMCHMM": {
       "name": "DMCHMM",
-      "version": "1.28.0",
-      "sha256": "1hb55m1z4da92bmlqzm0yvp5bsflf9c4kvl0jf0wpawz0xdz71fi",
+      "version": "1.30.0",
+      "sha256": "1iyapqrqgf39mjw7xv47r6khkw4ryb5ipd8vfrph0cr8k5nsjnk1",
       "depends": ["BiocParallel", "GenomicRanges", "IRanges", "S4Vectors", "SummarizedExperiment", "calibrate", "fdrtool", "multcomp", "rtracklayer"]
     },
     "DMRScan": {
       "name": "DMRScan",
-      "version": "1.28.0",
-      "sha256": "1nkw0njm6ghmagj3k87yxhx7w0zf5plpajcgv137hawmwyzllqp4",
+      "version": "1.30.0",
+      "sha256": "1ln100csirxyvy3z0sn7k1vqmhb6rgc5y6ngvg335b6rhfwnqs2s",
       "depends": ["GenomeInfoDb", "GenomicRanges", "IRanges", "MASS", "Matrix", "RcppRoll", "mvtnorm"]
     },
     "DMRcaller": {
       "name": "DMRcaller",
-      "version": "1.38.0",
-      "sha256": "0zhviryy86ml9gk8mmr2dixmdyrhgajjydc4d0xmskhslyd3q9r5",
+      "version": "1.40.0",
+      "sha256": "04cclx7p9clnraj6d14wsx60h6wlxs923dzqx287rxfkj5a61723",
       "depends": ["GenomicRanges", "IRanges", "Rcpp", "RcppRoll", "S4Vectors", "betareg"]
     },
     "DMRcate": {
       "name": "DMRcate",
-      "version": "3.2.1",
-      "sha256": "1k0hbyqk4l6kqr60anmgk1jyk7kb1m0c1gjzvbbw2yc154ncyscq",
+      "version": "3.3.1",
+      "sha256": "1bjvxvhaa0fpxdlx2klnp0ny4klmrzw3pz86xz036hlk8viwpa5s",
       "depends": ["AnnotationHub", "ExperimentHub", "GenomeInfoDb", "GenomicRanges", "Gviz", "IRanges", "S4Vectors", "SummarizedExperiment", "biomaRt", "bsseq", "edgeR", "limma", "minfi", "missMethyl", "plyr"]
     },
     "DNABarcodeCompatibility": {
       "name": "DNABarcodeCompatibility",
-      "version": "1.22.0",
-      "sha256": "1rhll5bmy85kk89g1v5yk0j3zm22pkf6rbq1agxb07lll4nlim01",
+      "version": "1.24.0",
+      "sha256": "04pfilpvbp3n3a021x6i22y2lx05l99xlxq2qq71hzvq8icf7l2d",
       "depends": ["BH", "Rcpp", "dplyr", "numbers", "purrr", "stringr", "tidyr"]
     },
     "DNABarcodes": {
       "name": "DNABarcodes",
-      "version": "1.36.0",
-      "sha256": "0pppm937415xsmw0g39022lr07x3551ki6h11p8d7cpwbjmym44f",
+      "version": "1.38.0",
+      "sha256": "1v2snhg4bx9sdy75vipv5ik64r437kfb7bbi9cqncg4i81pgni1x",
       "depends": ["BH", "Matrix", "Rcpp"]
     },
     "DNAcopy": {
       "name": "DNAcopy",
-      "version": "1.80.0",
-      "sha256": "1ckbj338brcsj5kx5w0xs1gh8j3mx41b55lzf48irvfnslxk3iws",
+      "version": "1.82.0",
+      "sha256": "1r9yppn98qphkj97v94hkg9llw25xxafdh7f87xs9n5f07l186rr",
       "depends": []
+    },
+    "DNAcycP2": {
+      "name": "DNAcycP2",
+      "version": "1.0.0",
+      "sha256": "1p5wfkawsa5d0q4xksy6k5sc78xyjq0c62wgn8nzsgc5yqd17ww3",
+      "depends": ["basilisk", "reticulate"]
     },
     "DNAfusion": {
       "name": "DNAfusion",
-      "version": "1.8.0",
-      "sha256": "0c9m0952ypgr19fzkydcy5sckdi2snvanrlgm59hnjyj6q524xbf",
+      "version": "1.10.0",
+      "sha256": "038f81458s3329rgsbjfn0hibj8awiybgglxlgdj56xkph0757d6",
       "depends": ["BiocBaseUtils", "BiocGenerics", "GenomicAlignments", "GenomicFeatures", "GenomicRanges", "IRanges", "Rsamtools", "S4Vectors", "TxDb_Hsapiens_UCSC_hg38_knownGene", "bamsignals"]
     },
     "DNAshapeR": {
       "name": "DNAshapeR",
-      "version": "1.34.0",
-      "sha256": "1dshmby6jxs2qizz87k7ad5i2cbzidliarkcm3s6r7s6dfak3r2n",
+      "version": "1.36.0",
+      "sha256": "0c2jdwy42vlpyv18628df4b1byd1mkrqp1zdyqc0qs1fv33ig3zc",
       "depends": ["Biostrings", "GenomicRanges", "Rcpp", "fields"]
     },
     "DOSE": {
       "name": "DOSE",
-      "version": "4.0.0",
-      "sha256": "1x0dnlbgx2wsiki7l7c8np7v8kh4m5f30yjnavfzg9pjy3j98myq",
+      "version": "4.2.0",
+      "sha256": "1hs3f7mhzc3pf2f8xyp38430l4zqq2vkjx52zwavnk1dqpp8cbdh",
       "depends": ["AnnotationDbi", "BiocParallel", "GOSemSim", "fgsea", "ggplot2", "qvalue", "reshape2", "yulab_utils"]
     },
     "DRIMSeq": {
       "name": "DRIMSeq",
-      "version": "1.34.0",
-      "sha256": "0bfchi7igh21ifjjim59lwbql69gcddl39imxh49w2hv7pr3227w",
+      "version": "1.36.0",
+      "sha256": "1sfm0wzjypbdvvx97jk5qbnx2a1bbmsccsvjn5imziqh7hil7cbv",
       "depends": ["BiocGenerics", "BiocParallel", "GenomicRanges", "IRanges", "MASS", "S4Vectors", "edgeR", "ggplot2", "limma", "reshape2"]
     },
     "DSS": {
       "name": "DSS",
-      "version": "2.54.0",
-      "sha256": "03dzxxlyqymp827w2sdrpwn51q8n5xggx06m8gh7p1aigk5c50ah",
+      "version": "2.56.0",
+      "sha256": "02811qmnpj2jn85mhj1whddn2pj16ymylz3nj8bmw95z3n2dsjk7",
       "depends": ["Biobase", "BiocParallel", "bsseq"]
     },
     "DTA": {
       "name": "DTA",
-      "version": "2.52.0",
-      "sha256": "04piid5sp39r9xfgxz6kiicf47608yisxdmb1rfjkx4sjkwxwwfl",
+      "version": "2.54.0",
+      "sha256": "1jfdiisj2f77mgkyp7qgaf9zysj2nhbfrczqsnkws0c4mpzhiaz1",
       "depends": ["LSD", "scatterplot3d"]
     },
     "DaMiRseq": {
       "name": "DaMiRseq",
-      "version": "2.18.0",
-      "sha256": "0c6q6cf4v77hrjphnndk78gsmcsv4d7ivmsihnjhnh0z9z6hiy36",
+      "version": "2.20.0",
+      "sha256": "03953d0j4r9bh79wkcs9781nana3cwa9yf59vl64p87ng9xwbx08",
       "depends": ["DESeq2", "EDASeq", "FSelector", "FactoMineR", "Hmisc", "MASS", "RColorBrewer", "RSNNS", "SummarizedExperiment", "arm", "caret", "corrplot", "e1071", "edgeR", "ggplot2", "ineq", "kknn", "limma", "lubridate", "pheatmap", "pls", "plsVarSel", "plyr", "randomForest", "reshape2", "sva"]
     },
     "Damsel": {
       "name": "Damsel",
-      "version": "1.2.0",
-      "sha256": "05szhq61vbrhbp4zyh45c3s575jisq62j7ldf3malljk5576dn6m",
+      "version": "1.4.0",
+      "sha256": "1hd923bx1ypvdgyixyd5bgshbc3ikikbx3nmvmnqicypalxnm8cz",
       "depends": ["AnnotationDbi", "Biostrings", "ComplexHeatmap", "GenomeInfoDb", "GenomicFeatures", "GenomicRanges", "Rsamtools", "Rsubread", "dplyr", "edgeR", "ggbio", "ggplot2", "goseq", "magrittr", "patchwork", "plyranges", "reshape2", "rlang", "stringr", "tidyr"]
     },
     "DeMAND": {
       "name": "DeMAND",
-      "version": "1.36.0",
-      "sha256": "1sf09sq05hv0h3a8396kqdfk8r6fh7d8kkgz3nz5nzmdvphmv970",
+      "version": "1.38.0",
+      "sha256": "1w3qpiv7zj603c3iqasi702mx3sbxi6rkyj3q024wjwsbb1114n4",
       "depends": ["KernSmooth"]
     },
     "DeMixT": {
       "name": "DeMixT",
-      "version": "1.22.0",
-      "sha256": "0l6nj59wa9iw7y2r5l4wrmzkgxlhlczax2lpzqz0m7mlsfrjw47n",
+      "version": "1.24.0",
+      "sha256": "1cagx7i2vyzjyjh31zk23r6frnqqmj31ak5i1anw1qslqibwsb9m",
       "depends": ["DSS", "KernSmooth", "Rcpp", "SummarizedExperiment", "base64enc", "dendextend", "ggplot2", "knitr", "matrixStats", "matrixcalc", "psych", "rmarkdown", "sva", "truncdist"]
     },
     "DeconRNASeq": {
       "name": "DeconRNASeq",
-      "version": "1.48.0",
-      "sha256": "0v37kdv3cvh8s8ih5bk397k19b3fd4wldc7h0h8nyzv1z9lyal7v",
+      "version": "1.50.0",
+      "sha256": "06dkxdikfgiay72z9p0kmk8bayvdbrg641cl39nwk109dms0vc6f",
       "depends": ["ggplot2", "limSolve", "pcaMethods"]
+    },
+    "DeconvoBuddies": {
+      "name": "DeconvoBuddies",
+      "version": "1.0.0",
+      "sha256": "1qaajr5rm7qkqg7kg8qnqbaq7ijnzn83l4vncjf1hz4c5j8vzw1s",
+      "depends": ["AnnotationHub", "BiocFileCache", "ExperimentHub", "S4Vectors", "SingleCellExperiment", "SummarizedExperiment", "dplyr", "ggplot2", "matrixStats", "purrr", "rafalib", "reshape2", "scran", "spatialLIBD", "stringr", "tibble"]
     },
     "DeepPINCS": {
       "name": "DeepPINCS",
-      "version": "1.14.0",
-      "sha256": "0vl2wjx59wlpf1nbk1pp8cb8vbf9gkq3zhgary0k56y9ck982df7",
+      "version": "1.16.0",
+      "sha256": "0sc72ghyrhr29xhyhwgnq0sqqdn9xlwkv3p3mfyrbb0rxrkm07zs",
       "depends": ["CatEncoders", "PRROC", "keras", "matlab", "purrr", "rcdk", "reticulate", "stringdist", "tensorflow", "tokenizers", "ttgsea", "webchem"]
     },
     "DeepTarget": {
       "name": "DeepTarget",
-      "version": "1.0.0",
-      "sha256": "0cs5287jis2jby18knkxi7x9vxmwzbk4p1cy3j75wvmzhhbv6hnx",
+      "version": "1.2.0",
+      "sha256": "1yhyjspnfk3q3z4jny1lpbbvj62h7d8ka58xcwzj8ckp6pg04dp4",
       "depends": ["BiocParallel", "depmap", "dplyr", "fgsea", "ggplot2", "ggpubr", "pROC", "readr", "stringr"]
     },
     "DegCre": {
       "name": "DegCre",
-      "version": "1.2.0",
-      "sha256": "1q2x3nwsgbw7dwlw8h9ml458rjbrjdf5nxynfibfhds5rska70y9",
+      "version": "1.4.0",
+      "sha256": "044kr8ic0rjd8l4y5ypdxf4ajh6q8w10p825acp4qn09fh453k4x",
       "depends": ["BiocGenerics", "BiocParallel", "GenomeInfoDb", "GenomicRanges", "IRanges", "InteractionSet", "S4Vectors", "TxDb_Hsapiens_UCSC_hg38_knownGene", "org_Hs_eg_db", "plotgardener", "qvalue"]
     },
     "DegNorm": {
       "name": "DegNorm",
-      "version": "1.16.0",
-      "sha256": "144ap65xcih6x38d3f8g1vshx82ahj35bl9hkkgqs3b1f807np4s",
+      "version": "1.18.0",
+      "sha256": "1a4yxwj2jfjp06sw3kyh6zyh8h7f83prabp9h0zl3zzbp6fh44pn",
       "depends": ["GenomicAlignments", "GenomicFeatures", "GenomicRanges", "IRanges", "Rcpp", "RcppArmadillo", "Rsamtools", "S4Vectors", "data_table", "doParallel", "foreach", "ggplot2", "heatmaply", "plotly", "plyr", "txdbmaker", "viridis"]
     },
     "DelayedArray": {
       "name": "DelayedArray",
-      "version": "0.32.0",
-      "sha256": "12dbzjchx1f20i1va0fmh74xvn5pj84flnf0srmma2fma1i4rszy",
+      "version": "0.34.0",
+      "sha256": "053dhbbhnpcbxr2px7ffpfkqr8iyf8xxzh6qpwz0y9g6wvjzw99i",
       "depends": ["BiocGenerics", "IRanges", "Matrix", "MatrixGenerics", "S4Arrays", "S4Vectors", "SparseArray"]
     },
     "DelayedDataFrame": {
       "name": "DelayedDataFrame",
-      "version": "1.22.0",
-      "sha256": "1dw3y3z8zf38d606372r4vywgfh9j111hhz2g3i60qwz7hq2ix1k",
+      "version": "1.24.0",
+      "sha256": "130qd102wyh9chdjsw1nbp5lzigzaajz429zslwjpbwvi9vd72zd",
       "depends": ["BiocGenerics", "DelayedArray", "S4Vectors"]
     },
     "DelayedMatrixStats": {
       "name": "DelayedMatrixStats",
-      "version": "1.28.1",
-      "sha256": "0a55pnqwxsav61vkwck6wkwf5r0q50dwsk2ln22z22w4hrlni320",
+      "version": "1.30.0",
+      "sha256": "0mwflq5rdb172w2pjd0rkdivinilgdvh7r7zm0iqxxsw1imkj6sp",
       "depends": ["DelayedArray", "IRanges", "Matrix", "MatrixGenerics", "S4Vectors", "SparseArray", "sparseMatrixStats"]
     },
     "DelayedRandomArray": {
       "name": "DelayedRandomArray",
-      "version": "1.14.0",
-      "sha256": "1132mkigdj6ipjdr0vhi6av46b49vxnbb6281ba57bvd5zig88rq",
+      "version": "1.16.0",
+      "sha256": "1l1m2lvzpgryw2d41gy2issr4lrxrrfqg9mypj18wwgyd6p6bfvi",
       "depends": ["BH", "DelayedArray", "Rcpp", "SparseArray", "dqrng"]
     },
     "DelayedTensor": {
       "name": "DelayedTensor",
-      "version": "1.12.0",
-      "sha256": "0bp4r2jwphrykp09a7xv3q1zacgmvnj2hz8jwbck2v4pm6vfp1zr",
+      "version": "1.14.0",
+      "sha256": "1pqvabsdfg21axx3w12gg6kjadinwmrcrvr0jadzmxr8p816vprj",
       "depends": ["BiocSingular", "DelayedArray", "DelayedRandomArray", "HDF5Array", "Matrix", "S4Arrays", "SparseArray", "einsum", "irlba", "rTensor"]
     },
     "DepInfeR": {
       "name": "DepInfeR",
-      "version": "1.10.0",
-      "sha256": "14qwapq867bz5df0f74076fbx4igqq74cf1x9n8sx8vasinf238m",
+      "version": "1.12.0",
+      "sha256": "1cl6bzp5hs10yh9r0rp7ww251farwr0w49izgwy8pah9x7ran52z",
       "depends": ["BiocParallel", "glmnet", "matrixStats"]
     },
     "DepecheR": {
       "name": "DepecheR",
-      "version": "1.22.0",
-      "sha256": "0xxgkj672ncsp8dfa27cp101albvy4rq6f1jm0zmcmmf5lwc9v1m",
+      "version": "1.24.0",
+      "sha256": "1x00w0qs4pl5j6q7pr7iq83fw5frk9yk5bysr87sv6qpc84afhz4",
       "depends": ["ClusterR", "FNN", "MASS", "Rcpp", "RcppEigen", "beanplot", "collapse", "doSNOW", "dplyr", "foreach", "ggplot2", "gmodels", "gplots", "matrixStats", "mixOmics", "moments", "reshape2", "robustbase", "viridis"]
     },
     "DiffBind": {
       "name": "DiffBind",
-      "version": "3.16.0",
-      "sha256": "1whb4k54wm21k74r6qyng130nnaii9czh9dhvl1x7hnqa8gq0dx7",
+      "version": "3.18.0",
+      "sha256": "1dcdslb8zd3i5fpkn5nmg36gmil3q8g1vzjgbq17hif6gnah8bgi",
       "depends": ["BiocParallel", "DESeq2", "GenomicAlignments", "GenomicRanges", "GreyListChIP", "IRanges", "RColorBrewer", "Rcpp", "Rhtslib", "Rsamtools", "S4Vectors", "SummarizedExperiment", "amap", "apeglm", "ashr", "dplyr", "ggplot2", "ggrepel", "gplots", "lattice", "limma", "locfit", "systemPipeR"]
     },
     "DiffLogo": {
       "name": "DiffLogo",
-      "version": "2.30.0",
-      "sha256": "0qqs31xdl5nvir60vsbz286fh3qfpng4j82vk9fs1l77isz43251",
+      "version": "2.32.0",
+      "sha256": "0rkwlsqqc1d2zw25415cj43033vh722jpgglr8k4ljbp99z5yydn",
       "depends": ["cba"]
     },
     "DifferentialRegulation": {
       "name": "DifferentialRegulation",
-      "version": "2.4.0",
-      "sha256": "1vdch5dlrh0izq6ng9hkmnv9yn87vqq88iyj87bd90lv5ig9rz71",
+      "version": "2.6.0",
+      "sha256": "0jjpaviyfms733m0v0lfig40rqg1j0jw3ifz8vd6knk8bcr3227q",
       "depends": ["BANDITS", "MASS", "Matrix", "Rcpp", "RcppArmadillo", "SingleCellExperiment", "SummarizedExperiment", "data_table", "doParallel", "doRNG", "foreach", "ggplot2", "gridExtra", "tximport"]
     },
     "Dino": {
       "name": "Dino",
-      "version": "1.12.0",
-      "sha256": "19hykazb6ysax10n1zpfsxabjhv9nnkm14awyxh5iskd0n4s6fxp",
+      "version": "1.14.0",
+      "sha256": "1f75740fbnzkl4qmgr8vkc79xrj4cxy7rfwl3hmpjv28wwvnbmgl",
       "depends": ["BiocParallel", "BiocSingular", "Matrix", "S4Vectors", "Seurat", "SingleCellExperiment", "SummarizedExperiment", "matrixStats", "scran"]
     },
     "Director": {
       "name": "Director",
-      "version": "1.32.0",
-      "sha256": "1acfr9m1hbl4ji5i5dv7i9byg9abgfncqqnam5c6lksmh5wh0cyv",
+      "version": "1.34.0",
+      "sha256": "0xvpr1j36q46dlfympsivv5kxxnhskywc4fhxk0010yvx92ngpsw",
       "depends": ["htmltools"]
     },
     "DirichletMultinomial": {
       "name": "DirichletMultinomial",
-      "version": "1.48.0",
-      "sha256": "1chwd1zidc0abjl4kc5j58f4dwbghwnzlqx47ymln35b2gggj61w",
+      "version": "1.50.0",
+      "sha256": "0v4ch5nrz6kf6scxc98w9jdalmgllzy9qh35pfdx0z7wbbklk9z8",
       "depends": ["BiocGenerics", "IRanges", "S4Vectors"]
     },
     "DiscoRhythm": {
       "name": "DiscoRhythm",
-      "version": "1.22.0",
-      "sha256": "1325b75svg47mknfq31z0v14bc58zm21gl2nqpwb1g49nlscgl8j",
+      "version": "1.24.0",
+      "sha256": "0i6l1q5xj3qn6pqzqdfpax1phh8c9vfan6k12vydlvbx2q14m1pb",
       "depends": ["BiocGenerics", "BiocStyle", "DT", "MetaCycle", "S4Vectors", "SummarizedExperiment", "UpSetR", "VennDiagram", "broom", "data_table", "dplyr", "ggExtra", "ggplot2", "gridExtra", "heatmaply", "kableExtra", "knitr", "magick", "matrixStats", "matrixTests", "plotly", "reshape2", "rmarkdown", "shiny", "shinyBS", "shinycssloaders", "shinydashboard", "shinyjs", "viridis", "zip"]
     },
     "DominoEffect": {
       "name": "DominoEffect",
-      "version": "1.26.0",
-      "sha256": "0b7b2kgx0vr3nwiwmd9044a6sf36aplvh2gr8x4v656rgvws6adh",
+      "version": "1.28.0",
+      "sha256": "1x5pik4wj9b3zbmhd15v3pn8grhz1cn47d4cslwc8pgl7s3rzcwi",
       "depends": ["AnnotationDbi", "Biostrings", "GenomeInfoDb", "GenomicRanges", "IRanges", "SummarizedExperiment", "VariantAnnotation", "biomaRt", "data_table", "pwalign"]
     },
     "Doscheda": {
       "name": "Doscheda",
-      "version": "1.28.0",
-      "sha256": "0xix7bh9cvyjr24lciwrah4ag4b9hsydkqivh7fv7kvdi63ayy00",
+      "version": "1.30.0",
+      "sha256": "03qvng07nv346gn6df3bp1574yiampl26zjcln4by7f0fjdisfx5",
       "depends": ["DT", "affy", "calibrate", "corrgram", "drc", "ggplot2", "gridExtra", "httr", "jsonlite", "limma", "matrixStats", "prodlim", "readxl", "reshape2", "shiny", "shinydashboard", "stringr", "vsn"]
     },
     "DriverNet": {
       "name": "DriverNet",
-      "version": "1.46.0",
-      "sha256": "17rl5drdsj8c7dr1cpsj9q654pi5jrk3n6y4rlhaw2yi10gjprmv",
+      "version": "1.48.0",
+      "sha256": "03cfjq0j72q2aqzkaz4qg2idmb4dfhi0grhd6d1m98q3xdnw37dw",
       "depends": []
     },
     "DropletUtils": {
       "name": "DropletUtils",
-      "version": "1.26.0",
-      "sha256": "0659hpzjcch68dwi73a9rnkbxxfvivd09208z60q2fd22w2qgdjx",
+      "version": "1.27.2",
+      "sha256": "1bg6g5cy8v8q0l5yv9jgx2hgm2zihwgcsmmlibh9kgxkyrvxvk9w",
       "depends": ["BH", "BiocGenerics", "BiocParallel", "DelayedArray", "DelayedMatrixStats", "GenomicRanges", "HDF5Array", "IRanges", "Matrix", "R_utils", "Rcpp", "Rhdf5lib", "S4Vectors", "SingleCellExperiment", "SparseArray", "SummarizedExperiment", "beachmat", "dqrng", "edgeR", "rhdf5", "scuttle"]
     },
     "DrugVsDisease": {
       "name": "DrugVsDisease",
-      "version": "2.48.0",
-      "sha256": "165n6dcsayqs2s4s2xpmxrwyfb6fpakdyb1dsbndycpar48dh0vi",
+      "version": "2.50.0",
+      "sha256": "0svqjmlkxfxwians5nmjhwzcyfq3p99ajywamhp9shsqjfqmry3x",
       "depends": ["ArrayExpress", "BiocGenerics", "DrugVsDiseasedata", "GEOquery", "RUnit", "affy", "annotate", "biomaRt", "cMap2data", "hgu133a2_db", "hgu133a_db", "hgu133plus2_db", "limma", "qvalue", "xtable"]
     },
     "Dune": {
       "name": "Dune",
-      "version": "1.18.0",
-      "sha256": "0clqfw8qc56y92q8xmpgknvc2gp2g4pailzfd9s428nihxn1448l",
+      "version": "1.20.0",
+      "sha256": "1xk27ywjd87qbbbzh1lwrbwzkq05hb3p3wz54i7p52rc5s3isp48",
       "depends": ["BiocParallel", "RColorBrewer", "SummarizedExperiment", "aricode", "dplyr", "gganimate", "ggplot2", "magrittr", "purrr", "tidyr"]
     },
     "DuplexDiscovereR": {
       "name": "DuplexDiscovereR",
-      "version": "1.0.0",
-      "sha256": "0x44mf83n23gqpknhyv5lqhibaasx0h81mci4g02klisp81a2gab",
+      "version": "1.2.0",
+      "sha256": "1nm7jjrgvpivn4hfffridm5r0m933qwldvgbmqfxqn0hhczx335q",
       "depends": ["Biostrings", "GenomicAlignments", "GenomicRanges", "Gviz", "InteractionSet", "dplyr", "ggsci", "igraph", "purrr", "rlang", "rtracklayer", "scales", "stringr", "tibble", "tidyr"]
     },
     "DynDoc": {
       "name": "DynDoc",
-      "version": "1.84.0",
-      "sha256": "0pz2sz99p5dqprfwhnh22mw9j8895jk1gm3ffqysq7afim2fla5m",
+      "version": "1.86.0",
+      "sha256": "08dlkhm9nw5xbc1qi4chknx0lalwnnv69w9jgsmr7qf554xvq54q",
       "depends": []
     },
     "EBImage": {
       "name": "EBImage",
-      "version": "4.48.0",
-      "sha256": "16p3bzs13ihfx36fav3y1dxfryhyj00wvcwqc6mzx5ln2a2jpdbv",
+      "version": "4.50.0",
+      "sha256": "05ndq0dwdwprl076g866zayjrk85ha3vihm9qh4dchwkmn2rm9hi",
       "depends": ["BiocGenerics", "RCurl", "abind", "fftwtools", "htmltools", "htmlwidgets", "jpeg", "locfit", "png", "tiff"]
     },
     "EBSEA": {
       "name": "EBSEA",
-      "version": "1.34.0",
-      "sha256": "0mrsabqh3fph231757l3sw8jka3lkxmd75fjaqcaf9zwc5vi4wf0",
+      "version": "1.36.0",
+      "sha256": "19px1nsrny4v203f65qs3xbgrf1n6l9vlmpmi02b1sy8fg39wd28",
       "depends": ["DESeq2", "EmpiricalBrownsMethod"]
     },
     "EBSeq": {
       "name": "EBSeq",
-      "version": "2.4.0",
-      "sha256": "0hhs265p6y2118wmp5h8lp1b60d6vl27lb8fv12b0jfmln8ninzl",
+      "version": "2.6.0",
+      "sha256": "03r31hba6qiy7x11cxlhy2gwgk6b3biz9r9j9y8mc9c6vh9h6q0h",
       "depends": ["BH", "Rcpp", "RcppEigen", "blockmodeling", "gplots", "testthat"]
     },
     "EBarrays": {
       "name": "EBarrays",
-      "version": "2.70.0",
-      "sha256": "1wzfi2bfzhdjc5nvs1iwb8b7ln0n9fhkvpqf27y3p082ajhybjdf",
+      "version": "2.72.0",
+      "sha256": "04p4zxx4z5hzgw957rl3zwfpy8yrsaj7jab70xz05i1nc315l0kp",
       "depends": ["Biobase", "cluster", "lattice"]
     },
     "EBcoexpress": {
       "name": "EBcoexpress",
-      "version": "1.50.0",
-      "sha256": "0jns301q57gm527riq906p1nn41g9ss5sgyjwrjzqfw8452g09av",
+      "version": "1.52.0",
+      "sha256": "0a2jrs8w5a69581w0zr5bqfrmm3z2a2325jb48spm6ijb5903wry",
       "depends": ["EBarrays", "mclust", "minqa"]
     },
     "EDASeq": {
       "name": "EDASeq",
-      "version": "2.40.0",
-      "sha256": "1k061w169p8r71xq4ss2hda7k2p38h8pxcggfpjfii57wb3mvdk0",
+      "version": "2.42.0",
+      "sha256": "0ij2aa4a5x4s636lx3sc9f81r97x4dl17dnigf632zmkiy84h3i5",
       "depends": ["AnnotationDbi", "Biobase", "BiocGenerics", "BiocManager", "Biostrings", "GenomicFeatures", "GenomicRanges", "IRanges", "Rsamtools", "ShortRead", "aroma_light", "biomaRt"]
     },
     "EDIRquery": {
       "name": "EDIRquery",
-      "version": "1.6.0",
-      "sha256": "0q3fypzcrarviiqnawgpf1vbfqxsy31fsfdk54lgb34q24xifrkd",
+      "version": "1.8.0",
+      "sha256": "1lrlh5vkgxxbx0yy82fszjf4c9lqz7f9in1xib3ndnhn87jz52k8",
       "depends": ["GenomicRanges", "InteractionSet", "readr", "tibble", "tictoc"]
     },
     "EGAD": {
       "name": "EGAD",
-      "version": "1.34.0",
-      "sha256": "1przn4yncg04nc9cb36ljk2v4xn8i788fbh9jf07vv4z83bn3dvg",
+      "version": "1.36.0",
+      "sha256": "0jhsal57sfa9f8c0sxj2vg2y8i3djl84i0qcczd6zrfg22jlpnfz",
       "depends": ["Biobase", "GEOquery", "MASS", "RColorBrewer", "RCurl", "gplots", "igraph", "impute", "limma", "plyr", "zoo"]
     },
     "EGSEA": {
       "name": "EGSEA",
-      "version": "1.34.0",
-      "sha256": "192zw8ms6hqzdybpz11bw5fygbl77hy1n12vpdw1gmxcg6qar8zx",
+      "version": "1.36.0",
+      "sha256": "0ria6saf1ki2pip4l1r7f4lhzxjfb4pk1791xxc7v0pwmz31ar70",
       "depends": ["AnnotationDbi", "Biobase", "DT", "EGSEAdata", "GSVA", "HTMLUtils", "PADOG", "RColorBrewer", "edgeR", "gage", "ggplot2", "globaltest", "gplots", "htmlwidgets", "hwriter", "limma", "metap", "org_Hs_eg_db", "org_Mm_eg_db", "org_Rn_eg_db", "pathview", "plotly", "safe", "stringi", "topGO"]
     },
     "ELMER": {
       "name": "ELMER",
-      "version": "2.30.0",
-      "sha256": "12pvv1gc9g66nwzdi72knjh0y01bxkmwqi3iscswvcwzxa1ggc0q",
+      "version": "2.32.0",
+      "sha256": "06nyap0qalkycvj7z4bx2d3ii694rdc7cdv498xingxln54b25d7",
       "depends": ["ComplexHeatmap", "DelayedArray", "ELMER_data", "GenomeInfoDb", "GenomicFeatures", "GenomicRanges", "Gviz", "IRanges", "Matrix", "MultiAssayExperiment", "S4Vectors", "SummarizedExperiment", "TCGAbiolinks", "biomaRt", "circlize", "doParallel", "downloader", "dplyr", "ggplot2", "ggpubr", "ggrepel", "gridExtra", "lattice", "magrittr", "plotly", "plyr", "progress", "purrr", "readr", "reshape", "reshape2", "rmarkdown", "rtracklayer", "rvest", "scales", "stringr", "tibble", "tidyr", "xml2"]
+    },
+    "ELViS": {
+      "name": "ELViS",
+      "version": "1.0.0",
+      "sha256": "0xxdrp51mlk4vn317wm01nximzwvdg47gvy6rwbr4ivnr5m7s89k",
+      "depends": ["BiocGenerics", "ComplexHeatmap", "GenomicFeatures", "GenomicRanges", "IRanges", "basilisk", "circlize", "data_table", "dplyr", "ggplot2", "glue", "igraph", "magrittr", "memoise", "patchwork", "scales", "segclust2d", "stringr", "txdbmaker", "uuid", "zoo"]
     },
     "EMDomics": {
       "name": "EMDomics",
-      "version": "2.36.0",
-      "sha256": "1hahqy0vvg3qkqzmdfcvrjba4zcj018ifh6gzh119qinphajdm30",
+      "version": "2.38.0",
+      "sha256": "0xg8kpsf2lrjw94lh3m0s7k6092mmfvkc1r4ylikkzspq1yk857h",
       "depends": ["BiocParallel", "CDFt", "emdist", "ggplot2", "matrixStats", "preprocessCore"]
     },
     "ENmix": {
       "name": "ENmix",
-      "version": "1.42.0",
-      "sha256": "1p0x2jq327r0lsnq1wdy19w5bsa4kvkhj5b6cr1dy1sgdxa7n4wr",
+      "version": "1.44.0",
+      "sha256": "1x5f0hfbjnbxjjfr8n3hzxdi94fna7gan7fa9sm734mijvh6jmpz",
       "depends": ["AnnotationHub", "Biobase", "ExperimentHub", "IRanges", "RPMM", "S4Vectors", "SummarizedExperiment", "doParallel", "dynamicTreeCut", "foreach", "genefilter", "geneplotter", "gplots", "gtools", "illuminaio", "impute", "irlba", "matrixStats", "minfi", "quadprog"]
     },
     "ERSSA": {
       "name": "ERSSA",
-      "version": "1.24.0",
-      "sha256": "1vbwyaj3jqi1dcmnz7q02iwshm3axfyw35r4bbpkx47b74yskf06",
+      "version": "1.26.0",
+      "sha256": "0x0r1kv1x91lxgczzf57qz8vxpvn6vflgm0v2cn2r6w9q3ydk23j",
       "depends": ["BiocParallel", "DESeq2", "RColorBrewer", "apeglm", "edgeR", "ggplot2", "plyr"]
     },
     "EWCE": {
       "name": "EWCE",
-      "version": "1.14.0",
-      "sha256": "0j8dj9dscy6ia2wy59a79rp53xnrj3dx48bfxwhhhld0s1zzs643",
+      "version": "1.16.0",
+      "sha256": "0ibbj6m344mf5n1wk9l8xgpczvkjmbiysmlf58f41la25r2nja5x",
       "depends": ["BiocParallel", "DelayedArray", "HGNChelper", "Matrix", "RNOmni", "SingleCellExperiment", "SummarizedExperiment", "data_table", "dplyr", "ewceData", "ggplot2", "limma", "orthogene", "reshape2", "stringr"]
     },
     "EasyCellType": {
       "name": "EasyCellType",
-      "version": "1.8.0",
-      "sha256": "181564vl9fcm200svn7ilbhjy28xd9xvw9iyg6v03pi1ij8ls3pm",
+      "version": "1.10.0",
+      "sha256": "0360xqgcrhx7hcw3afam7y83s3wgzl53fnyjpv22rsyll0nx7vdx",
       "depends": ["AnnotationDbi", "BiocStyle", "clusterProfiler", "dplyr", "forcats", "ggplot2", "magrittr", "org_Hs_eg_db", "org_Mm_eg_db", "rlang", "vctrs"]
     },
     "EmpiricalBrownsMethod": {
       "name": "EmpiricalBrownsMethod",
-      "version": "1.34.0",
-      "sha256": "0vbzxw5cyhzadlazbrn4pwr2g7gl7wpgzf665v2hqn7f3pjbnw4s",
+      "version": "1.36.0",
+      "sha256": "139nj1iafr79psi6qpy32lw08whrphcqj621wf7j66lfb7l9kvh0",
       "depends": []
     },
     "EnMCB": {
       "name": "EnMCB",
-      "version": "1.18.0",
-      "sha256": "1y15nl9gx1qb6112ikx1pbslx0jz7s988mra7aq63q0igd33yz8n",
+      "version": "1.20.0",
+      "sha256": "1m3sbmlcq8441mqyh9dz27qb2wi0hp2jyzgswa6ca7y7m56g3ski",
       "depends": ["BiocFileCache", "Matrix", "boot", "e1071", "ggplot2", "glmnet", "igraph", "mboost", "rms", "survival", "survivalROC", "survivalsvm"]
     },
     "EnhancedVolcano": {
       "name": "EnhancedVolcano",
-      "version": "1.24.0",
-      "sha256": "16z9117cgggq1dn9fymq39wbsjlhn2dvwqh69kzhf7cg79b2czap",
+      "version": "1.26.0",
+      "sha256": "19dxqk5dk9443a3949y3b2dhcphhn2lvi6fvlakqxll2lvhjqivi",
       "depends": ["ggplot2", "ggrepel"]
     },
     "EnrichDO": {
       "name": "EnrichDO",
-      "version": "1.0.0",
-      "sha256": "11hfq4qb0q9jylincbk89zp0r73hp9y2zw14ghlrabphyzgg287f",
-      "depends": ["BiocGenerics", "RColorBrewer", "Rgraphviz", "S4Vectors", "clusterProfiler", "dplyr", "ggplot2", "graph", "hash", "magrittr", "pheatmap", "purrr", "readr", "stringr", "tidyr"]
+      "version": "1.2.0",
+      "sha256": "1qk9jw0nb0xgy346p69p4b15ax9kcpfbc1axk1hw92zdxhczpxpn",
+      "depends": ["BiocGenerics", "Rgraphviz", "S4Vectors", "clusterProfiler", "dplyr", "ggplot2", "graph", "hash", "magrittr", "pheatmap", "purrr", "tidyr"]
     },
     "EnrichedHeatmap": {
       "name": "EnrichedHeatmap",
-      "version": "1.36.0",
-      "sha256": "0qihf4ff9wwg2yfm5lgc8g59ni1spm3n2wjmvp2md83571cczm15",
+      "version": "1.38.0",
+      "sha256": "1l1rpbwd0l48rfgs6y4bk922h0ihyb8ds1ch6ckznwmis48pnlca",
       "depends": ["ComplexHeatmap", "GenomicRanges", "GetoptLong", "IRanges", "Rcpp", "circlize", "locfit", "matrixStats"]
     },
     "EnrichmentBrowser": {
       "name": "EnrichmentBrowser",
-      "version": "2.36.0",
-      "sha256": "0a2dgkmrqvnqkbvjlq1z4lmncg41dhgbh5pvvrniqzqsaqc7pyqz",
+      "version": "2.38.0",
+      "sha256": "0z7yc1r41jikbhb3x2pgzhq7c3my0r9i9001wdvdsxpsxas11f4x",
       "depends": ["AnnotationDbi", "BiocFileCache", "BiocManager", "GO_db", "GSEABase", "KEGGREST", "KEGGgraph", "Rgraphviz", "S4Vectors", "SPIA", "SummarizedExperiment", "edgeR", "graph", "graphite", "hwriter", "limma", "pathview", "safe"]
     },
     "EpiCompare": {
       "name": "EpiCompare",
-      "version": "1.10.1",
-      "sha256": "1s02yxpw3sr0qi7bizh1yxpzc8cx5pyqgx4s3ahzy2sx0as6kn16",
+      "version": "1.12.0",
+      "sha256": "1yd56d40lv4wpdd1gw9cs3ds50q3fzyhn09qvwp1x8dr1df7khrf",
       "depends": ["AnnotationHub", "BiocGenerics", "ChIPseeker", "GenomeInfoDb", "GenomicRanges", "IRanges", "data_table", "downloadthis", "genomation", "ggplot2", "htmltools", "plotly", "reshape2", "rmarkdown", "rtracklayer", "stringr"]
     },
     "EpiDISH": {
       "name": "EpiDISH",
-      "version": "2.22.0",
-      "sha256": "1az3paxj20bkp75q71lprdsws4vya6bwgjsw6nxx8j4rpd8jz8hn",
+      "version": "2.24.0",
+      "sha256": "1jq1vk4g3fij7yanap17xwvk7wrypgj11axbv7chg7m7m66r3p5a",
       "depends": ["MASS", "Matrix", "e1071", "locfdr", "matrixStats", "quadprog", "stringr"]
     },
     "EpiMix": {
       "name": "EpiMix",
-      "version": "1.8.0",
-      "sha256": "1cj0675faiy472gmhqvdwbf1fwrwajgfjmwllqj9ah7xr0q5mk5q",
+      "version": "1.10.0",
+      "sha256": "10s6nqrnpyx0w799iddgl01snk4cl94j5glhydyclxn6893i68dm",
       "depends": ["AnnotationDbi", "AnnotationHub", "Biobase", "ELMER_data", "EpiMix_data", "ExperimentHub", "GenomeInfoDb", "GenomicFeatures", "GenomicRanges", "IRanges", "RColorBrewer", "RCurl", "RPMM", "R_matlab", "S4Vectors", "SummarizedExperiment", "biomaRt", "data_table", "doParallel", "doSNOW", "downloader", "dplyr", "foreach", "ggplot2", "impute", "limma", "plyr", "progress", "rlang", "tibble", "tidyr"]
     },
     "EpiTxDb": {
       "name": "EpiTxDb",
-      "version": "1.18.0",
-      "sha256": "1m60d36q4ldjyrx1j4f6nr7qy07ghvy3cnsjsj9w3zf60ragiiqf",
+      "version": "1.20.0",
+      "sha256": "1i0bkwpqi9ffnb31c7nkc1046x45kr7zrrkhg2bnvwm080bpzl0z",
       "depends": ["AnnotationDbi", "BiocFileCache", "BiocGenerics", "Biostrings", "DBI", "GenomeInfoDb", "GenomicFeatures", "GenomicRanges", "IRanges", "Modstrings", "RSQLite", "S4Vectors", "curl", "httr", "rex", "tRNAdbImport", "txdbmaker", "xml2"]
     },
     "EpipwR": {
       "name": "EpipwR",
-      "version": "1.0.0",
-      "sha256": "09wxys47arlxvriwh78n1vycb0ph09wfxlgprsxgpizna6pxwmzl",
+      "version": "1.2.0",
+      "sha256": "1zk4khh0pi3vqkq3k7z9zkimaigzssd1v6ymlqncq9qyrqbyn8kx",
       "depends": ["EpipwR_data", "ExperimentHub", "ggplot2"]
     },
     "EventPointer": {
       "name": "EventPointer",
-      "version": "3.14.0",
-      "sha256": "1frr399md73nd12h8avn7hm8yxqg7dan3xwlc11842sgjg3f37rm",
+      "version": "3.16.0",
+      "sha256": "0kli48ckmirifqgrb15nbpyjfd7zlmprpnwkiqncwxcfd8sp5ask",
       "depends": ["BSgenome", "Biostrings", "GenomeInfoDb", "GenomicFeatures", "GenomicRanges", "IRanges", "MASS", "Matrix", "RBGL", "S4Vectors", "SGSeq", "SummarizedExperiment", "abind", "affxparser", "cobs", "doParallel", "fgsea", "foreach", "glmnet", "graph", "igraph", "iterators", "limma", "lpSolve", "matrixStats", "nnls", "poibin", "prodlim", "qvalue", "rhdf5", "speedglm", "stringr", "tximport"]
     },
     "ExCluster": {
       "name": "ExCluster",
-      "version": "1.24.0",
-      "sha256": "10ppwx5aj16d54qpcjs8v57ln0dipvr1sx7dfhm1f8l1ji37h3i2",
+      "version": "1.26.0",
+      "sha256": "12x3l7vav6xwc7gmmp9bpl7xjnsd33hxyr70ilhl4j9a3f9609l7",
       "depends": ["GenomicRanges", "IRanges", "Rsubread", "matrixStats", "rtracklayer"]
     },
     "ExiMiR": {
       "name": "ExiMiR",
-      "version": "2.48.0",
-      "sha256": "1xm7c01x27xmdrlzzrc10bw3w4wz0wjd3h8fwvcf2paib0f181lq",
+      "version": "2.50.0",
+      "sha256": "1gki46ajd8xmhxiqs23wz7xxq96q1srafgzvi7snf2dbkaca9xnc",
       "depends": ["Biobase", "affy", "affyio", "limma", "preprocessCore"]
     },
     "ExperimentHub": {
       "name": "ExperimentHub",
-      "version": "2.14.0",
-      "sha256": "1zawq85nffj4jvq2yvrgrxph4vhi2fjw2sc4qll0r45pdkx4vjr4",
+      "version": "2.16.0",
+      "sha256": "1kib4ajkdjic89z195y8aq9qd9r24r3wmc1anm2djp6cx9m0dvzs",
       "depends": ["AnnotationHub", "BiocFileCache", "BiocGenerics", "BiocManager", "S4Vectors", "rappdirs"]
     },
     "ExperimentHubData": {
       "name": "ExperimentHubData",
-      "version": "1.32.0",
-      "sha256": "1bg11hpmia4gbzslvlawrq8z5ycyx0sby9sg678x881zkaf107fm",
+      "version": "1.34.0",
+      "sha256": "19n37gf7kz8jvm90f1lg0mc7izvbdy9wasp59qq3l89gifvj3ky6",
       "depends": ["AnnotationHubData", "BiocGenerics", "BiocManager", "DBI", "ExperimentHub", "S4Vectors", "curl", "httr"]
     },
     "ExperimentSubset": {
       "name": "ExperimentSubset",
-      "version": "1.16.0",
-      "sha256": "0ip1qqfyhvlyp5alzpmqi9cgfdxm45w9m61zkpjyiy12r1wgvs6g",
+      "version": "1.18.0",
+      "sha256": "10sgxk8rl12xid776mvr034yan0767w69d76yvkj4872fiplgawc",
       "depends": ["Matrix", "S4Vectors", "SingleCellExperiment", "SpatialExperiment", "SummarizedExperiment", "TreeSummarizedExperiment"]
     },
     "ExploreModelMatrix": {
       "name": "ExploreModelMatrix",
-      "version": "1.18.0",
-      "sha256": "1wpp7pi0yayqm1mr3l9jszviym00gghl8ajm19436nyn3mkzmqxj",
+      "version": "1.20.0",
+      "sha256": "0zm0kjx6ckxldq76yaac26s9bm398xk8fqan9p0jwsapp729l085",
       "depends": ["DT", "MASS", "S4Vectors", "cowplot", "dplyr", "ggplot2", "limma", "magrittr", "rintrojs", "scales", "shiny", "shinydashboard", "shinyjs", "tibble", "tidyr"]
     },
     "ExpressionAtlas": {
       "name": "ExpressionAtlas",
-      "version": "1.34.0",
-      "sha256": "0j5s9c9k1vyxj3zbp4njapa4ccasr19av9vfba3g41d4d9fwqrrl",
+      "version": "2.0.0",
+      "sha256": "0hwy4w7p8afx0jgi1sdczb6qcffpyjmj5rap432zb8fra1wmrdv7",
       "depends": ["Biobase", "BiocStyle", "RCurl", "S4Vectors", "SummarizedExperiment", "XML", "httr", "jsonlite", "limma", "xml2"]
     },
     "FEAST": {
       "name": "FEAST",
-      "version": "1.14.0",
-      "sha256": "0z0mqrdbk9g89431hkl1gc5yszrmw6n7yghngdyis29gykhcf5h3",
+      "version": "1.16.0",
+      "sha256": "01490rmdb8xpcpa0l62r8b1v5i4blpgiljwnndzgardwsi1ylxzm",
       "depends": ["BiocParallel", "SC3", "SingleCellExperiment", "SummarizedExperiment", "TSCAN", "irlba", "matrixStats", "mclust"]
     },
     "FELLA": {
       "name": "FELLA",
-      "version": "1.26.0",
-      "sha256": "1r744bnvwzswfq3q31r2ybq3k10dm04hziqxdcpyj0lg4x29rq2l",
+      "version": "1.28.0",
+      "sha256": "1l7rbp02z7w4vl80ablrdvp689i54lm1l35wjgqlmiijxh9f81il",
       "depends": ["KEGGREST", "Matrix", "igraph", "plyr"]
     },
     "FGNet": {
       "name": "FGNet",
-      "version": "3.40.0",
-      "sha256": "1xbba8r4z634kvi749ac2idzmpsv7q9ajk5djh425a8d18679pm5",
+      "version": "3.42.0",
+      "sha256": "0z7zpwk6fcbxi0lxmxl2hlfx7p7hwxjqiwz3lyq6z3cwa10fhk0a",
       "depends": ["RColorBrewer", "R_utils", "XML", "hwriter", "igraph", "plotrix", "png", "reshape2"]
     },
     "FISHalyseR": {
       "name": "FISHalyseR",
-      "version": "1.40.0",
-      "sha256": "0nb47jnfv9i9z99l249a96zkal5m6clk34ywp6p8hhzcqc20gwg3",
+      "version": "1.42.0",
+      "sha256": "1z5zypnbkfba1l81wxy4z39m8q8qj03254x458l86nx2xcl45y6w",
       "depends": ["EBImage", "abind"]
     },
     "FLAMES": {
       "name": "FLAMES",
-      "version": "2.0.2",
-      "sha256": "0yszsrnvs13h1vdv5gfja54g48f8b0dadlwd2h7n02pl8b569q38",
-      "depends": ["BiocGenerics", "BiocParallel", "Biostrings", "ComplexHeatmap", "DropletUtils", "GenomeInfoDb", "GenomicAlignments", "GenomicFeatures", "GenomicRanges", "IRanges", "Matrix", "MatrixGenerics", "RColorBrewer", "Rcpp", "Rhtslib", "Rsamtools", "S4Vectors", "SingleCellExperiment", "SpatialExperiment", "SummarizedExperiment", "bambu", "basilisk", "circlize", "cowplot", "dplyr", "future", "ggbio", "ggplot2", "gridExtra", "igraph", "jsonlite", "magrittr", "readr", "reticulate", "rtracklayer", "scater", "scatterpie", "scran", "scuttle", "stringr", "testthat", "tibble", "tidyr", "tidyselect", "txdbmaker", "withr"]
+      "version": "2.2.0",
+      "sha256": "0h3lxrdacmch21lpf91alnmjsnca9l4r80r093rvzqagrm002ji5",
+      "depends": ["BiocGenerics", "BiocParallel", "Biostrings", "ComplexHeatmap", "DropletUtils", "GenomeInfoDb", "GenomicAlignments", "GenomicFeatures", "GenomicRanges", "IRanges", "Matrix", "MatrixGenerics", "RColorBrewer", "Rcpp", "Rhtslib", "Rsamtools", "S4Vectors", "SingleCellExperiment", "SparseArray", "SpatialExperiment", "SummarizedExperiment", "abind", "bambu", "basilisk", "circlize", "cowplot", "dplyr", "future", "ggbio", "ggplot2", "gridExtra", "igraph", "jsonlite", "magick", "magrittr", "readr", "reticulate", "rtracklayer", "scater", "scatterpie", "scran", "scuttle", "stringr", "testthat", "tibble", "tidyr", "tidyselect", "txdbmaker", "withr"]
     },
     "FRASER": {
       "name": "FRASER",
-      "version": "2.2.0",
-      "sha256": "1br4cb764r036kgpfbd7azkyddkv4vnin9g0jnnyy1hw3c0zkl67",
+      "version": "2.4.0",
+      "sha256": "1lpf4gs3z82zll2qbniz7h7p69pdhiwjd2izi0magc2l7f8rgry3",
       "depends": ["AnnotationDbi", "BBmisc", "BSgenome", "Biobase", "BiocGenerics", "BiocParallel", "DelayedArray", "DelayedMatrixStats", "GenomeInfoDb", "GenomicAlignments", "GenomicFeatures", "GenomicRanges", "HDF5Array", "IRanges", "OUTRIDER", "PRROC", "RColorBrewer", "R_utils", "Rcpp", "RcppArmadillo", "Rsamtools", "Rsubread", "S4Vectors", "SummarizedExperiment", "VGAM", "biomaRt", "cowplot", "data_table", "extraDistr", "generics", "ggplot2", "ggrepel", "matrixStats", "pcaMethods", "pheatmap", "plotly", "rhdf5", "tibble"]
     },
     "FRGEpistasis": {
       "name": "FRGEpistasis",
-      "version": "1.42.0",
-      "sha256": "0l56zdxw7p7ld6r2bxqvdkva0ljv7lbddp6jyf8dajg1n7hph9ni",
+      "version": "1.44.0",
+      "sha256": "00y0lvpz2rvpyvv2qb1zwx0iyniivcznrrj9ilr5asspa0pzinkh",
       "depends": ["MASS", "fda"]
     },
     "FamAgg": {
       "name": "FamAgg",
-      "version": "1.34.0",
-      "sha256": "0i32yz7764vcaijy7pyfh30s3sf39a2k3v4n30pz0mvd0r1l9ix5",
+      "version": "1.36.0",
+      "sha256": "0ryhp0yq44p1rcq10f7s3ggkc9h8s8h4qbvx9c2szawagqlfbfp4",
       "depends": ["BiocGenerics", "Matrix", "gap", "igraph", "kinship2", "survey"]
     },
     "FastqCleaner": {
       "name": "FastqCleaner",
-      "version": "1.24.0",
-      "sha256": "1w320w45g8vhas53ly43gdj9445i3ha1bhdrhc179r9ykfgc5k6v",
+      "version": "1.26.0",
+      "sha256": "0slczf0x3vvvfkdpxncf89vplx0vxbhxq042bhfpmxlkd720rhmb",
       "depends": ["Biostrings", "DT", "IRanges", "Rcpp", "S4Vectors", "ShortRead", "htmltools", "shiny", "shinyBS"]
     },
     "FeatSeekR": {
       "name": "FeatSeekR",
-      "version": "1.6.0",
-      "sha256": "0mcn5m18wn7h2j3zxq54h0lfzzv0vicj5pbvgv11bnxbnhan9vih",
+      "version": "1.8.0",
+      "sha256": "1yi8gs5vjlqr19a2a2kjiybbf7qaxnzihvhfcrnxr91ajdjrarkb",
       "depends": ["MASS", "SummarizedExperiment", "pheatmap", "pracma"]
     },
     "FilterFFPE": {
       "name": "FilterFFPE",
-      "version": "1.16.0",
-      "sha256": "02haiwb1pl507b4vmzlzcrghp7qwfbhdjbq1zx60sxa25avgm5m7",
+      "version": "1.18.0",
+      "sha256": "0zc1mm6636kgwx0zw4wxlbw6p7m32smvyphrzfvbf1aff599fjg3",
       "depends": ["GenomicRanges", "IRanges", "Rsamtools", "S4Vectors", "doParallel", "foreach"]
     },
     "FindIT2": {
       "name": "FindIT2",
-      "version": "1.12.0",
-      "sha256": "067pv3q4is8rgkibnb4agc1cjgg6gsr9ssaahj931fdlcapl1j43",
+      "version": "1.14.0",
+      "sha256": "0kwckjk0czkvfsr8s2d6rrrkq8vrg36cdxi1laf3qrf7mc9mxwq2",
       "depends": ["BiocGenerics", "BiocParallel", "GenomeInfoDb", "GenomicFeatures", "GenomicRanges", "IRanges", "MultiAssayExperiment", "S4Vectors", "SummarizedExperiment", "dplyr", "ggplot2", "ggrepel", "glmnet", "patchwork", "progress", "purrr", "qvalue", "rlang", "rtracklayer", "stringr", "tibble", "tidyr", "withr"]
     },
     "FitHiC": {
       "name": "FitHiC",
-      "version": "1.32.0",
-      "sha256": "166djgps0k8xb9rjx8i6sfh71a4cqkgpkw3dr25plprafj4qlxva",
+      "version": "1.34.0",
+      "sha256": "0fkqrj89si23x8dwp4z3fdb6b0zb05578x3jxpsvzvq8bgvpjygm",
       "depends": ["Rcpp", "data_table", "fdrtool"]
     },
     "FlowSOM": {
       "name": "FlowSOM",
-      "version": "2.14.0",
-      "sha256": "01dy2dxp1m6sx0wzy0q9axx2xrp30sqcjl4jhjnv8zxghk3m0frv",
+      "version": "2.16.0",
+      "sha256": "19x5s09yyxnyk0b4l4mxzx2mq1mqsgcxr7flfazyjcg7qa8kgyld",
       "depends": ["BiocGenerics", "ConsensusClusterPlus", "Rtsne", "XML", "colorRamps", "dplyr", "flowCore", "ggforce", "ggnewscale", "ggplot2", "ggpubr", "igraph", "magrittr", "rlang", "tidyr"]
     },
     "FuseSOM": {
       "name": "FuseSOM",
-      "version": "1.8.0",
-      "sha256": "0mrh4lkk1gknfny50j240wcg2sf3l9fakb5xnwd58jfv31459w1w",
+      "version": "1.10.0",
+      "sha256": "07f6ki9dm268zmwqiimbs12rxzsz00ncvs4hbp6nvn2q0by25pid",
       "depends": ["FCPS", "Rcpp", "S4Vectors", "SummarizedExperiment", "analogue", "cluster", "coop", "diptest", "fastcluster", "fpc", "ggplot2", "ggplotify", "ggpubr", "pheatmap", "proxy", "psych", "stringr"]
+    },
+    "G4SNVHunter": {
+      "name": "G4SNVHunter",
+      "version": "1.0.0",
+      "sha256": "1nldzl5rdg1qmayycdkzabivk1aqln8shjksykw5nz2i6vxwhxc7",
+      "depends": ["Biostrings", "GenomeInfoDb", "GenomicRanges", "IRanges", "Rcpp", "RcppRoll", "S4Vectors", "cowplot", "data_table", "ggplot2", "ggpointdensity", "ggseqlogo", "progress", "viridis"]
     },
     "GA4GHclient": {
       "name": "GA4GHclient",
-      "version": "1.30.0",
-      "sha256": "02l9yrg7j9qm2890zxvc5ybizj3vcyghav9qnffdgblk47c2zghq",
+      "version": "1.32.0",
+      "sha256": "0666w3avkkvpah7bkz2qi61wjqn1jjd6xrxz77w6jz0yz42wjlr3",
       "depends": ["BiocGenerics", "Biostrings", "GenomeInfoDb", "GenomicRanges", "IRanges", "S4Vectors", "VariantAnnotation", "dplyr", "httr", "jsonlite"]
     },
     "GA4GHshiny": {
       "name": "GA4GHshiny",
-      "version": "1.28.0",
-      "sha256": "1df8ph0mkzggi9ph3bpg5barqwbvhrd5kb2xvpm9m2659si82944",
+      "version": "1.30.0",
+      "sha256": "0dnh41pfih21i7pn817zil8sw2jsps7jygzv9w87xfdbikz1chxv",
       "depends": ["AnnotationDbi", "BiocGenerics", "DT", "GA4GHclient", "GenomeInfoDb", "GenomicFeatures", "S4Vectors", "dplyr", "openxlsx", "purrr", "shiny", "shinyjs", "shinythemes", "tidyr"]
     },
     "GARS": {
       "name": "GARS",
-      "version": "1.26.0",
-      "sha256": "16v1fi4gcqn1abq096fy45clv0i537ndgql38yl25ajlfi9w9j9p",
+      "version": "1.28.0",
+      "sha256": "15izb8wfgn821flbg4wajsz89zd2pa1ydafkx0x93pqjkhl2dik9",
       "depends": ["DaMiRseq", "MLSeq", "SummarizedExperiment", "cluster", "ggplot2"]
     },
     "GAprediction": {
       "name": "GAprediction",
-      "version": "1.32.0",
-      "sha256": "12waqgv7lyp9p64x1k0kmj4kc1ahybhjyjz9f0achj2jh1m3iv2g",
+      "version": "1.34.0",
+      "sha256": "1aibsgawv4vgcxwbhyj8c6qjfwpqyck6i7z5l9kpdg9r6ii2bik0",
       "depends": ["Matrix", "glmnet"]
     },
     "GBScleanR": {
       "name": "GBScleanR",
-      "version": "2.0.3",
-      "sha256": "1w3ww42l2db20ysckmrr1mvpk3flpgc6cx45fmdfkznc0qzj3f75",
+      "version": "2.2.0",
+      "sha256": "1k63l46q8hacq9vg6jpqq23s946p3v1p9ijxkrk29xl8dk02hz19",
       "depends": ["Rcpp", "RcppParallel", "SeqArray", "expm", "gdsfmt", "ggplot2", "tidyr"]
     },
     "GDCRNATools": {
       "name": "GDCRNATools",
-      "version": "1.26.0",
-      "sha256": "0mbkwh6rmhr2193qjrswsimxnl53jymsarjkbp9hr3mljm8caxr5",
+      "version": "1.28.0",
+      "sha256": "0aldc1h7zgzqbq8kxfbh3iab8xlyawjxdmm1kajhjmwmiy2w0ya7",
       "depends": ["BiocParallel", "DESeq2", "DOSE", "DT", "GenomicDataCommons", "XML", "biomaRt", "clusterProfiler", "edgeR", "ggplot2", "gplots", "jsonlite", "limma", "org_Hs_eg_db", "pathview", "rjson", "shiny", "survival", "survminer"]
     },
     "GDSArray": {
       "name": "GDSArray",
-      "version": "1.26.0",
-      "sha256": "1wmx2q6q4glnjqghfc5iriv4hxkd55f0y4mpf5vkwkld8ha1rjm5",
+      "version": "1.28.0",
+      "sha256": "0djk1kj98vj3kgzjk9dcvhx51p804a6v5nl54pxqhlwwm0r3yzgj",
       "depends": ["BiocGenerics", "DelayedArray", "S4Vectors", "SNPRelate", "SeqArray", "gdsfmt"]
     },
     "GEM": {
       "name": "GEM",
-      "version": "1.32.0",
-      "sha256": "014xqm0qzvz0vnnd2gvp6vm6cib6dg0cpjdr25favlzl8k89yci5",
+      "version": "1.34.0",
+      "sha256": "163yfacdzjklkzfmi1xqc5wwrbwfa8m74s4xrrvv854ri2qsal37",
       "depends": ["ggplot2"]
     },
     "GENESIS": {
       "name": "GENESIS",
-      "version": "2.36.0",
-      "sha256": "0x5y2wvmnmdvj0swjax38bcl9isf3jbq7dllw7lv84yj7z250n79",
+      "version": "2.38.0",
+      "sha256": "03nzp87cn8kr01lv1lrai2cbsh0ci611hjk3483rlh6iyjizyx6v",
       "depends": ["Biobase", "BiocGenerics", "BiocParallel", "GWASTools", "GenomicRanges", "IRanges", "Matrix", "S4Vectors", "SNPRelate", "SeqArray", "SeqVarTools", "data_table", "gdsfmt", "igraph", "reshape2"]
     },
     "GENIE3": {
       "name": "GENIE3",
-      "version": "1.28.0",
-      "sha256": "0hc6vhlgd0p4f2cf2v2wbjfs068ag3ix1rrk91a25lj1mjnhh5ic",
+      "version": "1.30.0",
+      "sha256": "1h3nmijn28q7l9y37l32kh42f3gj2fhw7c6ria42yqvqhgcjhj9p",
       "depends": ["dplyr", "reshape2"]
     },
     "GEOexplorer": {
       "name": "GEOexplorer",
-      "version": "1.12.0",
-      "sha256": "1cd2flf1vlizmz1b5zsyr3zvjz69fhckrxzb257p9g7m07a9mswm",
+      "version": "1.14.0",
+      "sha256": "144pj7aj93rjg315biizapg1m9yywyfx27pk9646klqnrnp2yxi5",
       "depends": ["Biobase", "DT", "GEOquery", "R_utils", "XML", "car", "edgeR", "enrichR", "factoextra", "ggplot2", "heatmaply", "htmltools", "httr", "impute", "knitr", "limma", "markdown", "pheatmap", "plotly", "readxl", "scales", "shiny", "shinyHeatmaply", "shinybusy", "shinycssloaders", "stringr", "sva", "umap", "xfun", "xml2"]
     },
     "GEOfastq": {
       "name": "GEOfastq",
-      "version": "1.14.0",
-      "sha256": "0fm08n9lnxh9ppm5afzydlq8r4hx369pi75imi77lzc57jx5iqlq",
+      "version": "1.16.0",
+      "sha256": "1y3jz1zmzpbsfm84pib872n5669w3ggs08dwp2vz1drfz5kh3ldr",
       "depends": ["RCurl", "doParallel", "foreach", "plyr", "rvest", "stringr", "xml2"]
     },
     "GEOmetadb": {
       "name": "GEOmetadb",
-      "version": "1.68.1",
-      "sha256": "17q9ab1jly5g0q0ijd6bm2j6xr097bk4n6kyp6g9zh6pcb76yhl8",
+      "version": "1.70.0",
+      "sha256": "0vrxg3mj3sspp51hf261jswh3si7vqg8j0ibgfy59il3gn9zjnx0",
       "depends": ["RSQLite", "R_utils"]
     },
     "GEOquery": {
       "name": "GEOquery",
-      "version": "2.74.0",
-      "sha256": "0lwi8cxlzgnd59bcn5mxkxijb292y857phafyskfs9k7951lxznl",
+      "version": "2.76.0",
+      "sha256": "17iw6h74qzljcah3m3xzl8hqzmz9v30lafwdbhdfqy8xdhf79jlh",
       "depends": ["Biobase", "R_utils", "S4Vectors", "SummarizedExperiment", "curl", "data_table", "dplyr", "httr2", "limma", "magrittr", "readr", "rentrez", "rvest", "stringr", "tidyr", "xml2"]
     },
     "GEOsubmission": {
       "name": "GEOsubmission",
-      "version": "1.58.0",
-      "sha256": "0swqsm8l8vki7pcxpjh3p3k7rhbvkmlx794zlildb7nyh560ll02",
+      "version": "1.60.0",
+      "sha256": "1rc81dq3bm6w09ans7lkk82hmwlkhcs12hi22q0kb5jppllkzff6",
       "depends": ["Biobase", "affy"]
     },
     "GEWIST": {
       "name": "GEWIST",
-      "version": "1.50.0",
-      "sha256": "1hf9rbc9a0mas1ydd2j6448xhz4iqkxv2cxnd0zsbpqr07w75fs9",
+      "version": "1.52.0",
+      "sha256": "1ylycj5ipdb0k7kf49ki3wd9063ynz5skhj6vnapl3z260ad514f",
       "depends": ["car"]
     },
     "GGPA": {
       "name": "GGPA",
-      "version": "1.18.0",
-      "sha256": "0dbhgvkh7w8bi58ljjvv45d9m648dm8n62ps8b0l2j9kxdxh1cil",
+      "version": "1.20.0",
+      "sha256": "0709y2is1a34rq35801mhlmcl869ilsdzdamrbwxn1sbvy2qkzld",
       "depends": ["GGally", "Rcpp", "RcppArmadillo", "matrixStats", "network", "scales", "sna"]
     },
     "GIGSEA": {
       "name": "GIGSEA",
-      "version": "1.24.0",
-      "sha256": "158aypdf8qs3a3ravjd9cw16z64vrv5zpzljs7v5rxkxadbp75js",
+      "version": "1.26.0",
+      "sha256": "02i1fa5k22q39n8a4n07cw5x51qfp33w8zcimplyljpyzr7whi6i",
       "depends": ["MASS", "Matrix", "locfdr"]
     },
     "GLAD": {
       "name": "GLAD",
-      "version": "2.70.0",
-      "sha256": "05vn4zmazkkf0m3shm08dkwlb8whwqqw0vr5h27vlxlz3bcjnqcf",
+      "version": "2.72.0",
+      "sha256": "05a1v5b3f6q0ka6sblg56fmcczz5fd80nzvlqcpfg0qd5ck7527h",
       "depends": ["aws"]
     },
     "GMRP": {
       "name": "GMRP",
-      "version": "1.34.0",
-      "sha256": "0xfgafsrmpp1iv2vkw00b9n57zh8azf0ak1s1nwby2870q5q11pv",
+      "version": "1.36.0",
+      "sha256": "0fz187b5f7xsxgc9l7514dpddm2fi392rdvpc9fp1vbsx7nd6hjn",
       "depends": ["GenomicRanges", "diagram", "plotrix"]
     },
     "GNET2": {
       "name": "GNET2",
-      "version": "1.22.0",
-      "sha256": "0k9dcyl69vpm885mdk81aldcdw29vjc12vjrhcgs298w9g78azn3",
+      "version": "1.24.0",
+      "sha256": "1w2w2swjakh1cjfwcj1x3y5d3il2am5rxbi3mkxrd48pzwaylync",
       "depends": ["DiagrammeR", "Rcpp", "SummarizedExperiment", "dplyr", "ggplot2", "igraph", "matrixStats", "reshape2", "xgboost"]
     },
     "GNOSIS": {
       "name": "GNOSIS",
-      "version": "1.4.0",
-      "sha256": "1g50a9ip2dlfzczjd8c6lx34cwkfzqgrcd3gbc53rimbmy7zrlgy",
+      "version": "1.6.0",
+      "sha256": "1q91b8qh0wd587kycbjzs1dlfg33q5yvv34zilz2lfjfkr65q50y",
       "depends": ["DT", "DescTools", "RColorBrewer", "cBioPortalData", "car", "compareGroups", "dashboardthemes", "fabricatr", "fontawesome", "maftools", "magrittr", "operator_tools", "partykit", "reshape2", "rpart", "rstatix", "shiny", "shinyWidgets", "shinycssloaders", "shinydashboard", "shinydashboardPlus", "shinyjs", "shinylogs", "shinymeta", "survival", "survminer", "tidyverse"]
     },
     "GOSemSim": {
       "name": "GOSemSim",
-      "version": "2.32.0",
-      "sha256": "0ql5mxaks11dpkykggylnpi2jymh467w1zqi6s6bp1gb4h399jly",
+      "version": "2.34.0",
+      "sha256": "1pxz30zfpfwsp9sx3ca99jb5acrsxbl9d7pscm57d767rhm8kq83",
       "depends": ["AnnotationDbi", "DBI", "GO_db", "R_utils", "Rcpp", "digest", "rlang", "yulab_utils"]
     },
     "GOTHiC": {
       "name": "GOTHiC",
-      "version": "1.42.0",
-      "sha256": "0cazfyrnxrl266yapy34hh4af1dkdzrb041idjapxjd7mdbnvv9w",
+      "version": "1.44.0",
+      "sha256": "1ps0v7r0y2abyfk402d2pf5ivnl81hw2fsxz1vrpfywg1al0dy83",
       "depends": ["BSgenome", "BiocGenerics", "BiocManager", "Biostrings", "GenomeInfoDb", "GenomicRanges", "IRanges", "Rsamtools", "S4Vectors", "ShortRead", "data_table", "ggplot2", "rtracklayer"]
     },
     "GOexpress": {
       "name": "GOexpress",
-      "version": "1.40.0",
-      "sha256": "0ykaxs70sy4w5ymq7cfijasgz8l88b9yf03pd8f27pg0806dpmy7",
+      "version": "1.42.0",
+      "sha256": "02889570wxmpq08lszc072sa7bhv8k8ywgcy0j24xiq8rpww3d70",
       "depends": ["Biobase", "RColorBrewer", "RCurl", "biomaRt", "ggplot2", "gplots", "randomForest", "stringr"]
     },
     "GOfuncR": {
       "name": "GOfuncR",
-      "version": "1.26.0",
-      "sha256": "0s6dmfv2cd88crhmq1i5sp7r37l1zabdxwdspydz9mh3008mqrqp",
+      "version": "1.28.0",
+      "sha256": "0db0n6c2zz4x8ayxcarxa0gwww5jd2l2pq08q89xil1cy551bipm",
       "depends": ["AnnotationDbi", "GenomicRanges", "IRanges", "Rcpp", "gtools", "mapplots", "vioplot"]
     },
     "GOpro": {
       "name": "GOpro",
-      "version": "1.32.0",
-      "sha256": "0vdp86h1af6jksij9dy3kv9r9lhhhh2nysb2572xwya43q6zwcq1",
+      "version": "1.34.0",
+      "sha256": "10rn1izwpra3lk60xw5amfxx5xmc5fm24vm4615fz9xk163kmf56",
       "depends": ["AnnotationDbi", "BH", "GO_db", "IRanges", "MultiAssayExperiment", "Rcpp", "S4Vectors", "dendextend", "doParallel", "foreach", "org_Hs_eg_db"]
     },
     "GOstats": {
       "name": "GOstats",
-      "version": "2.72.0",
-      "sha256": "0zz2gmv2hg8cr0bxj4zb95p8cf8a19zx1v925cv5f4xh7m698bzj",
+      "version": "2.74.0",
+      "sha256": "0r7nxmd6lr68c2w1g6y85mx6nzc5ric8qji0nqcqixxcjh27c724",
       "depends": ["AnnotationDbi", "AnnotationForge", "Biobase", "Category", "GO_db", "RBGL", "Rgraphviz", "annotate", "graph"]
     },
     "GPA": {
       "name": "GPA",
-      "version": "1.18.0",
-      "sha256": "0f69vpza558rv6mzjjnb15sff0ksjly1mjz0ghhrqiqz7kp6qahz",
+      "version": "1.20.0",
+      "sha256": "1bcq2m1zn1nrsxvv28a9l0vwp9y8akaha9qjvizr2m7mwx0d54l2",
       "depends": ["DT", "Rcpp", "ggplot2", "ggrepel", "plyr", "shiny", "shinyBS", "vegan"]
     },
     "GRENITS": {
       "name": "GRENITS",
-      "version": "1.58.0",
-      "sha256": "1w1nlh4ic6h0bf8jw2ln39r02nxs8kcbap6js3h5ckrk9fyqrwi0",
+      "version": "1.60.0",
+      "sha256": "06y861ym21vdsg9r88k4nwy38kl3r4z96slasn3wy8pvw8srjk7c",
       "depends": ["Rcpp", "RcppArmadillo", "ggplot2", "reshape2"]
     },
     "GRaNIE": {
       "name": "GRaNIE",
-      "version": "1.10.0",
-      "sha256": "0q4l9iqz7mzvm523ya489yjnbcxl4zxx12q869c4npzd01x12pcn",
+      "version": "1.12.0",
+      "sha256": "1bn3frs3lhlq0abkip72wb3kvqm9h1y9m9qnn72zrb728nghx1fq",
       "depends": ["AnnotationHub", "Biostrings", "ComplexHeatmap", "DESeq2", "GenomeInfoDb", "GenomicRanges", "Matrix", "RColorBrewer", "S4Vectors", "SummarizedExperiment", "biomaRt", "checkmate", "circlize", "colorspace", "data_table", "dplyr", "ensembldb", "forcats", "futile_logger", "ggplot2", "gridExtra", "igraph", "limma", "magrittr", "matrixStats", "patchwork", "progress", "readr", "reshape2", "rlang", "scales", "stringr", "tibble", "tidyr", "tidyselect", "topGO", "viridis"]
     },
     "GRmetrics": {
       "name": "GRmetrics",
-      "version": "1.32.0",
-      "sha256": "1k0rpkg7w1zcmc99ar0j7hi0w8glp17017q799m36vlv5dcky52s",
+      "version": "1.34.0",
+      "sha256": "12wchdvj2h5lw5nq8fb61wia06wz9iyik6v0662fn0vx5xvrra3z",
       "depends": ["S4Vectors", "SummarizedExperiment", "drc", "ggplot2", "plotly"]
     },
     "GSALightning": {
       "name": "GSALightning",
-      "version": "1.34.0",
-      "sha256": "10hk1hnkq1xm8sxym517pbpznbhlh3n8xsifz9if4sy7yi19nij6",
+      "version": "1.36.0",
+      "sha256": "06xv5rsd6blxgajndhwh8kb28sp1aq1b0fai4x74rpfkmvlrf2r5",
       "depends": ["Matrix", "data_table"]
     },
     "GSAR": {
       "name": "GSAR",
-      "version": "1.40.0",
-      "sha256": "19lbzxh7mzarr9xjyqjp3a5hvha2mh73pc3byafsysg2qrf5w1bn",
+      "version": "1.42.0",
+      "sha256": "1a5bfinak614x057kaacn74vff3f9cy2m715w4kl1i6y8x1d1w0a",
       "depends": ["igraph"]
     },
     "GSCA": {
       "name": "GSCA",
-      "version": "2.36.0",
-      "sha256": "07nvhdwyiiznw5jlil02rxqq1v61drczv3a0bzbxhq5925ygvkdq",
+      "version": "2.38.0",
+      "sha256": "1ydwjnpw1ckj60gixymak1rv4j8ri7ms0dyrxns78vmpbl4zdm2d",
       "depends": ["RColorBrewer", "ggplot2", "gplots", "reshape2", "rhdf5", "shiny", "sp"]
     },
     "GSEABase": {
       "name": "GSEABase",
-      "version": "1.68.0",
-      "sha256": "0zd37jpx2zy9gxl3b2vkr7m2fq8xm1pcxk352dw3mlv1gadhsz9n",
+      "version": "1.70.0",
+      "sha256": "122akpdafm4kpbcjn4bnpfjr48rnmj2jmjrxzv184dp1gwdgqqw5",
       "depends": ["AnnotationDbi", "Biobase", "BiocGenerics", "XML", "annotate", "graph"]
     },
     "GSEABenchmarkeR": {
       "name": "GSEABenchmarkeR",
-      "version": "1.26.0",
-      "sha256": "1s0fsi4dxkaql53jdxi392bg1y9fmvvqvkcz00njhdw7zzh18m2y",
+      "version": "1.28.0",
+      "sha256": "0lfaq1283prn7ngazybc2h6rp6c10khdhshsi2y2hgnvgq9q3rfj",
       "depends": ["AnnotationDbi", "AnnotationHub", "Biobase", "BiocFileCache", "BiocParallel", "EnrichmentBrowser", "ExperimentHub", "KEGGandMetacoreDzPathwaysGEO", "KEGGdzPathwaysGEO", "S4Vectors", "SummarizedExperiment", "edgeR"]
     },
     "GSEAlm": {
       "name": "GSEAlm",
-      "version": "1.66.0",
-      "sha256": "1x4hfz3qsi08ffyfwgbl1b9mnnybp81911hhaqrk6v70vzcmcl35",
+      "version": "1.68.0",
+      "sha256": "0i9bpir41ml2bd8wpl1ldv5syjg788zy7hmvdd9yd82fjlflpfxi",
       "depends": ["Biobase"]
     },
     "GSEAmining": {
       "name": "GSEAmining",
-      "version": "1.16.0",
-      "sha256": "1fdl487y72dpf8qibagi2nzr188vqfjhm9fn9wpm5w2cs7ds5qk5",
+      "version": "1.18.0",
+      "sha256": "119n5nqlq5700xzljv7jfiganw70cvzcpn2aw6831da2d3wlyv0j",
       "depends": ["dendextend", "dplyr", "ggplot2", "ggwordcloud", "gridExtra", "rlang", "stringr", "tibble", "tidytext"]
     },
     "GSRI": {
       "name": "GSRI",
-      "version": "2.54.0",
-      "sha256": "1l00wmv1kqgswf6fsk5qxiwv5d8yj075dpzvq0g5cc2if5w843xw",
+      "version": "2.56.0",
+      "sha256": "121pxkb1k8z8lzj5rxh24n26v8427vw7mfgqn20s52pss8rh2p9r",
       "depends": ["Biobase", "GSEABase", "fdrtool", "genefilter", "les"]
     },
     "GSReg": {
       "name": "GSReg",
-      "version": "1.40.0",
-      "sha256": "1j28j14f7v49miayaiwrbi9axhfn8cmv5kvj3qh6swsr70vdapap",
+      "version": "1.42.0",
+      "sha256": "1vnxhclwfdmf53xjkq4iw3wvgnm37x28c1pz23qcp49kl5k7k5gz",
       "depends": ["AnnotationDbi", "GenomicFeatures", "Homo_sapiens", "org_Hs_eg_db"]
     },
     "GSVA": {
       "name": "GSVA",
-      "version": "2.0.5",
-      "sha256": "1d0qz1jdc945r5vwbl58s6ii2djcmlqwjz39p0r4rlysb7nswqi6",
+      "version": "2.2.0",
+      "sha256": "0xnn5v9p2rvy7z935ni8a7psxdl07mzw44sdi63n33rgj8kcnlax",
       "depends": ["Biobase", "BiocParallel", "BiocSingular", "DelayedArray", "DelayedMatrixStats", "GSEABase", "HDF5Array", "IRanges", "Matrix", "S4Vectors", "SingleCellExperiment", "SpatialExperiment", "SummarizedExperiment", "cli", "sparseMatrixStats"]
     },
     "GSgalgoR": {
       "name": "GSgalgoR",
-      "version": "1.16.0",
-      "sha256": "0aj0843ny8j5v879kl5ahzljkzw79m4cfac6hcyc64vrqixzjxwa",
+      "version": "1.18.0",
+      "sha256": "0sf6jrcbzl2pm5iviy4vxgp2zw6923b7gx85r20475wgq71wgdb2",
       "depends": ["cluster", "doParallel", "foreach", "matchingR", "nsga2R", "proxy", "survival"]
     },
     "GUIDEseq": {
       "name": "GUIDEseq",
-      "version": "1.36.0",
-      "sha256": "077ig53g8nlzikybhn1cvhypi25sxssjjpd3919sic47sk23z7bk",
+      "version": "1.38.0",
+      "sha256": "18r2i6d7gak1w065a2xjd5hn7viaqdl2q7vcipgfzakqsbhczgxi",
       "depends": ["BSgenome", "BiocGenerics", "Biostrings", "CRISPRseek", "ChIPpeakAnno", "GenomeInfoDb", "GenomicAlignments", "GenomicFeatures", "GenomicRanges", "IRanges", "Rsamtools", "S4Vectors", "data_table", "dplyr", "ggplot2", "hash", "limma", "matrixStats", "multtest", "openxlsx", "patchwork", "purrr", "pwalign", "rio", "rlang", "stringr", "tidyr"]
     },
     "GWAS_BAYES": {
       "name": "GWAS.BAYES",
-      "version": "1.16.0",
-      "sha256": "0pl4p746fhc8794cxanh35gm9s28p0741ybaqgr6a2zd8fimi8hx",
+      "version": "1.18.0",
+      "sha256": "1mh606v8ajc8zp5dhxhrxvbs8101mkdy3caxhh8p0br3vwland9c",
       "depends": ["GA", "MASS", "Matrix", "caret", "limma", "memoise"]
     },
     "GWASTools": {
       "name": "GWASTools",
-      "version": "1.52.0",
-      "sha256": "12crhc552cypi8ffl12vskrf4qw5567ag6h84ngnrmbn2k1nvjy4",
+      "version": "1.54.0",
+      "sha256": "0b2jgaald2b1m2gz2s54ar0kyk0bbn6f50h9i13g2phpfanv3j1k",
       "depends": ["Biobase", "DBI", "DNAcopy", "GWASExactHW", "RSQLite", "data_table", "gdsfmt", "lmtest", "logistf", "quantsmooth", "sandwich", "survival"]
     },
     "GWENA": {
       "name": "GWENA",
-      "version": "1.16.0",
-      "sha256": "0ccrdb0c0mcyq4bnky3f2km1144gab5cf6xlzh2zcbdnh1iqzmh9",
+      "version": "1.18.0",
+      "sha256": "13w9989ama92k2ds2apsyb6dbs5w09p34vhiy5mkayqsr2s3l2wn",
       "depends": ["NetRep", "RColorBrewer", "SummarizedExperiment", "WGCNA", "cluster", "dplyr", "dynamicTreeCut", "ggplot2", "gprofiler2", "igraph", "magrittr", "matrixStats", "purrr", "rlist", "stringr", "tibble", "tidyr"]
     },
     "GateFinder": {
       "name": "GateFinder",
-      "version": "1.26.0",
-      "sha256": "02f5c6dsmjym1d0nkcmjsadsllfsqi4dlwvfx1zgwiz9cgnynh23",
+      "version": "1.28.0",
+      "sha256": "1rcqpv33y2n4k96id2r2g59wix9rc06byn7c0rb1kq3nmhgzr4vh",
       "depends": ["diptest", "flowCore", "flowFP", "mvoutlier", "splancs"]
     },
     "GeDi": {
       "name": "GeDi",
-      "version": "1.2.0",
-      "sha256": "0nczjz3z89c253akifs3v1p04gf10kvndi6w42zw56z81n96762r",
+      "version": "1.4.0",
+      "sha256": "0mxnbk0xqwc8v4vn50s59gb8gxl5y4dwy8n6sg2ydd23qzd2al9p",
       "depends": ["BiocFileCache", "BiocNeighbors", "BiocParallel", "ComplexHeatmap", "DT", "GOSemSim", "GeneTonic", "Matrix", "RColorBrewer", "STRINGdb", "bs4Dash", "circlize", "cluster", "dplyr", "fontawesome", "ggdendro", "ggplot2", "igraph", "plotly", "readxl", "rintrojs", "scales", "shiny", "shinyBS", "shinyWidgets", "shinycssloaders", "tm", "visNetwork", "wordcloud2"]
     },
     "GenProSeq": {
       "name": "GenProSeq",
-      "version": "1.10.0",
-      "sha256": "1kky5mx6pscvqk1vkhyqrm8p41z8fmfqrmisxfm3d42plzsds6fc",
+      "version": "1.12.0",
+      "sha256": "0izkzms0xlb2pvhc766lyhc0lw1z889k49060xs4bk9kf4saw1yj",
       "depends": ["CatEncoders", "DeepPINCS", "keras", "mclust", "reticulate", "tensorflow", "ttgsea", "word2vec"]
     },
     "GenVisR": {
       "name": "GenVisR",
-      "version": "1.38.0",
-      "sha256": "1blairc6n6z679f9c34572hk7z58kjwd6ysb6l4pnl9akbqf4bm5",
+      "version": "1.39.0",
+      "sha256": "1ax1r53zdjgmgfkj6y9hfd6w19wprpsm6mfbpi168cdskivnpva3",
       "depends": ["AnnotationDbi", "BSgenome", "BiocGenerics", "Biostrings", "DBI", "GenomeInfoDb", "GenomicFeatures", "GenomicRanges", "IRanges", "Rsamtools", "VariantAnnotation", "biomaRt", "data_table", "ggplot2", "gridExtra", "gtable", "gtools", "plyr", "reshape2", "scales", "viridis"]
     },
     "GeneBreak": {
       "name": "GeneBreak",
-      "version": "1.36.0",
-      "sha256": "12mb8zp9w8f9bg8whpr7y4nl8kdfnryxx24d6w2azrknrdypa1fm",
+      "version": "1.38.0",
+      "sha256": "0k5pg20qmhzbmjpl8ncarrygqm6g49m1z8hpx42zcqpkmmhw3zc3",
       "depends": ["CGHbase", "CGHcall", "GenomicRanges", "QDNAseq"]
     },
     "GeneExpressionSignature": {
       "name": "GeneExpressionSignature",
-      "version": "1.52.0",
-      "sha256": "0s2pzy667f00c7jwq51bl90hk1jjk972bjdw9jlwyvcj5873p15m",
+      "version": "1.54.0",
+      "sha256": "18n2is10v2x9s8yjv5z7q3ban4jkvz623w343ilnzc7il2nkiaxc",
       "depends": ["Biobase"]
     },
     "GeneGA": {
       "name": "GeneGA",
-      "version": "1.56.0",
-      "sha256": "0vi6vy62gvf8y0aw5ygx5x6qqzjjmfwks7w9n3bpkqab3yli13dw",
+      "version": "1.58.0",
+      "sha256": "0cnjgvxp7liimbc6axm565521jqc4srkbk9xf5269hw9i60p8370",
       "depends": ["hash", "seqinr"]
     },
     "GeneGeneInteR": {
       "name": "GeneGeneInteR",
-      "version": "1.32.0",
-      "sha256": "12cg3d5b5byx3ck1s11bwz6s0b1yc8y6csag38qihkql1qizgync",
+      "version": "1.33.0",
+      "sha256": "1wsm0l14mx2qd9gcs6m2n2pn0sgymf79fm8kvxjxvijqjv8n82ca",
       "depends": ["FactoMineR", "GenomicRanges", "IRanges", "Rsamtools", "data_table", "igraph", "kernlab", "mvtnorm", "snpStats"]
     },
     "GeneMeta": {
       "name": "GeneMeta",
-      "version": "1.78.0",
-      "sha256": "1iyhqjdwf17r8grb8q1kxsi1a5mv34q10bnyypvy7yc61mlp3d19",
+      "version": "1.80.0",
+      "sha256": "1wsiqhjz94lfj766v4qafgnqv691vsd9kawxids7g8133fd02ksc",
       "depends": ["Biobase", "genefilter"]
     },
     "GeneNetworkBuilder": {
       "name": "GeneNetworkBuilder",
-      "version": "1.48.0",
-      "sha256": "1sd83cxcx6wri80mlmhjj7j694cjg1z6zilwgjpbcirrv7n485gn",
+      "version": "1.50.0",
+      "sha256": "14f4cb5w7ymlvcl3b61nhbnrl0f2q9l37fhlgchxh2ps397mxada",
       "depends": ["RCy3", "Rcpp", "Rgraphviz", "XML", "graph", "htmlwidgets", "plyr", "rjson"]
     },
     "GeneOverlap": {
       "name": "GeneOverlap",
-      "version": "1.42.0",
-      "sha256": "05ca6g9qxkhb55b7bcr449xa0x4qdixxyx1y2d5kn0xj2zcy3lp9",
+      "version": "1.44.0",
+      "sha256": "0fb380czwrnb7s8my1vdzpj3vakjvclqhvbwr0ycnlhc74n2n3np",
       "depends": ["RColorBrewer", "gplots"]
     },
     "GeneRegionScan": {
       "name": "GeneRegionScan",
-      "version": "1.62.0",
-      "sha256": "15xn7ypg89ad4s4dg44dsyvr9191wd8van64gsbm1wbbx779sg3c",
+      "version": "1.64.0",
+      "sha256": "1zfimj9xdvwn49ijzhpfncic3kqxpdyg5pvwiwy5v0179ymdc86z",
       "depends": ["Biobase", "Biostrings", "RColorBrewer", "S4Vectors", "affxparser"]
     },
     "GeneSelectMMD": {
       "name": "GeneSelectMMD",
-      "version": "2.50.0",
-      "sha256": "0h32303901smny2sdkwgf5280fj6pjjakjlf738ii4pgnhkzvn8x",
+      "version": "2.52.0",
+      "sha256": "0khxl4zlkm8rap01k3sdfm7q61pby4fsrh6scxcjndjrkf5ap6q5",
       "depends": ["Biobase", "MASS", "limma"]
     },
     "GeneStructureTools": {
       "name": "GeneStructureTools",
-      "version": "1.26.0",
-      "sha256": "1km7pi8mfplsywxnr2vidmb3d5k9fpjigvnnkkpqrw7civvlqdx4",
+      "version": "1.28.0",
+      "sha256": "1rrlsfyvcni5b8ybbavkvf8pk2m0690irynl7jlvp5i2igfia3ll",
       "depends": ["BSgenome_Mmusculus_UCSC_mm10", "Biostrings", "GenomicRanges", "Gviz", "IRanges", "S4Vectors", "data_table", "plyr", "rtracklayer", "stringdist", "stringr"]
     },
     "GeneTonic": {
       "name": "GeneTonic",
-      "version": "3.0.0",
-      "sha256": "18qvz6gj7y6d46yj7y2yyfi3a7yb0950nx9w1w7fb6fv4qgb2pv7",
+      "version": "3.2.0",
+      "sha256": "1q61akm9sllrjbk3dy2mbvcv0fl10qyqvgvwaz1klixkfwi03hm3",
       "depends": ["AnnotationDbi", "ComplexHeatmap", "ComplexUpset", "DESeq2", "DT", "GO_db", "RColorBrewer", "S4Vectors", "SummarizedExperiment", "backbone", "bs4Dash", "circlize", "colorspace", "colourpicker", "dendextend", "dplyr", "dynamicTreeCut", "expm", "ggforce", "ggplot2", "ggrepel", "ggridges", "igraph", "matrixStats", "mosdef", "plotly", "rintrojs", "rlang", "rmarkdown", "scales", "shiny", "shinyAce", "shinyWidgets", "shinycssloaders", "tidyr", "tippy", "viridis", "visNetwork"]
     },
     "GeneticsPed": {
       "name": "GeneticsPed",
-      "version": "1.68.0",
-      "sha256": "0345vir3x2jn1gkjyw2bphq3h1ic93van7p34wfamz7ryf2p2188",
+      "version": "1.70.0",
+      "sha256": "01ikcv8qxfwnffs8mqvis68c91xqbshkzpaqz5as810i7vkvqkln",
       "depends": ["MASS", "gdata", "genetics"]
     },
     "GenomAutomorphism": {
       "name": "GenomAutomorphism",
-      "version": "1.8.1",
-      "sha256": "1f0hy36hwq0gaml4b3g7rfhqlbj2laa3bwsf0mppc1bmm3n5x9sb",
+      "version": "1.10.0",
+      "sha256": "1wnwxzpzy4h4vi1dhqqx67q5bn8fwl0h48g4b59sipwd8s0w4v5d",
       "depends": ["BiocGenerics", "BiocParallel", "Biostrings", "GenomeInfoDb", "GenomicRanges", "IRanges", "S4Vectors", "XVector", "data_table", "doParallel", "dplyr", "foreach", "matrixStats", "numbers"]
     },
     "GenomeInfoDb": {
       "name": "GenomeInfoDb",
-      "version": "1.42.3",
-      "sha256": "0blvkdgswypd0dhdq9m8y83kqppynng691dj6xyh3v5s8cr5d8ml",
+      "version": "1.44.0",
+      "sha256": "0rvf2v2bcspm0xlrdxcvyjfp3h5vcykmd61x073sizdsxkn4dd68",
       "depends": ["BiocGenerics", "GenomeInfoDbData", "IRanges", "S4Vectors", "UCSC_utils"]
     },
     "GenomicAlignments": {
       "name": "GenomicAlignments",
-      "version": "1.42.0",
-      "sha256": "1ycawwp0b8gk9sccqdwklq4yh3rns9iw34qdx5ysw4nxksi4vf6y",
+      "version": "1.44.0",
+      "sha256": "048j2jr1jpgjckl18wx35q518ydv8b2bmdiyiaxjc65283b77614",
       "depends": ["BiocGenerics", "BiocParallel", "Biostrings", "GenomeInfoDb", "GenomicRanges", "IRanges", "Rsamtools", "S4Vectors", "SummarizedExperiment"]
     },
     "GenomicDataCommons": {
       "name": "GenomicDataCommons",
-      "version": "1.30.1",
-      "sha256": "08inzfvxxwnln5ssxw8q9bsqsi1qyglj7j3xzrw47vp5cfcv0hhw",
+      "version": "1.32.0",
+      "sha256": "07mpgsyi9gdb2jhkrdsxv09l1sncv214avpp68isdddk1mipk1w4",
       "depends": ["GenomicRanges", "IRanges", "dplyr", "httr", "jsonlite", "rappdirs", "readr", "rlang", "tibble", "tidyr", "xml2"]
     },
     "GenomicDistributions": {
       "name": "GenomicDistributions",
-      "version": "1.14.0",
-      "sha256": "1jq2k7mzj8r9ah77icfh3y7kryqa4lmazlvb5smrlbzjl3lfav6p",
+      "version": "1.16.0",
+      "sha256": "1c68z7g5cli3jwknbnc14dqjcl5bsyb0ckaami48jqiawdzmagni",
       "depends": ["Biostrings", "GenomeInfoDb", "GenomicRanges", "IRanges", "broom", "data_table", "dplyr", "ggplot2", "plyr", "reshape2", "scales"]
     },
     "GenomicFeatures": {
       "name": "GenomicFeatures",
-      "version": "1.58.0",
-      "sha256": "0ixc6hmfdh2dn985d92iwcmk2v5m1c2l3d27y76bzmw9whpd89i5",
+      "version": "1.60.0",
+      "sha256": "16j78sgjk0hrdbhcbwrwq03355bvgg4d3lzvy773ypg8pwg0jjid",
       "depends": ["AnnotationDbi", "BiocGenerics", "Biostrings", "DBI", "GenomeInfoDb", "GenomicRanges", "IRanges", "S4Vectors", "XVector", "rtracklayer"]
     },
     "GenomicFiles": {
       "name": "GenomicFiles",
-      "version": "1.42.0",
-      "sha256": "0vfk4nxdgvh57swcf9p898cli7v3i8c6q4aw9qr5sjv01kxr51rg",
+      "version": "1.44.0",
+      "sha256": "0ylhag6ic1lcs59vjrpr6yny4hbcfxya9zf1s3hzn33wzz7xmv5q",
       "depends": ["BiocGenerics", "BiocParallel", "GenomeInfoDb", "GenomicAlignments", "GenomicRanges", "IRanges", "MatrixGenerics", "Rsamtools", "S4Vectors", "SummarizedExperiment", "VariantAnnotation", "rtracklayer"]
     },
     "GenomicInteractionNodes": {
       "name": "GenomicInteractionNodes",
-      "version": "1.10.0",
-      "sha256": "0gb5p6bsyzr0jpvdi1p8rwg4f5njfm06jfbvikh0lillhdr2n4lq",
+      "version": "1.12.0",
+      "sha256": "0wkzkrd8s8fb7jhpwpl3w97bs4ja0r1xfzcc50ccwynlp4cx4sr2",
       "depends": ["AnnotationDbi", "GO_db", "GenomeInfoDb", "GenomicFeatures", "GenomicRanges", "IRanges", "RBGL", "S4Vectors", "graph"]
     },
     "GenomicInteractions": {
       "name": "GenomicInteractions",
-      "version": "1.40.0",
-      "sha256": "1p3dcpm8bggxxiqzx238dvv3nyybg9agy6i1k7ngdvrxr6zlb0c8",
+      "version": "1.42.0",
+      "sha256": "02wwbxn9kcpscvkkllad42wa8i5nfqc54nmm550zfhh15qlvazys",
       "depends": ["Biobase", "BiocGenerics", "GenomeInfoDb", "GenomicRanges", "Gviz", "IRanges", "InteractionSet", "Rsamtools", "S4Vectors", "data_table", "dplyr", "ggplot2", "gridExtra", "igraph", "rtracklayer", "stringr"]
     },
     "GenomicOZone": {
       "name": "GenomicOZone",
-      "version": "1.20.0",
-      "sha256": "1i9naq9dlfm5sldl0va2j0a1ajzd5qsmz4kp4v09v0c3yagp54zd",
+      "version": "1.22.0",
+      "sha256": "0j2xp2c65l491z753vmpis2a988dq0af0vfhm1m8nbhfd8n45lnd",
       "depends": ["Ckmeans_1d_dp", "GenomeInfoDb", "GenomicRanges", "IRanges", "Rdpack", "S4Vectors", "biomaRt", "ggbio", "ggplot2", "gridExtra", "lsr", "plyr"]
     },
     "GenomicPlot": {
       "name": "GenomicPlot",
-      "version": "1.4.0",
-      "sha256": "07j12zsalha46pkwbkjn21l1n8rsa2bp2rf3gckqlb0cysvfyj4c",
+      "version": "1.6.0",
+      "sha256": "1572hy15rajjakpclvbrikyaqabakx3r69nszqx4hxiy3nskbm22",
       "depends": ["BiocGenerics", "ComplexHeatmap", "GenomeInfoDb", "GenomicAlignments", "GenomicFeatures", "GenomicRanges", "IRanges", "RCAS", "Rsamtools", "VennDiagram", "circlize", "cowplot", "dplyr", "edgeR", "genomation", "ggplot2", "ggplotify", "ggpubr", "ggsci", "ggsignif", "plyranges", "rtracklayer", "scales", "tidyr", "txdbmaker", "viridis"]
     },
     "GenomicRanges": {
       "name": "GenomicRanges",
-      "version": "1.58.0",
-      "sha256": "1iccjn5gb8k2l1hw7nhi30w3dnlpdf8mh3xwf3x3dky3mhxw3j0h",
+      "version": "1.60.0",
+      "sha256": "082g27miaa13nyjbr6ygc3928kbn5nkmb4l3si4z85dj26k6xgs8",
       "depends": ["BiocGenerics", "GenomeInfoDb", "IRanges", "S4Vectors", "XVector"]
     },
     "GenomicScores": {
       "name": "GenomicScores",
-      "version": "2.18.1",
-      "sha256": "0naad6dqhx78n9bsczwy4k3xjaa5dqs9iz71aa887ck9riy4ibwf",
+      "version": "2.20.0",
+      "sha256": "0c1997f3xbj19wgikqfad7bd573wf7czyazilcy662jmal9dnxmw",
       "depends": ["AnnotationHub", "Biobase", "BiocFileCache", "BiocGenerics", "BiocManager", "Biostrings", "DelayedArray", "GenomeInfoDb", "GenomicRanges", "HDF5Array", "IRanges", "S4Vectors", "XML", "httr", "rhdf5"]
     },
     "GenomicSuperSignature": {
       "name": "GenomicSuperSignature",
-      "version": "1.14.0",
-      "sha256": "0y1lylj20qi5ca63ym771hvs3iw02p93sckbhs0qs07awjcyl8v2",
+      "version": "1.16.0",
+      "sha256": "04vk5qiljnrf7rsv9s5w8rwrdsxavshak827w43clb0yvq2csg6v",
       "depends": ["Biobase", "BiocFileCache", "ComplexHeatmap", "S4Vectors", "SummarizedExperiment", "dplyr", "flextable", "ggplot2", "ggpubr", "irlba", "plotly"]
     },
     "GenomicTuples": {
       "name": "GenomicTuples",
-      "version": "1.40.0",
-      "sha256": "0fqqlkc231qkvh58n1kg2wa1r4539xxx8kvmwdfdlvrqkg38yn0i",
+      "version": "1.42.0",
+      "sha256": "1i7rfnq16fl053s9y8dgiyik4g50c69zymx9iarz3haryr945vrj",
       "depends": ["BiocGenerics", "GenomeInfoDb", "GenomicRanges", "IRanges", "Rcpp", "S4Vectors", "data_table"]
     },
     "GeoDiff": {
       "name": "GeoDiff",
-      "version": "1.12.0",
-      "sha256": "1bn553qw8cyh4agm8mjhhrlarwy8qgfgy4pz64rhzipimk1rkyxv",
+      "version": "1.14.0",
+      "sha256": "0dzlksssdmz4bvscak9x8k7bxkk6lc4xhdljqgdm6fslsbywlbqy",
       "depends": ["Biobase", "GeomxTools", "Matrix", "NanoStringNCTools", "Rcpp", "RcppArmadillo", "lme4", "plyr", "robust", "roptim", "testthat", "withr"]
     },
     "GeoTcgaData": {
       "name": "GeoTcgaData",
-      "version": "2.6.0",
-      "sha256": "14a2p3im5v7hfvsb67wd6djvg8cm0xwb1l9k1j8m521j1v04ya9z",
+      "version": "2.8.0",
+      "sha256": "1yi3dbb6gamnsi2lgfr9rhh981pmhsqmvjlniczxdh1rwdpixrzl",
       "depends": ["SummarizedExperiment", "cqn", "data_table", "plyr", "topconfects"]
     },
     "GeomxTools": {
       "name": "GeomxTools",
-      "version": "3.10.0",
-      "sha256": "02zrn4zj3i20wgsfgpmhgyi05xhnw872h9dg1ig3hj97f70h5da4",
+      "version": "3.11.0",
+      "sha256": "052xdxg97zazwzwyx2ijyysny4nqpfdqbs81km2mnfph1b4d12kl",
       "depends": ["Biobase", "BiocGenerics", "EnvStats", "GGally", "NanoStringNCTools", "S4Vectors", "SeuratObject", "data_table", "dplyr", "ggplot2", "lmerTest", "readxl", "reshape2", "rjson", "rlang", "stringr"]
     },
     "GladiaTOX": {
       "name": "GladiaTOX",
-      "version": "1.22.0",
-      "sha256": "1aarqwk5wqq1d8mawi2bh01bcak6sq1cd3f5cwanyjybsdawp0ij",
+      "version": "1.24.0",
+      "sha256": "0k80njzbcgiy4gnddg2jcs7gxj291ihpn2lc4mcxkpd04i54441m",
       "depends": ["DBI", "RColorBrewer", "RCurl", "RJSONIO", "RMariaDB", "RSQLite", "XML", "brew", "data_table", "ggplot2", "ggrepel", "numDeriv", "stringr", "tidyr", "xtable"]
     },
     "Glimma": {
       "name": "Glimma",
-      "version": "2.16.0",
-      "sha256": "0jqgk8bb7izblhfpjdqkf12jmhkmpwj8sv07429jrxvlj3c84k7a",
+      "version": "2.18.0",
+      "sha256": "1mrx7l7s3ddvlqrzb3wgx3nis1nd4jjfmamdnlcpl09x4x3fd4w2",
       "depends": ["DESeq2", "S4Vectors", "SummarizedExperiment", "edgeR", "htmlwidgets", "jsonlite", "limma"]
     },
     "GloScope": {
       "name": "GloScope",
-      "version": "1.4.0",
-      "sha256": "19kanrm6fzkbgka89anr7z8fm58hmbksdqf77sq1x4dirnp52p9s",
+      "version": "1.6.0",
+      "sha256": "09q9dy0cv2n3f5j31wa9zms4ab7azkivckix6jksqaq5d273fi1n",
       "depends": ["BiocParallel", "FNN", "MASS", "RANN", "SingleCellExperiment", "ggplot2", "mclust", "mvnfast", "rlang"]
     },
     "GlobalAncova": {
       "name": "GlobalAncova",
-      "version": "4.24.0",
-      "sha256": "1hxggdicpqhwyai53sa20y63dmn48rlys56iyk1rwnxwd8dsmjn0",
+      "version": "4.26.0",
+      "sha256": "1gmqfchhkz9157g76jl373w7gg5djn83qz5ic0hbgfwlm906xi7a",
       "depends": ["AnnotationDbi", "Biobase", "GSEABase", "VGAM", "annotate", "corpcor", "dendextend", "globaltest"]
     },
     "GmicR": {
       "name": "GmicR",
-      "version": "1.20.0",
-      "sha256": "0h9sfx9rbg13mghbw6ks1kaprbdx1iq66cg0520pd6zx35kszx6q",
+      "version": "1.22.0",
+      "sha256": "0m3ww2nxp22vjbcy0l66wxr01fmgiz87xqciqs0g9l3yv04iglwa",
       "depends": ["AnnotationDbi", "Category", "DT", "GOstats", "GSEABase", "WGCNA", "ape", "bnlearn", "data_table", "doParallel", "foreach", "gRain", "gRbase", "org_Hs_eg_db", "org_Mm_eg_db", "reshape2", "shiny"]
     },
     "GrafGen": {
       "name": "GrafGen",
-      "version": "1.2.0",
-      "sha256": "1m99q14g2c19ch54w3y828dyqkn19zivyhxdism3j2wx8yxs5wcr",
-      "depends": ["GenomicRanges", "RColorBrewer", "cowplot", "dplyr", "ggplot2", "ggpubr", "plotly", "rlang", "scales", "shiny", "stringr", "zlibbioc"]
+      "version": "1.4.0",
+      "sha256": "1bi6d3pyy5spx80chis3gyl3drwhgldb1y5ysv9209mjx24nvqgq",
+      "depends": ["GenomicRanges", "RColorBrewer", "cowplot", "dplyr", "ggplot2", "ggpubr", "plotly", "rlang", "scales", "shiny", "stringr"]
     },
     "GraphAT": {
       "name": "GraphAT",
-      "version": "1.78.0",
-      "sha256": "16nps59vwnrd4myhra3gilcr5n04b7mhg2hz7abxfy9am88pih1g",
+      "version": "1.80.0",
+      "sha256": "1gavp5wplslmxvpk9bjxvvsbb9i5qw3iyny7dypfk4f00gfdd3rl",
       "depends": ["MCMCpack", "graph"]
     },
     "GraphAlignment": {
       "name": "GraphAlignment",
-      "version": "1.70.0",
-      "sha256": "0fvyq7dgzdy58njqwz2c2m7hpfch15hyr81v6lj0sd2rkqrdwdy8",
+      "version": "1.72.0",
+      "sha256": "0j5f98cz80qy4qzfz5v5fswwbz428a4iv5ph8p3cl8wg7yabz0w7",
       "depends": []
     },
     "GreyListChIP": {
       "name": "GreyListChIP",
-      "version": "1.38.0",
-      "sha256": "0annhgzl4b5ykn0993zdqlcxppbrrn8rcxivfkjhdqmq41r4n4bm",
+      "version": "1.40.0",
+      "sha256": "1aykzjz3wg82k9ri4vc42dc3s93pjp5raxayq2ysf61v5j8qg17r",
       "depends": ["BSgenome", "GenomeInfoDb", "GenomicAlignments", "GenomicRanges", "MASS", "Rsamtools", "SummarizedExperiment", "rtracklayer"]
     },
     "Guitar": {
       "name": "Guitar",
-      "version": "2.22.0",
-      "sha256": "1hy17ajwrw1bvx6rsyxsv5h656z98ms3nj0v52xsy1ryi4iyqs49",
+      "version": "2.24.0",
+      "sha256": "0nmxfiwfw1q5rn7642k3x1s6p8q7dssm8c0zcqiq6404f5j44qwq",
       "depends": ["AnnotationDbi", "GenomicFeatures", "GenomicRanges", "dplyr", "ggplot2", "knitr", "magrittr", "rtracklayer"]
     },
     "Gviz": {
       "name": "Gviz",
-      "version": "1.50.0",
-      "sha256": "17jb2y3sgmkfs08lzb4p2l45xy8c3bfzqq653r1a6bg6rgaxviah",
+      "version": "1.52.0",
+      "sha256": "1jsvh8mxjsqr9x8nf40jhachk0rf9civ64x34wk3ymn0ym56vj3w",
       "depends": ["AnnotationDbi", "BSgenome", "Biobase", "BiocGenerics", "Biostrings", "GenomeInfoDb", "GenomicAlignments", "GenomicFeatures", "GenomicRanges", "IRanges", "RColorBrewer", "Rsamtools", "S4Vectors", "XVector", "biomaRt", "biovizBase", "digest", "ensembldb", "lattice", "latticeExtra", "matrixStats", "rtracklayer"]
     },
     "HDF5Array": {
       "name": "HDF5Array",
-      "version": "1.34.0",
-      "sha256": "1jkrlmnsf5ncs4l77b29p8cjn6nmaadpvrsn5z1qixsw1axbqwi0",
-      "depends": ["BiocGenerics", "DelayedArray", "IRanges", "Matrix", "Rhdf5lib", "S4Arrays", "S4Vectors", "SparseArray", "rhdf5", "rhdf5filters"]
+      "version": "1.36.0",
+      "sha256": "1il3a5vdyf6ddazxqcll1d8ca1bl8q1pq2l5ss9n159isdimb410",
+      "depends": ["BiocGenerics", "DelayedArray", "IRanges", "Matrix", "S4Arrays", "S4Vectors", "SparseArray", "h5mread", "rhdf5"]
     },
     "HDTD": {
       "name": "HDTD",
-      "version": "1.40.0",
-      "sha256": "17gsmam37wki0a7db5i6vizz2q86y3waq1pjfl5cz10icycjjiwy",
+      "version": "1.42.0",
+      "sha256": "0njyi579pvhjxrzrfv8rm74chhblzfd11p2c6nql7qkfw5lj687m",
       "depends": ["Rcpp", "RcppArmadillo"]
     },
     "HELP": {
       "name": "HELP",
-      "version": "1.64.0",
-      "sha256": "075x2zylyc1ap5a3dd0k6hd93nr1vpwj2k5p502zrjza9cp9hkxa",
+      "version": "1.66.0",
+      "sha256": "1r63qfp77mm61yz7iz2hjgfcji028zsrkdxhk88m9w9adchi4fvp",
       "depends": ["Biobase"]
     },
     "HEM": {
       "name": "HEM",
-      "version": "1.78.0",
-      "sha256": "1yk0jh1jrd6ix7jqgj12h46h05qjjw3z4dxjmvnzbwyyvn06ipn4",
+      "version": "1.80.0",
+      "sha256": "12lb81lasxwazczibpydppbn2z64qfkcpbaa08f959i1gridf98b",
       "depends": ["Biobase"]
     },
     "HERON": {
       "name": "HERON",
-      "version": "1.4.0",
-      "sha256": "1mdjyk6di9fhyj1gxbvgxyzd77wy8xjqmx2fdbdf5m1r9xffzmkg",
+      "version": "1.6.0",
+      "sha256": "16gymagac66c3ja72jrp79zgwhqfk0ha117xdjy6ckgbh98cvdmn",
       "depends": ["GenomicRanges", "IRanges", "Matrix", "S4Vectors", "SummarizedExperiment", "cluster", "data_table", "harmonicmeanp", "limma", "matrixStats", "metap", "spdep"]
     },
     "HGC": {
       "name": "HGC",
-      "version": "1.14.0",
-      "sha256": "0qr55rf3sl5301q6sv24iq3ba417iifl5p4yrc3qxii9gs5jyn4s",
+      "version": "1.16.0",
+      "sha256": "0n224nv1ylh79xbd9sdp6283zi3dmia5ng1k51wvkl6hq748m4ba",
       "depends": ["Matrix", "RANN", "Rcpp", "RcppEigen", "ape", "dendextend", "dplyr", "ggplot2", "mclust", "patchwork"]
     },
     "HIBAG": {
       "name": "HIBAG",
-      "version": "1.42.0",
-      "sha256": "1z9rn67fh2d79d15hp1cv6j6s9glnvf1nkwp7f6r2bh4m6g0h200",
+      "version": "1.44.0",
+      "sha256": "1yrbw13k0w448q0pg4k8ylik84v9lb5khj7ax2fn4gvmhaa26v7w",
       "depends": ["RcppParallel"]
     },
     "HIPPO": {
       "name": "HIPPO",
-      "version": "1.18.0",
-      "sha256": "0y94sniglz5pm841fi6vq2km3n1hygng88hwj0kwapvpvjkdp6ar",
+      "version": "1.20.0",
+      "sha256": "0k43hcl0byjyi496g73xq8b23mn20m1i0zlfvf1vand6cwrs4zdh",
       "depends": ["Matrix", "Rtsne", "SingleCellExperiment", "dplyr", "ggplot2", "ggrepel", "gridExtra", "irlba", "magrittr", "reshape2", "rlang", "umap"]
     },
     "HIREewas": {
       "name": "HIREewas",
-      "version": "1.24.0",
-      "sha256": "1wsf015i68vbvqwy3d8h6nn7r7hqw2r8vvhpnbg7dxi1d5gbgrrr",
+      "version": "1.26.0",
+      "sha256": "105jw39xfm4l7c2ncliba2ismc9xw0chdzkhscd772g9nz20avhs",
       "depends": ["gplots", "quadprog"]
     },
     "HMMcopy": {
       "name": "HMMcopy",
-      "version": "1.48.0",
-      "sha256": "169hxg2cnhc48gfyz2rag1ahs2q1slp70v89bvzibkn00srclgk5",
+      "version": "1.50.0",
+      "sha256": "1pwhakhx880815dr5gs2m9f4jr402p8h2ccs01n8cbjkm32w6nq7",
       "depends": ["data_table"]
     },
     "HPAanalyze": {
       "name": "HPAanalyze",
-      "version": "1.24.0",
-      "sha256": "1nad5qqa76b6ifzyz7awxh9p86kfjar0i5ljqbmhh14dsr6pmywy",
+      "version": "1.26.0",
+      "sha256": "1jr0q37q3jrz7cii033g0fh0jm8b4r5mxys9s13gb528aw6n5zg5",
       "depends": ["dplyr", "ggplot2", "gridExtra", "openxlsx", "tibble", "xml2"]
     },
     "HPiP": {
       "name": "HPiP",
-      "version": "1.12.0",
-      "sha256": "161nnbkzwfsnswb9zp8kx9795ikmmyi2abz9fi8m7627aqwl3riy",
+      "version": "1.14.0",
+      "sha256": "0dbpzacyhwv0080ql3p3gsrmclb5sil9rj3kh2lf7b61qsikh701",
       "depends": ["MCL", "PRROC", "caret", "corrplot", "dplyr", "ggplot2", "httr", "igraph", "magrittr", "pROC", "protr", "purrr", "readr", "stringr", "tibble", "tidyr"]
     },
     "HTSFilter": {
       "name": "HTSFilter",
-      "version": "1.46.0",
-      "sha256": "1wa2wmsln3ycan4lyy41rhn31mmbq0rpgr2s4yp7nimkdhh06fbl",
+      "version": "1.48.0",
+      "sha256": "16k9rhbhm24almk2sclsn4w3rp681pmv171y8w8w65mcrl9x3hm9",
       "depends": ["Biobase", "BiocParallel", "DESeq2", "edgeR"]
+    },
+    "HTqPCR": {
+      "name": "HTqPCR",
+      "version": "1.62.0",
+      "sha256": "1bky9ybsjj0y9qf3klbdmic8izbqc391p6nz8jk9hjgx54w8xg6g",
+      "depends": ["Biobase", "RColorBrewer", "affy", "gplots", "limma"]
     },
     "Harman": {
       "name": "Harman",
-      "version": "1.34.0",
-      "sha256": "1n2ipv53520acgvh577ip3gvdw0qlmkidyvqzcja5r76320y6287",
+      "version": "1.36.0",
+      "sha256": "0j99mi8mxrpmm2ypakc7k9ja59iqsxdn8189a70wipyzs5srnnp5",
       "depends": ["Ckmeans_1d_dp", "Rcpp", "matrixStats"]
     },
     "HarmonizR": {
       "name": "HarmonizR",
-      "version": "1.4.0",
-      "sha256": "1cbhigwfx1354fvjfmmbafq09q2w4viy91n4k1w7kamg5svh56ld",
+      "version": "1.6.0",
+      "sha256": "016bkk6h9w430dpg1afnfwaiy4piz6qyyq26lwng2w0jpvyxr7h9",
       "depends": ["SummarizedExperiment", "doParallel", "foreach", "janitor", "limma", "plyr", "seriation", "sva"]
     },
     "Harshlight": {
       "name": "Harshlight",
-      "version": "1.78.0",
-      "sha256": "14fnbvrk7cdfnsdv47cv1k4krqlf9a8hiax0m7g8rw1y7qjkf0z4",
+      "version": "1.79.0",
+      "sha256": "1jm0ia06ls1m7dsbzp1hk68qi5wbqzhcf6x66534bj1kxdll17k7",
       "depends": ["Biobase", "affy", "altcdfenvs"]
     },
     "Heatplus": {
       "name": "Heatplus",
-      "version": "3.14.0",
-      "sha256": "1kfm07dcs4gvkr1ry57q8r564v2b73vd67ysy83riz9qvan5r63b",
+      "version": "3.16.0",
+      "sha256": "1an32ghqbd2j39509v1anzp65ahndwi6nhjzcvvv5ixl6s006n9k",
       "depends": ["RColorBrewer"]
     },
     "HelloRanges": {
       "name": "HelloRanges",
-      "version": "1.32.0",
-      "sha256": "11hmnqvmhd7rn5dcm20wg109sp8cmaq5k06x0cyaimi0dmf1psxv",
+      "version": "1.34.0",
+      "sha256": "1ihjcwrxsbfd0sv9fdk21vszi9wjw61fycqjxv276a7i1s9r0k37",
       "depends": ["BSgenome", "BiocGenerics", "BiocIO", "Biostrings", "GenomeInfoDb", "GenomicAlignments", "GenomicFeatures", "GenomicRanges", "IRanges", "Rsamtools", "S4Vectors", "SummarizedExperiment", "VariantAnnotation", "docopt", "rtracklayer"]
     },
     "Herper": {
       "name": "Herper",
-      "version": "1.16.0",
-      "sha256": "1nblfwfjfkhjj02a5g7yhhilxw7xvmjs4dd3fd71xzyd74mkz7m0",
+      "version": "1.18.0",
+      "sha256": "1x4f11rrnf9sy496w2m94jrrs1ljidkswwyr645h3dcd6rf6igks",
       "depends": ["reticulate", "rjson", "withr"]
     },
     "HiCBricks": {
       "name": "HiCBricks",
-      "version": "1.24.0",
-      "sha256": "1xv8i6c40nbgd4cda6wy4q94l58m9l8sirl0bkhqagc1av42rq2c",
+      "version": "1.26.0",
+      "sha256": "0gn9n0rgppkwxj4l90aqvaw93mvxaqjfi5h8z52n9azcdb5n91ky",
       "depends": ["BiocParallel", "GenomeInfoDb", "GenomicRanges", "IRanges", "R6", "RColorBrewer", "R_utils", "S4Vectors", "curl", "data_table", "digest", "ggplot2", "jsonlite", "readr", "reshape2", "rhdf5", "scales", "stringr", "tibble", "viridis"]
     },
     "HiCDCPlus": {
       "name": "HiCDCPlus",
-      "version": "1.14.0",
-      "sha256": "18knyy8r134hix90dpy6lgkz9a67gpdaw2lgbpppac7ls5hhdkbl",
+      "version": "1.16.0",
+      "sha256": "1r4y5jn56f02bhxamsrimhrp6mk1gk51xnf6jpgi4g3mpli66yv7",
       "depends": ["BSgenome", "Biostrings", "GenomeInfoDb", "GenomicInteractions", "GenomicRanges", "IRanges", "InteractionSet", "MASS", "R_utils", "Rcpp", "S4Vectors", "bbmle", "data_table", "dplyr", "pscl", "rlang", "rtracklayer", "tibble", "tidyr"]
     },
     "HiCDOC": {
       "name": "HiCDOC",
-      "version": "1.8.0",
-      "sha256": "0vkkddsqwisl7n1wv0zlygv1g875h09mq0zj8hg1yv06pwq3b140",
-      "depends": ["BiocGenerics", "BiocParallel", "GenomeInfoDb", "GenomicRanges", "InteractionSet", "Rcpp", "S4Vectors", "SummarizedExperiment", "cowplot", "data_table", "ggplot2", "gridExtra", "gtools", "multiHiCcompare", "pbapply", "zlibbioc"]
+      "version": "1.10.0",
+      "sha256": "1vmk6xd3cxfjjihqxc30s1f0lg3avw1cb2jvw5bzysfp2s89ll96",
+      "depends": ["BiocGenerics", "BiocParallel", "GenomeInfoDb", "GenomicRanges", "InteractionSet", "Rcpp", "S4Vectors", "SummarizedExperiment", "cowplot", "data_table", "ggplot2", "gridExtra", "gtools", "multiHiCcompare", "pbapply"]
     },
     "HiCExperiment": {
       "name": "HiCExperiment",
-      "version": "1.6.0",
-      "sha256": "12276hl11s3z69197rplaq2ac4dhrpc74dh4174m3l5b6sq2gg0y",
+      "version": "1.8.0",
+      "sha256": "13ccm1d2k6p4lah9bqq2jqnfba1zm2xk6ifkwy6hzrrxyaxav8xm",
       "depends": ["BiocGenerics", "BiocIO", "BiocParallel", "GenomeInfoDb", "GenomicRanges", "IRanges", "InteractionSet", "Matrix", "S4Vectors", "dplyr", "rhdf5", "strawr", "vroom"]
+    },
+    "HiCParser": {
+      "name": "HiCParser",
+      "version": "1.0.0",
+      "sha256": "0dq5s8g6p77i1c7gmhzyz86ylqh3r4v77wf5i702cd7d9xzpaz6j",
+      "depends": ["BiocGenerics", "GenomeInfoDb", "GenomicRanges", "InteractionSet", "Rcpp", "S4Vectors", "SummarizedExperiment", "data_table", "gtools", "pbapply"]
     },
     "HiCcompare": {
       "name": "HiCcompare",
-      "version": "1.28.0",
-      "sha256": "1ww5fhslanpgf54x7rshfznyyqd6knrf1njn9975v9hm6ya01sff",
+      "version": "1.30.0",
+      "sha256": "1v886calffi7al5aibyc8xdk68vla2mif5y3awb3s03s3cb16n2v",
       "depends": ["BiocParallel", "GenomicRanges", "IRanges", "InteractionSet", "KernSmooth", "S4Vectors", "data_table", "dplyr", "ggplot2", "gridExtra", "gtools", "mgcv", "pheatmap", "rhdf5"]
     },
     "HiContacts": {
       "name": "HiContacts",
-      "version": "1.8.0",
-      "sha256": "1jc138ailpk3x6jgijvszskj6rf10qv3wy89qwv9cxk3jhpprj6x",
+      "version": "1.10.0",
+      "sha256": "1vwyzskp489vclaw43pqc8gwxr81vi4aia2cg0zjazn7wrjyjgzj",
       "depends": ["BiocGenerics", "BiocIO", "BiocParallel", "GenomeInfoDb", "GenomicRanges", "HiCExperiment", "IRanges", "InteractionSet", "Matrix", "RSpectra", "S4Vectors", "SummarizedExperiment", "dplyr", "ggplot2", "ggrastr", "readr", "scales", "stringr", "tibble", "tidyr"]
     },
     "HiCool": {
       "name": "HiCool",
-      "version": "1.6.0",
-      "sha256": "1pkn0a1gh9hr6pwigjy8xf6zyzbjhprk2ni9jmxnffqp4w0i923k",
+      "version": "1.8.0",
+      "sha256": "0cnzbi4if3cn0lr78yh4a76kn3pv8c332w69s3l9gsqxvjx16kqs",
       "depends": ["BiocIO", "GenomicRanges", "HiCExperiment", "IRanges", "InteractionSet", "S4Vectors", "basilisk", "dplyr", "plotly", "reticulate", "rmarkdown", "rmdformats", "sessioninfo", "stringr", "vroom"]
     },
     "HiLDA": {
       "name": "HiLDA",
-      "version": "1.20.0",
-      "sha256": "0v3r6av7k5ifl4xplgy02f4w26si8ilfh5w6b5kjx045ga2yyczk",
+      "version": "1.22.0",
+      "sha256": "1zyf3z2p9ln3zxpqqb18zyn4c8yr6jccagc8wfya6yvp42f2h95y",
       "depends": ["BSgenome_Hsapiens_UCSC_hg19", "BiocGenerics", "Biostrings", "GenomicFeatures", "GenomicRanges", "R2jags", "Rcpp", "S4Vectors", "TxDb_Hsapiens_UCSC_hg19_knownGene", "XVector", "abind", "cowplot", "forcats", "ggplot2", "stringr", "tidyr"]
     },
     "HiTC": {
       "name": "HiTC",
-      "version": "1.50.0",
-      "sha256": "0y5qlr36pj7mrgs70v4zf9s19rpa11mzyagmpxs77n0pl9nrhgwj",
+      "version": "1.52.0",
+      "sha256": "0y0srz1w6yp9dkk0zyij7lq18413651z7svv9ydfyimr8gqjb2a9",
       "depends": ["Biostrings", "GenomeInfoDb", "GenomicRanges", "IRanges", "Matrix", "RColorBrewer", "rtracklayer"]
     },
     "HicAggR": {
       "name": "HicAggR",
-      "version": "1.2.0",
-      "sha256": "1lw1jasa387rlngapcs4mb5bvwc855sxrb4rdyzkvsxphmi7gffc",
+      "version": "1.4.0",
+      "sha256": "1y8s6dp6ilia1gznv4v09xz7lmhg05h7szharapw0jdqszzygvif",
       "depends": ["BiocGenerics", "BiocParallel", "GenomeInfoDb", "GenomicRanges", "IRanges", "InteractionSet", "Matrix", "S4Vectors", "checkmate", "data_table", "dplyr", "ggplot2", "gridExtra", "purrr", "reshape", "rhdf5", "rlang", "rtracklayer", "strawr", "stringr", "tibble", "tidyr", "withr"]
     },
     "HilbertCurve": {
       "name": "HilbertCurve",
-      "version": "2.0.0",
-      "sha256": "07cai4pd199wj58032cz3qmqi2zjnzl1an7s243m0lm0dkxgb623",
+      "version": "2.2.0",
+      "sha256": "08n25ybwmd5dwd8hl13pfnsni7m7l1irpijfryn649sgigg2nx96",
       "depends": ["GenomicRanges", "IRanges", "Rcpp", "circlize", "png", "polylabelr"]
     },
     "HilbertVis": {
       "name": "HilbertVis",
-      "version": "1.64.0",
-      "sha256": "0zljdf0q41dgkm0ysqs4l1k4v3h3qd2asf8p85xvkcf5axfciipz",
+      "version": "1.65.0",
+      "sha256": "145xvvf6y2q8h2rg10xy1fkfislydxdy1f1v2zjgsv09x2hmcpz9",
       "depends": ["lattice"]
     },
     "HilbertVisGUI": {
       "name": "HilbertVisGUI",
-      "version": "1.64.0",
-      "sha256": "1q96nzbdi3zgfclzzk8b8p68bb33g84h0v6hd7v75p8f2wsi5m24",
+      "version": "1.65.0",
+      "sha256": "0sfc3k9mgpgn262cm6dv6c48dd1yvr6k7dm3skdmbqagnnaqll16",
       "depends": ["HilbertVis"]
     },
     "HoloFoodR": {
       "name": "HoloFoodR",
-      "version": "1.0.0",
-      "sha256": "0civpc6r9prfx0gi5p7fz9nlphy3fgc0y4apnyz2sq29x6r6zyz1",
-      "depends": ["MultiAssayExperiment", "S4Vectors", "TreeSummarizedExperiment", "dplyr", "httr2", "jsonlite"]
+      "version": "1.2.0",
+      "sha256": "1siw3q0byd9vw892kg4rv40jp1d9v001gwfiwzlwn4vpni6hqrjg",
+      "depends": ["MultiAssayExperiment", "S4Vectors", "SummarizedExperiment", "TreeSummarizedExperiment", "dplyr", "httr2", "jsonlite"]
     },
     "HuBMAPR": {
       "name": "HuBMAPR",
-      "version": "1.0.8",
-      "sha256": "0sx885vjnj47ld5zk0sbabpw6pcbwrhjvaqxlfj5sjnvd42zzvcw",
+      "version": "1.2.0",
+      "sha256": "04m7i8q8j5krs1s4bsvc94m0hv3dqqysvi2l96bab8mwdx2xipdx",
       "depends": ["dplyr", "httr2", "purrr", "rjsoncons", "rlang", "stringr", "tibble", "tidyr", "whisker"]
     },
     "HubPub": {
       "name": "HubPub",
-      "version": "1.14.0",
-      "sha256": "0qwh71mg69q568sslpcczcsyldx7dffzprvyzmm6b46vd4mkzzwb",
+      "version": "1.16.0",
+      "sha256": "05w075lp72b0njkf13mvsfy2q1c35bljy9srcczd8f9kvh79n73s",
       "depends": ["BiocManager", "available", "aws_s3", "biocthis", "dplyr", "fs", "usethis"]
     },
     "HybridExpress": {
       "name": "HybridExpress",
-      "version": "1.2.0",
-      "sha256": "1glb2acxd0a703hn1455xnvm0i2pf3r39c5gg6qsmfsqrqd195r9",
+      "version": "1.4.0",
+      "sha256": "0d0519kb7sjhnfap93mhxlsfi4mah2s21p7g79bdaks419j8s4c2",
       "depends": ["BiocParallel", "ComplexHeatmap", "DESeq2", "RColorBrewer", "SummarizedExperiment", "ggplot2", "patchwork", "rlang"]
     },
     "HybridMTest": {
       "name": "HybridMTest",
-      "version": "1.50.0",
-      "sha256": "14i9pvs4fpiw6bv6lrj8v4sc4y848a566cn2ia3lpsfs0naf79gk",
+      "version": "1.52.0",
+      "sha256": "1qkzh25d79hmpa6fh9binc3bhsw4yd9h6sdbl5gnxl1nn1cm2rzw",
       "depends": ["Biobase", "MASS", "fdrtool", "survival"]
     },
     "IFAA": {
       "name": "IFAA",
-      "version": "1.8.0",
-      "sha256": "1s8l4hp38hk7psqpxn9sr5d3l93ivzzsad594ff2j28l9vl0pkz8",
+      "version": "1.10.0",
+      "sha256": "1hrd5mwbd6bqxvzgsa0g99vr5kzzsgpip08jbysir9dj99w8gr5j",
       "depends": ["DescTools", "HDCI", "Matrix", "MatrixExtra", "S4Vectors", "SummarizedExperiment", "doParallel", "doRNG", "foreach", "glmnet", "mathjaxr", "parallelly", "stringr"]
     },
     "IHW": {
       "name": "IHW",
-      "version": "1.34.0",
-      "sha256": "1dwzwv3y9shy2fxm8ni1ai0v86fh74g4fml6p4x38pwkbxcc6qn6",
+      "version": "1.36.0",
+      "sha256": "05qwdcx92ryih2919d7rikliwzy0ddsbf02bqfy1vwa4rgzxna1d",
       "depends": ["BiocGenerics", "fdrtool", "lpsymphony", "slam"]
     },
     "ILoReg": {
       "name": "ILoReg",
-      "version": "1.16.0",
-      "sha256": "1apwqrkja5z9ig0pmmi0kq4xx1m451h7s65h0kfd0a6i532bkhaa",
+      "version": "1.18.0",
+      "sha256": "0rpj6hhn3wl818q4sybl9q1yvsrb8fz1rngj1iyn9z1f0g244wq6",
       "depends": ["DescTools", "LiblineaR", "Matrix", "RSpectra", "Rtsne", "S4Vectors", "SingleCellExperiment", "SparseM", "SummarizedExperiment", "aricode", "cluster", "cowplot", "dendextend", "doRNG", "doSNOW", "dplyr", "fastcluster", "foreach", "ggplot2", "parallelDist", "pheatmap", "plyr", "reshape2", "scales", "umap"]
     },
     "IMAS": {
       "name": "IMAS",
-      "version": "1.30.0",
-      "sha256": "09zrk9cw1sydg4fjvpmlzw20ik42f0j60h1b70aacjs3mkcsfq90",
+      "version": "1.32.0",
+      "sha256": "1b1vy4mdnna15ckmh6n5jqz4bkyq4izm5zij71brg3b21214c0ja",
       "depends": ["AnnotationDbi", "BiocGenerics", "BiocParallel", "GenomeInfoDb", "GenomicAlignments", "GenomicFeatures", "GenomicRanges", "IRanges", "IVAS", "Matrix", "Rsamtools", "S4Vectors", "doParallel", "foreach", "ggfortify", "ggplot2", "gridExtra", "lattice", "lme4", "survival"]
     },
     "IMMAN": {
       "name": "IMMAN",
-      "version": "1.26.0",
-      "sha256": "0wmdhvy506f86qy179i8dqf41p47jfcvcaipdlgn2asjhhvnzywr",
+      "version": "1.28.0",
+      "sha256": "0n1y0ypkxa8bma3jqpds0hx16iyq8i42vaygx690qk5vll5gs6dh",
       "depends": ["STRINGdb", "igraph", "pwalign", "seqinr"]
     },
     "IMPCdata": {
       "name": "IMPCdata",
-      "version": "1.42.0",
-      "sha256": "15b1wmwpi5kp4hbvasnvlqdj89m7g153ynkphlza6g4arzyi6fxg",
+      "version": "1.44.0",
+      "sha256": "01vslnask0kslb17vxp48pp6wmm3y4lk12hi398r4ggzq6k56z1x",
       "depends": ["rjson"]
     },
     "INDEED": {
       "name": "INDEED",
-      "version": "2.20.0",
-      "sha256": "1654kzz5f7m0lh7rvhk1mbh0dglx11i0qsrpkdhzxr6m651i56x8",
+      "version": "2.22.0",
+      "sha256": "1dp0kdglk0ygnhmlqvfdwvlvzmc600dm22zxbgzpgg2m1qfx1alv",
       "depends": ["devtools", "glasso", "igraph", "visNetwork"]
     },
     "INPower": {
       "name": "INPower",
-      "version": "1.42.0",
-      "sha256": "1aq7pns8xihpwfaj5hrm7k8ljnqhfxc4sc0qcx4n7pqb7izhrpvl",
+      "version": "1.44.0",
+      "sha256": "0nadgph0mi9i830cmmlcih30v2xlxj53j8lgbysa9z358adk67cd",
       "depends": ["mvtnorm"]
     },
     "INSPEcT": {
       "name": "INSPEcT",
-      "version": "1.36.0",
-      "sha256": "1w5w5vcdf2i7dzss05z2h32fis9w3ivg1jixcviwsavk4k5bvwdb",
+      "version": "1.38.0",
+      "sha256": "0k67dmifjpy1csbrcyhibsdixppwwil62rczjxggwrqdskpph1zy",
       "depends": ["Biobase", "BiocGenerics", "BiocParallel", "DESeq2", "GenomeInfoDb", "GenomicAlignments", "GenomicFeatures", "GenomicRanges", "IRanges", "KernSmooth", "Rsamtools", "S4Vectors", "SummarizedExperiment", "TxDb_Mmusculus_UCSC_mm9_knownGene", "deSolve", "pROC", "plgem", "readxl", "rootSolve", "rtracklayer", "shiny"]
     },
     "INTACT": {
       "name": "INTACT",
-      "version": "1.6.0",
-      "sha256": "0xjakmai4iy6xnhw3jvy2c7bg8hvk4yr42kzix98h6jpcwsf9ks6",
+      "version": "1.8.0",
+      "sha256": "1n0chf0y5dkfnz54fy8rkvhchyk28jyqa3hjxj1ib9hk12zy1nzr",
       "depends": ["SQUAREM", "bdsmatrix", "ggplot2", "numDeriv", "tidyr"]
     },
     "IONiseR": {
       "name": "IONiseR",
-      "version": "2.30.0",
-      "sha256": "1jb540h8klzxywm9dndijx04fnvk0gih9kxi351l24fwk8vppiqb",
+      "version": "2.32.0",
+      "sha256": "1wbfgvckws9lya62dxys4rj140qjfz5kaxsj5292lq9r69j160rp",
       "depends": ["BiocGenerics", "BiocParallel", "Biostrings", "ShortRead", "XVector", "bit64", "dplyr", "ggplot2", "magrittr", "rhdf5", "stringr", "tibble", "tidyr"]
     },
     "IPO": {
       "name": "IPO",
-      "version": "1.32.0",
-      "sha256": "1429465ymnwh9ny8dzjmj6674yl8ki1d6sc7q660f13yd4v6s0qg",
+      "version": "1.34.0",
+      "sha256": "1lg4k3hrhmgvnqj6w0ic2hblmszllms53zn3dh9yxw445yry9c5h",
       "depends": ["BiocParallel", "CAMERA", "rsm", "xcms"]
     },
     "IRanges": {
       "name": "IRanges",
-      "version": "2.40.1",
-      "sha256": "1yn8j6n7w789ivcrmi670n4a861hnar1626hc4rmyx3g36pkpq4s",
+      "version": "2.42.0",
+      "sha256": "1z03nrhn0nk4aam0vdiw4r41b38ds29jzaprg335y70ijgp03fqa",
       "depends": ["BiocGenerics", "S4Vectors"]
     },
     "ISAnalytics": {
       "name": "ISAnalytics",
-      "version": "1.16.1",
-      "sha256": "1yigf51xmwr9481ag0xh7bcp5wkvxfjqv0w3sg8z7xnbkjb3zb57",
+      "version": "1.18.0",
+      "sha256": "0mwcjxvsnqygpj4z0c5ib2570ryhxwv8qivvjsgdnl8wlk16z8xm",
       "depends": ["DT", "bslib", "datamods", "dplyr", "forcats", "fs", "ggplot2", "ggrepel", "glue", "lifecycle", "lubridate", "purrr", "readr", "readxl", "rlang", "shiny", "shinyWidgets", "stringr", "tibble", "tidyr"]
     },
     "ISLET": {
       "name": "ISLET",
-      "version": "1.8.0",
-      "sha256": "0xx7qrv5mr7xj7az2fivi40vrhvzg7k7lqaq53fbpim9gq3yiq7z",
+      "version": "1.10.0",
+      "sha256": "128z6c6108jgcindgk8b43kralcpvshnkrqd1jw70ppgrhk0avgg",
       "depends": ["BiocGenerics", "BiocParallel", "Matrix", "SummarizedExperiment", "abind", "lme4", "nnls", "purrr"]
     },
     "ISoLDE": {
       "name": "ISoLDE",
-      "version": "1.34.0",
-      "sha256": "1zwm6klhyxbv7licrdk4n0ww96n8j9ww6xqdiwi75zkizv6lkhiv",
+      "version": "1.36.0",
+      "sha256": "00ij2bjm1hyc3rl38bi47ysysgvp087m79bkf7g205r2lbfjv2ks",
       "depends": []
     },
     "ITALICS": {
       "name": "ITALICS",
-      "version": "2.66.0",
-      "sha256": "1wvyqp0fji0hhshr4y1fwqjy6vlqgdrnj7is9glbvvjb9505rzp1",
+      "version": "2.68.0",
+      "sha256": "0hlqsqk6acjrzaqffrivaq4kd6zbr48a89wh1lwqbgxz20pc29dc",
       "depends": ["DBI", "GLAD", "ITALICSData", "affxparser", "oligo", "oligoClasses", "pd_mapping50k_xba240"]
     },
     "IVAS": {
       "name": "IVAS",
-      "version": "2.26.0",
-      "sha256": "0krbcq1spj5bagcjxc2vr4i3qc3c8376mpzndmg0f7kiyn272lzc",
+      "version": "2.28.0",
+      "sha256": "0xl2q1zd36cc8qf9c9yhlc4nah68crplkp2agkzqhlbr4gx22z8h",
       "depends": ["AnnotationDbi", "Biobase", "BiocGenerics", "BiocParallel", "GenomeInfoDb", "GenomicFeatures", "GenomicRanges", "IRanges", "Matrix", "S4Vectors", "doParallel", "foreach", "ggfortify", "ggplot2", "lme4"]
     },
     "IWTomics": {
       "name": "IWTomics",
-      "version": "1.30.0",
-      "sha256": "1r5qg0pk4qib8b56hvfz520wn23f84ynypvpji2anr5cvg353q7n",
+      "version": "1.32.0",
+      "sha256": "0ls0yb2iam95wq9kdgdl0fsyh541mf2ai584ybg1w1kpbrypjq6p",
       "depends": ["GenomicRanges", "IRanges", "KernSmooth", "S4Vectors", "fda", "gtable"]
     },
     "Icens": {
       "name": "Icens",
-      "version": "1.78.0",
-      "sha256": "0f07k20dg3hdwg4q67yg2n9q8carddz135g6p15admz2bmdx7lsy",
+      "version": "1.80.0",
+      "sha256": "125n4kd2b7fd4x198y70wyapab32wmxnf877cq1ngr9ryhlnnjl7",
       "depends": ["survival"]
     },
     "IdeoViz": {
       "name": "IdeoViz",
-      "version": "1.42.0",
-      "sha256": "0n4q519x6fndz68w7zd0naw7cdrricxsvd2cqwc6y05w11jk34f3",
+      "version": "1.44.0",
+      "sha256": "16zrlkhhbc9hmq0pg0fl8q6i6snfhizjrbv5yr1psbqm9p2wvjgh",
       "depends": ["Biobase", "GenomeInfoDb", "GenomicRanges", "IRanges", "RColorBrewer", "rtracklayer"]
     },
     "IgGeneUsage": {
       "name": "IgGeneUsage",
-      "version": "1.20.0",
-      "sha256": "1b3003yvzf89hqiqc5ikxw30mqr86xlvvb4djcypznyka2wqqw7g",
+      "version": "1.22.0",
+      "sha256": "1xfmgfxhxzxi061ff1ac6rfm9pm93mrhaw77ml1cqp5bfd5pr5f9",
       "depends": ["BH", "Rcpp", "RcppEigen", "RcppParallel", "StanHeaders", "SummarizedExperiment", "reshape2", "rstan", "rstantools", "tidyr"]
     },
     "InPAS": {
       "name": "InPAS",
-      "version": "2.14.1",
-      "sha256": "0xqw7aqbl86kg599m6pasy5w4jc8ma0za0ysbxh1iv10n5dka9ix",
+      "version": "2.16.0",
+      "sha256": "0q8klqci4sr39ijvahn9z1jsrc0szv1lc5c1nbrrbgcngw7w7kjb",
       "depends": ["AnnotationDbi", "BSgenome", "Biobase", "Biostrings", "GenomeInfoDb", "GenomicFeatures", "GenomicRanges", "IRanges", "RSQLite", "S4Vectors", "batchtools", "cleanUpdTSeq", "depmixS4", "dplyr", "flock", "future", "future_apply", "ggplot2", "limma", "magrittr", "parallelly", "plyranges", "preprocessCore", "readr", "reshape2"]
     },
     "InTAD": {
       "name": "InTAD",
-      "version": "1.26.0",
-      "sha256": "11k9gn3vziwwfvvcw9sslyrxxsb4qwczbb1nyz2z2j1kjsdbidx5",
+      "version": "1.28.0",
+      "sha256": "1mxqhrkd5f7l77n0dw5n305h0vg35izcfg2g3jd5grc140mcv003",
       "depends": ["Biobase", "BiocGenerics", "GenomicRanges", "IRanges", "MultiAssayExperiment", "S4Vectors", "SummarizedExperiment", "ggplot2", "ggpubr", "mclust", "qvalue", "rtracklayer"]
     },
     "Informeasure": {
       "name": "Informeasure",
-      "version": "1.16.0",
-      "sha256": "0nj9c73d8qahi9ha7vh2w9m1z0gxl98l2wjln9bw7k865qzplsw6",
+      "version": "1.18.0",
+      "sha256": "0yx57py6mnv6ndba69crvyig59367qipb7drzlnn227hvyyc1ms5",
       "depends": ["entropy"]
     },
     "IntEREst": {
       "name": "IntEREst",
-      "version": "1.30.1",
-      "sha256": "1f5icaq81jb1i7yjs5i0i1q92fh46i9dz7zm6ig94j8cfb0gqg4c",
+      "version": "1.32.0",
+      "sha256": "0mpx75idzghpscxsqf1hkpx5n5q99xrmnwzc4kdyxqm0bmg71q3r",
       "depends": ["BiocGenerics", "BiocParallel", "Biostrings", "DBI", "DESeq2", "DEXSeq", "GenomicAlignments", "GenomicFeatures", "GenomicFiles", "GenomicRanges", "IRanges", "RMariaDB", "Rsamtools", "S4Vectors", "SummarizedExperiment", "edgeR", "seqLogo", "seqinr", "txdbmaker"]
     },
     "InterCellar": {
       "name": "InterCellar",
-      "version": "2.12.0",
-      "sha256": "1js69rr7np1q5km8dl8bjzn8qpsvvis3x3rfhq3wx4kf7h1hkxxk",
+      "version": "2.14.0",
+      "sha256": "0mx7sygw3ixs2d3ixkj5wfkk7yznlp2hdz3rp7dzgii77n2spza4",
       "depends": ["ComplexHeatmap", "DT", "biomaRt", "circlize", "colorspace", "colourpicker", "config", "data_table", "dendextend", "dplyr", "factoextra", "fmsb", "fs", "ggplot2", "golem", "htmltools", "htmlwidgets", "igraph", "plotly", "plyr", "readxl", "rlang", "scales", "shiny", "shinyFeedback", "shinyFiles", "shinyalert", "shinycssloaders", "shinydashboard", "signal", "tibble", "tidyr", "umap", "visNetwork", "wordcloud2"]
     },
     "InteractionSet": {
       "name": "InteractionSet",
-      "version": "1.34.0",
-      "sha256": "15mvpd64hhgwc30m7ayd60bc1icmrgchpjp21dxpw2za5r4162kq",
+      "version": "1.36.0",
+      "sha256": "18y34s2hzrk432lkgv99lw9xkqsfj46lwzc230rfallqv48a7zmm",
       "depends": ["BiocGenerics", "GenomeInfoDb", "GenomicRanges", "IRanges", "Matrix", "Rcpp", "S4Vectors", "SummarizedExperiment"]
     },
     "InteractiveComplexHeatmap": {
       "name": "InteractiveComplexHeatmap",
-      "version": "1.14.0",
-      "sha256": "1pk8gmkpa9ppxa96a4k2iklx3n1x8s197hpg5xi5vpsbywq8ivh2",
+      "version": "1.16.0",
+      "sha256": "1xzi7x0p9x8him3wd8v1hy2v01hf8a5jpnxj69s27463jy33kqpf",
       "depends": ["ComplexHeatmap", "GetoptLong", "IRanges", "RColorBrewer", "S4Vectors", "clisymbols", "digest", "fontawesome", "htmltools", "jsonlite", "kableExtra", "shiny", "svglite"]
     },
     "IntramiRExploreR": {
       "name": "IntramiRExploreR",
-      "version": "1.28.0",
-      "sha256": "0dm47k0pkp01x8xchapww3jwgviawkdjvz8kg2ifb603ksr9ivh5",
+      "version": "1.30.0",
+      "sha256": "0d43lcc4cmcqh7m4ch6731w5cc61qzyf06lwqpldp0klaybb2gs3",
       "depends": ["FGNet", "igraph", "knitr"]
     },
     "IsoBayes": {
       "name": "IsoBayes",
-      "version": "1.4.0",
-      "sha256": "1rmqrv7gjx4v9qwrs8gbdxr71y4hybbc75x2drv9k4cgg8j2xqzs",
+      "version": "1.6.0",
+      "sha256": "1v4cjxwmq0qn7fa6wgzm7hizmk1cmd26wivdmyqshqlk31khbbk7",
       "depends": ["HDInterval", "Rcpp", "RcppArmadillo", "S4Vectors", "SummarizedExperiment", "data_table", "doParallel", "doRNG", "foreach", "ggplot2", "glue", "iterators"]
     },
     "IsoCorrectoR": {
       "name": "IsoCorrectoR",
-      "version": "1.24.0",
-      "sha256": "17hw6kphrb3cq7f9dclka8hvrwf3m2qmrndpr0i3la6kdgr7y8fx",
+      "version": "1.26.0",
+      "sha256": "129n4cl72dlk9wdjcxz635gfsag839ilgpxalp355s7p9i56fynd",
       "depends": ["WriteXLS", "dplyr", "magrittr", "pracma", "quadprog", "readr", "readxl", "stringr", "tibble"]
     },
     "IsoCorrectoRGUI": {
       "name": "IsoCorrectoRGUI",
-      "version": "1.22.0",
-      "sha256": "1aqrc1spr9ppwc6q7qzgciikd24fzj4nfwp6rh66p3cqbygp6dj3",
+      "version": "1.24.0",
+      "sha256": "19r4x578gjc9jx62l12nzprmwz17mm143xfcdlsgfcb9myb8r4dk",
       "depends": ["IsoCorrectoR", "readxl", "tcltk2"]
     },
     "IsoformSwitchAnalyzeR": {
       "name": "IsoformSwitchAnalyzeR",
-      "version": "2.6.0",
-      "sha256": "13vp30mgf0v604i4vxbklbq1fh0wwn15gk05dvm7lpf5zppaqvgd",
+      "version": "2.8.0",
+      "sha256": "156v2c8d3szhhpfra3jyczpw5wxv1lhfr4kyfzw3v1l965dci75q",
       "depends": ["BSgenome", "Biobase", "BiocGenerics", "BiocParallel", "Biostrings", "DBI", "DEXSeq", "GenomeInfoDb", "GenomicRanges", "IRanges", "RColorBrewer", "RCurl", "S4Vectors", "SummarizedExperiment", "VennDiagram", "XVector", "dplyr", "edgeR", "futile_logger", "ggplot2", "gridExtra", "limma", "magrittr", "pfamAnalyzeR", "plyr", "pwalign", "readr", "reshape2", "rtracklayer", "satuRn", "stringr", "sva", "tibble", "tidyr", "tximeta", "tximport"]
     },
     "KBoost": {
       "name": "KBoost",
-      "version": "1.14.0",
-      "sha256": "1vk6r4fkf54xnmf2hcaicy9vwdbi97n5kr45xx6w0f89d9n3mixg",
+      "version": "1.16.0",
+      "sha256": "1m352d1azcqsrjjrcz1s7c1bbqsdq8h8ak0p752ja8z6gcqhslf5",
       "depends": []
     },
     "KCsmart": {
       "name": "KCsmart",
-      "version": "2.64.0",
-      "sha256": "06frvvlkq8fp60kb2071kjnw6ln265gzzwsvnp02qwbxcp8axvh5",
+      "version": "2.66.0",
+      "sha256": "1ys7zpj87i21m7yg8afac85qmjrqqdlr6f7hys04zydpqzq3ldcv",
       "depends": ["BiocGenerics", "KernSmooth", "multtest", "siggenes"]
     },
     "KEGGREST": {
       "name": "KEGGREST",
-      "version": "1.46.0",
-      "sha256": "19jy6nl46krlspzyqgmyix0d53izrdy3yx69nlamzph4gwjf5m0f",
+      "version": "1.48.0",
+      "sha256": "10l2hbgjp96y6wz9v95c03m6kshpky4g34ycbvmhdd2xnmqrnq0f",
       "depends": ["Biostrings", "httr", "png"]
     },
     "KEGGgraph": {
       "name": "KEGGgraph",
-      "version": "1.66.0",
-      "sha256": "08xk85p76dbywsxw5w0ckw31m0raar5frkz14qwz4x88ilwhrw25",
+      "version": "1.68.0",
+      "sha256": "0cz2knpjhkq5b762gp4ahygd123ipdn1dlb4dkndd8n94gmfplyy",
       "depends": ["RCurl", "Rgraphviz", "XML", "graph"]
     },
     "KEGGlincs": {
       "name": "KEGGlincs",
-      "version": "1.32.0",
-      "sha256": "18jacz85kz05wrl4pjqrfjlfs9msrchmaid67v602zbnlvgiiqz6",
+      "version": "1.34.0",
+      "sha256": "1yl4vma9dsb2mw16r9n285chw3xgsjij1wmvd6msrspjc97cb37j",
       "depends": ["AnnotationDbi", "KEGGREST", "KEGGgraph", "KOdata", "RJSONIO", "XML", "gtools", "hgu133a_db", "httr", "igraph", "org_Hs_eg_db", "plyr"]
     },
     "KinSwingR": {
       "name": "KinSwingR",
-      "version": "1.24.0",
-      "sha256": "1w0l47p4dpcqx2abj0vinawb12v1zg3gsdgpg7rxjjgs268jd5xc",
+      "version": "1.26.0",
+      "sha256": "0izs400ylnhzlqq0ln2v0977yixvncfv90lp9q4cxdh6332k6b54",
       "depends": ["BiocParallel", "data_table", "sqldf"]
     },
     "KnowSeq": {
       "name": "KnowSeq",
-      "version": "1.20.0",
-      "sha256": "187jqsb1xy239ghlsrgdvlgsxwi9q3n4b9s427fk1kqlc7pfcngr",
+      "version": "1.22.0",
+      "sha256": "0k39fh0npnlj240y59wmzgg8fbfz7fkbafg5y2npjic68lqsp9pv",
       "depends": ["Hmisc", "R_utils", "XML", "caret", "cqn", "e1071", "edgeR", "ggplot2", "gridExtra", "httr", "jsonlite", "kernlab", "limma", "praznik", "randomForest", "reshape2", "rlist", "rmarkdown", "stringr", "sva"]
     },
     "LACE": {
       "name": "LACE",
-      "version": "2.10.0",
-      "sha256": "1x1h38qav4f5gndlq6xf9rcwsv5pjphcxz11jsykv2bg33fcqaj2",
+      "version": "2.12.0",
+      "sha256": "1f1d9k4mxkv17p2p00rrxh4nr6sxbpkp6s5jmsh17cb52japn4sj",
       "depends": ["DT", "Matrix", "RColorBrewer", "Rfast", "SummarizedExperiment", "biomaRt", "bsplus", "callr", "configr", "curl", "data_table", "data_tree", "doParallel", "dplyr", "forcats", "foreach", "fs", "ggplot2", "htmltools", "htmlwidgets", "igraph", "jsonlite", "logr", "purrr", "readr", "shiny", "shinyBS", "shinyFiles", "shinydashboard", "shinyjs", "shinythemes", "shinyvalidate", "sortable", "stringi", "stringr", "svglite", "tidyr"]
     },
     "LBE": {
       "name": "LBE",
-      "version": "1.74.0",
-      "sha256": "0hjgq630m4yy8pd4sm2s0nbxcm7y1rqg6kbggrk3hbiqbrzlq0ay",
+      "version": "1.76.0",
+      "sha256": "0r7xhzgmbm6jgsf95421gw8124g6j05kiv17c802a4k3dkdnp3ya",
       "depends": []
     },
     "LEA": {
       "name": "LEA",
-      "version": "3.18.0",
-      "sha256": "0ayc6gqw426ygdj6fsixqfyq8br3szz3ghmn85rq4bizdabnkjpg",
+      "version": "3.20.0",
+      "sha256": "0n8mk1vgjlvrqasx1nsivypz76r4zl2k9d470s6973dyawzh2xxs",
       "depends": []
     },
     "LOBSTAHS": {
       "name": "LOBSTAHS",
-      "version": "1.32.0",
-      "sha256": "1pwzfclnna5f1a6sdcradf08i5a562m68ghrd216r8c38x7lg55k",
+      "version": "1.33.0",
+      "sha256": "0wh2akkwkh88wfh8gg1n1zq3jgp0a9wgyv0c6fcr8z5zwprkach6",
       "depends": ["CAMERA", "xcms"]
     },
     "LOLA": {
       "name": "LOLA",
-      "version": "1.36.0",
-      "sha256": "0gxz27jvhw64i7r9acn5kj95s1hr8n5kajig6wi2pqxkmasiafk1",
+      "version": "1.38.0",
+      "sha256": "0k7fj7rv43df27n54v58d3j1jk1h1847klms1l63vhf32xlgdsnh",
       "depends": ["BiocGenerics", "GenomicRanges", "IRanges", "S4Vectors", "data_table", "reshape2"]
     },
     "LPE": {
       "name": "LPE",
-      "version": "1.80.0",
-      "sha256": "15bjkkb089kq9k9i7qmchs245lf1kgdpcilkym44fsviy08lqzlg",
+      "version": "1.82.0",
+      "sha256": "0r58af20b4mfwabm81rrkr55fzj7jwxhwmhj2lqz76h87jfwdfvh",
       "depends": []
     },
     "LRBaseDbi": {
       "name": "LRBaseDbi",
-      "version": "2.16.0",
-      "sha256": "0s2f2y2fzqz6fawc8rjpmiap5m9vzjwslvcgilb28cfzrz4azp6y",
+      "version": "2.17.0",
+      "sha256": "0lip3bfij0gzqmsnvzvw6nnpw7jv5qlvvvnm58wf4q7nxywabq7w",
       "depends": ["AnnotationDbi", "Biobase", "DBI", "RSQLite"]
     },
     "LRcell": {
       "name": "LRcell",
-      "version": "1.14.0",
-      "sha256": "0h8jl25kzy03igndb56ard1vngmpmyggcmhzw5m5chx11vz7548v",
+      "version": "1.16.0",
+      "sha256": "1jdkj1slrq37amnjaqb8c6swzcz0n857wwv82ac2lbi60a96dn7n",
       "depends": ["AnnotationHub", "BiocParallel", "ExperimentHub", "dplyr", "ggplot2", "ggrepel", "magrittr"]
     },
     "LedPred": {
       "name": "LedPred",
-      "version": "1.40.0",
-      "sha256": "0f8c69k9gmm1fak48xp3h2d4n6y71qgjff2ifmyfsl8k0y39jyb3",
+      "version": "1.42.0",
+      "sha256": "0v1f0y87wph6ycww1inz1wak2fvr28bas26sqvcc36wa0w5c6n7s",
       "depends": ["RCurl", "ROCR", "akima", "e1071", "ggplot2", "irr", "jsonlite", "plot3D", "plyr", "testthat"]
+    },
+    "Lheuristic": {
+      "name": "Lheuristic",
+      "version": "1.0.0",
+      "sha256": "1cxfzfdhhhzvaf2a0ky5vlibqvmv2wqwxlnj6pfgfb74hd26n005",
+      "depends": ["Hmisc", "MultiAssayExperiment", "energy", "ggplot2", "ggpubr"]
+    },
+    "LimROTS": {
+      "name": "LimROTS",
+      "version": "1.0.0",
+      "sha256": "1q8cznz9gngrd87raj76vs0daiiqcv7dy1x09dfykfa0zhxak8a1",
+      "depends": ["BiocParallel", "S4Vectors", "SummarizedExperiment", "basilisk_utils", "dplyr", "limma", "qvalue", "stringr"]
     },
     "LinTInd": {
       "name": "LinTInd",
-      "version": "1.10.0",
-      "sha256": "0yvfwwc81nf29wvdhpwzxbpd5wg3mdb30384pj9sx3hlbp8spnfn",
+      "version": "1.12.0",
+      "sha256": "0hk602dvj93j3nqplm8nrxy51xl59ynplif63w5scbvngnvhlc9y",
       "depends": ["BiocGenerics", "Biostrings", "IRanges", "S4Vectors", "ape", "cowplot", "data_tree", "dplyr", "ggnewscale", "ggplot2", "ggtree", "networkD3", "pheatmap", "purrr", "pwalign", "reshape2", "rlist", "stringdist", "stringr"]
     },
     "LinkHD": {
       "name": "LinkHD",
-      "version": "1.20.0",
-      "sha256": "15db7s91qxj3vfnidrss03fklnv9z8g960vny7jmh3k4jr70wkva",
+      "version": "1.22.0",
+      "sha256": "1389pp0i4ahbi4i370p0il9rwiqk9plxy2a7s1x0nsycnb0df63q",
       "depends": ["MultiAssayExperiment", "cluster", "data_table", "emmeans", "ggplot2", "ggpubr", "gridExtra", "reshape2", "rio", "scales", "vegan"]
     },
     "Linnorm": {
       "name": "Linnorm",
-      "version": "2.30.0",
-      "sha256": "03prx6qzkk5cdr83x4i3m2irjsm9ay31bz581ms0ji27y5l7c0wh",
+      "version": "2.32.0",
+      "sha256": "1qqiqk43ag6pgpf027p3w4cphcnx1l70h6pcvm1fh1pmjkr35859",
       "depends": ["MASS", "Rcpp", "RcppArmadillo", "Rtsne", "amap", "apcluster", "ellipse", "fastcluster", "fpc", "ggdendro", "ggplot2", "gmodels", "igraph", "limma", "mclust", "statmod", "vegan", "zoo"]
     },
     "LiquidAssociation": {
       "name": "LiquidAssociation",
-      "version": "1.60.0",
-      "sha256": "14l5z0wahdgirz0rxnbkgmhv636w57yp17z5gw220a7vk2w5v4lf",
+      "version": "1.62.0",
+      "sha256": "077fp1knsanjc1ijraakp60q6icyzgqx6hhqnysgbgg2i53ra7d3",
       "depends": ["Biobase", "geepack", "org_Sc_sgd_db", "yeastCC"]
     },
     "LoomExperiment": {
       "name": "LoomExperiment",
-      "version": "1.24.0",
-      "sha256": "17cxi4f4bc65finx24bd6z15zpy9w19fwyzbi27iia022f28m5ya",
+      "version": "1.26.0",
+      "sha256": "17jg7mqql1vr9hj4fiajf5ivmil04rjr8sf8sqliajhqh6mf6cbi",
       "depends": ["BiocIO", "DelayedArray", "GenomicRanges", "HDF5Array", "Matrix", "S4Vectors", "SingleCellExperiment", "SummarizedExperiment", "rhdf5", "stringr"]
     },
     "LymphoSeq": {
       "name": "LymphoSeq",
-      "version": "1.34.0",
-      "sha256": "0ss46q1y07p17qgfir4vklpmqsx4ywgaa99rsdn8b41pdgcwxvy2",
+      "version": "1.36.0",
+      "sha256": "0smb2fpixdxvf8rmvrzcpddqhf6q56qwxpkjq1432vlsxijmkhax",
       "depends": ["Biostrings", "LymphoSeqDB", "RColorBrewer", "UpSetR", "VennDiagram", "circlize", "data_table", "dplyr", "ggplot2", "ggtree", "ineq", "msa", "phangorn", "plyr", "reshape", "stringdist"]
     },
     "M3C": {
       "name": "M3C",
-      "version": "1.28.0",
-      "sha256": "11ll6ry20qmiciw2ma5rqbmggd9ahxddk24sh7mqxkrw1c1im760",
+      "version": "1.30.0",
+      "sha256": "159123f7357hi59b1pmb3r1ckbd63gkj8ax93s73jvi2jkhx6921",
       "depends": ["Matrix", "Rtsne", "cluster", "corpcor", "doParallel", "doSNOW", "foreach", "ggplot2", "matrixcalc", "umap"]
     },
     "M3Drop": {
       "name": "M3Drop",
-      "version": "1.32.0",
-      "sha256": "1wqlkshzlq724n5r4c7bqlhvjz80fn74dd8kw5r290z9qicqxx6x",
+      "version": "1.34.0",
+      "sha256": "0aa3imi6j0nq1yk7b8iivyflxs83h3fqrys9cmhpi0nn6p5wyj1s",
       "depends": ["Hmisc", "Matrix", "RColorBrewer", "bbmle", "gplots", "irlba", "matrixStats", "numDeriv", "reldist", "scater", "statmod"]
     },
     "MACSQuantifyR": {
       "name": "MACSQuantifyR",
-      "version": "1.20.0",
-      "sha256": "1nmbj1xqmrnr9ig1dc2l94signj1azkrq3madcciw2rkixr426lf",
+      "version": "1.22.0",
+      "sha256": "1xf8x90m4s334m6zgzyqqxbwpg46ly8d1m4d3pa49nnlq2a5i0b7",
       "depends": ["ggplot2", "ggrepel", "gridExtra", "lattice", "latticeExtra", "png", "prettydoc", "readxl", "rmarkdown", "rvest", "xml2"]
     },
     "MACSr": {
       "name": "MACSr",
-      "version": "1.14.0",
-      "sha256": "1g6ibxy2ffwq5gb9jh37mrql1aq7ap14spcrx0mrcb684rgvyi5x",
+      "version": "1.16.0",
+      "sha256": "1a9g40z16rwzq8aw0msgvjwqkxnjwpqm4m98n255vkw66fgdv08i",
       "depends": ["AnnotationHub", "ExperimentHub", "S4Vectors", "basilisk", "reticulate"]
     },
     "MADSEQ": {
       "name": "MADSEQ",
-      "version": "1.32.0",
-      "sha256": "14rxkzcz0q5h6f9inzl3chjk2jhph0y538k6pshgx54vw68rqzpm",
+      "version": "1.34.0",
+      "sha256": "1fir4xvhg9n33wzq0s5191k9z1ywj02g8khz1337hp137i2vn6jy",
       "depends": ["BSgenome", "BSgenome_Hsapiens_UCSC_hg19", "Biostrings", "GenomeInfoDb", "GenomicAlignments", "GenomicRanges", "IRanges", "Rsamtools", "S4Vectors", "SummarizedExperiment", "VGAM", "VariantAnnotation", "coda", "preprocessCore", "rjags", "rtracklayer", "vcfR", "zlibbioc"]
     },
     "MAGAR": {
       "name": "MAGAR",
-      "version": "1.14.0",
-      "sha256": "1hx5wxkld3fk4hw5k7bgfg1sykid0wxsplxv2dz5cjqa83ki4lvl",
+      "version": "1.16.0",
+      "sha256": "1m8q3xszwr2fw2wv1f4b0agxi8yk8n9dyq1fdil1480s22qc4yzn",
       "depends": ["HDF5Array", "RnBeads", "RnBeads_hg19", "RnBeads_hg38", "UpSetR", "argparse", "bigstatsr", "crlmm", "data_table", "doParallel", "ff", "igraph", "impute", "jsonlite", "plyr", "reshape2", "rjson", "snpStats"]
-    },
-    "MAGeCKFlute": {
-      "name": "MAGeCKFlute",
-      "version": "2.9.0",
-      "sha256": "1m2yq73q9wwv5kfybgnkdb877dy539x9vpx713pr6xjpkqvksfiv",
-      "depends": ["Biobase", "DOSE", "clusterProfiler", "depmap", "enrichplot", "ggplot2", "ggrepel", "gridExtra", "msigdbr", "pathview", "reshape2"]
     },
     "MAI": {
       "name": "MAI",
-      "version": "1.12.0",
-      "sha256": "0l1g08x75phw2cbn6d4yydp2j1ca037mdgc8vx93fng1yi9nk88j",
+      "version": "1.14.0",
+      "sha256": "1agndinb8dihfgp22x111vxg8y0lcm1ig7afi73czijjmdhwygj3",
       "depends": ["S4Vectors", "SummarizedExperiment", "caret", "doParallel", "e1071", "foreach", "future", "future_apply", "missForest", "pcaMethods", "tidyverse"]
     },
     "MAIT": {
       "name": "MAIT",
-      "version": "1.40.0",
-      "sha256": "1fq2wz12h115pgi7gc5qvz9c64qb863409x60kc2clzc0ddc8xfg",
+      "version": "1.42.0",
+      "sha256": "0rz7a8087pigsw4h1hm9cyd28ij6pqvyczgg7jiy4far0xsals52",
       "depends": ["CAMERA", "MASS", "Rcpp", "agricolae", "caret", "class", "e1071", "gplots", "pls", "plsgenomics", "xcms"]
     },
     "MANOR": {
       "name": "MANOR",
-      "version": "1.78.0",
-      "sha256": "0v99f4pkjgz5qjj68xsabfh5prgkz0fjlqn8yn7f1d4sv8cigq6l",
+      "version": "1.80.0",
+      "sha256": "1kyg0ar2hvk5cqn8jxbzypw9rvzpkb2qkim6rdjb3dc01jaach1p",
       "depends": ["GLAD"]
     },
     "MAPFX": {
       "name": "MAPFX",
-      "version": "1.2.0",
-      "sha256": "0cdmawbp6iz3wis4w848gcj3nvc598hyj1mycyw8gyifpfwg2yq7",
+      "version": "1.4.0",
+      "sha256": "077qqgd196spi064wj0hgj7xlhkv6qwas87gxip84fa9vj7rs35a",
       "depends": ["Biobase", "ComplexHeatmap", "RColorBrewer", "Rfast", "circlize", "cowplot", "e1071", "flowCore", "ggplot2", "glmnetUtils", "gtools", "iCellR", "igraph", "pbapply", "reshape2", "stringr", "uwot", "xgboost"]
     },
     "MAST": {
       "name": "MAST",
-      "version": "1.32.0",
-      "sha256": "0fn50b4yxsslgvw8l6zfbxr4bl8hd9rb7p3dggw040hfm8gadgl9",
+      "version": "1.33.0",
+      "sha256": "00rpm0w3cndza5dbiss7bmx6vpy1fqxw1rci44yap2m7z482xbjg",
       "depends": ["Biobase", "BiocGenerics", "Matrix", "S4Vectors", "SingleCellExperiment", "SummarizedExperiment", "abind", "data_table", "ggplot2", "plyr", "progress", "reshape2", "stringr"]
     },
     "MBASED": {
       "name": "MBASED",
-      "version": "1.40.0",
-      "sha256": "0073j8fc2fqj2wg89b1p4h9v9hi4lrmyi01bsvd69mgsa3g843ka",
+      "version": "1.42.0",
+      "sha256": "0nq3p1wam0ms69w01j7j0myvamvbv5dsyz7gwxh3vs7j00wz6i5l",
       "depends": ["BiocGenerics", "BiocParallel", "GenomicRanges", "RUnit", "SummarizedExperiment"]
     },
     "MBAmethyl": {
       "name": "MBAmethyl",
-      "version": "1.40.0",
-      "sha256": "1fq2g3gf0hbl9c4rl6j506i37a022wvsvhfq3l0r032p1p43wvdb",
+      "version": "1.42.0",
+      "sha256": "1dq44ks1pzx9950w6fjn1wjhbir99s0llr1z47xwxr90p5zm9h6p",
       "depends": []
     },
     "MBCB": {
       "name": "MBCB",
-      "version": "1.60.0",
-      "sha256": "0qyghk27d6qdj5xzgnh5k267h106cqq7287cmczbfgjjk3x63jn6",
+      "version": "1.62.0",
+      "sha256": "1z8y0hg4qybwazig81kmhvi2ii09afc4iaggjmmwaf3n1vfcpcr3",
       "depends": ["preprocessCore", "tcltk2"]
     },
     "MBECS": {
       "name": "MBECS",
-      "version": "1.10.0",
-      "sha256": "0b8apb9gybapl9dnc7h6f0kk4ra35wsypr9gr83hbjp85wwv8glc",
+      "version": "1.12.0",
+      "sha256": "01hjnbaxjzjrlygqajzjlahvdqbf42a8kisiqkk8a2vv93vg8xyj",
       "depends": ["Matrix", "cluster", "dplyr", "ggplot2", "gridExtra", "limma", "lme4", "lmerTest", "magrittr", "pheatmap", "phyloseq", "rmarkdown", "ruv", "sva", "tibble", "tidyr", "vegan"]
     },
     "MBQN": {
       "name": "MBQN",
-      "version": "2.18.0",
-      "sha256": "17wx2f25mk34j9wchl7ircpirdnq1d65vmlvjf86sjgdrcf1g9jk",
+      "version": "2.20.0",
+      "sha256": "1kfa4ahxszqazd9vqpwjsafn2x7bki2qh1mfsfi6b3ypqnzls9vs",
       "depends": ["BiocFileCache", "PairedData", "RCurl", "SummarizedExperiment", "ggplot2", "limma", "preprocessCore", "rappdirs", "rmarkdown", "xml2"]
     },
     "MBttest": {
       "name": "MBttest",
-      "version": "1.34.0",
-      "sha256": "1x13z9f4jjpi9fhwwz69jd4cbqbrw6fk2k8jdflix8l1xmpqkxab",
+      "version": "1.36.0",
+      "sha256": "06b3fidffqk92p48wicddngf6n4d361fpg2rblyg8d4655scpym5",
       "depends": ["gplots", "gtools"]
     },
     "MCbiclust": {
       "name": "MCbiclust",
-      "version": "1.30.0",
-      "sha256": "1i99yxbnr43mmwq1w1r3pjf0yzrzbcqs8yq247kw3pzyg02jr33q",
+      "version": "1.32.0",
+      "sha256": "1dhdwx3zxvjc14vzgapwd8640l6i410i0mhxlba31lrgn5x2qla4",
       "depends": ["AnnotationDbi", "BiocParallel", "GGally", "GO_db", "WGCNA", "cluster", "ggplot2", "org_Hs_eg_db", "scales"]
     },
     "MDTS": {
       "name": "MDTS",
-      "version": "1.26.0",
-      "sha256": "0rjz1jmfihvg1ymyws8p0mibpa1yg1nh9l7h65620xmmk172xgv2",
+      "version": "1.28.0",
+      "sha256": "192l91jg1z52zsix988s2jx9ijlyd6i60mzwxr38gvr1i21rpyxc",
       "depends": ["Biostrings", "DNAcopy", "GenomicAlignments", "GenomicRanges", "IRanges", "Rsamtools", "stringr"]
     },
     "MEAL": {
       "name": "MEAL",
-      "version": "1.36.0",
-      "sha256": "06wmhpa3xqff1fcb8v35ia7zgn0zwmb3spzl75fw0xxk37czv8li",
+      "version": "1.38.0",
+      "sha256": "1agl6fa6ib8ynb7gi3bl12djj2zh3ppyvq8nwsrcki9nb5dz95kr",
       "depends": ["Biobase", "BiocGenerics", "GenomicRanges", "Gviz", "IRanges", "MultiDataSet", "S4Vectors", "SmartSVA", "SummarizedExperiment", "ggplot2", "isva", "limma", "matrixStats", "minfi", "missMethyl", "permute", "vegan"]
     },
     "MEAT": {
       "name": "MEAT",
-      "version": "1.18.0",
-      "sha256": "0ia95li2xp1rf3c48gz5rjmds3r2sfrl0jpr3vqqj9mkrzxr7q84",
+      "version": "1.20.0",
+      "sha256": "1qn4pkljvddq171qpmd97c11xvvfk6nk3v5h0lg4vj8wh8f0ky0n",
       "depends": ["RPMM", "SummarizedExperiment", "dplyr", "dynamicTreeCut", "glmnet", "impute", "minfi", "stringr", "tibble", "wateRmelon"]
     },
     "MEB": {
       "name": "MEB",
-      "version": "1.20.0",
-      "sha256": "1b9rdbxwzkzxwpr0653q37wshhxfqhwllmciph06s0lzjinccxml",
+      "version": "1.22.0",
+      "sha256": "12dgmfqcxx387kbhq03a89rqfz04yjypyr5qqw5yhh4kss4jvnhd",
       "depends": ["SingleCellExperiment", "SummarizedExperiment", "e1071", "edgeR", "scater", "wrswoR"]
     },
     "MEDIPS": {
       "name": "MEDIPS",
-      "version": "1.58.0",
-      "sha256": "0jf572ripjnpksyjbpid26rw08529ybdjcz1sa33vxkarbgg2lgp",
+      "version": "1.60.0",
+      "sha256": "1rvwnsrdcj437zq7g6z05phw1yvwa0jycvqlgqw9q1yl59nyqfmz",
       "depends": ["BSgenome", "Biostrings", "DNAcopy", "GenomicRanges", "IRanges", "Rsamtools", "biomaRt", "edgeR", "gtools", "preprocessCore", "rtracklayer"]
     },
     "MEDME": {
       "name": "MEDME",
-      "version": "1.66.0",
-      "sha256": "0awv9p388lkgk9cwj2plnpw0nv7v6rf76isdz5iwwklvvrlykylx",
+      "version": "1.68.0",
+      "sha256": "14z92ds6s99v5ahvxi764hg1zzwdai0823vpv230c6vzsc9751af",
       "depends": ["Biostrings", "MASS", "drc"]
     },
     "MEIGOR": {
       "name": "MEIGOR",
-      "version": "1.40.0",
-      "sha256": "0chwp09cys757cb7xzqcixyslsdp5909c91m0a8c75b0ld8qsra8",
+      "version": "1.42.0",
+      "sha256": "1f9nw1w31w31xlgw5xhk07c1kdh8ihl8ri8l1i6pzkq1n7iv9xn9",
       "depends": ["CNORode", "Rsolnp", "deSolve", "snowfall"]
     },
     "MGFM": {
       "name": "MGFM",
-      "version": "1.40.0",
-      "sha256": "0fjhfpmhchx64hf3c1gwm2l15p12r7zfa5js1n5rj604pi2ibpmh",
+      "version": "1.42.0",
+      "sha256": "0y35ai43i85w4rfzlmdyfpskywi9w8nakxi04ra2g6mbnlnfxp8v",
       "depends": ["AnnotationDbi", "annotate"]
     },
     "MGFR": {
       "name": "MGFR",
-      "version": "1.32.0",
-      "sha256": "1ydgx34ixyzdlzz2ad8wb8srssqpzyi0vrh1xn5k3mqyz1s4zv4y",
+      "version": "1.34.0",
+      "sha256": "02d2m9yj5yq66b638jrwavpy2fsl41chh3gb13b4k0sca120bbxb",
       "depends": ["annotate", "biomaRt"]
     },
     "MGnifyR": {
       "name": "MGnifyR",
-      "version": "1.2.0",
-      "sha256": "0ka9zlx035v65zdi2q7hni3768vgihaa91kwdg2l2dpmqzgq6ngk",
+      "version": "1.4.0",
+      "sha256": "17h6zckhd2l11yzqzk0nq9v066dfhbaicnngvygg8f7mvmlrbppn",
       "depends": ["BiocGenerics", "MultiAssayExperiment", "S4Vectors", "SummarizedExperiment", "TreeSummarizedExperiment", "ape", "dplyr", "httr", "mia", "plyr", "reshape2", "tidyjson", "urltools"]
     },
     "MICSQTL": {
       "name": "MICSQTL",
-      "version": "1.4.0",
-      "sha256": "0xka43qw13b00g6rmbs0ilhz5alw4z1wx6d1kmfaga74wf103y5n",
+      "version": "1.6.0",
+      "sha256": "12ns11va32v6a41bqrksbs4mgppnv7zhlj6f911jxw952gghm406",
       "depends": ["BiocParallel", "S4Vectors", "SummarizedExperiment", "TCA", "TOAST", "dirmult", "ggplot2", "ggpubr", "ggridges", "glue", "magrittr", "nnls", "purrr"]
     },
     "MIRA": {
       "name": "MIRA",
-      "version": "1.28.0",
-      "sha256": "173nj8hmycrddjnbx2if1w04085sw4sxhkxs52k1ifhwza6iibp3",
+      "version": "1.30.0",
+      "sha256": "1dpp2fwnp9yj69dq6c9d2fsxlvx2pq1k47lgbcvhckzn2h2m8cwx",
       "depends": ["Biobase", "BiocGenerics", "GenomicRanges", "IRanges", "S4Vectors", "bsseq", "data_table", "ggplot2"]
     },
     "MIRit": {
       "name": "MIRit",
-      "version": "1.2.0",
-      "sha256": "11wwbm6qvg6gjngn3zk8lgmrfrgaycfmmlkzpka10w0k57xflhgv",
+      "version": "1.4.0",
+      "sha256": "110r2vmvm1xz6n61y83yi0pbxsdapgyn35pnr32mw7ykcjka50xz",
       "depends": ["AnnotationDbi", "BiocFileCache", "BiocParallel", "DESeq2", "MultiAssayExperiment", "Rcpp", "Rgraphviz", "edgeR", "fgsea", "genekitr", "geneset", "ggplot2", "ggpubr", "graph", "graphite", "httr", "limma", "rlang"]
     },
     "MLInterfaces": {
       "name": "MLInterfaces",
-      "version": "1.86.0",
-      "sha256": "1r00hcisp4i2q7nki9rkp753ms3g7biw9h9hxfwajfjqlwpb3l5y",
+      "version": "1.88.0",
+      "sha256": "0vv29pfd75l8h7m3d4lax2a5wmpgy2sfdkdgzlw72xwfvhjvd8m7",
       "depends": ["Biobase", "BiocGenerics", "MASS", "RColorBrewer", "Rcpp", "SummarizedExperiment", "annotate", "cluster", "fpc", "gbm", "gdata", "genefilter", "ggvis", "hwriter", "magrittr", "mlbench", "pls", "rpart", "sfsmisc", "shiny", "threejs"]
     },
     "MLP": {
       "name": "MLP",
-      "version": "1.54.0",
-      "sha256": "0sqk5cyffhwp1gpds4jxx06iypg3ygz2d7zrk8n4s8zx06q3x1ng",
+      "version": "1.56.0",
+      "sha256": "18vcin3m27b0yschk4c6p3ljgcv26jfvfnxvi95pdqms200ykq3m",
       "depends": ["AnnotationDbi", "gplots"]
     },
     "MLSeq": {
       "name": "MLSeq",
-      "version": "2.24.0",
-      "sha256": "0h293r553nvkwr3kpp5l3jfkxpr699fvfp39d1k37gw9w7rn2r4k",
+      "version": "2.26.0",
+      "sha256": "1b1bv4p1z4kpldzla3yn0c52g66fnkr0nn1043niljc4b53lkv80",
       "depends": ["Biobase", "DESeq2", "SummarizedExperiment", "VennDiagram", "caret", "edgeR", "foreach", "ggplot2", "limma", "pamr", "plyr", "sSeq", "testthat", "xtable"]
     },
     "MMDiff2": {
       "name": "MMDiff2",
-      "version": "1.34.0",
-      "sha256": "0n3a2ydxr36q02v6ndagm378zqa5sakz02zsk0d7z668wbjawn55",
+      "version": "1.36.0",
+      "sha256": "1fd8mzkmbxfs0px6vwi5zrzgaj23149mj4s2528p0dib6pakx1w3",
       "depends": ["BSgenome", "Biobase", "Biostrings", "GenomicRanges", "RColorBrewer", "Rsamtools", "S4Vectors", "ggplot2", "locfit", "shiny"]
     },
     "MMUPHin": {
       "name": "MMUPHin",
-      "version": "1.20.0",
-      "sha256": "1iws7vagj58x65shjy8xiaj9da752ahd2qmjn7wjydq578vbayza",
+      "version": "1.22.0",
+      "sha256": "0d8i9b6pjwz409jd46fm1n9h21hzg8zgzpvchywpyc1k896fvz4l",
       "depends": ["Maaslin2", "cowplot", "dplyr", "fpc", "ggplot2", "igraph", "metafor", "stringr", "tidyr"]
     },
     "MODA": {
       "name": "MODA",
-      "version": "1.32.0",
-      "sha256": "198rpf9zcid6ipzshcr0ip26apjznz4p8wmp5qycyv0sp9k2gcf8",
+      "version": "1.34.0",
+      "sha256": "1sgzwqh7445q1y6m1gslwhp14xqd2kqihdrmbjcw90ddbal0c249",
       "depends": ["AMOUNTAIN", "RColorBrewer", "WGCNA", "cluster", "dynamicTreeCut", "igraph"]
     },
     "MOFA2": {
       "name": "MOFA2",
-      "version": "1.16.0",
-      "sha256": "0m5xrphhlrzl16fg39m512rcmf0cnvjgw1pdmz43imyzh2339jrp",
+      "version": "1.18.0",
+      "sha256": "111i10ppnv8nkh7q2jhiz7w3r6iyw23a3pmmx8cnb1lhbl1p38lk",
       "depends": ["DelayedArray", "HDF5Array", "RColorBrewer", "Rtsne", "basilisk", "corrplot", "cowplot", "dplyr", "forcats", "ggplot2", "ggrepel", "magrittr", "pheatmap", "reshape2", "reticulate", "rhdf5", "stringi", "tidyr", "uwot"]
     },
     "MOGAMUN": {
       "name": "MOGAMUN",
-      "version": "1.16.0",
-      "sha256": "15khhn3bvcnncc7mb4zvyxg1w3a5j90ywwqhdpj1h329pgnlzyfq",
+      "version": "1.18.0",
+      "sha256": "00cfx9m0b14bbci2j07vzmfcfwj5mbjsh9dxrvgwdmafiw0vvmfl",
       "depends": ["BiocParallel", "RCy3", "RUnit", "igraph", "stringr"]
     },
     "MOMA": {
       "name": "MOMA",
-      "version": "1.18.0",
-      "sha256": "0af1yplxrbdgmr3vqjizy147gv5f9gl2frix51gj0i70h157wlgh",
+      "version": "1.20.0",
+      "sha256": "0fdhkb080hkwl7xzz3xmkfc21plhxji1mcnl8i6irdrl6azd1rcx",
       "depends": ["ComplexHeatmap", "MKmisc", "MultiAssayExperiment", "RColorBrewer", "circlize", "cluster", "dplyr", "ggplot2", "magrittr", "qvalue", "readr", "reshape2", "rlang", "stringr", "tibble", "tidyr"]
     },
     "MOSClip": {
       "name": "MOSClip",
-      "version": "1.0.0",
-      "sha256": "16fscjhv7v4wq5kgm0snmjdykn1qam3rd424l0m2c94f3l8l60xf",
+      "version": "1.1.0",
+      "sha256": "0pskd9wfg7vgjf1as7jm31v0gkhxl4rhzgbbdck9x175h7p4mhj8",
       "depends": ["AnnotationDbi", "ComplexHeatmap", "FactoMineR", "Matrix", "MultiAssayExperiment", "NbClust", "RColorBrewer", "S4Vectors", "SuperExactTest", "checkmate", "circlize", "corpcor", "coxrobust", "elasticnet", "gRbase", "ggplot2", "ggplotify", "graph", "graphite", "gridExtra", "igraph", "org_Hs_eg_db", "pheatmap", "qpgraph", "reshape", "survival", "survminer"]
     },
     "MOSim": {
       "name": "MOSim",
-      "version": "2.2.0",
-      "sha256": "114hmlbk3schfbm6zwczs59bn9hki9iid5ap55akjaxls1s0rsca",
+      "version": "2.4.0",
+      "sha256": "0fzk1zlhfxrmsw9lkl25zmaa9136kdj6mni4mgslik3ixkyg3w0x",
       "depends": ["HiddenMarkov", "IRanges", "Rcpp", "S4Vectors", "Seurat", "Signac", "cpp11", "dplyr", "edgeR", "ggplot2", "lazyeval", "matrixStats", "rlang", "scran", "stringi", "stringr", "zoo"]
     },
     "MPAC": {
       "name": "MPAC",
-      "version": "1.0.0",
-      "sha256": "0i6cmsxabmlsnp1z7ip2dk9w8q820n5b43jm8v7r0ckx70ii3b5h",
-      "depends": ["BiocParallel", "BiocSingular", "ComplexHeatmap", "S4Vectors", "SingleCellExperiment", "SummarizedExperiment", "bluster", "data_table", "fgsea", "fitdistrplus", "igraph", "scran"]
+      "version": "1.2.0",
+      "sha256": "1yjrfwrickyj92qixbmg9aya22vlpcxb7fyklx491c85a5kyha5b",
+      "depends": ["BiocParallel", "BiocSingular", "ComplexHeatmap", "S4Vectors", "SingleCellExperiment", "SummarizedExperiment", "bluster", "circlize", "data_table", "fgsea", "fitdistrplus", "ggplot2", "ggraph", "igraph", "scales", "scran", "stringr", "survival", "survminer", "viridis"]
     },
     "MPFE": {
       "name": "MPFE",
-      "version": "1.42.0",
-      "sha256": "0xvasm0fywkfdp8yq7vs35nkgjd2c2r5n472kbj1pw4wxbmbxaq3",
+      "version": "1.44.0",
+      "sha256": "0agif5jpqxids56m5a2866gw7ikk6w0x7yv05hy30ckjakx46fds",
       "depends": []
     },
     "MPRAnalyze": {
       "name": "MPRAnalyze",
-      "version": "1.24.0",
-      "sha256": "0xmhmkcd79f33wnkjlxx70b5n406phc46cpc9vwy2yxjjls7az7f",
+      "version": "1.26.0",
+      "sha256": "0zrjii1daf025544fpqvximl7imwpkijpnvm74yxdis2ip43y6c4",
       "depends": ["BiocParallel", "SummarizedExperiment", "progress"]
     },
     "MSA2dist": {
       "name": "MSA2dist",
-      "version": "1.10.1",
-      "sha256": "0wcnaappdikx7ma2g59k0wq299a1s2wkk50ck08jrc0ixnbr3jlf",
+      "version": "1.12.0",
+      "sha256": "0i5wq4882jjm16gyx0k0qzmrb7mlpk5nkfj6fnaazqbqs5nqssgw",
       "depends": ["Biostrings", "GenomicRanges", "IRanges", "Rcpp", "RcppThread", "ape", "doParallel", "dplyr", "foreach", "pwalign", "rlang", "seqinr", "stringi", "stringr", "tibble", "tidyr"]
     },
     "MSPrep": {
       "name": "MSPrep",
-      "version": "1.16.0",
-      "sha256": "0n10a75aj3f4pj7iw4dkzl24bywchfjrmsj37kj7ws3cwmhl6nna",
+      "version": "1.18.0",
+      "sha256": "0nxynjxddz4wj4lvgn223gz25r38lbpk3sh53gpgp7ncmjsvmpjm",
       "depends": ["S4Vectors", "SummarizedExperiment", "VIM", "crmn", "dplyr", "magrittr", "missForest", "pcaMethods", "preprocessCore", "rlang", "stringr", "sva", "tibble", "tidyr"]
     },
     "MSnID": {
       "name": "MSnID",
-      "version": "1.40.0",
-      "sha256": "1mdd7k71w8iiy9wkdaaq78y23547i7rcx5zn2rqzh09rgz68dnni",
+      "version": "1.42.0",
+      "sha256": "11w8x37pzhk0849152mdkl00bfacxrgbgrgzcca0qybd10vpfx5p",
       "depends": ["AnnotationDbi", "AnnotationHub", "Biobase", "BiocGenerics", "BiocStyle", "Biostrings", "MSnbase", "ProtGenerics", "RUnit", "R_cache", "Rcpp", "data_table", "doParallel", "dplyr", "foreach", "ggplot2", "iterators", "msmsTests", "mzID", "mzR", "purrr", "reshape2", "rlang", "stringr", "tibble", "xtable"]
     },
     "MSnbase": {
       "name": "MSnbase",
-      "version": "2.32.0",
-      "sha256": "0cykb5kk524i3ssps798c7wfpa3f8svdgxa8sfvc1pxm0fxypfgb",
+      "version": "2.34.0",
+      "sha256": "19n60bzbjhyn1bn79x6329c5389ycm6ai7ipvqrspz1azrwzfa9x",
       "depends": ["Biobase", "BiocGenerics", "BiocParallel", "IRanges", "MALDIquant", "MASS", "MsCoreUtils", "PSMatch", "ProtGenerics", "Rcpp", "S4Vectors", "affy", "digest", "ggplot2", "impute", "lattice", "mzID", "mzR", "pcaMethods", "plyr", "scales", "vsn"]
     },
     "MSstats": {
       "name": "MSstats",
-      "version": "4.14.1",
-      "sha256": "16gaiaipl5p2zf6f2yracsrkk8fhwnn0740lf0fgc6psrh9cr5r5",
+      "version": "4.16.0",
+      "sha256": "1jadszjnl6cz1zz95h25hhisvxcm2qp8plq8yqmjd9a87pldvxal",
       "depends": ["MASS", "MSstatsConvert", "Rcpp", "RcppArmadillo", "checkmate", "data_table", "ggplot2", "ggrepel", "gplots", "htmltools", "limma", "lme4", "marray", "plotly", "preprocessCore", "statmod", "survival"]
     },
     "MSstatsBig": {
       "name": "MSstatsBig",
-      "version": "1.4.0",
-      "sha256": "12x1nhq413wq6nd3c2y2iwbaii8kkxyn5pmnm8z0l4jabf0frdf5",
+      "version": "1.6.0",
+      "sha256": "0ry5pi8wy0ylncgcc9prmk57wka7z1vy7mzgqyflw4bqmcwa5mfz",
       "depends": ["DBI", "MSstats", "MSstatsConvert", "arrow", "dplyr", "readr", "sparklyr"]
+    },
+    "MSstatsBioNet": {
+      "name": "MSstatsBioNet",
+      "version": "1.0.0",
+      "sha256": "1gl7mx0x0jf90mmsggl8s6cp3r4g1agf6g2dzza9m0d8d05vzqzv",
+      "depends": ["MSstats", "RCy3", "httr", "jsonlite", "r2r", "tidyr"]
     },
     "MSstatsConvert": {
       "name": "MSstatsConvert",
-      "version": "1.16.1",
-      "sha256": "0rg721h3g68njkjz9rdfv99n5vslggiy96zc3grhbrlnq5x8ygzy",
+      "version": "1.18.0",
+      "sha256": "0hxmv5ngfkrsv5zib3jf68py333lk33mrmh3z21rb353qdkmks5n",
       "depends": ["checkmate", "data_table", "log4r", "stringi"]
     },
     "MSstatsLOBD": {
       "name": "MSstatsLOBD",
-      "version": "1.14.0",
-      "sha256": "11jxy1npwb3dswrkr4ynswwx6jpg58wz9b6scmp5zw9qyf17syng",
+      "version": "1.16.0",
+      "sha256": "0jyp7lrk2f99gmxv76s9pbp7npybm3ml7wd97mdms8vw82alk2p9",
       "depends": ["Rcpp", "ggplot2", "minpack_lm"]
     },
     "MSstatsLiP": {
       "name": "MSstatsLiP",
-      "version": "1.12.0",
-      "sha256": "1s72lnj2ghdc0zfvn7qkzwqj0vz2fl35dbmd52mqrbcgc02k4f7a",
+      "version": "1.13.0",
+      "sha256": "1b4j52mqkkk8mqjxkyrjp8qw9vw1qli4xgcmrizyrjhkzchl520r",
       "depends": ["Biostrings", "MSstats", "MSstatsConvert", "MSstatsPTM", "Rcpp", "checkmate", "data_table", "dplyr", "factoextra", "ggplot2", "ggpubr", "gridExtra", "purrr", "scales", "stringr", "tibble", "tidyr", "tidyverse"]
     },
     "MSstatsPTM": {
       "name": "MSstatsPTM",
-      "version": "2.8.1",
-      "sha256": "1fna3fww9np5hgc197a2ld14fcaavq1a5w46y9ff1kvl8miayjw7",
+      "version": "2.10.0",
+      "sha256": "148kh0i2ksqfykx0a8jwh7nz05403r6v61ihh63lrybr74vbdc9d",
       "depends": ["Biostrings", "MSstats", "MSstatsConvert", "MSstatsTMT", "Rcpp", "checkmate", "data_table", "dplyr", "ggplot2", "ggrepel", "gridExtra", "stringi", "stringr"]
     },
     "MSstatsQC": {
       "name": "MSstatsQC",
-      "version": "2.24.0",
-      "sha256": "1h9k8k7080396h05cd4k2h100jv69c1rkscacs77kh200z8nb95g",
+      "version": "2.26.0",
+      "sha256": "0xxzxpd889xfdjjyh3w19n4wpnhilp20b33jagyiphn7zjmhyiw3",
       "depends": ["MSnbase", "dplyr", "ggExtra", "ggplot2", "plotly", "qcmetrics"]
     },
     "MSstatsQCgui": {
       "name": "MSstatsQCgui",
-      "version": "1.26.0",
-      "sha256": "0hd2s8l4r52cpgc7apwhbzpnq14qjgvgkd2ykzrlvk71sq8vgwvk",
+      "version": "1.28.0",
+      "sha256": "0i1s7hl4xp4wzwgy05y4pa0arxpndagljchbd59jb15k30rlb170",
       "depends": ["MSstatsQC", "dplyr", "ggExtra", "gridExtra", "plotly", "shiny"]
     },
     "MSstatsShiny": {
       "name": "MSstatsShiny",
-      "version": "1.8.0",
-      "sha256": "1kklcz24v3xdbz9lqypw28dzjlcfhvdnq5c6nn983ay1cf12kk5h",
+      "version": "1.10.0",
+      "sha256": "01ia4rzzgminlr3gxvcv7g4y5lqa481d93rmr4iack9b0mmmjbiq",
       "depends": ["DT", "Hmisc", "MSstats", "MSstatsConvert", "MSstatsPTM", "MSstatsTMT", "data_table", "dplyr", "ggplot2", "ggrepel", "gplots", "htmltools", "marray", "mockery", "plotly", "readxl", "shiny", "shinyBS", "shinybusy", "shinyjs", "tidyr", "uuid"]
     },
     "MSstatsTMT": {
       "name": "MSstatsTMT",
-      "version": "2.14.1",
-      "sha256": "1snqp1swramsc6bmmsnkq33vndmrfdc61vqm2mslgsh61p49mnmm",
+      "version": "2.16.0",
+      "sha256": "023xi2xq2ga9y7m6s4xgv9paj31j35g0yvz9wb9vnln410309bv8",
       "depends": ["MSstats", "MSstatsConvert", "checkmate", "data_table", "ggplot2", "htmltools", "limma", "lme4", "lmerTest", "plotly"]
     },
     "MVCClass": {
       "name": "MVCClass",
-      "version": "1.80.0",
-      "sha256": "0y96dhsqg01vcr77p7p6z5449jrg9gypqdg5raspcvz90gxivc6x",
+      "version": "1.82.0",
+      "sha256": "0k2xxflf9dvpzbr6kp4m5599biq4pjlypsaas93xb5275wmmjvfr",
       "depends": []
     },
     "MWASTools": {
       "name": "MWASTools",
-      "version": "1.30.0",
-      "sha256": "1kv2pxhmn7lwd63al4qvgbwi2ffgf12cb55siwb62q6767b5gw77",
+      "version": "1.32.0",
+      "sha256": "1n7iyay8l3gpqqa83h1fyl3lm51j6d8gkijrhpnj0amplg32j3n2",
       "depends": ["ComplexHeatmap", "KEGGREST", "KEGGgraph", "RCurl", "SummarizedExperiment", "boot", "car", "ggplot2", "glm2", "gridExtra", "igraph", "ppcor", "qvalue"]
     },
     "Maaslin2": {
       "name": "Maaslin2",
-      "version": "1.20.0",
-      "sha256": "1k36dy33q3kggz226b7569fdcmybl5rdxk74xv1fm8qzbnyx0b6r",
+      "version": "1.22.0",
+      "sha256": "10hdjhi1ykk513hzvs0bi6avzghqmkqns8knhz3ycv7bj3ynp70x",
       "depends": ["MASS", "biglm", "car", "chemometrics", "cplm", "data_table", "dplyr", "edgeR", "ggplot2", "glmmTMB", "hash", "lme4", "lmerTest", "logging", "metagenomeSeq", "optparse", "pbapply", "pcaPP", "pheatmap", "pscl", "robustbase", "tibble", "vegan"]
     },
     "Macarron": {
       "name": "Macarron",
-      "version": "1.10.0",
-      "sha256": "1vmcjb2avjmni51n47srjzk5s3ybb7nsv7qs5lw64vp0p9pmsd4x",
+      "version": "1.12.0",
+      "sha256": "10wivwyka0jn1cc57fds85zz0ybl3q0sk9hi6dczwb4wdz8d1l6m",
       "depends": ["BiocParallel", "DelayedArray", "Maaslin2", "RJSONIO", "SummarizedExperiment", "WGCNA", "data_table", "dynamicTreeCut", "ff", "httr", "logging", "plyr", "psych", "xml2"]
     },
     "MantelCorr": {
       "name": "MantelCorr",
-      "version": "1.76.0",
-      "sha256": "0bwxwn3g2s8zyik1j8m0x47a7p3mzh9lb9a38afc6n01xcgsmx28",
+      "version": "1.78.0",
+      "sha256": "108sq7x47x4qwnzlypjak4wshja79hrd4njazp4fckfw8hd9ahsg",
       "depends": []
     },
     "MassArray": {
       "name": "MassArray",
-      "version": "1.58.0",
-      "sha256": "0z8xp1xiq2nns5hakg5ixx785v3j4asqi2br7y4hbddqw5bnf590",
+      "version": "1.60.0",
+      "sha256": "1hb3wpvbfiqxfvncxcqgxvb8g32zdsiryhp4zqmf47dq4k8xvz7z",
       "depends": []
     },
     "MassSpecWavelet": {
       "name": "MassSpecWavelet",
-      "version": "1.72.1",
-      "sha256": "0na7zqp2xblz4pjchsgwcabhci15pxnmnzlyr6yihlavf83b53cg",
+      "version": "1.74.0",
+      "sha256": "1g5d13057g7mn2m33gpchm71jb38fs2kc667hj7ry4yc14750ji8",
       "depends": []
     },
     "MatrixGenerics": {
       "name": "MatrixGenerics",
-      "version": "1.18.1",
-      "sha256": "1b66vv8nbvdf0zvapmkcn8hxbvh5d4pv12l1rpawijzp3xg7r7p9",
+      "version": "1.20.0",
+      "sha256": "1ys0239gzg3lq12g954b9zwhyqasbny2w1ra452kaj4pqc5p1dpl",
       "depends": ["matrixStats"]
     },
     "MatrixQCvis": {
       "name": "MatrixQCvis",
-      "version": "1.14.0",
-      "sha256": "1im4gg1is7nhqf34zqbcn7w5y48anaphy6p5n82qgmn4j81rkmqc",
+      "version": "1.16.0",
+      "sha256": "1c230z0bkyk5ga2lc4imzjrgbqsria5xqyvv4i4sihggb8iwmfwg",
       "depends": ["ComplexHeatmap", "DT", "ExperimentHub", "Hmisc", "MASS", "Rtsne", "SummarizedExperiment", "UpSetR", "dplyr", "ggplot2", "htmlwidgets", "impute", "imputeLCMD", "limma", "pcaMethods", "plotly", "proDA", "rlang", "rmarkdown", "shiny", "shinydashboard", "shinyhelper", "shinyjs", "sva", "tibble", "tidyr", "umap", "vsn"]
     },
     "MatrixRider": {
       "name": "MatrixRider",
-      "version": "1.38.0",
-      "sha256": "1lklc14jri0x8b3irm5rzs14ill6jdh3rs9230kmb38ylc38kpr5",
+      "version": "1.40.0",
+      "sha256": "0lmrfwfcymf3anc9x3d6lb5rchkip5wn4sjxpiv88rzvw1qhfql3",
       "depends": ["Biostrings", "IRanges", "S4Vectors", "TFBSTools", "XVector"]
     },
     "MeSHDbi": {
       "name": "MeSHDbi",
-      "version": "1.42.0",
-      "sha256": "0bzkpzjvlgapxnlsvbqqxhcwbxp7g4a98lwr7nv5jdx05j10fpng",
+      "version": "1.44.0",
+      "sha256": "11xcaj09yrc3ama11irpy65amgfj2x996ialjvxnf6vlz4dx5hb4",
       "depends": ["AnnotationDbi", "Biobase", "RSQLite"]
     },
     "MeasurementError_cor": {
       "name": "MeasurementError.cor",
-      "version": "1.78.0",
-      "sha256": "0wfi9a52vazl7zzp5rc47yar1yvmgp917pcq51zmrnvz90wvv1z4",
+      "version": "1.80.0",
+      "sha256": "10fj8lw7p86b4pm994i3g4b3djz74zwy4g42p74f6ld65ap141as",
       "depends": []
     },
     "Melissa": {
       "name": "Melissa",
-      "version": "1.22.0",
-      "sha256": "1jn8x6qch151h3iwx6w76ab8n7l9qnq4ccvf43bcsyy461ymr4n1",
+      "version": "1.24.0",
+      "sha256": "0y80p2jp4i7wsgqilaz1xkp573z97zxx0gwc7bg6d78bqsych11b",
       "depends": ["BPRMeth", "BiocStyle", "GenomicRanges", "MCMCpack", "ROCR", "assertthat", "cowplot", "data_table", "doParallel", "foreach", "ggplot2", "magrittr", "matrixcalc", "mclust", "mvtnorm", "truncnorm"]
     },
     "Mergeomics": {
       "name": "Mergeomics",
-      "version": "1.34.0",
-      "sha256": "0sg5wf2gm6sq9051mjsvlhnbbjbardypvw2nbn1wskdmkajy7afk",
+      "version": "1.36.0",
+      "sha256": "0v9dn19rx8q0vaysycv869al8krfv1s1xsi5rvkjw5f9nl7rlqph",
       "depends": []
     },
     "MesKit": {
       "name": "MesKit",
-      "version": "1.16.0",
-      "sha256": "1risccm9r8zlfx3zpzfmwhnarjc9903nmfd3bp9i2xp8iqxpws3r",
+      "version": "1.18.0",
+      "sha256": "1mq8gdnmw9hjz51pairm95hpxpbih6sk06xxk5z19bcwv10ykpf1",
       "depends": ["AnnotationDbi", "Biostrings", "ComplexHeatmap", "IRanges", "RColorBrewer", "S4Vectors", "ape", "circlize", "cowplot", "data_table", "dplyr", "ggplot2", "ggrepel", "ggridges", "mclust", "phangorn", "pracma", "tidyr"]
     },
     "MetCirc": {
       "name": "MetCirc",
-      "version": "1.36.0",
-      "sha256": "1zgn54ssxmn7k2bdvw02wwsj6bddfyzngk3zanmmjmmfm3il28yy",
+      "version": "1.38.0",
+      "sha256": "05jd5vdfsjmh4zg77l6apjggda0yfrywzjg0i8584gbvwy93jrfx",
       "depends": ["MsCoreUtils", "S4Vectors", "Spectra", "amap", "circlize", "ggplot2", "scales", "shiny"]
     },
     "MetID": {
       "name": "MetID",
-      "version": "1.24.0",
-      "sha256": "08ixkzhyqqkridjbms4x9f4ljmxbqidnb6habic24yjjb2qk1r8w",
+      "version": "1.26.0",
+      "sha256": "0sb67qwyyhzrqblrbgka07xh5wzf91cbnmhwjfca1959b09j44fw",
       "depends": ["ChemmineR", "Matrix", "devtools", "igraph", "stringr"]
     },
     "MetMashR": {
       "name": "MetMashR",
-      "version": "1.0.0",
-      "sha256": "1dj9x41ar7y8a7iyljwpi3a9gx46xgjzds6axih5cfimiq967d0k",
+      "version": "1.2.0",
+      "sha256": "1505j1jvmgnrxpbpkyh6am0baqmy312sc0fkg1dgzimq6pmwm170",
       "depends": ["cowplot", "dplyr", "ggplot2", "ggthemes", "httr", "rlang", "scales", "struct"]
     },
     "MetNet": {
       "name": "MetNet",
-      "version": "1.24.0",
-      "sha256": "0dga9gqqy5qg4y6xpsq8x9391h04x6ipyniji27br5dz0qqgwff5",
+      "version": "1.26.0",
+      "sha256": "0631i90sxw68m9xfraaasvcaz1861fpz3c2jhwv66190kg6qj889",
       "depends": ["BiocParallel", "GENIE3", "GeneNet", "S4Vectors", "SummarizedExperiment", "bnlearn", "corpcor", "dplyr", "ggplot2", "parmigene", "psych", "rlang", "stabs", "tibble", "tidyr"]
     },
     "MetaCyto": {
       "name": "MetaCyto",
-      "version": "1.28.0",
-      "sha256": "02nwni5z5gkcgfk5fnhkyjq9qpyirvz00jq251g6b2qbx8hn28i9",
+      "version": "1.30.0",
+      "sha256": "1whln405cwxzv0wa5vshjph64kga1l65sadqs2cxnvykdhfvrxyn",
       "depends": ["FlowSOM", "cluster", "fastcluster", "flowCore", "ggplot2", "metafor", "tidyr"]
     },
     "MetaNeighbor": {
       "name": "MetaNeighbor",
-      "version": "1.26.0",
-      "sha256": "1pmnxkf893zhvxyyihc10xfn18y742v82mxj538r6q3x08wp9gj8",
+      "version": "1.28.0",
+      "sha256": "0fb3zljwcdpwssflpvw387zjfck0r5lg33lysvvbcz0993il6q5g",
       "depends": ["Matrix", "RColorBrewer", "SingleCellExperiment", "SummarizedExperiment", "beanplot", "dplyr", "ggplot2", "gplots", "igraph", "matrixStats", "tibble", "tidyr"]
     },
     "MetaPhOR": {
       "name": "MetaPhOR",
-      "version": "1.8.0",
-      "sha256": "0jj9c4d2qdbz193gad89cay1h2hl0hbj70m1kakriw1117hnhzk6",
+      "version": "1.10.0",
+      "sha256": "0vwvxmzqpf9y16slqcm5rjg5bk1x48h0zf6acaa5z97hijya0v09",
       "depends": ["RCy3", "RecordLinkage", "clusterProfiler", "ggplot2", "ggrepel", "pheatmap", "stringr"]
     },
     "MetaboAnnotation": {
       "name": "MetaboAnnotation",
-      "version": "1.10.1",
-      "sha256": "0qzhl68viam5h1f3ky21m7092fwvfr7bjkzsbbfskn259pj9g5bc",
+      "version": "1.12.0",
+      "sha256": "0rdacrj5vdf0j2943biqkn0qbckrqa8ajl33b246pq55c8ndd76k",
       "depends": ["AnnotationHub", "BiocGenerics", "BiocParallel", "CompoundDb", "MetaboCoreUtils", "MsCoreUtils", "ProtGenerics", "QFeatures", "S4Vectors", "Spectra", "SummarizedExperiment"]
     },
     "MetaboCoreUtils": {
       "name": "MetaboCoreUtils",
-      "version": "1.14.0",
-      "sha256": "0gwghyc59cjp9arrwzm9j643a1nkl14mmcmadw55x7i9gyxvdils",
+      "version": "1.16.0",
+      "sha256": "1xx8jirj08b8f1f6y3i10gkh3i2n8anwd5r3d5jbzjm52cfasdy2",
       "depends": ["BiocParallel", "MsCoreUtils"]
+    },
+    "MetaboDynamics": {
+      "name": "MetaboDynamics",
+      "version": "1.0.0",
+      "sha256": "1llxv4295y78w6kwylm5vp6f0cbkvi2mzhzqm8z4lw1ad18ffyg0",
+      "depends": ["BH", "KEGGREST", "Rcpp", "RcppEigen", "RcppParallel", "S4Vectors", "StanHeaders", "SummarizedExperiment", "dendextend", "dplyr", "dynamicTreeCut", "ggplot2", "rstan", "rstantools", "stringr", "tidyr"]
     },
     "MetaboSignal": {
       "name": "MetaboSignal",
-      "version": "1.36.0",
-      "sha256": "1wgqyc2vjs7xakv03k0sgsqdnbwi08aqcf6f1qj50vcn72klf0vf",
+      "version": "1.38.0",
+      "sha256": "045l0n26qi9rng6rs1rvzd8nn34s5ssa9fhnzvkrdslkwvsdws8y",
       "depends": ["AnnotationDbi", "EnsDb_Hsapiens_v75", "KEGGREST", "KEGGgraph", "MWASTools", "RCurl", "biomaRt", "hpar", "igraph", "mygene", "org_Hs_eg_db"]
     },
     "MethPed": {
       "name": "MethPed",
-      "version": "1.34.0",
-      "sha256": "0bc5928i1jh9asn575gmqiykassilah94p78spfpr61yyzwgsw0f",
+      "version": "1.36.0",
+      "sha256": "0hvy4g3p1gx7jc5ff9xqy8ns3gv6b2jpiqw9c9skc8zv948z6z9f",
       "depends": ["Biobase", "randomForest"]
     },
     "MethReg": {
       "name": "MethReg",
-      "version": "1.16.0",
-      "sha256": "0aggc95l1lv2pck2p4vfj92lllkd6cgzqw18wy88zpm92qny8abl",
+      "version": "1.18.0",
+      "sha256": "0k3ji740r12kdjbrlrycjqw5z4ar106k6v18p68zqa1ppbcpmlsa",
       "depends": ["AnnotationHub", "DelayedArray", "ExperimentHub", "GenomicRanges", "IRanges", "JASPAR2024", "MASS", "Matrix", "RSQLite", "S4Vectors", "SummarizedExperiment", "TFBSTools", "dplyr", "ggplot2", "ggpubr", "openxlsx", "plyr", "progress", "pscl", "readr", "rlang", "sesame", "sesameData", "sfsmisc", "stringr", "tibble", "tidyr"]
     },
     "MethTargetedNGS": {
       "name": "MethTargetedNGS",
-      "version": "1.38.0",
-      "sha256": "0kj0ib0p9jql74d5jp0vyjs8cip728lac403pr93z0nbdlngmjyv",
+      "version": "1.40.0",
+      "sha256": "1n87jfs4pvhsr1qp1n1mnn9bibzm124ski7psq3gqrwkx7l9lwyz",
       "depends": ["Biostrings", "gplots", "pwalign", "seqinr", "stringr"]
     },
     "MethylAid": {
       "name": "MethylAid",
-      "version": "1.40.0",
-      "sha256": "0iq4ba4hsf7zwb063gqf00al031lydpg0yhlxwx8aczmyly00a9q",
+      "version": "1.42.0",
+      "sha256": "1y7i7xq2xblhbxsabwh8vhvmimf3s9jqs6q0vff94809rhmqaifj",
       "depends": ["Biobase", "BiocGenerics", "BiocParallel", "RColorBrewer", "SummarizedExperiment", "ggplot2", "gridBase", "hexbin", "matrixStats", "minfi", "shiny"]
     },
     "MethylMix": {
       "name": "MethylMix",
-      "version": "2.36.0",
-      "sha256": "0hkdn4930ic7cx16fixgi5bilv7plz910nv1skpjh2qi7xr95cnw",
+      "version": "2.38.0",
+      "sha256": "10nlklml75clsndjm07sbab4pwkp4qxdd3bh05mmmhjg375c7gdy",
       "depends": ["RColorBrewer", "RCurl", "RPMM", "R_matlab", "data_table", "digest", "foreach", "ggplot2", "impute", "limma"]
     },
     "MethylSeekR": {
       "name": "MethylSeekR",
-      "version": "1.46.0",
-      "sha256": "0lsm8ic5g0pbdlm0b7yldrzdpj4mx41cjsbssp35k9xywq2bvs2r",
+      "version": "1.47.0",
+      "sha256": "014kw18gj3mz635b0izhdf9iagax9d2qsp0a8df33jn6gb34g8yi",
       "depends": ["BSgenome", "GenomicRanges", "IRanges", "geneplotter", "mhsmm", "rtracklayer"]
     },
     "Mfuzz": {
       "name": "Mfuzz",
-      "version": "2.66.0",
-      "sha256": "1217hd20byymrldzydp3r9qmvssznzy1yggdsdm1hbcvrvrxmd4s",
+      "version": "2.68.0",
+      "sha256": "0642fgqba2jr0ldfmngrn4nsdqd1qmsfalwbykgzpf5daq9bgrxv",
       "depends": ["Biobase", "e1071", "tkWidgets"]
     },
     "MiChip": {
       "name": "MiChip",
-      "version": "1.60.0",
-      "sha256": "0xy1by5famnxbznplpma4bvp8fkn6a4fq4jj2359q8198vxrr4af",
+      "version": "1.62.0",
+      "sha256": "18wdspm6g8aj7gryha1sxda47yaq5prhr4099m0f9all6i3zkxx9",
       "depends": ["Biobase"]
     },
     "MiPP": {
       "name": "MiPP",
-      "version": "1.78.0",
-      "sha256": "1r6cz4nz7xsmr1cylnsxzx0qdpmj3jzqlaypj33qfaz8vcpnaakj",
+      "version": "1.80.0",
+      "sha256": "1z6giz0m2ri6iy9p5rcpjalnzl3j6aqiqhf5giy29shhyqnw4zmk",
       "depends": ["Biobase", "MASS", "e1071"]
     },
     "MiRaGE": {
       "name": "MiRaGE",
-      "version": "1.48.0",
-      "sha256": "00byplqc0bfgl4d0597z0as4p5k56xnxvydkvxx90gng6ikgl71m",
+      "version": "1.50.0",
+      "sha256": "07qv210jk2wv83rc2fc3p9vk1lljyrl2hp6lpk7vx2g1x62qnvbx",
       "depends": ["AnnotationDbi", "Biobase", "BiocGenerics", "BiocManager", "S4Vectors"]
     },
     "MicrobiomeProfiler": {
       "name": "MicrobiomeProfiler",
-      "version": "1.12.0",
-      "sha256": "0ibs1m9lhp59wxr75n8w9q313kk2aggcnch6xx7kp5ljmxmpsrmd",
+      "version": "1.14.0",
+      "sha256": "183shj5jdxpmb4gihwilfi5k63bl162svazn5xlkhyz4lgp7lrfc",
       "depends": ["DT", "clusterProfiler", "config", "enrichplot", "ggplot2", "golem", "gson", "htmltools", "magrittr", "shiny", "shinyWidgets", "shinycustomloader", "yulab_utils"]
     },
     "MicrobiotaProcess": {
       "name": "MicrobiotaProcess",
-      "version": "1.18.0",
-      "sha256": "0k12q5m8z6xfgnadkj4ckqgqai56i4wzz8gz1cd4yfqv8hcfdwwm",
+      "version": "1.20.0",
+      "sha256": "0y50fnm3d3y2amzf8bq6wgmwzzqw10l0ffarkyk4gy80mqdbr26b",
       "depends": ["Biostrings", "MASS", "SummarizedExperiment", "ape", "cli", "coin", "data_table", "dplyr", "dtplyr", "foreach", "ggfun", "ggplot2", "ggrepel", "ggsignif", "ggstar", "ggtree", "ggtreeExtra", "magrittr", "patchwork", "pillar", "plyr", "rlang", "tibble", "tidyr", "tidyselect", "tidytree", "treeio", "vegan", "zoo"]
     },
     "MineICA": {
       "name": "MineICA",
-      "version": "1.46.0",
-      "sha256": "0piyklqddp5wqqv7yx47195827w61x9p0gzdyxlg6a322iv42sn7",
+      "version": "1.48.0",
+      "sha256": "1kcaj2gmm7m4cm5w6rik0dsqscf9sph3adxmk9hd00cmpav78vxb",
       "depends": ["AnnotationDbi", "Biobase", "BiocGenerics", "GOstats", "Hmisc", "JADE", "RColorBrewer", "Rgraphviz", "annotate", "biomaRt", "cluster", "colorspace", "fastICA", "foreach", "fpc", "ggplot2", "graph", "gtools", "igraph", "lumi", "lumiHumanAll_db", "marray", "mclust", "plyr", "scales", "xtable"]
     },
     "MinimumDistance": {
       "name": "MinimumDistance",
-      "version": "1.50.0",
-      "sha256": "0c80yrqg1l2iyfm50rhczbnlvy77psd4mzrx16xhyd65slb6mj2v",
+      "version": "1.52.0",
+      "sha256": "1sli0kfajji1skmps9i01mcbn6ajw8wlc5j8ah92csyr6j1j7g0f",
       "depends": ["Biobase", "BiocGenerics", "DNAcopy", "GenomeInfoDb", "GenomicRanges", "IRanges", "MatrixGenerics", "S4Vectors", "SummarizedExperiment", "VanillaICE", "data_table", "ff", "foreach", "lattice", "matrixStats", "oligoClasses"]
     },
     "ModCon": {
       "name": "ModCon",
-      "version": "1.14.0",
-      "sha256": "1iq1b68cz9fkwba0nbm464n7x9zzi90vvcskm95rinmm4mbzif7f",
+      "version": "1.16.0",
+      "sha256": "0gz3gb0ljj2gvpgchr6v0lspx0ylfqbsw35s9pxry7qwwzybarx2",
       "depends": ["data_table"]
     },
     "Modstrings": {
       "name": "Modstrings",
-      "version": "1.22.0",
-      "sha256": "1jffh3ril1lwggfva8k319mang0i75xrk6fkp0xk6kp1979qpyxz",
+      "version": "1.24.0",
+      "sha256": "15cqi11y7vwv3w8mzirrv4sn3mb6h18mfmjflbayvs0wk1ngnwwq",
       "depends": ["BiocGenerics", "Biostrings", "GenomicRanges", "IRanges", "S4Vectors", "XVector", "crayon", "stringi", "stringr"]
     },
     "MoleculeExperiment": {
       "name": "MoleculeExperiment",
-      "version": "1.6.0",
-      "sha256": "07xys5p57k91mfxh1a2wcy5lj1c7v6k0wniqnk6v0sj8fmvkrf6z",
+      "version": "1.8.0",
+      "sha256": "0x7960yn8qbrlf4rqjs8lqhnn8x5ricqm4lrypcn2a2yla9sbyf3",
       "depends": ["BiocParallel", "EBImage", "Matrix", "S4Vectors", "SpatialExperiment", "cli", "data_table", "dplyr", "ggplot2", "magrittr", "purrr", "rhdf5", "rjson", "rlang", "terra"]
     },
     "Moonlight2R": {
       "name": "Moonlight2R",
-      "version": "1.4.0",
-      "sha256": "01na4bl43h0hxwhajsaaqzjr7hqxcf7rxix8xkm6mlwq987k1n47",
-      "depends": ["AnnotationHub", "Biobase", "BiocGenerics", "ComplexHeatmap", "DOSE", "EpiMix", "ExperimentHub", "GEOquery", "GenomicRanges", "HiveR", "RColorBrewer", "RISmed", "circlize", "clusterProfiler", "doParallel", "dplyr", "easyPubMed", "foreach", "fuzzyjoin", "ggplot2", "gplots", "magrittr", "org_Hs_eg_db", "parmigene", "purrr", "qpdf", "randomForest", "readr", "rtracklayer", "seqminer", "stringr", "tibble", "tidyHeatmap", "tidyr"]
+      "version": "1.6.0",
+      "sha256": "1rjldg6kh3iy5sbmj75j0n80hbl75capxv2yrqhabpm608gcax1d",
+      "depends": ["AnnotationHub", "Biobase", "BiocGenerics", "ComplexHeatmap", "DOSE", "EpiMix", "ExperimentHub", "GEOquery", "GenomicRanges", "HiveR", "RColorBrewer", "RISmed", "circlize", "clusterProfiler", "data_table", "doParallel", "dplyr", "easyPubMed", "foreach", "fuzzyjoin", "ggplot2", "gplots", "magrittr", "org_Hs_eg_db", "parmigene", "purrr", "qpdf", "randomForest", "readr", "rlang", "rtracklayer", "seqminer", "stringr", "tibble", "tidyHeatmap", "tidyr", "withr"]
     },
     "MoonlightR": {
       "name": "MoonlightR",
-      "version": "1.32.0",
-      "sha256": "1rva7ggqb2n303lc9kz3a94qxjxjcp2g597lb2zaqwwnclc2i2y9",
+      "version": "1.34.0",
+      "sha256": "0hkq4821cg5ks49qqi256dnmys2yl9c660qhbidhq2h7ja3m8smi",
       "depends": ["Biobase", "DOSE", "GEOquery", "HiveR", "RColorBrewer", "RISmed", "SummarizedExperiment", "TCGAbiolinks", "circlize", "clusterProfiler", "doParallel", "foreach", "gplots", "limma", "parmigene", "randomForest"]
     },
     "Motif2Site": {
       "name": "Motif2Site",
-      "version": "1.10.0",
-      "sha256": "1c88m338j6gh2lvdpx3n2s2sx42qka5j6bxdhh46dcbgb09f6kf4",
+      "version": "1.12.0",
+      "sha256": "102qbjvv9bf0r6j26didxai0zv6aw5lzd8sh81khw9qbdbc9342w",
       "depends": ["BSgenome", "BiocGenerics", "Biostrings", "GenomeInfoDb", "GenomicAlignments", "GenomicRanges", "IRanges", "MASS", "S4Vectors", "edgeR", "mixtools"]
     },
     "MotifDb": {
       "name": "MotifDb",
-      "version": "1.48.0",
-      "sha256": "0bgq927ch7b79sypr5fxgw6d2y5q0srny2k2ysxsyhcbagpl42b8",
+      "version": "1.50.0",
+      "sha256": "1i7ih5g6wc7d2phqgjcj97y21w59d78qz22ik0sxcv4nw1zhg826",
       "depends": ["BiocGenerics", "Biostrings", "GenomicRanges", "IRanges", "S4Vectors", "rtracklayer", "splitstackshape"]
+    },
+    "MotifPeeker": {
+      "name": "MotifPeeker",
+      "version": "1.0.0",
+      "sha256": "1rhmb7b28y96zdh9cxnh2c8qr7y0v05lxj9lil7cphlv2vdx3vfp",
+      "depends": ["BSgenome", "BiocFileCache", "BiocParallel", "Biostrings", "DT", "GenomeInfoDb", "GenomicAlignments", "GenomicRanges", "IRanges", "Rsamtools", "S4Vectors", "SummarizedExperiment", "dplyr", "ggplot2", "heatmaply", "htmltools", "htmlwidgets", "memes", "plotly", "purrr", "rmarkdown", "rtracklayer", "tidyr", "universalmotif", "viridis"]
     },
     "MouseFM": {
       "name": "MouseFM",
-      "version": "1.16.0",
-      "sha256": "1i2rrd51757pdggx1ffv3rnv2d1z142ys4fbxl3vciy5i3rmgh4g",
+      "version": "1.18.0",
+      "sha256": "0v3dr3jlihqpx50nfy0qm8gjkwg9lqikpwmkaj2qwa55k73iilml",
       "depends": ["GenomeInfoDb", "GenomicRanges", "IRanges", "biomaRt", "curl", "data_table", "dplyr", "ggplot2", "gtools", "httr", "jsonlite", "reshape2", "rlist", "scales", "tidyr"]
     },
     "MsBackendMassbank": {
       "name": "MsBackendMassbank",
-      "version": "1.14.0",
-      "sha256": "001xnr19pg38g5cm4jxqbrwv135lyzhrhfdkbfwmq89imcw8inm4",
+      "version": "1.16.0",
+      "sha256": "1xnnlf893gq9bsv1x0ckq0qvmykb42lhrp2k1dp2d90p2va5ksnx",
       "depends": ["BiocParallel", "DBI", "IRanges", "MsCoreUtils", "ProtGenerics", "S4Vectors", "Spectra"]
     },
     "MsBackendMetaboLights": {
       "name": "MsBackendMetaboLights",
-      "version": "1.0.0",
-      "sha256": "03np0c0b8hhv8axzcnxf3pxlbjvcxar7wyfj2jayrg8lzssv9q1n",
-      "depends": ["BiocFileCache", "ProtGenerics", "S4Vectors", "Spectra", "curl"]
+      "version": "1.2.0",
+      "sha256": "1drirfjdfc026a7v0ll09cbiwjyxb088vm08mclvg5jk4hm5agq7",
+      "depends": ["BiocFileCache", "ProtGenerics", "S4Vectors", "Spectra", "curl", "progress"]
     },
     "MsBackendMgf": {
       "name": "MsBackendMgf",
-      "version": "1.14.0",
-      "sha256": "0hr70d8kc27xfgvad23fyfkfh5mvld8z2xw8b2165b9f6gbwkrsi",
+      "version": "1.16.0",
+      "sha256": "0rwl5kmnvg31q7dgs2r5gkwwyn6n3yqcwxqcz4kc0yar85kgvmds",
       "depends": ["BiocParallel", "IRanges", "MsCoreUtils", "ProtGenerics", "S4Vectors", "Spectra"]
     },
     "MsBackendMsp": {
       "name": "MsBackendMsp",
-      "version": "1.10.0",
-      "sha256": "0d6v4i55k34hnvv71lb1s4yj13ssfjwlkpwk27xxwzpm5i6n4frd",
+      "version": "1.12.0",
+      "sha256": "0c9f0ghkmh1xhbs2bfyn7ydwgwbpjwdrawcyixydwl00k9nma2h5",
       "depends": ["BiocParallel", "IRanges", "MsCoreUtils", "ProtGenerics", "S4Vectors", "Spectra"]
     },
     "MsBackendRawFileReader": {
       "name": "MsBackendRawFileReader",
-      "version": "1.12.0",
-      "sha256": "06j1m0amjksxr52j46bmyiakj208jn8c1alf1k3xgsnacm5mrd94",
+      "version": "1.14.0",
+      "sha256": "1783c06bx4fvz50c5x6c5wjd2427crlyq61jcgjz8x712d1ji7iq",
       "depends": ["BiocParallel", "IRanges", "MsCoreUtils", "ProtGenerics", "S4Vectors", "Spectra", "rawrr"]
     },
     "MsBackendSql": {
       "name": "MsBackendSql",
-      "version": "1.6.0",
-      "sha256": "0hs4nh3bij5jzscdjjfkq2agcpysyy7ziv40713z7p7ai6wkppyj",
-      "depends": ["BiocGenerics", "BiocParallel", "DBI", "IRanges", "MsCoreUtils", "ProtGenerics", "S4Vectors", "Spectra", "data_table", "progress"]
+      "version": "1.8.0",
+      "sha256": "0ca8l2h7w7hhrnacd37b4bmqd3lmr01l08j3df78b0yf5fgbimb6",
+      "depends": ["BiocGenerics", "BiocParallel", "DBI", "IRanges", "MsCoreUtils", "ProtGenerics", "S4Vectors", "Spectra", "data_table", "fastmatch", "progress", "stringi"]
     },
     "MsCoreUtils": {
       "name": "MsCoreUtils",
-      "version": "1.18.0",
-      "sha256": "0d1n5mib93rw4x4iimz7scgxw1929m7g3cnbyfrj6iqxrp721an1",
+      "version": "1.20.0",
+      "sha256": "0xlnlgqmg8mzha8g6a6zhy735ia3dmnrrsyvlgv62n6bspcrh1g4",
       "depends": ["MASS", "Rcpp", "S4Vectors", "clue"]
     },
     "MsDataHub": {
       "name": "MsDataHub",
-      "version": "1.6.0",
-      "sha256": "0cs37d0ba56mcig9gydx37gbgqfsqdgnawkcw18i06cladghprmw",
+      "version": "1.8.0",
+      "sha256": "0b96yw687i3b0g00aaah2r2968iqashif4sd4a51nrzrf1vmpfsa",
       "depends": ["ExperimentHub"]
     },
     "MsExperiment": {
       "name": "MsExperiment",
-      "version": "1.8.0",
-      "sha256": "15vxwvgimliyzj0rb06s7rpm3wrz3gc1n0wdgs0jd4flwp152g9h",
+      "version": "1.10.0",
+      "sha256": "0wwwm4b1yp1d8ppzyricqa3859macffi8ncddmfaipiziglcc7l4",
       "depends": ["BiocGenerics", "DBI", "IRanges", "ProtGenerics", "QFeatures", "S4Vectors", "Spectra", "SummarizedExperiment"]
     },
     "MsFeatures": {
       "name": "MsFeatures",
-      "version": "1.14.0",
-      "sha256": "15bligvlwhdrzmw842a4kgnzciibh8ab3aw7m73l6zaqdn4isl02",
+      "version": "1.16.0",
+      "sha256": "12hvv8pgahknhc4y1lkvrmgw1yr5v5j32nwad6pigi3c094pnir2",
       "depends": ["MsCoreUtils", "ProtGenerics", "SummarizedExperiment"]
     },
     "MsQuality": {
       "name": "MsQuality",
-      "version": "1.6.2",
-      "sha256": "0cqsfydxz53ppqlq8nmqspxcg52jj0d01anw1r8m8f1fxxfghln4",
+      "version": "1.8.0",
+      "sha256": "071zkcpjc189rfxdnq7qyjb34x6ap5ln1vji9sl3fbgw62zl0v00",
       "depends": ["BiocParallel", "MsExperiment", "ProtGenerics", "Spectra", "ggplot2", "htmlwidgets", "msdata", "plotly", "rlang", "rmzqc", "shiny", "shinydashboard", "stringr", "tibble", "tidyr"]
     },
     "MuData": {
       "name": "MuData",
-      "version": "1.10.0",
-      "sha256": "0pppxgmplp7qf6flhzf27i58xajglcbhxabbf1y3bs60fsgbyw43",
+      "version": "1.12.0",
+      "sha256": "1nf0mffw0r0z9l4pgssw1dc5v54nkmr6ccl9kg3fd7dpnkhlba70",
       "depends": ["DelayedArray", "Matrix", "MultiAssayExperiment", "S4Vectors", "SingleCellExperiment", "SummarizedExperiment", "rhdf5"]
     },
     "Mulcom": {
       "name": "Mulcom",
-      "version": "1.56.0",
-      "sha256": "1cnzwyn7rsjj1l2fia9mh0gljpqd2fyq6bwxzdjii5apm21sswyp",
+      "version": "1.58.0",
+      "sha256": "1bbrcidbrp6i7a370gigdlmlf34qjlg6yxj4lcmfxy88qbk2rs3f",
       "depends": ["Biobase", "fields"]
     },
     "MultiAssayExperiment": {
       "name": "MultiAssayExperiment",
-      "version": "1.32.0",
-      "sha256": "1lsnw4w0ln4596vwd4a69nnhmnf7z05brpisripjisjrgr374sgy",
+      "version": "1.34.0",
+      "sha256": "0nq9s319kdhi5rq886d1rpdww7bn06hm6d7298q8aqa6jaral2b3",
       "depends": ["Biobase", "BiocBaseUtils", "BiocGenerics", "DelayedArray", "GenomicRanges", "IRanges", "S4Vectors", "SummarizedExperiment", "tidyr"]
     },
     "MultiBaC": {
       "name": "MultiBaC",
-      "version": "1.16.0",
-      "sha256": "0bg9jgkrb16g6xxvw1acqc0ydwljwk1zvx3zh597893jifsx0b45",
+      "version": "1.18.0",
+      "sha256": "142h4wx5wyks9xfl30vxcj82sjzgrkkwjd6r16364z5b3cxlamsj",
       "depends": ["Matrix", "MultiAssayExperiment", "ggplot2", "pcaMethods", "plotrix", "ropls"]
     },
     "MultiDataSet": {
       "name": "MultiDataSet",
-      "version": "1.34.0",
-      "sha256": "048wnzw5qkfr0fhcz0i031zxz7xkvwyc451a1xbllkqpb9jsvi50",
+      "version": "1.36.0",
+      "sha256": "1a1d073nxwsfgw58aj0d5lsvky3p3jjxf1sa2csxqk2rkn0c0w5p",
       "depends": ["Biobase", "BiocGenerics", "GenomicRanges", "IRanges", "S4Vectors", "SummarizedExperiment", "ggplot2", "ggrepel", "limma", "qqman"]
     },
     "MultiMed": {
       "name": "MultiMed",
-      "version": "2.28.0",
-      "sha256": "1cfgv405ywrdlaa421707z0k5yn0iair4nzgg0ykxnbapszwqlmz",
+      "version": "2.30.0",
+      "sha256": "1rg3n2jli67dl5sgnbb987ax0vi31axx5n7hnmsvqngxd5iqpmff",
       "depends": []
     },
     "MultiRNAflow": {
       "name": "MultiRNAflow",
-      "version": "1.4.0",
-      "sha256": "12y734m5dnyyh1c8pdnh6v1xkjg0vm3c6c6zckgwl3rvwriq84ky",
+      "version": "1.6.0",
+      "sha256": "04cwbf5ahyxn06055dn0jvif54y6d53yxxqjqrkr8f0r1ir2x2zg",
       "depends": ["Biobase", "ComplexHeatmap", "DESeq2", "FactoMineR", "Mfuzz", "S4Vectors", "SummarizedExperiment", "UpSetR", "factoextra", "ggalluvial", "ggplot2", "ggplotify", "ggrepel", "gprofiler2", "plot3D", "plot3Drgl", "reshape2"]
     },
     "MultimodalExperiment": {
       "name": "MultimodalExperiment",
-      "version": "1.6.0",
-      "sha256": "0a8ibx3xphay9lzg4g4f7pal805kd2mcsj8gxwfjxhvvdbdqz6cj",
+      "version": "1.8.0",
+      "sha256": "0yl420p6wpq92vpn1ji84qimw20975cwc08354qp0ccw29c1msrq",
       "depends": ["BiocGenerics", "IRanges", "MultiAssayExperiment", "S4Vectors"]
     },
     "MungeSumstats": {
       "name": "MungeSumstats",
-      "version": "1.14.1",
-      "sha256": "1clkpvvwwxdb8c6xrxqc6bpz6q3r2vi7igq2yd5l5q93nlcnhff6",
-      "depends": ["BSgenome", "Biostrings", "GenomeInfoDb", "GenomicRanges", "IRanges", "RCurl", "R_utils", "VariantAnnotation", "data_table", "dplyr", "googleAuthR", "httr", "jsonlite", "magrittr", "rtracklayer", "stringr"]
+      "version": "1.16.0",
+      "sha256": "1raygfrqhpg4f1ifvc9f8ikb9p0mijc6l0mnlvz37bns9qgfip53",
+      "depends": ["BSgenome", "Biostrings", "GenomeInfoDb", "GenomicRanges", "IRanges", "RCurl", "R_utils", "VariantAnnotation", "data_table", "dplyr", "ieugwasr", "rtracklayer", "stringr"]
     },
     "MutationalPatterns": {
       "name": "MutationalPatterns",
-      "version": "3.16.0",
-      "sha256": "16a5g9l025pj7xrl3g78nkqyrcnldj8y2025ibvsfg0921zyqiyp",
+      "version": "3.18.0",
+      "sha256": "1mjjqhwzsma3yq21dvnrmmb5y5d25dng01wrmk850w30dg5lgq8j",
       "depends": ["BSgenome", "BiocGenerics", "Biostrings", "GenomeInfoDb", "GenomicRanges", "IRanges", "NMF", "RColorBrewer", "S4Vectors", "VariantAnnotation", "cowplot", "dplyr", "ggalluvial", "ggdendro", "ggplot2", "magrittr", "pracma", "purrr", "stringr", "tibble", "tidyr"]
     },
     "NADfinder": {
       "name": "NADfinder",
-      "version": "1.30.0",
-      "sha256": "1vn1q0jks8d30mg9icn8s71ax9ixk2n2jxmsgprimvd9qrpwg7hj",
+      "version": "1.32.0",
+      "sha256": "0dv9x6dy0wiqqkydrvrp7lfxdlib7as62gl8ja6yhd29d1zg25ws",
       "depends": ["ATACseqQC", "BiocGenerics", "EmpiricalBrownsMethod", "GenomeInfoDb", "GenomicAlignments", "GenomicRanges", "IRanges", "Rsamtools", "S4Vectors", "SummarizedExperiment", "baseline", "corrplot", "csaw", "limma", "metap", "rtracklayer", "signal", "trackViewer"]
     },
     "NBAMSeq": {
       "name": "NBAMSeq",
-      "version": "1.22.0",
-      "sha256": "0cd3vmkprf4klkg5m0ak0mmdhbvy6rgvi96rn8r2s1jp6chdvcxp",
+      "version": "1.24.0",
+      "sha256": "1crgzaa1kf0c2hs9zcg79a5d46kb3d2y3fywam9dbay21zbfzjhh",
       "depends": ["BiocParallel", "DESeq2", "S4Vectors", "SummarizedExperiment", "genefilter", "mgcv"]
     },
     "NCIgraph": {
       "name": "NCIgraph",
-      "version": "1.54.0",
-      "sha256": "1bh1bpsb9fgnbyrfpi9n54ffxf513dqdr9w1i7xfnbkpv1q1zkmn",
+      "version": "1.56.0",
+      "sha256": "1i4nqa84hi4f5c888rn8pzn1ysw1da1anl59rxvnfaaqs29svrsq",
       "depends": ["KEGGgraph", "RBGL", "RCy3", "R_oo", "graph"]
     },
     "NOISeq": {
       "name": "NOISeq",
-      "version": "2.50.0",
-      "sha256": "0398hvwqr7cal7xnxbpv2dcbg3j5xhkv6n54h0niswrvd1d68fzy",
+      "version": "2.52.0",
+      "sha256": "1nd9dbjzvnpmpz107hjl3j4jq0yra13hk78lwz162xzr1275j0q4",
       "depends": ["Biobase", "Matrix"]
     },
     "NPARC": {
       "name": "NPARC",
-      "version": "1.18.0",
-      "sha256": "1fic3ss8vnvz0gf8xfv0x995c0pw1s6qij3x3jyhwp0f4gn3h9mb",
+      "version": "1.20.0",
+      "sha256": "0pggskl6nr0qjya95fk8ly0x9bhjx1a2avgchmwmv114lbi00di9",
       "depends": ["BiocParallel", "MASS", "broom", "dplyr", "magrittr", "rlang", "tidyr"]
     },
     "NTW": {
       "name": "NTW",
-      "version": "1.56.0",
-      "sha256": "044ampz8mwvs5kqfy97pz8f50d39ssjmgr5j5s7lyijr4y4dkvlx",
+      "version": "1.58.0",
+      "sha256": "1an109y4gkrl3d65ssbd2s2cypc2cry75569marikms0pbb8iaid",
       "depends": ["mvtnorm"]
     },
     "NanoMethViz": {
       "name": "NanoMethViz",
-      "version": "3.2.0",
-      "sha256": "17k55c7cr07ixnkas402jphjga5ixywmpiyd7bk8y6d5r5llxmgy",
-      "depends": ["AnnotationDbi", "BiocSingular", "Biostrings", "GenomicRanges", "IRanges", "R_utils", "Rcpp", "Rsamtools", "S4Vectors", "SummarizedExperiment", "assertthat", "bsseq", "cli", "cpp11", "dbscan", "dplyr", "e1071", "forcats", "fs", "ggplot2", "ggrastr", "glue", "limma", "patchwork", "purrr", "readr", "rlang", "scales", "stringr", "tibble", "tidyr", "withr", "zlibbioc"]
+      "version": "3.4.0",
+      "sha256": "0iiyihx60bjg4zl51ikljmw52p8g5y582zgzqj9xmwdlcvc1x7ws",
+      "depends": ["AnnotationDbi", "BiocSingular", "Biostrings", "GenomicRanges", "IRanges", "R_utils", "Rcpp", "Rsamtools", "S4Vectors", "SummarizedExperiment", "assertthat", "bsseq", "cli", "cpp11", "dbscan", "dplyr", "e1071", "forcats", "fs", "ggplot2", "ggrastr", "glue", "limma", "patchwork", "purrr", "readr", "rlang", "scales", "stringr", "tibble", "tidyr", "withr"]
     },
     "NanoStringDiff": {
       "name": "NanoStringDiff",
-      "version": "1.36.0",
-      "sha256": "12nags3h5261k4qhr8lclyyjbk4ai3hmw9wixpf3pp4qfjqcrmrq",
+      "version": "1.38.0",
+      "sha256": "0kfyrv0bkyhx8cp8q9jgsva7p44jng395r9g05gcn5cs9sz462g8",
       "depends": ["Biobase", "Rcpp", "matrixStats"]
     },
     "NanoStringNCTools": {
       "name": "NanoStringNCTools",
-      "version": "1.14.0",
-      "sha256": "0yxp14jyw9xmnji1wc377hq3wnw4jrkcjwp1rqbfa75bnqcpfivk",
+      "version": "1.15.0",
+      "sha256": "1b86ji5fffnvyjsf0zj6d8cqqm49hy9nc33pmk3fsl4cbq7vxp9l",
       "depends": ["Biobase", "BiocGenerics", "Biostrings", "IRanges", "RColorBrewer", "S4Vectors", "ggbeeswarm", "ggiraph", "ggplot2", "ggthemes", "pheatmap"]
     },
     "NanoTube": {
       "name": "NanoTube",
-      "version": "1.12.0",
-      "sha256": "0phdjxvikia3bx6l8v9b1r85kclrc5zi6s0jrsg2dvpdyhcyjwn0",
+      "version": "1.14.0",
+      "sha256": "06fcdly6r4kc51j3rbnx2zw2svp5j2ghwvlyabdsp9f7mbvicf21",
       "depends": ["Biobase", "fgsea", "ggplot2", "limma", "reshape"]
     },
     "Nebulosa": {
       "name": "Nebulosa",
-      "version": "1.16.0",
-      "sha256": "15bdddc34y6i1j06fpi82p8xz07p4q07p2js657gssh4lwxkz5n1",
+      "version": "1.18.0",
+      "sha256": "0n2a8fhrqk9fsr3lc6mgl32iv3ydwj4ixv7p80v9xxi40fyxrzj2",
       "depends": ["Matrix", "SeuratObject", "SingleCellExperiment", "SummarizedExperiment", "ggplot2", "ggrastr", "ks", "patchwork"]
     },
     "NetActivity": {
       "name": "NetActivity",
-      "version": "1.8.0",
-      "sha256": "0m0256dsfkbx5b7qba04dywyphpqlw7zyciyddx48wzmxkasrabd",
+      "version": "1.10.0",
+      "sha256": "1y3wrzijzm6anqjdwndbjcnjkyxkp5ayydw15grqz7yxld6w53bg",
       "depends": ["DESeq2", "DelayedArray", "DelayedMatrixStats", "NetActivityData", "SummarizedExperiment", "airway"]
     },
     "NetPathMiner": {
       "name": "NetPathMiner",
-      "version": "1.42.0",
-      "sha256": "0dh2wp4ljg5vw13cg8h4hdvhd6n5sj50xjj04h7zpp96a2rjcr1i",
+      "version": "1.44.0",
+      "sha256": "1k04y4bllfkx6w0i0sk6aiqmy9l6dmbpvwjlr8f8qxydb0w79082",
       "depends": ["igraph"]
     },
     "NetSAM": {
       "name": "NetSAM",
-      "version": "1.46.0",
-      "sha256": "15c4z3fpk9kwqslkrds9jk8mf7gl618smi53dwgfbg3gi7vysgmp",
+      "version": "1.48.0",
+      "sha256": "1km7jwqfmmkjjw35rpi8xx1p48ig06k0g2v53l27bygynfrfk7ig",
       "depends": ["AnnotationDbi", "DBI", "GO_db", "R2HTML", "WGCNA", "biomaRt", "doParallel", "foreach", "igraph", "seriation", "survival"]
     },
     "NewWave": {
       "name": "NewWave",
-      "version": "1.16.0",
-      "sha256": "14iwsgcl9pfljb0zvsfmm7wr38zrcvd5i9vpx4aira7b2l9c18rc",
+      "version": "1.18.0",
+      "sha256": "1ygy6biw62qbi6msgwbzmm18xz36ic38xxzhy4cl06b0j9dgzwwj",
       "depends": ["BiocSingular", "DelayedArray", "Matrix", "SharedObject", "SingleCellExperiment", "SummarizedExperiment", "irlba"]
     },
     "NoRCE": {
       "name": "NoRCE",
-      "version": "1.18.0",
-      "sha256": "0npl2x2d5jxjljwd6z3rdhw39psy1mdv2rb03ag4mj1zkxqjdzyf",
+      "version": "1.19.0",
+      "sha256": "08kdwlxri7jsw0hvfbc2fv08qhwm6hkdyzplf5za4rhcrcyhzda4",
       "depends": ["AnnotationDbi", "DBI", "GO_db", "GenomeInfoDb", "GenomicFeatures", "GenomicRanges", "IRanges", "KEGGREST", "RCurl", "RSQLite", "S4Vectors", "SummarizedExperiment", "biomaRt", "dbplyr", "dplyr", "ggplot2", "igraph", "png", "rWikiPathways", "reactome_db", "readr", "reshape2", "rtracklayer", "stringr", "tidyr", "zlibbioc"]
     },
     "NormalyzerDE": {
       "name": "NormalyzerDE",
-      "version": "1.24.0",
-      "sha256": "17f6224zl25vi2z2mf69i4273356bwrq8myr0dvqap63cmfilbbc",
+      "version": "1.26.0",
+      "sha256": "1l1jm0rhcvgiscl061yr791p0dncskxm3yniajlrgjg9lpmdc7i1",
       "depends": ["MASS", "SummarizedExperiment", "ape", "car", "ggforce", "ggplot2", "limma", "matrixStats", "preprocessCore", "vsn"]
     },
     "NormqPCR": {
       "name": "NormqPCR",
-      "version": "1.52.0",
-      "sha256": "1ykpyv8wbz2lvw5b6bwi3b97sk084wdzafy0zrghbxhvpjdkaqiy",
+      "version": "1.54.0",
+      "sha256": "0dg0idsx2v7nj7jg44adg2vw06405b1c4f288sdkpin6azak0i67",
       "depends": ["Biobase", "RColorBrewer", "ReadqPCR", "qpcR"]
     },
     "NuPoP": {
       "name": "NuPoP",
-      "version": "2.14.0",
-      "sha256": "1rrilv50pldi76sypxp42ibh676x9cp7d4cfcc9bh02220ai8zqv",
+      "version": "2.16.0",
+      "sha256": "1giy3jjlcmhh99f1gmhsl2ifcvblzzglbd8kyp1k16i9n1dgb899",
       "depends": []
     },
     "OCplus": {
       "name": "OCplus",
-      "version": "1.80.0",
-      "sha256": "13wl5zfxc6ls5m7x5v5dpi6f850x72pbixggyhklyg90440dzr2b",
+      "version": "1.82.0",
+      "sha256": "01s8jb6mh2ipxhnws05dv6r5b1m3cy196gf6szly1harg3wilm1q",
       "depends": ["interp", "multtest"]
     },
     "OGRE": {
       "name": "OGRE",
-      "version": "1.10.0",
-      "sha256": "1hwc1wgaigjg1cikja7fa1asd2119nhq61mc7jg687bli44j1wy8",
+      "version": "1.12.0",
+      "sha256": "18hn4hjlfrxxzkw4mw6wymwwp3ivfp5zww6jypc9ncxx5pxjygj6",
       "depends": ["AnnotationHub", "DT", "GenomeInfoDb", "GenomicRanges", "Gviz", "IRanges", "S4Vectors", "assertthat", "data_table", "ggplot2", "rtracklayer", "shiny", "shinyBS", "shinyFiles", "shinydashboard", "tidyr"]
     },
     "OLIN": {
       "name": "OLIN",
-      "version": "1.84.0",
-      "sha256": "1vmpvkdzdks649xws45s144xjqynf845wffldgzhydib6lkwjm5j",
+      "version": "1.86.0",
+      "sha256": "09xrkawmsznjvpxb8xp59lb01q2lw7vsk9xyxdvrgila5fbvhb7k",
       "depends": ["limma", "locfit", "marray"]
     },
     "OLINgui": {
       "name": "OLINgui",
-      "version": "1.80.0",
-      "sha256": "0vcvxck7qpb1n5r0qli0z50h32c0pffc2qny3fmsklff5xi4c059",
+      "version": "1.82.0",
+      "sha256": "06j39p518jrp6xhcqwif3nkhf0xflxc6sk6x73642wx9q3cwml9d",
       "depends": ["OLIN", "marray", "tkWidgets", "widgetTools"]
     },
     "OMICsPCA": {
       "name": "OMICsPCA",
-      "version": "1.24.0",
-      "sha256": "01rh5f6ajyjd9nzxs2b3ykwrvfsaz4yn30m24rdlaz3qiw4zqjsk",
+      "version": "1.26.0",
+      "sha256": "0iixl74v7q0xxl7k52dv5k7ly4nawmw24lcbcy9baf46xdq7cfiq",
       "depends": ["FactoMineR", "GenomeInfoDb", "HelloRanges", "IRanges", "MASS", "MultiAssayExperiment", "NbClust", "OMICsPCAdata", "PerformanceAnalytics", "clValid", "cluster", "corrplot", "cowplot", "data_table", "factoextra", "fpc", "ggplot2", "kableExtra", "magick", "pdftools", "reshape2", "rgl", "rmarkdown", "rtracklayer", "tidyr"]
     },
     "OPWeight": {
       "name": "OPWeight",
-      "version": "1.28.0",
-      "sha256": "1z9j5glj8522f4ldixl40gx02rila171ksc136zddcyl7whz52bd",
+      "version": "1.30.0",
+      "sha256": "1jaflmghgh6pb26xnq4pp4cx0m63fa0nd0gaqaflswycxp1fkx0j",
       "depends": ["MASS", "qvalue", "tibble"]
     },
     "ORFhunteR": {
       "name": "ORFhunteR",
-      "version": "1.14.0",
-      "sha256": "1rzk7rmjjlsnba6kjwyv8y208g8pm361nr84fvm5b7qnh17nndq8",
+      "version": "1.16.0",
+      "sha256": "1rcs8rav0xhpx0fdx8i12q8zl4x2wa2d6kq0vvgx9md9nxpqcqjc",
       "depends": ["BSgenome_Hsapiens_UCSC_hg38", "Biostrings", "Peptides", "Rcpp", "data_table", "randomForest", "rtracklayer", "stringr", "xfun"]
     },
     "ORFik": {
       "name": "ORFik",
-      "version": "1.26.1",
-      "sha256": "0x07lzq3asifzc2r4yk2marcb4v3wkzdaf8xalfq0aab8x3gl0fn",
+      "version": "1.28.0",
+      "sha256": "0ghyrf93nn247hdnnadhl3yspabb71yhga8bj11nbqw1qjnhvv7g",
       "depends": ["AnnotationDbi", "BSgenome", "BiocFileCache", "BiocGenerics", "BiocParallel", "Biostrings", "DESeq2", "GenomeInfoDb", "GenomicAlignments", "GenomicFeatures", "GenomicRanges", "IRanges", "R_utils", "Rcpp", "Rsamtools", "S4Vectors", "SummarizedExperiment", "XML", "biomaRt", "biomartr", "cowplot", "data_table", "fst", "ggplot2", "gridExtra", "httr", "jsonlite", "rtracklayer", "txdbmaker", "withr", "xml2"]
     },
     "OSAT": {
       "name": "OSAT",
-      "version": "1.54.0",
-      "sha256": "078nnn7g497pci81wnxf166aidp41cb5vaj6bsbimhaxb75alyjk",
+      "version": "1.56.0",
+      "sha256": "119jncjfpmh2gswdd0cr9z2x2lr6sm0nsc0skpnmhkbhsrdw47la",
       "depends": []
+    },
+    "OSTA_data": {
+      "name": "OSTA.data",
+      "version": "1.0.0",
+      "sha256": "07p6n49sykvs8hkhs0qkdhs8khgikqlyydjqm2mn7g06alakbmpn",
+      "depends": ["BiocFileCache", "osfr"]
     },
     "OTUbase": {
       "name": "OTUbase",
-      "version": "1.56.0",
-      "sha256": "1mya1bg2a1dikbpq0yh7b6lwsal5aqzv1ifxxckfq3wf23snk5gl",
+      "version": "1.58.0",
+      "sha256": "1kq18jhivv2kpg91dz02pqfj1r3rxq61y7f2i2al965wqlhdjzni",
       "depends": ["Biobase", "Biostrings", "IRanges", "S4Vectors", "ShortRead", "vegan"]
     },
     "OUTRIDER": {
       "name": "OUTRIDER",
-      "version": "1.24.0",
-      "sha256": "0slpkq7smja67yrcz992jnr176324n6wan7q9lrs8j8cylz9zwsf",
+      "version": "1.26.0",
+      "sha256": "1mfg5jim929h0vajmwd3b0ncc3rizx2cfhfpr1q4ccjggyliii53",
       "depends": ["BBmisc", "BiocGenerics", "BiocParallel", "DESeq2", "GenomicFeatures", "GenomicRanges", "IRanges", "PRROC", "RColorBrewer", "Rcpp", "RcppArmadillo", "S4Vectors", "SummarizedExperiment", "data_table", "generics", "ggplot2", "ggrepel", "heatmaply", "matrixStats", "pcaMethods", "pheatmap", "plotly", "plyr", "reshape2", "scales", "txdbmaker"]
     },
     "OVESEG": {
       "name": "OVESEG",
-      "version": "1.22.0",
-      "sha256": "1dad4bw2vnh9vkklrh1r0gmk1rrdnfgs85dirgh90zdcgzr6k5jz",
+      "version": "1.24.0",
+      "sha256": "1lc6k59f6v6rs3nd5him4lh2zq7rkzz12689dxpqys1kwn19ja99",
       "depends": ["BiocParallel", "Rcpp", "SummarizedExperiment", "fdrtool", "limma"]
     },
     "OmaDB": {
       "name": "OmaDB",
-      "version": "2.22.0",
-      "sha256": "1sz14v1cnxcfrynpra53dmwk5va9h20z2bhsqx91kril2k6yiyjk",
+      "version": "2.24.0",
+      "sha256": "14b9xyhimvn4fmjvgd4qgzd6lq4k4bdw08w1wsivjkqd5s6fjs8k",
       "depends": ["Biostrings", "GenomicRanges", "IRanges", "ape", "httr", "jsonlite", "plyr", "topGO"]
     },
     "OmicCircos": {
       "name": "OmicCircos",
-      "version": "1.44.0",
-      "sha256": "0k56433qrlg3hd6kj7wpcapv2jpn0c1c5l924shlfpb7xbxhhq2r",
+      "version": "1.46.0",
+      "sha256": "020m88v5msigzl448g5f89ijwjbdfbz9b33c4yhal05503zqjw2j",
       "depends": ["GenomicRanges"]
     },
     "OmicsMLRepoR": {
       "name": "OmicsMLRepoR",
-      "version": "1.0.0",
-      "sha256": "0pvm7w1ca9mgamhad6rb16rm38xmcfxipnkj9xv0xskmzc7wg361",
+      "version": "1.2.0",
+      "sha256": "0cfa80zylasvi7qbjiwsavl0yfn9ahji2sgzkfmi1lsbryppgyvc",
       "depends": ["BiocFileCache", "DiagrammeR", "data_tree", "dplyr", "jsonlite", "lubridate", "plyr", "readr", "rlang", "rols", "stringr", "tibble", "tidyr"]
     },
     "Omixer": {
       "name": "Omixer",
-      "version": "1.16.0",
-      "sha256": "1s0kdf2hjjjwz77mcvk65y8vi9py2d8cbxxglkx1krvj2xb1j3zr",
+      "version": "1.18.0",
+      "sha256": "132mx5y60cqhpv584js7fk5qs9573jh0k6cmq4iikvqaxbf5x32v",
       "depends": ["dplyr", "forcats", "ggplot2", "gridExtra", "magrittr", "readr", "stringr", "tibble", "tidyselect"]
     },
     "OmnipathR": {
       "name": "OmnipathR",
-      "version": "3.14.0",
-      "sha256": "14fwdckmsilq7jj1y9rg0qj0z2xrryajwhib8k8wss0ys6sk7fzz",
-      "depends": ["RSQLite", "R_utils", "XML", "checkmate", "crayon", "curl", "digest", "dplyr", "httr", "igraph", "jsonlite", "later", "logger", "lubridate", "magrittr", "progress", "purrr", "rappdirs", "readr", "readxl", "rlang", "rmarkdown", "rvest", "stringi", "stringr", "tibble", "tidyr", "tidyselect", "vctrs", "withr", "xml2", "yaml", "zip"]
+      "version": "3.15.99",
+      "sha256": "09dapbfpvyywv0ysyvqh6xl43k86b0yvphslyf6y0ba438kkg37v",
+      "depends": ["RSQLite", "R_utils", "XML", "checkmate", "crayon", "curl", "digest", "dplyr", "fs", "httr2", "igraph", "jsonlite", "later", "logger", "lubridate", "magrittr", "progress", "purrr", "rappdirs", "readr", "readxl", "rlang", "rmarkdown", "rvest", "sessioninfo", "stringi", "stringr", "tibble", "tidyr", "tidyselect", "vctrs", "withr", "xml2", "yaml", "zip"]
     },
     "OncoScore": {
       "name": "OncoScore",
-      "version": "1.34.0",
-      "sha256": "128a2vfgcvvqah7d90d023q874r65rg8bhvmiyvc26fp7sl8gjks",
+      "version": "1.36.0",
+      "sha256": "1nqyxl0l8q0v9nwp8nzjhmf5sdsiwmlrn3pwgg15da8s5i4j52kq",
       "depends": ["biomaRt"]
     },
     "OncoSimulR": {
       "name": "OncoSimulR",
-      "version": "4.8.0",
-      "sha256": "09060zpc9wyj1wixdg7ibahyhhmqnc0k95crwq8djb1f94vafzl7",
+      "version": "4.10.0",
+      "sha256": "1ps64p8svpfqxws7d3lzrkg3fymxnyhb5gsb88chncdixq2lfgp5",
       "depends": ["RColorBrewer", "Rcpp", "Rgraphviz", "car", "data_table", "dplyr", "ggplot2", "ggrepel", "graph", "gtools", "igraph", "smatr", "stringr"]
     },
     "OpenStats": {
       "name": "OpenStats",
-      "version": "1.18.0",
-      "sha256": "0mzg67y0wbd11cqizqha5hx51kii6zj1sylwd39bli8yk22rz7h8",
+      "version": "1.20.0",
+      "sha256": "0kbxpfjssb4ilkf8yw2xbzdhbp3sy8x68s2m5k3zpk8fiqhha04j",
       "depends": ["AICcmodavg", "Hmisc", "MASS", "car", "jsonlite", "knitr", "nlme", "rlist", "summarytools"]
     },
     "OrderedList": {
       "name": "OrderedList",
-      "version": "1.78.0",
-      "sha256": "17k3zyn7pcwnzpscmcyvz2z97gc1y0sdn48kkrjhjn3s5gyfq74v",
+      "version": "1.80.0",
+      "sha256": "1hv3ffhwyc7y5d5ckdcn544v9k2bmd2axqs35ansqa2f1h9fhzv8",
       "depends": ["Biobase", "twilight"]
     },
     "Organism_dplyr": {
       "name": "Organism.dplyr",
-      "version": "1.34.0",
-      "sha256": "0phm4vl879ak98rjffb7z3khwrsmjd814y86zidmfailwrzmp3xx",
+      "version": "1.36.0",
+      "sha256": "03zb5w7pvgkgmszw3hryk18djpxdsvkns4klpj1d1fhxszh4m7x3",
       "depends": ["AnnotationDbi", "AnnotationFilter", "BiocFileCache", "DBI", "GenomeInfoDb", "GenomicFeatures", "GenomicRanges", "IRanges", "RSQLite", "S4Vectors", "dbplyr", "dplyr", "rlang", "tibble"]
     },
     "OrganismDbi": {
       "name": "OrganismDbi",
-      "version": "1.48.0",
-      "sha256": "1xbwvpxcn23yvibsf12g9irxcmz6ckp87991zzmk449xckayavrx",
+      "version": "1.50.0",
+      "sha256": "1lcxyb1xk81i4x4xjpbnkpbk2zfsbgw01q93i17fgahyrx2aa0d4",
       "depends": ["AnnotationDbi", "Biobase", "BiocGenerics", "BiocManager", "DBI", "GenomicFeatures", "GenomicRanges", "IRanges", "RBGL", "S4Vectors", "graph", "txdbmaker"]
     },
     "Oscope": {
       "name": "Oscope",
-      "version": "1.36.0",
-      "sha256": "02ysp86ssx1w9vmm4yc674xlhnclksh3f25skb8c9z4axi5708hk",
+      "version": "1.38.0",
+      "sha256": "01m2rj837nmcvd1kiwxsdl76cdh0cjsdcyg8skkv1396s9716kj9",
       "depends": ["BiocParallel", "EBSeq", "cluster", "testthat"]
     },
     "OutSplice": {
       "name": "OutSplice",
-      "version": "1.6.0",
-      "sha256": "1ashzh7g527dz0xq6qv0rsy0sw8rszbrr5z9rjs1kgagjrz42g9v",
+      "version": "1.8.0",
+      "sha256": "01kgyvrw7xs9hinppxlf3xyj7whwl9hpp9xp7sjs1nhbcmjla2f2",
       "depends": ["AnnotationDbi", "GenomicFeatures", "GenomicRanges", "IRanges", "S4Vectors", "TxDb_Hsapiens_UCSC_hg19_knownGene", "TxDb_Hsapiens_UCSC_hg38_knownGene", "org_Hs_eg_db"]
     },
     "PAA": {
       "name": "PAA",
-      "version": "1.40.0",
-      "sha256": "1nqhrvrl3h7wj7w1davfavcaknaq9dnhr91lr2l8g6hlzqi48q1k",
+      "version": "1.42.0",
+      "sha256": "1grcf0859qnr7k4n8yj6f08jjfhc4fygj40sxnmqf0cyqqwn6djq",
       "depends": ["MASS", "ROCR", "Rcpp", "e1071", "gplots", "gtools", "limma", "mRMRe", "randomForest", "sva"]
     },
     "PADOG": {
       "name": "PADOG",
-      "version": "1.48.0",
-      "sha256": "0sbsnizmfplkli7j88qgksphzn40567z126kpmrjlndfn04nlx6h",
+      "version": "1.50.0",
+      "sha256": "07bmnc1ajfr0dc4r6qnvkcxh39vhhwjx4bnai7mh0ni5z8aar1kz",
       "depends": ["AnnotationDbi", "Biobase", "GSA", "KEGGREST", "KEGGdzPathwaysGEO", "doRNG", "foreach", "hgu133a_db", "hgu133plus2_db", "limma", "nlme"]
     },
     "PAIRADISE": {
       "name": "PAIRADISE",
-      "version": "1.22.0",
-      "sha256": "13qdac7gra6wm4c9wmm8qp5aawhyqplpl15kbjr466yh5ixqk15q",
+      "version": "1.24.0",
+      "sha256": "0iffqvdmvyqlmq1hvncd4h7w2rzdsr0diyrq45n4074yf02zrfs2",
       "depends": ["BiocParallel", "S4Vectors", "SummarizedExperiment", "abind", "nloptr"]
     },
     "PANR": {
       "name": "PANR",
-      "version": "1.52.0",
-      "sha256": "1r76yr00f3xprxnvsffy2kyrbzkkq6r9cm5qy07kbq4k40kws8b3",
+      "version": "1.54.0",
+      "sha256": "1z4acn3y4rm1py0g8glvnwim1rpnagl31jx8x4h4c9wn3vi4lqi6",
       "depends": ["MASS", "RedeR", "igraph", "pvclust"]
     },
     "PAST": {
       "name": "PAST",
-      "version": "1.22.0",
-      "sha256": "1wvddpwdxmhvvczfgk5mnyqrrzglsi9s7cknv8j08sdhlqgqd82y",
+      "version": "1.24.0",
+      "sha256": "0qmws4g8km6zd0vn99q2v2c16g94p2zafsc05j6maram4kxwj5v7",
       "depends": ["GenomicRanges", "S4Vectors", "doParallel", "dplyr", "foreach", "ggplot2", "iterators", "qvalue", "rlang", "rtracklayer"]
     },
     "PCAN": {
       "name": "PCAN",
-      "version": "1.34.0",
-      "sha256": "1g92h79fcy6sh6vbrk8as2pk16dxnmhb37g87h97bsrnpmwl2v8r",
+      "version": "1.36.0",
+      "sha256": "1q0jarcvqw9j83458ym9jl7qxh8175p39nhp9xbccy20p1gdx0yi",
       "depends": ["BiocParallel"]
     },
     "PCAtools": {
       "name": "PCAtools",
-      "version": "2.18.0",
-      "sha256": "12w8jqadfcnvavhiksxs8sc8lg4k6053gl5czamdssqb2rqiy14l",
+      "version": "2.20.0",
+      "sha256": "0jik25f4rpmr8gjy22i2myjhgsgqgslfjfskhv5bgkmqwbn931ar",
       "depends": ["BH", "BiocParallel", "BiocSingular", "DelayedArray", "DelayedMatrixStats", "Matrix", "Rcpp", "beachmat", "cowplot", "dqrng", "ggplot2", "ggrepel", "lattice", "reshape2"]
+    },
+    "PDATK": {
+      "name": "PDATK",
+      "version": "1.16.0",
+      "sha256": "0zsmwd6bgy2ln2swz84zd2li1b0lkk8jif2hr3calsi95qnqpwhb",
+      "depends": ["BiocGenerics", "BiocParallel", "ConsensusClusterPlus", "CoreGx", "MatrixGenerics", "MultiAssayExperiment", "RColorBrewer", "S4Vectors", "SummarizedExperiment", "caret", "clusterRepro", "data_table", "dplyr", "genefu", "ggplot2", "ggplotify", "igraph", "matrixStats", "pROC", "piano", "plyr", "reportROC", "rlang", "scales", "survcomp", "survival", "survminer", "switchBox", "verification"]
     },
     "PECA": {
       "name": "PECA",
-      "version": "1.42.0",
-      "sha256": "1zz950pjaz6f202zihnjqpmx5vx7rzjlrd70v02y27agyfcsnf4a",
+      "version": "1.44.0",
+      "sha256": "01w197gy41m03pj1xvhws8wl29r2jdrzmbrr4wqzfdia188xlbn1",
       "depends": ["ROTS", "affy", "aroma_affymetrix", "aroma_core", "genefilter", "limma", "preprocessCore"]
+    },
+    "PICB": {
+      "name": "PICB",
+      "version": "1.0.0",
+      "sha256": "1xafxl79c8srrp4kyjqmn475iw5p0clndssw27samkkjz4pr1k75",
+      "depends": ["Biostrings", "GenomeInfoDb", "GenomicAlignments", "GenomicRanges", "IRanges", "Rsamtools", "S4Vectors", "data_table", "dplyr", "openxlsx", "seqinr"]
     },
     "PICS": {
       "name": "PICS",
-      "version": "2.50.0",
-      "sha256": "0189nsd3qx8dw414d0j3nfkn89i5vclgdmq2y3x3v2nva24whrka",
+      "version": "2.51.0",
+      "sha256": "1fchi92ka52902c4prscm85acw8f7sjihz2nx8lrc0qz421msdv7",
       "depends": ["GenomicAlignments", "GenomicRanges", "IRanges", "Rsamtools"]
     },
     "PING": {
       "name": "PING",
-      "version": "2.50.0",
-      "sha256": "0bw2w2f01brryz2x36qi82v4v47wwd7fk47bkhcs4yb3qm6xa5k0",
+      "version": "2.51.0",
+      "sha256": "1fhw93llsslbn13679iph91klzpaqzi953zbxl4n9c9r2sbngsc9",
       "depends": ["BSgenome", "BiocGenerics", "GenomicRanges", "Gviz", "IRanges", "PICS", "S4Vectors", "fda"]
     },
     "PIPETS": {
       "name": "PIPETS",
-      "version": "1.2.0",
-      "sha256": "1bysmh2ylmj18rabw6zk8wjqd2dg83pzf67awzvdkx55kr2gvadf",
+      "version": "1.4.0",
+      "sha256": "08q4rrzs0zvjbdjx36xcp71xmxwwx5f03sq0zkz9rx1bdkc51v68",
       "depends": ["BiocGenerics", "GenomicRanges", "dplyr"]
     },
     "PIUMA": {
       "name": "PIUMA",
-      "version": "1.2.0",
-      "sha256": "1s1zwl0ny3s2b84fl2fwxfbcl078mxl20cdgx8ydnmxdv0197a41",
+      "version": "1.4.0",
+      "sha256": "1g6ad3v8rw7rznbmqs0i31cjsl16m7cwhj43yhvrgyq4agcbc067",
       "depends": ["Hmisc", "SummarizedExperiment", "cluster", "dbscan", "ggplot2", "igraph", "kernlab", "patchwork", "scales", "tsne", "umap", "vegan"]
     },
     "PLPE": {
       "name": "PLPE",
-      "version": "1.66.0",
-      "sha256": "1jfmrxd878kyy129349rq8papf20mb1ji2p494y92x6vxcr8hhwa",
+      "version": "1.68.0",
+      "sha256": "06alwh01c6bxq7611grzy2qwv9591hpp34d86pb804sfdz9gs03z",
       "depends": ["Biobase", "LPE", "MASS"]
     },
     "PLSDAbatch": {
       "name": "PLSDAbatch",
-      "version": "1.2.0",
-      "sha256": "0nzrfz61lly9mmijdilm56cn6h86kb55hrirx71qlrf791ifzis1",
+      "version": "1.4.0",
+      "sha256": "1ac2zpim5r8v2cvqcs26w5n4vy30wzax3ph1rcd4kbxhm2m2z4ms",
       "depends": ["Biobase", "BiocStyle", "Rdpack", "TreeSummarizedExperiment", "ggplot2", "ggpubr", "gridExtra", "lmerTest", "mixOmics", "performance", "pheatmap", "scales", "vegan"]
     },
     "POMA": {
       "name": "POMA",
-      "version": "1.16.0",
-      "sha256": "0kw8sfk38qc547acg62hbarzml4cnwsnf8bgxhsnk3lh250m0als",
+      "version": "1.18.0",
+      "sha256": "1sh3la8da590sd3vx736bpjjsq27f8p32g0qxrd3b8536i1223pd",
       "depends": ["ComplexHeatmap", "DESeq2", "FSA", "MASS", "RankProd", "SummarizedExperiment", "broom", "caret", "dbscan", "dplyr", "fgsea", "ggcorrplot", "ggplot2", "ggrepel", "glmnet", "impute", "janitor", "limma", "lme4", "magrittr", "mixOmics", "msigdbr", "multcomp", "purrr", "randomForest", "rlang", "sva", "tibble", "tidyr", "uwot", "vegan"]
     },
     "POWSC": {
       "name": "POWSC",
-      "version": "1.14.0",
-      "sha256": "0il151al5jb5r7zp2j408v6cm7j8n9kwnwd4crsm5qv2hnc6vvhs",
+      "version": "1.16.0",
+      "sha256": "1y3kf1ngr4ri6p96xj4q0kqijsiwy53m5b6q0aqkgh60cb3h6lzq",
       "depends": ["Biobase", "MAST", "RColorBrewer", "SingleCellExperiment", "SummarizedExperiment", "ggplot2", "limma", "pheatmap"]
     },
     "PPInfer": {
       "name": "PPInfer",
-      "version": "1.32.0",
-      "sha256": "0a4xb82hf192ybhi6w78jdc2qpk12qp4zc1c4sy0ybyll27njkj9",
+      "version": "1.34.0",
+      "sha256": "0hw97rxbjxyhymgbwcikc0cq01jzl5019zrimwglrxlsm3b6r440",
       "depends": ["STRINGdb", "biomaRt", "fgsea", "ggplot2", "httr", "igraph", "kernlab", "yeastExpData"]
     },
     "PREDA": {
       "name": "PREDA",
-      "version": "1.52.0",
-      "sha256": "0bhgdirz7spxph6wxg90rqbl2qqck95ys3688g77ls13ka371zry",
+      "version": "1.54.0",
+      "sha256": "1pfna5d18dd74zbl5xsd610mhanknkm7kfyq9sqfw4dyd0pajzbn",
       "depends": ["Biobase", "annotate", "lokern", "multtest"]
     },
     "PROMISE": {
       "name": "PROMISE",
-      "version": "1.58.0",
-      "sha256": "182lf80d6hw2yisxndzn7zzqjl92zlrc7irzdfjncyipmng07x88",
+      "version": "1.60.0",
+      "sha256": "1q8nm83fkrdl72hmzd8pfsi79ads20d05a4lhf1b7x6hd8107i4h",
       "depends": ["Biobase", "GSEABase"]
     },
     "PRONE": {
       "name": "PRONE",
-      "version": "1.0.2",
-      "sha256": "1wikf9lhxkifb1zk8rvjmb9zcksm4fsr43jjg7bhsnw876ajkgjr",
-      "depends": ["Biobase", "ComplexHeatmap", "ComplexUpset", "DEqMS", "MASS", "MSnbase", "NormalyzerDE", "POMA", "RColorBrewer", "ROTS", "S4Vectors", "SummarizedExperiment", "UpSetR", "circlize", "data_table", "dendsort", "dplyr", "edgeR", "ggplot2", "ggtext", "gprofiler2", "gtools", "limma", "magrittr", "matrixStats", "plotROC", "preprocessCore", "purrr", "reshape2", "scales", "stringr", "tibble", "tidyr", "vsn"]
+      "version": "1.2.0",
+      "sha256": "1zdp7s64nvs5knhk1f6kmvvsdga8k79fgj24bdr194zizz1fplvq",
+      "depends": ["Biobase", "ComplexHeatmap", "ComplexUpset", "DEqMS", "MASS", "MSnbase", "NormalyzerDE", "POMA", "RColorBrewer", "ROTS", "S4Vectors", "SummarizedExperiment", "UpSetR", "circlize", "data_table", "dendsort", "dplyr", "edgeR", "ggplot2", "ggtext", "gprofiler2", "gtools", "limma", "magrittr", "matrixStats", "plotROC", "preprocessCore", "purrr", "reshape2", "scales", "stringr", "tibble", "tidyr", "vegan", "vsn"]
     },
     "PROPER": {
       "name": "PROPER",
-      "version": "1.38.0",
-      "sha256": "1dxps7nqd764agzfdba23fcxnxqdb5d8v4mxhw2kiy0qspk30f3r",
+      "version": "1.40.0",
+      "sha256": "0zsanqknfdx5x5p9x2f1n5l88201lxbwkniycfz11129dirma6j1",
       "depends": ["edgeR"]
     },
     "PROPS": {
       "name": "PROPS",
-      "version": "1.28.0",
-      "sha256": "0yc4mfwaamh1wsqzgrnh1mi2niajg0c3cckd935glmp2cv7cspsm",
+      "version": "1.30.0",
+      "sha256": "0nr49zqrnrwrpa488g9yiasy9azskkwpiyf7dh6r5wp1cdavab4y",
       "depends": ["Biobase", "bnlearn", "reshape2", "sva"]
     },
     "PROcess": {
       "name": "PROcess",
-      "version": "1.82.0",
-      "sha256": "0pfx5jzykcb4ap1mh2ysg1brdf9mg10h775prnk3lc67rjps334r",
+      "version": "1.84.0",
+      "sha256": "1bk87vp5kjw9kz8gibq8zisfx0qjiacgz5wvbq6mdddy1cl6a0xi",
       "depends": ["Icens"]
     },
     "PSMatch": {
       "name": "PSMatch",
-      "version": "1.10.0",
-      "sha256": "1aq6kdvw5n0d9c8pg7clfbpm5v52svx438sk5wphj4x0l3qvbdhh",
-      "depends": ["BiocGenerics", "BiocParallel", "Matrix", "MsCoreUtils", "ProtGenerics", "QFeatures", "S4Vectors", "igraph"]
+      "version": "1.12.0",
+      "sha256": "1nz75m19g6jpvpm8ajx4hdyr03kg9h6yip5w4mjrnagyww4ksbkb",
+      "depends": ["BiocGenerics", "BiocParallel", "IRanges", "Matrix", "MsCoreUtils", "ProtGenerics", "QFeatures", "S4Vectors", "Spectra", "igraph"]
     },
     "PWMEnrich": {
       "name": "PWMEnrich",
-      "version": "4.42.0",
-      "sha256": "1p5p6wp2p8nkbgd6v527g90wkz1184n29y7n3lx4v7nn0b7581k3",
+      "version": "4.44.0",
+      "sha256": "1zv08xi8r30j7pd4sqp3qciyjharqb4w3gryphf194l1jbd4lpds",
       "depends": ["BiocGenerics", "Biostrings", "S4Vectors", "evd", "gdata", "seqLogo"]
     },
     "PanomiR": {
       "name": "PanomiR",
-      "version": "1.10.0",
-      "sha256": "0hnh8y428q1scnk7hw7y2inlwqxj887cv541mb4fvjxgxdhsdnsd",
+      "version": "1.12.0",
+      "sha256": "1jjk39fa73jq1l330xbcrz15y0pqynx5nazhb755xhsd69g5r2v0",
       "depends": ["GSEABase", "RColorBrewer", "clusterProfiler", "dplyr", "forcats", "igraph", "limma", "metap", "org_Hs_eg_db", "preprocessCore", "rlang", "tibble", "withr"]
     },
     "Path2PPI": {
       "name": "Path2PPI",
-      "version": "1.36.0",
-      "sha256": "09pmdl9133cgjd1d30m2qhbwwd4ckql3d1hl58xz9fiif2f9sxrw",
+      "version": "1.38.0",
+      "sha256": "1s8clrvnc56jzhc3q5dc7nxllzxf3dh8lykw2zxxqq082nhzgd5k",
       "depends": ["igraph"]
     },
     "PathNet": {
       "name": "PathNet",
-      "version": "1.46.0",
-      "sha256": "0y60fw08i2kh15h2vh264yy7njyv6vvppxwic91631z992w3rw31",
+      "version": "1.48.0",
+      "sha256": "11696s9q7kg72w0mgn82qm3hm4m86x37sgzp0s4sw0jmwi4nfh2q",
       "depends": []
     },
     "PathoStat": {
       "name": "PathoStat",
-      "version": "1.32.0",
-      "sha256": "1n855cc9wbshqg8zp6bg1c3dqx3hbqsgxx65wdgl8d0xr4jp0r3b",
+      "version": "1.34.0",
+      "sha256": "1l2cxd8dhd6q6d35n4v3f6zl4gcigwak7bdc9lmdf3cximy12xp5",
       "depends": ["BiocStyle", "ComplexHeatmap", "DESeq2", "DT", "RColorBrewer", "ROCR", "XML", "ape", "corpcor", "devtools", "dplyr", "edgeR", "ggplot2", "glmnet", "gmodels", "knitr", "limma", "matrixStats", "phyloseq", "plotly", "plyr", "rentrez", "reshape2", "scales", "shiny", "shinyjs", "tidyr", "vegan", "webshot"]
     },
     "PeacoQC": {
       "name": "PeacoQC",
-      "version": "1.16.0",
-      "sha256": "05rq1l7wz92d6lc97f1yy5kyccp9rk75cqpyhxqjpcm6lqx40djk",
+      "version": "1.18.0",
+      "sha256": "197yshr2c15rxp38q6dm5kwwgnwq1kkjlbavj1vqz7gghw020c6n",
       "depends": ["ComplexHeatmap", "circlize", "flowCore", "flowWorkspace", "ggplot2", "gridExtra", "plyr"]
     },
     "Pedixplorer": {
       "name": "Pedixplorer",
-      "version": "1.2.0",
-      "sha256": "0krm6mhg6nywnmf481rbgj9s0ax5x6zf6vxqavl8s011yav5f2wr",
+      "version": "1.4.0",
+      "sha256": "03i36mh6qwb0mppmx7vfaj5cr4l5xfdbbdskjxfmsb7dmxckx3bi",
       "depends": ["DT", "Matrix", "S4Vectors", "colourpicker", "data_table", "dplyr", "ggplot2", "gridExtra", "htmlwidgets", "plotly", "plyr", "quadprog", "readxl", "scales", "shiny", "shinyWidgets", "shinycssloaders", "shinytoastr", "stringr", "tidyr"]
     },
     "PepSetTest": {
       "name": "PepSetTest",
-      "version": "1.0.0",
-      "sha256": "0d6q1nkn4rp1rpwjgi0xzk8x02dinzd2w6zjrf7k4xlkacysn1gy",
+      "version": "1.2.0",
+      "sha256": "1c5fbwa9w83050ikjk8g8xy7zzjp9486n199i3xbrd2dn87da69f",
       "depends": ["MASS", "SummarizedExperiment", "dplyr", "limma", "lme4", "matrixStats", "reshape2", "tibble"]
     },
     "PepsNMR": {
       "name": "PepsNMR",
-      "version": "1.24.0",
-      "sha256": "03sipcga9gmcypryq3c0lhvdp1dzgbjfzxldrrp2ycyjwzwr9wzn",
+      "version": "1.26.0",
+      "sha256": "145a8979akhwd8j865j1x3fk81x64a5d5784hyi57cjsi5drgbk6",
       "depends": ["Matrix", "ggplot2", "gridExtra", "matrixStats", "ptw", "reshape2"]
     },
     "PhIPData": {
       "name": "PhIPData",
-      "version": "1.14.0",
-      "sha256": "0y0jjnz107srnz4mhx8wy1mrn0g50nsjn8727hdyzn0hybq8inld",
+      "version": "1.16.0",
+      "sha256": "0nisvh8dv0sh339cl4mnr98r6yycn6mx5nasqzip7ii4s9kxlsmb",
       "depends": ["BiocFileCache", "BiocGenerics", "GenomicRanges", "IRanges", "S4Vectors", "SummarizedExperiment", "cli", "edgeR"]
     },
     "PharmacoGx": {
       "name": "PharmacoGx",
-      "version": "3.10.1",
-      "sha256": "06y3f2f7qw641432h7fb0ibipppqx9j41kx0rphircvy6qpbx70x",
+      "version": "3.11.1",
+      "sha256": "00rlkl5bri5phsbhp0z80aqkpaxnw987qbggvwrzckqp03ndsp10",
       "depends": ["Biobase", "BiocGenerics", "BiocParallel", "CoreGx", "MultiAssayExperiment", "RColorBrewer", "Rcpp", "S4Vectors", "SummarizedExperiment", "boot", "caTools", "checkmate", "coop", "data_table", "downloader", "ggplot2", "jsonlite", "magicaxis", "reshape2"]
     },
     "PhenStat": {
       "name": "PhenStat",
-      "version": "2.42.0",
-      "sha256": "0jzgpmkk4ljz7kxqmjpp6kspw8a36yiprk8zyhqzb9rw2a5g85xj",
+      "version": "2.44.0",
+      "sha256": "0gzhfy6mz3dazwy9hcb8ffgsfry6r4byl2a8b9qkir8ymv3q6s2p",
       "depends": ["MASS", "SmoothWin", "car", "corrplot", "ggplot2", "graph", "knitr", "lme4", "logistf", "msgps", "nlme", "nortest", "pingr", "reshape"]
     },
     "PhenoGeneRanker": {
       "name": "PhenoGeneRanker",
-      "version": "1.14.0",
-      "sha256": "0np50456hvkwxcikpsz2d7ji392r6indzqrn9lyjyqvf5as6nw0y",
+      "version": "1.16.0",
+      "sha256": "1a8x7yry49k891bfyv3ijillnzy1xfh2n11rz0mp07j6fy2sim26",
       "depends": ["Matrix", "doParallel", "dplyr", "foreach", "igraph"]
     },
     "PhosR": {
       "name": "PhosR",
-      "version": "1.16.0",
-      "sha256": "0m3gz1g8a0wvfdjyp2vcarizaxbvs9zqa9zaivq5ns2nhbs2wd5f",
+      "version": "1.18.0",
+      "sha256": "1ivr9yyca33zgn8fb1hra36ckv0y74gg7lr17fiag184p5dvsiis",
       "depends": ["BiocGenerics", "GGally", "RColorBrewer", "S4Vectors", "SummarizedExperiment", "circlize", "dendextend", "dplyr", "e1071", "ggdendro", "ggplot2", "ggpubr", "ggtext", "igraph", "limma", "network", "pcaMethods", "pheatmap", "preprocessCore", "reshape2", "rlang", "ruv", "stringi", "tidyr"]
     },
     "PhyloProfile": {
       "name": "PhyloProfile",
-      "version": "1.20.4",
-      "sha256": "0vv0a6vknjx3zh92ypmbvl4rcbrpfzsgnj1vmjx0y4p3vxkwvhx0",
-      "depends": ["BiocStyle", "Biostrings", "DT", "ExperimentHub", "RColorBrewer", "RCurl", "ape", "bioDist", "colourpicker", "data_table", "dplyr", "energy", "extrafont", "fastcluster", "ggplot2", "gridExtra", "pbapply", "plotly", "scattermore", "shiny", "shinyBS", "shinyFiles", "shinycssloaders", "shinyjs", "stringr", "tsne", "umap", "xml2", "yaml", "zoo"]
+      "version": "2.0.0",
+      "sha256": "1zsnvfijckvpb51gyd427mjd7bkmxp4yf6ij306pj7zdhyw02jrs",
+      "depends": ["BiocStyle", "Biostrings", "DT", "ExperimentHub", "RColorBrewer", "RCurl", "Rfast", "ape", "bioDist", "colourpicker", "data_table", "dplyr", "energy", "extrafont", "fastcluster", "ggplot2", "gridExtra", "pbapply", "plotly", "scattermore", "shiny", "shinyBS", "shinyFiles", "shinycssloaders", "shinyjs", "stringr", "svglite", "tsne", "umap", "xml2", "yaml", "zoo"]
     },
     "Pigengene": {
       "name": "Pigengene",
-      "version": "1.32.0",
-      "sha256": "1r8m1pm7xnbzvjgyffp5izvb9gln1w4by97nnqnlk06hr027r5sw",
+      "version": "1.34.0",
+      "sha256": "02f1p69ci15r3l52g3fxvb4mfn4ldpl3vkh9710ynfdbn67dg0r9",
       "depends": ["BiocStyle", "C50", "DBI", "DOSE", "GO_db", "MASS", "ReactomePA", "Rgraphviz", "WGCNA", "bnlearn", "clusterProfiler", "dplyr", "gdata", "ggplot2", "graph", "impute", "matrixStats", "openxlsx", "partykit", "pheatmap", "preprocessCore"]
     },
     "Pirat": {
       "name": "Pirat",
-      "version": "1.0.2",
-      "sha256": "1cd4w3nrhg1fp5awwlx5a6w119p9h56lxlysgmgxl0iwwjzsbl2l",
-      "depends": ["BiocManager", "MASS", "S4Vectors", "SummarizedExperiment", "basilisk", "ggplot2", "invgamma", "progress", "reticulate"]
+      "version": "1.2.0",
+      "sha256": "0wky524d2j1qw80rwr8v211bqfkrdn4zfp5v2j8d24p9x3f9iyj6",
+      "depends": ["MASS", "S4Vectors", "SummarizedExperiment", "basilisk", "ggplot2", "invgamma", "progress", "reticulate"]
     },
     "PoDCall": {
       "name": "PoDCall",
-      "version": "1.14.0",
-      "sha256": "0j4bzkm6h8rhd9xf44n6cfscivi9y30nhacyb1zi79349vd8wiky",
+      "version": "1.16.0",
+      "sha256": "07cxwddq24gdm9ns78ahi5ak7kc4nz517gqkd011pf8pkrxnf8z3",
       "depends": ["DT", "LaplacesDemon", "diptest", "ggplot2", "gridExtra", "mclust", "purrr", "readr", "rlist", "shiny", "shinyjs"]
     },
     "PolySTest": {
       "name": "PolySTest",
-      "version": "1.0.2",
-      "sha256": "04ib8irmfa0jf0a4gz96nk3k5cwb7fa0hv9f9jmbvc7pxyn6gmkw",
+      "version": "1.2.0",
+      "sha256": "0aplpw2vscnx92vi14dfvmw0cifhbpy3rsrvrhqj5zr6a1r4vpm4",
       "depends": ["S4Vectors", "SummarizedExperiment", "UpSetR", "circlize", "fdrtool", "gplots", "heatmaply", "knitr", "limma", "matrixStats", "plotly", "qvalue", "shiny"]
+    },
+    "Polytect": {
+      "name": "Polytect",
+      "version": "1.0.0",
+      "sha256": "0x28mwn6wxmxczl1zb10jxnnxrh5vdskjnyn30ymbwlgxblpagmb",
+      "depends": ["BiocManager", "DiceKriging", "ParamHelpers", "cowplot", "dplyr", "flowPeaks", "ggplot2", "lhs", "mlrMBO", "mvtnorm", "rgenoud", "smoof", "sn", "tidyverse"]
     },
     "PrInCE": {
       "name": "PrInCE",
-      "version": "1.22.0",
-      "sha256": "1z4b75br68wghjky6x8mc522jw4cfa2v4490qdg7z75kpgdld8sw",
+      "version": "1.24.0",
+      "sha256": "04vnigzbv4iz4739cgfwkvaxarqc3xvd4hbqz19ar85hmx65ljhj",
       "depends": ["Biobase", "Hmisc", "LiblineaR", "MSnbase", "Rdpack", "dplyr", "forecast", "magrittr", "naivebayes", "progress", "purrr", "ranger", "robustbase", "speedglm", "tester", "tidyr"]
     },
     "Prostar": {
       "name": "Prostar",
-      "version": "1.38.1",
-      "sha256": "153s3na25nka2hxjswzdcbddr0hkglwjs489y6h3h7h03m9by8bw",
+      "version": "1.40.0",
+      "sha256": "1jpdmr7xpxhfmig6hvld6b07idvd9zaxdnv5a9ghkd5afni37qr3",
       "depends": ["Biobase", "DAPAR", "DAPARdata", "DT", "RColorBrewer", "R_utils", "XML", "colourpicker", "data_table", "future", "ggplot2", "gplots", "gtools", "highcharter", "htmlwidgets", "later", "markdown", "promises", "rclipboard", "rhandsontable", "sass", "shiny", "shinyAce", "shinyBS", "shinyTree", "shinyWidgets", "shinycssloaders", "shinyjqui", "shinyjs", "shinythemes", "tibble", "vioplot", "webshot"]
     },
     "ProtGenerics": {
       "name": "ProtGenerics",
-      "version": "1.38.0",
-      "sha256": "0pg7rqz0ixaiihqybynm94qvdc5y953xzxzxvwv5gbmxdk9s3lmk",
+      "version": "1.40.0",
+      "sha256": "0a8niarfkb9jqamqj3ild5d2l6kc1amxgzn2aqk58w4whcip39i3",
       "depends": []
     },
     "ProteoDisco": {
       "name": "ProteoDisco",
-      "version": "1.12.0",
-      "sha256": "07hbf2h31ff4adfp28f92823h387z29ygj8fdqkchsx8ras8a8fm",
+      "version": "1.14.0",
+      "sha256": "10rkzgas94rj2x8pdcyf488vlmfwlchblxrc1lxlq68f9xvs6i6l",
       "depends": ["BiocGenerics", "BiocParallel", "Biostrings", "GenomeInfoDb", "GenomicFeatures", "GenomicRanges", "IRanges", "ParallelLogger", "S4Vectors", "VariantAnnotation", "XVector", "checkmate", "cleaver", "dplyr", "plyr", "rlang", "tibble", "tidyr"]
     },
     "ProteoMM": {
       "name": "ProteoMM",
-      "version": "1.24.0",
-      "sha256": "0z51pa8nmdl1895z3ky2zagxpgss2az58pcdnjmln9mbzdl3cvhi",
+      "version": "1.26.0",
+      "sha256": "1a40b6q8689s44kc2fd2gn0skcp4b4kfsn2ads3lsyx8nj0dgm69",
       "depends": ["biomaRt", "gdata", "ggplot2", "ggrepel", "gtools", "matrixStats"]
     },
     "PureCN": {
       "name": "PureCN",
-      "version": "2.12.0",
-      "sha256": "0y24clqg7gs4696mwpsmxc4js7s17jlqmkrhkq8vard2hyh9vy0y",
+      "version": "2.13.3",
+      "sha256": "0yd8lrapai04bag0q9g1bj2dm5psq0fw46yini6k9zc3xbd2mjcl",
       "depends": ["Biobase", "BiocGenerics", "Biostrings", "DNAcopy", "GenomeInfoDb", "GenomicFeatures", "GenomicRanges", "IRanges", "Matrix", "RColorBrewer", "Rsamtools", "S4Vectors", "SummarizedExperiment", "VGAM", "VariantAnnotation", "data_table", "futile_logger", "ggplot2", "gridExtra", "mclust", "rhdf5", "rtracklayer"]
     },
     "Pviz": {
       "name": "Pviz",
-      "version": "1.40.0",
-      "sha256": "0w9zxdyyzg6c9wjf1jsyrqihhi30rv5lx94136rks9l3m5vzvlqb",
+      "version": "1.42.0",
+      "sha256": "1n261ywz7hy8wrkflycarf122lnh4vllxvs1nvqwhdzxgsk96q6w",
       "depends": ["Biostrings", "GenomicRanges", "Gviz", "IRanges", "biovizBase", "data_table"]
     },
     "QDNAseq": {
       "name": "QDNAseq",
-      "version": "1.42.0",
-      "sha256": "06ips85m2yrp7iwqm1l9hxkr3d5ny3myhjr8dkyhmw819gvdfhq8",
+      "version": "1.44.0",
+      "sha256": "0zkdfs6axmw4qwr11q8mv8rdji1k64004r8w7ml789wn0chzdk4p",
       "depends": ["Biobase", "CGHbase", "CGHcall", "DNAcopy", "GenomicRanges", "IRanges", "R_utils", "Rsamtools", "future_apply", "matrixStats"]
     },
     "QFeatures": {
       "name": "QFeatures",
-      "version": "1.16.0",
-      "sha256": "0c3zv42vb792pn74k1s3hxfhi6vp78nzfvmq5fwa4950bvhfp9s0",
+      "version": "1.18.0",
+      "sha256": "027qmi1cnbvjxzgyfhhm2kn3zgviw8w2px34jh85v7x4kbaxfwjb",
       "depends": ["AnnotationFilter", "Biobase", "BiocGenerics", "IRanges", "MsCoreUtils", "MultiAssayExperiment", "ProtGenerics", "S4Vectors", "SummarizedExperiment", "igraph", "lazyeval", "plotly", "reshape2", "tidyr", "tidyselect"]
+    },
+    "QRscore": {
+      "name": "QRscore",
+      "version": "1.0.0",
+      "sha256": "09bcsj415mcbzcliww5nc8vs2ki4a8pdalz0p8yjc3xkm8zwdskb",
+      "depends": ["BiocParallel", "MASS", "arrangements", "assertthat", "dplyr", "hitandrun", "pscl"]
     },
     "QSutils": {
       "name": "QSutils",
-      "version": "1.24.0",
-      "sha256": "1w02369xr15593nc0ri8ivp2p7j247nkjrqgy5ir590cx8yv2z1z",
+      "version": "1.26.0",
+      "sha256": "0nx8hqpn1p0ny0hfzkajk4kws4vn22q9y2whn65cp7qy6z6fz42f",
       "depends": ["BiocGenerics", "Biostrings", "ape", "psych", "pwalign"]
     },
     "QTLExperiment": {
       "name": "QTLExperiment",
-      "version": "1.4.0",
-      "sha256": "0kspdd7b2a9kkdmhgqwsh19pgv9s7h2vww53krf0azsdc72wddb2",
+      "version": "2.0.0",
+      "sha256": "0q5hfhd6rs6k5dmm187hk3syfmd8lxhw7hpc5635hhy23k6yrasi",
       "depends": ["BiocGenerics", "S4Vectors", "SummarizedExperiment", "ashr", "checkmate", "collapse", "dplyr", "rlang", "tibble", "tidyr", "vroom"]
     },
     "QUBIC": {
       "name": "QUBIC",
-      "version": "1.34.0",
-      "sha256": "130ymhsw0gq7r8f6f0835r1c6594di1f5x2a6f8hl15yi230n0lm",
+      "version": "1.36.0",
+      "sha256": "1xjr4idyfgddlrdcdhnkzbi1f9d42klqs661frckak21c6d7q009",
       "depends": ["Matrix", "Rcpp", "RcppArmadillo", "biclust"]
     },
     "Qtlizer": {
       "name": "Qtlizer",
-      "version": "1.20.0",
-      "sha256": "0pdk81ja3arvfb5g8h8ybjm6k8idy19mdkly9bl2g0ksn1z3inf3",
+      "version": "1.22.0",
+      "sha256": "12pdn4z3wiqivngrs5sw7y0zv8q25a9daw01vxm3z0vymfda8i6c",
       "depends": ["GenomicRanges", "curl", "httr", "stringi"]
     },
     "QuasR": {
       "name": "QuasR",
-      "version": "1.46.0",
-      "sha256": "14c923hhk9pn2a6kslcw5ai5xn50bba43fp9b5p9viaqikgr2nby",
+      "version": "1.48.0",
+      "sha256": "0qgc9zfw58d3lp1qyyl4pj9vmd2k2k2614dyg860ynwm38f4wrsy",
       "depends": ["AnnotationDbi", "BSgenome", "Biobase", "BiocGenerics", "BiocParallel", "Biostrings", "GenomeInfoDb", "GenomicFeatures", "GenomicFiles", "GenomicRanges", "IRanges", "Rbowtie", "Rhtslib", "Rsamtools", "S4Vectors", "ShortRead", "rtracklayer", "txdbmaker"]
     },
     "QuaternaryProd": {
       "name": "QuaternaryProd",
-      "version": "1.40.0",
-      "sha256": "0ngxs9xxnwqgwgdv9pm90s8513cn73khjwrzfg8iv4m98bhkjx3l",
+      "version": "1.42.0",
+      "sha256": "03b7jw8w4ii3j1yga583bh1b26l9x7z7ah60lsp1mqaak9jida3q",
       "depends": ["Rcpp", "dplyr", "yaml"]
     },
     "R3CPET": {
       "name": "R3CPET",
-      "version": "1.38.0",
-      "sha256": "1f0sswwq2iqp29l3hb28aiyvdnx3nsczwi4hgy3nbj1y0x57v7x6",
+      "version": "1.40.0",
+      "sha256": "1b21kbqrd53bhxxwxq4hbfd0v7gsmnjjnaain4s6lap1j5dlm99z",
       "depends": ["BiocGenerics", "GenomeInfoDb", "GenomicRanges", "Hmisc", "IRanges", "RCurl", "Rcpp", "S4Vectors", "clValid", "data_table", "ggbio", "ggplot2", "igraph", "pheatmap", "reshape2"]
     },
     "R453Plus1Toolbox": {
       "name": "R453Plus1Toolbox",
-      "version": "1.56.0",
-      "sha256": "1nbfrj6r1xf9l16hl88z5g1fxbkasbwbmrs1zfsi1zw8yxhwly9j",
+      "version": "1.58.0",
+      "sha256": "1jc585yid6s9aw2if073hqi50wgmlr7g4pkdwvgrcsck45g7llfg",
       "depends": ["BSgenome", "Biobase", "BiocGenerics", "Biostrings", "GenomicRanges", "IRanges", "R2HTML", "Rsamtools", "S4Vectors", "ShortRead", "SummarizedExperiment", "TeachingDemos", "VariantAnnotation", "XVector", "biomaRt", "pwalign", "xtable"]
     },
     "R4RNA": {
       "name": "R4RNA",
-      "version": "1.34.0",
-      "sha256": "0g0lrj5vs2dd3hgm5l0h91hrprzbg02cr5r3kyjqmmzfixr1rzqc",
+      "version": "1.36.0",
+      "sha256": "1a34bxsn668ir8j8vkyp7s5chsji9yyv3wz3nrqnfq1pdmv6avlk",
       "depends": ["Biostrings"]
     },
     "RAIDS": {
       "name": "RAIDS",
-      "version": "1.4.0",
-      "sha256": "0qp0xhj5nv6991l3j9dkznjlg9dl6x0avwqgw7il30i81s8gjjid",
-      "depends": ["AnnotationDbi", "AnnotationFilter", "BSgenome", "GENESIS", "GenomicRanges", "IRanges", "MatrixGenerics", "S4Vectors", "SNPRelate", "VariantAnnotation", "class", "ensembldb", "gdsfmt", "ggplot2", "pROC", "rlang", "stringr"]
+      "version": "1.6.0",
+      "sha256": "0s37f86abyhjr1bl809g2ikrrh93k6kggz0kyqwdi2w3pin6ssvi",
+      "depends": ["AnnotationDbi", "AnnotationFilter", "BSgenome", "GENESIS", "GenomicRanges", "IRanges", "MatrixGenerics", "Rsamtools", "S4Vectors", "SNPRelate", "VariantAnnotation", "class", "dplyr", "ensembldb", "gdsfmt", "ggplot2", "pROC", "rlang", "stringr"]
     },
     "RAREsim": {
       "name": "RAREsim",
-      "version": "1.10.0",
-      "sha256": "183qp2pnpsqv00v651x9vg4wf1zncx0207daxwxjypnkzs2zdsr3",
+      "version": "1.12.0",
+      "sha256": "042k84jicjrp0ckzdxax036r0gi70y9ylkxfbyksmyzmlzrdsypf",
       "depends": ["nloptr"]
     },
     "RBGL": {
       "name": "RBGL",
-      "version": "1.82.0",
-      "sha256": "04sy7kgsjvwlzr6r3lnyrk6l7d9jqfqqzlfcs0b90ciq8gldxlw8",
+      "version": "1.84.0",
+      "sha256": "0mp3xk2v7kf5c2pil6rjdz6s5adla9xrgk008hyj331gpgh6rq22",
       "depends": ["BH", "graph"]
     },
     "RBM": {
       "name": "RBM",
-      "version": "1.38.0",
-      "sha256": "19r1yfik2m5yppq9y5kpslbgfhfla6nhird6h7k2harmncc88k06",
+      "version": "1.40.0",
+      "sha256": "0yzjjf6qndrr66490mrfy9yk38d34lmdccfy14rckazwy595djlw",
       "depends": ["limma", "marray"]
     },
     "RBioFormats": {
       "name": "RBioFormats",
-      "version": "1.6.0",
-      "sha256": "0vqpr5g6v96gnfpznx09pwzcj4n2230hqh8hiip3m3pbnxicilnx",
+      "version": "1.8.0",
+      "sha256": "1nnlrzrw93vgn3xc1syg852mi0cbwydbrmagdksdca1c4bcmz3gh",
       "depends": ["EBImage", "S4Vectors", "rJava"]
     },
     "RBioinf": {
       "name": "RBioinf",
-      "version": "1.66.0",
-      "sha256": "1zx9g3n60xzrrpbslwxi1cmp5rqk5hgj7902swbj5sqgicp23aic",
+      "version": "1.68.0",
+      "sha256": "1q58rgg9mwnj47r945gpnpgdrp2hpkhfmgrs8w8hrqv718v2dx58",
       "depends": ["graph"]
     },
     "RCAS": {
       "name": "RCAS",
-      "version": "1.32.0",
-      "sha256": "0sg3ngb7jwh8gyhmmm7fkxn9ixj590j47rfcfdcnbbk9pwd9y07p",
+      "version": "1.34.0",
+      "sha256": "1p38q8qdbsy8aylv4m07srjs2zzblgmnyal55dd1bi7pxq2ifl2y",
       "depends": ["BSgenome", "BSgenome_Hsapiens_UCSC_hg19", "BiocGenerics", "Biostrings", "DT", "GenomeInfoDb", "GenomicFeatures", "GenomicRanges", "IRanges", "RSQLite", "S4Vectors", "cowplot", "data_table", "genomation", "ggplot2", "gprofiler2", "knitr", "pbapply", "pheatmap", "plotly", "plotrix", "proxy", "ranger", "rmarkdown", "rtracklayer", "seqLogo", "txdbmaker"]
     },
     "RCASPAR": {
       "name": "RCASPAR",
-      "version": "1.52.0",
-      "sha256": "17dzn7gjlkzqskmi6jq11zw419zydkfaw4k7rjm6mlhn5njqhypw",
+      "version": "1.54.0",
+      "sha256": "15yzy4f16rvb1vpspzs85cr5lfx69340js0q32vj3gpfs5riakl9",
       "depends": []
     },
     "RCM": {
       "name": "RCM",
-      "version": "1.22.0",
-      "sha256": "0dgvad2f60l8l5jxgwm084qsh1dx619q641kagjxilg9abhwkzy3",
+      "version": "1.24.0",
+      "sha256": "0czpl1grlkjc66gnjnqkzz8r29p3i5m4m0mlpby3vlqp3gyb1k35",
       "depends": ["DBI", "MASS", "RColorBrewer", "VGAM", "alabama", "edgeR", "ggplot2", "nleqslv", "phyloseq", "reshape2", "tensor", "tseries"]
     },
     "RCSL": {
       "name": "RCSL",
-      "version": "1.14.0",
-      "sha256": "180d278n17n21y1gyvh5dn0x32m8w36h9h9zd7rnxkvkpnv9pc84",
+      "version": "1.16.0",
+      "sha256": "0443frf0wvbjaw9b44j62ksbx8444a5607ldix7bqfdq49ys41ni",
       "depends": ["MatrixGenerics", "NbClust", "Rcpp", "RcppAnnoy", "Rtsne", "SingleCellExperiment", "ggplot2", "igraph", "pracma", "umap"]
     },
     "RCX": {
       "name": "RCX",
-      "version": "1.10.0",
-      "sha256": "1r5yx5w65mk5a9451jp4nqnfjmchf1q9kjqgkrs9blxy5m6dbs2y",
+      "version": "1.12.0",
+      "sha256": "0vjjgz9l153g4k5phci7xi3w7xx3msjkhl3crb75qaldginlxj2n",
       "depends": ["igraph", "jsonlite", "plyr"]
     },
     "RCy3": {
       "name": "RCy3",
-      "version": "2.26.0",
-      "sha256": "17bclz2bv7xzzx2rgpd89d19vlkkv0i67vcrva0v0gxm1cf4zvs1",
+      "version": "2.28.0",
+      "sha256": "0y1vpyvaihh1cm7vxmsrh11i84mm9l60c1xgsqdvil17ycbnsagy",
       "depends": ["BiocGenerics", "IRdisplay", "IRkernel", "RColorBrewer", "RCurl", "RJSONIO", "XML", "base64enc", "base64url", "fs", "glue", "gplots", "graph", "httr", "stringi", "uuid"]
     },
     "RCyjs": {
       "name": "RCyjs",
-      "version": "2.28.0",
-      "sha256": "139c6mw5hwhaw27n51psy9ygwb9wzd73vc9bdykwnmx7s4r9x63w",
+      "version": "2.30.0",
+      "sha256": "0kwfj1fy4plkgpghqbar7c99bandzgq88cjzrcr7y5k5ayq2i82r",
       "depends": ["BiocGenerics", "BrowserViz", "base64enc", "graph", "httpuv"]
     },
     "RDRToolbox": {
       "name": "RDRToolbox",
-      "version": "1.56.0",
-      "sha256": "027s328kp3m9x5wgn17j7g944abxyhf9hm9dk9iqiy1m4zjwnfdz",
+      "version": "1.58.0",
+      "sha256": "0z74xzh658ihg4rgyx83ywc18fa6gmiq2c5vilh4g0rgzhym8b22",
       "depends": ["MASS", "rgl"]
     },
     "REBET": {
       "name": "REBET",
-      "version": "1.24.0",
-      "sha256": "10am2gwl808phnamkd6a2wbsl6k257d73l2gcmshvi8ywziwy5mi",
+      "version": "1.26.0",
+      "sha256": "06rrsv3ixafp44dyyc8p833488jnqs26xwp9x6ihr6j7bhkhlr7d",
       "depends": ["ASSET"]
     },
     "REDseq": {
       "name": "REDseq",
-      "version": "1.52.0",
-      "sha256": "0z46k34dcp9k558k79mpl3jjg999j6294h6ly4gvhxa46f2fvxdy",
+      "version": "1.54.0",
+      "sha256": "1n0z42gp1ar8qy3zrsw7fymykizaihr5azr9xafhn23vs14cbvxw",
       "depends": ["AnnotationDbi", "BSgenome", "BSgenome_Celegans_UCSC_ce2", "BiocGenerics", "Biostrings", "ChIPpeakAnno", "IRanges", "multtest"]
     },
     "REMP": {
       "name": "REMP",
-      "version": "1.30.0",
-      "sha256": "1fckxyhj3m808r8fqs84jachj1sb6s3dvhvrg1l6vm50yhmr8n51",
+      "version": "1.32.0",
+      "sha256": "0lshm5imd49ffg4hjgsc8hm7v5x70yvzxnk463yp7xyv982br00j",
       "depends": ["AnnotationHub", "BSgenome", "BiocGenerics", "BiocParallel", "Biostrings", "GenomeInfoDb", "GenomicRanges", "IRanges", "S4Vectors", "SummarizedExperiment", "caret", "doParallel", "foreach", "impute", "iterators", "kernlab", "minfi", "org_Hs_eg_db", "ranger", "readr", "rtracklayer", "settings"]
     },
     "RESOLVE": {
       "name": "RESOLVE",
-      "version": "1.8.0",
-      "sha256": "1n4xz9pjydnm549b75dmygwxwi71r9xpcx2sh9r7zy0z5dzpa9zx",
-      "depends": ["BSgenome", "BSgenome_Hsapiens_1000genomes_hs37d5", "Biostrings", "GenomeInfoDb", "GenomicRanges", "IRanges", "MutationalPatterns", "RhpcBLASctl", "S4Vectors", "data_table", "ggplot2", "glmnet", "gridExtra", "lsa", "nnls", "reshape2"]
+      "version": "1.10.0",
+      "sha256": "1xmngfmf6wivhrc7k382h270bnkmmd84ciz5824bfgn26apikgb2",
+      "depends": ["BSgenome", "BSgenome_Hsapiens_1000genomes_hs37d5", "Biostrings", "GenomeInfoDb", "GenomicRanges", "IRanges", "MutationalPatterns", "RhpcBLASctl", "S4Vectors", "cluster", "data_table", "ggplot2", "glmnet", "gridExtra", "lsa", "nnls", "reshape2", "survival"]
+    },
+    "RFLOMICS": {
+      "name": "RFLOMICS",
+      "version": "1.0.0",
+      "sha256": "06n5c5v7y6y1mc8jfw96rz046qmhq40daq7qa82kv8yd6ancy450",
+      "depends": ["AnnotationDbi", "ComplexHeatmap", "DT", "EnhancedVolcano", "FactoMineR", "MOFA2", "MultiAssayExperiment", "RColorBrewer", "S4Vectors", "SummarizedExperiment", "UpSetR", "circlize", "clusterProfiler", "coseq", "data_table", "dplyr", "edgeR", "enrichplot", "ggplot2", "ggpubr", "ggrepel", "htmltools", "httr", "knitr", "limma", "magrittr", "mixOmics", "org_At_tair_db", "purrr", "reshape2", "reticulate", "rmarkdown", "shiny", "shinyBS", "shinyWidgets", "shinydashboard", "stringr", "tibble", "tidyr", "tidyselect", "vroom"]
     },
     "RGSEA": {
       "name": "RGSEA",
-      "version": "1.40.0",
-      "sha256": "0g3qw2f5qcb0lsqji3f6mrp62gp5xcx1ibvrv0j4mg6pg2hjp6k2",
+      "version": "1.42.0",
+      "sha256": "08xnvp9bgplilvkch5kwhgh42b4idbyk1ifjik8d66pmcpgh20ln",
       "depends": ["BiocGenerics"]
     },
     "RGraph2js": {
       "name": "RGraph2js",
-      "version": "1.34.0",
-      "sha256": "0x6isz3kxfrsig04wa8y3jvsjg9hcc9r7cv0sqfb0fpfa5hsp376",
+      "version": "1.36.0",
+      "sha256": "0x12x6lhfmiypi3if91dzqgy7s80iwa0y74clj1g3vr9hyrfchix",
       "depends": ["digest", "graph", "rjson", "whisker"]
     },
     "RITAN": {
       "name": "RITAN",
-      "version": "1.30.0",
-      "sha256": "0afnaiv3xvnazx94bzmsh4xny6ingbyvasdgdd25m11i5hnhvy0y",
+      "version": "1.32.0",
+      "sha256": "0ah14512zk6dixis8h61p02hawjdkbxaizar9yzlw5i59b7q0mc2",
       "depends": ["AnnotationFilter", "BgeeDB", "EnsDb_Hsapiens_v86", "GenomicFeatures", "MCL", "RColorBrewer", "RITANdata", "STRINGdb", "dynamicTreeCut", "ensembldb", "ggplot2", "gplots", "gridExtra", "gsubfn", "hash", "igraph", "knitr", "linkcomm", "plotrix", "png", "reshape2", "sqldf"]
     },
     "RIVER": {
       "name": "RIVER",
-      "version": "1.30.0",
-      "sha256": "04fdsfi1j8wrxkh5h18jfhgcbl1rvm7igpzxas5j037mfmfl55cl",
+      "version": "1.32.0",
+      "sha256": "143xkc9pw91nnjc1ckj802mbq8fda6d1n36hb6f2zxjz8lvv4yb6",
       "depends": ["Biobase", "ggplot2", "glmnet", "pROC"]
     },
     "RImmPort": {
       "name": "RImmPort",
-      "version": "1.34.0",
-      "sha256": "007klfjgnaimqrplps50r4hfw22b032ynsb032kdx9z2lp5k8a9i",
+      "version": "1.36.0",
+      "sha256": "1rg3vlh06lzh3k95as0gn4hz11f0h62awd05fg1kzajxlq9g8pmk",
       "depends": ["DBI", "RSQLite", "data_table", "dplyr", "plyr", "reshape2", "sqldf"]
     },
     "RJMCMCNucleosomes": {
       "name": "RJMCMCNucleosomes",
-      "version": "1.30.0",
-      "sha256": "069nyidfr6466z8bzcjikhdgfyjxzrh4fh93wvz06rvrj9wb0sgc",
+      "version": "1.32.0",
+      "sha256": "0bl3kipfs0sn53215al0aq8388c285wx0skvlvcv43n9pi69q31y",
       "depends": ["BiocGenerics", "BiocParallel", "GenomeInfoDb", "GenomicRanges", "IRanges", "Rcpp", "S4Vectors", "consensusSeekeR"]
     },
     "RLMM": {
       "name": "RLMM",
-      "version": "1.68.0",
-      "sha256": "00s9k5wylzkqb3256v4g0rnl7340a5fjb9a6m76p1fdhdr3bwcnv",
+      "version": "1.70.0",
+      "sha256": "08f3w217cqwa467kl5mp33f9vzy4ncx2wxjisl98ga6154ycyfjc",
       "depends": ["MASS"]
     },
     "RLassoCox": {
       "name": "RLassoCox",
-      "version": "1.14.0",
-      "sha256": "0n142f0p5z5723jbz52j8psq37xjc081fdqzm48gcwq85cz6gy7c",
+      "version": "1.16.0",
+      "sha256": "0md18npzq5naddpzhdzx03kdz73173lv8bgrf1igbk59c0jh4psf",
       "depends": ["Matrix", "glmnet", "igraph", "survival"]
     },
     "RMassBank": {
       "name": "RMassBank",
-      "version": "3.16.0",
-      "sha256": "13c4xd28zyvd903ix9x68684251yzyqpihzsjhr2s2d1dxpw8kga",
+      "version": "3.18.0",
+      "sha256": "1ndgm79033daiwlky5b0p3fd3sj2d0qv6nizs0z4wy2kszhwsasp",
       "depends": ["Biobase", "ChemmineR", "MSnbase", "R_utils", "Rcpp", "S4Vectors", "XML", "assertthat", "data_table", "digest", "dplyr", "enviPat", "glue", "httr", "httr2", "logger", "mzR", "purrr", "rcdk", "readJDX", "readr", "rjson", "tibble", "tidyselect", "webchem", "yaml"]
     },
     "RNAAgeCalc": {
       "name": "RNAAgeCalc",
-      "version": "1.18.0",
-      "sha256": "1f4vvx56jfs3ag0z1d815ysg54ff5p5l13cqq2gl9xfq2glqv6qn",
+      "version": "1.20.0",
+      "sha256": "0jqy569c2z09xsczsp2iq9dphcv99giy99yxpqw198ps9dx59a7p",
       "depends": ["AnnotationDbi", "SummarizedExperiment", "ggplot2", "impute", "org_Hs_eg_db", "recount"]
     },
     "RNASeqPower": {
       "name": "RNASeqPower",
-      "version": "1.46.0",
-      "sha256": "0990h7zkfspnxmkfb7lb6i4v7g63ja6yvxxr6k5dvg2pzqpd8bdb",
+      "version": "1.48.0",
+      "sha256": "1fgvgy3dqrpqp26f93d0bi97s5c4y43lhjlbqnjy97qh8iaaz2q8",
       "depends": []
     },
     "RNAdecay": {
       "name": "RNAdecay",
-      "version": "1.26.0",
-      "sha256": "0vqxlncsx686xzdkh5phdaniypb8f5xqf57192qpmw7cimlff729",
+      "version": "1.28.0",
+      "sha256": "10d1ciz37rxgkbi2hnqqq2cqkwrfflx1gcyjb5gl0zl8076rvy3m",
       "depends": ["TMB", "ggplot2", "gplots", "nloptr", "scales"]
     },
     "RNAmodR": {
       "name": "RNAmodR",
-      "version": "1.20.0",
-      "sha256": "01ghazxhl2vgbr215nah46wm5l25ksws69d0lkzbxqv3gbn55q5k",
+      "version": "1.22.0",
+      "sha256": "0xmbr3pfihxq6yhqcw0nrvl3zbxg6z6ajp7xyssa5gv5s52clr64",
       "depends": ["BSgenome", "BiocGenerics", "BiocParallel", "Biostrings", "GenomeInfoDb", "GenomicAlignments", "GenomicFeatures", "GenomicRanges", "Gviz", "IRanges", "Modstrings", "RColorBrewer", "ROCR", "Rsamtools", "S4Vectors", "colorRamps", "ggplot2", "matrixStats", "reshape2", "rtracklayer", "txdbmaker"]
     },
     "RNAmodR_AlkAnilineSeq": {
       "name": "RNAmodR.AlkAnilineSeq",
-      "version": "1.20.0",
-      "sha256": "19ibdmwns9489s42ydym30x0g8g2jhynvayplvw0g24r31q1hkv4",
+      "version": "1.22.0",
+      "sha256": "0kh4mdc6qhl3gdmpa34cxpcn9kplpvq8z47zcyhrm3ghw1gcajyr",
       "depends": ["BiocGenerics", "GenomicRanges", "Gviz", "IRanges", "RNAmodR", "S4Vectors"]
     },
     "RNAmodR_ML": {
       "name": "RNAmodR.ML",
-      "version": "1.20.0",
-      "sha256": "10gc7wq2drdbgch09lwn3q1xwkf63z6wlr40kjr9cs3r1lggmn5h",
+      "version": "1.22.0",
+      "sha256": "1gc91kmnirkiisvizr8m9l16jlfb6zg5bkkjrlhz4i6yzscm8ljp",
       "depends": ["BiocGenerics", "GenomicRanges", "IRanges", "RNAmodR", "S4Vectors", "ranger"]
     },
     "RNAmodR_RiboMethSeq": {
       "name": "RNAmodR.RiboMethSeq",
-      "version": "1.20.0",
-      "sha256": "0z2xaf6f5w9sdkvjf3w6yd01faw12wnppsw82770b56q56a16rvb",
+      "version": "1.22.0",
+      "sha256": "0sk74zkdfvf6pz2xxbga8fmp3r9sa4mk9zmd60j16049mhg6nicq",
       "depends": ["BiocGenerics", "GenomicRanges", "Gviz", "IRanges", "RNAmodR", "S4Vectors"]
     },
     "RNAsense": {
       "name": "RNAsense",
-      "version": "1.20.0",
-      "sha256": "0n187h5sw9idzs897c9gvx2wfw9qzlzs2w5a0vkgphfd9jnk29r3",
+      "version": "1.22.0",
+      "sha256": "0x9njljjkmcb7nw27wf1ka31g7r4g8cd3pnlv33sc01fm1lzs53f",
       "depends": ["NBPSeq", "SummarizedExperiment", "ggplot2", "qvalue"]
     },
     "RNAseqCovarImpute": {
       "name": "RNAseqCovarImpute",
-      "version": "1.4.0",
-      "sha256": "1w5nzf21yagnzb8m3npf1za970fpnki2vfccziihwg24i8mr1klz",
+      "version": "1.6.0",
+      "sha256": "0phxjvg4ym8bcva22zyhq3rzi7jkv3m9af1spscpglcbs5kw4wcy",
       "depends": ["Biobase", "BiocGenerics", "BiocParallel", "dplyr", "edgeR", "foreach", "limma", "magrittr", "mice", "rlang"]
     },
     "ROC": {
       "name": "ROC",
-      "version": "1.82.0",
-      "sha256": "1dmpi47pdxx0zfqvjc8najqr6qgqh6472qnsvycx44ldh5prl4lr",
+      "version": "1.84.0",
+      "sha256": "0bnw1n8bc03s0lfc6nlsbbzh2jkq95dvsfyv4dmxnr5cg5xvr6rm",
       "depends": ["knitr"]
     },
     "ROCpAI": {
       "name": "ROCpAI",
-      "version": "1.18.0",
-      "sha256": "0xsfcvc4n4yfyxnzp27jzmw3rlmcgz29aqvr262xf0g49p9j1fxv",
+      "version": "1.20.0",
+      "sha256": "09lvnaf1ampnmknq5g5fb68rm9gy02bn3747zi3zrvlh2dx0v3dl",
       "depends": ["SummarizedExperiment", "boot", "fission", "knitr"]
     },
     "ROSeq": {
       "name": "ROSeq",
-      "version": "1.18.0",
-      "sha256": "0p2ws8i3yns98b3nq8w46kd005r994da7fkbnd0sic05af29piqx",
+      "version": "1.20.0",
+      "sha256": "0dym341bbjwrc2w7ikiv92c6z27h107n32j1c7xjk0wjj6lji5nb",
       "depends": ["edgeR", "limma", "pbmcapply"]
     },
     "ROTS": {
       "name": "ROTS",
-      "version": "1.34.0",
-      "sha256": "16prf1kwkgqcal37jhk4s3hz6yzlklxwm2clsmw8jf74n0igp0x0",
-      "depends": ["Biobase", "Rcpp"]
+      "version": "2.0.0",
+      "sha256": "0y7n4bxw2945ygr1qk1yranvw57f2aspsk32hiyf3rhwvbl3vq2q",
+      "depends": ["Biobase", "BiocParallel", "Rcpp", "lme4"]
     },
     "ROntoTools": {
       "name": "ROntoTools",
-      "version": "2.34.0",
-      "sha256": "1yaidmivm4qhm6d1dqzl88wp637wp64pk2agbwykqgxah537j7rs",
+      "version": "2.36.0",
+      "sha256": "10gszx387x7clilzz31m0bmyh6r12q11585ayki0bmxfarkjp9jv",
       "depends": ["KEGGREST", "KEGGgraph", "Rgraphviz", "boot", "graph"]
     },
     "RPA": {
       "name": "RPA",
-      "version": "1.62.0",
-      "sha256": "1xgz995kxw8ydrra7npwsxywy1darm45fhgmmf9hlrkq05cqpjqa",
+      "version": "1.64.0",
+      "sha256": "15v1dmz6vdmf7n90vx4v3lrxqb94mqs72i839dplalw75z3jb6ly",
       "depends": ["BiocGenerics", "BiocStyle", "affy", "phyloseq", "rmarkdown"]
     },
     "RProtoBufLib": {
       "name": "RProtoBufLib",
-      "version": "2.18.0",
-      "sha256": "1r9462sx6qfxbvrzzngcahg6mh77giapfvl16qswddn19jh8yc2g",
+      "version": "2.20.0",
+      "sha256": "1vz9kdjdgcfipz743df4w060xzw2bx102ymps5j8x9brvjjp0h4q",
       "depends": []
     },
     "RRHO": {
       "name": "RRHO",
-      "version": "1.46.0",
-      "sha256": "0hil5s0b1xfl0hh2vsgiw13kdn3qb6bx6wxqv60xx1qgy6sd33y6",
+      "version": "1.48.0",
+      "sha256": "16yxzb8919hj3bbbwmgrb56igcskdq6gcf4pdpvg2aflzpd44p9h",
       "depends": ["VennDiagram"]
     },
     "RSVSim": {
       "name": "RSVSim",
-      "version": "1.46.0",
-      "sha256": "0pqzxk26wsnsw6a7nir1nkv3kbyjwc67hyfw829jlipgfbjb0pn5",
+      "version": "1.48.0",
+      "sha256": "0ac7bs02jbdi0nmlrc60lb4j58291cvq8nnc5aa4y4gkmczzay28",
       "depends": ["Biostrings", "GenomicRanges", "IRanges", "ShortRead"]
     },
     "RSeqAn": {
       "name": "RSeqAn",
-      "version": "1.26.0",
-      "sha256": "14a20xi288c88m5m82qqarnsz6bj2kf20k2r6pxldc9w1y524l2j",
+      "version": "1.28.0",
+      "sha256": "12a0vsykhsb948lgfvr378idhxg07kaxr7ipllya4nwcbghpfk1p",
       "depends": ["Rcpp"]
     },
     "RTCA": {
       "name": "RTCA",
-      "version": "1.58.0",
-      "sha256": "1bvkpg1lj4cmqib3r3i6v477d0sl620g51ihl9ay409c7z3d09k2",
+      "version": "1.60.0",
+      "sha256": "09dzdxpkn29kpqx0av9xns53l1xfv3cs9r8vx3kf0rznag8ibm6r",
       "depends": ["Biobase", "RColorBrewer", "gtools"]
     },
     "RTCGA": {
       "name": "RTCGA",
-      "version": "1.36.0",
-      "sha256": "0x6fxfc75gkkvmp9ah7v0c0kg8v9m6jnysygvj76r62bkqziigr4",
+      "version": "1.38.0",
+      "sha256": "0s7wyp8i7nqwpcvrg5w92q8k24qfh7n8cn8rk5nyg0wpfy3594z7",
       "depends": ["RCurl", "XML", "assertthat", "data_table", "dplyr", "ggplot2", "ggthemes", "htmltools", "knitr", "purrr", "rmarkdown", "rvest", "scales", "stringi", "survival", "survminer", "viridis", "xml2"]
     },
     "RTCGAToolbox": {
       "name": "RTCGAToolbox",
-      "version": "2.36.0",
-      "sha256": "1824p551155qj7g85wb2spp6v77hjl37s86zy9n2zyfkwiwg321y",
+      "version": "2.38.0",
+      "sha256": "1b6f1v56mg59i1kzp63i57cqqw2d3ni8g6wbry7igf0k4r4ys401",
       "depends": ["BiocGenerics", "DelayedArray", "GenomeInfoDb", "GenomicRanges", "RCurl", "RJSONIO", "RaggedExperiment", "S4Vectors", "SummarizedExperiment", "TCGAutils", "data_table", "httr", "rvest", "stringr"]
     },
     "RTN": {
       "name": "RTN",
-      "version": "2.30.0",
-      "sha256": "05kn9lwcg5cmlsg6yi2f4ccp8slcmfgppikk80rp5cvqs9ymhcmm",
+      "version": "2.32.0",
+      "sha256": "02w4szrmpf83n6bac763d2jn8d8aashi15zp30652c17s0l7i6vr",
       "depends": ["IRanges", "RedeR", "S4Vectors", "SummarizedExperiment", "car", "data_table", "igraph", "limma", "minet", "mixtools", "pheatmap", "pwr", "snow", "viper"]
     },
     "RTNduals": {
       "name": "RTNduals",
-      "version": "1.30.0",
-      "sha256": "18qzwzjzn97js7ms9pzyvxyj14axplzn4ji5lh2nfvk6biw06ir1",
+      "version": "1.32.0",
+      "sha256": "1zfig6q8rs93923fry7rjbipwcw6x5f7mfdmzvq3zp26x50yhkbj",
       "depends": ["RTN"]
     },
     "RTNsurvival": {
       "name": "RTNsurvival",
-      "version": "1.30.0",
-      "sha256": "02jixshfbk2jxhj1659fmr5bxjqmb71c3pfljl7yff6wsl33a2g6",
+      "version": "1.32.0",
+      "sha256": "0l6kahakgygx1q8sn4naidnf2y5v7nx61d2bkikjlm8nbk3r0b34",
       "depends": ["RColorBrewer", "RTN", "RTNduals", "data_table", "dunn_test", "egg", "ggplot2", "pheatmap", "scales", "survival"]
     },
     "RTopper": {
       "name": "RTopper",
-      "version": "1.52.0",
-      "sha256": "0qxbapwky27zc75sjsm2msqp0nrwvqfx4n386z7jlp4hqbj992wq",
+      "version": "1.54.0",
+      "sha256": "1prgabp4cxaswl6kqdpnp1928cmbw3vgw69wfjq342n08ldrmnm4",
       "depends": ["Biobase", "limma", "multtest"]
+    },
+    "RUCova": {
+      "name": "RUCova",
+      "version": "1.0.0",
+      "sha256": "15ampn6mdsi3gjrpa38f0j51fsmgfvl7nc00icfci8p95xbfn4f9",
+      "depends": ["ComplexHeatmap", "Matrix", "S4Vectors", "SingleCellExperiment", "SummarizedExperiment", "circlize", "dplyr", "fastDummies", "ggplot2", "magrittr", "stringr", "tibble", "tidyr", "tidyverse"]
     },
     "RUVSeq": {
       "name": "RUVSeq",
-      "version": "1.40.0",
-      "sha256": "0218z7g8c48lhpgd98kpsqph4pa4pdq35lkpwsbhh9l3bzn4db17",
+      "version": "1.42.0",
+      "sha256": "1b7f8zpkaz5h9ir8ajygnynh4n3ym4yd42vchjiv1w5zbc6q1s92",
       "depends": ["Biobase", "EDASeq", "MASS", "edgeR"]
     },
     "RUVcorr": {
       "name": "RUVcorr",
-      "version": "1.38.0",
-      "sha256": "174h0dvm8xaqg7mikmzzc2870gwfnx9bcbbf5ys5ksnifzh8ihz8",
+      "version": "1.40.0",
+      "sha256": "15jc2rbry8vgibsw5iivjnghzkdyjnqqvq9pfdklqp2ngwxqh26c",
       "depends": ["BiocParallel", "MASS", "bladderbatch", "corrplot", "gridExtra", "lattice", "psych", "reshape2", "snowfall"]
     },
     "RUVnormalize": {
       "name": "RUVnormalize",
-      "version": "1.40.0",
-      "sha256": "0ds9s7xlaz02jrk57gzn4dnalgs2l4gwx1s8rlk806la8zdj25dq",
+      "version": "1.42.0",
+      "sha256": "13r06k8vwhj37bf7y9s2yanwa2z6avrsp9wy1q5gsrx8x5bds3va",
       "depends": ["Biobase", "RUVnormalizeData"]
     },
     "RVS": {
       "name": "RVS",
-      "version": "1.28.0",
-      "sha256": "13f9m4w9dy3j6ayqpysiahmsn8mf03mhrjjcq094g58nqxpqly8s",
+      "version": "1.30.0",
+      "sha256": "1v6rqj5prxiy9zh8xzgh0dwa2vb2sg2km36221jjijzf58h1gsb2",
       "depends": ["GENLIB", "R_utils", "gRain", "kinship2", "snpStats"]
     },
     "RadioGx": {
       "name": "RadioGx",
-      "version": "2.10.0",
-      "sha256": "0lcsvbqcw7rf21d5gwis6n055r2j30qh0526j0im70vqyhp4928m",
+      "version": "2.12.0",
+      "sha256": "1jqyyzipabs4s245f4rsvv0pyxgjwan7hawkldqcldkvap9yw1za",
       "depends": ["Biobase", "BiocGenerics", "BiocParallel", "CoreGx", "RColorBrewer", "S4Vectors", "SummarizedExperiment", "assertthat", "caTools", "data_table", "downloader", "magicaxis", "matrixStats", "reshape2", "scales"]
     },
     "RaggedExperiment": {
       "name": "RaggedExperiment",
-      "version": "1.30.0",
-      "sha256": "0np94bh1qxwwmllxsf2hf4vv7lnjmghrjfg1g07kcwfhnmm5n56l",
+      "version": "1.32.0",
+      "sha256": "0mr7jm6lf9f235bqldpsjcqm29f94y7l53shr4flymmh7vrnjh7y",
       "depends": ["BiocBaseUtils", "BiocGenerics", "GenomeInfoDb", "GenomicRanges", "IRanges", "Matrix", "MatrixGenerics", "S4Vectors", "SummarizedExperiment"]
     },
     "RankProd": {
       "name": "RankProd",
-      "version": "3.32.0",
-      "sha256": "0zmsg8cn20jcx8dk3dnn3477k6ncdml548qp4p4g5v17ijs04mym",
+      "version": "3.34.0",
+      "sha256": "1dj2bgqkm82j0xx2wcdvh2gp42v15xjn8w5jymwslxhpqvzyvjdm",
       "depends": ["Rmpfr", "gmp"]
     },
     "RareVariantVis": {
       "name": "RareVariantVis",
-      "version": "2.34.0",
-      "sha256": "0984sk6hhkczvz9b6kkak2v1s1j695if6s321a47z6k0h20ddzpl",
+      "version": "2.36.0",
+      "sha256": "1ycna49rl2ym79i8sdhndpz36glv96diwd5pblqcpk5zicnmq773",
       "depends": ["BSgenome", "BSgenome_Hsapiens_UCSC_hg19", "BiocGenerics", "GenomeInfoDb", "GenomicFeatures", "GenomicRanges", "GenomicScores", "IRanges", "S4Vectors", "SummarizedExperiment", "TxDb_Hsapiens_UCSC_hg19_knownGene", "VariantAnnotation", "googleVis", "gtools", "phastCons100way_UCSC_hg19"]
     },
     "Rarr": {
       "name": "Rarr",
-      "version": "1.6.0",
-      "sha256": "0d9nnil8x010p7b96fnzigzs3za4dm8iq9f9j2vz02j0kmlk32x7",
+      "version": "1.8.0",
+      "sha256": "0xgy7crpl8cx4a31ka3nsvd58jhq3181ihrid69b9cxlbi5dx0r1",
       "depends": ["BiocGenerics", "DelayedArray", "R_utils", "httr", "jsonlite", "paws_storage", "stringr"]
     },
     "RbcBook1": {
       "name": "RbcBook1",
-      "version": "1.74.0",
-      "sha256": "1b3c8swhkrnf1j1smca8vp4g0kzxv2qrgvf9mm5wraxhnwycdm4q",
+      "version": "1.76.0",
+      "sha256": "0skv22msidapcir87glhl29k1gw931yfar5927m4vk7rn2hv4qv3",
       "depends": ["Biobase", "graph", "rpart"]
     },
     "Rbec": {
       "name": "Rbec",
-      "version": "1.14.0",
-      "sha256": "12lv7rwsvmxhxzq22d8rxc87xr2n325zz9vfsv5kqwh3cr6y4dnn",
+      "version": "1.16.0",
+      "sha256": "0whybz4pj99bpsfbxa1qa954cc888k5n7xmba5aj8f9zxk384hvd",
       "depends": ["Rcpp", "dada2", "doParallel", "foreach", "ggplot2", "readr"]
     },
     "Rbowtie": {
       "name": "Rbowtie",
-      "version": "1.46.0",
-      "sha256": "0cbdg469796ij1n8l42mp1c30y2r28j7as6q7add38rpfrmj57b7",
+      "version": "1.48.0",
+      "sha256": "0jcj8z1p2k993ngwyndv60gqm7kwsmc0wsazllgi1y68dxcawwav",
       "depends": []
     },
     "Rbowtie2": {
       "name": "Rbowtie2",
-      "version": "2.12.3",
-      "sha256": "0raa82fc90zb6z24scf395k0gg1qfabjcwcgzl5w15vlgfzj0byy",
+      "version": "2.14.0",
+      "sha256": "0hg9xdybx3wnqgwf21df7mdabi73n5v8shw6jj4zx545g7j6sk95",
       "depends": ["Rsamtools", "magrittr"]
+    },
+    "RbowtieCuda": {
+      "name": "RbowtieCuda",
+      "version": "1.0.0",
+      "sha256": "0rwpk0d1hvwwg1jahmwp0flp1s2vk9zgls6xlb8ka4381mj6rbmm",
+      "depends": []
     },
     "Rbwa": {
       "name": "Rbwa",
-      "version": "1.10.0",
-      "sha256": "1v8l0srjgw29dnp5aln8n44hp4zvvngagz3498rs0930kx2fqrxk",
+      "version": "1.12.0",
+      "sha256": "01qwndi4831l25l74rlq9jxzidslcf8yrwvqqsr633s33fr6cwa3",
       "depends": []
     },
     "RcisTarget": {
       "name": "RcisTarget",
-      "version": "1.26.0",
-      "sha256": "0iggn3p3i36xgl79dbs0nf9nv9cyiap7mlgg2s5q1fx9mni501xw",
+      "version": "1.28.0",
+      "sha256": "1rfk1z9mnla8d8wj50ajvyr7bwnsl49ragjcbxdckzix6v276l9p",
       "depends": ["AUCell", "BiocGenerics", "GSEABase", "GenomeInfoDb", "GenomicRanges", "R_utils", "S4Vectors", "SummarizedExperiment", "arrow", "data_table", "dplyr", "tibble", "zoo"]
     },
     "Rcollectl": {
       "name": "Rcollectl",
-      "version": "1.6.0",
-      "sha256": "01ghyjm47xrs1cgfn7kr57kcq9mhfsppc30fwaaw8j5hav0cpmm1",
+      "version": "1.8.0",
+      "sha256": "1c7xm74k1sdf4nc9js0pgigl984n38vik5xkhwb2fz14xz8ww4v6",
       "depends": ["ggplot2", "lubridate", "processx"]
     },
     "Rcpi": {
       "name": "Rcpi",
-      "version": "1.42.0",
-      "sha256": "15rq90391mgcdgjwas4a3kfjjnbazm9hmhffmsmyrhw9b3s3dhjj",
+      "version": "1.44.0",
+      "sha256": "0apx48n35hsnavhpk19h0qif5918q81x862vs5m3b2l9dsizy10v",
       "depends": ["Biostrings", "GOSemSim", "curl", "doParallel", "foreach", "httr2", "jsonlite", "rlang"]
     },
     "Rcwl": {
       "name": "Rcwl",
-      "version": "1.22.0",
-      "sha256": "0z9wh5cgi4zx3qxr10ly02h8qg27fphjp0fid9wlxpicrvq13b9w",
+      "version": "1.24.0",
+      "sha256": "1yk29i6kx722vgxnkgjj5jc0p3kiyd5gr3ixgcd8aph7ysfwnvbz",
       "depends": ["BiocParallel", "DiagrammeR", "R_utils", "S4Vectors", "basilisk", "batchtools", "codetools", "shiny", "yaml"]
     },
     "RcwlPipelines": {
       "name": "RcwlPipelines",
-      "version": "1.22.0",
-      "sha256": "1l9rn16cz9hl9n1h59zps4zn5gkc9l0cm8v15pcghqh1fnrsa0mg",
+      "version": "1.24.0",
+      "sha256": "1jmyz3pxs9wb828laa38yz549hnl99c1nsgypdb1z4iqi5nn2n6i",
       "depends": ["BiocFileCache", "Rcwl", "S4Vectors", "git2r", "httr", "rappdirs"]
     },
     "Rdisop": {
       "name": "Rdisop",
-      "version": "1.66.0",
-      "sha256": "04w3cdk110n9cx6rzpgrxjz4dl6sghqpjj4hvh37axv7f8p52f02",
+      "version": "1.68.0",
+      "sha256": "0miqpygj9fk38qdxw51sr593hl131l9hx5kgjm71qq8wpwyd5ffd",
       "depends": ["Rcpp"]
     },
     "ReUseData": {
       "name": "ReUseData",
-      "version": "1.6.0",
-      "sha256": "1jq1zyh0fy7cdjmiq4332gwfvh5c8s29x795jczgkjp7br4zaf5j",
+      "version": "1.8.0",
+      "sha256": "19sp94y9yik24wwvwjx2phvc79azlr0336g7b32xacb8q27vzvl5",
       "depends": ["BiocFileCache", "Rcwl", "RcwlPipelines", "S4Vectors", "basilisk", "jsonlite", "yaml"]
     },
     "ReactomeGSA": {
       "name": "ReactomeGSA",
-      "version": "1.20.0",
-      "sha256": "11y40xxm6h35sjcmlmmlxkfxii3i4sa6zmbxd3zym2ra5hhaak8v",
-      "depends": ["Biobase", "RColorBrewer", "dplyr", "ggplot2", "gplots", "httr", "jsonlite", "progress", "tidyr"]
+      "version": "1.22.0",
+      "sha256": "1454alxr3hb9kmcbs6hsgqhds8cx11skw0fbxbdsf3jqn9niqvqy",
+      "depends": ["Biobase", "BiocSingular", "RColorBrewer", "SummarizedExperiment", "dplyr", "ggplot2", "gplots", "httr", "igraph", "jsonlite", "progress", "tidyr"]
     },
     "ReactomePA": {
       "name": "ReactomePA",
-      "version": "1.50.0",
-      "sha256": "15l2j7jhwr3f024h3px18z9kgva3g0kghgwm8gy9dp5ljdz68d4w",
+      "version": "1.52.0",
+      "sha256": "0gh2p7c7kab84kyrqad9ai6ywnpc5l9zryizj939mc88akjywgdx",
       "depends": ["AnnotationDbi", "DOSE", "enrichplot", "ggplot2", "ggraph", "graphite", "gson", "igraph", "reactome_db", "yulab_utils"]
     },
     "ReadqPCR": {
       "name": "ReadqPCR",
-      "version": "1.52.0",
-      "sha256": "0j0d65yp8z9mx6j1s66wj2cvj1ms8pwc2i3jjarhpbbvsg1lwsda",
+      "version": "1.54.0",
+      "sha256": "0lzqr14rszkzhdg183kqpzamh2ii65rfrvb28iibzjmj0amp5khx",
       "depends": ["Biobase"]
     },
     "RedeR": {
       "name": "RedeR",
-      "version": "3.2.0",
-      "sha256": "08zjh71si6dp2dmf03lbnxm1alq5yy5pkik06a0d2hsjp1jmikxl",
+      "version": "3.4.0",
+      "sha256": "0nfnjhklhpsx149rqb0zldzs82nq39mhh4r3p1hl70ixk3xb3qbf",
       "depends": ["igraph", "scales"]
     },
     "RedisParam": {
       "name": "RedisParam",
-      "version": "1.8.0",
-      "sha256": "1flb5r16x5n5c0y08gyr86apa2hn8jz0vd8kf7m6k412cy2sm8q3",
+      "version": "1.10.0",
+      "sha256": "1bangsygwq1g3ijh9g3cbjp9pa1axb19jcs927d3gw0mdrqq3cbv",
       "depends": ["BiocParallel", "futile_logger", "redux", "withr"]
+    },
+    "ReducedExperiment": {
+      "name": "ReducedExperiment",
+      "version": "0.99.6",
+      "sha256": "1740r20m83407i79pbpqrqwwy0pc7vwgs9jdhgaw2r1aqq959wf4",
+      "depends": ["BiocGenerics", "BiocParallel", "RColorBrewer", "S4Vectors", "SummarizedExperiment", "WGCNA", "biomaRt", "car", "clusterProfiler", "ggplot2", "ica", "lme4", "lmerTest", "moments", "msigdbr", "patchwork", "pheatmap"]
     },
     "RegEnrich": {
       "name": "RegEnrich",
-      "version": "1.16.0",
-      "sha256": "0l419ymjwj2r8113xl3nr5njrch5wy9ny7rspikiy15w36xyy02x",
+      "version": "1.18.0",
+      "sha256": "15wwghc7mv0cvx1rs7s49qlkb44j688fkxr8icwns4zq8819h71v",
       "depends": ["BiocParallel", "BiocSet", "BiocStyle", "DESeq2", "DOSE", "S4Vectors", "SummarizedExperiment", "WGCNA", "dplyr", "fgsea", "ggplot2", "limma", "magrittr", "randomForest", "reshape2", "tibble"]
     },
     "RegionalST": {
       "name": "RegionalST",
-      "version": "1.4.2",
-      "sha256": "1mc2gx8cf2d91cf7r71pmbim0wmfd38i9ldavwakajvq7j0s4pw4",
+      "version": "1.6.0",
+      "sha256": "003lpwgckxpnfqxi4ha5rm9djqy29r9yiwf23m5lcry8p6rwbjpx",
       "depends": ["BayesSpace", "BiocStyle", "RColorBrewer", "S4Vectors", "Seurat", "SingleCellExperiment", "SummarizedExperiment", "TOAST", "assertthat", "colorspace", "dplyr", "fgsea", "ggplot2", "gridExtra", "magrittr", "scater", "shiny", "tibble"]
     },
     "RepViz": {
       "name": "RepViz",
-      "version": "1.22.0",
-      "sha256": "1rysb9f8jqy5l7ywn4i7yg6323rri6a40rfibxj4a0il54h4a275",
+      "version": "1.24.0",
+      "sha256": "0822djg1akxrbz02wvvyn54b25nsrnhvwprnj4nj5bz981gcbn2p",
       "depends": ["GenomicRanges", "IRanges", "Rsamtools", "S4Vectors", "biomaRt"]
     },
     "Repitools": {
       "name": "Repitools",
-      "version": "1.52.0",
-      "sha256": "0pbr9dj2v7nyv8c9synx6k5w3yj28k02m8jlfjc9yhly56qz95yr",
+      "version": "1.54.0",
+      "sha256": "0k5vgpdnk4l0bi55dpidb2c6g13gyfia4xjzgsaliqaz3ss5w61x",
       "depends": ["BSgenome", "BiocGenerics", "Biostrings", "DNAcopy", "GenomeInfoDb", "GenomicAlignments", "GenomicRanges", "IRanges", "MASS", "Rsamtools", "Rsolnp", "S4Vectors", "cluster", "edgeR", "gplots", "gsmoothr", "rtracklayer"]
     },
     "ReportingTools": {
       "name": "ReportingTools",
-      "version": "2.46.0",
-      "sha256": "1w749cn04lkicdb5p9xw4zs2i7i6810m8wm10lpvcby66lja1d7l",
+      "version": "2.48.0",
+      "sha256": "153y3v6wwdwn93m361xg6xb1nfl0v6px55p2rs2g08x82l5awmaj",
       "depends": ["AnnotationDbi", "Biobase", "BiocGenerics", "Category", "DESeq2", "GOstats", "GSEABase", "IRanges", "PFAM_db", "R_utils", "XML", "annotate", "edgeR", "ggbio", "ggplot2", "hwriter", "knitr", "lattice", "limma"]
     },
     "ResidualMatrix": {
       "name": "ResidualMatrix",
-      "version": "1.16.0",
-      "sha256": "0kxazkh6hz1x5jj1j2n3rww3jknb4nmgj8pjmj3jpqq0sb1gf292",
+      "version": "1.18.0",
+      "sha256": "0abf6i2z79d6jaa2ysibx9fx45f6chzra9q10s1rl02af6l6x3av",
       "depends": ["DelayedArray", "Matrix", "S4Vectors"]
     },
     "Rfastp": {
       "name": "Rfastp",
-      "version": "1.16.0",
-      "sha256": "1pa9qiix3bajxsdibkx6l0y8qq0livk86r91d4idm6pl6l1jxncb",
+      "version": "1.18.0",
+      "sha256": "0lbfwgy5iv7jbbfgsijcyd7kfx7r5lpj3k5xypfdcx8cj9mm3ysb",
       "depends": ["Rcpp", "Rhtslib", "ggplot2", "reshape2", "rjson", "zlibbioc"]
     },
     "RgnTX": {
       "name": "RgnTX",
-      "version": "1.8.0",
-      "sha256": "0sps5c621k3vlq492ijly9w9450hsymdgg2hrnvk2ggw4i7zjq3m",
+      "version": "1.10.0",
+      "sha256": "1vxpsnq94zddz3db62x69pmq7j9rwqgryh2zc116pgzk28hs98nm",
       "depends": ["GenomeInfoDb", "GenomicFeatures", "GenomicRanges", "IRanges", "S4Vectors", "TxDb_Hsapiens_UCSC_hg19_knownGene", "ggplot2", "regioneR"]
     },
     "Rgraphviz": {
       "name": "Rgraphviz",
-      "version": "2.50.0",
-      "sha256": "0jljp88rxdq16b1976g77ix5x61ajr60fjf20wp9j17x4q9h2c1p",
+      "version": "2.52.0",
+      "sha256": "14capi4azvrk8lfidp8akp9l3nml5c4c0rv1j0wwbw3gqqvi1daz",
       "depends": ["graph"]
     },
     "Rhdf5lib": {
       "name": "Rhdf5lib",
-      "version": "1.28.0",
-      "sha256": "0l9hq7444azc72h3185qch053a9rvm89aagisrsn01k5c32jwk9r",
+      "version": "1.30.0",
+      "sha256": "0il7gj2msd25c4xmg5aw4z4y4gm1bzrdr9n0pn4h9k0nm7m0c1hp",
       "depends": []
     },
     "Rhisat2": {
       "name": "Rhisat2",
-      "version": "1.22.0",
-      "sha256": "1gmkr0k6qlp3cp4pkankasv098rf7bjrw5bm905w5m4mzw0r1sai",
+      "version": "1.24.0",
+      "sha256": "04frc8xw60hvqkcss85pya2ajxrrwihlb5x0wwhhyf32rkfxl9q1",
       "depends": ["GenomicRanges", "SGSeq", "txdbmaker"]
     },
     "Rhtslib": {
       "name": "Rhtslib",
-      "version": "3.2.0",
-      "sha256": "099j1hmmqqs6v5gffxxvizv784ildadqg6kicfshb45ykc8kkvzm",
-      "depends": ["zlibbioc"]
+      "version": "3.4.0",
+      "sha256": "19y80cmm7njws4v30h55izm5qkvsz8hszm58i23xi8niw8s5qp47",
+      "depends": []
     },
     "RiboCrypt": {
       "name": "RiboCrypt",
-      "version": "1.12.0",
-      "sha256": "0in80q3b0h0ih2yjw990p3fy59bjf92aczywh9ari7s3qmjaickr",
+      "version": "1.13.0",
+      "sha256": "0sxj27rpf43vqdf16k53msxxam16l1z441ndnqc1insx2ggkannp",
       "depends": ["BiocGenerics", "BiocParallel", "Biostrings", "GenomeInfoDb", "GenomicFeatures", "GenomicRanges", "IRanges", "NGLVieweR", "ORFik", "RCurl", "bslib", "data_table", "dplyr", "ggplot2", "htmlwidgets", "httr", "jsonlite", "knitr", "markdown", "plotly", "rlang", "shiny", "shinycssloaders", "shinyhelper", "shinyjqui", "stringr"]
     },
     "RiboDiPA": {
       "name": "RiboDiPA",
-      "version": "1.14.0",
-      "sha256": "1p5d5z6g9yc060sp00kkkyi03b01gh463qyvbwhj7fcd0l6z2399",
+      "version": "1.16.0",
+      "sha256": "1kmjkqvn2l8vrhd88y16kzkb7ff1l0kg6s3sp6r17mzgnv5873ij",
       "depends": ["BiocFileCache", "BiocGenerics", "DESeq2", "GenomicAlignments", "GenomicFeatures", "GenomicRanges", "IRanges", "Rcpp", "Rsamtools", "S4Vectors", "data_table", "doParallel", "elitism", "foreach", "ggplot2", "matrixStats", "qvalue", "reldist", "txdbmaker"]
     },
     "RiboProfiling": {
       "name": "RiboProfiling",
-      "version": "1.36.0",
-      "sha256": "1lw88kw3wqzqb5ahq6p9zchqbkq7f2hm8djngq1r81ydjdmnih3p",
+      "version": "1.38.0",
+      "sha256": "0yasqc6pqqxnhqfhwas1c9bm1820q716laq8fvdymah7l6x0gjb8",
       "depends": ["BiocGenerics", "Biostrings", "GenomeInfoDb", "GenomicAlignments", "GenomicFeatures", "GenomicRanges", "IRanges", "Rsamtools", "S4Vectors", "data_table", "ggbio", "ggplot2", "plyr", "reshape2", "rtracklayer", "sqldf"]
+    },
+    "Rigraphlib": {
+      "name": "Rigraphlib",
+      "version": "1.0.0",
+      "sha256": "1fvr24vhnmbzvymqpbz2zsmxr2ii9j82j0v4s6g91lhz36z7fnx5",
+      "depends": ["biocmake"]
     },
     "Rmagpie": {
       "name": "Rmagpie",
-      "version": "1.62.0",
-      "sha256": "11qmda8w5na9hfjnhdgbycvpgvzwj956qav5i8l39r2p9vrajli9",
+      "version": "1.64.0",
+      "sha256": "127jqfp2slhxj1h14w1gxs312nn4g30km6g6y5ishnh175lx2h2v",
       "depends": ["Biobase", "e1071", "kernlab", "pamr"]
     },
     "Rmmquant": {
       "name": "Rmmquant",
-      "version": "1.24.0",
-      "sha256": "1glgrwf1bb0lm31fsq0jil866b1xqd2gv75nc2fapnbmvkcc65gj",
+      "version": "1.26.0",
+      "sha256": "1ahpllp6illda2sh4nng3wgkdawmgx4wp7p4jgr7vr71m64vxwlw",
       "depends": ["BiocStyle", "DESeq2", "GenomicRanges", "Rcpp", "S4Vectors", "SummarizedExperiment", "TBX20BamSubset", "TxDb_Mmusculus_UCSC_mm9_knownGene", "apeglm", "devtools", "org_Mm_eg_db"]
     },
     "RnBeads": {
       "name": "RnBeads",
-      "version": "2.24.0",
-      "sha256": "006kmfg1lysa9z9cbc507l54xh1apslrxxk41w65zp7bqkhs2zj9",
+      "version": "2.26.0",
+      "sha256": "15vp5c40g1xlqvbwivc9zgiqm9ra5capbj37xpk0kjn8vl0qwa9x",
       "depends": ["BiocGenerics", "GenomicRanges", "IRanges", "MASS", "S4Vectors", "cluster", "ff", "fields", "ggplot2", "gplots", "gridExtra", "illuminaio", "limma", "matrixStats", "methylumi", "plyr"]
     },
     "RnaSeqSampleSize": {
       "name": "RnaSeqSampleSize",
-      "version": "2.16.0",
-      "sha256": "1lrcqpcclc1a77vbqpwlq31nv7v0x357rkwmw5ybfx8b5bwivqsw",
+      "version": "2.18.0",
+      "sha256": "18w0jl42ra0xl90ym9ai0imr38gnw0vf1nksm9ymvj4mfaxmv51s",
       "depends": ["KEGGREST", "Rcpp", "RnaSeqSampleSizeData", "SummarizedExperiment", "biomaRt", "dplyr", "edgeR", "ggplot2", "ggpubr", "heatmap3", "matlab", "recount", "tidyr", "tidyselect"]
     },
     "Rnits": {
       "name": "Rnits",
-      "version": "1.40.0",
-      "sha256": "1s848gr4vmwhl74ar1fam260cwd5ffba2qj2ssfnbvzr9mp16ydg",
+      "version": "1.42.0",
+      "sha256": "1myjsg7gsp7ml64yahrbc3iyq2x07m8d9id24gg9p9z2lzafcnxk",
       "depends": ["Biobase", "affy", "boot", "ggplot2", "impute", "limma", "qvalue", "reshape2"]
     },
     "RolDE": {
       "name": "RolDE",
-      "version": "1.10.0",
-      "sha256": "1pc5lysp9diazskcw8sn969i5iibksbhwff2kfnxzjgxhw3h2c5s",
+      "version": "1.12.0",
+      "sha256": "0l8mm8dmxy2jgpjfmkvfq60r34p3k489b4mp6zla2mmjvf0rllml",
       "depends": ["ROTS", "SummarizedExperiment", "doParallel", "doRNG", "foreach", "matrixStats", "nlme", "qvalue", "rngtools"]
     },
     "Rqc": {
       "name": "Rqc",
-      "version": "1.40.0",
-      "sha256": "061nrck7d8499bc92m24fv7zyyb98lwjrqrbpmab0pa79vh2q1zz",
+      "version": "1.42.0",
+      "sha256": "07n050h9gfzgs76dyk1q7gjlq5vqbp4j64fps7xp2xanwq8ppm0h",
       "depends": ["BiocGenerics", "BiocParallel", "BiocStyle", "Biostrings", "GenomicAlignments", "GenomicFiles", "IRanges", "Rcpp", "Rsamtools", "S4Vectors", "ShortRead", "biovizBase", "ggplot2", "knitr", "markdown", "plyr", "reshape2", "shiny"]
     },
     "Rsamtools": {
       "name": "Rsamtools",
-      "version": "2.22.0",
-      "sha256": "0wqh1spqmf30cv3v0v5bawpjwfjrlnxz2n8cc0a11c2kbbdxrnr5",
-      "depends": ["BiocGenerics", "BiocParallel", "Biostrings", "GenomeInfoDb", "GenomicRanges", "IRanges", "Rhtslib", "S4Vectors", "XVector", "bitops", "zlibbioc"]
+      "version": "2.24.0",
+      "sha256": "183pish6qf0b8c76lx09hgmxy8j9sw3hh5nv5n6klx7r1y95k5id",
+      "depends": ["BiocGenerics", "BiocParallel", "Biostrings", "GenomeInfoDb", "GenomicRanges", "IRanges", "Rhtslib", "S4Vectors", "XVector", "bitops"]
     },
     "Rsubread": {
       "name": "Rsubread",
-      "version": "2.20.0",
-      "sha256": "1n7pvx30sm6fxmydn33v2cr1nlrbdd8kqzg6pw9l78zaydqbl8r3",
+      "version": "2.22.0",
+      "sha256": "18p3q57g5zyxgqh7df4nc95zhj3qy49kfqj8q6dlrgcypfgyy181",
       "depends": ["Matrix"]
     },
     "Rtpca": {
       "name": "Rtpca",
-      "version": "1.16.0",
-      "sha256": "1kznxx9l61gdcbdzxxckgmbf3m9gjcm416jbz78cqjvismbq07m3",
+      "version": "1.18.0",
+      "sha256": "18ydwza5in3svszk4m73caki2asyqrzygr8vzg34x2nd5ylhincv",
       "depends": ["Biobase", "dplyr", "fdrtool", "ggplot2", "pROC", "tibble", "tidyr"]
     },
     "Rtreemix": {
       "name": "Rtreemix",
-      "version": "1.68.0",
-      "sha256": "1n5wfwsj6x2rjq0b7ix8yhwsrxbmik55fnsk1681y7xd5krqprgh",
+      "version": "1.69.0",
+      "sha256": "1sw0linj05wz2f9ax5809mcl1l7h16nvdk8xxl2pwgv78jkfzq8h",
       "depends": ["Biobase", "Hmisc", "graph"]
     },
     "Rvisdiff": {
       "name": "Rvisdiff",
-      "version": "1.4.0",
-      "sha256": "0l90dykrhjqdww8667i825d0dik44q0bprxz8rwqyb4bc0pwqicq",
+      "version": "1.6.0",
+      "sha256": "15a7r82bv854alx1dciaa4lxr56pbqz1bs78qmrqy346q6n8369p",
       "depends": ["edgeR"]
     },
     "S4Arrays": {
       "name": "S4Arrays",
-      "version": "1.6.0",
-      "sha256": "0fjf1q9wlm8n1w8sb9n0yx6s1di33ngk4kanhychy5hqli73v3dh",
+      "version": "1.8.0",
+      "sha256": "17xkmb5vvzmrappfx0ddx0bkdqfxiw2j7nhkwywn442ak46cjs3l",
       "depends": ["BiocGenerics", "IRanges", "Matrix", "S4Vectors", "abind", "crayon"]
     },
     "S4Vectors": {
       "name": "S4Vectors",
-      "version": "0.44.0",
-      "sha256": "0wic4nri42yiasshal96ykxj8skrya5szffnawqzs1kmq2b8zail",
+      "version": "0.46.0",
+      "sha256": "0h3s32z6jxa118jifdyrhpj03fgjjh1fdnaq87ls38k7lg34jhn3",
       "depends": ["BiocGenerics"]
     },
     "SAIGEgds": {
       "name": "SAIGEgds",
-      "version": "2.6.0",
-      "sha256": "04xvq25mrahqvdw8cvgyn5f81zg34h58gk3ydisc5c10za6hkida",
+      "version": "2.8.0",
+      "sha256": "1xrwi3i07gnaka4alm9v9n2ix38afdr98g4dhlv79lv0bwl44hq5",
       "depends": ["CompQuadForm", "Matrix", "Rcpp", "RcppArmadillo", "RcppParallel", "SeqArray", "gdsfmt", "survey"]
     },
     "SANTA": {
       "name": "SANTA",
-      "version": "2.42.0",
-      "sha256": "1kkdd8q5ikw1abshg0r1cw7sbxdxvzwfq859g9n5f9j0d4k5ri6q",
+      "version": "2.44.0",
+      "sha256": "1khvriq362n9my3w7k70rkwwpiv1b78mrclc6bgq8mzwlly136gm",
       "depends": ["Matrix", "igraph"]
     },
     "SARC": {
       "name": "SARC",
-      "version": "1.4.0",
-      "sha256": "0wrpsw5p82i1rwc3hm30x3nk3dhhix619sqskwdxwrzw1nxays9g",
+      "version": "1.6.0",
+      "sha256": "04g3pq9az8jfffgq19y8lzlhjrwi7gjlynfcpxpqsy8dk3gw5fwj",
       "depends": ["DescTools", "GenomicFeatures", "GenomicRanges", "IRanges", "RColorBrewer", "RaggedExperiment", "data_table", "ggplot2", "gridExtra", "gtable", "metap", "multtest", "plotly", "plyranges", "reshape2", "scales", "tidyverse"]
     },
     "SBGNview": {
       "name": "SBGNview",
-      "version": "1.20.0",
-      "sha256": "05c65npglqlxpxf20w523mgc1hmhf5w5nr7v30izwpa3vbs6b02n",
+      "version": "1.22.0",
+      "sha256": "06mq8m80670q3i046c1nmcabxnb9ahzygbshrpli19c4rq86wsy0",
       "depends": ["AnnotationDbi", "KEGGREST", "Rdpack", "SBGNview_data", "SummarizedExperiment", "bookdown", "httr", "igraph", "knitr", "pathview", "rmarkdown", "rsvg", "xml2"]
     },
     "SBMLR": {
       "name": "SBMLR",
-      "version": "2.2.0",
-      "sha256": "0w87dg2q96mhril91m8sksnq5304g4rpxi9y6v65kgz0b5yf7a55",
+      "version": "2.4.0",
+      "sha256": "0v4gcnqjb3vv7p0b9zmmqw58k567925xbjmk6sw9x1b31vn9wqnw",
       "depends": ["XML", "deSolve"]
     },
     "SC3": {
       "name": "SC3",
-      "version": "1.34.0",
-      "sha256": "1lkaw29s6vmfhj39frkz55dzn5gnl4y1ww50jd5vh3xg5vvlljmi",
+      "version": "1.36.0",
+      "sha256": "08akfziaczpzl7kvkchbr8a6w7qi7pnw0k4jklq0pyinx3ph713k",
       "depends": ["BiocGenerics", "ROCR", "Rcpp", "RcppArmadillo", "S4Vectors", "SingleCellExperiment", "SummarizedExperiment", "WriteXLS", "cluster", "doParallel", "doRNG", "e1071", "foreach", "ggplot2", "pheatmap", "robustbase", "rrcov", "shiny"]
     },
     "SCAN_UPC": {
       "name": "SCAN.UPC",
-      "version": "2.48.0",
-      "sha256": "0qwbyg9lbmyy0c8h8fy5sh8w8jjwppzjhm13gq0vmbc37zqr4lmi",
+      "version": "2.50.0",
+      "sha256": "1l5p9v780a3kh934xl3wi9wm7787ij70x8wsn9kag8p40813pzlw",
       "depends": ["Biobase", "Biostrings", "GEOquery", "IRanges", "MASS", "affy", "affyio", "foreach", "oligo", "sva"]
     },
     "SCANVIS": {
       "name": "SCANVIS",
-      "version": "1.20.0",
-      "sha256": "0f5wvcrq671jsm0xpmc1d7v9i83v6ang2406hv3lz4qixsqmpb1p",
+      "version": "1.22.0",
+      "sha256": "162h8zcdw7ixqyql06sqgvcw0ydwlp1ahv3an1vzr0kw37vrshd0",
       "depends": ["IRanges", "RCurl", "plotrix", "rtracklayer"]
     },
     "SCArray": {
       "name": "SCArray",
-      "version": "1.14.0",
-      "sha256": "1pf7pjz8zp8p24qnay5rd6pm1blswz8b1caghcv5ac6hq6iiqll0",
+      "version": "1.16.0",
+      "sha256": "0dcl2aaq5g822lkigqfcyfhpj7c56blbgnwdqlx6vj7g8wxhqrmb",
       "depends": ["BiocParallel", "BiocSingular", "DelayedArray", "DelayedMatrixStats", "Matrix", "S4Vectors", "SingleCellExperiment", "SparseArray", "SummarizedExperiment", "gdsfmt"]
     },
     "SCArray_sat": {
       "name": "SCArray.sat",
-      "version": "1.6.0",
-      "sha256": "0hfqsmmdn7ik4mif0p65dvywbral1gx3sl889i3b8vp48fi0yx5n",
+      "version": "1.8.0",
+      "sha256": "09i47n84pj5vmi8h9l4nd6nln4f9znl7iy0whvq477zfpijihf96",
       "depends": ["BiocGenerics", "BiocParallel", "BiocSingular", "DelayedArray", "Matrix", "S4Vectors", "SCArray", "Seurat", "SeuratObject", "SummarizedExperiment", "gdsfmt"]
     },
     "SCBN": {
       "name": "SCBN",
-      "version": "1.24.0",
-      "sha256": "0vq58kd9hgy5iw1v8nvbv3n5vr3sj8shqwph8f2pd3ihd531j2cx",
+      "version": "1.26.0",
+      "sha256": "0d5kfkr2ljz27yfjxi98dc7ps2pdrkr9x5sw8dx0w38lsmm1zspc",
       "depends": []
     },
     "SCFA": {
       "name": "SCFA",
-      "version": "1.16.0",
-      "sha256": "15csa4sh3bj5ycxb03fyn664xqhbca5x2lnkj2gnrfg3xxh9rfpm",
+      "version": "1.18.0",
+      "sha256": "1fbvjm9qm0bfz024262fb6ffsm2c39b8180isfxwfiwzafpqp67w",
       "depends": ["BiocParallel", "Matrix", "RhpcBLASctl", "cluster", "coro", "glmnet", "igraph", "matrixStats", "psych", "survival", "torch"]
     },
     "SCOPE": {
       "name": "SCOPE",
-      "version": "1.18.0",
-      "sha256": "0adxphn2wb2njsxb37i3f5gnf0i0d9gfl053h8r98jg2vb0n2sax",
+      "version": "1.20.0",
+      "sha256": "1fv8ryfqjwh94wfyya0w10bvgfqiwcvwand5r2kymkykgamrg6qn",
       "depends": ["BSgenome", "BSgenome_Hsapiens_UCSC_hg19", "BiocGenerics", "Biostrings", "DNAcopy", "DescTools", "GenomeInfoDb", "GenomicRanges", "IRanges", "RColorBrewer", "Rsamtools", "S4Vectors", "doParallel", "foreach", "gplots"]
     },
     "SCnorm": {
       "name": "SCnorm",
-      "version": "1.28.0",
-      "sha256": "04llc5x7m393l3if14a10pkyiagpc8hxb93yi16vpzbw81qyy7cq",
+      "version": "1.30.0",
+      "sha256": "1c99faz7rbfsjdxszy1xvc0rqwrimdzx2gvqd7mvawrl7cqqvcry",
       "depends": ["BiocGenerics", "BiocParallel", "S4Vectors", "SingleCellExperiment", "SummarizedExperiment", "cluster", "data_table", "forcats", "ggplot2", "moments", "quantreg"]
     },
     "SDAMS": {
       "name": "SDAMS",
-      "version": "1.26.0",
-      "sha256": "04sq4cwvlv1s048bh4rhf5nhq96p811p07z7ikc77jxjq8g4hwrp",
+      "version": "1.28.0",
+      "sha256": "1mdjwpik5hc03d18rp9gmmyxibqnkcb5vf4p4ljk80310sdmqh31",
       "depends": ["SummarizedExperiment", "qvalue", "trust"]
     },
     "SELEX": {
       "name": "SELEX",
-      "version": "1.38.0",
-      "sha256": "08swdg8z9qnav7qs8s295h18h0qprkyzs419c605yirhv1v41hhi",
+      "version": "1.40.0",
+      "sha256": "1wjqpgrif5baqp3gfvvvb75g4jlqsaqsb5ql65gl43al79id7ih3",
       "depends": ["Biostrings", "rJava"]
+    },
+    "SEraster": {
+      "name": "SEraster",
+      "version": "1.0.0",
+      "sha256": "1wg14s4vam6c6plfzgn61x8f8xyvlfk4x6ryzw7vq6rpha1az2d8",
+      "depends": ["BiocParallel", "Matrix", "SpatialExperiment", "SummarizedExperiment", "ggplot2", "rearrr", "sf"]
     },
     "SEtools": {
       "name": "SEtools",
-      "version": "1.20.0",
-      "sha256": "163q5a6i5qj30b97k7iqlm3zhs7r6ps8zvy4yj0a5x8vpq0gpir4",
+      "version": "1.22.0",
+      "sha256": "05grm67znmjcmmj16pbk4r4zzlgly8h55504f6lnwlw656ic5vfi",
       "depends": ["BiocParallel", "DESeq2", "Matrix", "S4Vectors", "SummarizedExperiment", "circlize", "data_table", "edgeR", "openxlsx", "pheatmap", "sechm", "sva"]
     },
     "SGCP": {
       "name": "SGCP",
-      "version": "1.6.0",
-      "sha256": "1zz1az37gyw0mcidhfd5n6khdd0px23an6q6b1wzda452n52lk0y",
+      "version": "1.8.0",
+      "sha256": "0jagx4ygl1sz32l4hskqn87qmnpqwdjj2y0basa07gapny3df879",
       "depends": ["DescTools", "GO_db", "GOstats", "RColorBrewer", "RSpectra", "Rgraphviz", "SummarizedExperiment", "annotate", "caret", "dplyr", "expm", "genefilter", "ggplot2", "ggridges", "graph", "openxlsx", "org_Hs_eg_db", "plyr", "reshape2", "xtable"]
     },
     "SGSeq": {
       "name": "SGSeq",
-      "version": "1.40.0",
-      "sha256": "1xchrzd384wzm81vzrcixyzn3mgnd343cp544yvfzfn2vxr4y1ij",
+      "version": "1.42.0",
+      "sha256": "0flrhlsw3l7xbjdl5sr2zlijcjzii8jbfygzgj5lyjr4wr51033g",
       "depends": ["AnnotationDbi", "BiocGenerics", "Biostrings", "GenomeInfoDb", "GenomicAlignments", "GenomicFeatures", "GenomicRanges", "IRanges", "RUnit", "Rsamtools", "S4Vectors", "SummarizedExperiment", "igraph", "rtracklayer"]
     },
     "SIAMCAT": {
       "name": "SIAMCAT",
-      "version": "2.10.0",
-      "sha256": "13zmjwcxsv3slx8bfy02dix691ajvyacpapkkcwsy7gswym9pirz",
+      "version": "2.12.0",
+      "sha256": "1z2lfa5dm8v8h9ld377bn4wd70663qwc9fcdgvr91danlfq9yldr",
       "depends": ["LiblineaR", "PRROC", "RColorBrewer", "beanplot", "corrplot", "glmnet", "gridBase", "gridExtra", "infotheo", "lgr", "lmerTest", "matrixStats", "mlr3", "mlr3learners", "mlr3tuning", "pROC", "paradox", "phyloseq", "progress", "scales", "stringr"]
     },
     "SICtools": {
       "name": "SICtools",
-      "version": "1.36.0",
-      "sha256": "0jyycm82aw7xfx0h7ngd4nz4s8xfq7ky71nrvbj5m6jb3bkr4hjz",
+      "version": "1.38.0",
+      "sha256": "1f1dkrvnxqvcll1ywmckfi2glap0y2rilvw9y6s9qnlq21kcidy5",
       "depends": ["Biostrings", "GenomicRanges", "IRanges", "Rsamtools", "doParallel", "matrixStats", "plyr", "stringr"]
     },
     "SIM": {
       "name": "SIM",
-      "version": "1.76.0",
-      "sha256": "07xp28qc6kibngc4b0xy20ghxgydj0ksgx7yb92m4rdhca6qfqxl",
+      "version": "1.78.0",
+      "sha256": "0nlfg1m78idmfwzan435319i2x8my7lsdsjabaanpv54010kksam",
       "depends": ["globaltest", "quantreg", "quantsmooth"]
     },
     "SIMAT": {
       "name": "SIMAT",
-      "version": "1.38.0",
-      "sha256": "1f4lw95sd0pm4mmnjc375cp6j3p630ixapg8jwy2mq9zakagbh9x",
+      "version": "1.40.0",
+      "sha256": "1h7ny2c9sph0qd8dp0m7v273n3s87wzx18bhsbghns87s3h8d16q",
       "depends": ["Rcpp", "ggplot2", "mzR", "reshape2"]
     },
     "SIMD": {
       "name": "SIMD",
-      "version": "1.24.0",
-      "sha256": "0pndimzv1qx11djdplfwil6bzs2nhkk0d7gqypxfcnkigprsqpb2",
+      "version": "1.26.0",
+      "sha256": "0ha591zbq14sibl67j3l3w32pachivh0g3fxq0fzdxzh9gdsmp69",
       "depends": ["edgeR", "methylMnM", "statmod"]
     },
     "SIMLR": {
       "name": "SIMLR",
-      "version": "1.32.0",
-      "sha256": "1qk1wf7xya1b3xsir6xl5q46w2qlsgwdvlshk6v6q75h169gm03x",
+      "version": "1.34.0",
+      "sha256": "19mziwmzhs40dnaqn6s6grlx3kjaggdnd97zy5brjhwlrx67vpfh",
       "depends": ["Matrix", "RSpectra", "Rcpp", "RcppAnnoy", "pracma"]
     },
     "SLqPCR": {
       "name": "SLqPCR",
-      "version": "1.72.0",
-      "sha256": "0n1z1908p2p9xc44p6cjxvh0k181bzm7zgm8z4sgcahl1g8m5xmh",
+      "version": "1.74.0",
+      "sha256": "0phhd8ih6s3fb5pkivjm9bmdn1mzjm30r44waza8a284kx2s7cir",
       "depends": []
     },
     "SMAD": {
       "name": "SMAD",
-      "version": "1.22.0",
-      "sha256": "0jxiv15z1a48m055rcqgdfyqj006c532zghnq0qg80bjyyw4h80z",
+      "version": "1.24.0",
+      "sha256": "0bs9sp6c4mn3r0gzxxbvj4qzqrc7igcl483m68jqvzximn52kv7y",
       "depends": ["Rcpp", "RcppAlgos", "dplyr", "magrittr", "tidyr"]
     },
     "SMITE": {
       "name": "SMITE",
-      "version": "1.34.0",
-      "sha256": "0yf6pr6ch2dlr2jfrhljcr9dzxwr6rkvrmx9dddw4s1vmp3ynymr",
+      "version": "1.36.0",
+      "sha256": "11wv0xmhmxlff24ljqx4jsdbxa7h10kv2irzkyfi7mmpf8zxa2yf",
       "depends": ["AnnotationDbi", "BioNet", "Biobase", "GenomicRanges", "Hmisc", "IRanges", "KEGGREST", "S4Vectors", "geneLenDataBase", "ggplot2", "goseq", "igraph", "org_Hs_eg_db", "plyr", "reactome_db", "scales"]
     },
     "SNAGEE": {
       "name": "SNAGEE",
-      "version": "1.46.0",
-      "sha256": "170ailsf8rdgbixqhpq5g83fm13rshxlnq78z760jslcq8y68dnh",
+      "version": "1.48.0",
+      "sha256": "17n9vfgg1kk904244snlrmi7mcnd77h6afz10adf85ai015f4m9d",
       "depends": ["SNAGEEdata"]
     },
     "SNPRelate": {
       "name": "SNPRelate",
-      "version": "1.40.0",
-      "sha256": "00zspm09zxp52kkivhv1pixndz7gfzb6p7rp5xvkq89qx7a9hsnn",
+      "version": "1.42.0",
+      "sha256": "01lxwm9a1vzk1cmf3bcpgad60kgj49xwryzmjdgmvhjl3pckwdha",
       "depends": ["gdsfmt"]
     },
     "SNPediaR": {
       "name": "SNPediaR",
-      "version": "1.32.0",
-      "sha256": "01ibz9qgc2v7325nzlmj0ppbqf2jx6lczjazigidr7zhjr48rhjx",
+      "version": "1.34.0",
+      "sha256": "0v0n9y090x9r986dqqqx2h3p0byswhdnc6xq73yfimdihhcbj6k3",
       "depends": ["RCurl", "jsonlite"]
     },
     "SNPhood": {
       "name": "SNPhood",
-      "version": "1.36.0",
-      "sha256": "1nn3wdljx5zrsy4gp6pc7bk78fprd00fw599f9wlnb55yikj813c",
+      "version": "1.38.0",
+      "sha256": "0hp2gc6ab5sd0b29k37ncd4wsq8sncrcw37lvchyqjbi5bw38h7a",
       "depends": ["BiocGenerics", "BiocParallel", "Biostrings", "DESeq2", "GenomeInfoDb", "GenomicRanges", "IRanges", "RColorBrewer", "Rsamtools", "S4Vectors", "SummarizedExperiment", "VariantAnnotation", "checkmate", "cluster", "data_table", "ggplot2", "gridExtra", "lattice", "reshape2", "scales"]
     },
     "SOMNiBUS": {
       "name": "SOMNiBUS",
-      "version": "1.14.2",
-      "sha256": "1dfb7sy8b613agknmi1sa46f7dc701h714b633isx1lajkbmahm9",
+      "version": "1.16.0",
+      "sha256": "0lf9l4i4q5d19zyfk9cnfp0mqslf657vgqgy0ncgbdcwzjc0ln93",
       "depends": ["BiocManager", "GenomeInfoDb", "GenomicRanges", "IRanges", "Matrix", "S4Vectors", "VGAM", "annotatr", "bsseq", "data_table", "ggplot2", "mgcv", "reshape2", "rtracklayer", "tidyr", "yaml"]
     },
     "SPEM": {
       "name": "SPEM",
-      "version": "1.46.0",
-      "sha256": "0y2jf2sfiw5zss6jvirmaib6061bx19pxlk619xz1lb91sxzh9ia",
+      "version": "1.48.0",
+      "sha256": "0zd61792n0zvjfhr2m75k0rqmpv0xfj3b231xpjs6fawm63ccr0p",
       "depends": ["Biobase", "Rsolnp"]
     },
     "SPIA": {
       "name": "SPIA",
-      "version": "2.58.0",
-      "sha256": "152iskr8arssvnjzzpgmva03wz1vwadhgm5njl229d7mb2bg5nky",
+      "version": "2.60.0",
+      "sha256": "1cyw7n54krb0867pn73jvdflslpx8848chpmiw7dvb82zpns43h0",
       "depends": ["KEGGgraph"]
     },
     "SPIAT": {
       "name": "SPIAT",
-      "version": "1.8.0",
-      "sha256": "1q4c7kpnfbkiw3fwg16f2dzf3ygl38jp48mvlh1iymprzlnw408q",
+      "version": "1.10.0",
+      "sha256": "0jmjvvcqghbj8z5993803lb112safnkwv0cfygsxdpdanbddbc1x",
       "depends": ["RANN", "SpatialExperiment", "SummarizedExperiment", "apcluster", "dbscan", "dittoSeq", "dplyr", "ggplot2", "gridExtra", "gtools", "mmand", "pracma", "raster", "reshape2", "rlang", "sp", "spatstat_explore", "spatstat_geom", "tibble", "vroom"]
     },
     "SPLINTER": {
       "name": "SPLINTER",
-      "version": "1.32.0",
-      "sha256": "06nrhx9xsv8i8xnd9gyk630hk0zxh21q8abb8h64857c20kfs4rg",
+      "version": "1.34.0",
+      "sha256": "09g7yyks7pd6lbaaivaizjs6xffavg8mw07pzkc2w1fb677ry10k",
       "depends": ["BSgenome_Mmusculus_UCSC_mm9", "Biostrings", "GenomeInfoDb", "GenomicAlignments", "GenomicFeatures", "GenomicRanges", "Gviz", "IRanges", "S4Vectors", "biomaRt", "ggplot2", "googleVis", "plyr", "pwalign", "seqLogo", "stringr"]
     },
     "SPONGE": {
       "name": "SPONGE",
-      "version": "1.28.0",
-      "sha256": "0kavc9anlcq62829vpc1ra57c7mgdcriqaypywrr28m4aavi56ji",
+      "version": "1.30.0",
+      "sha256": "1imz1avffk0dhvjgi6n6h445s9hpamdzr9kwc4bdy6ln4z1q8hwr",
       "depends": ["Biobase", "ComplexHeatmap", "MASS", "MetBrewer", "biomaRt", "caret", "cvms", "data_table", "doRNG", "dplyr", "expm", "foreach", "gRbase", "ggplot2", "ggpubr", "ggridges", "glmnet", "igraph", "iterators", "logging", "ppcor", "randomForest", "rlang", "stringr", "tidyr", "tidyverse", "tnet"]
     },
     "SPOTlight": {
       "name": "SPOTlight",
-      "version": "1.10.0",
-      "sha256": "1cyxll0l1wdzyb9fxh7iagvd6kg7fx0iv7wjcqsczkqa221gqild",
+      "version": "1.12.0",
+      "sha256": "15qlf9599zy3p4nhhc0dcnix9b89qr7yvpaqyi2xldsriwph3vwb",
       "depends": ["Matrix", "NMF", "SingleCellExperiment", "ggplot2", "matrixStats", "nnls", "sparseMatrixStats"]
     },
     "SPsimSeq": {
       "name": "SPsimSeq",
-      "version": "1.16.0",
-      "sha256": "0z348rhx5qlhb6yifc71ir7l5pi6p0zmxx9zzxnp2rxm6c587ixm",
+      "version": "1.18.0",
+      "sha256": "0b0d6agni29c4w6r1bh149djy1cqqzwlvyvnz12q8sl02xjyiza6",
       "depends": ["Hmisc", "SingleCellExperiment", "WGCNA", "edgeR", "fitdistrplus", "limma", "mvtnorm", "phyloseq"]
     },
     "SQLDataFrame": {
       "name": "SQLDataFrame",
-      "version": "1.20.0",
-      "sha256": "1j97d37fv43h1n4sxdfglriiivplp6i21q7qk27aphcccpchbyvf",
+      "version": "1.22.0",
+      "sha256": "1hhllinhlb4byhjizkh68lk7rjxwgg1w7s4ngd99dlws814gav1z",
       "depends": ["BiocGenerics", "DBI", "DelayedArray", "RSQLite", "S4Vectors", "duckdb"]
     },
     "SRAdb": {
       "name": "SRAdb",
-      "version": "1.68.1",
-      "sha256": "02g8vbvh5f7y943djz01p7w3cbj07qd59lmxl5s1642gycjbf801",
+      "version": "1.70.0",
+      "sha256": "0hnq6pkzzs6s52lcqc3w4iqn19q72rwi25zn6mdvgihf6d7wdyxy",
       "depends": ["RCurl", "RSQLite", "R_utils", "graph"]
     },
     "STATegRa": {
       "name": "STATegRa",
-      "version": "1.42.0",
-      "sha256": "0bc8c38865i8ch562az4w43kha986x12i9jqn3qja0p539x7zzks",
+      "version": "1.44.0",
+      "sha256": "07m4z817hf89qb7g95ry8vlwl49wfqw9whl7kp5v7j09g4bllxkx",
       "depends": ["Biobase", "MASS", "affy", "calibrate", "edgeR", "foreach", "ggplot2", "gplots", "gridExtra", "limma"]
     },
     "STRINGdb": {
       "name": "STRINGdb",
-      "version": "2.18.0",
-      "sha256": "118n30lq01xp7irdxffc5hmym7wini8pfsk2xszh8lwf9ii0l5z9",
+      "version": "2.20.0",
+      "sha256": "1dis3x4rx8g5wavgihbkhgvyb37cvjr6kdgyfi5lahnabxyyf6s8",
       "depends": ["RColorBrewer", "gplots", "hash", "httr", "igraph", "plotrix", "plyr", "png", "sqldf"]
     },
     "SUITOR": {
       "name": "SUITOR",
-      "version": "1.8.0",
-      "sha256": "0446b1jqsanw74qvla4ml10z6f1gdh4njbf58h98dc66lfg6s0x6",
+      "version": "1.10.0",
+      "sha256": "1gkg15r7xp47rmmzy8w38j04zfmfvi9ffr79zbzlkbchn9cp58a1",
       "depends": ["BiocParallel", "ggplot2"]
     },
     "SVMDO": {
       "name": "SVMDO",
-      "version": "1.6.0",
-      "sha256": "1yxdz6hvdrf8i0wm1xa977gfrhwsnl4s750vr09ihm4xizpbh87a",
+      "version": "1.8.0",
+      "sha256": "15j8f66akb26rl5jygnb4kjr7py1a5f939ybwvllzmd5iz8lwsds",
       "depends": ["AnnotationDbi", "BSDA", "DOSE", "DT", "SummarizedExperiment", "caTools", "caret", "data_table", "dplyr", "e1071", "golem", "klaR", "nortest", "org_Hs_eg_db", "shiny", "shinyFiles", "shinytitle", "sjmisc", "survival"]
+    },
+    "SVP": {
+      "name": "SVP",
+      "version": "1.0.0",
+      "sha256": "0fyq9ycinw986graf70hgl9d3kig1pii0bmnmiy47386vkv5zi3h",
+      "depends": ["BiocGenerics", "BiocNeighbors", "BiocParallel", "DelayedMatrixStats", "Matrix", "Rcpp", "RcppArmadillo", "RcppEigen", "RcppParallel", "S4Vectors", "SingleCellExperiment", "SpatialExperiment", "SummarizedExperiment", "cli", "deldir", "dplyr", "dqrng", "fastmatch", "ggfun", "ggplot2", "ggstar", "ggtree", "pracma", "rlang", "withr"]
     },
     "SWATH2stats": {
       "name": "SWATH2stats",
-      "version": "1.36.0",
-      "sha256": "05fqp6h6zj65n58qm4irbk2lq5dm338378shzyk0lddlym2j18pb",
+      "version": "1.38.0",
+      "sha256": "16jg3ny67wz3x0dx0gqf9npi60sl7r33g6rpsgs9j1bj32zgfkvd",
       "depends": ["biomaRt", "data_table", "ggplot2", "reshape2"]
     },
     "SamSPECTRAL": {
       "name": "SamSPECTRAL",
-      "version": "1.60.0",
-      "sha256": "0hj36h61v5811ic4fgrxzavk8hli42aw4k58wccya1vz36ij65i6",
+      "version": "1.62.0",
+      "sha256": "0si3m1dkv03d773irrcfvzk0zrkwzppwg4k5pk3iwhmmrimkpril",
       "depends": []
     },
     "Scale4C": {
       "name": "Scale4C",
-      "version": "1.28.0",
-      "sha256": "0rkbcw3mqjh29hc06ifpq360kxgyyckgvcd8231nid6dkdahgq7a",
+      "version": "1.30.0",
+      "sha256": "1fxmj3lsfgyvb5xka9wnmsdzdar04y9cgh987qmdsvpd96x8nvig",
       "depends": ["GenomicRanges", "IRanges", "SummarizedExperiment", "smoothie"]
     },
     "ScaledMatrix": {
       "name": "ScaledMatrix",
-      "version": "1.14.0",
-      "sha256": "1qkxwpxbcxqk2yifpbqgywrd1vsf53s8bckcfgj7zdh124xhwjwj",
+      "version": "1.16.0",
+      "sha256": "08q34yz58hcqjf4adnq0ihbrkiy04i3913bmmsr5giv0w6gywfx1",
       "depends": ["DelayedArray", "Matrix", "S4Vectors"]
     },
     "Sconify": {
       "name": "Sconify",
-      "version": "1.26.0",
-      "sha256": "1ma0brb964z491mcm9x3d2ig51f4rvwvhffvcv18prbn927633f4",
+      "version": "1.28.0",
+      "sha256": "0mg5ffs28x78c4plp9307hsyrg5hhl9vgy9kn7zpa7dz3pv3x94y",
       "depends": ["FNN", "Rtsne", "dplyr", "flowCore", "ggplot2", "magrittr", "readr", "tibble"]
     },
     "ScreenR": {
       "name": "ScreenR",
-      "version": "1.8.0",
-      "sha256": "118m7skvky0nv8an65p79fxi5jwan15ggngs4qhw4kp3aqn3r8ny",
+      "version": "1.10.0",
+      "sha256": "10mbdr4bf4pv8m8d6smppr6yrcsdk1dkx87qb9rr6fqvf3xwvdsq",
       "depends": ["dplyr", "edgeR", "ggplot2", "ggvenn", "limma", "magrittr", "patchwork", "purrr", "rlang", "scales", "stringr", "tibble", "tidyr", "tidyselect"]
     },
     "SemDist": {
       "name": "SemDist",
-      "version": "1.40.0",
-      "sha256": "11f2cy4n88gx7fc71s84rwly65ay3xpxjijzvknd6ly63l4ijqrw",
+      "version": "1.42.0",
+      "sha256": "15k53yb30h144rlrmw6c8v2y8cd67vn4jk393q1d9cj01g9h8q6b",
       "depends": ["AnnotationDbi", "GO_db", "annotate"]
     },
     "SeqArray": {
       "name": "SeqArray",
-      "version": "1.46.3",
-      "sha256": "1ls0qkrisy7y8bx09s95nqwqwx98950dyr7yhmldkbp24jrrnqmm",
+      "version": "1.48.0",
+      "sha256": "0nmd00asqqwxidydbmsr3dgy6lbnjsw9mqnv0s95b4pjsck3g8bp",
       "depends": ["Biostrings", "GenomeInfoDb", "GenomicRanges", "IRanges", "S4Vectors", "digest", "gdsfmt"]
     },
     "SeqGSEA": {
       "name": "SeqGSEA",
-      "version": "1.46.0",
-      "sha256": "13hmmk4s7ihdffq3ab4vxv0xq776b072hjhfag5kh7wv2z676l5x",
+      "version": "1.48.0",
+      "sha256": "1h8q0bhjcpsvwyd0s3z5jm8ggh5h9ay20aqayc1dpzs7fxj3n3fd",
       "depends": ["Biobase", "DESeq2", "biomaRt", "doParallel"]
     },
     "SeqGate": {
       "name": "SeqGate",
-      "version": "1.16.0",
-      "sha256": "0f2czbfyvmxb0bmybgwbazl3w9fr6rkkjm7q04dd9lrh0057zgii",
+      "version": "1.18.0",
+      "sha256": "0i4l79ih9n9cz6cwsakzwalvc2ggdw5kcsfjr6v040y7086ki0mp",
       "depends": ["BiocManager", "GenomicRanges", "S4Vectors", "SummarizedExperiment"]
     },
     "SeqSQC": {
       "name": "SeqSQC",
-      "version": "1.28.0",
-      "sha256": "1d8v0rhvnm41nhan1gsfamm21bkmhrawgkdhqpalcqimma9pkkqm",
+      "version": "1.30.0",
+      "sha256": "0lilyycxf7idi0mjxwjiy454nnv01sm56jg319z1czn2873224pb",
       "depends": ["ExperimentHub", "GGally", "GenomicRanges", "IRanges", "RColorBrewer", "S4Vectors", "SNPRelate", "e1071", "gdsfmt", "ggplot2", "plotly", "reshape2", "rmarkdown"]
     },
     "SeqVarTools": {
       "name": "SeqVarTools",
-      "version": "1.44.0",
-      "sha256": "0ayxfblsd7739f3k7fs82w98bpx7v9zkgvwnrw42a0mi7923ssrn",
+      "version": "1.46.0",
+      "sha256": "0d0fd7s7bwh19r4l70jbhskvjjgxl4k5kvwsx9hhv63f4ikrpvyh",
       "depends": ["Biobase", "BiocGenerics", "GWASExactHW", "GenomicRanges", "IRanges", "Matrix", "S4Vectors", "SeqArray", "data_table", "gdsfmt", "logistf"]
     },
     "SharedObject": {
       "name": "SharedObject",
-      "version": "1.20.0",
-      "sha256": "1wmvlqmizas3n3a07v311g85rsglfdd43r7cxipvi3zksm26krfl",
+      "version": "1.22.0",
+      "sha256": "17w14lpvd7ib917ym8gpwqvs7plmn6hrkyv41qcp1cqjphqz4s5c",
       "depends": ["BH", "BiocGenerics", "Rcpp"]
     },
     "ShortRead": {
       "name": "ShortRead",
-      "version": "1.64.0",
-      "sha256": "0zqk40r6cvmwqh7izwi57hy4z2fgpfl7crpcpxyvpn7zf82fd8f8",
+      "version": "1.66.0",
+      "sha256": "1f3wnzdcd05aqxiz61lzhsbaigkpk3kgsvcjk97vgacagl925v3p",
       "depends": ["Biobase", "BiocGenerics", "BiocParallel", "Biostrings", "GenomeInfoDb", "GenomicAlignments", "GenomicRanges", "IRanges", "Rhtslib", "Rsamtools", "S4Vectors", "XVector", "hwriter", "lattice", "latticeExtra", "pwalign"]
     },
     "SiPSiC": {
       "name": "SiPSiC",
-      "version": "1.6.0",
-      "sha256": "13zvzlwksz9hb8pl2c3133nkayfdv74pxmk8sjpr9g6d60aca448",
+      "version": "1.8.0",
+      "sha256": "1annhw2y1zyvgg6rry25alqy0z3cpfk3nnd2xkr4fpgpl99jm44r",
       "depends": ["Matrix", "SingleCellExperiment"]
     },
     "SigCheck": {
       "name": "SigCheck",
-      "version": "2.38.0",
-      "sha256": "0rwi2xx79bkys8pnws6bwmc94yhkyzmsvpw690q0q8k634kmyrf6",
+      "version": "2.40.0",
+      "sha256": "1hgygkk7814wpqvq4qnfg0xas63ka7lwybrvdjx4046k2rxl0yl8",
       "depends": ["Biobase", "BiocParallel", "MLInterfaces", "e1071", "survival"]
     },
     "SigFuge": {
       "name": "SigFuge",
-      "version": "1.44.0",
-      "sha256": "1kxkrk37z2c021nz3jnr5w7pw7gjs8r1v921wcxxrnq838chg96v",
+      "version": "1.46.0",
+      "sha256": "0x9px4mm24r2ffw1vd26rdm0ibv0023amsjhda59gkwxdgppkgj7",
       "depends": ["GenomicRanges", "ggplot2", "matlab", "reshape", "sigclust"]
     },
     "SigsPack": {
       "name": "SigsPack",
-      "version": "1.20.0",
-      "sha256": "09gcbfab6b7sk3fvvf45r86pcdj76v7s8j5cgkxx60w68i715hqi",
+      "version": "1.22.0",
+      "sha256": "0bwx9mbmjvvspihhapcwiacn1m4gyvrg1xmr04ga4haywlp53pq3",
       "depends": ["BSgenome", "Biobase", "Biostrings", "GenomeInfoDb", "GenomicRanges", "SummarizedExperiment", "VariantAnnotation", "quadprog", "rtracklayer"]
     },
     "SimBu": {
       "name": "SimBu",
-      "version": "1.8.0",
-      "sha256": "1k0yc90cx2h15rvwbq85bim70xcic7q4ww2h9yd0vlywnfs7l99q",
+      "version": "1.10.0",
+      "sha256": "1cs8fkcpg7k0jpj2ajf8zpz92anrihsrkqig2w16fymn03v4hbrk",
       "depends": ["BiocParallel", "Matrix", "RColorBrewer", "RCurl", "SummarizedExperiment", "basilisk", "data_table", "dplyr", "ggplot2", "phyloseq", "proxyC", "reticulate", "sparseMatrixStats", "tidyr"]
     },
     "SimFFPE": {
       "name": "SimFFPE",
-      "version": "1.18.0",
-      "sha256": "1jjn5nbscxzl4my2v7h0xfrh87bahmmnrczxz3snwq6fkwr6gd43",
+      "version": "1.20.0",
+      "sha256": "01v4aw3yf56sm5ashij69sw3hr4kbm6k9rmf2w76m47jck2hjhrr",
       "depends": ["Biostrings", "GenomicRanges", "IRanges", "Rsamtools", "doParallel", "dplyr", "foreach", "truncnorm"]
     },
     "SingleCellAlleleExperiment": {
       "name": "SingleCellAlleleExperiment",
-      "version": "1.2.0",
-      "sha256": "1grzl7gl5a9gfl03cwq688vy4n1qiqz679q9klynh9mhc7xgnbqd",
+      "version": "1.4.0",
+      "sha256": "1kb6p791f5rp7ais2f0272aw1p6zx3p8n5wqsx5f4657jqb9r0p0",
       "depends": ["BiocParallel", "DelayedArray", "Matrix", "S4Vectors", "SingleCellExperiment", "SummarizedExperiment"]
     },
     "SingleCellExperiment": {
       "name": "SingleCellExperiment",
-      "version": "1.28.1",
-      "sha256": "1kaxlhfg2c2vdvd1bw24qrxh2ffzxrxmd51znrisrhpvjl7r53jx",
+      "version": "1.30.0",
+      "sha256": "0dx6zp4vg7h2b3a9m6h568prg78dbr13fv7qgp422vcl7zgh7na9",
       "depends": ["BiocGenerics", "DelayedArray", "GenomicRanges", "S4Vectors", "SummarizedExperiment"]
     },
     "SingleCellSignalR": {
       "name": "SingleCellSignalR",
-      "version": "1.18.0",
-      "sha256": "1z7i7zxkgab00vqs4d5iwkman3y97805n1z75zxgm52c6fhms2gr",
+      "version": "1.20.0",
+      "sha256": "0rv28vaiw02kbr8fpmd96w5170any1fmpz3pm6m3hbncgv27dz7q",
       "depends": ["BiocManager", "Rtsne", "circlize", "data_table", "edgeR", "foreach", "gplots", "igraph", "limma", "multtest", "pheatmap", "scran", "stringr"]
     },
     "SingleMoleculeFootprinting": {
       "name": "SingleMoleculeFootprinting",
-      "version": "2.0.0",
-      "sha256": "1zg6cd7bd99v14sfxcd0j22fh86d33rjpkvcbds69gc6qmmhvgli",
-      "depends": ["BSgenome", "BiocGenerics", "Biostrings", "GenomeInfoDb", "GenomicRanges", "IRanges", "Matrix", "QuasR", "RColorBrewer", "S4Vectors", "dplyr", "ggplot2", "ggpointdensity", "ggrepel", "patchwork", "plyr", "plyranges", "rlang", "stringr", "tibble", "tidyr", "tidyverse", "viridis"]
+      "version": "2.2.0",
+      "sha256": "05vqmxxl1c7bq5k8z3nih9z0yh9j56cscgv6ahkwz250faxgxc6x",
+      "depends": ["BSgenome", "BiocGenerics", "Biostrings", "GenomeInfoDb", "GenomicRanges", "IRanges", "Matrix", "QuasR", "RColorBrewer", "S4Vectors", "cluster", "dplyr", "ggplot2", "ggpointdensity", "ggrepel", "magrittr", "miscTools", "parallelDist", "patchwork", "plyranges", "rlang", "stringr", "tibble", "tidyr", "viridis"]
     },
     "SingleR": {
       "name": "SingleR",
-      "version": "2.8.0",
-      "sha256": "1dlawx0hxnbb955yhbq4ryxv5yi62hgzh5di9vrzx1pi14vnc5nk",
-      "depends": ["BiocNeighbors", "BiocParallel", "BiocSingular", "DelayedArray", "DelayedMatrixStats", "Matrix", "Rcpp", "S4Vectors", "SummarizedExperiment", "assorthead", "beachmat"]
+      "version": "2.10.0",
+      "sha256": "0q5b8svzkif30ycpqdjibd04xzi3rj6nf8f9k2d339h711h0bmnf",
+      "depends": ["BiocNeighbors", "BiocParallel", "DelayedArray", "DelayedMatrixStats", "Matrix", "Rcpp", "S4Vectors", "SummarizedExperiment", "assorthead", "beachmat"]
+    },
+    "Site2Target": {
+      "name": "Site2Target",
+      "version": "1.0.0",
+      "sha256": "1xw2kdl2sijrvs5dx5pq6ay52vz19sbc27g23ah01m41dg807p7z",
+      "depends": ["BiocGenerics", "GenomeInfoDb", "GenomicRanges", "IRanges", "MASS", "S4Vectors"]
     },
     "SomaticSignatures": {
       "name": "SomaticSignatures",
-      "version": "2.42.0",
-      "sha256": "0qvlfcsb4wwk1h0gi0gira7vknpd6jkyzil9z05mbgip9cyn543n",
+      "version": "2.44.0",
+      "sha256": "109y5kk68zshvvbac78anfzvx2wxcvi504n75paa277x9zmklixv",
       "depends": ["Biobase", "Biostrings", "GenomeInfoDb", "GenomicRanges", "IRanges", "NMF", "S4Vectors", "VariantAnnotation", "ggbio", "ggplot2", "pcaMethods", "proxy", "reshape2"]
     },
     "SpaNorm": {
       "name": "SpaNorm",
-      "version": "1.0.0",
-      "sha256": "0imw7mmzh9yjihdfm74ziwm9fs47k343hz7xp1qvy7wi83vl1jv0",
+      "version": "1.2.0",
+      "sha256": "1ssvbmgid6lh29pfyymc97bpg5csf7rzhf39y8nxs40igknn9fz9",
       "depends": ["Matrix", "S4Vectors", "SeuratObject", "SingleCellExperiment", "SpatialExperiment", "SummarizedExperiment", "edgeR", "ggplot2", "matrixStats", "rlang", "scran"]
     },
     "SpaceMarkers": {
       "name": "SpaceMarkers",
-      "version": "1.2.1",
-      "sha256": "0f9kfz2flhnmj74xjkkrpdg6p0r8lav59bj12lq2mc1jf7apm38q",
-      "depends": ["Matrix", "ape", "hdf5r", "jsonlite", "matrixStats", "matrixTests", "qvalue", "rstatix", "spatstat_explore", "spatstat_geom"]
+      "version": "1.4.0",
+      "sha256": "03xwlilzx9568mqdcap5ynhjvaslgxm3v1cwc28a3k2v6iqpmqdv",
+      "depends": ["Matrix", "ape", "ggplot2", "hdf5r", "jsonlite", "matrixStats", "matrixTests", "nanoparquet", "qvalue", "reshape2", "rstatix", "spatstat_explore", "spatstat_geom"]
     },
     "Spaniel": {
       "name": "Spaniel",
-      "version": "1.20.0",
-      "sha256": "1zhvydmcpnvwwrajmrdznskhln2p2bwlj9kh8v3v4hvz9rzrixpr",
+      "version": "1.22.0",
+      "sha256": "0kbl3f5livdy7zjm415nc6ah8g8mdxl7bj7ma491wby3z44h9rlr",
       "depends": ["DropletUtils", "S4Vectors", "Seurat", "SingleCellExperiment", "SummarizedExperiment", "dplyr", "ggplot2", "igraph", "jpeg", "jsonlite", "magrittr", "png", "scater", "scran", "shiny"]
     },
     "SparseArray": {
       "name": "SparseArray",
-      "version": "1.6.2",
-      "sha256": "0pp4r6mcral0x44f79z6p0gp0qhv2x8qyzjadmlx2jc2dh4b879a",
+      "version": "1.8.0",
+      "sha256": "1kwb75kib4y0qbi0sv9m2lznj7iwjwjss5r3ignr4k68qy86mb48",
       "depends": ["BiocGenerics", "IRanges", "Matrix", "MatrixGenerics", "S4Arrays", "S4Vectors", "XVector", "matrixStats"]
     },
     "SparseSignatures": {
       "name": "SparseSignatures",
-      "version": "2.16.0",
-      "sha256": "1gnnn8vklh3ir7rb03gyh7r9dhr5y9mclsfnr4n9gngwl77glym3",
+      "version": "2.18.0",
+      "sha256": "00h1i8hy3mkfz7shf00l2jcnkm5fbzlswjydqs6piqg4p2gci33l",
       "depends": ["BSgenome", "Biostrings", "GenomeInfoDb", "GenomicRanges", "IRanges", "NMF", "RhpcBLASctl", "data_table", "ggplot2", "gridExtra", "nnlasso", "nnls", "reshape2"]
     },
     "SpatialCPie": {
       "name": "SpatialCPie",
-      "version": "1.22.0",
-      "sha256": "0k8sz39jkn1jb86w23xykqyh7zlw9bqqr06x29zwy4vgfb02ll3h",
+      "version": "1.24.0",
+      "sha256": "0pmznha6hqsz685vcw2zpc0cw9g6f3ww2a1pswmfkcn3rj55h0dg",
       "depends": ["SummarizedExperiment", "colorspace", "data_table", "digest", "dplyr", "ggforce", "ggiraph", "ggplot2", "ggrepel", "igraph", "lpSolve", "purrr", "readr", "rlang", "shiny", "shinyWidgets", "shinycssloaders", "shinyjs", "tibble", "tidyr", "tidyselect", "zeallot"]
     },
     "SpatialDecon": {
       "name": "SpatialDecon",
-      "version": "1.16.0",
-      "sha256": "1kyl04k0cwg8193j22dynigp5m6s394w66j7nbmxlz0gn4sxf5f9",
+      "version": "1.18.0",
+      "sha256": "1vcwi2njhkwgl46nyn817fycf8hajdc7457wfhs06d7k6dm6a5r5",
       "depends": ["Biobase", "GeomxTools", "Matrix", "SeuratObject", "logNormReg", "repmis"]
     },
     "SpatialExperiment": {
       "name": "SpatialExperiment",
-      "version": "1.16.0",
-      "sha256": "02lsz2yag9h94ylwsdbqwvlsdgx6ijz9702hg5prz122jqv7x9l3",
+      "version": "1.18.0",
+      "sha256": "0m8wk3mz2sfk1lh255m1w5kqwcjplbhyqf2jvjcqy7lp29lp36hm",
       "depends": ["BiocFileCache", "BiocGenerics", "S4Vectors", "SingleCellExperiment", "SummarizedExperiment", "magick", "rjson"]
+    },
+    "SpatialExperimentIO": {
+      "name": "SpatialExperimentIO",
+      "version": "1.0.0",
+      "sha256": "13syrqy7qkblirslrx2k4gikx32imzi97bi0j0j54bccssjrxpgx",
+      "depends": ["DropletUtils", "S4Vectors", "SingleCellExperiment", "SpatialExperiment", "arrow", "data_table", "purrr"]
     },
     "SpatialFeatureExperiment": {
       "name": "SpatialFeatureExperiment",
-      "version": "1.8.6",
-      "sha256": "0wfsj5chjid5xs9hx2lwfgci9rlqwz98rxhszl4rfaf4axjl5a9n",
+      "version": "1.10.0",
+      "sha256": "1da2zf8yxn62naa5jkv05rx950cfxx1668hl5pcvgikc3gcw70mx",
       "depends": ["Biobase", "BiocGenerics", "BiocNeighbors", "BiocParallel", "DropletUtils", "EBImage", "Matrix", "S4Vectors", "SingleCellExperiment", "SpatialExperiment", "SummarizedExperiment", "data_table", "lifecycle", "rjson", "rlang", "sf", "sfheaders", "spatialreg", "spdep", "terra", "zeallot"]
     },
     "SpatialOmicsOverlay": {
       "name": "SpatialOmicsOverlay",
-      "version": "1.6.0",
-      "sha256": "0pkfzmjcys257yrixscpzfll6vmr8jmvdc39346j87q5wg9m30gs",
+      "version": "1.8.0",
+      "sha256": "0dbhml4fybsxdk75nbxk2b39aymgzklki86rp0rz292hk9g8qqs2",
       "depends": ["Biobase", "BiocFileCache", "EBImage", "GeomxTools", "RBioFormats", "S4Vectors", "XML", "base64enc", "data_table", "dplyr", "ggplot2", "ggtext", "magick", "pbapply", "plotrix", "readxl", "scattermore", "stringr"]
     },
     "SpeCond": {
       "name": "SpeCond",
-      "version": "1.60.0",
-      "sha256": "1vfh1yyh3card0yap8d7qvbiiy3kyfrw51vpccr4n11lskb6zdbn",
+      "version": "1.62.0",
+      "sha256": "190qd4ydczkfckc1b87fm14m0259db53ff65251ygc65z4bw88cb",
       "depends": ["Biobase", "RColorBrewer", "fields", "hwriter", "mclust"]
     },
     "Spectra": {
       "name": "Spectra",
-      "version": "1.16.0",
-      "sha256": "00jsmbkcwndm82aj6gc3qn0b48niajx8aymijy7cpq3vh6hlxpyr",
+      "version": "1.18.0",
+      "sha256": "1nkvgrczagwg3z97c55dlixvl87sanalmx0nkpfxd94cc4jbh1d1",
       "depends": ["BiocGenerics", "BiocParallel", "IRanges", "MetaboCoreUtils", "MsCoreUtils", "ProtGenerics", "S4Vectors", "fs"]
     },
     "SpectraQL": {
       "name": "SpectraQL",
-      "version": "1.0.0",
-      "sha256": "01znp2wmfvmavqw8jlyv2g1172z08by0dx2c9vz0xnzd7bf817kz",
+      "version": "1.2.0",
+      "sha256": "16438fhl4gi3zspkkynry94pzzv1lxlvsxs3n1sm4bwccnwfdvdk",
       "depends": ["MsCoreUtils", "ProtGenerics", "Spectra"]
     },
     "SpectralTAD": {
       "name": "SpectralTAD",
-      "version": "1.22.0",
-      "sha256": "0kxxpf2yasip6r4dlsanv0j322isryc7j6g1i2lbxlwlsqicwh6d",
+      "version": "1.24.0",
+      "sha256": "09jm9lm4a0qhk1nz8g98pg2kmm90nnkb9cgd3c8jid6idfnzdgcq",
       "depends": ["BiocParallel", "GenomicRanges", "HiCcompare", "Matrix", "PRIMME", "cluster", "dplyr", "magrittr"]
     },
     "SpliceWiz": {
       "name": "SpliceWiz",
-      "version": "1.8.0",
-      "sha256": "1givc70wna0r6zr0jx6pw4wwls0q2nn69gn5f2gc4l1nakcjsn0i",
-      "depends": ["AnnotationHub", "BSgenome", "BiocFileCache", "BiocGenerics", "BiocParallel", "Biostrings", "DT", "DelayedArray", "DelayedMatrixStats", "GenomeInfoDb", "GenomicRanges", "HDF5Array", "IRanges", "NxtIRFdata", "RColorBrewer", "RSQLite", "R_utils", "Rcpp", "RcppProgress", "S4Vectors", "SummarizedExperiment", "data_table", "fst", "genefilter", "ggplot2", "heatmaply", "htmltools", "httr", "magrittr", "matrixStats", "ompBAM", "patchwork", "pheatmap", "plotly", "progress", "rhandsontable", "rhdf5", "rtracklayer", "rvest", "scales", "shiny", "shinyFiles", "shinyWidgets", "shinydashboard", "stringi"]
+      "version": "1.10.0",
+      "sha256": "1j723wxwdxv31xhn105w504xw0hz88gdslg2b8r505cf0f3wsyrh",
+      "depends": ["AnnotationHub", "BSgenome", "BiocFileCache", "BiocGenerics", "BiocParallel", "Biostrings", "DT", "DelayedArray", "DelayedMatrixStats", "GenomeInfoDb", "GenomicRanges", "HDF5Array", "IRanges", "NxtIRFdata", "RColorBrewer", "RSQLite", "R_utils", "Rcpp", "RcppProgress", "S4Vectors", "SummarizedExperiment", "data_table", "fst", "genefilter", "ggplot2", "h5mread", "heatmaply", "htmltools", "httr", "magrittr", "matrixStats", "ompBAM", "patchwork", "pheatmap", "plotly", "progress", "rhandsontable", "rhdf5", "rtracklayer", "rvest", "scales", "shiny", "shinyFiles", "shinyWidgets", "shinydashboard", "stringi"]
     },
     "SplicingFactory": {
       "name": "SplicingFactory",
-      "version": "1.14.0",
-      "sha256": "053yl2vdgp4hczbahqk290751c58r1ybirrdqfn0kxq64y7kpl5g",
+      "version": "1.16.0",
+      "sha256": "1x7c5pkii3f90mcbqmjb9wsbc08c776lb2hbws7hbz4wsg2rdyn5",
       "depends": ["SummarizedExperiment"]
     },
     "SplicingGraphs": {
       "name": "SplicingGraphs",
-      "version": "1.46.0",
-      "sha256": "1c9wdxsf54av0dlzah8jgbrxv3r2m2jd75qpfbl37gg6sim3732k",
+      "version": "1.48.0",
+      "sha256": "115qvj5zpr2axigr8laar4ja4xz0cjgbl13fki4gkmgckzhm9idl",
       "depends": ["BiocGenerics", "BiocParallel", "GenomeInfoDb", "GenomicAlignments", "GenomicFeatures", "GenomicRanges", "IRanges", "Rgraphviz", "Rsamtools", "S4Vectors", "graph", "igraph"]
+    },
+    "SplineDV": {
+      "name": "SplineDV",
+      "version": "1.0.0",
+      "sha256": "1mwabmbr4jky7zvzqyc6ya79xrpx4cybh2sd927r0jmcxp30s251",
+      "depends": ["Biobase", "BiocGenerics", "Matrix", "S4Vectors", "SingleCellExperiment", "SummarizedExperiment", "dplyr", "plotly", "scuttle", "sparseMatrixStats"]
     },
     "SpotClean": {
       "name": "SpotClean",
-      "version": "1.8.0",
-      "sha256": "0fiamnh5lx4fp7s75hm6scsgnyfccj3wm4gcgaha6i92d7dpw8ad",
+      "version": "1.10.0",
+      "sha256": "0dvzbwxg5gw1gkbqh5ddyg6c5yv4wn4a310cdxxdx9m74ra3f58i",
       "depends": ["Matrix", "RColorBrewer", "S4Vectors", "Seurat", "SpatialExperiment", "SummarizedExperiment", "dplyr", "ggplot2", "readbitmap", "rhdf5", "rjson", "rlang", "tibble", "viridis"]
     },
     "SpotSweeper": {
       "name": "SpotSweeper",
-      "version": "1.2.0",
-      "sha256": "1844jy1j6g80j94qn540gcxbwf2i4dwl7gyg2ffsy9hwnk54ws2j",
-      "depends": ["BiocNeighbors", "MASS", "SingleCellExperiment", "SpatialExperiment", "SummarizedExperiment", "escheR", "ggplot2", "spatialEco"]
+      "version": "1.4.0",
+      "sha256": "06q4rh1hxwir0cfyjn6lg6g3h886x0jznglfwnhyr2vlr62k2xhp",
+      "depends": ["BiocNeighbors", "BiocParallel", "MASS", "SingleCellExperiment", "SpatialExperiment", "SummarizedExperiment", "escheR", "ggplot2", "spatialEco"]
     },
     "StabMap": {
       "name": "StabMap",
-      "version": "1.0.0",
-      "sha256": "0k9jmys7b80wq94dm6jdl5ss4kn4w5syhx0l1a7qjiqqm1jbmwqf",
+      "version": "1.2.0",
+      "sha256": "15nkzvxsf62d12d4cw57z1vxhpdi1ap9i5l086vnwjybdznldg41",
       "depends": ["BiocGenerics", "BiocNeighbors", "BiocParallel", "BiocSingular", "MASS", "Matrix", "MatrixGenerics", "SummarizedExperiment", "abind", "igraph", "slam"]
     },
     "Statial": {
       "name": "Statial",
-      "version": "1.8.0",
-      "sha256": "0k7iaxkd2q3bqb6jf4w9nwi71qlqczmfm92v9cl86l899acgv15d",
+      "version": "1.10.0",
+      "sha256": "0nnbqj1qab4dhqzryfq1zq5dbvxpbqy84jl5842k4vb3r2fflrss",
       "depends": ["BiocParallel", "S4Vectors", "SingleCellExperiment", "SpatialExperiment", "SummarizedExperiment", "cluster", "concaveman", "data_table", "dplyr", "ggplot2", "limma", "magrittr", "plotly", "purrr", "ranger", "spatstat_explore", "spatstat_geom", "stringr", "tibble", "tidyr", "tidyselect", "treekoR"]
     },
     "Streamer": {
       "name": "Streamer",
-      "version": "1.52.0",
-      "sha256": "09ah00rmdlb914nag8hkvsvkx5k42l4apckdbzsq6cink5qg1yxs",
+      "version": "1.54.0",
+      "sha256": "0s4l5y0d1pgsf5fy0qz4qw5h95z9vimx95v090f4rzgpwyzn444z",
       "depends": ["BiocGenerics", "RBGL", "graph"]
     },
     "Structstrings": {
       "name": "Structstrings",
-      "version": "1.22.1",
-      "sha256": "02nzkn5iwqqixj92vyfazdxsv7j6hpzkn005gznv11kfkagv9hwn",
+      "version": "1.24.0",
+      "sha256": "1hrp77252g5bys6gj7lrqhki8kvsrqpimbyyr7sl6884avim20q2",
       "depends": ["BiocGenerics", "Biostrings", "IRanges", "S4Vectors", "XVector", "crayon", "stringi", "stringr"]
     },
     "StructuralVariantAnnotation": {
       "name": "StructuralVariantAnnotation",
-      "version": "1.22.0",
-      "sha256": "1b96zv2ny4anlxpxkda86cg65v8z13mf8h241if6aiks8pq0z7kr",
+      "version": "1.24.0",
+      "sha256": "0g6h1d5kk499b46dijlvz6nfgx3ihxh3fm97ijnx6k37h5z49md3",
       "depends": ["BiocGenerics", "Biostrings", "GenomeInfoDb", "GenomicFeatures", "GenomicRanges", "IRanges", "S4Vectors", "SummarizedExperiment", "VariantAnnotation", "assertthat", "dplyr", "pwalign", "rlang", "rtracklayer", "stringr"]
     },
     "SubCellBarCode": {
       "name": "SubCellBarCode",
-      "version": "1.22.0",
-      "sha256": "1akg68b2xs2wr9ry8dhjhksmidsaf66x47kv96ijr8b6klhayg9w",
+      "version": "1.24.0",
+      "sha256": "0wyiqqc5p3dlp44ljay6mgafjvjwhgdp8d1yrxjg4pwmm363ldb5",
       "depends": ["AnnotationDbi", "Rtsne", "caret", "e1071", "ggplot2", "ggrepel", "gridExtra", "networkD3", "org_Hs_eg_db", "scatterplot3d"]
     },
     "SummarizedExperiment": {
       "name": "SummarizedExperiment",
-      "version": "1.36.0",
-      "sha256": "1kfkdn57crg9l00bpd2z4ads14nd9c2lh1m1lqbc6kszbxpq9185",
+      "version": "1.38.0",
+      "sha256": "0485ppw901n6k4bsp21gv38kd520jl67gc9z0xg96v68ilzbwczs",
       "depends": ["Biobase", "BiocGenerics", "DelayedArray", "GenomeInfoDb", "GenomicRanges", "IRanges", "Matrix", "MatrixGenerics", "S4Arrays", "S4Vectors"]
     },
     "Summix": {
       "name": "Summix",
-      "version": "2.12.0",
-      "sha256": "0h2zvcbnm8zwaql0jn7zd8ffckgs9llgg4vzd1xjiqzx6kciy8di",
+      "version": "2.14.0",
+      "sha256": "1333xp20cfkcrfnna4a86xpba4i8i2npy841yzl851ahydb20avv",
       "depends": ["BEDASSLE", "dplyr", "magrittr", "nloptr", "randomcoloR", "scales", "tibble", "tidyselect", "visNetwork"]
     },
     "SurfR": {
       "name": "SurfR",
-      "version": "1.2.6",
-      "sha256": "0ls9dyhjvqq97bf1msfz8p89cwvmlnimvxfi297bmcawhvmki75f",
-      "depends": ["BiocFileCache", "DESeq2", "SPsimSeq", "SummarizedExperiment", "TCGAbiolinks", "assertr", "biomaRt", "dplyr", "edgeR", "ggplot2", "ggrepel", "gridExtra", "httr", "knitr", "magrittr", "metaRNASeq", "openxlsx", "rhdf5", "rjson", "scales", "stringr", "tidyr", "venn"]
+      "version": "1.3.7",
+      "sha256": "0zjbp0w2fn4fw476x7kj2f1y7j0drp6y8shbhbai0k4lw3lp80g3",
+      "depends": ["BiocFileCache", "DESeq2", "SPsimSeq", "SummarizedExperiment", "TCGAbiolinks", "assertr", "biomaRt", "curl", "dplyr", "edgeR", "ggplot2", "ggrepel", "gridExtra", "httr", "knitr", "magrittr", "metaRNASeq", "openxlsx", "rhdf5", "rjson", "scales", "stringr", "tidyr", "venn"]
     },
     "SwathXtend": {
       "name": "SwathXtend",
-      "version": "2.28.0",
-      "sha256": "16c08r2vc4z5bwa66w04hskr0mssrk7q7ycnqzfzkybp4c62yrwh",
+      "version": "2.30.0",
+      "sha256": "0z18qg1dc27zylgj9hqxvm2pn5s93r09mc9j3nqc106l5i1iarzp",
       "depends": ["VennDiagram", "e1071", "lattice", "openxlsx"]
     },
     "SynExtend": {
       "name": "SynExtend",
-      "version": "1.18.0",
-      "sha256": "0jhfa5l33kn6mb4ynm3976p9sz4dzr23fnlfazj6j6wsfs1l366r",
+      "version": "1.20.0",
+      "sha256": "0phis9bjfgk4kjv17n95518fpxrikibqby53f363078dkb3cb0ff",
       "depends": ["Biostrings", "DBI", "DECIPHER", "IRanges", "RSQLite", "S4Vectors"]
     },
     "SynMut": {
       "name": "SynMut",
-      "version": "1.22.0",
-      "sha256": "04wcvbppyhrr1gw76gg1p1s1v60cll57rjz7567wqdjnjzzd3g75",
+      "version": "1.24.0",
+      "sha256": "08f1lyvpfqy1268s6j2j9bf0lb4w3b32rc8i6j0mi0j9m3kzsfxf",
       "depends": ["BiocGenerics", "Biostrings", "seqinr", "stringr"]
     },
     "TADCompare": {
       "name": "TADCompare",
-      "version": "1.16.0",
-      "sha256": "1svq0h9bwydghsqgmbr239i6df8pyvg26xqvbghv6rl8p12712n5",
+      "version": "1.18.0",
+      "sha256": "0mc1rf56p5xyycn4rp73jfv46gi6vbgbd562ccvhkj0mb124xajl",
       "depends": ["HiCcompare", "Matrix", "PRIMME", "RColorBrewer", "cluster", "cowplot", "dplyr", "ggplot2", "ggpubr", "magrittr", "reshape2", "tidyr"]
     },
     "TAPseq": {
       "name": "TAPseq",
-      "version": "1.18.0",
-      "sha256": "030pcjdbdypj44w6m6byllcnr926psrckz4ycvfalfgx05dncdzs",
+      "version": "1.20.0",
+      "sha256": "1p19mx3zipdrk5nmlsa8lc55rrrgdca4jflk1bhf4c0plviympz1",
       "depends": ["BSgenome", "BiocGenerics", "BiocParallel", "Biostrings", "GenomeInfoDb", "GenomicAlignments", "GenomicFeatures", "GenomicRanges", "IRanges", "S4Vectors", "dplyr", "tidyr"]
+    },
+    "TBSignatureProfiler": {
+      "name": "TBSignatureProfiler",
+      "version": "1.20.0",
+      "sha256": "1k6hzklr16rh3fn79q1cskzvnwlq3sxmsymslra4bgyq9kik6bcv",
+      "depends": ["ASSIGN", "BiocParallel", "ComplexHeatmap", "DESeq2", "DT", "GSVA", "HGNChelper", "RColorBrewer", "ROCit", "S4Vectors", "SummarizedExperiment", "edgeR", "gdata", "ggplot2", "glmnet", "magrittr", "pROC", "reshape2", "singscore", "tibble"]
     },
     "TCC": {
       "name": "TCC",
-      "version": "1.46.0",
-      "sha256": "0g0kd1r4rx2418n4vw3wh3g918d5lbh3arxwg509g0a5w6clcaf3",
+      "version": "1.48.0",
+      "sha256": "1f627k01p47rh6f8isba6ydwvsg28xr1n6zharnp5z4m0hiapf5w",
       "depends": ["DESeq2", "ROC", "edgeR"]
     },
     "TCGAbiolinks": {
       "name": "TCGAbiolinks",
-      "version": "2.34.0",
-      "sha256": "0rrk97956kyd17apjm29fxnqjhbh5mllpfr3y4yf3a3ras9chgw4",
+      "version": "2.35.4",
+      "sha256": "18ja7a1k5ds49mhyav2v8y2vw1rlxr1l5bilkqwjfnvwj6h5wcq5",
       "depends": ["GenomicRanges", "IRanges", "R_utils", "S4Vectors", "SummarizedExperiment", "TCGAbiolinksGUI_data", "XML", "biomaRt", "data_table", "downloader", "dplyr", "ggplot2", "httr", "jsonlite", "knitr", "plyr", "purrr", "readr", "rvest", "stringr", "tibble", "tidyr", "xml2"]
     },
     "TCGAutils": {
       "name": "TCGAutils",
-      "version": "1.26.0",
-      "sha256": "0zspiaj7s9ij466dl25k5lrr1r2gpav2dwpmzhqpqpm0pg436xpg",
+      "version": "1.28.0",
+      "sha256": "1jkqmla4wr1dg78g29clhb0vljmyhlz8ad2wm8acs6gx4irbdxg0",
       "depends": ["AnnotationDbi", "BiocBaseUtils", "BiocGenerics", "GenomeInfoDb", "GenomicDataCommons", "GenomicFeatures", "GenomicRanges", "IRanges", "MultiAssayExperiment", "RaggedExperiment", "S4Vectors", "SummarizedExperiment", "rvest", "stringr", "xml2"]
     },
     "TCseq": {
       "name": "TCseq",
-      "version": "1.30.0",
-      "sha256": "0djjsjx5yva9khxpr35a9qrvx1xbd3wbh7ybklgcc2fhhbsz1ir5",
+      "version": "1.32.0",
+      "sha256": "0n3w1dgpqfyq6gkdc5cqx7p6srb1pjfwq66rn32956wja43v9q1x",
       "depends": ["BiocGenerics", "GenomicAlignments", "GenomicRanges", "IRanges", "Rsamtools", "SummarizedExperiment", "cluster", "e1071", "edgeR", "ggplot2", "locfit", "reshape2"]
     },
     "TDbasedUFE": {
       "name": "TDbasedUFE",
-      "version": "1.6.0",
-      "sha256": "0dl3b4pzmqm22pfvrkb6j2229r72y9j7jibcw1ycd5zvw71l0g60",
+      "version": "1.8.0",
+      "sha256": "17y5yi0x168ma9b33fhkykc1w94y394r5l716rfqr8s9iqsddmf2",
       "depends": ["GenomicRanges", "MOFAdata", "rTensor", "readr", "shiny", "tximport", "tximportData"]
     },
     "TDbasedUFEadv": {
       "name": "TDbasedUFEadv",
-      "version": "1.6.0",
-      "sha256": "0if9myqv4zkzafnr5h76wkyph63napwv1svg35h7zlih5kxy2i78",
+      "version": "1.8.0",
+      "sha256": "0r7cms37pzsjfj2gsgrqc1rrfifx6c2jjvl2gzkm7kij801lcbjn",
       "depends": ["Biobase", "DOSE", "GenomicRanges", "RTCGA", "STRINGdb", "TDbasedUFE", "enrichR", "enrichplot", "hash", "rTensor", "shiny"]
     },
     "TEKRABber": {
       "name": "TEKRABber",
-      "version": "1.10.0",
-      "sha256": "0k004jncqvp3vcfmr8y56kj57rc5swqq369nq2zwyr3vacmdq6p8",
+      "version": "1.12.0",
+      "sha256": "1nbisldzrxadw86nffarrcnkyrhs76qsfimsx2mhj98dcv7190ig",
       "depends": ["DESeq2", "GenomeInfoDb", "Rcpp", "SCBN", "apeglm", "biomaRt", "doParallel", "dplyr", "foreach", "magrittr", "rtracklayer"]
+    },
+    "TENET": {
+      "name": "TENET",
+      "version": "1.0.0",
+      "sha256": "1kcdkryzsd7jf9vxji9s1cd06gasv9p947nbkps85jblljwfmvhx",
+      "depends": ["AnnotationHub", "BSgenome_Hsapiens_UCSC_hg38", "Biostrings", "ExperimentHub", "GenomicRanges", "IRanges", "MultiAssayExperiment", "RCircos", "R_utils", "S4Vectors", "SummarizedExperiment", "TCGAbiolinks", "TENET_ExperimentHub", "ggplot2", "matlab", "pastecs", "rtracklayer", "seqLogo", "sesame", "sesameData", "survival"]
     },
     "TENxIO": {
       "name": "TENxIO",
-      "version": "1.8.2",
-      "sha256": "1hcs4ga5lmziq1lw19jjj04nhf97v319d8m7jx8llz7jwizri34m",
+      "version": "1.10.0",
+      "sha256": "0b2whwz4pijjd62qnn0m07i609i27vrx4qqq3l9r2cppw7vlvfhi",
       "depends": ["BiocBaseUtils", "BiocGenerics", "BiocIO", "GenomeInfoDb", "GenomicRanges", "HDF5Array", "Matrix", "MatrixGenerics", "RCurl", "R_utils", "S4Vectors", "SingleCellExperiment", "SummarizedExperiment", "readr", "rhdf5"]
     },
     "TEQC": {
       "name": "TEQC",
-      "version": "4.28.0",
-      "sha256": "0025hm2m9hpbba1bdc60lb9ar8iij2k3p0hiyfzbvad8gwi7g4x2",
+      "version": "4.30.0",
+      "sha256": "0mm33s75i527h8q3p4sdxmrcwh4xcr6lff3334719mh296gfgqja",
       "depends": ["Biobase", "BiocGenerics", "IRanges", "Rsamtools", "hwriter"]
     },
     "TFARM": {
       "name": "TFARM",
-      "version": "1.28.0",
-      "sha256": "17n2mfanifq2h2pkw9qi97ghhhb0rh9y0vbf8wbhh10j056xq6vf",
+      "version": "1.30.0",
+      "sha256": "11qrxlcwdkhnqgki4b47dpc0zcv1w7scmprjiy84afid9kyykfp9",
       "depends": ["GenomicRanges", "arules", "fields", "gplots", "stringr"]
     },
     "TFBSTools": {
       "name": "TFBSTools",
-      "version": "1.44.0",
-      "sha256": "129qkllv3i0pifigw255g3k4b6ki6sf8hql56x2nbm6h64bcfd9c",
-      "depends": ["BSgenome", "Biobase", "BiocGenerics", "BiocParallel", "Biostrings", "CNEr", "DBI", "DirichletMultinomial", "GenomeInfoDb", "GenomicRanges", "IRanges", "RSQLite", "S4Vectors", "TFMPvalue", "XML", "XVector", "caTools", "gtools", "pwalign", "rtracklayer", "seqLogo"]
+      "version": "1.46.0",
+      "sha256": "149bhv3h8d5lr17l7bndjpmp0g48yp07kiankwvqkrl2zilr17kk",
+      "depends": ["BSgenome", "Biobase", "BiocGenerics", "BiocParallel", "Biostrings", "DBI", "DirichletMultinomial", "GenomeInfoDb", "GenomicRanges", "IRanges", "RSQLite", "S4Vectors", "TFMPvalue", "XML", "XVector", "caTools", "gtools", "pwalign", "rtracklayer", "seqLogo"]
     },
     "TFEA_ChIP": {
       "name": "TFEA.ChIP",
-      "version": "1.26.0",
-      "sha256": "18s89xjzlrick8hln25n7xb3x0rl8c54z6zlpyfw3g2i47l5ya6m",
+      "version": "1.28.0",
+      "sha256": "1pwf4gxxls9mzbzm7crnhw01pajl3plbh1fm6qaz4m5ra9b7wkq2",
       "depends": ["GenomicFeatures", "GenomicRanges", "IRanges", "R_utils", "biomaRt", "dplyr", "org_Hs_eg_db"]
     },
     "TFHAZ": {
       "name": "TFHAZ",
-      "version": "1.28.0",
-      "sha256": "1nrz1binbvkqmv3b276gs3isxrca7hm3asaqgdasvdbjqidcv96l",
+      "version": "1.30.0",
+      "sha256": "0hl6wmbkaq9g7imhh95sqz832ccq524hax1j5vrypgbxcvk73vgv",
       "depends": ["GenomicRanges", "IRanges", "ORFik", "S4Vectors"]
     },
     "TFutils": {
       "name": "TFutils",
-      "version": "1.26.0",
-      "sha256": "1mxk7yf031x75ssxj2icc6ffm22617y6ca1m4why24qqr7yjlzdv",
-      "depends": ["AnnotationDbi", "BiocFileCache", "DT", "GSEABase", "Rsamtools", "dplyr", "httr", "magrittr", "miniUI", "org_Hs_eg_db", "readxl", "rjson", "shiny"]
+      "version": "1.28.0",
+      "sha256": "1ciwf64gia2fn7xxxksjf4kg9996yx9zfjn0fk0xlrjaj8ald4ps",
+      "depends": ["AnnotationDbi", "BiocFileCache", "DT", "GSEABase", "GenomicFiles", "Rsamtools", "SummarizedExperiment", "dplyr", "httr", "magrittr", "miniUI", "org_Hs_eg_db", "readxl", "rjson", "shiny"]
     },
     "TIN": {
       "name": "TIN",
-      "version": "1.38.0",
-      "sha256": "1avwkbbl5k8zx526mjkxdqbxl7fz4qnis9v5rmnr2p0gz2jfdgqs",
+      "version": "1.40.0",
+      "sha256": "063j4axil7yy1b555jhq36d2v6lsw4ar53vkghyb0hh1j9yhgcw6",
       "depends": ["WGCNA", "aroma_affymetrix", "data_table", "impute", "squash", "stringr"]
     },
     "TMSig": {
       "name": "TMSig",
-      "version": "1.0.0",
-      "sha256": "0lcmkgclx7biydlgmwldgwlxfig4jvw6z04xk6f37983wgn7mr3j",
+      "version": "1.2.0",
+      "sha256": "165xbvn61l8zxlywdczx1r0sakhq956qdhxjk73ixq486qz9zn16",
       "depends": ["ComplexHeatmap", "GSEABase", "Matrix", "circlize", "data_table", "limma"]
     },
     "TMixClust": {
       "name": "TMixClust",
-      "version": "1.28.0",
-      "sha256": "1ql8dliniyw0qwqb40z4s7hcz7kgnlmv3vr08czadi0xxjjddag7",
+      "version": "1.30.0",
+      "sha256": "06bk1h4ngxgaws27n8yd6pqp730gwimnvqq9acmvkxwh35yph9ab",
       "depends": ["Biobase", "BiocParallel", "SPEM", "cluster", "flexclust", "gss", "mvtnorm", "zoo"]
     },
     "TOAST": {
       "name": "TOAST",
-      "version": "1.20.0",
-      "sha256": "1iv9hfj9qijbvwcphm1l0syac8n7crb78sgb3b2pzvnzg5v71avn",
+      "version": "1.22.0",
+      "sha256": "0zi8j5g4gifg40yhr6z0ip7xkrivd8b0hjsg8ik6i258n2dn9100",
       "depends": ["EpiDISH", "GGally", "SummarizedExperiment", "corpcor", "doParallel", "ggplot2", "limma", "nnls", "quadprog", "tidyr"]
     },
     "TOP": {
       "name": "TOP",
-      "version": "1.6.0",
-      "sha256": "0a3vm3pms5vvq0q3b8ard7p057dfrlcjxf0cjhyhlis6gcwi48jk",
+      "version": "1.8.0",
+      "sha256": "1g7ghaw2diq3p7l985rid1yi8lgpig4pdj2m0a9bnp6ri22lxfr0",
       "depends": ["ClassifyR", "Hmisc", "assertthat", "caret", "directPA", "doParallel", "dplyr", "ggnewscale", "ggplot2", "ggraph", "ggrepel", "ggthemes", "glmnet", "igraph", "latex2exp", "limma", "magrittr", "pROC", "plotly", "purrr", "reshape2", "statmod", "stringr", "survival", "tibble", "tidygraph", "tidyr"]
     },
     "TPP": {
       "name": "TPP",
-      "version": "3.34.0",
-      "sha256": "0q0rs312bfq6nyri5j2dzzg7v9r38zdmn33zw6rg0id4ig0jb9i0",
+      "version": "3.36.0",
+      "sha256": "0mkwp5q0qm9cp7wwsnxy55ljrgkzxxzsf51yfr7428w33mmwwq2b",
       "depends": ["Biobase", "MASS", "RColorBrewer", "RCurl", "VGAM", "VennDiagram", "biobroom", "broom", "data_table", "doParallel", "dplyr", "foreach", "futile_logger", "ggplot2", "gridExtra", "knitr", "limma", "magrittr", "mefa", "nls2", "openxlsx", "plyr", "purrr", "reshape2", "rmarkdown", "stringr", "tibble", "tidyr"]
     },
     "TPP2D": {
       "name": "TPP2D",
-      "version": "1.22.0",
-      "sha256": "0h238hqq9p5n2s8jp7679yzvrn9szznmq6wkmfv5c8bsisvn9j0i",
+      "version": "1.24.0",
+      "sha256": "0yf7g0yzh9hidk6qdp47y0263l2mn710zj0fw32j0ynjlm96m5l4",
       "depends": ["BiocParallel", "MASS", "RCurl", "doParallel", "dplyr", "foreach", "ggplot2", "limma", "openxlsx", "stringr", "tidyr"]
     },
     "TREG": {
       "name": "TREG",
-      "version": "1.10.0",
-      "sha256": "05hc0sishbv5psq7d1i4fqrwlp3lhc85gp6gxxckr8khcx3i8baf",
+      "version": "1.12.0",
+      "sha256": "14yl6vxnrajmqh7nrpaa2nmyq8713rnkgq7b53vd9mxpb4plfv1f",
       "depends": ["Matrix", "SummarizedExperiment", "purrr", "rafalib"]
     },
     "TRESS": {
       "name": "TRESS",
-      "version": "1.12.0",
-      "sha256": "13fs80zi8i408s6y59chkalbdz1jrkdwb3l0n1cr0s21w9rksxq1",
+      "version": "1.14.0",
+      "sha256": "1hc755ng31ks1sxndg3lmr8faif5rcqdi17fvwi21x2cjy88msxy",
       "depends": ["AnnotationDbi", "GenomicFeatures", "GenomicRanges", "IRanges", "Matrix", "Rsamtools", "S4Vectors", "matrixStats", "rtracklayer"]
     },
     "TRONCO": {
       "name": "TRONCO",
-      "version": "2.38.0",
-      "sha256": "1qmhwdnvqz48jgzjhjyba6skmccz6n7rja1yscd1ckrx6c1dc41b",
+      "version": "2.40.0",
+      "sha256": "0il19f229glhim96sr6h1h31lkg86ancmqfr9r4gfkbmwf6lmnh5",
       "depends": ["RColorBrewer", "R_matlab", "Rgraphviz", "bnlearn", "circlize", "doParallel", "foreach", "gridExtra", "gtable", "gtools", "igraph", "iterators", "scales", "xtable"]
     },
     "TSAR": {
       "name": "TSAR",
-      "version": "1.4.0",
-      "sha256": "03lcgws6pzr7mcyq3gz0xprqr85s94ca1dkpbxnqzs0xr6r4mip3",
+      "version": "1.6.0",
+      "sha256": "1ng2l4k8wx8s4i2w16fv2b0pl5c95whx63ybmmva4l7abyrx5k0p",
       "depends": ["dplyr", "ggplot2", "ggpubr", "jsonlite", "magrittr", "mgcv", "minpack_lm", "openxlsx", "plotly", "readxl", "rhandsontable", "shiny", "shinyWidgets", "shinyjs", "stringr", "tidyr"]
     },
     "TSCAN": {
       "name": "TSCAN",
-      "version": "1.44.0",
-      "sha256": "0kcmql4wgi4kwrq1z7mf3zihxx36al5rwnifa43dd6hffd333h8k",
+      "version": "1.46.0",
+      "sha256": "1xn3wvrsydqyjd7nq8a3iz079ci25cv16zvx2s9gn9mjpcjw3hl6",
       "depends": ["DelayedArray", "Matrix", "S4Vectors", "SingleCellExperiment", "SparseArray", "SummarizedExperiment", "TrajectoryUtils", "combinat", "fastICA", "ggplot2", "gplots", "igraph", "mclust", "mgcv", "plyr", "shiny"]
     },
     "TTMap": {
       "name": "TTMap",
-      "version": "1.28.0",
-      "sha256": "1f2gpi15xy7489bwkldgm0ssg8mbigr4lcmmmqcphqdpzd4d4lsl",
+      "version": "1.30.0",
+      "sha256": "1f3klkw9gy1f70dvpvgjrc4f1iq2001s22m57yr5g0d0vi9aprf0",
       "depends": ["Biobase", "SummarizedExperiment", "colorRamps", "rgl"]
     },
     "TVTB": {
       "name": "TVTB",
-      "version": "1.32.0",
-      "sha256": "1iksgp3adwa1w62bhim9i1ha31zr3mvlq5za4lw1rzh0fnxfsbjy",
+      "version": "1.34.0",
+      "sha256": "06rw3jsjkmnfh088yd31a2n7vnblg3ppgjiz2gd8skcic13asbvj",
       "depends": ["AnnotationFilter", "BiocGenerics", "BiocParallel", "Biostrings", "GGally", "GenomeInfoDb", "GenomicRanges", "Gviz", "IRanges", "Rsamtools", "S4Vectors", "SummarizedExperiment", "VariantAnnotation", "ensembldb", "ggplot2", "limma", "reshape2"]
     },
     "TargetDecoy": {
       "name": "TargetDecoy",
-      "version": "1.12.0",
-      "sha256": "0p1l812iip5gk99kcf5dk1p8nr5qwrwgq27jywkp149zwmdmb4xw",
+      "version": "1.14.0",
+      "sha256": "15l5adc20m4pf77ywifzm3m3yavm59nxjbk3kh51brj6s0y97k0x",
       "depends": ["ggplot2", "ggpubr", "miniUI", "mzID", "mzR", "shiny"]
     },
     "TargetScore": {
       "name": "TargetScore",
-      "version": "1.44.0",
-      "sha256": "17yd04dhwamxk5nlrkxpl6qc34ps83wazpsynj58rkbcs8wxgb8x",
+      "version": "1.46.0",
+      "sha256": "1m1p9n3h7gsbln061fcnjynz4p8k97vwfnj7bz90v8608d456lbm",
       "depends": ["Matrix", "pracma"]
     },
     "TargetSearch": {
       "name": "TargetSearch",
-      "version": "2.8.0",
-      "sha256": "0xbb9vhs1s8am1g5ds7wrq3wrj3x5fg2siq7g4b7dj0785l6dlws",
+      "version": "2.10.0",
+      "sha256": "0iq9yhx897igc9gimkf7ig6116bk9rzvrh0v0sp8n9z3r79khzw9",
       "depends": ["assertthat", "ncdf4"]
+    },
+    "TaxSEA": {
+      "name": "TaxSEA",
+      "version": "1.0.0",
+      "sha256": "1vhilxjfprbxl6vrms6ar4fm0pr1v3bydfwpwb1vgvh23wy3mvrr",
+      "depends": []
     },
     "TileDBArray": {
       "name": "TileDBArray",
-      "version": "1.16.0",
-      "sha256": "1zlbnyd7d8m1qyf6b85fnx68kdswnd9j8zqs3xgq6mxlq732wnw4",
+      "version": "1.18.0",
+      "sha256": "1l7hgy39szsslzxi2hmhi5764l39a1jx1sh0xickbyawjn1jp442",
       "depends": ["DelayedArray", "S4Vectors", "SparseArray", "tiledb"]
     },
     "TissueEnrich": {
       "name": "TissueEnrich",
-      "version": "1.26.0",
-      "sha256": "1jzncpyl6b7x6njndbwq8989l9a0rrjsbx9xap16mmdw7bfldz7c",
+      "version": "1.28.0",
+      "sha256": "0b8claj69x94k79mgvy6jw2iz3axl9nkdh27vljsv29gw7lf2vyh",
       "depends": ["GSEABase", "SummarizedExperiment", "dplyr", "ggplot2", "tidyr"]
     },
     "TitanCNA": {
       "name": "TitanCNA",
-      "version": "1.44.0",
-      "sha256": "0c4ynjbsaf9wjsmpq6byv427dcj04icqlqpzcv7z7mlmk1a25h61",
+      "version": "1.45.0",
+      "sha256": "19znhy9gd40fcv3m1zx6kdh178f74j88rb5pkrdv53q48vcq68l3",
       "depends": ["BiocGenerics", "GenomeInfoDb", "GenomicRanges", "IRanges", "VariantAnnotation", "data_table", "dplyr", "foreach"]
     },
     "TnT": {
       "name": "TnT",
-      "version": "1.28.0",
-      "sha256": "1mr1vknykycrgigdjb8alafb5pgk6j92djr7qi3cb8pqzmbhv979",
+      "version": "1.30.0",
+      "sha256": "1f8790i64qlbl6kjyfq971vyjppx56qavrm8fh0hykp36f21swzs",
       "depends": ["Biobase", "GenomeInfoDb", "GenomicRanges", "IRanges", "S4Vectors", "data_table", "htmlwidgets", "jsonlite", "knitr"]
     },
     "ToxicoGx": {
       "name": "ToxicoGx",
-      "version": "2.10.0",
-      "sha256": "13rkrcd3c4gzkxs14m92sxcr6vliqxbyp8hvf16cjaz11hh8qrmv",
+      "version": "2.12.0",
+      "sha256": "072xin3r4hwbgln4qyj1w1by9w6vbjfn3fy1g6jpzhq9b6czj7m1",
       "depends": ["Biobase", "BiocGenerics", "BiocParallel", "CoreGx", "S4Vectors", "SummarizedExperiment", "assertthat", "caTools", "data_table", "downloader", "dplyr", "ggplot2", "jsonlite", "limma", "magrittr", "reshape2", "scales", "tibble", "tidyr"]
+    },
+    "TrIdent": {
+      "name": "TrIdent",
+      "version": "1.0.0",
+      "sha256": "1pp5qm058k1kz03prq2072nwnzncxb6akwq005bj358v3k0gjlsn",
+      "depends": ["dplyr", "ggplot2", "patchwork", "roll", "stringr", "tidyr"]
     },
     "TrajectoryGeometry": {
       "name": "TrajectoryGeometry",
-      "version": "1.14.0",
-      "sha256": "15jkk26mprs7pw8fy2dzssm6pgdvgm4n2074zhqgkdlsfhv3782b",
+      "version": "1.16.0",
+      "sha256": "0k639jwadjz9kg7l7cc5i30xc24dz456kn7y6d66b2w92ad0zvds",
       "depends": ["ggplot2", "pracma", "rgl"]
     },
     "TrajectoryUtils": {
       "name": "TrajectoryUtils",
-      "version": "1.14.0",
-      "sha256": "10ldajw1a3naxy58w4zf9ri5ql93fd6r06cdwg2dyagsb8qg3l20",
+      "version": "1.16.0",
+      "sha256": "1mr9h5jp3945sdpyvv7y5kks3gbv77g5p25b867c55glqv7ncxrc",
       "depends": ["Matrix", "S4Vectors", "SingleCellExperiment", "SummarizedExperiment", "igraph"]
     },
     "TreeAndLeaf": {
       "name": "TreeAndLeaf",
-      "version": "1.18.0",
-      "sha256": "03d47cyyc6nkhbqv24b92nppcmydbqmmaqbmg71vdj5d9wgb9c8i",
+      "version": "1.20.0",
+      "sha256": "12jg75hh8ldvcx6yp5ml9l4dps0y297za9v7snpqp5aj88aszxz8",
       "depends": ["RedeR", "ape", "igraph"]
     },
     "TreeSummarizedExperiment": {
       "name": "TreeSummarizedExperiment",
-      "version": "2.14.0",
-      "sha256": "187dbjb1w45v2gx510yk28hxvhc1bdjz5l853kmxdpr4wxs7nh4z",
+      "version": "2.16.0",
+      "sha256": "1mwnkqb57p76f2h9hx6azngl6l1q82yz0nn509q2scpd032rw5nc",
       "depends": ["BiocGenerics", "BiocParallel", "Biostrings", "IRanges", "S4Vectors", "SingleCellExperiment", "SummarizedExperiment", "ape", "dplyr", "rlang", "treeio"]
     },
     "Trendy": {
       "name": "Trendy",
-      "version": "1.28.0",
-      "sha256": "05qa0nzb6fzcvrn68s60adxyp5kbg7779s6qnp94ylmalwb04qvh",
+      "version": "1.30.0",
+      "sha256": "0b7crg1hw4kl0rizwivpzvbj5q0i7mz3kih5x6r01qdxg9a17v95",
       "depends": ["BiocParallel", "DT", "S4Vectors", "SummarizedExperiment", "gplots", "magrittr", "segmented", "shiny", "shinyFiles"]
     },
     "TurboNorm": {
       "name": "TurboNorm",
-      "version": "1.54.0",
-      "sha256": "10rs5rwwnbwsq8by0gk7k5v51y6298k3qnhsy5xqylqygqff4dy5",
+      "version": "1.56.0",
+      "sha256": "14lnlmasfhbybmnxnrdvksihgilk8qv5c86pkpl0is3a8jjgcb7b",
       "depends": ["affy", "convert", "lattice", "limma", "marray"]
     },
     "UCSC_utils": {
       "name": "UCSC.utils",
-      "version": "1.2.0",
-      "sha256": "14nyaqwz1mvaab5kj63j8h56f2n14v6dz5l1nl9zpp4icgx9hp64",
+      "version": "1.4.0",
+      "sha256": "09hs7p43b4p7yif427v4jp10c43im6sqfm4hhfbi38llib7q09nv",
       "depends": ["S4Vectors", "httr", "jsonlite"]
     },
     "UCell": {
       "name": "UCell",
-      "version": "2.10.1",
-      "sha256": "11fxdfyxnq6kvsp9iklb4wqywlplgi9s4nnz6qpr8ssbqqjlsm0c",
+      "version": "2.12.0",
+      "sha256": "0s4i76ar2igg6jfas4a8l801ma914kvk4qx3sz8f5l3j73yjishx",
       "depends": ["BiocNeighbors", "BiocParallel", "Matrix", "SingleCellExperiment", "SummarizedExperiment", "data_table"]
     },
     "UMI4Cats": {
       "name": "UMI4Cats",
-      "version": "1.16.0",
-      "sha256": "192ns76kri831g8x6x63yvpiknhydvvby5gcfsn5rgbpfws7pwng",
+      "version": "1.18.0",
+      "sha256": "02y926nq31nf0j2f0lwamxqzw4xrp969d5qbgapxlm4yci8pigxs",
       "depends": ["BSgenome", "BiocFileCache", "BiocGenerics", "Biostrings", "DESeq2", "GenomeInfoDb", "GenomicAlignments", "GenomicFeatures", "GenomicRanges", "IRanges", "RColorBrewer", "R_utils", "Rbowtie2", "Rsamtools", "S4Vectors", "ShortRead", "SummarizedExperiment", "TxDb_Hsapiens_UCSC_hg19_knownGene", "annotate", "cowplot", "dplyr", "fda", "ggplot2", "magick", "magrittr", "org_Hs_eg_db", "rappdirs", "regioneR", "reshape2", "rlang", "scales", "stringr", "zoo"]
     },
     "UNDO": {
       "name": "UNDO",
-      "version": "1.48.0",
-      "sha256": "0n7gsrzybjvji5pyglbjcx9fajf750hj4lff9gjxpaz605rvbn10",
+      "version": "1.50.0",
+      "sha256": "190j8khw7dc7axk656cvdl7qqc0i5rxyx6h5wp1hbw1zz8xq4vx0",
       "depends": ["Biobase", "BiocGenerics", "MASS", "boot", "nnls"]
     },
     "UPDhmm": {
       "name": "UPDhmm",
-      "version": "1.2.0",
-      "sha256": "01234ywkb6q04lk9xb6f68rq6b81q5wd0c3ra22cz1w84knqfgx0",
+      "version": "1.4.0",
+      "sha256": "0iq3fa1scqgh91b6vrn39156vsfvfdzhak36a39zd72v1c7xznhi",
       "depends": ["GenomicRanges", "HMM", "IRanges", "S4Vectors", "VariantAnnotation"]
     },
     "Ularcirc": {
       "name": "Ularcirc",
-      "version": "1.24.0",
-      "sha256": "1891x3127lfkjnhjcjqm2l38kslv5zmc0pg1cfy1p7jndqxw8lxi",
+      "version": "1.26.0",
+      "sha256": "1sshb36x9vnqfc2bbya1ikpy44arz19a3dmcbqwnbf6al7xfcpmx",
       "depends": ["AnnotationDbi", "AnnotationHub", "BSgenome", "BiocGenerics", "Biostrings", "DT", "GenomeInfoDb", "GenomeInfoDbData", "GenomicAlignments", "GenomicFeatures", "GenomicRanges", "Organism_dplyr", "R_utils", "S4Vectors", "data_table", "ggplot2", "ggrepel", "gsubfn", "mirbase_db", "moments", "plotgardener", "shiny", "shinyFiles", "shinydashboard", "shinyjs", "yaml"]
     },
     "UniProt_ws": {
       "name": "UniProt.ws",
-      "version": "2.46.1",
-      "sha256": "00z3fgwq9p664qm9c277b7fg26kza222ja7nhbyy37qjw9h8zscc",
-      "depends": ["AnnotationDbi", "BiocBaseUtils", "BiocFileCache", "BiocGenerics", "RSQLite", "httpcache", "httr", "jsonlite", "progress", "rjsoncons"]
+      "version": "2.48.0",
+      "sha256": "17yzrwkr3126zc56pq4kxd36jfklm515sd6l8qx0x2s0n5q44gch",
+      "depends": ["AnVILBase", "AnnotationDbi", "BiocBaseUtils", "BiocFileCache", "BiocGenerics", "httr2", "jsonlite", "progress", "rjsoncons"]
     },
     "Uniquorn": {
       "name": "Uniquorn",
-      "version": "2.26.0",
-      "sha256": "153bjmgr63y4c12bhrxi9dzyd5sqfwzp8ly7bx2d39lvk0yaakwy",
+      "version": "2.28.0",
+      "sha256": "01ynlr38hwxvwa93miqyr7f1idr8aanhcn48mqq1jfgzzwn860a6",
       "depends": ["GenomicRanges", "IRanges", "R_utils", "VariantAnnotation", "WriteXLS", "data_table", "doParallel", "foreach", "stringr"]
     },
     "VAExprs": {
       "name": "VAExprs",
-      "version": "1.12.0",
-      "sha256": "0gzzjnc1ywdyx5j5cwcynnkmmf8x28w249bv1n0xvy4d86rrmd74",
+      "version": "1.14.0",
+      "sha256": "1g4n28m54kmswfqklfkv8ssdqzfzywv7vwjkglf74z98plymhrc0",
       "depends": ["CatEncoders", "DeepPINCS", "DiagrammeR", "SingleCellExperiment", "SummarizedExperiment", "keras", "mclust", "purrr", "scater", "tensorflow"]
     },
     "VCFArray": {
       "name": "VCFArray",
-      "version": "1.22.0",
-      "sha256": "0mmjiq5rqzlg671sdvs9xlb78pblls9xg5db1ljgm1xcvaqajafd",
+      "version": "1.24.0",
+      "sha256": "1az9sk8xydmpqlb3xcv5df11gpmcy1b12nq33svka1h0gxi1ynlj",
       "depends": ["BiocGenerics", "DelayedArray", "GenomicFiles", "GenomicRanges", "Rsamtools", "S4Vectors", "VariantAnnotation"]
     },
     "VDJdive": {
       "name": "VDJdive",
-      "version": "1.8.0",
-      "sha256": "1ahw1rysr30rq8paqbabky9nzazcharghjn433r1sq821s9yfk3c",
+      "version": "1.10.0",
+      "sha256": "102ldkmabxw755y32yxba6604a61gxlsrn5a1zpk8qh4l54zpvj6",
       "depends": ["BiocParallel", "IRanges", "Matrix", "RColorBrewer", "Rcpp", "S4Vectors", "SingleCellExperiment", "SummarizedExperiment", "cowplot", "ggplot2", "gridExtra"]
     },
     "VERSO": {
       "name": "VERSO",
-      "version": "1.16.0",
-      "sha256": "12q8m3gvjzsfqk81irwj59b0j1bls7xx1hsbzccxkcsi88y562kz",
+      "version": "1.18.0",
+      "sha256": "0ldn8ahzy1wlsx2jly2vkcvkgknzqmh7mb573rzk05m9fpaaym7l",
       "depends": ["Rfast", "ape", "data_tree"]
     },
     "VaSP": {
       "name": "VaSP",
-      "version": "1.18.0",
-      "sha256": "13wvb9zqaihz4s5sz4j6nimcdji72x7dn1l78nwr1rryvl3l98zw",
+      "version": "1.20.0",
+      "sha256": "0d7rn0v0w5a71703ivw590f93qaa7720zpa9zaqzy24bg4nh19gn",
       "depends": ["GenomeInfoDb", "GenomicAlignments", "GenomicRanges", "IRanges", "Rsamtools", "S4Vectors", "ballgown", "cluster", "matrixStats"]
     },
     "VanillaICE": {
       "name": "VanillaICE",
-      "version": "1.68.0",
-      "sha256": "19vqs0q7jyrwv6b2nin31dj72m1vnvgfqbva99vvni9y3c0s1yl1",
+      "version": "1.70.0",
+      "sha256": "0p1pz6dn5v6vs23qlyhpb03dbx1f41qsplzrv76jbmign3wbq292",
       "depends": ["BSgenome_Hsapiens_UCSC_hg18", "Biobase", "BiocGenerics", "GenomeInfoDb", "GenomicRanges", "IRanges", "MatrixGenerics", "S4Vectors", "SummarizedExperiment", "crlmm", "data_table", "foreach", "lattice", "matrixStats", "oligoClasses"]
     },
     "VarCon": {
       "name": "VarCon",
-      "version": "1.14.0",
-      "sha256": "11n272q6chyy8zsgakmms6zghbvwl7rvhhmfs9dw44akfipj4z02",
+      "version": "1.16.0",
+      "sha256": "0ssv561x3ippngwc64s1drf4ls7r93c082klkr2ayly1wp93kcyn",
       "depends": ["BSgenome", "Biostrings", "GenomicRanges", "IRanges", "ggplot2", "shiny", "shinyFiles", "shinycssloaders"]
     },
     "VariantAnnotation": {
       "name": "VariantAnnotation",
-      "version": "1.52.0",
-      "sha256": "0agkfdzs4nr2js94g1cnwxykc4f1678cfjx70r69gmy41s1ghybm",
-      "depends": ["AnnotationDbi", "BSgenome", "Biobase", "BiocGenerics", "Biostrings", "DBI", "GenomeInfoDb", "GenomicFeatures", "GenomicRanges", "IRanges", "MatrixGenerics", "Rhtslib", "Rsamtools", "S4Vectors", "SummarizedExperiment", "XVector", "rtracklayer", "zlibbioc"]
+      "version": "1.54.0",
+      "sha256": "1g8jmfgwdia6hpq9pbhm34f6z94b6ics2miv636r5nlxhmi4ac5a",
+      "depends": ["AnnotationDbi", "BSgenome", "Biobase", "BiocGenerics", "Biostrings", "DBI", "GenomeInfoDb", "GenomicFeatures", "GenomicRanges", "IRanges", "MatrixGenerics", "Rhtslib", "Rsamtools", "S4Vectors", "SummarizedExperiment", "XVector", "rtracklayer"]
     },
     "VariantExperiment": {
       "name": "VariantExperiment",
-      "version": "1.20.0",
-      "sha256": "1i6821ll192ygvdkzhjix63wnrn4ch1i0ih7xq8gzv83my5w6r50",
+      "version": "1.22.0",
+      "sha256": "112w5sqkvx4vi50z9n6h2xxjrh4ir9n35k3zybvxmv0glksamizg",
       "depends": ["Biostrings", "DelayedArray", "DelayedDataFrame", "GDSArray", "GenomicRanges", "IRanges", "S4Vectors", "SNPRelate", "SeqArray", "SummarizedExperiment", "gdsfmt"]
     },
     "VariantFiltering": {
       "name": "VariantFiltering",
-      "version": "1.42.0",
-      "sha256": "0839ljb4fh1qrjk1xm89q2hwnbbxi2slaw3l36dk8kmpifhqqi16",
+      "version": "1.44.0",
+      "sha256": "124d1zn0ap1kfc8f1ks8rr392dsks3h4qr6i9pkkz1q8s9mk420b",
       "depends": ["AnnotationDbi", "BSgenome", "Biobase", "BiocGenerics", "BiocParallel", "Biostrings", "DT", "GenomeInfoDb", "GenomicFeatures", "GenomicRanges", "GenomicScores", "Gviz", "IRanges", "RBGL", "Rsamtools", "S4Vectors", "SummarizedExperiment", "VariantAnnotation", "XVector", "graph", "shiny", "shinyTree", "shinyjs", "shinythemes"]
     },
     "VariantTools": {
       "name": "VariantTools",
-      "version": "1.48.0",
-      "sha256": "1wv3xklgggn6ajjf7l068ybr1x38n6dv0kkkxna7d39y7q2dfqxc",
+      "version": "1.50.0",
+      "sha256": "03x4q4siz32fcljzvxdvz58zly11pnvycv65kbzam1nb9vg312v2",
       "depends": ["BSgenome", "Biobase", "BiocGenerics", "BiocParallel", "Biostrings", "GenomeInfoDb", "GenomicFeatures", "GenomicRanges", "IRanges", "Matrix", "Rsamtools", "S4Vectors", "VariantAnnotation", "rtracklayer"]
     },
     "VegaMC": {
       "name": "VegaMC",
-      "version": "3.44.0",
-      "sha256": "0q3lfc7q77zvg8ibjh7nfiznkqnj06kib5lwcslshb2blim96sjj",
+      "version": "3.46.0",
+      "sha256": "0xxbpynwgaywrgkazd97shkk34yl3skhgbms1vxgypgrzhhhhiag",
       "depends": ["Biobase", "biomaRt"]
     },
     "VennDetail": {
       "name": "VennDetail",
-      "version": "1.22.0",
-      "sha256": "01s7vr42fwh624b3b69hvg3v4jmiv1fs815y69vwj1nx093y072a",
+      "version": "1.23.0",
+      "sha256": "0c64dk2w4azavz2b9455gilimxnmng0ix02bksl4j99868wdfhgh",
       "depends": ["UpSetR", "VennDiagram", "dplyr", "futile_logger", "ggplot2", "magrittr", "purrr", "tibble"]
+    },
+    "ViSEAGO": {
+      "name": "ViSEAGO",
+      "version": "1.22.0",
+      "sha256": "0hwaq9zlyfrb5yc10i4kbfxgq06b2272b0mb17smd5cmax3i336g",
+      "depends": ["AnnotationDbi", "AnnotationForge", "ComplexHeatmap", "DT", "DiagrammeR", "GOSemSim", "GO_db", "RColorBrewer", "R_utils", "UpSetR", "biomaRt", "circlize", "data_table", "dendextend", "dynamicTreeCut", "fgsea", "ggplot2", "heatmaply", "htmlwidgets", "igraph", "plotly", "scales", "topGO"]
     },
     "VisiumIO": {
       "name": "VisiumIO",
-      "version": "1.2.0",
-      "sha256": "07h20ajmlwj0wvnljfr2w10ggmdc5pillrf4sm9yc5p4amx5bsnj",
+      "version": "1.4.0",
+      "sha256": "00qgk8m59081bkjy7fhab04y695m8jlbkhyl6xc3dk3wcwmpgs61",
       "depends": ["BiocBaseUtils", "BiocGenerics", "BiocIO", "S4Vectors", "SingleCellExperiment", "SpatialExperiment", "SummarizedExperiment", "TENxIO", "jsonlite"]
     },
     "Voyager": {
       "name": "Voyager",
-      "version": "1.8.1",
-      "sha256": "19y8ikmfk40sbdc4q8ryf1n9q7nszrycc02h8vrl7xskpb5ixlss",
-      "depends": ["BiocParallel", "DelayedArray", "Matrix", "RSpectra", "S4Vectors", "SingleCellExperiment", "SpatialExperiment", "SpatialFeatureExperiment", "SummarizedExperiment", "bluster", "ggnewscale", "ggplot2", "lifecycle", "matrixStats", "memuse", "patchwork", "rlang", "scales", "scico", "sf", "spdep", "terra", "zeallot"]
+      "version": "1.10.0",
+      "sha256": "0q4bk4vgaxynrj2vqdlwv187fplxm86g5myizfwvb6s52q85d039",
+      "depends": ["BiocParallel", "DelayedArray", "Matrix", "MatrixGenerics", "RSpectra", "S4Vectors", "SingleCellExperiment", "SpatialExperiment", "SpatialFeatureExperiment", "SummarizedExperiment", "bluster", "ggnewscale", "ggplot2", "lifecycle", "memuse", "patchwork", "rlang", "scales", "scico", "sf", "spdep", "terra", "zeallot"]
     },
     "VplotR": {
       "name": "VplotR",
-      "version": "1.16.0",
-      "sha256": "0bbwxpmjfials3pqkzn54z7aspvh8il02f906by6dk4nr48p22qg",
+      "version": "1.18.0",
+      "sha256": "01qs6cnbb4vb3z5al2irgllg3xk3g6vy4ymb4jjybaz0kykbn8bn",
       "depends": ["GenomeInfoDb", "GenomicAlignments", "GenomicRanges", "IRanges", "RColorBrewer", "Rsamtools", "S4Vectors", "cowplot", "ggplot2", "magrittr", "reshape2", "zoo"]
     },
     "Wrench": {
       "name": "Wrench",
-      "version": "1.24.0",
-      "sha256": "151a4fnrdghayaj6fhkfxl2s1rjc1ph0gbf9hfkz4s5mxj92fc5a",
+      "version": "1.26.0",
+      "sha256": "13487bw2330g5vsj3qx3kff2h9b1qzb81gx15qsdmpbrgp00n5dg",
       "depends": ["limma", "locfit", "matrixStats"]
+    },
+    "XAItest": {
+      "name": "XAItest",
+      "version": "1.0.0",
+      "sha256": "1nfb0j4jzqi5xqjnbmi7gpipm066138nxpx74aich242dz8is880",
+      "depends": ["DT", "SummarizedExperiment", "caret", "ggplot2", "kernelshap", "lime", "limma", "randomForest"]
     },
     "XDE": {
       "name": "XDE",
-      "version": "2.52.0",
-      "sha256": "1smp38qmpd1khziccmyqxq3wc8l4aviclsb0srmyjligjchp6x3p",
+      "version": "2.54.0",
+      "sha256": "127s5y121g2x669mcmyvvx5qxbzp8nsqcda1gkfjskbmwi7lhycf",
       "depends": ["Biobase", "BiocGenerics", "GeneMeta", "RColorBrewer", "genefilter", "gtools", "mvtnorm", "siggenes"]
     },
     "XINA": {
       "name": "XINA",
-      "version": "1.24.0",
-      "sha256": "0x7gkx1ib6ggbr3dc97wxs52ph1chqcwqrn7xc4jmzs122gh52k0",
+      "version": "1.26.0",
+      "sha256": "0nyasz6bn7qkxayihbh26qdmzmw716sqbwzysr17p24p3bzs5rhl",
       "depends": ["STRINGdb", "alluvial", "ggplot2", "gridExtra", "igraph", "mclust", "plyr"]
     },
     "XNAString": {
       "name": "XNAString",
-      "version": "1.14.0",
-      "sha256": "05d6f2zlv7rs36vncz0ywn4g51kch7cps8gmyax9vxv3jsszq2r0",
+      "version": "1.15.0",
+      "sha256": "1q50h6fvkc8fr5kvz3whvfiqx3fkxi8m7r1h459sqk362j9pydrj",
       "depends": ["BSgenome", "Biostrings", "GenomicRanges", "IRanges", "Rcpp", "S4Vectors", "data_table", "formattable", "future_apply", "pwalign", "stringi", "stringr"]
     },
     "XVector": {
       "name": "XVector",
-      "version": "0.46.0",
-      "sha256": "0dpnsvam6971b19xqlv1zniwjznya22jmffjpl4shz4sv8zin9nf",
-      "depends": ["BiocGenerics", "IRanges", "S4Vectors", "zlibbioc"]
+      "version": "0.48.0",
+      "sha256": "0mwv82k50jmqgmjwdlsjk5pviszvblidg3447g5381zj8489g9r3",
+      "depends": ["BiocGenerics", "IRanges", "S4Vectors"]
+    },
+    "XeniumIO": {
+      "name": "XeniumIO",
+      "version": "1.0.0",
+      "sha256": "0yd0kf34dw3lyphvlqhw1h6b0qcyfq86lg4455mqvklx96vpvm3c",
+      "depends": ["BiocBaseUtils", "BiocGenerics", "BiocIO", "S4Vectors", "SingleCellExperiment", "SpatialExperiment", "SummarizedExperiment", "TENxIO", "VisiumIO", "jsonlite"]
     },
     "Xeva": {
       "name": "Xeva",
-      "version": "1.22.0",
-      "sha256": "13215sfszwqfpgr5glnsxhhg2qcxgq849hsyh25vln107ghq0w6d",
+      "version": "1.24.0",
+      "sha256": "1f3jlk8827r1pq4aj7bkqla0i05f6qn4bya8gxxqghdby5nkphhp",
       "depends": ["BBmisc", "Biobase", "ComplexHeatmap", "PharmacoGx", "Rmisc", "doParallel", "downloader", "ggplot2", "nlme", "scales"]
     },
     "YAPSA": {
       "name": "YAPSA",
-      "version": "1.32.0",
-      "sha256": "1yc8j06v4ap5zvzvd40rfzc6fd9a295m7mwskis76qs4nhz29hz5",
+      "version": "1.34.0",
+      "sha256": "1i8n46ifxbhnngqk4qb93mxj07ngzr43759mw58kf0j73xp5vx4b",
       "depends": ["BSgenome_Hsapiens_UCSC_hg19", "Biostrings", "ComplexHeatmap", "GenomeInfoDb", "GenomicRanges", "GetoptLong", "KEGGREST", "PMCMRplus", "SomaticSignatures", "VariantAnnotation", "circlize", "corrplot", "dendextend", "doParallel", "dplyr", "ggbeeswarm", "ggplot2", "gridExtra", "gtrellis", "limSolve", "magrittr", "pracma", "reshape2"]
     },
     "ZygosityPredictor": {
       "name": "ZygosityPredictor",
-      "version": "1.6.0",
-      "sha256": "0vi51s3mwrkmvz54jhzxhnklc1m19zv5mxgdzyxrcng6b0c277wh",
+      "version": "1.8.0",
+      "sha256": "1ain9yvg80vw3av9izqb6my3pqsgp7cqmdcjgq7a3rdw1jwngv33",
       "depends": ["DelayedArray", "GenomicAlignments", "GenomicRanges", "IRanges", "Rsamtools", "VariantAnnotation", "dplyr", "igraph", "knitr", "magrittr", "purrr", "readr", "rlang", "stringr", "tibble"]
     },
     "a4": {
       "name": "a4",
-      "version": "1.54.0",
-      "sha256": "0izl2b306lj9768p1lxi02sj6sbih5isa0f2k6g8igjq7z08mk8c",
+      "version": "1.56.0",
+      "sha256": "0x43160m0slxpfqv3irdg56j6l1vrvj1lllh9iwrgp3m0mvsysab",
       "depends": ["a4Base", "a4Classif", "a4Core", "a4Preproc", "a4Reporting"]
     },
     "a4Base": {
       "name": "a4Base",
-      "version": "1.54.0",
-      "sha256": "1x62125rinav1g3s549f4s59z3ddcmzznnghlh8w54sabnz3i45d",
+      "version": "1.56.0",
+      "sha256": "077cmq1m0mwjlpyxb3wa9z1j1cfagvj1c116y90izvznb1pmsf7s",
       "depends": ["Biobase", "a4Core", "a4Preproc", "annaffy", "genefilter", "glmnet", "gplots", "limma", "mpm", "multtest"]
     },
     "a4Classif": {
       "name": "a4Classif",
-      "version": "1.54.0",
-      "sha256": "0h6i6nxfq2nnla8559bjinydaywwc8lzg0xs8z2adj4cr52r6h74",
+      "version": "1.56.0",
+      "sha256": "0yk5ww3f90fyy3jd2p93560708ii66sxij3mfqxpi0012mqlhlkh",
       "depends": ["Biobase", "ROCR", "a4Core", "a4Preproc", "glmnet", "pamr", "varSelRF"]
     },
     "a4Core": {
       "name": "a4Core",
-      "version": "1.54.0",
-      "sha256": "0rc3aragscizy067qx46sc5w2d5cimdizkmcy41y771aj1kbpygh",
+      "version": "1.56.0",
+      "sha256": "0mwkgw34z5smnrj38jn1vlbicxv4xy799dgr4nxbpcydnn5xlhxf",
       "depends": ["Biobase", "glmnet"]
     },
     "a4Preproc": {
       "name": "a4Preproc",
-      "version": "1.54.0",
-      "sha256": "108ns2ln2j5bkaqmah0w8132b2p995wrcd4a98a1vnsgs806mwfp",
+      "version": "1.56.0",
+      "sha256": "01z9yr9syn6yfndc4vk2cfkc2kgfabpp1fq0liivglpdyzjg0mk2",
       "depends": ["Biobase", "BiocGenerics"]
     },
     "a4Reporting": {
       "name": "a4Reporting",
-      "version": "1.54.0",
-      "sha256": "11zpq6zk67m72qx09ng6g4h32206f6lzldndirwxzqbv0ix9yy1v",
+      "version": "1.56.0",
+      "sha256": "0akwk8l3d49qx5prs7l4zyyjx55vja7v4gmv3drxgcg5782f7923",
       "depends": ["xtable"]
     },
     "aCGH": {
       "name": "aCGH",
-      "version": "1.84.0",
-      "sha256": "1z9phvx461s64i251rvxwr9x62mm18pc0qlifzr8z4ybmlrbyazi",
+      "version": "1.86.0",
+      "sha256": "0md1dpwvhpmb21j2l0n5vkc7k0iw1mviksja0yxmwpjvcbhdwg7v",
       "depends": ["Biobase", "cluster", "multtest", "survival"]
     },
     "abseqR": {
       "name": "abseqR",
-      "version": "1.24.0",
-      "sha256": "1d52aiix3pixhcr6pjmz48p4wkcik4cwpbq4fhngv48y1sgd5d8i",
+      "version": "1.26.0",
+      "sha256": "09d1jd35q6sc5f807hlc65nmglyv34zsicciwbr4s80dgn6i0qih",
       "depends": ["BiocParallel", "BiocStyle", "RColorBrewer", "VennDiagram", "circlize", "flexdashboard", "ggcorrplot", "ggdendro", "ggplot2", "gridExtra", "knitr", "plotly", "plyr", "png", "reshape2", "rmarkdown", "stringr", "vegan"]
     },
     "acde": {
       "name": "acde",
-      "version": "1.36.0",
-      "sha256": "0x49x7xyjwfw5zf4w4rchapnb40mr1c6shj5cdsg9cbwwdz971ws",
+      "version": "1.38.0",
+      "sha256": "1zns18s5mcqlqcnjfhgppayilnpg2b14rmm76phq1a9zbxn7i8yg",
       "depends": ["boot"]
     },
     "adSplit": {
       "name": "adSplit",
-      "version": "1.76.0",
-      "sha256": "0x1n2k5pgn5gkfsr15h2vj7mzywxq0b02h6ivwahq2albhmb7ci4",
+      "version": "1.78.0",
+      "sha256": "1lan9m80596c8fawyn1s1dz9bbcaggl726yigssycbkhpdla2yzv",
       "depends": ["AnnotationDbi", "Biobase", "GO_db", "KEGGREST", "cluster", "multtest"]
     },
     "adductomicsR": {
       "name": "adductomicsR",
-      "version": "1.22.0",
-      "sha256": "0946x9a2y7yrbgbcn7fmwhkm0caraahl9wcz09aj02gnm5zvlxxs",
+      "version": "1.24.0",
+      "sha256": "02xzzp42m3zamys2xag2j3n5l7g7viig53alrswvflcscb8qjzcy",
       "depends": ["AnnotationHub", "DT", "ExperimentHub", "OrgMassSpecR", "RcppEigen", "adductData", "ade4", "bootstrap", "data_table", "doSNOW", "dplyr", "fastcluster", "foreach", "fpc", "mzR", "pastecs", "pracma", "reshape2", "rvest", "smoother", "zoo"]
     },
     "adverSCarial": {
       "name": "adverSCarial",
-      "version": "1.4.0",
-      "sha256": "0lri1mc23f9mhg3gwq0hjq09vk8fhc2jpais5vy60dym1dz2nnn7",
+      "version": "1.6.0",
+      "sha256": "14jd37klw8xzfb7fbvaqj5jyc8dy2p0cwc1hyl239p8yjxqindkr",
       "depends": ["DelayedArray", "S4Vectors", "gtools"]
     },
     "affxparser": {
       "name": "affxparser",
-      "version": "1.78.0",
-      "sha256": "1b68jnl1w9lk3z20774dlhj98fb4hfjkq3y8pv4gbz4kkgy44a6f",
+      "version": "1.80.0",
+      "sha256": "1j3l2i2z23rsayr0g2wzyp31vpb7h027jmjz8cbx8hnnapwyd36f",
       "depends": []
     },
     "affy": {
       "name": "affy",
-      "version": "1.84.0",
-      "sha256": "1x27cbqsip5m7lzv5nvffdfjp46cdqh53qb1xvi2rf0wfdnd7763",
-      "depends": ["Biobase", "BiocGenerics", "BiocManager", "affyio", "preprocessCore", "zlibbioc"]
+      "version": "1.86.0",
+      "sha256": "0pk7wvqk5xzlnwly7sbpij3waypwlnrli0bnxvjhbrlgc3pnks4g",
+      "depends": ["Biobase", "BiocGenerics", "BiocManager", "affyio", "preprocessCore"]
     },
     "affyContam": {
       "name": "affyContam",
-      "version": "1.64.0",
-      "sha256": "0vsh2qazn8zjy9k7ha59krv4psmzl6cvka68h8gkz6xj38f9kxjw",
+      "version": "1.66.0",
+      "sha256": "1r3zhfpzb65h4l92bij06z7k9kidmd7c6i2815mb22975x5hg66z",
       "depends": ["Biobase", "affy", "affydata"]
     },
     "affyILM": {
       "name": "affyILM",
-      "version": "1.58.0",
-      "sha256": "0x56j63yzssq3brnacz23v02hxlmmki6s89mw09wwhawyia6pv2x",
+      "version": "1.60.0",
+      "sha256": "0bf9hl0afv9zm1vskqiszzqb3lpqz8yzjw74dyw7739j4p0gfqn8",
       "depends": ["Biobase", "affxparser", "affy", "gcrma"]
     },
     "affyPLM": {
       "name": "affyPLM",
-      "version": "1.82.0",
-      "sha256": "182zym9g8rzyrmj78yzpdh44av616x6228xzxwa45wz2spg9bj47",
-      "depends": ["Biobase", "BiocGenerics", "affy", "gcrma", "preprocessCore", "zlibbioc"]
+      "version": "1.84.0",
+      "sha256": "0lhin8wn2jh7p5rfgbnz84xjr7xhvks1qlnfj078aypk2b8di1hl",
+      "depends": ["Biobase", "BiocGenerics", "affy", "gcrma", "preprocessCore"]
     },
     "affycomp": {
       "name": "affycomp",
-      "version": "1.82.0",
-      "sha256": "10z63g0vj8c7gnzqi3dpx543idyp2fa6majs2ydv41jah6s10zs2",
+      "version": "1.84.0",
+      "sha256": "10xcsbiwbkhyfxjp4xkxi6fbrj10m1v2isl2m5frcqcffjw2ss41",
       "depends": ["Biobase"]
     },
     "affycoretools": {
       "name": "affycoretools",
-      "version": "1.78.0",
-      "sha256": "1xyanwj6psrqqj2m5rb0p3890m7kddkj7gnbllknbbib1jjh24rf",
+      "version": "1.80.0",
+      "sha256": "06ajyglz4sida0vqnmlknga4kb3gv626j5ky0lfw0y1y73kjk19i",
       "depends": ["AnnotationDbi", "Biobase", "BiocGenerics", "DBI", "GOstats", "Glimma", "RSQLite", "ReportingTools", "S4Vectors", "affy", "edgeR", "gcrma", "ggplot2", "gplots", "hwriter", "lattice", "limma", "oligoClasses", "xtable"]
     },
     "affyio": {
       "name": "affyio",
-      "version": "1.76.0",
-      "sha256": "01asrih2ish0l2yr0g6azbsn23cf8f3fc4ks8rn6w1rc054405ci",
-      "depends": ["zlibbioc"]
+      "version": "1.78.0",
+      "sha256": "1j3r28m0daxlbysyajwhyl6j1vcy4mbq951yyh2j1c8b4jnncf9i",
+      "depends": []
     },
     "affylmGUI": {
       "name": "affylmGUI",
-      "version": "1.80.0",
-      "sha256": "11ihq29ydmx264vlgvf923rf3xdspckbgqcjwgwkwvdfa5i6scsp",
+      "version": "1.82.0",
+      "sha256": "0lpf71axddzvlji2sbf4jrjzh7lxyxf017w5wnr0ccnxa34pdm3j",
       "depends": ["AnnotationDbi", "BiocGenerics", "BiocManager", "R2HTML", "affy", "affyPLM", "affyio", "gcrma", "limma", "tkrplot", "xtable"]
     },
     "aggregateBioVar": {
       "name": "aggregateBioVar",
-      "version": "1.16.0",
-      "sha256": "00v0chcvisd735f9pyinwn3lg9dq0wdq9jpsm4kp2m45pf22n7p1",
+      "version": "1.18.0",
+      "sha256": "0db183h2vb4f8j7rjvs3hm6xnv0k52313m63hxk9ap4n8k140yis",
       "depends": ["Matrix", "S4Vectors", "SingleCellExperiment", "SummarizedExperiment", "rlang", "tibble"]
     },
     "agilp": {
       "name": "agilp",
-      "version": "3.38.0",
-      "sha256": "1gzfzbgxb07zmr66h38zy1c1hpb89qnsfg1wsr5p8qwlf76ynzz7",
+      "version": "3.40.0",
+      "sha256": "0xvg8fbvp0rb015pvlry8v81kdjmikw47lajfmpvkpirsdl4dp51",
       "depends": []
     },
     "airpart": {
       "name": "airpart",
-      "version": "1.14.0",
-      "sha256": "0aggyvbx4vjg3sh4s7jsl2l612vqvgcb2wlymkdjzaj8hykaprvs",
+      "version": "1.16.0",
+      "sha256": "0hsqzzx800py6j95c9mbf212nyki0fhxbjlwj51giarnnfsghl1r",
       "depends": ["ComplexHeatmap", "RColorBrewer", "S4Vectors", "SingleCellExperiment", "SummarizedExperiment", "apeglm", "clue", "dplyr", "dynamicTreeCut", "emdbook", "forestplot", "ggplot2", "lpSolve", "matrixStats", "mclust", "pbapply", "plyr", "rlang", "scater", "smurf"]
     },
     "alabaster": {
       "name": "alabaster",
-      "version": "1.6.0",
-      "sha256": "1jb7dh4kamr6ypfkjm306797jrbn6n37nk533k3h74ckhb06xf33",
+      "version": "1.8.0",
+      "sha256": "00av666zqam85k1zhv6a3b1k6233kd7mkqfr5ldr5zpp74rlarq6",
       "depends": ["alabaster_base", "alabaster_bumpy", "alabaster_mae", "alabaster_matrix", "alabaster_ranges", "alabaster_sce", "alabaster_se", "alabaster_spatial", "alabaster_string", "alabaster_vcf"]
     },
     "alabaster_base": {
       "name": "alabaster.base",
-      "version": "1.6.1",
-      "sha256": "02bgq5z7p2di62d8167qd02drhrwyjk3c9iq38g7lbk89vbi1f1h",
-      "depends": ["Rcpp", "Rhdf5lib", "S4Vectors", "alabaster_schemas", "jsonlite", "jsonvalidate", "rhdf5"]
+      "version": "1.8.0",
+      "sha256": "0jj26kgd1wi2rn89d2a2v4r559qy9jh8syh5mryxl68q38rkmvrr",
+      "depends": ["Rcpp", "Rhdf5lib", "S4Vectors", "alabaster_schemas", "assorthead", "jsonlite", "jsonvalidate", "rhdf5"]
     },
     "alabaster_bumpy": {
       "name": "alabaster.bumpy",
-      "version": "1.6.0",
-      "sha256": "0my4zqrvjnnrs85263rgxnvaq0a936zhq134hzq8c2lng3csir7d",
+      "version": "1.8.0",
+      "sha256": "1bv12pwwjri951r93vd2w1mrhhjk45rmz06zdvjw6dkyx76sim6w",
       "depends": ["BiocGenerics", "BumpyMatrix", "IRanges", "Matrix", "S4Vectors", "alabaster_base", "rhdf5"]
     },
     "alabaster_files": {
       "name": "alabaster.files",
-      "version": "1.4.0",
-      "sha256": "1d905lq0s1dd15qpj9drh14vk8xalgp2r6cdirjxyc44nyk6kfp5",
+      "version": "1.6.0",
+      "sha256": "1qcssc491v9zv6025vg0kma2dydi3pdjbmnjv3h6z9qcq5fpvb28",
       "depends": ["BiocGenerics", "Rsamtools", "S4Vectors", "alabaster_base"]
     },
     "alabaster_mae": {
       "name": "alabaster.mae",
-      "version": "1.6.0",
-      "sha256": "150b2wcm7bq3ickwfz1vpw3s0h63gk0s57n1j58dn2ssni4y2z5r",
+      "version": "1.8.0",
+      "sha256": "0pfdfc6a1gpp5v4n3sjbhplk73sds22989wvmr1l7rf91v19xh10",
       "depends": ["MultiAssayExperiment", "S4Vectors", "alabaster_base", "alabaster_se", "jsonlite", "rhdf5"]
     },
     "alabaster_matrix": {
       "name": "alabaster.matrix",
-      "version": "1.6.1",
-      "sha256": "1cppp2p8gpynyngxlyyxmgzvd27650z4bi5akw8bzimqphxfap3f",
+      "version": "1.8.0",
+      "sha256": "176kmp9fgjdhsijh58zqsn9bmq28l1crgs7zqm9p4cga58549jaj",
       "depends": ["BiocGenerics", "DelayedArray", "HDF5Array", "Matrix", "Rcpp", "S4Arrays", "S4Vectors", "SparseArray", "alabaster_base", "rhdf5"]
     },
     "alabaster_ranges": {
       "name": "alabaster.ranges",
-      "version": "1.6.0",
-      "sha256": "06xky6gdwhvz09v6yafwr65lq3bj4s8qz5iqpp120m9nncfzf1f4",
+      "version": "1.8.0",
+      "sha256": "0xijg8rr7zq3jx0zp1pf9rkxlkgv0dg7n8dsn2aisy1lznz7l8cs",
       "depends": ["BiocGenerics", "GenomeInfoDb", "GenomicRanges", "IRanges", "S4Vectors", "alabaster_base", "rhdf5"]
     },
     "alabaster_sce": {
       "name": "alabaster.sce",
-      "version": "1.6.0",
-      "sha256": "0ddi6y2c8csxrzqv5h0lmxvhvhiz285f0hd01q8mpn9rs4n5cljs",
+      "version": "1.8.0",
+      "sha256": "06jhis9rinfa6b5d2aphcia4x52dwlh4rz4yrm7xy0ylix37p7vn",
       "depends": ["SingleCellExperiment", "alabaster_base", "alabaster_se", "jsonlite"]
     },
     "alabaster_schemas": {
       "name": "alabaster.schemas",
-      "version": "1.6.0",
-      "sha256": "0sqkm3f1vha1iw8az0giz7yj78b75dh4g9qkly0yd3bpmb9g3zd9",
+      "version": "1.8.0",
+      "sha256": "0gli9hs5c09b8mfga1r7xf50gxd2m6wyfkcqf0vxzk57zr9scq9w",
       "depends": []
     },
     "alabaster_se": {
       "name": "alabaster.se",
-      "version": "1.6.0",
-      "sha256": "01963yn5iyc0ksxr1nlwkddfll9259x2w3y1b82db36kjj3bac2y",
+      "version": "1.8.0",
+      "sha256": "1psl8dqw1x5zcyikf72libc4lzmjgczdfvmlc2xfrnd98ad5v9wi",
       "depends": ["BiocGenerics", "GenomicRanges", "IRanges", "S4Vectors", "SummarizedExperiment", "alabaster_base", "alabaster_matrix", "alabaster_ranges", "jsonlite"]
+    },
+    "alabaster_sfe": {
+      "name": "alabaster.sfe",
+      "version": "1.0.0",
+      "sha256": "068rs6hnh31vfby4kn43893d0g41853678fbwx740w2yj7k8c7l6",
+      "depends": ["EBImage", "RBioFormats", "S4Vectors", "SingleCellExperiment", "SpatialFeatureExperiment", "SummarizedExperiment", "alabaster_base", "alabaster_sce", "alabaster_spatial", "jsonlite", "sfarrow", "spatialreg", "spdep", "terra", "xml2"]
     },
     "alabaster_spatial": {
       "name": "alabaster.spatial",
-      "version": "1.6.1",
-      "sha256": "15lswhfdxpg8mdhf1nqivvck9ncygk5m0mnx8px3xam3c5kc7lsd",
+      "version": "1.8.0",
+      "sha256": "0q2x88bf28l008j1bgjna7g5xrig1wp180yqcqxifcjgi74hvjmy",
       "depends": ["S4Vectors", "SpatialExperiment", "alabaster_base", "alabaster_sce", "rhdf5"]
     },
     "alabaster_string": {
       "name": "alabaster.string",
-      "version": "1.6.0",
-      "sha256": "18kbc1gc1bi9vp95adi5kxy2yg3ygdipdvf827vfnl36cn5imna3",
+      "version": "1.8.0",
+      "sha256": "0bb3am1ifqwgjj5qz0l991grsfhlxf1a49cy896f8n2hkhgra3sa",
       "depends": ["Biostrings", "S4Vectors", "alabaster_base"]
     },
     "alabaster_vcf": {
       "name": "alabaster.vcf",
-      "version": "1.6.0",
-      "sha256": "0f96s0wzmlzy7cchzf7lgbprc78k6vq03603h55l94z4bcn8n077",
+      "version": "1.8.0",
+      "sha256": "12il80xwgynwalbh1ip3ly1p2nb6hs26zl03r4m2r8lp74ddzrpp",
       "depends": ["Rsamtools", "S4Vectors", "VariantAnnotation", "alabaster_base", "alabaster_se", "alabaster_string"]
     },
     "alevinQC": {
       "name": "alevinQC",
-      "version": "1.22.0",
-      "sha256": "01ywmi5k5y9x5ds743qhzjn975gc5h8k0csxs78pnrjng5ij2gh2",
+      "version": "1.24.0",
+      "sha256": "1ak04r3hhbbkqjmxdj81wra1pwjg58hq5i0gjkdh7f5vq64i5xsf",
       "depends": ["DT", "GGally", "Rcpp", "cowplot", "dplyr", "ggplot2", "rjson", "rlang", "rmarkdown", "shiny", "shinydashboard", "tximport"]
     },
     "altcdfenvs": {
       "name": "altcdfenvs",
-      "version": "2.68.0",
-      "sha256": "1fj22d7c8gid26x7383ihq82yfcnpyljl0qk4yh48p8qhgh3wysa",
+      "version": "2.70.0",
+      "sha256": "0ga0v478q4ms8n3ad8nw1q5a48ghr04z3hk6vmmxirbkg7lzyjp6",
       "depends": ["Biobase", "BiocGenerics", "Biostrings", "S4Vectors", "affy", "hypergraph", "makecdfenv"]
     },
     "amplican": {
       "name": "amplican",
-      "version": "1.28.0",
-      "sha256": "1xv392kxhzal2b8dp0kdjnny75311qm6vvbajx9hlb3k6v34dpqc",
+      "version": "1.30.0",
+      "sha256": "0y5bknkn6l32bk2ia0dv3c8pp2dx2n83iwhbqh0l13jajv8j1csd",
       "depends": ["BiocGenerics", "BiocParallel", "Biostrings", "GenomeInfoDb", "GenomicRanges", "IRanges", "Matrix", "Rcpp", "S4Vectors", "ShortRead", "cluster", "data_table", "dplyr", "ggplot2", "ggthemes", "gridExtra", "gtable", "knitr", "matrixStats", "pwalign", "rmarkdown", "stringr", "waffle"]
     },
     "animalcules": {
       "name": "animalcules",
-      "version": "1.22.0",
-      "sha256": "02dbfx159b9ivlzgyhd1ikhw2ciq6q7f3b3sdq4hsp49yp6ps7nl",
+      "version": "1.24.0",
+      "sha256": "1i38rmggbblkv75kn5rc56zlkgm51slalqi3nvmh6y2ils68x1m6",
       "depends": ["DESeq2", "DT", "GUniFrac", "Matrix", "MultiAssayExperiment", "ROCit", "S4Vectors", "SummarizedExperiment", "XML", "ape", "assertthat", "caret", "covr", "dplyr", "forcats", "ggforce", "ggplot2", "lattice", "limma", "magrittr", "plotly", "rentrez", "reshape2", "scales", "shiny", "shinyjs", "tibble", "tidyr", "tsne", "umap", "vegan"]
     },
     "annaffy": {
       "name": "annaffy",
-      "version": "1.78.0",
-      "sha256": "0spsiywh2xxzi8xjg2gk08p4fpha01pc0x65z18gsps6lh1zj1gk",
+      "version": "1.80.0",
+      "sha256": "1ac95hxhvacvccw01x8g0yzqc3azx0h79pnxnv7cfihb0lpvd331",
       "depends": ["AnnotationDbi", "Biobase", "BiocManager", "DBI", "GO_db"]
     },
     "annmap": {
       "name": "annmap",
-      "version": "1.48.0",
-      "sha256": "0rq8v5dfmmr43nyri3yr2q4wcq7p9c0ia3nfj4ry5xpkiyqj4n1x",
+      "version": "1.50.0",
+      "sha256": "0xw75x0zgl7nzl4frxqcnj2fyzw59i1xzlwfnvs32c04bjnzmx30",
       "depends": ["Biobase", "BiocGenerics", "DBI", "GenomicRanges", "IRanges", "RMySQL", "Rsamtools", "digest", "genefilter", "lattice"]
     },
     "annotate": {
       "name": "annotate",
-      "version": "1.84.0",
-      "sha256": "1m7cc5hawzdvm0b1il4fcilipnsv1n94zqvwhkbr3041rklf7l7y",
+      "version": "1.86.0",
+      "sha256": "1n5x0ia1138ghc3xii7cfxny3z1fxgbzj92p0qdprsf6m6fmn0i8",
       "depends": ["AnnotationDbi", "Biobase", "BiocGenerics", "DBI", "XML", "httr", "xtable"]
     },
     "annotationTools": {
       "name": "annotationTools",
-      "version": "1.80.0",
-      "sha256": "03hqhq6xyaf24ryrnf9q3x00m8600kxhinzag8a9cvw1x0h2d1pz",
+      "version": "1.82.0",
+      "sha256": "06p7lzib1br503clyib07lx17b9y8xmxz5yr6ajhbwd8qz2pj3k1",
       "depends": ["Biobase"]
     },
     "annotatr": {
       "name": "annotatr",
-      "version": "1.32.0",
-      "sha256": "11j633mhm4b0ndl6mbqqwgz7rsggb7gzr3yhvamrnvag7l4wzvss",
+      "version": "1.34.0",
+      "sha256": "00d0q534apwnzal3xabgcgcd659zsg73xb3md756caipx7qlcam8",
       "depends": ["AnnotationDbi", "AnnotationHub", "GenomeInfoDb", "GenomicFeatures", "GenomicRanges", "IRanges", "S4Vectors", "dplyr", "ggplot2", "readr", "regioneR", "reshape2", "rtracklayer"]
     },
     "anota": {
       "name": "anota",
-      "version": "1.54.0",
-      "sha256": "1y5gxm896la45f2psdc2792nw25a8mxd3b45i9kh68wni6d2drdr",
+      "version": "1.56.0",
+      "sha256": "1hbr8lyh8bjssyfq7p8g2ilpr2218ab8fravwr89s2nhiq557z5f",
       "depends": ["multtest", "qvalue"]
     },
     "anota2seq": {
       "name": "anota2seq",
-      "version": "1.28.0",
-      "sha256": "0lzpp2pxbpza1wijmj9cz9ia94pyc5b5fknw2njy0qv8rcwxjwhh",
+      "version": "1.30.0",
+      "sha256": "0widc82rxb16ix61s66ppjxbin0mpda5l6a2194cxxfflxdziafb",
       "depends": ["DESeq2", "RColorBrewer", "SummarizedExperiment", "edgeR", "limma", "multtest", "qvalue"]
     },
     "antiProfiles": {
       "name": "antiProfiles",
-      "version": "1.46.0",
-      "sha256": "0xg1kjb0g7cxkj6qv2979n9yfyfwgfllzi2zp9jaml6cw30ma0ya",
+      "version": "1.48.0",
+      "sha256": "1pf9fdafvaiy87s13455chgbym5najv58wfk5aw2yn7bmyvqcqnr",
       "depends": ["locfit", "matrixStats"]
     },
     "apComplex": {
       "name": "apComplex",
-      "version": "2.72.0",
-      "sha256": "0s8yg9rhi43v35l9hkp2fl7zk3rpn84rbwyn1l00l9fm3fr03qdm",
+      "version": "2.74.0",
+      "sha256": "0a7k2a8i29a21d4ag3m33yvclsr13fm687hmnds7asy22fjid5lb",
       "depends": ["RBGL", "Rgraphviz", "graph", "org_Sc_sgd_db"]
     },
     "apeglm": {
       "name": "apeglm",
-      "version": "1.28.0",
-      "sha256": "1xzh8p4ybal3m4rfpja5qnnqd8hqbszppkxfqf7rm4z2kz2ga25q",
+      "version": "1.30.0",
+      "sha256": "10va8admxwd71bql3biad66fzdl8ancdj37g7wzijbdhmss5y6k4",
       "depends": ["GenomicRanges", "Rcpp", "RcppEigen", "RcppNumerical", "SummarizedExperiment", "emdbook"]
     },
     "appreci8R": {
       "name": "appreci8R",
-      "version": "1.24.0",
-      "sha256": "1kd2ds216620hrzaxjdccc1skwal575n5zz6qqyyq1jh2vwggy7x",
+      "version": "1.26.0",
+      "sha256": "1ha8jalkjb8v98hn4kvg638wycl0gjyrpx76gcqz64d0c2197zka",
       "depends": ["BSgenome", "BSgenome_Hsapiens_UCSC_hg19", "Biostrings", "COSMIC_67", "DT", "GenomicFeatures", "GenomicRanges", "GenomicScores", "Homo_sapiens", "IRanges", "MafDb_1Kgenomes_phase3_hs37d5", "MafDb_ExAC_r1_0_hs37d5", "MafDb_gnomADex_r2_1_hs37d5", "PolyPhen_Hsapiens_dbSNP131", "Rsamtools", "S4Vectors", "SIFT_Hsapiens_dbSNP137", "SNPlocs_Hsapiens_dbSNP144_GRCh37", "SummarizedExperiment", "TxDb_Hsapiens_UCSC_hg19_knownGene", "VariantAnnotation", "XtraSNPlocs_Hsapiens_dbSNP144_GRCh37", "openxlsx", "rentrez", "seqinr", "shiny", "shinyjs", "stringr"]
     },
     "aroma_light": {
       "name": "aroma.light",
-      "version": "3.36.0",
-      "sha256": "0n92bmjm97kzv2lpkkc2d4lgs7nzqwrcijq2j4v53xawbcgdxcfd",
+      "version": "3.38.0",
+      "sha256": "0i6b5mp7m61dy00scqmb2aa63fl9a9pxaf1zw13sdxj5xhpns7wa",
       "depends": ["R_methodsS3", "R_oo", "R_utils", "matrixStats"]
     },
     "arrayMvout": {
       "name": "arrayMvout",
-      "version": "1.64.0",
-      "sha256": "0hfal4q9l8g0nfmp2835qagym4hx7xnbic0xh8653lxsy7sbimf0",
+      "version": "1.66.0",
+      "sha256": "1fp73lwfwdg9hyk4jja903bh6w5gnlhaqfk9wcjk22kcj35y6pn3",
       "depends": ["Biobase", "affy", "affyContam", "lumi", "mdqc", "parody"]
     },
     "arrayQuality": {
       "name": "arrayQuality",
-      "version": "1.84.0",
-      "sha256": "0rsb1gxy34jyacmy6w5av9gisknb1pqi7irjqimgaqzyvq00hzal",
+      "version": "1.86.0",
+      "sha256": "09qv9hy0yjsdjmmigj5v1yng00km834pg95zhx4v371fvcf0iagk",
       "depends": ["RColorBrewer", "gridBase", "hexbin", "limma", "marray"]
     },
     "arrayQualityMetrics": {
       "name": "arrayQualityMetrics",
-      "version": "3.62.0",
-      "sha256": "04xc1kqz26l74hsrk6p5bj6c3i5pc19v7y1rwz46wszk40p1rln5",
+      "version": "3.64.0",
+      "sha256": "1kz2d40wx2ksy9dz1z3wylcj7y7ad9z8xphsnz39j02m4g5mbvlp",
       "depends": ["Biobase", "Hmisc", "RColorBrewer", "XML", "affy", "affyPLM", "beadarray", "genefilter", "gridSVG", "hwriter", "lattice", "latticeExtra", "limma", "setRNG", "svglite", "vsn"]
     },
     "artMS": {
       "name": "artMS",
-      "version": "1.24.0",
-      "sha256": "0r13816m50qc1w840sd0hx014fgx8bm98kfqh5s0i3rp93fdjsw3",
+      "version": "1.26.0",
+      "sha256": "18j9pq2llia7kxm5wkfd1w5qfjdfgx2c57hjn8kwfg10pnxpabmv",
       "depends": ["AnnotationDbi", "MSstats", "RColorBrewer", "UpSetR", "VennDiagram", "bit64", "circlize", "cluster", "corrplot", "data_table", "dplyr", "getopt", "ggdendro", "ggplot2", "ggrepel", "gplots", "limma", "openxlsx", "org_Hs_eg_db", "pheatmap", "plotly", "plyr", "scales", "seqinr", "stringr", "tidyr", "yaml"]
     },
     "assorthead": {
       "name": "assorthead",
-      "version": "1.0.1",
-      "sha256": "1mcihw19fnja4n07bzhrmiw3rjzc5i0pxijvgh62pfv5j6v3bxcq",
+      "version": "1.2.0",
+      "sha256": "15bj82llark5pr6w7ncf66vcaifplx2k1hiv0vdf2kmmjqblc03d",
       "depends": []
     },
     "atSNP": {
       "name": "atSNP",
-      "version": "1.22.0",
-      "sha256": "04gawccjzgjbzrvb98djf9g07pb812rkdwwv3hhbr4sp02yr9hr1",
+      "version": "1.24.0",
+      "sha256": "0c7w0pf91hhwa33xcbf5qx39lln29hdmz1w1lqd0011jgkazsgsr",
       "depends": ["BSgenome", "BiocFileCache", "BiocParallel", "Rcpp", "data_table", "ggplot2", "lifecycle", "motifStack", "rappdirs", "testthat"]
     },
     "atena": {
       "name": "atena",
-      "version": "1.12.0",
-      "sha256": "15dvcymd9svp0mw6s0qrfnsc8zlnvxz1lmkzns0rm8ivflf36q1r",
+      "version": "1.14.0",
+      "sha256": "013bfmsy4dkb7zl31vb72pz9kmlkcghrnpkrdrzkrxcf1mgyzad4",
       "depends": ["AnnotationHub", "BiocGenerics", "BiocParallel", "GenomeInfoDb", "GenomicAlignments", "GenomicFeatures", "GenomicRanges", "IRanges", "Matrix", "MatrixGenerics", "Rsamtools", "S4Vectors", "SQUAREM", "SummarizedExperiment", "cli", "matrixStats", "sparseMatrixStats"]
     },
     "attract": {
       "name": "attract",
-      "version": "1.58.0",
-      "sha256": "1nlfnrf7brlqlb7dqzmzqyv6xca5axs1044j22m8lrgwjjpc5xry",
+      "version": "1.60.0",
+      "sha256": "1a0kcmp97j565g2f2xwf5nm3bqvp4w3rksgj97s2cn64g2gyn1jw",
       "depends": ["AnnotationDbi", "Biobase", "GOstats", "KEGGREST", "cluster", "limma", "org_Hs_eg_db", "reactome_db"]
     },
     "autonomics": {
       "name": "autonomics",
-      "version": "1.14.8",
-      "sha256": "1wgzr20md0wlv5kiibg1jyvnpnhg94linlrfk7kcyg0grpw1hyfa",
-      "depends": ["BiocFileCache", "BiocGenerics", "MultiAssayExperiment", "RColorBrewer", "R_utils", "S4Vectors", "SummarizedExperiment", "abind", "bit64", "cluster", "codingMatrices", "colorspace", "data_table", "dplyr", "edgeR", "ggforce", "ggplot2", "ggrepel", "gridExtra", "limma", "magrittr", "matrixStats", "readxl", "rlang", "scales", "stringi", "tidyr", "tidyselect", "vsn"]
+      "version": "1.16.0",
+      "sha256": "1n3v27k5jzaj94sf6nqvzkifidw283j1n6skw9hhl8cvmwqhdda2",
+      "depends": ["BiocFileCache", "BiocGenerics", "MultiAssayExperiment", "RColorBrewer", "R_utils", "S4Vectors", "SummarizedExperiment", "abind", "bit64", "cluster", "codingMatrices", "colorspace", "data_table", "dplyr", "edgeR", "ggforce", "ggplot2", "ggrepel", "gridExtra", "limma", "magrittr", "matrixStats", "readxl", "rlang", "scales", "stringi", "survival", "tidyr", "tidyselect", "vsn"]
     },
     "awst": {
       "name": "awst",
-      "version": "1.14.0",
-      "sha256": "1l23vnp5xwl61ag4djvsg06dp543il8rv3an6hs1qi1wd1lk3llh",
+      "version": "1.16.0",
+      "sha256": "0fphbg5q1dh3khw7vjkkajmmn6rd9wq0l9r6gdk759lnn0nvx26j",
       "depends": ["SummarizedExperiment"]
     },
     "bacon": {
       "name": "bacon",
-      "version": "1.34.0",
-      "sha256": "1ihhxnz5b12r6mh9j4k9nzwxaiw9m3mgc740y4j6xz67csi0xih0",
+      "version": "1.36.0",
+      "sha256": "1af7186valdc32rgn2ab0vjsqmdwjvyryv1pqwpfsrr0q6lcrkih",
       "depends": ["BiocParallel", "ellipse", "ggplot2"]
     },
     "ballgown": {
       "name": "ballgown",
-      "version": "2.38.0",
-      "sha256": "1b49hxr5glxzpcy3ykk62fcn9kqyadlhwyl01rhz70wcnryhzzd8",
+      "version": "2.40.0",
+      "sha256": "0zcim1yahbmyajyz4b8iw7zb52m1b0gfg6mflqv9440dqp1fwnvi",
       "depends": ["Biobase", "GenomeInfoDb", "GenomicRanges", "IRanges", "RColorBrewer", "S4Vectors", "limma", "rtracklayer", "sva"]
     },
     "bambu": {
       "name": "bambu",
-      "version": "3.8.3",
-      "sha256": "05mydm8cxkv7qcpkpny4hjkyl7p5dmqj1fyvmqa6rj9rh4ccxsl7",
+      "version": "3.10.0",
+      "sha256": "0f2rznakgkbqd8i7zgmdgjwwmdz69hkh1fr8jv1n7d05yxyc2m6l",
       "depends": ["BSgenome", "BiocGenerics", "BiocParallel", "GenomeInfoDb", "GenomicAlignments", "GenomicFeatures", "GenomicRanges", "IRanges", "Rcpp", "RcppArmadillo", "Rsamtools", "S4Vectors", "SummarizedExperiment", "data_table", "dplyr", "tidyr", "xgboost"]
     },
     "bamsignals": {
       "name": "bamsignals",
-      "version": "1.38.0",
-      "sha256": "1cp4wh9w12vw7iq5cj3v4nh99md1bizrnw312sgib2r3x4p6vpf6",
+      "version": "1.40.0",
+      "sha256": "0bjmsciw3rrn8pid5yq5pn18w52gks6p41syggv5w21pfj3vdqxa",
       "depends": ["BiocGenerics", "GenomicRanges", "IRanges", "Rcpp", "Rhtslib", "zlibbioc"]
     },
     "bandle": {
       "name": "bandle",
-      "version": "1.10.0",
-      "sha256": "0bq0wmsq4lv16d1hiqbqj6djv55zdnrz4zm7lhi4vxvn3rlywl4g",
-      "depends": ["BH", "Biobase", "BiocParallel", "BiocStyle", "MSnbase", "Rcpp", "RcppArmadillo", "S4Vectors", "circlize", "dplyr", "ggalluvial", "ggplot2", "ggrepel", "knitr", "lbfgs", "pRoloc", "pRolocdata", "plyr", "rlang", "robustbase", "tidyr"]
+      "version": "1.12.0",
+      "sha256": "1ss70psnr5avk6ny6hgasx3c2yxr6slrw2xk6wga64l0aiyki4d1",
+      "depends": ["BH", "Biobase", "BiocParallel", "BiocStyle", "MSnbase", "RColorBrewer", "Rcpp", "RcppArmadillo", "S4Vectors", "circlize", "coda", "dplyr", "ggalluvial", "ggplot2", "ggrepel", "gridExtra", "gtools", "knitr", "lbfgs", "pRoloc", "pRolocdata", "plyr", "rlang", "robustbase", "tidyr"]
     },
     "banocc": {
       "name": "banocc",
-      "version": "1.30.0",
-      "sha256": "1npmkj4a834k4kkaa6az94mzs17nhqq1i74zg7s81n3xi4ghd66k",
+      "version": "1.32.0",
+      "sha256": "1y2zmym9l5d2ny6vjzwc192cbgkszmglmb23xmcqrzr1q34i2vc7",
       "depends": ["coda", "mvtnorm", "rstan", "stringr"]
+    },
+    "barbieQ": {
+      "name": "barbieQ",
+      "version": "0.99.1",
+      "sha256": "18b2rvk4r2qyic054p1lzlj1q4bzrif6bxqybivn5h74w7fqvgqw",
+      "depends": ["ComplexHeatmap", "S4Vectors", "SummarizedExperiment", "circlize", "data_table", "dplyr", "ggplot2", "igraph", "limma", "logistf", "magrittr", "tidyr"]
     },
     "barcodetrackR": {
       "name": "barcodetrackR",
-      "version": "1.14.0",
-      "sha256": "1vmfq5llvg7s8f919jafllip2v710sqsrpfxa8imjg30hr9h9fkl",
+      "version": "1.16.0",
+      "sha256": "1n2rj50gwqmqj5gs5d3asd3gcs0iv1rr1zh12s55lcsdxyfgp1ar",
       "depends": ["RColorBrewer", "S4Vectors", "SummarizedExperiment", "circlize", "cowplot", "dplyr", "ggdendro", "ggplot2", "ggridges", "magrittr", "plyr", "proxy", "rlang", "scales", "shiny", "tibble", "tidyr", "vegan", "viridis"]
     },
     "basecallQC": {
       "name": "basecallQC",
-      "version": "1.30.0",
-      "sha256": "020hnl1vkfxncfahgypg3ryzskmzcg68cpkh04kmiz16vdrpjv6d",
+      "version": "1.32.0",
+      "sha256": "00p17azjppzfji35ps3j9cspyi4x5ikwnympkhmdkf1l816ijwb6",
       "depends": ["DT", "ShortRead", "XML", "data_table", "dplyr", "ggplot2", "knitr", "lazyeval", "magrittr", "prettydoc", "raster", "rmarkdown", "stringr", "tidyr", "yaml"]
     },
     "basilisk": {
       "name": "basilisk",
-      "version": "1.18.0",
-      "sha256": "0ziyxi6qcsvs2ks28vh0sdfp3xilh1kfzyhy0qwa2fwn7j7dnhr3",
+      "version": "1.20.0",
+      "sha256": "05j16g9bamd7k2h4j2mnmdlmvivwzsjmjjld0k67jvlza7lynayb",
       "depends": ["basilisk_utils", "dir_expiry", "reticulate"]
     },
     "basilisk_utils": {
       "name": "basilisk.utils",
-      "version": "1.18.0",
-      "sha256": "0vq0188f6wz0j4w0yqyki4dcp47z3d7w7m19diw7bfgy4yprqdgk",
+      "version": "1.20.0",
+      "sha256": "12wfmyq2as6vfg94fnlw4hxi6y8gw45x27hbh99mkn496vqng575",
       "depends": ["dir_expiry"]
     },
     "batchelor": {
       "name": "batchelor",
-      "version": "1.22.0",
-      "sha256": "0l63w2c2jl27rj47604lx80wlppsp7h1panbm0n89fvf4vbzgm22",
+      "version": "1.24.0",
+      "sha256": "1bffk38xa8p0zhhz4bav3i3jc2ih85zrzl1in2yfplqnk8wlfq2z",
       "depends": ["BiocGenerics", "BiocNeighbors", "BiocParallel", "BiocSingular", "DelayedArray", "DelayedMatrixStats", "Matrix", "Rcpp", "ResidualMatrix", "S4Vectors", "ScaledMatrix", "SingleCellExperiment", "SparseArray", "SummarizedExperiment", "beachmat", "igraph", "scuttle"]
     },
     "bayNorm": {
       "name": "bayNorm",
-      "version": "1.24.0",
-      "sha256": "1302l7j613psz19l7jshpd8aj4971qscdm7cgdr3knkfgk3dqnyz",
+      "version": "1.26.0",
+      "sha256": "0k3a66p4hsbv3k6brd8vj5n87hr82s2mzys3n9zc1qzdykjylh4f",
       "depends": ["BB", "BiocParallel", "MASS", "Matrix", "Rcpp", "RcppArmadillo", "RcppProgress", "SingleCellExperiment", "SummarizedExperiment", "doSNOW", "fitdistrplus", "foreach", "iterators", "locfit"]
     },
     "baySeq": {
       "name": "baySeq",
-      "version": "2.40.0",
-      "sha256": "0vhp9agxqkfm7fs07kkd9gqzp4v7936wdmbd2qc2gf4g3rw3akzm",
+      "version": "2.42.0",
+      "sha256": "030r5xlimmn6mwmkyrm8jwb0jg5nfbzmdv17gss4c9pmpkahs18v",
       "depends": ["GenomicRanges", "abind", "edgeR"]
     },
     "bcSeq": {
       "name": "bcSeq",
-      "version": "1.28.0",
-      "sha256": "1yjy87nsng26x03lvqdwm1wdclf9wk7v4dad1ki08xv9gl8fzsvk",
+      "version": "1.30.0",
+      "sha256": "084sqic3wzklh34s2h33ml7ylb5si7ss50pwnjq9zqw4jqd8pb9r",
       "depends": ["Biostrings", "Matrix", "Rcpp"]
     },
     "beachmat": {
       "name": "beachmat",
-      "version": "2.22.0",
-      "sha256": "0w1abs9nwpn66zc81alnzvdrg5y5w0sl2qdqw6bx3hp0ry1sjfr5",
+      "version": "2.24.0",
+      "sha256": "0hf1x1lmzchl2imyw0cbf17akcyjpwifz627v85nkj1lngygd865",
       "depends": ["BiocGenerics", "DelayedArray", "Matrix", "Rcpp", "SparseArray", "assorthead"]
     },
     "beachmat_hdf5": {
       "name": "beachmat.hdf5",
-      "version": "1.4.0",
-      "sha256": "0jla4by5y8qalswfam348p2459lk191x4p057w24jqgcf98gbbhg",
+      "version": "1.6.0",
+      "sha256": "061x88pqi2nksxm8kfcn817ggk6i9256krf63cvfzj8why3w7sjj",
       "depends": ["DelayedArray", "HDF5Array", "Rcpp", "Rhdf5lib", "assorthead", "beachmat"]
+    },
+    "beachmat_tiledb": {
+      "name": "beachmat.tiledb",
+      "version": "1.0.0",
+      "sha256": "1dsaxvf1vlimi08jdx41m07ypcbn56jprv4s1dyv3kypi0kx103f",
+      "depends": ["DelayedArray", "Rcpp", "TileDBArray", "assorthead", "beachmat", "tiledb"]
     },
     "beadarray": {
       "name": "beadarray",
-      "version": "2.56.0",
-      "sha256": "1khlljv6q32y2jg17g3lf6hvjs36ld27nasv03vlq7mb61pgda7d",
+      "version": "2.58.0",
+      "sha256": "0m9hmy4xn7q2v4ra95b9h08d0qh5qmjgqmg96vabyv46gn5i7qp4",
       "depends": ["AnnotationDbi", "BeadDataPackR", "Biobase", "BiocGenerics", "GenomicRanges", "IRanges", "ggplot2", "hexbin", "illuminaio", "limma", "reshape2"]
+    },
+    "bedbaser": {
+      "name": "bedbaser",
+      "version": "1.0.0",
+      "sha256": "0lvaxshgarcx4shkm87ifphzwydaxp3vgw4hswcjlm1qyvrbik88",
+      "depends": ["AnVIL", "BiocFileCache", "GenomeInfoDb", "GenomicRanges", "R_utils", "dplyr", "httr", "purrr", "rlang", "rtracklayer", "stringr", "tibble", "tidyr"]
     },
     "beer": {
       "name": "beer",
-      "version": "1.10.0",
-      "sha256": "0mix24ny5g9b6lk1810f6288rbr7i3dlkw5ppxz1z03kzvisjpb0",
+      "version": "1.12.0",
+      "sha256": "1g88qs5hkgj48fqi067p3p1pav220368i06fpjizpbnl8c4p8a77",
       "depends": ["BiocParallel", "PhIPData", "SummarizedExperiment", "cli", "edgeR", "progressr", "rjags"]
     },
     "benchdamic": {
       "name": "benchdamic",
-      "version": "1.12.2",
-      "sha256": "00wi2v5rmxgx2rny1yd8ndda33mkl7cxk0spwypginqc2jias8yp",
+      "version": "1.14.0",
+      "sha256": "1p9fnjbfq3cyvsy0fxh3gj9chvm42rjlv0kxvk8k3a0h2zg74fzd",
       "depends": ["ALDEx2", "ANCOMBC", "BiocParallel", "DESeq2", "GUniFrac", "MAST", "MGLM", "Maaslin2", "MicrobiomeStat", "NOISeq", "RColorBrewer", "Seurat", "SummarizedExperiment", "TreeSummarizedExperiment", "corncob", "cowplot", "dearseq", "edgeR", "ggdendro", "ggplot2", "ggridges", "limma", "lme4", "metagenomeSeq", "microbiome", "mixOmics", "phyloseq", "plyr", "reshape2", "tidytext", "zinbwave"]
     },
     "betaHMM": {
       "name": "betaHMM",
-      "version": "1.2.1",
-      "sha256": "06r5b8yw1rpi49chmzkrgbzrgdds2i16xb6mb7fdphzzr0q0v4ki",
+      "version": "1.4.0",
+      "sha256": "1jzl9p3j30y21w6jn287j0k7m7zj7njkmk770v0h1598y4mpwbbx",
       "depends": ["GenomicRanges", "S4Vectors", "SummarizedExperiment", "cowplot", "doParallel", "dplyr", "foreach", "ggplot2", "pROC", "scales", "stringr", "tidyr", "tidyselect"]
     },
     "bettr": {
       "name": "bettr",
-      "version": "1.2.0",
-      "sha256": "03jv8nfbnxi200dy9kslsx9pyfzmzy992f3bnmdghkxq8fd3wzqc",
+      "version": "1.4.0",
+      "sha256": "0qbxxrjddb0h4m2xx2f40c85vzhxhq2nmfyga6l8ms6f7ljfpybh",
       "depends": ["ComplexHeatmap", "DT", "Hmisc", "S4Vectors", "SummarizedExperiment", "bslib", "circlize", "cowplot", "dplyr", "ggplot2", "rlang", "scales", "shiny", "shinyjqui", "sortable", "tibble", "tidyr"]
     },
     "bigmelon": {
       "name": "bigmelon",
-      "version": "1.32.0",
-      "sha256": "05l7kgjgjx4rk3vgffmmh5jrg8qx9bvr9bmq9f70w4bxx4kj6xry",
+      "version": "1.34.0",
+      "sha256": "1g0jp0l5fb91ys07ks64q8vi759phpfifrlvjz463xy7qd42z8kj",
       "depends": ["Biobase", "BiocGenerics", "GEOquery", "gdsfmt", "illuminaio", "methylumi", "minfi", "wateRmelon"]
     },
     "bioCancer": {
       "name": "bioCancer",
-      "version": "1.34.0",
-      "sha256": "1334qfqyi6cmyvf7x98v0hnbz2wfdqq5v0s1zp35k1r91g86dhrr",
+      "version": "1.36.0",
+      "sha256": "18rgnbqipbkb6gjscnsb88zqwi1qm7q4fhsy6py76mxyzar4kcrw",
       "depends": ["AlgDesign", "AnnotationDbi", "Biobase", "DOSE", "DT", "DiagrammeR", "GO_db", "R_methodsS3", "R_oo", "ReactomePA", "XML", "cBioPortalData", "clusterProfiler", "dplyr", "geNetClassifier", "htmlwidgets", "org_Bt_eg_db", "org_Hs_eg_db", "plyr", "r_import", "radiant_data", "reactome_db", "shiny", "shinythemes", "tibble", "tidyr", "visNetwork"]
     },
     "bioDist": {
       "name": "bioDist",
-      "version": "1.78.0",
-      "sha256": "0c2dwb6znpfcfcz5nxjvi4scs4nhn4h42gb48jhnyz4p2i96rmqb",
+      "version": "1.80.0",
+      "sha256": "0nkbg6bv72bzfkqqr8y9rfl6wi74w188wmvpdcc4mjj59w6pv18n",
       "depends": ["Biobase", "KernSmooth"]
     },
     "bioassayR": {
       "name": "bioassayR",
-      "version": "1.44.0",
-      "sha256": "0zxrmxsq3hvim288w16029xazk3fksiwdl444f211yyfhwkb1n31",
+      "version": "1.46.0",
+      "sha256": "17wv3yx9pgkpp1zvrk7w3df9x3rp3bf52ixvwsrpb7sh0j47cwbr",
       "depends": ["BiocGenerics", "ChemmineR", "DBI", "Matrix", "RSQLite", "XML", "rjson"]
     },
     "biobroom": {
       "name": "biobroom",
-      "version": "1.38.0",
-      "sha256": "1ihzrx46320fxhbxvxk4c87bidvj2m2cy6qxya61n7p807qqq76q",
+      "version": "1.40.0",
+      "sha256": "13c5cj8wmkhrghri5vrwrb3vzxs7vmcxn5ffib1rckxdm65hxby7",
       "depends": ["Biobase", "broom", "dplyr", "tidyr"]
     },
     "biobtreeR": {
       "name": "biobtreeR",
-      "version": "1.18.0",
-      "sha256": "1kzlssv731qlpjrqa4l72bw2fwjzdxc5045arydnggfvcksfr2q6",
+      "version": "1.20.0",
+      "sha256": "0fdim4k0s5f70xbbf4cbr7idha8w4sfv327l94cfmzh5k3zxdm1a",
       "depends": ["httpuv", "httr", "jsonlite", "stringi"]
     },
     "biocGraph": {
       "name": "biocGraph",
-      "version": "1.68.0",
-      "sha256": "13k619dazrrfh52pmq6jqx3q2sr3jx5jilbvkbn4yk55md6dxjcy",
+      "version": "1.70.0",
+      "sha256": "0iy7xg4yrsb1n0ggpzin9ll9hf80yxplvdiymahhpv6kp7c8l0mk",
       "depends": ["BiocGenerics", "Rgraphviz", "geneplotter", "graph"]
     },
     "biocViews": {
       "name": "biocViews",
-      "version": "1.74.0",
-      "sha256": "0y1i7sl76kczmkynb2lyd7v6mmz4gfp3j1qp4w4swn221q5p1cjr",
+      "version": "1.76.0",
+      "sha256": "1572jbg29lvnn1gan47mfqj7fn33hv9fw1bdvprjfmabq9n2cv9r",
       "depends": ["Biobase", "BiocManager", "RBGL", "RCurl", "RUnit", "XML", "graph"]
+    },
+    "biocmake": {
+      "name": "biocmake",
+      "version": "1.0.0",
+      "sha256": "136djx32fbny228jpmpqqa5r0dbzgyw4ymmi0wnpx34s4qgr6k2x",
+      "depends": ["dir_expiry"]
     },
     "biocroxytest": {
       "name": "biocroxytest",
-      "version": "1.2.0",
-      "sha256": "0fh6h0isswnljvl8dqlcs6kka2834d3w2plx5prw7k7qhz99xcfg",
+      "version": "1.4.0",
+      "sha256": "1m35dw7j0jld0fpgn3vbhdh0rrz7f8lljasf79y54mga4shragls",
       "depends": ["cli", "glue", "roxygen2", "stringr"]
     },
     "biocthis": {
       "name": "biocthis",
-      "version": "1.16.0",
-      "sha256": "0ajwp3880fr0cn647wxsd1gcyq78d2mdqwsalijh0npbr1r3zjyk",
+      "version": "1.18.0",
+      "sha256": "06kjalns95273p3bfbnj1349zmyvmmmkdqhbingjfczgaz8sfnv5",
       "depends": ["BiocManager", "fs", "glue", "rlang", "styler", "usethis"]
     },
     "biodb": {
       "name": "biodb",
-      "version": "1.14.0",
-      "sha256": "1mkkj2x37n5j90g5ixh6jaz5gwd0fz35wqb4s1jlp4pvxhd8jyjj",
+      "version": "1.16.0",
+      "sha256": "1xja9fl4yskqj2b51smddnpqgzi5i3w4ap18rwlpw9ci07rafyk5",
       "depends": ["BiocFileCache", "R6", "RCurl", "RSQLite", "Rcpp", "XML", "chk", "git2r", "jsonlite", "lgr", "lifecycle", "openssl", "plyr", "progress", "rappdirs", "stringr", "testthat", "withr", "yaml"]
     },
     "biodbChebi": {
       "name": "biodbChebi",
-      "version": "1.12.0",
-      "sha256": "10v1vl60jkc6168gnb08bl2j3fvj971xwy2i1az2mzkjjlz3csng",
+      "version": "1.14.0",
+      "sha256": "0z2xrc6qpipiw6s00nlh4wp8k2xwx8h18g40bk7kdji3l9fvx73p",
       "depends": ["R6", "biodb"]
     },
     "biodbHmdb": {
       "name": "biodbHmdb",
-      "version": "1.12.0",
-      "sha256": "1v1s7ivcdjlj6xqs36h151kd08q38sfpk2p4q5ffcyrw73ax5jnj",
+      "version": "1.14.0",
+      "sha256": "0xpc2dygjm8gy7612ggk2kgd599859l0i8qdjzx01vvchckkps5h",
       "depends": ["R6", "Rcpp", "biodb", "testthat", "zip"]
     },
     "biodbNcbi": {
       "name": "biodbNcbi",
-      "version": "1.10.0",
-      "sha256": "0v3mbvjimy98d0a3j0238a5h7xi8qhxapjps9157qs7d7can7ivy",
+      "version": "1.12.0",
+      "sha256": "19f37fgbhb22k27riklbdary3a1ybnm7drapfkss7grizwpa9d0x",
       "depends": ["R6", "XML", "biodb", "chk"]
     },
     "biodbNci": {
       "name": "biodbNci",
-      "version": "1.10.0",
-      "sha256": "1jdqsfly751pyh3d3nsc615glg5ni4xv9y3bbg7hv95i1501krkz",
+      "version": "1.12.0",
+      "sha256": "10fyx0mdhllqlykhm3xnv59hw0ham27wgnswapk0a36rr804mfpj",
       "depends": ["R6", "Rcpp", "biodb", "chk", "testthat"]
     },
     "biodbUniprot": {
       "name": "biodbUniprot",
-      "version": "1.12.0",
-      "sha256": "1srh6m3q76f5wc0a58vf353rcish9ciak9l1fxwp342bafnb3w8l",
+      "version": "1.14.0",
+      "sha256": "1m27a7ngn4gwhj37vwg2mq5588q3cp85fcq5fjbjygi7l3d3pwg3",
       "depends": ["R6", "biodb"]
     },
     "biomaRt": {
       "name": "biomaRt",
-      "version": "2.62.1",
-      "sha256": "1g0qz7wn87iszws5khc61a22rxlc5frswxv4gm56hxgk1387glgi",
+      "version": "2.64.0",
+      "sha256": "1yyzl573jyv61q6q3h36k7as6nkgh7cpxz5i4f28q6yfcz2imjsz",
       "depends": ["AnnotationDbi", "BiocFileCache", "curl", "digest", "httr2", "progress", "rappdirs", "stringr", "xml2"]
     },
     "biomformat": {
       "name": "biomformat",
-      "version": "1.34.0",
-      "sha256": "0a0260rr13czrwfnzxmgq168jgiqd4app8rjdmywh9wg2w2xy7hf",
+      "version": "1.36.0",
+      "sha256": "0dlwfm0hkyh2y21grbjbrq26ix5f8jq1rbnqwklq6v85kf6ddhb6",
       "depends": ["Matrix", "jsonlite", "plyr", "rhdf5"]
     },
     "biomvRCNS": {
       "name": "biomvRCNS",
-      "version": "1.46.0",
-      "sha256": "14cvhm3r43g1b2wmjj63cfgafjbaf3zzxy0jlkp1bix4bs9fvgns",
+      "version": "1.48.0",
+      "sha256": "0wbca3hyc0k1r6l7c4rl0m4447jy9svjmxz7fm6jk29afchxa1jh",
       "depends": ["GenomicRanges", "Gviz", "IRanges", "mvtnorm"]
     },
     "biosigner": {
       "name": "biosigner",
-      "version": "1.34.0",
-      "sha256": "0d2prfx2w3kfja5gzp88q15cnhaswx2kg30l1zcb0bnsvzfblr8k",
+      "version": "1.36.0",
+      "sha256": "1gx5v9jmmgfdxqyfzihfi0l0azn42i9f3mqd7wxfc0fmbv5nzixr",
       "depends": ["Biobase", "MultiAssayExperiment", "MultiDataSet", "SummarizedExperiment", "e1071", "randomForest", "ropls"]
     },
     "biotmle": {
       "name": "biotmle",
-      "version": "1.30.0",
-      "sha256": "06m79562baskma0vyj1632w2j669s2pymfniid5b8fyd3vqi4c6w",
+      "version": "1.32.0",
+      "sha256": "1rlza8x6dc0493ygz69f7cg36zl256nr4yrjmqwwl64spc9ldjxv",
       "depends": ["BiocGenerics", "BiocParallel", "S4Vectors", "SummarizedExperiment", "assertthat", "dplyr", "drtmle", "ggplot2", "ggsci", "limma", "superheat", "tibble"]
     },
     "biovizBase": {
       "name": "biovizBase",
-      "version": "1.54.0",
-      "sha256": "0g4hh3ka9891yamf90y1964xn7qsgzqwnb3f0dsmqbmbryk8pyz6",
+      "version": "1.56.0",
+      "sha256": "14xlvcjf1w283rb3249hzh9k8c2w2z8fimh0qsjnzhm1l82dihga",
       "depends": ["AnnotationDbi", "AnnotationFilter", "BiocGenerics", "Biostrings", "GenomeInfoDb", "GenomicAlignments", "GenomicFeatures", "GenomicRanges", "Hmisc", "IRanges", "RColorBrewer", "Rsamtools", "S4Vectors", "SummarizedExperiment", "VariantAnnotation", "dichromat", "ensembldb", "rlang", "scales"]
     },
     "biscuiteer": {
       "name": "biscuiteer",
-      "version": "1.20.0",
-      "sha256": "1hdfhmfgg2chsk54vrrcazi26x5adrbchmzz5wyhqi7rb85cs804",
+      "version": "1.22.0",
+      "sha256": "03q31l3cljvb6vqbdxdhpjfy39fw0gk043l5dkzwpwxirimw4kgn",
       "depends": ["Biobase", "BiocGenerics", "BiocParallel", "DelayedMatrixStats", "GenomeInfoDb", "GenomicRanges", "HDF5Array", "Homo_sapiens", "IRanges", "Matrix", "Mus_musculus", "QDNAseq", "R_utils", "Rsamtools", "S4Vectors", "SummarizedExperiment", "VariantAnnotation", "biscuiteerData", "bsseq", "data_table", "dmrseq", "gtools", "impute", "matrixStats", "qualV", "readr", "rtracklayer"]
     },
     "blacksheepr": {
       "name": "blacksheepr",
-      "version": "1.20.0",
-      "sha256": "0riggz2nx7w8cfacn7b2kx9gnh01jd50pa6xw4k3j5bxcj0zwpcs",
+      "version": "1.22.0",
+      "sha256": "05ywzx7sbx1bas24hl36d52a3bzclm22q7nwpvfraxv2d9k8dvpd",
       "depends": ["ComplexHeatmap", "RColorBrewer", "SummarizedExperiment", "circlize", "pasilla", "viridis"]
     },
     "blima": {
       "name": "blima",
-      "version": "1.40.0",
-      "sha256": "1qk3kajfp5j4mk8g1hqijaxd5kihg12q67wa4aln25f6rsx55lsn",
+      "version": "1.42.0",
+      "sha256": "0hsgd1zl3i2v4916c7dxlwlpm3affmgpb9s58p9rj1as3nvk6z9l",
       "depends": ["Biobase", "BiocGenerics", "Rcpp", "beadarray"]
     },
     "bluster": {
       "name": "bluster",
-      "version": "1.16.0",
-      "sha256": "1k8aj5zj297l5yf15f3xak9adcrxr79ax7ifwhz2jq23ifd4dmfs",
+      "version": "1.18.0",
+      "sha256": "0q51rpjj2m61ax2n192pcbaix26f3jxjl5pk09w5mcppr6cym0hi",
       "depends": ["BiocNeighbors", "BiocParallel", "Matrix", "Rcpp", "S4Vectors", "assorthead", "cluster", "igraph"]
     },
     "bnbc": {
       "name": "bnbc",
-      "version": "1.28.0",
-      "sha256": "0fcnx7arvm520f0cj47dprlaxwbff4zx0md3yffrwyi9gs579jqk",
+      "version": "1.30.0",
+      "sha256": "0ly0hb5893fblxjz5jmbsyd4452dxwcd0wzkfzw7p4f4qmfrqqlm",
       "depends": ["BiocGenerics", "EBImage", "GenomeInfoDb", "GenomicRanges", "HiCBricks", "IRanges", "Rcpp", "S4Vectors", "SummarizedExperiment", "data_table", "matrixStats", "preprocessCore", "rhdf5", "sva"]
     },
     "bnem": {
       "name": "bnem",
-      "version": "1.14.0",
-      "sha256": "08wkank5vg0liqzciafkivmpyqk3faznr2cq0dzkhwj249l7p5l0",
+      "version": "1.16.0",
+      "sha256": "00ynmwi9zf2sbprr2lcahrjfvcz34cnrpp7n0haa3f5dsccr9cfw",
       "depends": ["Biobase", "CellNOptR", "RColorBrewer", "Rgraphviz", "affy", "binom", "cluster", "epiNEM", "flexclust", "graph", "limma", "matrixStats", "mnem", "rmarkdown", "snowfall", "sva", "vsn"]
     },
     "borealis": {
       "name": "borealis",
-      "version": "1.10.0",
-      "sha256": "0z5giwwm3sg6z437ais2pdkmp44lyg2zms53jqqyhxqz230dkax9",
+      "version": "1.12.0",
+      "sha256": "1k5qjg1nndmdbpynjivlh5xy44y1b0q29g9f7rmxx9c8r2pg6pmj",
       "depends": ["Biobase", "DSS", "GenomicRanges", "R_utils", "bsseq", "cowplot", "doParallel", "dplyr", "foreach", "gamlss", "gamlss_dist", "ggplot2", "plyr", "purrr", "rlang", "snow"]
     },
     "branchpointer": {
       "name": "branchpointer",
-      "version": "1.32.0",
-      "sha256": "0r1qqdvwymhv7bw74bys2ns2i2l96amz7lmybih2n0vc3x7ndqzb",
+      "version": "1.34.0",
+      "sha256": "0n3linwha0lj65m72k7zm2bslxkdkjb1yqgs5ksdxrlziwmfs2nj",
       "depends": ["BSgenome_Hsapiens_UCSC_hg38", "Biostrings", "GenomeInfoDb", "GenomicRanges", "IRanges", "S4Vectors", "biomaRt", "caret", "cowplot", "data_table", "gbm", "ggplot2", "kernlab", "plyr", "rtracklayer", "stringr"]
     },
     "breakpointR": {
       "name": "breakpointR",
-      "version": "1.24.0",
-      "sha256": "0x95r30dvkkpsbang8vj0xg4mc48ljc5ci318m55n92lk0lfzpa0",
+      "version": "1.26.0",
+      "sha256": "12sns2h0m5w9jp4yr9f0i9v77v2a7r64cakqkmrjm4svciqaj6n5",
       "depends": ["BiocGenerics", "GenomeInfoDb", "GenomicAlignments", "GenomicRanges", "IRanges", "Rsamtools", "S4Vectors", "breakpointRdata", "cowplot", "doParallel", "foreach", "ggplot2", "gtools"]
     },
     "brendaDb": {
       "name": "brendaDb",
-      "version": "1.20.0",
-      "sha256": "15hqmpjci5kfv2gvrzjj3jxkmifjgx4h01w6alrrwhp09z729crm",
+      "version": "1.22.0",
+      "sha256": "1libb78j7i03fw6y5bpv45aljmllysv7yn80yx3whvzzxzn4h1ss",
       "depends": ["BiocFileCache", "BiocParallel", "Rcpp", "crayon", "dplyr", "magrittr", "purrr", "rappdirs", "rlang", "stringr", "tibble", "tidyr"]
     },
     "broadSeq": {
       "name": "broadSeq",
-      "version": "1.0.0",
-      "sha256": "143x96pa2bsq1amcx434p937d1v4q03s95bnhrs5pv4bwm3w151g",
+      "version": "1.2.0",
+      "sha256": "1s2jd5b0gyb692zdgn4vffvi3s9kjs8b1627wmhrdzf83xq4gf1g",
       "depends": ["BiocStyle", "DELocal", "DESeq2", "EBSeq", "NOISeq", "SummarizedExperiment", "clusterProfiler", "dplyr", "edgeR", "forcats", "genefilter", "ggplot2", "ggplotify", "ggpubr", "pheatmap", "plyr", "purrr", "sechm", "stringr"]
     },
     "bsseq": {
       "name": "bsseq",
-      "version": "1.42.0",
-      "sha256": "0gxjx1x2rw07615f7p9fixf4j3ph9x9b36mcb4vwg4h0avq5wfdx",
-      "depends": ["BSgenome", "Biobase", "BiocGenerics", "BiocParallel", "Biostrings", "DelayedArray", "DelayedMatrixStats", "GenomeInfoDb", "GenomicRanges", "HDF5Array", "IRanges", "R_utils", "Rcpp", "S4Vectors", "SummarizedExperiment", "beachmat", "data_table", "gtools", "limma", "locfit", "permute", "rhdf5", "scales"]
+      "version": "1.44.0",
+      "sha256": "1sscy6q119g84malz2yq1fgf8q6izrq4ljh13ycyh4zhgmbqk4rl",
+      "depends": ["BSgenome", "Biobase", "BiocGenerics", "BiocParallel", "Biostrings", "DelayedArray", "DelayedMatrixStats", "GenomeInfoDb", "GenomicRanges", "HDF5Array", "IRanges", "R_utils", "Rcpp", "S4Vectors", "SummarizedExperiment", "assorthead", "beachmat", "data_table", "gtools", "limma", "locfit", "permute", "rhdf5", "scales"]
     },
     "bugsigdbr": {
       "name": "bugsigdbr",
-      "version": "1.12.0",
-      "sha256": "1rjmrdslx3ifbg268x57hiq189hjmj46w4vxrd79ism25lzqzp77",
+      "version": "1.14.0",
+      "sha256": "1bz3v4srw5ar8wb171b6j24pn0hz5jxc4m8qy6gjwiip83mnipzr",
       "depends": ["BiocFileCache", "vroom"]
     },
     "bumphunter": {
       "name": "bumphunter",
-      "version": "1.48.0",
-      "sha256": "185kxkx7lcnylfwp6c9hnnxarwa3rrwb1q45c5z6hl3wj7d74154",
+      "version": "1.50.0",
+      "sha256": "05dsx5a3xagq6jajkcg6dzd43w5b4nbjqhjkl1wvg5va3dx4hl5z",
       "depends": ["AnnotationDbi", "BiocGenerics", "GenomeInfoDb", "GenomicFeatures", "GenomicRanges", "IRanges", "S4Vectors", "doRNG", "foreach", "iterators", "limma", "locfit", "matrixStats"]
     },
     "cBioPortalData": {
       "name": "cBioPortalData",
-      "version": "2.18.1",
-      "sha256": "192p8nw4963dwncwh1y4akfzlk1gcyjifann531hm0mk13qk2qfs",
-      "depends": ["AnVIL", "BiocFileCache", "GenomeInfoDb", "GenomicRanges", "IRanges", "MultiAssayExperiment", "RTCGAToolbox", "RaggedExperiment", "S4Vectors", "SummarizedExperiment", "TCGAutils", "digest", "dplyr", "httr", "readr", "tibble", "tidyr"]
+      "version": "2.20.0",
+      "sha256": "1if4dkzlx9zclk0n32a4bc8sy3dxf9nrzgacy095lbp83qs1najc",
+      "depends": ["AnVIL", "BiocBaseUtils", "BiocFileCache", "GenomeInfoDb", "GenomicRanges", "IRanges", "MultiAssayExperiment", "RTCGAToolbox", "RaggedExperiment", "S4Vectors", "SummarizedExperiment", "TCGAutils", "digest", "dplyr", "httr", "readr", "tibble", "tidyr"]
     },
     "cTRAP": {
       "name": "cTRAP",
-      "version": "1.24.0",
-      "sha256": "0rnmhz04vm141imi8dxn3fl6mf6gy0mk2jn0wi8qidrn0qmyjbz4",
+      "version": "1.26.0",
+      "sha256": "0l14km7mn8lf19wg4vydid0r2q84mw7wakfx6kwzgjzb6kgar4xb",
       "depends": ["AnnotationDbi", "AnnotationHub", "DT", "R_utils", "binr", "cowplot", "data_table", "dplyr", "fastmatch", "fgsea", "ggplot2", "ggrepel", "highcharter", "htmltools", "httr", "limma", "pbapply", "purrr", "qs", "readxl", "reshape2", "rhdf5", "rlang", "scales", "shiny", "shinycssloaders", "tibble"]
     },
     "cageminer": {
       "name": "cageminer",
-      "version": "1.12.0",
-      "sha256": "124kja2p24b4zcshh85lyj6fg7agz2ga28r94ajp86d1nj6vi0pc",
+      "version": "1.14.0",
+      "sha256": "0qmvzjk08p547qjmjrmgk4n647qmy9v3djdic8hygkkq1ii9ilbp",
       "depends": ["BioNERO", "GenomeInfoDb", "GenomicRanges", "IRanges", "ggbio", "ggplot2", "ggtext", "reshape2", "rlang"]
     },
     "calm": {
       "name": "calm",
-      "version": "1.20.0",
-      "sha256": "1hf7znmvgwkpxlwy1983fnnsk40brm9bc60g7bflid6ck3w38gsv",
+      "version": "1.22.0",
+      "sha256": "01m2rpdmn0479x91i6g02m4fxrg5s5yj5vvmivklf32gb366s4s0",
       "depends": ["mgcv"]
     },
     "canceR": {
       "name": "canceR",
-      "version": "1.40.0",
-      "sha256": "1lilpakq2fi4xynn6674xgp3a22732fd2zafz182q5086cn2xi3l",
+      "version": "1.42.0",
+      "sha256": "15a4pic5hbxhs89bhv074jl43222idin3zqxxph8nmmcpg8an215",
       "depends": ["Biobase", "Formula", "GSEABase", "RUnit", "R_methodsS3", "R_oo", "cBioPortalData", "circlize", "dplyr", "geNetClassifier", "phenoTest", "plyr", "rpart", "survival", "tidyr", "tkrplot"]
     },
     "cancerclass": {
       "name": "cancerclass",
-      "version": "1.50.0",
-      "sha256": "0yap9vzd2ff7hzznvl87k1fy6vffv5a68l5601pw4i23r14j2dkq",
+      "version": "1.52.0",
+      "sha256": "106wizfqbxjnxyzi5jyhpg6yck6kcxw6k7xb2qx2w1bk5pgiks95",
       "depends": ["Biobase", "binom"]
     },
     "cardelino": {
       "name": "cardelino",
-      "version": "1.8.0",
-      "sha256": "1zglflqc53izs5rh8cdld0y129mdvwlhmv9pgbgrl4clcnnbiwac",
+      "version": "1.10.0",
+      "sha256": "1apnzwia944cclsdc3x8plp87id3sd0qyz6xg2m61cl18nq17wl7",
       "depends": ["GenomeInfoDb", "GenomicRanges", "Matrix", "S4Vectors", "VariantAnnotation", "combinat", "ggplot2", "ggtree", "matrixStats", "pheatmap", "snpStats", "vcfR"]
     },
     "casper": {
       "name": "casper",
-      "version": "2.40.0",
-      "sha256": "1f8gg39madycigcl5xqrb04sa4dy6a2z1a4f15jryaddf3s62q36",
+      "version": "2.42.0",
+      "sha256": "02ncaglam553874ygp9ddr37xkpvhpqpvkncy4czwsblqhnzpla1",
       "depends": ["Biobase", "BiocGenerics", "EBarrays", "GenomeInfoDb", "GenomicFeatures", "GenomicRanges", "IRanges", "Rsamtools", "S4Vectors", "VGAM", "coda", "gaga", "gtools", "limma", "mgcv", "rtracklayer", "sqldf", "survival"]
     },
     "categoryCompare": {
       "name": "categoryCompare",
-      "version": "1.50.0",
-      "sha256": "1hpd5c21qvf0wh2rmcybcsm632lr6cp9069dyk3sccqyx1r6aw8v",
+      "version": "1.52.0",
+      "sha256": "13qm189x70l6nnspwdy612i5f0l31ljrgiz78fjrh5nplmgffr4l",
       "depends": ["AnnotationDbi", "Biobase", "BiocGenerics", "Category", "GOstats", "GSEABase", "RCy3", "annotate", "colorspace", "graph", "hwriter"]
     },
     "cbaf": {
       "name": "cbaf",
-      "version": "1.28.0",
-      "sha256": "0cymffvrpf7zyb7jvkn6pvkxn8g12j8bh25sq6z23piwiqa0s3gw",
+      "version": "1.30.0",
+      "sha256": "1qdlv8pls8fif1qlc30xmzd8vf3l09srpabzy397pj28x3j9xp88",
       "depends": ["BiocFileCache", "RColorBrewer", "cBioPortalData", "genefilter", "gplots", "openxlsx", "zip"]
     },
     "cbpManager": {
       "name": "cbpManager",
-      "version": "1.14.0",
-      "sha256": "13xdiga7s7izhx5jl4i6zrqmn21xb68q1r3qh5a96dlvmspfw30q",
+      "version": "1.16.0",
+      "sha256": "06hk0mrc9pz2wic5gil0zacnhwqq0ar1j9b63cr4xxgy7r2wmk6k",
       "depends": ["DT", "basilisk", "dplyr", "htmltools", "jsonlite", "magrittr", "markdown", "plyr", "rapportools", "reticulate", "rintrojs", "rlang", "shiny", "shinyBS", "shinycssloaders", "shinydashboard", "vroom"]
     },
     "ccImpute": {
       "name": "ccImpute",
-      "version": "1.8.0",
-      "sha256": "1k3hy1bdvj5zm2y42n67zkzbkkm6s8qa93krs4kvxnfdzmbkf5l3",
+      "version": "1.10.0",
+      "sha256": "0p2qglfy5wlsqs45z223wd4ym4kzhl9l9ww0ay7vrynsnzh1216n",
       "depends": ["BiocParallel", "Matrix", "Rcpp", "RcppEigen", "SingleCellExperiment", "SummarizedExperiment", "irlba", "sparseMatrixStats"]
     },
     "ccfindR": {
       "name": "ccfindR",
-      "version": "1.26.0",
-      "sha256": "1v8lrgs5rqf0pz5gg7g5hh9y7cj90s8k04bhimhlzr0iah27vhc5",
+      "version": "1.28.0",
+      "sha256": "1203v7shhcrazq2jz9s79dvdqnz07a5hpa50g1w8wl539pzf2x8p",
       "depends": ["Matrix", "RColorBrewer", "Rcpp", "RcppEigen", "Rdpack", "Rmpi", "Rtsne", "S4Vectors", "SingleCellExperiment", "SummarizedExperiment", "ape", "gtools", "irlba"]
     },
     "ccmap": {
       "name": "ccmap",
-      "version": "1.32.0",
-      "sha256": "1g0r1vfbh2w21cb891wxqdcs06cnmc8vpkxs65pydqkxvbjbccji",
+      "version": "1.34.0",
+      "sha256": "1khc7n1qpm7f4mpqy4qa74v03q581knig30hbvcd0a5x8gk8bvj3",
       "depends": ["AnnotationDbi", "BiocManager", "ccdata", "data_table", "doParallel", "foreach", "lsa", "xgboost"]
     },
     "ccrepe": {
       "name": "ccrepe",
-      "version": "1.42.0",
-      "sha256": "0xfk14wpldxfad3zr44i2jpi67didlfp3l6a040mv2i6xf3df3hc",
+      "version": "1.44.0",
+      "sha256": "07lxcz5mmj33dam2mvzr7a3crinjydvlxzsavncnnlgy8m7156lh",
       "depends": ["infotheo"]
     },
     "ceRNAnetsim": {
       "name": "ceRNAnetsim",
-      "version": "1.18.0",
-      "sha256": "06yjjxfrpsb057x0l92d9l0sdpb53c4xk4psi7ng0r3plpbp5g5q",
+      "version": "1.20.0",
+      "sha256": "0whd1gd7r66pcxzy5mjxg9nfdm9gw56lrr9afzxdrknys2dc8kk6",
       "depends": ["dplyr", "furrr", "future", "ggplot2", "ggraph", "igraph", "purrr", "rlang", "tibble", "tidygraph", "tidyr"]
     },
     "celaref": {
       "name": "celaref",
-      "version": "1.24.0",
-      "sha256": "19qr4s74ppq07x1da3c65aaw4gmcky0n9pxfv8v5pl5k90mzyfp6",
+      "version": "1.26.0",
+      "sha256": "1c0lgrx4p5prdv6byl0gm7qm928lw9z1d5g3005l21hf5qv4zxs2",
       "depends": ["BiocGenerics", "DelayedArray", "MAST", "Matrix", "S4Vectors", "SummarizedExperiment", "dplyr", "ggplot2", "magrittr", "readr", "rlang", "tibble"]
     },
     "celda": {
       "name": "celda",
-      "version": "1.22.1",
-      "sha256": "14rcw2mz8kgn0nl6w9w6l3h3f66gjbzyxdbdr9xapafg29gqpw1h",
+      "version": "1.24.0",
+      "sha256": "08v99r9g0jcjnwh6vlpvlnzpxgnjqry5jh384m4v4m253jwz544l",
       "depends": ["ComplexHeatmap", "DelayedArray", "MCMCprecision", "Matrix", "RColorBrewer", "Rcpp", "RcppEigen", "Rtsne", "S4Vectors", "SingleCellExperiment", "SummarizedExperiment", "circlize", "data_table", "dbscan", "dendextend", "digest", "doParallel", "enrichR", "foreach", "ggdendro", "ggplot2", "ggrepel", "gridExtra", "gtable", "matrixStats", "pROC", "plyr", "reshape2", "scales", "scater", "scran", "stringr", "uwot", "withr"]
     },
     "cellbaseR": {
       "name": "cellbaseR",
-      "version": "1.30.0",
-      "sha256": "1glaidjcr2iralq3vppvsri7mavdvnp5gizgd8qrpcqcdw7kgq24",
+      "version": "1.32.0",
+      "sha256": "1ih99x5bjqvmbh49n3shkx789fcvpysmnrxzmfpz9mzz8wdi0gn7",
       "depends": ["BiocParallel", "R_utils", "Rsamtools", "data_table", "doParallel", "foreach", "httr", "jsonlite", "pbapply", "tidyr"]
     },
     "cellity": {
       "name": "cellity",
-      "version": "1.34.0",
-      "sha256": "0p6xwhzdlrwmzlvv518h1iyigq8if9clyhqi11vszih7y77n80w6",
+      "version": "1.36.0",
+      "sha256": "1d23gkfba6ym7qhkm9mydsslnizh549xjlv86nkaf4pnvpcbjc8s",
       "depends": ["AnnotationDbi", "e1071", "ggplot2", "mvoutlier", "org_Hs_eg_db", "org_Mm_eg_db", "robustbase", "topGO"]
     },
     "cellmigRation": {
       "name": "cellmigRation",
-      "version": "1.14.0",
-      "sha256": "1vaxq1ysrsmavnv3nsbs3cl587zmdjjwapm7qkv6m75l5qzmjjg9",
+      "version": "1.16.0",
+      "sha256": "18bq8hml1pa7w5dw2lil7dlb5wrma99l46djklrg479872m8f5vd",
       "depends": ["FME", "FactoMineR", "Hmisc", "SpatialTools", "doParallel", "foreach", "matrixStats", "reshape2", "sp", "tiff", "vioplot"]
     },
     "cellscape": {
       "name": "cellscape",
-      "version": "1.30.0",
-      "sha256": "1x728l0jyn1w0phx44z39gaqhywahpra1qvbbsnngvz8brdh0bvw",
+      "version": "1.32.0",
+      "sha256": "009f2yfqnrcm61hm1nvl9hvxmpxk257ycw9a3lymvi255wxq4xr0",
       "depends": ["dplyr", "gtools", "htmlwidgets", "jsonlite", "reshape2", "stringr"]
     },
     "cellxgenedp": {
       "name": "cellxgenedp",
-      "version": "1.10.0",
-      "sha256": "17n0g2ch4ja8kibli6i2kfrsnx84nyn829hydl34byadf3b6arz7",
+      "version": "1.12.0",
+      "sha256": "0myv4zgnxzay5xn462l6nzixb57l544rqpiiksfqz631ng6f1zp3",
       "depends": ["DT", "cli", "curl", "dplyr", "httr", "rjsoncons", "shiny"]
     },
     "censcyt": {
       "name": "censcyt",
-      "version": "1.14.0",
-      "sha256": "1v176nzxh8ggc16ffv5rhql7165lmaysmdgih1rvw0k547ac3gzl",
+      "version": "1.16.0",
+      "sha256": "0hxbjx6as76n5nh03nfznl7x128pgr8p6xvyw5w1w6834zdzarha",
       "depends": ["BiocParallel", "MASS", "S4Vectors", "SummarizedExperiment", "broom_mixed", "diffcyt", "dirmult", "dplyr", "edgeR", "fitdistrplus", "lme4", "magrittr", "mice", "multcomp", "purrr", "rlang", "stringr", "survival", "tibble", "tidyr"]
     },
     "cfDNAPro": {
       "name": "cfDNAPro",
-      "version": "1.12.0",
-      "sha256": "0aqwwabdw27wwq4a6is5cvrs6pr8mhmci5bamrrgap39hbmpjbjg",
+      "version": "1.14.0",
+      "sha256": "078878mfqsvnl2bxa3qlw80ld3lql0h2amzg5x5jsga0j8lhwldy",
       "depends": ["BSgenome_Hsapiens_NCBI_GRCh38", "BSgenome_Hsapiens_UCSC_hg19", "BSgenome_Hsapiens_UCSC_hg38", "BiocGenerics", "GenomeInfoDb", "GenomicAlignments", "GenomicRanges", "IRanges", "Rsamtools", "dplyr", "ggplot2", "magrittr", "plyranges", "quantmod", "rlang", "stringr", "tibble"]
     },
     "cfTools": {
       "name": "cfTools",
-      "version": "1.6.0",
-      "sha256": "085nygijrdcf9fyw32i13wy4kjsp7nhwmjfk3149bvf38vln7n2z",
+      "version": "1.8.0",
+      "sha256": "02mqfjvlhczbv2l55sif2b95x78vp59r8lml9vdzv0jyjrbi8q15",
       "depends": ["BH", "GenomicRanges", "R_utils", "Rcpp", "basilisk", "cfToolsData"]
     },
     "cfdnakit": {
       "name": "cfdnakit",
-      "version": "1.4.0",
-      "sha256": "1mzqgazfy1srjxj54d7df5kpbkj58blqal8l8adi4f6jx2z426p2",
+      "version": "1.5.0",
+      "sha256": "0v53vqgzaq48a8l6xid030injafz1bc84pnsp50lpj7vvy0dx234",
       "depends": ["Biobase", "GenomeInfoDb", "GenomicRanges", "IRanges", "PSCBS", "QDNAseq", "Rsamtools", "S4Vectors", "dplyr", "ggplot2", "magrittr", "rlang"]
     },
     "cghMCR": {
       "name": "cghMCR",
-      "version": "1.64.0",
-      "sha256": "1cdmmzvwwx8msvsc9inmm34ssc6psgpwwh13l0lf6mcirqj9ar2f",
+      "version": "1.66.0",
+      "sha256": "1ygk4j9j296ybnqxdr5p41akvhn2na1rm3icnpcf6zmm36xlvpww",
       "depends": ["BiocGenerics", "CNTools", "DNAcopy", "limma"]
+    },
+    "chevreulPlot": {
+      "name": "chevreulPlot",
+      "version": "1.0.0",
+      "sha256": "0lb34gxyaqxcjnhkyc63b9gfiw28hqg4l6myynmxa4xs5054paip",
+      "depends": ["ComplexHeatmap", "EnsDb_Hsapiens_v86", "S4Vectors", "SingleCellExperiment", "chevreulProcess", "circlize", "cluster", "clustree", "dplyr", "forcats", "fs", "ggplot2", "patchwork", "plotly", "purrr", "scales", "scater", "scran", "scuttle", "stringr", "tibble", "tidyr", "tidyselect", "wiggleplotr"]
+    },
+    "chevreulProcess": {
+      "name": "chevreulProcess",
+      "version": "1.0.0",
+      "sha256": "01a2hihlbyvanf34z2ajnkfg3glib6bq6rnay7dl3q1dbygk9w8f",
+      "depends": ["DBI", "EnsDb_Hsapiens_v86", "GenomicFeatures", "RSQLite", "S4Vectors", "SingleCellExperiment", "batchelor", "bluster", "circlize", "cluster", "dplyr", "ensembldb", "fs", "glue", "megadepth", "purrr", "scater", "scran", "scuttle", "stringr", "tibble", "tidyr", "tidyselect"]
+    },
+    "chevreulShiny": {
+      "name": "chevreulShiny",
+      "version": "1.0.0",
+      "sha256": "0cl1wx66wk2l206yjvhnjmdacn3vbci6gzxii5djqiisr8zp42ml",
+      "depends": ["ComplexHeatmap", "DBI", "DT", "DataEditR", "EnhancedVolcano", "RSQLite", "S4Vectors", "SingleCellExperiment", "alabaster_base", "chevreulPlot", "chevreulProcess", "clustree", "dplyr", "fs", "future", "ggplot2", "ggplotify", "patchwork", "plotly", "purrr", "rappdirs", "readr", "scales", "shiny", "shinyFiles", "shinyWidgets", "shinydashboard", "shinyhelper", "shinyjs", "stringr", "tibble", "tidyr", "tidyselect", "waiter", "wiggleplotr"]
     },
     "chihaya": {
       "name": "chihaya",
-      "version": "1.6.0",
-      "sha256": "0k52ym2x489k1k4d52jyd6jy4wnr7gd2p9n1pwfqbca3b91cmaj0",
+      "version": "1.8.0",
+      "sha256": "164rhh0qf0c2vfr71admiwhrkr79kg3hby22cx5sifwaml3wmw7m",
       "depends": ["DelayedArray", "HDF5Array", "Matrix", "Rcpp", "Rhdf5lib", "rhdf5"]
     },
     "chimeraviz": {
       "name": "chimeraviz",
-      "version": "1.32.0",
-      "sha256": "06ln5z1ckg573baxfmh33641i6a586j20ysr11jlklqp7151an05",
+      "version": "1.34.0",
+      "sha256": "02y0bjlyjhh540fx3dss6lh3b7nvfv2yflmf81vsxrp24bg2y9pv",
       "depends": ["AnnotationDbi", "AnnotationFilter", "BiocStyle", "Biostrings", "DT", "GenomeInfoDb", "GenomicAlignments", "GenomicRanges", "Gviz", "IRanges", "RCircos", "RColorBrewer", "Rgraphviz", "Rsamtools", "S4Vectors", "checkmate", "data_table", "dplyr", "ensembldb", "graph", "gtools", "magick", "org_Hs_eg_db", "org_Mm_eg_db", "plyr", "rmarkdown"]
     },
     "chipenrich": {
       "name": "chipenrich",
-      "version": "2.30.0",
-      "sha256": "1546jnwc44l0ahg90cmz7s26lcnzrzvhbmz4qswgccz57jzfd3yp",
+      "version": "2.32.0",
+      "sha256": "0iia6lap366dkyyql06w19gxms782wrymxhx6jv7akkp8918f071",
       "depends": ["AnnotationDbi", "BiocGenerics", "GenomeInfoDb", "GenomicRanges", "IRanges", "MASS", "S4Vectors", "chipenrich_data", "lattice", "latticeExtra", "mgcv", "org_Dm_eg_db", "org_Dr_eg_db", "org_Hs_eg_db", "org_Mm_eg_db", "org_Rn_eg_db", "plyr", "rms", "rtracklayer", "stringr"]
     },
     "chipseq": {
       "name": "chipseq",
-      "version": "1.56.0",
-      "sha256": "0s50i1dzbqwdxb6zn8v4ip2n6r3dmkgahx5kjixpi45s42d8yn31",
+      "version": "1.58.0",
+      "sha256": "1wav01504azcp1ghcm51nxz41nf1xz7yqfdd94yxnbfq24x9k6cw",
       "depends": ["BiocGenerics", "GenomicRanges", "IRanges", "S4Vectors", "ShortRead", "lattice"]
     },
     "chopsticks": {
       "name": "chopsticks",
-      "version": "1.72.0",
-      "sha256": "0d7mgrdabakzml9c7kqs4sa4jh5l9ivji5c64j432lcx6qpxr5ag",
+      "version": "1.74.0",
+      "sha256": "142m7732nm9h3j828kqyi1pj2w0fakryb3nampficwdfyhzdxs2r",
       "depends": ["survival"]
     },
     "chromDraw": {
       "name": "chromDraw",
-      "version": "2.36.0",
-      "sha256": "0j8ilcn0dcqn9vcd256rb39pv1ql239xk2pqjzf293pfq8vs6wab",
+      "version": "2.38.0",
+      "sha256": "00qg03dqw1j6hsih92fvdy7hxr713nkq817d4qig3k43csfbyiv4",
       "depends": ["GenomicRanges", "Rcpp"]
     },
     "chromPlot": {
       "name": "chromPlot",
-      "version": "1.34.0",
-      "sha256": "1x39p5lczqgri9cvb0r56x5klgj52aimv7qm9mm57g64a9kwf06w",
+      "version": "1.36.0",
+      "sha256": "09wwhk0cvmyzac9mhczrzwk78zjsdc31kl6s39fqpm17b4cm4q9c",
       "depends": ["GenomicRanges", "biomaRt"]
     },
     "chromVAR": {
       "name": "chromVAR",
-      "version": "1.28.0",
-      "sha256": "0mv8bfjr80k3nmmy0vsvjsrb4hi7n4adazmzgf6xi3hiiyajiv87",
+      "version": "1.30.0",
+      "sha256": "1k42md1n22ms1jbk52vzgqlsmxvlg59cdbq5h5sariymbc6ihx6d",
       "depends": ["BSgenome", "BiocGenerics", "BiocParallel", "Biostrings", "DT", "GenomeInfoDb", "GenomicRanges", "IRanges", "Matrix", "RColorBrewer", "Rcpp", "RcppArmadillo", "Rsamtools", "Rtsne", "S4Vectors", "SummarizedExperiment", "TFBSTools", "ggplot2", "miniUI", "nabor", "plotly", "shiny"]
-    },
-    "chromstaR": {
-      "name": "chromstaR",
-      "version": "1.32.0",
-      "sha256": "071aipwk1awr71hvzflps49dzp83p12zm1pbyx4l8d2v3wbj0dlz",
-      "depends": ["BiocGenerics", "GenomeInfoDb", "GenomicAlignments", "GenomicRanges", "IRanges", "Rsamtools", "S4Vectors", "bamsignals", "chromstaRData", "doParallel", "foreach", "ggplot2", "mvtnorm", "reshape2"]
     },
     "cicero": {
       "name": "cicero",
-      "version": "1.24.0",
-      "sha256": "12j1j553pg5rd1ndg3xfjk9jgv2i72cck9pg74kylfhj5z2a1mfp",
+      "version": "1.26.0",
+      "sha256": "1vmmgvwscrag8dv5n4k70pdichfii11j2jiav3nv9l5pqby469na",
       "depends": ["Biobase", "BiocGenerics", "FNN", "GenomicRanges", "Gviz", "IRanges", "Matrix", "S4Vectors", "VGAM", "assertthat", "data_table", "dplyr", "ggplot2", "glasso", "igraph", "monocle", "plyr", "reshape2", "stringi", "stringr", "tibble", "tidyr"]
     },
     "circRNAprofiler": {
       "name": "circRNAprofiler",
-      "version": "1.20.0",
-      "sha256": "0yszs0mzh9bdzaak1sqfypr05xn4nxy78g2b9m6rszxrf1g7k56b",
+      "version": "1.22.0",
+      "sha256": "115hzanh0bs45qbk1j854jvpd8242aabzpwjzd0hk79k5ng8yqnm",
       "depends": ["AnnotationHub", "BSgenome", "BSgenome_Hsapiens_UCSC_hg19", "Biostrings", "DESeq2", "GenomeInfoDb", "GenomicRanges", "IRanges", "R_utils", "S4Vectors", "dplyr", "edgeR", "ggplot2", "gwascat", "magrittr", "readr", "reshape2", "rlang", "rtracklayer", "seqinr", "stringi", "stringr", "universalmotif"]
     },
     "cisPath": {
       "name": "cisPath",
-      "version": "1.46.0",
-      "sha256": "05vcrqanf4q3d8lqy04lch06zd6rdm58953sf9vprscd1ng49hcs",
+      "version": "1.47.0",
+      "sha256": "0q9fk47jwsbslyqjx6b4qr65xvxappr63xkvm2a6458r3hxaf41y",
       "depends": []
     },
     "cleanUpdTSeq": {
       "name": "cleanUpdTSeq",
-      "version": "1.44.0",
-      "sha256": "0xhkhxdz9233yykzw32kipm86qysg7cgxrwf92320xay5y50hr4k",
+      "version": "1.46.0",
+      "sha256": "0nkhs4rrwpk6sxvr57ca934aknazcjlf4qx3il8l0xg7dzm2w2jl",
       "depends": ["BSgenome", "BSgenome_Drerio_UCSC_danRer7", "Biostrings", "GenomeInfoDb", "GenomicRanges", "IRanges", "S4Vectors", "e1071", "seqinr", "stringr"]
     },
     "cleaver": {
       "name": "cleaver",
-      "version": "1.44.0",
-      "sha256": "00za5jx7zdarcvrz822ivvp13l0jvfhwzlknwqc6260gym8j4hxy",
+      "version": "1.46.0",
+      "sha256": "0brds9xq1fywl946rbr4mqfbhvranla4vxxmk7ndma3s6hxsar7v",
       "depends": ["Biostrings", "IRanges", "S4Vectors"]
     },
     "clevRvis": {
       "name": "clevRvis",
-      "version": "1.6.0",
-      "sha256": "03sjrls4prn76svxmz901v00yljnd8h201s853am6mrkx8ir9p4p",
+      "version": "1.8.0",
+      "sha256": "1kshwlklcq3lhwa52bkz8alglv84xnzgcbmrxzyhwgmjnph84544",
       "depends": ["DT", "R_utils", "colorspace", "colourpicker", "cowplot", "dplyr", "ggiraph", "ggnewscale", "ggplot2", "ggraph", "htmlwidgets", "igraph", "magrittr", "patchwork", "purrr", "readr", "readxl", "shiny", "shinyWidgets", "shinycssloaders", "shinydashboard", "shinyhelper", "tibble"]
     },
     "cliProfiler": {
       "name": "cliProfiler",
-      "version": "1.12.0",
-      "sha256": "183wlk9xq051n7i44g01xgapyzn0csdkbd767glvda2n7ap92chi",
+      "version": "1.14.0",
+      "sha256": "1hwz4wqhh69xrfir7jlvc9bkl30g6sb5a17gq13kjn1wr901pxly",
       "depends": ["BSgenome", "Biostrings", "GenomicRanges", "S4Vectors", "dplyr", "ggplot2", "rtracklayer"]
     },
     "clippda": {
       "name": "clippda",
-      "version": "1.56.0",
-      "sha256": "1c9ms94xfzq5954jphn11j2fc00kfbgg3ssv2pprij1qkmvs0i9y",
+      "version": "1.58.0",
+      "sha256": "03fbf53cjqb4xni2y97mjla001r1g3znpj481pj9f429fmscbjhx",
       "depends": ["Biobase", "lattice", "limma", "rgl", "scatterplot3d", "statmod"]
     },
     "clipper": {
       "name": "clipper",
-      "version": "1.46.0",
-      "sha256": "1pfah7a461lgzrp7chxmddjyvzjh65drm5614b7g5graas62mx45",
+      "version": "1.48.0",
+      "sha256": "0r0bwvj0lagpkcidx5qffh83n9fn85wp80m2j0qrzf2bvzygmvsr",
       "depends": ["Biobase", "KEGGgraph", "Matrix", "Rcpp", "corpcor", "gRbase", "graph", "igraph", "qpgraph"]
     },
     "cliqueMS": {
       "name": "cliqueMS",
-      "version": "1.20.0",
-      "sha256": "01n3yvih4dwvwhv2rw0yv9bain0lbkws1pccnfv00prakhgli2f2",
+      "version": "1.22.0",
+      "sha256": "1x9wnhdfapbhrsjwd01c0ccq00zjsv2iaqw24nzmcykv89v9nv6y",
       "depends": ["BH", "MSnbase", "Rcpp", "RcppArmadillo", "coop", "igraph", "matrixStats", "slam", "xcms"]
     },
     "clst": {
       "name": "clst",
-      "version": "1.54.0",
-      "sha256": "0is27v6yx7nr95i268f4qx7jphki1hcwkzc02q3bzyf3za57f2kq",
+      "version": "1.56.0",
+      "sha256": "0sl6mv46r4fs8ga0s3xpqcc94y3kv1lxg1bmxwxmifqzm84bj9b4",
       "depends": ["ROC", "lattice"]
     },
     "clstutils": {
       "name": "clstutils",
-      "version": "1.54.0",
-      "sha256": "05iv8zbma9r0fz7116xjv4nj76imfl3kdmp0vks8hwhdp18g3wi6",
+      "version": "1.56.0",
+      "sha256": "1rwrgbdij8p925maspynqqjkjk5wf92dv5y9g4yhfj99d7j9fvjw",
       "depends": ["RSQLite", "ape", "clst", "lattice", "rjson"]
     },
     "clustComp": {
       "name": "clustComp",
-      "version": "1.34.0",
-      "sha256": "14fslhpqslxhckanf6qv5lrzd6k3qxlfpm005yrvdl6vp8fqclgg",
+      "version": "1.36.0",
+      "sha256": "06dw1pqf6ialfqqbiwzmvlbfm0lqzy0102gg6lcgpcxlj47b2vm1",
       "depends": ["sm"]
+    },
+    "clustSIGNAL": {
+      "name": "clustSIGNAL",
+      "version": "1.0.0",
+      "sha256": "1gibrs3bcjbc6gwp67d8xg0i6ikh91xa7iqmkcwwwc3659qlvv3i",
+      "depends": ["BiocNeighbors", "BiocParallel", "Matrix", "SingleCellExperiment", "SpatialExperiment", "SummarizedExperiment", "bluster", "harmony", "reshape2", "scater"]
     },
     "clusterExperiment": {
       "name": "clusterExperiment",
-      "version": "2.26.0",
-      "sha256": "1csj6xn5kldfrrzl5qhd5dh59c0inmabx5pbbjq0zb2rad5scqj9",
+      "version": "2.28.0",
+      "sha256": "0pwhd2skps4m2pz59b2bqzfhkqqmxyj89npnwg9zbpkqf0cjrlsn",
       "depends": ["BiocGenerics", "BiocSingular", "DelayedArray", "HDF5Array", "Matrix", "NMF", "RColorBrewer", "Rcpp", "S4Vectors", "SingleCellExperiment", "SummarizedExperiment", "ape", "cluster", "edgeR", "kernlab", "limma", "locfdr", "matrixStats", "mbkmeans", "phylobase", "pracma", "scales", "stringr", "zinbwave"]
     },
     "clusterProfiler": {
       "name": "clusterProfiler",
-      "version": "4.14.4",
-      "sha256": "0vmjhzxq59zdxywyyqa31fcsasckq8qfpbjp70ml1vcxnvkr49ck",
+      "version": "4.16.0",
+      "sha256": "1vgyhaisk5vx812kqyzg4kyxmn8q64i99xy9di6ds3fp84j79xyl",
       "depends": ["AnnotationDbi", "DOSE", "GOSemSim", "GO_db", "dplyr", "enrichplot", "gson", "httr", "igraph", "magrittr", "plyr", "qvalue", "rlang", "tidyr", "yulab_utils"]
     },
     "clusterSeq": {
       "name": "clusterSeq",
-      "version": "1.30.0",
-      "sha256": "12pzjfazagfx3k4dvc2hcljr50skyrshpzp9n0rlavgcq5x0b4c8",
+      "version": "1.32.0",
+      "sha256": "1klbjr2y8jymjgm4g9b680sb69n0djrclz2vqj8ca2kn36sva3dq",
       "depends": ["BiocGenerics", "BiocParallel", "baySeq"]
     },
     "clusterStab": {
       "name": "clusterStab",
-      "version": "1.78.0",
-      "sha256": "1mdxjbc3ygnfm86vcbkrbj7z7g0yx4z3caah4v0b9d1v7ckc33gh",
+      "version": "1.80.0",
+      "sha256": "1j7m5f5xhnnrpnl6f9zd23s2v6vaiywcrxliaql7sfkfkpmw9kj3",
       "depends": ["Biobase"]
     },
     "clustifyr": {
       "name": "clustifyr",
-      "version": "1.18.0",
-      "sha256": "1lx9ikdd1m2lgkwx68h4myy3vf0xsws05s3kkdsan30rq760d2vd",
+      "version": "1.20.0",
+      "sha256": "06lc9mmhiayij5hdws05h08l16z0wg6q022k301czgh0g52p0z2x",
       "depends": ["Matrix", "S4Vectors", "SeuratObject", "SingleCellExperiment", "SummarizedExperiment", "cowplot", "dplyr", "entropy", "fgsea", "ggplot2", "httr", "matrixStats", "proxy", "rlang", "scales", "stringr", "tibble", "tidyr"]
     },
     "cmapR": {
       "name": "cmapR",
-      "version": "1.18.0",
-      "sha256": "18wl5ncdjg8mvh33n3fwi41mi66gj4xmldjy8hvhh8ch0j7yj6dl",
+      "version": "1.20.0",
+      "sha256": "036xm08qr7xxcmyvkvm4im57y1ydmhvdpbihmwgivd04q7vpalj7",
       "depends": ["SummarizedExperiment", "data_table", "flowCore", "matrixStats", "rhdf5"]
     },
     "cn_farms": {
       "name": "cn.farms",
-      "version": "1.54.0",
-      "sha256": "1wcx1040z5b0x4ram1y2kllrm91sax2g7s76ww2nfrwx6m3bai6f",
+      "version": "1.55.0",
+      "sha256": "061qxr4pbl31kd6f3dhjazgmr23m48ng3vszvm0rxdz2bbzgq0yr",
       "depends": ["Biobase", "DBI", "DNAcopy", "affxparser", "ff", "lattice", "oligo", "oligoClasses", "preprocessCore", "snow"]
     },
     "cn_mops": {
       "name": "cn.mops",
-      "version": "1.52.0",
-      "sha256": "12dcxdvj7n8a24vmambb8ghk7mmgzbzjq1ssdx26znxz5g8149yr",
+      "version": "1.54.0",
+      "sha256": "17n2pl93gijcq8cjqkjgk5w8m201f6rn0k6bh1jib42nfyx0hnl3",
       "depends": ["Biobase", "BiocGenerics", "GenomeInfoDb", "GenomicRanges", "IRanges", "Rsamtools", "S4Vectors"]
     },
     "cnvGSA": {
       "name": "cnvGSA",
-      "version": "1.50.0",
-      "sha256": "1i86r9zfwqzpbxfxwdf0c7k1qnbmw37l74ysii03x625jjy33225",
+      "version": "1.52.0",
+      "sha256": "1wl5f27mnpi3rbqisl7bl5ywvl3rzksw2zzx4faf8p11cipjzsw8",
       "depends": ["GenomicRanges", "brglm", "doParallel", "foreach", "splitstackshape"]
     },
     "coGPS": {
       "name": "coGPS",
-      "version": "1.50.0",
-      "sha256": "1wkhxp4682l3204v4pxidvjlxjc1iz45sz66cjyivl8ipizvf8zq",
+      "version": "1.52.0",
+      "sha256": "1rd4yyv6c1qmqyr1bz1xwakys44drc62fqln6pkxn5mhxkv462zr",
       "depends": []
     },
     "coMethDMR": {
       "name": "coMethDMR",
-      "version": "1.10.0",
-      "sha256": "0wmrfrw5ivyqnkqi6phzzb7jmqnpqx111ssrvlyd8gczd688ngx1",
+      "version": "1.12.0",
+      "sha256": "0qa19ccclzrxr2079avxf2j06f82dbqjyvfv69c0b45svr7hzcmf",
       "depends": ["AnnotationHub", "BiocParallel", "ExperimentHub", "GenomicRanges", "IRanges", "bumphunter", "lmerTest"]
     },
     "coRdon": {
       "name": "coRdon",
-      "version": "1.24.0",
-      "sha256": "04pprr15b9bss6nh2gd83iyzk30m6ma1vpn5qp3c5h5mi7bbk4x8",
+      "version": "1.26.0",
+      "sha256": "0yadnd5mc5b62jjqh3zz7si3rgwfid4r3ccxjgiqpaw6lh4a784b",
       "depends": ["Biobase", "Biostrings", "data_table", "dplyr", "ggplot2", "purrr", "stringr"]
     },
     "codelink": {
       "name": "codelink",
-      "version": "1.74.0",
-      "sha256": "129avd4i14ym06nd1yw2njrlzjd8k8vc04g23f61z6g44al3faiv",
+      "version": "1.76.0",
+      "sha256": "1bwi83n99xrys4s2ir40ngh39pdyxcp9bacpph28l8pqfb1a7mf5",
       "depends": ["Biobase", "BiocGenerics", "annotate", "limma"]
     },
     "cogena": {
       "name": "cogena",
-      "version": "1.40.0",
-      "sha256": "0wjpahn90lrcg64iglbfqbnwc7xk005dn101kqa75xpvmmv51fqc",
+      "version": "1.42.0",
+      "sha256": "11wncf16k393jr31qvcqlhnclavvqi9sacwr5vnlz80a23nnm38b",
       "depends": ["Biobase", "amap", "apcluster", "biwt", "class", "cluster", "corrplot", "devtools", "doParallel", "dplyr", "fastcluster", "foreach", "ggplot2", "gplots", "kohonen", "mclust", "reshape2", "stringr", "tibble", "tidyr"]
     },
     "cogeqc": {
       "name": "cogeqc",
-      "version": "1.10.0",
-      "sha256": "1iw4rjpl9prrhw52radd119phkafvqcsq3in691c0pp3bzv3fkr0",
+      "version": "1.12.0",
+      "sha256": "0cmc7gqq4psl291bh81bm8nailaravnq4qbas1rpz70x1ikjx4wz",
       "depends": ["Biostrings", "ggbeeswarm", "ggplot2", "ggtree", "igraph", "jsonlite", "patchwork", "reshape2", "rlang", "scales"]
     },
     "cola": {
       "name": "cola",
-      "version": "2.12.0",
-      "sha256": "03w1rmk8b2lpjngad0jb7lk2yr28n2ss2lk0scis5c2i61flq6g4",
+      "version": "2.14.0",
+      "sha256": "0m048k36fbqardgg6qi078cc5w6fqxr3w5285nb1jc7s778sdk9j",
       "depends": ["BiocGenerics", "ComplexHeatmap", "GetoptLong", "GlobalOptions", "RColorBrewer", "Rcpp", "brew", "circlize", "clue", "cluster", "crayon", "digest", "doParallel", "doRNG", "eulerr", "foreach", "httr", "impute", "irlba", "knitr", "markdown", "matrixStats", "mclust", "microbenchmark", "png", "skmeans", "xml2"]
     },
     "comapr": {
       "name": "comapr",
-      "version": "1.10.0",
-      "sha256": "0zfdylcwa4bcx65y6q04ya1v79l3dhajzbrybqz1nxi0lz9lgx5p",
+      "version": "1.12.0",
+      "sha256": "0ggks950kr5c8x4l0479lh882r4svxagaq2y65hv26x23c03hzkx",
       "depends": ["BiocParallel", "GenomeInfoDb", "GenomicRanges", "Gviz", "IRanges", "Matrix", "RColorBrewer", "S4Vectors", "SummarizedExperiment", "circlize", "dplyr", "foreach", "ggplot2", "gridExtra", "plotly", "plyr", "reshape2", "rlang", "scales", "tidyr"]
     },
     "combi": {
       "name": "combi",
-      "version": "1.18.0",
-      "sha256": "1i0x0w2ri80vm92wnxq5wvs7paq02k4h36f8nqw9mjk8gfqbp9ir",
+      "version": "1.20.0",
+      "sha256": "08yqd9n60bh2gc0hry9y52xx7z65qrsid2ri75zy70vy33ck516r",
       "depends": ["BB", "Biobase", "DBI", "Matrix", "SummarizedExperiment", "alabama", "cobs", "ggplot2", "limma", "nleqslv", "phyloseq", "reshape2", "tensor", "vegan"]
     },
     "compEpiTools": {
       "name": "compEpiTools",
-      "version": "1.40.0",
-      "sha256": "1kbz2y5p6rv9nn8c91isns4ah9mpvhncxjwb0950x60mg3jys0s6",
+      "version": "1.42.0",
+      "sha256": "1dmsd3g4qly6s748qkq0glvad4nmfyqsp9gfyx4b31j7hc0mml49",
       "depends": ["AnnotationDbi", "BiocGenerics", "Biostrings", "GO_db", "GenomeInfoDb", "GenomicFeatures", "GenomicRanges", "IRanges", "Rsamtools", "S4Vectors", "XVector", "gplots", "methylPipe", "topGO"]
     },
     "compSPOT": {
       "name": "compSPOT",
-      "version": "1.4.0",
-      "sha256": "1p8xv3wyqdbrhhyan1ydz9nqfc4j31bay6fhbp6sannbz48kr9xc",
+      "version": "1.6.0",
+      "sha256": "1b6i8kbz1c56njpldh71y7g9l0xmvcm6hjyhq2cqymdz2sdz26rs",
       "depends": ["data_table", "ggplot2", "ggpubr", "gridExtra", "magrittr", "plotly"]
     },
     "compcodeR": {
       "name": "compcodeR",
-      "version": "1.42.0",
-      "sha256": "17l3ax2b0rapdi4p12vy5fzy14img2dij0sq8szvadvqgsgzd4p2",
+      "version": "1.44.0",
+      "sha256": "09h8yixf7559kcby4kqr6jiw5pcdr7y1lf952ai5zdjx2f7cdsvf",
       "depends": ["KernSmooth", "MASS", "ROCR", "ape", "caTools", "edgeR", "ggplot2", "gplots", "gtools", "knitr", "lattice", "limma", "markdown", "matrixStats", "modeest", "phylolm", "rmarkdown", "shiny", "shinydashboard", "sm", "stringr", "vioplot"]
     },
     "concordexR": {
       "name": "concordexR",
-      "version": "1.6.0",
-      "sha256": "0zkydxybif94p5ka8wrbwbgbbp01n3c15lff62nraldz0yhvs5jn",
+      "version": "1.8.0",
+      "sha256": "1l7507zk08d0idygkh4h3a281xvkrnn28wnsmpp04pq3smhabsck",
       "depends": ["BiocGenerics", "BiocNeighbors", "BiocParallel", "DelayedArray", "Matrix", "SingleCellExperiment", "SpatialExperiment", "SummarizedExperiment", "bluster", "cli", "purrr", "rlang", "sparseMatrixStats"]
     },
     "condiments": {
       "name": "condiments",
-      "version": "1.14.0",
-      "sha256": "0zcvb4893yq35wfqr29bqm40lqmdcp5gc39y9cly8nqhya8jbq4k",
+      "version": "1.16.0",
+      "sha256": "13c65xq648c946nz625dl2sj2brbpbcz6wmxka6lvs29cwz7sb96",
       "depends": ["BiocParallel", "Ecume", "RANN", "SingleCellExperiment", "SummarizedExperiment", "TrajectoryUtils", "distinct", "dplyr", "igraph", "magrittr", "matrixStats", "mgcv", "pbapply", "slingshot"]
     },
     "consICA": {
       "name": "consICA",
-      "version": "2.4.0",
-      "sha256": "0r5qqd4a6h08ah1vj5wbmwhdsg5q7piia03y7nq6qd6l6shbvd8z",
+      "version": "2.6.0",
+      "sha256": "137mkgrp95k45nh7ljv94xgf5c5ahrz1xzxq2qchrjmvh0yahwgp",
       "depends": ["BiocParallel", "GO_db", "Rfast", "SummarizedExperiment", "fastICA", "ggplot2", "graph", "org_Hs_eg_db", "pheatmap", "sm", "survival", "topGO"]
     },
     "consensus": {
       "name": "consensus",
-      "version": "1.24.0",
-      "sha256": "0c2wy2ci2zxswjh2hckx4j1ym1wjgb9lhs2ws8zpcmam4h9cy1zh",
+      "version": "1.26.0",
+      "sha256": "01kh517ml7nb1qkhc8lhl4kaalfjddi3kq1pcnar0aq796vpgmby",
       "depends": ["RColorBrewer", "gplots", "matrixStats"]
     },
     "consensusDE": {
       "name": "consensusDE",
-      "version": "1.24.0",
-      "sha256": "0vqr72v6mfdzhwhlg2v9q25s8i5qimaqn7rjd1wjp8cnccvg47mj",
+      "version": "1.26.0",
+      "sha256": "0r2agk29v5ahnp56j61gq81dradymn8v7x6cc5cnv7hvfl4bzv40",
       "depends": ["AnnotationDbi", "Biobase", "BiocGenerics", "BiocParallel", "Biostrings", "DESeq2", "EDASeq", "EnsDb_Hsapiens_v86", "GenomicAlignments", "GenomicFeatures", "RColorBrewer", "RUVSeq", "Rsamtools", "S4Vectors", "SummarizedExperiment", "TxDb_Dmelanogaster_UCSC_dm3_ensGene", "airway", "data_table", "dendextend", "edgeR", "ensembldb", "limma", "org_Hs_eg_db", "pcaMethods"]
+    },
+    "consensusOV": {
+      "name": "consensusOV",
+      "version": "1.30.0",
+      "sha256": "10zdr72admvmvcy41aa223cdc4vzbj1xklamnqvsvwxbcw9yvfms",
+      "depends": ["Biobase", "BiocParallel", "GSVA", "gdata", "genefu", "limma", "matrixStats", "randomForest"]
     },
     "consensusSeekeR": {
       "name": "consensusSeekeR",
-      "version": "1.34.0",
-      "sha256": "1wpy08a2mr5rxqbmb5kw1kidmmfk2ybx0jin5gd2ywc1gsf98pn7",
+      "version": "1.36.0",
+      "sha256": "1vpkl58q4gn5wamynz0bfmhqa3zzza6fxla1qrv5wm0adrfqsm9c",
       "depends": ["BiocGenerics", "BiocParallel", "GenomeInfoDb", "GenomicRanges", "IRanges", "S4Vectors", "rtracklayer", "stringr"]
     },
     "conumee": {
       "name": "conumee",
-      "version": "1.40.0",
-      "sha256": "1jy68njrqvjv4l4zh3f8wh93qr2mw65i4nrf51fh1xhjas1jj7g0",
+      "version": "1.42.0",
+      "sha256": "17qqljnph3gk995prqld61b7wl3gafxpjbdylcc73wrmfqby5xd6",
       "depends": ["DNAcopy", "GenomeInfoDb", "GenomicRanges", "IRanges", "IlluminaHumanMethylation450kanno_ilmn12_hg19", "IlluminaHumanMethylation450kmanifest", "IlluminaHumanMethylationEPICanno_ilm10b2_hg19", "IlluminaHumanMethylationEPICmanifest", "minfi", "rtracklayer"]
     },
     "convert": {
       "name": "convert",
-      "version": "1.82.0",
-      "sha256": "0ghbsfc62bqxy8cz71ld59m0a0r7wb5fn9lj8kxwgpvgfiflcq7d",
+      "version": "1.84.0",
+      "sha256": "08cx9q4f588cpcc45pwvfql3sv84s3xmjs4fi00983clf8glqn38",
       "depends": ["Biobase", "limma", "marray"]
     },
     "copa": {
       "name": "copa",
-      "version": "1.74.0",
-      "sha256": "1nb4q4jmksbsnfjbhfygxz34hnxfm0dl2f21gakbr8iq3vg2ns5q",
+      "version": "1.76.0",
+      "sha256": "0041ik9frfsz15mjsagz40rd9bs0v5lnvr6dj8xnvph1n47gyarv",
       "depends": ["Biobase"]
     },
     "corral": {
       "name": "corral",
-      "version": "1.16.0",
-      "sha256": "1g6lhyj2fr6dwfgsammmnyh2krswl0zhicbpcjcbdjqp2042zf1n",
+      "version": "1.18.0",
+      "sha256": "0ax8dxpz9idb50v90m70m3qv1bm8p2iz23i90czz19iv4vzgrnid",
       "depends": ["Matrix", "MultiAssayExperiment", "SingleCellExperiment", "SummarizedExperiment", "ggplot2", "ggthemes", "gridExtra", "irlba", "pals", "reshape2", "transport"]
     },
     "coseq": {
       "name": "coseq",
-      "version": "1.30.0",
-      "sha256": "0x3z4zci7s89c8h19a52r5czr052jng5sqifj4flm8lwigh8kxz3",
+      "version": "1.32.0",
+      "sha256": "19x53d6wisyl7dpwxxlv7lh7h4jzdh180cax6rdac2xz4sy36760",
       "depends": ["BiocParallel", "DESeq2", "HTSCluster", "HTSFilter", "Rmixmod", "S4Vectors", "SummarizedExperiment", "capushe", "compositions", "corrplot", "e1071", "edgeR", "ggplot2", "mvtnorm", "scales"]
     },
     "cosmiq": {
       "name": "cosmiq",
-      "version": "1.40.0",
-      "sha256": "038xn54vskc155yilqblz91fjmk6qd1r7yb0ga7szrqa1lm10l1v",
+      "version": "1.42.0",
+      "sha256": "0q3vprsnywlifagr5250ff7df0r72jk7ly7vgb3v11sy6bibqz0i",
       "depends": ["MassSpecWavelet", "Rcpp", "faahKO", "pracma", "xcms"]
     },
     "cosmosR": {
       "name": "cosmosR",
-      "version": "1.14.0",
-      "sha256": "17rd4d5ssz0l0v48wyff1j3ffhia02qqxcivgbj1iaqyr5dxf2f5",
+      "version": "1.16.0",
+      "sha256": "1wbw0cd98gvxq030s7vl7yzhap1h7i623vjsagsdmb2dc8nffhf8",
       "depends": ["CARNIVAL", "GSEABase", "decoupleR", "dorothea", "dplyr", "igraph", "progress", "purrr", "rlang", "stringr", "visNetwork"]
     },
     "countsimQC": {
       "name": "countsimQC",
-      "version": "1.24.0",
-      "sha256": "1abbp6hdbmxf7j005anl2l63g8kyxv3l87ds5k7m3r7rx87j5y51",
+      "version": "1.26.0",
+      "sha256": "0ygl54aji9gy685ylgnv5iflb82q4dmvjpy20bljld6n78mlhn86",
       "depends": ["DESeq2", "DT", "GenomeInfoDbData", "SummarizedExperiment", "caTools", "dplyr", "edgeR", "genefilter", "ggplot2", "ragg", "randtests", "rmarkdown", "tidyr"]
     },
     "covEB": {
       "name": "covEB",
-      "version": "1.32.0",
-      "sha256": "02yxd4amnahgib8dgkn3pydjmbgd9lz53ydcib3ls6qfbxd3pk8q",
+      "version": "1.34.0",
+      "sha256": "1vvd43z6m3jczamz56v16siziwlap98zpfflij2k4zladbkm2qwg",
       "depends": ["Biobase", "LaplacesDemon", "Matrix", "gsl", "igraph", "mvtnorm"]
     },
     "covRNA": {
       "name": "covRNA",
-      "version": "1.32.0",
-      "sha256": "1lspmjr1ih985wakhi3bsq94zmpzvzk0cxh2msvqb4cdx39s4mii",
+      "version": "1.34.0",
+      "sha256": "11cv5q9ppki925j4ccmddv5n7224xviacvrdivzjnby94mfwmhad",
       "depends": ["Biobase", "ade4", "genefilter"]
     },
     "cpvSNP": {
       "name": "cpvSNP",
-      "version": "1.38.0",
-      "sha256": "0qqakgpj35jzqpslh5b53f3jhq3gdhvdwfwfgsla84lprmjy2fla",
+      "version": "1.40.0",
+      "sha256": "17v7h3q1b491allvwlga0irjywa0sz0c8gjwhh6gqv0f2sww71ns",
       "depends": ["BiocParallel", "GSEABase", "GenomicFeatures", "corpcor", "ggplot2", "plyr"]
     },
     "cqn": {
       "name": "cqn",
-      "version": "1.52.0",
-      "sha256": "1iqpfav92psi1v6yz0q1kl1pjpyf4fwf2b6iviggykz54kachva9",
+      "version": "1.54.0",
+      "sha256": "05rhs2cd9cmvn1ayn33r1ji4gjzxjym36nv6z04jy3zhac3mmzi5",
       "depends": ["mclust", "nor1mix", "quantreg"]
     },
     "crisprBase": {
       "name": "crisprBase",
-      "version": "1.10.0",
-      "sha256": "0azk53vdrwhkb3ipybgz5g5x31wjiz1w0x6k0rx4gwir8wjq60g3",
+      "version": "1.12.0",
+      "sha256": "1c7bjr87xr0rhmxm5wvwrl32rrh6axpmazyrm8wljzgvn3gj0v0h",
       "depends": ["BiocGenerics", "Biostrings", "GenomicRanges", "IRanges", "S4Vectors", "stringr"]
     },
     "crisprBowtie": {
       "name": "crisprBowtie",
-      "version": "1.10.0",
-      "sha256": "0li9m4r3xwp3djyrqx0x7x1mai1x638djimnqzfnicc9d404z66c",
+      "version": "1.12.0",
+      "sha256": "0hs0lawivrxjh936aq90y3c6kjmfdwl3xxqgs5pqb3za77kh73sl",
       "depends": ["BSgenome", "BiocGenerics", "Biostrings", "GenomeInfoDb", "GenomicRanges", "IRanges", "Rbowtie", "crisprBase", "readr", "stringr"]
     },
     "crisprBwa": {
       "name": "crisprBwa",
-      "version": "1.10.0",
-      "sha256": "0891ll8zjydb1cf37msy6d49fbs28fp7ba33m6ljix1m021rsk1v",
+      "version": "1.12.0",
+      "sha256": "11p6khzahab919kcvm7kyxqqww3i4n9xh2z65zj4l27hrz91crf5",
       "depends": ["BSgenome", "BiocGenerics", "GenomeInfoDb", "Rbwa", "crisprBase", "readr", "stringr"]
     },
     "crisprDesign": {
       "name": "crisprDesign",
-      "version": "1.8.0",
-      "sha256": "01qzfpjvsc478zax5hvl1ffjw6wjj6qdja076pqf2y3ax5z34c9y",
+      "version": "1.10.0",
+      "sha256": "0vfqnmsvj1xnwj2pd45c4li15nlpl1v626hhvasyklrwahsqw2qk",
       "depends": ["AnnotationDbi", "BSgenome", "BiocGenerics", "Biostrings", "GenomeInfoDb", "GenomicFeatures", "GenomicRanges", "IRanges", "Matrix", "MatrixGenerics", "S4Vectors", "VariantAnnotation", "crisprBase", "crisprBowtie", "crisprScore", "rtracklayer", "txdbmaker"]
     },
     "crisprScore": {
       "name": "crisprScore",
-      "version": "1.10.0",
-      "sha256": "1gwklmhxvazsm79gy21zk54zj13qxvv6kq27rfxz35rddys69ljk",
+      "version": "1.12.0",
+      "sha256": "06jwv69asw67lh6djmrax6c6dxvffr0s2dflfzvi2ld22phigwxm",
       "depends": ["BiocGenerics", "Biostrings", "IRanges", "XVector", "basilisk", "basilisk_utils", "crisprScoreData", "randomForest", "reticulate", "stringr"]
     },
     "crisprShiny": {
       "name": "crisprShiny",
-      "version": "1.2.0",
-      "sha256": "0qpawfgqvckvf9b0qi14ci9mcjmx8hwb4sn6k348da5hyvh0q1gp",
+      "version": "1.4.0",
+      "sha256": "0lqx31h9ixfhvvkdsw8kjjzghdb5jj7g4kbfjwv4an6z3bc4ambf",
       "depends": ["BSgenome", "BiocGenerics", "Biostrings", "DT", "GenomeInfoDb", "S4Vectors", "crisprBase", "crisprDesign", "crisprScore", "crisprViz", "htmlwidgets", "pwalign", "shiny", "shinyBS", "shinyjs", "waiter"]
     },
     "crisprVerse": {
       "name": "crisprVerse",
-      "version": "1.8.0",
-      "sha256": "188ilq0c8cgn70g2sahymdpfm1kdy89ayzlr6471aw05nlrfsh1i",
+      "version": "1.10.0",
+      "sha256": "1cqn0wh5c4cr6ibfk1gcnkasxkyabkc1dfrci22i4fq5chz189yl",
       "depends": ["BiocManager", "cli", "crisprBase", "crisprBowtie", "crisprDesign", "crisprScore", "crisprScoreData", "crisprViz", "rlang"]
     },
     "crisprViz": {
       "name": "crisprViz",
-      "version": "1.8.0",
-      "sha256": "08rsn3cf1r5w8k58slxv73gg1dgclf3i0yywp06l53yv9i5mf3id",
+      "version": "1.10.0",
+      "sha256": "1vdbnbnjhi7fm87kw9fdhyp248hxjp8k4d3bxiqj9iik4r926lll",
       "depends": ["BSgenome", "BiocGenerics", "Biostrings", "GenomeInfoDb", "GenomicFeatures", "GenomicRanges", "Gviz", "IRanges", "S4Vectors", "crisprBase", "crisprDesign", "txdbmaker"]
     },
     "crlmm": {
       "name": "crlmm",
-      "version": "1.64.0",
-      "sha256": "0fc87gn7k7i60sy5acg6dfs8bxamnch9riaxmzwpp7l20g5v6hd5",
+      "version": "1.66.0",
+      "sha256": "0nzn99xw28lr7rj3b91ca77kqmf00i4wy0bwvjy2ci0zlpdk61v3",
       "depends": ["Biobase", "BiocGenerics", "RcppEigen", "VGAM", "affyio", "beanplot", "ellipse", "ff", "foreach", "illuminaio", "lattice", "limma", "matrixStats", "mvtnorm", "oligoClasses", "preprocessCore"]
+    },
+    "crumblr": {
+      "name": "crumblr",
+      "version": "1.0.0",
+      "sha256": "1ymw4aqmj8ihagia1dh09qx19pzk1amipii1qbxpcjxcl1kx8iqv",
+      "depends": ["MASS", "Rdpack", "Rfast", "SingleCellExperiment", "dplyr", "ggplot2", "ggtree", "tidytree", "variancePartition", "viridis"]
+    },
+    "crupR": {
+      "name": "crupR",
+      "version": "1.0.0",
+      "sha256": "06q1bjbrgzj1lk08v28qvpw7rz057qrdslc483ys23hwzh1yny1i",
+      "depends": ["BiocParallel", "GenomeInfoDb", "GenomicAlignments", "GenomicFeatures", "GenomicRanges", "IRanges", "Rsamtools", "S4Vectors", "SummarizedExperiment", "TxDb_Hsapiens_UCSC_hg19_knownGene", "TxDb_Hsapiens_UCSC_hg38_knownGene", "TxDb_Mmusculus_UCSC_mm10_knownGene", "TxDb_Mmusculus_UCSC_mm9_knownGene", "bamsignals", "dplyr", "fs", "ggplot2", "magrittr", "matrixStats", "preprocessCore", "randomForest", "reshape2", "rtracklayer"]
     },
     "csaw": {
       "name": "csaw",
-      "version": "1.40.0",
-      "sha256": "02ajgkpwz5s7i72swnlix1djmnv8zmp7yl2ppwq4m60rs23d06wg",
-      "depends": ["BiocGenerics", "BiocParallel", "GenomeInfoDb", "GenomicRanges", "IRanges", "Matrix", "Rcpp", "Rhtslib", "Rsamtools", "S4Vectors", "SummarizedExperiment", "edgeR", "limma", "metapod", "zlibbioc"]
+      "version": "1.42.0",
+      "sha256": "01mq34niz767qj91al556w1y6k7yail3bfi20y0pf5zshnn71cs9",
+      "depends": ["BiocGenerics", "BiocParallel", "GenomeInfoDb", "GenomicRanges", "IRanges", "Matrix", "Rcpp", "Rhtslib", "Rsamtools", "S4Vectors", "SummarizedExperiment", "edgeR", "limma", "metapod"]
     },
     "csdR": {
       "name": "csdR",
-      "version": "1.12.0",
-      "sha256": "0r51n7vlddgg1rxxrpm9pfhq5nm4467933crvzln5dz9qsx34vs6",
+      "version": "1.14.0",
+      "sha256": "1bxip5ry510z1cvh38f63h8x3rk31cma7z0z809psclsxp74b1fw",
       "depends": ["Rcpp", "RhpcBLASctl", "WGCNA", "glue", "matrixStats"]
     },
     "ctc": {
       "name": "ctc",
-      "version": "1.80.0",
-      "sha256": "1k2s1kjcbj4gkpj3fbb1gk2apg8b4anybgdhaw4s0w5ximy69mp7",
+      "version": "1.82.0",
+      "sha256": "0l9vncl6xk3xnywn7v1bhxmwxrrmaxmvgg0l043qzn16r2vyk4sn",
       "depends": ["amap"]
     },
     "ctsGE": {
       "name": "ctsGE",
-      "version": "1.32.0",
-      "sha256": "0n8v12cijvna1078abfbbdqp5wpdi8blac7k7xzn3wql1p3z3awv",
+      "version": "1.34.0",
+      "sha256": "0n3xmipmx3r51b8zhxacf47k1g20zdqg8g0wz6cpf6srvzlvqx9z",
       "depends": ["ccaPP", "ggplot2", "limma", "reshape2", "shiny", "stringr"]
     },
     "cummeRbund": {
       "name": "cummeRbund",
-      "version": "2.48.0",
-      "sha256": "13505rlzwczgqzqs9fcfgij8558iwzhcn29ai4xl96qqz4qwx00k",
+      "version": "2.50.0",
+      "sha256": "1i1zcrfizp4ix0bgx3gjbd4y4hj7dfs15j4ssh87kkx61y7x6yl8",
       "depends": ["Biobase", "BiocGenerics", "Gviz", "RSQLite", "S4Vectors", "fastcluster", "ggplot2", "plyr", "reshape2", "rtracklayer"]
     },
     "customCMPdb": {
       "name": "customCMPdb",
-      "version": "1.16.0",
-      "sha256": "14fsg60j8kcqq13qm0k5vbqgr6kvz1055f0pv7pzmssih4v610yb",
+      "version": "1.18.0",
+      "sha256": "0pjv7dy0zlnqkqs3z6bgf5172bqvg1nvdip6xhkbmkyll4ai079c",
       "depends": ["AnnotationHub", "BiocFileCache", "ChemmineR", "RSQLite", "XML", "rappdirs"]
     },
     "customProDB": {
       "name": "customProDB",
-      "version": "1.46.0",
-      "sha256": "15q4mia5xh5s6kccaqj6wankp9bm5vzc0nwlbiy5s1qi9pj9x2hw",
+      "version": "1.48.0",
+      "sha256": "1ixpq5fasq2n2f1rbwi1icnb6v96hakkv7kqsvzmp2lraxqh5lv0",
       "depends": ["AhoCorasickTrie", "AnnotationDbi", "Biostrings", "DBI", "GenomeInfoDb", "GenomicAlignments", "GenomicFeatures", "GenomicRanges", "IRanges", "RCurl", "RSQLite", "Rsamtools", "S4Vectors", "VariantAnnotation", "biomaRt", "plyr", "rtracklayer", "stringr", "txdbmaker"]
     },
     "cyanoFilter": {
       "name": "cyanoFilter",
-      "version": "1.14.0",
-      "sha256": "1mlfwk1rfhxj6ky6vg62ahhxycj31jlsb8hqnkzh9i3xcvr2lgv2",
+      "version": "1.16.0",
+      "sha256": "1wr1lkvv9kjzcwf3zgz76h09ga95bnzcigvp2vnc7rk0f8lz7mn0",
       "depends": ["Biobase", "GGally", "cytometree", "flowClust", "flowCore", "flowDensity", "ggplot2", "mrfDepth"]
     },
     "cycle": {
       "name": "cycle",
-      "version": "1.60.0",
-      "sha256": "1f70fi3acbm403j0fh7c6n42ppn2ibhi1avzvj9brylagmrrzjzb",
+      "version": "1.62.0",
+      "sha256": "0q378jrqvrkm77y75fz6qjcw16njwfzlriy5249faxa0yf20xvab",
       "depends": ["Biobase", "Mfuzz"]
     },
     "cydar": {
       "name": "cydar",
-      "version": "1.30.0",
-      "sha256": "0xbf5dibvdb7h4y0anwi0574ypv4is9x62k7lnmq4jhvg6fjxmnv",
+      "version": "1.32.0",
+      "sha256": "1nj98qfcbzqdi9ynxc8yzkw7fjf0kiy2fzckwznd8wm26yhfk0ck",
       "depends": ["Biobase", "BiocGenerics", "BiocNeighbors", "BiocParallel", "Rcpp", "S4Vectors", "SingleCellExperiment", "SummarizedExperiment", "flowCore", "shiny", "viridis"]
     },
     "cypress": {
       "name": "cypress",
-      "version": "1.2.0",
-      "sha256": "1cqhm5nir8bcpb6jnd41wy4aw72lcwhv37q50jahla9n841p2gq6",
+      "version": "1.4.0",
+      "sha256": "0bvwwmaawa6xpxgfp775br5llqz82sz9wh5i3psvmwws7wsdczsn",
       "depends": ["BiocParallel", "DESeq2", "MASS", "PROPER", "RColorBrewer", "SummarizedExperiment", "TCA", "TOAST", "abind", "checkmate", "dplyr", "e1071", "edgeR", "mvtnorm", "preprocessCore", "rlang", "sirt", "tibble"]
     },
     "cytoKernel": {
       "name": "cytoKernel",
-      "version": "1.12.0",
-      "sha256": "0l1yxnjg3hvaya77vk5gl9sx9bpbb68ydapj7mpk5fqnflkw4f9s",
+      "version": "1.14.0",
+      "sha256": "07x046cwf59jsbnwcgwpjm5wzlmm84ccgwb1ygzsg1s8b6mzim6m",
       "depends": ["BiocParallel", "ComplexHeatmap", "Rcpp", "S4Vectors", "SummarizedExperiment", "ashr", "circlize", "data_table", "dplyr", "magrittr", "rlang"]
     },
     "cytoMEM": {
       "name": "cytoMEM",
-      "version": "1.10.0",
-      "sha256": "149ifhc28s844xyaa53yrcqp8yvfkbkddj3dxipc7xpyxkxi1ggp",
+      "version": "1.12.0",
+      "sha256": "0a86434v4v8phnssaza9zn5bgplq6667s0gss2ddn23l58yyc38b",
       "depends": ["flowCore", "gplots", "matrixStats"]
     },
     "cytofQC": {
       "name": "cytofQC",
-      "version": "1.6.0",
-      "sha256": "026v0j1jig4gm4gv3b382cvc2k69i811y9rqyk9cp3xrgmx5qld5",
+      "version": "1.8.0",
+      "sha256": "13lcf0bldkccpgz5673cn2n64wqmwx98qpb9vzdlbin981pxr5ny",
       "depends": ["CATALYST", "EZtune", "S4Vectors", "SingleCellExperiment", "SummarizedExperiment", "e1071", "flowCore", "gbm", "ggplot2", "hrbrthemes", "matrixStats", "randomForest", "rmarkdown", "ssc"]
     },
     "cytolib": {
       "name": "cytolib",
-      "version": "2.18.2",
-      "sha256": "0fiflwrrfz4259d7ykzq8kr443vwi80wg8y2v39v4ljxwlj7s9z8",
+      "version": "2.20.0",
+      "sha256": "1rv3dpqx6g7l6h1s6rpqipgyhhdzq6328zca1wg50kglqzdxx2a2",
       "depends": ["BH", "RProtoBufLib", "Rhdf5lib"]
     },
     "cytomapper": {
       "name": "cytomapper",
-      "version": "1.18.0",
-      "sha256": "0yadjkam643a99synnl2vx7nyfhc6x98qyhf972v5c3f8qj8jy08",
+      "version": "1.20.0",
+      "sha256": "0fgd654madgnr01v9wryh8yq2aqybqnq81nl34kki37dr73avfzb",
       "depends": ["BiocParallel", "DelayedArray", "EBImage", "HDF5Array", "RColorBrewer", "S4Vectors", "SingleCellExperiment", "SpatialExperiment", "SummarizedExperiment", "ggbeeswarm", "ggplot2", "matrixStats", "nnls", "raster", "rhdf5", "shiny", "shinydashboard", "svgPanZoom", "svglite", "viridis"]
     },
     "cytoviewer": {
       "name": "cytoviewer",
-      "version": "1.6.0",
-      "sha256": "11pn93r5sdzkd31jbyaajsmjx825yvhliadbzbnpw9v56l3gndxb",
+      "version": "1.8.0",
+      "sha256": "1qjmpkpy50izvb0aw92793k173hi88byny5ygna3bvv6mdf53glw",
       "depends": ["EBImage", "RColorBrewer", "S4Vectors", "SingleCellExperiment", "SummarizedExperiment", "archive", "colourpicker", "cytomapper", "shiny", "shinycssloaders", "shinydashboard", "svgPanZoom", "svglite", "viridis"]
     },
     "dStruct": {
       "name": "dStruct",
-      "version": "1.12.0",
-      "sha256": "0xa4lx5fj8w8biqnnfj2ks744bf7vprv8swa3lkds1nr8ydg1xzx",
+      "version": "1.14.0",
+      "sha256": "0xk5qmqkdi2pb6qfmxr1mm8lwdz9bxpxw0l49lfb3zwrhp5bssm7",
       "depends": ["IRanges", "S4Vectors", "ggplot2", "purrr", "reshape2", "rlang", "zoo"]
     },
     "daMA": {
       "name": "daMA",
-      "version": "1.78.0",
-      "sha256": "1gxh344z7jjisb5s8w3q1ky87ryn2n55ayadpwxdimqh2acbz9r5",
+      "version": "1.80.0",
+      "sha256": "0f7fcawfr8glqphihbvys8grirc13b4wlziqfbdljn1hi8sh6i8w",
       "depends": ["MASS"]
     },
     "dada2": {
       "name": "dada2",
-      "version": "1.34.0",
-      "sha256": "0vdvxr5s36wgkd4dry2m3ab3w4mcqhmf6y4phwg6vwmg4qrhdy0r",
+      "version": "1.36.0",
+      "sha256": "0lxva0lvh3xcpkrjalkg2ps8jlzaypnsy3ibd9mk4lnjpbn5hiii",
       "depends": ["BiocGenerics", "Biostrings", "IRanges", "Rcpp", "RcppParallel", "ShortRead", "XVector", "ggplot2", "reshape2"]
     },
     "dagLogo": {
       "name": "dagLogo",
-      "version": "1.44.0",
-      "sha256": "00x7abg5hrfd72lw70vqdvfbfdy49h3b7wzmd7c42nl26ryx1rm0",
+      "version": "1.46.0",
+      "sha256": "12pbxddfxwcd7izamzqjiac0vm4572lv4ghn39zysb9j8fbbjscm",
       "depends": ["BiocGenerics", "Biostrings", "UniProt_ws", "biomaRt", "httr", "motifStack", "pheatmap"]
+    },
+    "dandelionR": {
+      "name": "dandelionR",
+      "version": "1.0.0",
+      "sha256": "074ffacb89bg59byslfq27r2fp7ldp5647hdikd4ihn68bm4xbvv",
+      "depends": ["BiocGenerics", "MASS", "Matrix", "S4Vectors", "SingleCellExperiment", "SummarizedExperiment", "bluster", "destiny", "igraph", "miloR", "purrr", "rlang", "spam", "uwot"]
     },
     "dar": {
       "name": "dar",
-      "version": "1.2.0",
-      "sha256": "0j8ss3qc1m1klm83i8fpdsc1j66sb6wlw6b8fgcdgyvgd1ixj1yy",
+      "version": "1.4.0",
+      "sha256": "1yxvfk4dp4hpb90qkgwj7b4g79ydzykpxapwd1lvzk0iqa7f2nyx",
       "depends": ["ComplexHeatmap", "UpSetR", "cli", "crayon", "dplyr", "generics", "ggplot2", "glue", "gplots", "heatmaply", "magrittr", "mia", "phyloseq", "purrr", "readr", "rlang", "scales", "stringr", "tibble", "tidyr", "waldo"]
     },
     "dcGSA": {
       "name": "dcGSA",
-      "version": "1.34.0",
-      "sha256": "1bdw0g3ccx6rcqmjadrqi8j83hnyx9x2pk2w65mfnk7s9fhj23wp",
+      "version": "1.36.0",
+      "sha256": "0gpa7z68rrb7w866l3v37sx3i048r1jj42bxws26w8aldf6bzc7x",
       "depends": ["BiocParallel", "Matrix"]
     },
     "dcanr": {
       "name": "dcanr",
-      "version": "1.22.0",
-      "sha256": "1ddxvxsikfpq95bj5lrbf5a3gchal0idhksjj8mvxqjmxp7zclsr",
+      "version": "1.24.0",
+      "sha256": "1cmc40d8mbxh79pwwbqqwhbvmfib08asp04r2wi2gi24n80aw1im",
       "depends": ["Matrix", "RColorBrewer", "circlize", "doRNG", "foreach", "igraph", "plyr", "reshape2", "stringr"]
     },
     "dce": {
@@ -7877,5528 +8177,5678 @@
     },
     "ddCt": {
       "name": "ddCt",
-      "version": "1.62.0",
-      "sha256": "0j0p3c977ih7ha6wdb0p6xxv1q10invqzjf4yqc3bc29m9zxivbc",
+      "version": "1.64.0",
+      "sha256": "0qprpc9l6nzxlb66kq0zkylypc2ljjndbl5z70hpsy5vq5dwy1bv",
       "depends": ["Biobase", "BiocGenerics", "RColorBrewer", "lattice", "xtable"]
     },
     "ddPCRclust": {
       "name": "ddPCRclust",
-      "version": "1.26.0",
-      "sha256": "0zybz0lllg21w2h9a9yi8cinfcfgjamdgax2nciq17fhh3ngbfrd",
+      "version": "1.28.0",
+      "sha256": "0ky64kfan378xk4akjab7rh6s4bmghr2cdy8bvr07ihszbz3qrik",
       "depends": ["R_utils", "SamSPECTRAL", "clue", "flowCore", "flowDensity", "flowPeaks", "ggplot2", "openxlsx", "plotrix"]
     },
     "dearseq": {
       "name": "dearseq",
-      "version": "1.18.0",
-      "sha256": "0mk8flxgifwg8ckf41abiqqjmqi1217rrxqwg2xk26s4dk81m4pp",
+      "version": "1.20.0",
+      "sha256": "0as6dwgrxqshyid36435njkjvcjdasfrbl4lxgdm7yg930qr5al2",
       "depends": ["CompQuadForm", "KernSmooth", "dplyr", "ggplot2", "magrittr", "matrixStats", "patchwork", "pbapply", "reshape2", "rlang", "scattermore", "statmod", "survey", "tibble", "viridisLite"]
     },
     "debCAM": {
       "name": "debCAM",
-      "version": "1.24.0",
-      "sha256": "0wx6dvi5rihxlzm6wn67r5wni3dmk12fih2s0dw9qnwm56zk96a5",
+      "version": "1.26.0",
+      "sha256": "1sh8vbhgrkk1xfk139jxi88s2z70pnr4ji2pnb2gb3s5013zrhk8",
       "depends": ["Biobase", "BiocParallel", "DMwR2", "NMF", "SummarizedExperiment", "apcluster", "corpcor", "geometry", "nnls", "pcaPP", "rJava"]
     },
     "debrowser": {
       "name": "debrowser",
-      "version": "1.34.0",
-      "sha256": "13hw6w6ac4wk2vcj7yscdfjf9aqxi667911adq28gsgrdl0jjfkm",
+      "version": "1.36.0",
+      "sha256": "1p1r6hy8mamjvazg8cnz0v9i38fg15jnzndbm3707qa6caz5w7cz",
       "depends": ["AnnotationDbi", "DESeq2", "DOSE", "DT", "GenomicRanges", "Harman", "IRanges", "RColorBrewer", "RCurl", "S4Vectors", "SummarizedExperiment", "annotate", "apeglm", "ashr", "clusterProfiler", "colourpicker", "edgeR", "enrichplot", "ggplot2", "gplots", "heatmaply", "igraph", "jsonlite", "limma", "org_Hs_eg_db", "org_Mm_eg_db", "pathview", "plotly", "reshape2", "shiny", "shinyBS", "shinydashboard", "shinyjs", "stringi", "sva"]
     },
     "decompTumor2Sig": {
       "name": "decompTumor2Sig",
-      "version": "2.22.0",
-      "sha256": "1ixasxw98ymj793sd2crm0jdg73jmy535xhss5dws156mhzl4y0f",
+      "version": "2.24.0",
+      "sha256": "13rhg8hcraiqkdyyj85maj5zk37wlx7n5m046r9s8l4cm1pmvgqp",
       "depends": ["BSgenome_Hsapiens_UCSC_hg19", "BiocGenerics", "Biostrings", "GenomeInfoDb", "GenomicFeatures", "GenomicRanges", "Matrix", "S4Vectors", "SummarizedExperiment", "TxDb_Hsapiens_UCSC_hg19_knownGene", "VariantAnnotation", "data_table", "ggplot2", "ggseqlogo", "gridExtra", "plyr", "quadprog", "readxl"]
     },
     "decontX": {
       "name": "decontX",
-      "version": "1.4.1",
-      "sha256": "0rg5avvhxrnsnzkfbgry0s8s6wcahh5jy5g8jjvh3icfigk87krq",
+      "version": "1.6.0",
+      "sha256": "0yar28k3nk3xxx067iflza2zyl6c59k7s04515jmz3i6l9hyh764",
       "depends": ["BH", "DelayedArray", "MCMCprecision", "Matrix", "Rcpp", "RcppEigen", "RcppParallel", "S4Vectors", "Seurat", "SingleCellExperiment", "StanHeaders", "SummarizedExperiment", "celda", "dbscan", "ggplot2", "patchwork", "plyr", "reshape2", "rstan", "rstantools", "scater", "withr"]
     },
     "decontam": {
       "name": "decontam",
-      "version": "1.26.0",
-      "sha256": "0incm0dadkyn9n1k53cs19zgs3qc7y8hvfyq75vhqg670h4zyxkz",
+      "version": "1.28.0",
+      "sha256": "1xn071m88gd2dzqkz6avdwj04lwngfhmmx3v6rwn8dp7lmqlpxyb",
       "depends": ["ggplot2", "reshape2"]
     },
     "deconvR": {
       "name": "deconvR",
-      "version": "1.12.0",
-      "sha256": "1vl22cxrgfwixbrz40f0kq81ppybpv73fl8v14mfv6dp49pdkmml",
+      "version": "1.14.0",
+      "sha256": "076ay8fcihsk8y4kab7wdh96p6lpx4w3n78l3bnry2xnmywyxchk",
       "depends": ["BiocGenerics", "GenomicRanges", "IRanges", "MASS", "S4Vectors", "assertthat", "data_table", "dplyr", "e1071", "foreach", "magrittr", "matrixStats", "methylKit", "minfi", "nnls", "quadprog", "rsq", "tidyr"]
     },
     "decoupleR": {
       "name": "decoupleR",
-      "version": "2.12.0",
-      "sha256": "0m7rmx64lhxg1l4qnx3ajp8w97nabp62r5mi4rfy0gh40n7z34i7",
+      "version": "2.14.0",
+      "sha256": "00sx949jgnagil55miqb2mzq8bqfn8l44w761qwh7rs4xs83m33a",
       "depends": ["BiocParallel", "Matrix", "broom", "dplyr", "magrittr", "parallelly", "purrr", "rlang", "stringr", "tibble", "tidyr", "tidyselect", "withr"]
     },
     "deepSNV": {
       "name": "deepSNV",
-      "version": "1.52.0",
-      "sha256": "1prxiffyj2b7b7q5h2cc0w7ibzclm2wldqn0kcd66hqrmmcs7ypa",
+      "version": "1.54.0",
+      "sha256": "04m9k8gq7iv45srg8sa778dpc15qiq98rr9j3n1y5z11ghj15ijw",
       "depends": ["Biostrings", "GenomicRanges", "IRanges", "Rhtslib", "SummarizedExperiment", "VGAM", "VariantAnnotation"]
     },
     "deltaCaptureC": {
       "name": "deltaCaptureC",
-      "version": "1.20.0",
-      "sha256": "1dqn95480qb8imr85110z0x4chnx8kj0h78971dnvfckvldq1xqc",
+      "version": "1.22.0",
+      "sha256": "14qvbxbab930x4399vx64wz4l5bmspdj4kb7bmx8m1c0a2rwflws",
       "depends": ["DESeq2", "GenomicRanges", "IRanges", "SummarizedExperiment", "ggplot2", "tictoc"]
     },
     "deltaGseg": {
       "name": "deltaGseg",
-      "version": "1.46.0",
-      "sha256": "0lnz9vd7ji2b1lnrmanhj3nkra8hbbrs4w5pnkqhzx7p7al376mx",
+      "version": "1.48.0",
+      "sha256": "0xdm81wb0pmz9rcplfrc7px47hlaqv3kf92idvn3ldm46z4jlw4a",
       "depends": ["changepoint", "fBasics", "ggplot2", "pvclust", "reshape", "scales", "tseries", "wavethresh"]
     },
     "demuxSNP": {
       "name": "demuxSNP",
-      "version": "1.4.0",
-      "sha256": "0m8cry13chq7m80jhzxkv5gp1j48zc79ya1npdssr33iswj5jscs",
+      "version": "1.6.0",
+      "sha256": "02gnqd5myn8j4003hmyawaym43yb571dacd0i2np8sfzldc1v67m",
       "depends": ["BiocGenerics", "GenomeInfoDb", "IRanges", "KernelKnn", "Matrix", "MatrixGenerics", "SingleCellExperiment", "SummarizedExperiment", "VariantAnnotation", "class", "demuxmix", "dplyr", "ensembldb"]
     },
     "demuxmix": {
       "name": "demuxmix",
-      "version": "1.8.0",
-      "sha256": "06ln32h5jaqi3g0xs1crmbpyqbb6ycikr1ghszvwxsrgwx8sa1g7",
+      "version": "1.10.0",
+      "sha256": "1vdgalqwn1gflhabf9aqzb591gakaq0yh6ddic9l79awj1i04266",
       "depends": ["MASS", "Matrix", "ggplot2", "gridExtra"]
     },
     "densvis": {
       "name": "densvis",
-      "version": "1.16.0",
-      "sha256": "0acqdhi13ihv9bxr2n5gh8ysk0ciak273pj495qr3s1pd8qz8772",
+      "version": "1.18.0",
+      "sha256": "10finfm8fr0pvl6gnv9q90x3xlyccn2mbka4y08vjiyq50mzgla6",
       "depends": ["Rcpp", "Rtsne", "assertthat", "basilisk", "irlba", "reticulate"]
     },
     "derfinder": {
       "name": "derfinder",
-      "version": "1.40.0",
-      "sha256": "0qg1klbb4g8nw7v50xb0p022barlspwaisdymyk12a04vd9q4i79",
+      "version": "1.42.0",
+      "sha256": "083y2qsy1ix7ikz8ppf4b49ya4ipf18sxc3gznisybx807nsk4zs",
       "depends": ["AnnotationDbi", "BiocGenerics", "BiocParallel", "GenomeInfoDb", "GenomicAlignments", "GenomicFeatures", "GenomicFiles", "GenomicRanges", "Hmisc", "IRanges", "Rsamtools", "S4Vectors", "bumphunter", "derfinderHelper", "qvalue", "rtracklayer"]
     },
     "derfinderHelper": {
       "name": "derfinderHelper",
-      "version": "1.40.0",
-      "sha256": "0cs0m5ng6m932qsdzmi8rv2p3wc0d6hx17n75srgjbm4cdq70q8h",
+      "version": "1.42.0",
+      "sha256": "1sww441lkk6i24a8cxamwwfa64lgdgsv57h1sq605bsswml9ird0",
       "depends": ["IRanges", "Matrix", "S4Vectors"]
     },
     "derfinderPlot": {
       "name": "derfinderPlot",
-      "version": "1.40.0",
-      "sha256": "08bzrciqs32gjz1js2505lp11bhvbclaj96js1v5h9454ab7zkw4",
+      "version": "1.42.0",
+      "sha256": "12sjwmjj9b61m6baa24ghg6iy0f87yq32km1rr59j5mmjmdhmrj1",
       "depends": ["GenomeInfoDb", "GenomicFeatures", "GenomicRanges", "IRanges", "RColorBrewer", "S4Vectors", "derfinder", "ggbio", "ggplot2", "limma", "plyr", "reshape2", "scales"]
     },
     "destiny": {
       "name": "destiny",
-      "version": "3.20.0",
-      "sha256": "15avvn8mfr899j18pahn2w3wlgj7g8jy6plnxabrch81bv79rva3",
+      "version": "3.22.0",
+      "sha256": "01l01b6k55ifhppsp83scjf3f168r62xigz73s718ik8qbvirgqa",
       "depends": ["Biobase", "BiocGenerics", "Matrix", "RSpectra", "Rcpp", "RcppEigen", "RcppHNSW", "SingleCellExperiment", "SummarizedExperiment", "VIM", "ggplot2", "ggplot_multistats", "ggthemes", "irlba", "knn_covertree", "pcaMethods", "proxy", "rlang", "scales", "scatterplot3d", "smoother", "tidyr", "tidyselect"]
     },
     "diffGeneAnalysis": {
       "name": "diffGeneAnalysis",
-      "version": "1.88.0",
-      "sha256": "13rgdp2pycin7f1818yzc6a2ns9i5cj41g0dp0kg72qz9fjq685g",
+      "version": "1.90.0",
+      "sha256": "0vsbl4g5rq5dg1l3n3kapfwl9bmrxibdrm39hcjjh0rf7w5kfd3k",
       "depends": ["minpack_lm"]
     },
     "diffHic": {
       "name": "diffHic",
-      "version": "1.38.0",
-      "sha256": "095fpc8llijrbv51qp7gq5pniwwm5ggypipzgr9lnzbrlpi17qp8",
-      "depends": ["BSgenome", "BiocGenerics", "Biostrings", "GenomeInfoDb", "GenomicRanges", "IRanges", "InteractionSet", "Rcpp", "Rhtslib", "Rsamtools", "S4Vectors", "SummarizedExperiment", "csaw", "edgeR", "limma", "locfit", "rhdf5", "rtracklayer", "zlibbioc"]
+      "version": "1.40.0",
+      "sha256": "0yanl7awdxk9z4gxv48df9qpniwqmfalp4fisfac1yabrs681266",
+      "depends": ["BSgenome", "BiocGenerics", "Biostrings", "GenomeInfoDb", "GenomicRanges", "IRanges", "InteractionSet", "Rcpp", "Rhtslib", "Rsamtools", "S4Vectors", "SummarizedExperiment", "csaw", "edgeR", "limma", "locfit", "rhdf5", "rtracklayer"]
     },
     "diffUTR": {
       "name": "diffUTR",
-      "version": "1.14.0",
-      "sha256": "1grga6078841abgchq6baks0i0rc108b12jn8j9f7k0v8a4kmcvx",
+      "version": "1.16.0",
+      "sha256": "0srj0jv7kq5zs87k3d4s6h94mfbg9gdb2p98rhyyrx9bc36ijcqi",
       "depends": ["ComplexHeatmap", "DEXSeq", "GenomeInfoDb", "GenomicRanges", "IRanges", "Rsubread", "S4Vectors", "SummarizedExperiment", "dplyr", "edgeR", "ensembldb", "ggplot2", "ggrepel", "limma", "matrixStats", "rtracklayer", "stringi", "viridisLite"]
     },
     "diffcoexp": {
       "name": "diffcoexp",
-      "version": "1.26.0",
-      "sha256": "1wwpjw7vxz3572h2yy26cfinc314x10zcsjx7am0cynkzb16cidx",
+      "version": "1.28.0",
+      "sha256": "0gx8c3wsdzx7yh9sqykvh346lk47xw8zph50x1j5jrkqbnvrahws",
       "depends": ["BiocGenerics", "DiffCorr", "SummarizedExperiment", "WGCNA", "igraph", "psych"]
     },
     "diffcyt": {
       "name": "diffcyt",
-      "version": "1.26.1",
-      "sha256": "15204z21246hkh7nmizx7m9wh208ml3036anaxrq5yh5ymhhclss",
+      "version": "1.28.0",
+      "sha256": "16z53ghrvv3rc1c6bbw9n8yywfzvl1bzzm0h3axhqzk0r8mlzgj8",
       "depends": ["ComplexHeatmap", "FlowSOM", "S4Vectors", "SummarizedExperiment", "circlize", "dplyr", "edgeR", "flowCore", "limma", "lme4", "magrittr", "multcomp", "reshape2", "tidyr"]
     },
     "diffuStats": {
       "name": "diffuStats",
-      "version": "1.26.0",
-      "sha256": "1kl5nirs0n8x51p2x3yggn483hxwrgm2a301lky418fm1jvd0kv3",
+      "version": "1.28.0",
+      "sha256": "0plyan6dyp19ssba30k5giafg18h92by1vmfzncknjykj1sb3r9q",
       "depends": ["MASS", "Matrix", "Rcpp", "RcppArmadillo", "RcppParallel", "checkmate", "expm", "igraph", "plyr", "precrec"]
     },
     "diggit": {
       "name": "diggit",
-      "version": "1.38.0",
-      "sha256": "1x5pk95nwcz17gjrjj7vxyn2ci75qmjq054sj6p23ax2lplsvnir",
+      "version": "1.40.0",
+      "sha256": "19cg56s0aw2vnw8yg94l9zpg69q4cpmmqvdmh1wa31g0cg1rwsrw",
       "depends": ["Biobase", "ks", "viper"]
     },
     "dinoR": {
       "name": "dinoR",
-      "version": "1.2.0",
-      "sha256": "19q0223jqj7ag04r6gz6may5y66j01r6lv15dppqhv49icqnnd4a",
+      "version": "1.4.0",
+      "sha256": "1ys0jygld8jz06lh3lpa9cvmda8cc80da791fvg1fjklvg0p1zjh",
       "depends": ["BiocGenerics", "ComplexHeatmap", "GenomicRanges", "Matrix", "SummarizedExperiment", "circlize", "cowplot", "dplyr", "edgeR", "ggplot2", "rlang", "stringr", "tibble", "tidyr", "tidyselect"]
     },
     "dir_expiry": {
       "name": "dir.expiry",
-      "version": "1.14.0",
-      "sha256": "1907n8q1y57qvrl754r888zb0vgrc0pdpvgxxki26h1x6x1y3nf8",
+      "version": "1.16.0",
+      "sha256": "09hsmml075v0ccynq6mps24frjf79mj8nl7xbzykglvwbjbs9h7f",
       "depends": ["filelock"]
     },
     "discordant": {
       "name": "discordant",
-      "version": "1.30.0",
-      "sha256": "1404g5g1gvqym6xqpq03j5v9wfhkb822mdjk6mf4kxyh4ii1xr5d",
+      "version": "1.32.0",
+      "sha256": "1gjqxjypv323pa9klbhax61i884n5rdvzgwxnqbhbam6vzcid6vv",
       "depends": ["Biobase", "MASS", "Rcpp", "biwt", "dplyr", "gtools"]
     },
     "distinct": {
       "name": "distinct",
-      "version": "1.18.0",
-      "sha256": "13f711z8yqv23565qi7qh5p5b5dpaicrkqg4xdd1iw7aly5wshyv",
+      "version": "1.20.0",
+      "sha256": "09qccx43sj7pcffh8gbi7213iyz8paxh6z70lff0dv0zs9nza8k7",
       "depends": ["Matrix", "Rcpp", "RcppArmadillo", "SingleCellExperiment", "SummarizedExperiment", "doParallel", "doRNG", "foreach", "ggplot2", "limma", "scater"]
     },
     "dittoSeq": {
       "name": "dittoSeq",
-      "version": "1.18.0",
-      "sha256": "0c38wq57kpm7pjsca2kpyr2rmk37wak66d57mxsd6bwxmqzsys2r",
+      "version": "1.20.0",
+      "sha256": "013m2fhczxmq1jk05fjyih2aphaqylpmvfby7z8wk91g51221q48",
       "depends": ["S4Vectors", "SingleCellExperiment", "SummarizedExperiment", "colorspace", "cowplot", "ggplot2", "ggrepel", "ggridges", "gridExtra", "pheatmap", "reshape2"]
     },
     "divergence": {
       "name": "divergence",
-      "version": "1.22.0",
-      "sha256": "0qfs95j5541bfqb88lkvyk5nd96m68jiz3y54ifrdrfbp15hcrrs",
+      "version": "1.24.0",
+      "sha256": "0vzv741qxkjkq8l5xq53qlrdr7mjq2qlacpddr0w8b6sc6kjblh4",
       "depends": ["SummarizedExperiment"]
     },
     "dks": {
       "name": "dks",
-      "version": "1.52.0",
-      "sha256": "04m3klghrwjc3pbpv4i5d0sfq8i3ypj3jb42w8pwlx5am7jacmjy",
+      "version": "1.54.0",
+      "sha256": "1vibsj07rqix1b6dbgzv2z30jkv39mfqq1pajvxb99pb1q7gm009",
       "depends": ["cubature"]
     },
     "dmrseq": {
       "name": "dmrseq",
-      "version": "1.26.0",
-      "sha256": "1glhz06hl5x7326lp3b8wz79vmvx855yy691cm4qzmgyxi16pdxy",
+      "version": "1.28.0",
+      "sha256": "0zqp8nn3qhw7ds5y34apy3cwi6mb2kj8ywkkml26m5jyc613hj9i",
       "depends": ["AnnotationHub", "BiocParallel", "DelayedMatrixStats", "GenomeInfoDb", "GenomicRanges", "IRanges", "RColorBrewer", "S4Vectors", "annotatr", "bsseq", "bumphunter", "ggplot2", "locfit", "matrixStats", "nlme", "outliers", "rtracklayer"]
     },
     "dominoSignal": {
       "name": "dominoSignal",
-      "version": "1.0.0",
-      "sha256": "0lkd7w5j68ilzfzlgm275ic6ispiqbjmk6zjrjgggpb0nq7i67lm",
-      "depends": ["ComplexHeatmap", "Matrix", "biomaRt", "circlize", "ggpubr", "igraph", "plyr"]
+      "version": "1.2.0",
+      "sha256": "02bsz2nd6yjybhnkna8ixhchq0hvbkhm0jz5cfbddyvgyqg5f7ix",
+      "depends": ["ComplexHeatmap", "Matrix", "biomaRt", "circlize", "dplyr", "ggpubr", "igraph", "magrittr", "plyr", "purrr"]
     },
     "doppelgangR": {
       "name": "doppelgangR",
-      "version": "1.34.0",
-      "sha256": "1hhb6cbpx1w4g8m5f6gxghvnlizsmc91hz75jb75h3rgqrr6j1ns",
+      "version": "1.36.0",
+      "sha256": "1zjp2ds2xfxl85sczca416jbcfxgxigr266rzd24d2ggcpbh8jc5",
       "depends": ["Biobase", "BiocParallel", "SummarizedExperiment", "digest", "impute", "mnormt", "sva"]
     },
     "doseR": {
       "name": "doseR",
-      "version": "1.22.0",
-      "sha256": "1knc4gzblakcngg77gbwickr5rj665wqayqwc1wvc5yhgdp7k04q",
+      "version": "1.24.0",
+      "sha256": "0h6m4z9lk32xxy14dcrvpvwfsg574qgyfa89smrjxcnccsn3rck6",
       "depends": ["RUnit", "S4Vectors", "SummarizedExperiment", "digest", "edgeR", "lme4", "matrixStats", "mclust"]
     },
     "doubletrouble": {
       "name": "doubletrouble",
-      "version": "1.6.0",
-      "sha256": "09bzjfw199pp7dlcmpa0r7jnan8dhbx96n7yk5lfq160nwycq472",
+      "version": "1.8.0",
+      "sha256": "1m26a8m6sqsd1s2b6g1k7qb9n3ndrvlhz64py3fgqd38d1h47vpg",
       "depends": ["AnnotationDbi", "Biostrings", "GenomicFeatures", "GenomicRanges", "MSA2dist", "ggplot2", "mclust", "rlang", "syntenet"]
     },
     "drawProteins": {
       "name": "drawProteins",
-      "version": "1.26.0",
-      "sha256": "1kzjni6nyacjyjvrwqrr3pnh93cjhxzylrwm38wfpnmp1ng94mgl",
+      "version": "1.28.0",
+      "sha256": "06fv2fhka123kj9rc2h0z07ym30wxk24fq8v0pzmf8gfyg4ywgfj",
       "depends": ["dplyr", "ggplot2", "httr", "readr", "tidyr"]
     },
     "dreamlet": {
       "name": "dreamlet",
-      "version": "1.4.1",
-      "sha256": "0vbmqlv9ab5zqcwliszr6rxqac3fafdd0jdm9ggp6hl334rwc3m8",
+      "version": "1.6.0",
+      "sha256": "0cp6iwdkp399nzj3a7gmyak6y5v2kzkvhqcm7rrj047pxyjb7yc8",
       "depends": ["BiocGenerics", "BiocParallel", "DelayedArray", "DelayedMatrixStats", "GSEABase", "IRanges", "MASS", "Matrix", "MatrixGenerics", "Rcpp", "Rdpack", "S4Arrays", "S4Vectors", "SingleCellExperiment", "SparseArray", "SummarizedExperiment", "ashr", "beachmat", "broom", "data_table", "dplyr", "edgeR", "ggbeeswarm", "ggplot2", "ggrepel", "gtools", "irlba", "limma", "lme4", "mashr", "metafor", "purrr", "remaCor", "reshape2", "rlang", "scattermore", "sparseMatrixStats", "tidyr", "variancePartition", "zenith"]
     },
     "drugTargetInteractions": {
       "name": "drugTargetInteractions",
-      "version": "1.14.0",
-      "sha256": "0vlxc360k0qz1sljw9nxx5bw0y9kzyxpr28fj13a2psdr6zmgmjp",
+      "version": "1.16.0",
+      "sha256": "129bdb7aaf16az9nms0qv4akgqjkqvrn95g8m6c311c44f9a9rvs",
       "depends": ["AnnotationFilter", "BiocFileCache", "RSQLite", "S4Vectors", "UniProt_ws", "biomaRt", "dplyr", "ensembldb", "rappdirs"]
     },
     "dupRadar": {
       "name": "dupRadar",
-      "version": "1.36.0",
-      "sha256": "0pwp43w4w2xsbc8kq1x8svz35s3p116jwr3a4z895d0fizlyhahn",
+      "version": "1.38.0",
+      "sha256": "1r9n8fjb2spkvdaqbzpa50dn6cv9l995ljn4ac52ypr2z920nph1",
       "depends": ["KernSmooth", "Rsubread"]
     },
     "dyebias": {
       "name": "dyebias",
-      "version": "1.66.0",
-      "sha256": "0fgm33jshsxidrba1kqsnkkhzsfl8a2jwrwf69nljj36f6nn264l",
+      "version": "1.68.0",
+      "sha256": "0r42siraii99pvac7za1383c12pl1i2i2x4n64ca6rkyjqfpzqm6",
       "depends": ["Biobase", "marray"]
     },
     "easier": {
       "name": "easier",
-      "version": "1.12.0",
-      "sha256": "1p2134xi5d9miwfng1z04035ysb7vy9w6037sgky944dk1y6j0m2",
+      "version": "1.14.0",
+      "sha256": "1kdnglx6ixnff36vbpl01qv2y8kg61h936dx2qmqsqlyyc2id0n0",
       "depends": ["BiocParallel", "DESeq2", "ROCR", "coin", "decoupleR", "dorothea", "dplyr", "easierData", "ggplot2", "ggpubr", "ggrepel", "magrittr", "matrixStats", "progeny", "quantiseqr", "reshape2", "rlang", "rstatix", "tibble", "tidyr"]
     },
     "easyRNASeq": {
       "name": "easyRNASeq",
-      "version": "2.42.0",
-      "sha256": "1yjcha2mj736jl838g4km5zsbjilzdcrzcwf8ivwm1yap0jbsd3d",
+      "version": "2.44.0",
+      "sha256": "09nw3afdri5ypdmn5jb7s3pi3a4yv40f4ajh53wnsvsav47c7zla",
       "depends": ["Biobase", "BiocFileCache", "BiocGenerics", "BiocParallel", "Biostrings", "GenomeInfoDb", "GenomicAlignments", "GenomicRanges", "IRanges", "LSD", "Rsamtools", "S4Vectors", "ShortRead", "SummarizedExperiment", "biomaRt", "edgeR", "genomeIntervals", "rappdirs"]
     },
     "easylift": {
       "name": "easylift",
-      "version": "1.4.0",
-      "sha256": "05mfqwl2fxm487f3hal4ydv308dysd4kiwvnj4nk1ibfsh3hzxqf",
+      "version": "1.6.0",
+      "sha256": "1d07dmrcivw9z7sv274apbdkk2bi282j2ky3xxngzhjwvlq2lpxq",
       "depends": ["BiocFileCache", "GenomeInfoDb", "GenomicRanges", "R_utils", "rtracklayer"]
     },
     "easyreporting": {
       "name": "easyreporting",
-      "version": "1.18.0",
-      "sha256": "0b2ykgdipnpm77hw6k3f29lphw9y3c3ld6cb5m0hr43pjzvgiczm",
+      "version": "1.20.0",
+      "sha256": "1bjhqy7i6f4ymab22n23i6wyx1v1swlprkbxrldfwp9fqaqzn6ji",
       "depends": ["rlang", "rmarkdown", "shiny"]
     },
     "ecolitk": {
       "name": "ecolitk",
-      "version": "1.78.0",
-      "sha256": "1pj09s8jk5h7qwjlgvsmw97qmsjm7pw857ijswhy90gf3xv8h0s4",
+      "version": "1.80.0",
+      "sha256": "1mv4jp1gwhbcill3zcwalh146jz052dfxcsklvwd91v2x5n0d49f",
       "depends": ["Biobase"]
     },
     "edge": {
       "name": "edge",
-      "version": "2.38.0",
-      "sha256": "1qr8mq8isr2sw4b9y0r7vb567001r6pj7l950f4r9xlb440ravvk",
+      "version": "2.40.0",
+      "sha256": "0a4hlr3j4wwichiad40mvgdb6zs9ss0ap1qyjhjwbrbndlyjw0cd",
       "depends": ["Biobase", "MASS", "qvalue", "sva"]
     },
     "edgeR": {
       "name": "edgeR",
-      "version": "4.4.2",
-      "sha256": "0gvyc0iyn0ph888jryci52a2q35myr82m1ari8y5gjpkw4n5j846",
+      "version": "4.6.0",
+      "sha256": "138pnix9nslbafrxsa1l114abb5ajpk98yb57z9pfyxbdgad52hn",
       "depends": ["limma", "locfit"]
     },
     "eds": {
       "name": "eds",
-      "version": "1.8.0",
-      "sha256": "0ba57wg345970l2j780ipjxy8h803jnwxk7p81qdd887045kykqj",
+      "version": "1.10.0",
+      "sha256": "1a2wk6v9vx1zzwd7h71n1dqb4a0s7d0igmzp2fdb5sbscxshpgsr",
       "depends": ["Matrix", "Rcpp"]
     },
     "eiR": {
       "name": "eiR",
-      "version": "1.46.0",
-      "sha256": "1p5q54axwz23chgmay11w3vbnrji6gfz6w6prmpr24lpw5m3f9dr",
+      "version": "1.48.0",
+      "sha256": "0j9015icchzcgks55jpmix4xkxhrwfgc20vgblbv5c85h26mqhsk",
       "depends": ["BiocGenerics", "ChemmineR", "DBI", "RCurl", "RUnit", "RcppAnnoy", "digest", "snow", "snowfall"]
     },
     "eisaR": {
       "name": "eisaR",
-      "version": "1.18.0",
-      "sha256": "1778r9f11kmmp278lflfja9nk4rpijq295s9nz1w6bzfgccchvwf",
+      "version": "1.20.0",
+      "sha256": "1hhi2lbmja6xbcxzjplaarsslc1jvim1v1yr1skmknl8fq6zbzz5",
       "depends": ["BiocGenerics", "GenomicRanges", "IRanges", "S4Vectors", "SummarizedExperiment", "edgeR", "limma"]
     },
     "enhancerHomologSearch": {
       "name": "enhancerHomologSearch",
-      "version": "1.12.0",
-      "sha256": "0yzs9z3bwz5pkkwx26pqxgl3mkjq3cgpwfvbsf0l4p5r86nf4rv7",
+      "version": "1.14.0",
+      "sha256": "0i2aiq4q9lypyn0sgz6s1mbmw6hah0zffzmyp008hz82m86a8xpp",
       "depends": ["BSgenome", "BiocFileCache", "BiocGenerics", "BiocParallel", "Biostrings", "GenomeInfoDb", "GenomicRanges", "IRanges", "Matrix", "Rcpp", "S4Vectors", "httr", "jsonlite", "motifmatchr", "pwalign", "rtracklayer"]
     },
     "enrichViewNet": {
       "name": "enrichViewNet",
-      "version": "1.4.0",
-      "sha256": "06acbr0nmwf8q0cpwhdzd68900d5793p8gg0ljz35d2kcskpd017",
+      "version": "1.6.0",
+      "sha256": "0handzfkmnq0s7dy0h9dc4a0x98r1g2jf9hhp38snyxzlszjgkqx",
       "depends": ["DOSE", "RCy3", "enrichplot", "gprofiler2", "jsonlite", "strex", "stringr"]
     },
     "enrichplot": {
       "name": "enrichplot",
-      "version": "1.26.6",
-      "sha256": "15kvlswzlvingdldw7kjxd9lqbcd0qan5c4k6av8p1fikwsaj0wf",
+      "version": "1.28.0",
+      "sha256": "0djj893d361r5b09kjmqsakx9qgvxp8mxvxwzmd324l12fprs9pv",
       "depends": ["DOSE", "GOSemSim", "RColorBrewer", "aplot", "ggfun", "ggnewscale", "ggplot2", "ggrepel", "ggtangle", "ggtree", "igraph", "magrittr", "plyr", "purrr", "reshape2", "rlang", "scatterpie", "yulab_utils"]
     },
     "ensembldb": {
       "name": "ensembldb",
-      "version": "2.30.0",
-      "sha256": "1p7hlhyzirzcq1g0i62hr3l4k60fm4y04qb4k04lls8wynfxhy0a",
+      "version": "2.32.0",
+      "sha256": "0h7jhryn6f3gdr2189nm7d18n6kh7wgh95l93ng1rs1n20vsn1a4",
       "depends": ["AnnotationDbi", "AnnotationFilter", "Biobase", "BiocGenerics", "Biostrings", "DBI", "GenomeInfoDb", "GenomicFeatures", "GenomicRanges", "IRanges", "ProtGenerics", "RSQLite", "Rsamtools", "S4Vectors", "curl", "rtracklayer"]
     },
     "epiNEM": {
       "name": "epiNEM",
-      "version": "1.30.0",
-      "sha256": "0q8akbj67kra03fryi5b4lnlbkr0gcqrvf0gd6qmxn28fhsg3ph9",
+      "version": "1.32.0",
+      "sha256": "1mgdvfiq5lxp5j18b91rnaqjiqaxksm6g15crq0ivjllkad4564g",
       "depends": ["BoolNet", "BoutrosLab_plotting_general", "RColorBrewer", "e1071", "graph", "gtools", "igraph", "latex2exp", "lattice", "latticeExtra", "minet", "mnem", "pcalg"]
     },
     "epialleleR": {
       "name": "epialleleR",
-      "version": "1.14.0",
-      "sha256": "0zdas9qb4palfakwrahlk2l4qj2nz371iqlqphs2nclmr6dbhj5w",
+      "version": "1.16.0",
+      "sha256": "0qac87i0jfiz73m3npbqk77yzn2vv7b7p0bfpmhh57zc6xgg90c9",
       "depends": ["BH", "BiocGenerics", "GenomicRanges", "Rcpp", "Rhtslib", "data_table"]
     },
     "epidecodeR": {
       "name": "epidecodeR",
-      "version": "1.14.0",
-      "sha256": "0iy6ffyar28miyg8k0y1grri0kf9sr51ik7xlllhj4hdra8dffk3",
+      "version": "1.16.0",
+      "sha256": "0xamhd0zjx935v7lg009anfkrdrjhdbfskji4ngs05mq793m816y",
       "depends": ["EnvStats", "GenomicRanges", "IRanges", "dplyr", "ggplot2", "ggpubr", "rstatix", "rtracklayer"]
     },
     "epigenomix": {
       "name": "epigenomix",
-      "version": "1.46.0",
-      "sha256": "12dbs4gyypkykaswpwiyx3sfyrxsp3g44ngxgk0yp8nas76m8c4x",
+      "version": "1.48.0",
+      "sha256": "1hrzx21ycn8yf23k7mpp4vnpndiq8xawyhvy0ghsia4q9liv4fyv",
       "depends": ["Biobase", "BiocGenerics", "GenomeInfoDb", "GenomicRanges", "IRanges", "MCMCpack", "Rsamtools", "S4Vectors", "SummarizedExperiment", "beadarray"]
     },
     "epigraHMM": {
       "name": "epigraHMM",
-      "version": "1.14.0",
-      "sha256": "1cj9mypj3kbns4n4k4gm5d7g4zdhm4sddg8brv0yap94hpyj1lnp",
+      "version": "1.15.0",
+      "sha256": "1dyp2dryzd2bsxwaqym6ik5v7izg6pv9hncvdpp6jag7fi4f6zsk",
       "depends": ["GenomeInfoDb", "GenomicRanges", "GreyListChIP", "IRanges", "MASS", "Matrix", "Rcpp", "RcppArmadillo", "Rhdf5lib", "Rsamtools", "S4Vectors", "SummarizedExperiment", "bamsignals", "csaw", "data_table", "ggplot2", "ggpubr", "limma", "magrittr", "pheatmap", "rhdf5", "rtracklayer", "scales"]
     },
     "epimutacions": {
       "name": "epimutacions",
-      "version": "1.10.0",
-      "sha256": "1qpdmir7fi4pq1rh1bf35yak1snb8xcppj8kd42z17cjxqcr6f1h",
+      "version": "1.12.0",
+      "sha256": "1sv2vjpg4bdky9vjph6g6hpgmzhzk5142dbxmw26dwh5k4ix45xj",
       "depends": ["AnnotationDbi", "AnnotationHub", "BiocGenerics", "BiocParallel", "ExperimentHub", "GenomeInfoDb", "GenomicFeatures", "GenomicRanges", "Gviz", "Homo_sapiens", "IRanges", "IlluminaHumanMethylation450kanno_ilmn12_hg19", "IlluminaHumanMethylation450kmanifest", "IlluminaHumanMethylationEPICanno_ilm10b2_hg19", "IlluminaHumanMethylationEPICmanifest", "S4Vectors", "SummarizedExperiment", "TxDb_Hsapiens_UCSC_hg18_knownGene", "TxDb_Hsapiens_UCSC_hg19_knownGene", "TxDb_Hsapiens_UCSC_hg38_knownGene", "biomaRt", "bumphunter", "ensembldb", "epimutacionsData", "ggplot2", "ggrepel", "gridExtra", "isotree", "matrixStats", "minfi", "purrr", "reshape2", "robustbase", "rtracklayer", "tibble"]
     },
     "epiregulon": {
       "name": "epiregulon",
-      "version": "1.2.0",
-      "sha256": "0vjr1fhvl6q796n30kh7cssxskq2gmp9kqr27yny1ldj9dd4g0av",
+      "version": "1.4.0",
+      "sha256": "0kcbck56myl79npnsqapgsg2i5zxrlyd1j10qpr7i1dq41gjpqsm",
       "depends": ["AUCell", "AnnotationHub", "BSgenome_Hsapiens_UCSC_hg19", "BSgenome_Hsapiens_UCSC_hg38", "BSgenome_Mmusculus_UCSC_mm10", "BiocParallel", "ExperimentHub", "GenomeInfoDb", "GenomicRanges", "IRanges", "Matrix", "Rcpp", "S4Vectors", "SingleCellExperiment", "SummarizedExperiment", "assorthead", "beachmat", "bluster", "checkmate", "entropy", "lifecycle", "motifmatchr", "scMultiome", "scran", "scuttle"]
     },
     "epiregulon_extra": {
       "name": "epiregulon.extra",
-      "version": "1.2.0",
-      "sha256": "0kqdmc0csfyn7hw998pdsz45x3d7iwji1qdmhsmj8vr8gxm63gsk",
-      "depends": ["ComplexHeatmap", "Matrix", "SingleCellExperiment", "SummarizedExperiment", "checkmate", "circlize", "clusterProfiler", "ggplot2", "ggraph", "igraph", "lifecycle", "patchwork", "reshape2", "scales", "scater", "scran"]
+      "version": "1.4.0",
+      "sha256": "08mc1awkvhknsb5x8w7c4s0p8a1jhdcs8yygk1n93pw48n2vkb3c",
+      "depends": ["ComplexHeatmap", "Matrix", "SingleCellExperiment", "SummarizedExperiment", "checkmate", "circlize", "clusterProfiler", "ggplot2", "ggraph", "igraph", "patchwork", "reshape2", "scales", "scater", "scran"]
     },
     "epistack": {
       "name": "epistack",
-      "version": "1.12.0",
-      "sha256": "0yr9b4wgp7j23hqwd64vc5mwqz1lgis1rpfam67n95kwi6i516ca",
+      "version": "1.14.0",
+      "sha256": "1yr12p2xr39a4jjpfw5y605wsdh7sbmiwsfj0yjlyzxvjp48nkpj",
       "depends": ["BiocGenerics", "GenomicRanges", "IRanges", "S4Vectors", "SummarizedExperiment", "plotrix"]
     },
     "epistasisGA": {
       "name": "epistasisGA",
-      "version": "1.8.0",
-      "sha256": "1fknmbw91mg0aczpywl09d8kqzl9lzibf336v13p12cikzra6wph",
+      "version": "1.10.0",
+      "sha256": "18sg3csw8pp2zmvp2ly9ff2hfa7p5igs81sjmzqlhglcn08nll9w",
       "depends": ["BH", "BiocParallel", "Rcpp", "RcppArmadillo", "batchtools", "bigmemory", "data_table", "ggplot2", "igraph", "matrixStats", "qgraph", "survival"]
     },
     "epivizr": {
       "name": "epivizr",
-      "version": "2.36.0",
-      "sha256": "110zlfs8m3jz5hg2x60njh9cljnaxzzqdivdvdvwsbfs4lj8pmd6",
+      "version": "2.38.0",
+      "sha256": "0bj5wps73b5lxh9k8jkhyhprsfaifc4g6jllrzahlgdxy7yknj81",
       "depends": ["GenomeInfoDb", "GenomicRanges", "IRanges", "S4Vectors", "bumphunter", "epivizrData", "epivizrServer"]
     },
     "epivizrChart": {
       "name": "epivizrChart",
-      "version": "1.28.0",
-      "sha256": "1i7icadcidw7xpg81irk7415806v9ijhjchilldv03rka7qrrc98",
+      "version": "1.30.0",
+      "sha256": "0i2d7bxzz5mmdy9mkzw98mdj9bicycj4xz9flh29yavwg35kgwy7",
       "depends": ["BiocGenerics", "epivizrData", "epivizrServer", "htmltools", "rjson"]
     },
     "epivizrData": {
       "name": "epivizrData",
-      "version": "1.34.0",
-      "sha256": "19rlgvhbh13wgvj9dy7h4r0ik1fdvhwsjnbvxd0hkiylrlfzklbk",
+      "version": "1.36.0",
+      "sha256": "11m31lik07blzigb2z7skzapk7yn6n26gy4h20qh8dq2l6ijvqdc",
       "depends": ["Biobase", "GenomeInfoDb", "GenomicFeatures", "GenomicRanges", "IRanges", "OrganismDbi", "S4Vectors", "SummarizedExperiment", "ensembldb", "epivizrServer"]
     },
     "epivizrServer": {
       "name": "epivizrServer",
-      "version": "1.34.0",
-      "sha256": "0fyxkrjq125x8jkrx23c6k10p4fnjdmhs7lkh1kf54dwg0h3f2p3",
+      "version": "1.36.0",
+      "sha256": "12faax9c502yxd4k0dflcwgg7n2lydai6r65nr76pw4qs6pgczvp",
       "depends": ["R6", "httpuv", "mime", "rjson"]
     },
     "epivizrStandalone": {
       "name": "epivizrStandalone",
-      "version": "1.34.0",
-      "sha256": "02ighlzlb9j29ix2x1z18qxx5lizacpj0pna6qz0c4yh54gss7rb",
+      "version": "1.36.0",
+      "sha256": "0i8hzjj0d5pzrnz8w9y13k7awmxaf1ns28bkw34l41vb7yy46vap",
       "depends": ["BiocGenerics", "GenomeInfoDb", "GenomicFeatures", "S4Vectors", "epivizr", "epivizrServer", "git2r"]
     },
     "erccdashboard": {
       "name": "erccdashboard",
-      "version": "1.40.0",
-      "sha256": "06vsfzxxxkd34r2mz689p160h0cabg1y7zn48h2w7fs9isyy1kcm",
+      "version": "1.42.0",
+      "sha256": "103xyw11mij3yk0p3z4cd697pl2lxkfzh2blysdz2py4glc9m49w",
       "depends": ["MASS", "ROCR", "edgeR", "ggplot2", "gplots", "gridExtra", "gtools", "knitr", "limma", "locfit", "plyr", "qvalue", "reshape2", "scales", "stringr"]
     },
     "erma": {
       "name": "erma",
-      "version": "1.22.0",
-      "sha256": "15vkr4afhszlnj4171fjj78sprgd7rcafzj2lnbrgy3r443yfn66",
+      "version": "1.24.0",
+      "sha256": "1ybrjfwiwypnc7mdibkbs30scz3fyc11md9338w192vs7aggrhgp",
       "depends": ["AnnotationDbi", "Biobase", "BiocGenerics", "BiocParallel", "GenomeInfoDb", "GenomicFiles", "GenomicRanges", "Homo_sapiens", "IRanges", "S4Vectors", "SummarizedExperiment", "ggplot2", "rtracklayer", "shiny"]
     },
     "esATAC": {
       "name": "esATAC",
-      "version": "1.28.0",
-      "sha256": "06jc5nhqylyqmfz7650n538vw5k4n0lz74d9dnr2sm6dg0cjy1ll",
+      "version": "1.30.0",
+      "sha256": "09hwn5j2grjn4qhjwdvs2nj7cm68bx8j1v47jbpkpf0mhyvdjibq",
       "depends": ["AnnotationDbi", "BSgenome", "BiocGenerics", "BiocManager", "Biostrings", "ChIPseeker", "GenomeInfoDb", "GenomicAlignments", "GenomicFeatures", "GenomicRanges", "IRanges", "JASPAR2018", "R_utils", "Rbowtie2", "Rcpp", "Rsamtools", "S4Vectors", "ShortRead", "TFBSTools", "VennDiagram", "clusterProfiler", "corrplot", "digest", "ggplot2", "igraph", "knitr", "magrittr", "motifmatchr", "pipeFrame", "rJava", "rmarkdown", "rtracklayer"]
     },
     "escape": {
       "name": "escape",
-      "version": "2.2.3",
-      "sha256": "1n1pz7qvd9447b8v6wz0lfqkvkb099jgzcf882b3x9s7mzcjryh5",
-      "depends": ["AUCell", "BiocParallel", "GSEABase", "GSVA", "Matrix", "MatrixGenerics", "SeuratObject", "SingleCellExperiment", "SummarizedExperiment", "UCell", "dplyr", "ggdist", "ggplot2", "ggpointdensity", "ggridges", "msigdbr", "patchwork", "reshape2", "stringr"]
+      "version": "2.4.0",
+      "sha256": "1vwahi1c89jhdnnfk2z2pf1aa5h4sd5a66kgyzx30z907x2bc37a",
+      "depends": ["AUCell", "BiocParallel", "GSEABase", "GSVA", "Matrix", "MatrixGenerics", "SeuratObject", "SingleCellExperiment", "SummarizedExperiment", "UCell", "dplyr", "ggdist", "ggplot2", "ggpointdensity", "ggridges", "msigdb", "patchwork", "reshape2", "stringr"]
     },
     "escheR": {
       "name": "escheR",
-      "version": "1.6.0",
-      "sha256": "0p12baf4aqll216w04w9li2p3pwrrsjz9gqip0lzwirddxrf6ij7",
+      "version": "1.8.0",
+      "sha256": "10wx02wjmjyw22y7pk4jpm3j6bizrq33yl5ikbnf629vgav3qfaj",
       "depends": ["SingleCellExperiment", "SpatialExperiment", "SummarizedExperiment", "ggplot2", "rlang"]
     },
     "esetVis": {
       "name": "esetVis",
-      "version": "1.32.0",
-      "sha256": "0diabzn14yygpd8ddhnrvi4zh4paqdk2qzc0lqsbpl11spfhbgxl",
+      "version": "1.34.0",
+      "sha256": "0ssnbq8gib94w7s8x88a80nmpw050kz4m39d3shxdvi6vbz7ms39",
       "depends": ["Biobase", "MASS", "MLP", "Rtsne", "hexbin", "mpm"]
     },
     "eudysbiome": {
       "name": "eudysbiome",
-      "version": "1.36.0",
-      "sha256": "1f0r5xlkymr717ww8hp8anav8ss225li87jcr6n9a2wwimawhwfz",
+      "version": "1.38.0",
+      "sha256": "02spdv3dvkj6b0zhsyq481jrijmsrcpkr6xvf0g2d6b68bmkghj8",
       "depends": ["Biostrings", "R_utils", "Rsamtools", "plyr"]
     },
     "evaluomeR": {
       "name": "evaluomeR",
-      "version": "1.22.0",
-      "sha256": "07gycpis82lfsp5m477i2lgr4pa2w8psm9c64hpbxxq0ygybc94h",
+      "version": "1.24.0",
+      "sha256": "0dagpwlnbqhc3xya7l4xwr1c44mg9c88ck94rq6rr9psi1y05k8r",
       "depends": ["MASS", "MultiAssayExperiment", "RSKC", "Rdpack", "SummarizedExperiment", "class", "cluster", "corrplot", "dendextend", "dplyr", "flexmix", "fpc", "ggdendro", "ggplot2", "kableExtra", "matrixStats", "mclust", "plotrix", "prabclus", "randomForest", "reshape2", "sparcl"]
     },
     "extraChIPs": {
       "name": "extraChIPs",
-      "version": "1.10.0",
-      "sha256": "1d3jg7zrx96hm9d1gg24z1iwdpiy1lm2arix5y7kwa2mpbqfv010",
-      "depends": ["BiocIO", "BiocParallel", "ComplexUpset", "GenomeInfoDb", "GenomicAlignments", "GenomicInteractions", "GenomicRanges", "IRanges", "InteractionSet", "RColorBrewer", "Rsamtools", "S4Vectors", "SummarizedExperiment", "VennDiagram", "broom", "csaw", "dplyr", "edgeR", "forcats", "ggforce", "ggplot2", "ggrepel", "ggside", "glue", "matrixStats", "patchwork", "rlang", "rtracklayer", "scales", "stringr", "tibble", "tidyr", "tidyselect", "vctrs"]
+      "version": "1.12.0",
+      "sha256": "0gc9w6qccnncdlnn1vgc6nfiwhv865z2788cq9f3pmsgj80s0d7y",
+      "depends": ["BiocParallel", "GenomeInfoDb", "GenomicRanges", "IRanges", "InteractionSet", "RColorBrewer", "Rsamtools", "S4Vectors", "SummarizedExperiment", "csaw", "dplyr", "edgeR", "forcats", "ggplot2", "ggrepel", "ggside", "glue", "matrixStats", "patchwork", "rlang", "rtracklayer", "scales", "stringr", "tibble", "tidyr", "tidyselect", "vctrs"]
     },
     "fCCAC": {
       "name": "fCCAC",
-      "version": "1.32.0",
-      "sha256": "1l4v760ggpzyk22rf8qirandpxlzll2in7c7n2aii13mz51n1cla",
+      "version": "1.34.0",
+      "sha256": "0jbwdilz3vr4gpxn21q24kz44f3bdx3vf37ydkaaz10n3pbdsw7a",
       "depends": ["ComplexHeatmap", "GenomicRanges", "IRanges", "RColorBrewer", "S4Vectors", "fda", "genomation", "ggplot2"]
     },
     "fCI": {
       "name": "fCI",
-      "version": "1.36.0",
-      "sha256": "167sr70gd7ci9lc9y1pxr1bk5b67r4hvnv1k2y4hg01mbpl96dws",
+      "version": "1.38.0",
+      "sha256": "07npq64gmbaql37879d5kh2y5wqf56a7d22241qfmhjm799z1ggv",
       "depends": ["FNN", "VennDiagram", "gtools", "psych", "rgl", "zoo"]
     },
     "fabia": {
       "name": "fabia",
-      "version": "2.52.0",
-      "sha256": "1mzcc807viyl8gnvx65f1jm2nhm8s5h8sn2bm2x0nb7ywj37lfr2",
+      "version": "2.54.0",
+      "sha256": "1jvpqvd6cfs3id1cgjjbg7ifmzzkca3xkdbwb8rr9sm7lwfbcfs1",
       "depends": ["Biobase"]
     },
     "factDesign": {
       "name": "factDesign",
-      "version": "1.82.0",
-      "sha256": "0r4rjr9v6v6262sp82sghv478my4fvjpiw8rnw2z3g9kfj8ri5r2",
+      "version": "1.84.0",
+      "sha256": "11v6hhmkyq9saibw9fhv9m2ppdk8mxyhkrhnzy7w3fbd7z18gpf3",
       "depends": ["Biobase"]
     },
     "factR": {
       "name": "factR",
-      "version": "1.8.0",
-      "sha256": "0wlf0yrjmv55dr92s777g57zq85bhwn89gdb9dy4wkf1xg6sc25x",
+      "version": "1.10.0",
+      "sha256": "131rmjl1awazpapmdag3kcjxjgb5gdxh2xvrvpvzhw45r4nd69v0",
       "depends": ["BiocGenerics", "BiocParallel", "Biostrings", "GenomeInfoDb", "GenomicFeatures", "GenomicRanges", "IRanges", "RCurl", "S4Vectors", "XML", "crayon", "data_table", "dplyr", "drawProteins", "ggplot2", "pbapply", "purrr", "rlang", "rtracklayer", "stringr", "tibble", "tidyr", "wiggleplotr"]
     },
     "faers": {
       "name": "faers",
-      "version": "1.2.0",
-      "sha256": "12qgmbdmlal1s6hy2rca2jxvviy22hdb2ls0gw9m6yicwrw0zqjg",
+      "version": "1.4.0",
+      "sha256": "0snz9sd3pdcid1dws1j8x1hipxvphqqk98j8xap3arr17jq764c0",
       "depends": ["BiocParallel", "MCMCpack", "brio", "cli", "curl", "data_table", "httr2", "openEBGM", "rlang", "rvest", "vroom", "xml2"]
     },
     "famat": {
       "name": "famat",
-      "version": "1.16.0",
-      "sha256": "0zj32n5niaaiq9m7rln3a0jwrs4fiprvdwvqfn7vb518k77x80xa",
+      "version": "1.18.0",
+      "sha256": "00fzbqa065z2si0yq4gvici4vfxwa8dwfyx077kc9d7a4z99b2wa",
       "depends": ["BiasedUrn", "DT", "GO_db", "KEGGREST", "clusterProfiler", "dplyr", "gprofiler2", "magrittr", "mgcv", "ontologyIndex", "org_Hs_eg_db", "plotly", "rWikiPathways", "reactome_db", "shiny", "shinyBS", "shinydashboard", "stringr", "tidyr"]
     },
     "fastLiquidAssociation": {
       "name": "fastLiquidAssociation",
-      "version": "1.42.0",
-      "sha256": "1gzypl0p6l559hjldkp2hh2798gw24b0s8r4zmz0ril3j8lv5ram",
+      "version": "1.44.0",
+      "sha256": "1dp8z0541h63267h2p9zfiarfn44k9nnz3k2af2xb276r36wllri",
       "depends": ["Hmisc", "LiquidAssociation", "WGCNA", "doParallel", "impute", "preprocessCore"]
     },
     "fastreeR": {
       "name": "fastreeR",
-      "version": "1.10.0",
-      "sha256": "0yqn2dxzp7rqrbv56mif0fdfn4slx8ncy5dwwdq3bd1gdpcl4mlw",
+      "version": "1.12.0",
+      "sha256": "1jxacmqm1n0a491rkvijfz6ki1v8ff7d16cwj3f5aykark8abqz0",
       "depends": ["R_utils", "ape", "data_table", "dynamicTreeCut", "rJava", "stringr"]
     },
     "fastseg": {
       "name": "fastseg",
-      "version": "1.52.0",
-      "sha256": "1yjpn8qi3q7cc7hqrqpa5nnjd7r0nrahnqgxv2kzk85klkpiyq5f",
+      "version": "1.54.0",
+      "sha256": "04cshbi1jl730fs2dszzh9whviffp3bga6h6cxjxx6d9zr55l6za",
       "depends": ["Biobase", "BiocGenerics", "GenomicRanges", "IRanges", "S4Vectors"]
     },
     "fcScan": {
       "name": "fcScan",
-      "version": "1.20.0",
-      "sha256": "0llrp1q8py5rz9zd497yv3l0ranhdn6jmrwxam2byih2j35w8gbx",
+      "version": "1.22.0",
+      "sha256": "1sby20vm6pkrq3wwk9yhkp488w5m79mfdn0bbwnqfhlqhjacvpiy",
       "depends": ["GenomicRanges", "IRanges", "SummarizedExperiment", "VariantAnnotation", "doParallel", "foreach", "plyr", "rtracklayer"]
     },
     "fdrame": {
       "name": "fdrame",
-      "version": "1.78.0",
-      "sha256": "1pmnm7rjdwx609bzgmnwa0ahv85yl6kkmd75dxalrj7clrp2r77q",
+      "version": "1.80.0",
+      "sha256": "185d9isf0vrmhknxabhfic8jwr4jalxjmj9y0fnn67kc1ysf9nbf",
       "depends": []
     },
     "fedup": {
       "name": "fedup",
-      "version": "1.14.0",
-      "sha256": "04cw7a221bz9w8yw4yz8r9nqqn8l2lqzqi8g2s1vgzzq92xlpsnm",
+      "version": "1.16.0",
+      "sha256": "1aip4v07xvbcb7q9r248hsgqzgpbb3apda3x39gc168q2jamf5yd",
       "depends": ["RColorBrewer", "RCy3", "data_table", "dplyr", "forcats", "ggplot2", "ggthemes", "openxlsx", "tibble"]
     },
     "fenr": {
       "name": "fenr",
-      "version": "1.4.2",
-      "sha256": "1nvbf3wyhhv3f102hw5r2zsb06hs0p0j6c56sl6jlrlcs2yjn2gi",
+      "version": "1.6.0",
+      "sha256": "09v92fibkny0v2yx5qnvn7iyhwwbx67sal484lf1z96x7ln56hq8",
       "depends": ["BiocFileCache", "assertthat", "dplyr", "ggplot2", "httr2", "progress", "purrr", "readr", "rlang", "rvest", "shiny", "stringr", "tibble", "tidyr", "tidyselect"]
     },
     "ffpe": {
       "name": "ffpe",
-      "version": "1.50.0",
-      "sha256": "1zy51274rxkpxj1xfgj3c4nnd581mhimqj6q4jdq1zf271fscglm",
+      "version": "1.52.0",
+      "sha256": "1pgb6vga9id08zk4bw23sfn93asnvk2ardl3vc09dgb1414q8mvd",
       "depends": ["Biobase", "BiocGenerics", "TTR", "affy", "lumi", "methylumi", "sfsmisc"]
     },
     "fgga": {
       "name": "fgga",
-      "version": "1.14.0",
-      "sha256": "1arda97raf7if9xi8hn7ifb1d558kkhh4wsd5vl0rjkjmhilap72",
+      "version": "1.16.0",
+      "sha256": "1p6h1fg8x9d7v07sb48sqwshdxnk0zmb9nzq5c4g467dlpsn4zig",
       "depends": ["BiocFileCache", "RBGL", "curl", "e1071", "gRbase", "graph", "igraph", "jsonlite"]
     },
     "fgsea": {
       "name": "fgsea",
-      "version": "1.32.2",
-      "sha256": "191iy8pzc2j44675gwwa7q17mr9882h8a78jxfhs6nxg03xizd1f",
+      "version": "1.34.0",
+      "sha256": "0q04whwss0yrqq7yvizkcp1sj06p4zk1007y72djv73f5hzdvraa",
       "depends": ["BH", "BiocParallel", "Matrix", "Rcpp", "cowplot", "data_table", "fastmatch", "ggplot2", "scales"]
     },
     "findIPs": {
       "name": "findIPs",
-      "version": "1.2.0",
-      "sha256": "18984ndycgcg0kr15z7kll5r8h5ybqbb5sxxb9b2c05mc9dx2ibv",
+      "version": "1.4.0",
+      "sha256": "14zbzv9pxnz3g04v7c9cvn277n53qc4agyq6n4p7rdbl1jwy40p4",
       "depends": ["Biobase", "BiocParallel", "SummarizedExperiment", "survival"]
     },
     "fishpond": {
       "name": "fishpond",
-      "version": "2.12.0",
-      "sha256": "07qzplkpq1zbh671b44c1qa1k47jqqmyrrrdyixjz0fqj0ikw6ya",
+      "version": "2.14.0",
+      "sha256": "140p6xk45awb1a6x3d2am2mqn4m33fs5f8qpp5wdfl8arzvm38j9",
       "depends": ["GenomicRanges", "IRanges", "Matrix", "S4Vectors", "SingleCellExperiment", "SummarizedExperiment", "abind", "gtools", "jsonlite", "matrixStats", "qvalue", "svMisc"]
     },
     "flagme": {
       "name": "flagme",
-      "version": "1.62.0",
-      "sha256": "10ykp64pkkdfygbfrwrjmqgbq18j8ys3gi8k4g47b89sn6cnzr6z",
+      "version": "1.64.0",
+      "sha256": "0jvhjycnyzw7bny4wka3kws4ka5yrzmhmm3k3h4k6gvihmvhzzsf",
       "depends": ["CAMERA", "MASS", "SparseM", "gcspikelite", "gplots", "xcms"]
     },
     "flowAI": {
       "name": "flowAI",
-      "version": "1.36.0",
-      "sha256": "1g2bjfdrmglxb2b3h3j2d37nq7k4hy2ff3qp5jy1arjrblq45qfm",
+      "version": "1.38.0",
+      "sha256": "1w28hcfychhws8s5vkv27zssyvngrsrflnqc12y7f895f3lp72s1",
       "depends": ["RColorBrewer", "changepoint", "flowCore", "ggplot2", "knitr", "plyr", "reshape2", "rmarkdown", "scales"]
     },
     "flowBeads": {
       "name": "flowBeads",
-      "version": "1.44.0",
-      "sha256": "151pcq3dbsrzvclcfknlmqh7xhnxsckxk6z48yxjc607qkbp1hry",
+      "version": "1.46.0",
+      "sha256": "16vici8l03lnssxmdhl5lq36mk40yd0sxmr9j8jmkm6spmkz813k",
       "depends": ["Biobase", "flowCore", "knitr", "rrcov", "xtable"]
     },
     "flowBin": {
       "name": "flowBin",
-      "version": "1.42.0",
-      "sha256": "01raylkvy6jnh30f2c7rjxlnw280ay1n1mz78r6h6nvjs2mb9jx5",
+      "version": "1.44.0",
+      "sha256": "1b2rb9fci6p4nsp0a8m11hhghhd2fzvqbnykvm5dq0h0vm3i5sx1",
       "depends": ["BiocGenerics", "class", "flowCore", "flowFP", "limma", "snow"]
     },
     "flowCHIC": {
       "name": "flowCHIC",
-      "version": "1.40.0",
-      "sha256": "03z8jd1z3nbfjv16q0b57g99gqxwwjabmj4wbnhxsagcpzz7gf02",
+      "version": "1.42.0",
+      "sha256": "096br2ryviv69yr8av7k35d60z7c4pdgb0kaywhxjprk7iwjqhfy",
       "depends": ["EBImage", "flowCore", "ggplot2", "hexbin", "vegan"]
     },
     "flowClean": {
       "name": "flowClean",
-      "version": "1.44.0",
-      "sha256": "0rgqih8vvl2mbmb4l6vhw8algn4x5iikmv9cksxvpm0iq1p6m5rf",
+      "version": "1.46.0",
+      "sha256": "0m5la5r8qg3hbf5yhl0vinxncxjx44cvlj6f0kdpg542vkwp6bnz",
       "depends": ["bit", "changepoint", "flowCore", "sfsmisc"]
     },
     "flowClust": {
       "name": "flowClust",
-      "version": "3.44.0",
-      "sha256": "0li9vcgk82vn5wqzmz6hbn04vqa5l0mwsb6vyb537mkcg45dhcr3",
+      "version": "3.46.0",
+      "sha256": "04zmgp11fajl72kif74zy3974dg780hx9dwp3g7y6dywf5bihlg6",
       "depends": ["Biobase", "BiocGenerics", "flowCore", "graph"]
     },
     "flowCore": {
       "name": "flowCore",
-      "version": "2.18.0",
-      "sha256": "0zbxlwij9nc2fpsx5hg2q9inn1g5c0i34bmvbn6n56y3i0vzm8xj",
+      "version": "2.20.0",
+      "sha256": "15px1dc2z9vlvnh0kyg3l74bwmhnb22bpyzrsxi2bvx61lf3bzgp",
       "depends": ["BH", "Biobase", "BiocGenerics", "RProtoBufLib", "Rcpp", "S4Vectors", "cpp11", "cytolib", "matrixStats"]
     },
     "flowCut": {
       "name": "flowCut",
-      "version": "1.16.0",
-      "sha256": "0ib8agini4cij81z0prhv11m6qmrp8l9sg2piwp05cqd67r3h81x",
+      "version": "1.18.0",
+      "sha256": "0afdqildijv1rhhqwrnk4jqxq70y1vmm1ys1hpl6q9y2wig5ak03",
       "depends": ["Cairo", "e1071", "flowCore", "flowDensity"]
     },
     "flowCyBar": {
       "name": "flowCyBar",
-      "version": "1.42.0",
-      "sha256": "1vc1zlxp07jaf5z0p761x0jmyrfmczsj23pq8p24h3wip6kd8yl3",
+      "version": "1.44.0",
+      "sha256": "0n42kdyw6318nij1c4dzdfkaf6rma92hjmsydcs2aqw7fy99s8w8",
       "depends": ["gplots", "vegan"]
     },
     "flowDensity": {
       "name": "flowDensity",
-      "version": "1.40.0",
-      "sha256": "0fwfppwn0jxp8lvwyfpgmkizsfp3i6n3jaccc7m9fkmad3cd2yxv",
+      "version": "1.42.0",
+      "sha256": "0dwxl44aichngdsnyx33cxbhla7wv4zp6gx92xqryjmdfh375ic4",
       "depends": ["car", "flowCore", "flowViz", "gplots", "polyclip"]
     },
     "flowFP": {
       "name": "flowFP",
-      "version": "1.64.0",
-      "sha256": "109184ad3nwbzlkj22ha753lk7z382gwi2dbna6s4wjngr7rbavf",
+      "version": "1.66.0",
+      "sha256": "04p1zwb0d8yz966fpyaiaydhzylh5di1gfa29mvvba39kfjqy7ch",
       "depends": ["Biobase", "BiocGenerics", "flowCore", "flowViz"]
     },
     "flowGate": {
       "name": "flowGate",
-      "version": "1.6.0",
-      "sha256": "086nc8rjafhnqdzf00n342pxsdh2x4ysnkymihngj7s43xvppvjd",
+      "version": "1.8.0",
+      "sha256": "0wjgi20xina1d8xna4qg46r3m7ixns092pq2zpn90cgcvl05wa62",
       "depends": ["BiocManager", "dplyr", "flowCore", "flowWorkspace", "ggcyto", "ggplot2", "purrr", "rlang", "shiny", "tibble"]
     },
     "flowGraph": {
       "name": "flowGraph",
-      "version": "1.14.0",
-      "sha256": "0r7svnyqmf45mdr9v3bpqbv9352yfdkrvj2syisrhdhg7mbvhpcn",
+      "version": "1.16.0",
+      "sha256": "0x0q08rf89wscxzanqn6sw32bmdbk63y6m77ad82zr5zbc36hckj",
       "depends": ["Matrix", "Rdpack", "data_table", "effsize", "furrr", "future", "ggiraph", "ggplot2", "ggrepel", "gridExtra", "htmlwidgets", "igraph", "matrixStats", "purrr", "stringi", "stringr", "visNetwork"]
     },
     "flowMatch": {
       "name": "flowMatch",
-      "version": "1.42.0",
-      "sha256": "1v0l5974bynyiv4aw5az2x90jzi2qa383njifg8dxx6061qr1s3s",
+      "version": "1.44.0",
+      "sha256": "037lak2axxjjp2g79z1casfyrrpl7vjlyk70k5q1fmx2747b50rm",
       "depends": ["Biobase", "Rcpp", "flowCore"]
     },
     "flowMeans": {
       "name": "flowMeans",
-      "version": "1.66.0",
-      "sha256": "1sgk1x1cm2srrdv2bn312lvj1pcc8r9gaqlvr1fnngp98dhw5pb1",
+      "version": "1.68.0",
+      "sha256": "1jg9q3b0jkiiycd0zsc2jgmfdasrml8c9ri61bjmm7ps0wiq92il",
       "depends": ["Biobase", "feature", "flowCore", "rrcov"]
     },
     "flowMerge": {
       "name": "flowMerge",
-      "version": "2.54.0",
-      "sha256": "0jxi9zpq3vvz1mpqq9c7l9c4pvrjvgvcmma1v4w52gflrp1nxj7w",
+      "version": "2.56.0",
+      "sha256": "1b925163l0dkzjhrpbrxc35yndr4n6vicdpzk6qzigdw9fxw2k9v",
       "depends": ["Rgraphviz", "feature", "flowClust", "flowCore", "foreach", "graph", "rrcov", "snow"]
     },
     "flowPeaks": {
       "name": "flowPeaks",
-      "version": "1.52.0",
-      "sha256": "0sgxzywbzwz0y4c8ja2803ny3l3gywn90jil76r96s37ddn376ii",
+      "version": "1.54.0",
+      "sha256": "1dcd2h2jspiq1qh207mbajizsqbxlnrmn2927fwpshhckbkjkgm3",
       "depends": []
     },
     "flowPloidy": {
       "name": "flowPloidy",
-      "version": "1.32.0",
-      "sha256": "1cxppkg0knjadwbafmyyy5lx8jg9rjx58rfgzl7vn7bk0rrj253z",
+      "version": "1.34.0",
+      "sha256": "1nc4cly3by1qkdy2z24knlpw0k7n7d7j2p19xvg1nrh7znky5vwx",
       "depends": ["caTools", "car", "flowCore", "knitr", "minpack_lm", "rmarkdown", "shiny"]
     },
     "flowPlots": {
       "name": "flowPlots",
-      "version": "1.54.0",
-      "sha256": "0db5k4s6w7p3k3n4618w5wk9zl48lyr590s47wpbzi69m201jqfn",
+      "version": "1.56.0",
+      "sha256": "1b91pg78cby4da211ilgvs7flqwr77f9awpnrpg8d0rn1vb2qsz4",
       "depends": []
     },
     "flowSpecs": {
       "name": "flowSpecs",
-      "version": "1.20.0",
-      "sha256": "0l1ray2p5mzp5w0x6r70g1dv5zgl171259a942mvy7szd4b2h2an",
+      "version": "1.22.0",
+      "sha256": "1c1224gyw3rxhcsllg4z9lcy6v87j3lr3hmgv1yj0ihlmp9d7c12",
       "depends": ["Biobase", "BiocGenerics", "BiocParallel", "flowCore", "ggplot2", "reshape2", "zoo"]
     },
     "flowStats": {
       "name": "flowStats",
-      "version": "4.18.0",
-      "sha256": "0lp8wmfgav47c7lqga9hykv5spwysv84dhvj4hvv13l0a10dd61a",
+      "version": "4.20.0",
+      "sha256": "1dm5aqycdabw3q2pxvpwf1hhzsplyx4b9xw1pgc2h0wk2fvdr2qc",
       "depends": ["Biobase", "BiocGenerics", "KernSmooth", "MASS", "RColorBrewer", "clue", "cluster", "corpcor", "fda", "flowCore", "flowViz", "flowWorkspace", "ks", "lattice", "mnormt", "ncdfFlow", "rrcov"]
     },
     "flowTime": {
       "name": "flowTime",
-      "version": "1.30.0",
-      "sha256": "0x1bq9w0ggj27lig1n9hamag9qxvrmi20v2hnmi7ijjmg9z59yhd",
+      "version": "1.32.0",
+      "sha256": "1l9w8hxahbjm8x620hqyqiryj53ml9ffrq6ihf2v4sxalxz93vnp",
       "depends": ["dplyr", "flowCore", "magrittr", "plyr", "rlang", "tibble"]
     },
     "flowTrans": {
       "name": "flowTrans",
-      "version": "1.58.0",
-      "sha256": "0axc678vq221808b1diw2whhnl2hgp9ddixy6fc8xny16vbg3wln",
+      "version": "1.60.0",
+      "sha256": "0b9mfrbhr2dj31ck35ypzlynci9vbnk52mpfz7m5r3pjganlpfln",
       "depends": ["flowClust", "flowCore", "flowViz"]
     },
     "flowVS": {
       "name": "flowVS",
-      "version": "1.38.0",
-      "sha256": "13d6inmsqamlg23p5ah2skbprad9sqkz04dxc2c3ws8p8dqk9qmp",
+      "version": "1.40.0",
+      "sha256": "0p20bcbz67dwk51xwhrxdzj64v7p852xmhihihyzxp1fq7s4k0rs",
       "depends": ["flowCore", "flowStats", "flowViz"]
     },
     "flowViz": {
       "name": "flowViz",
-      "version": "1.70.0",
-      "sha256": "1ymqx5zasrr5snmg71p58hk526yxpvs4d78df2hgxfah5w6vxd6w",
+      "version": "1.72.0",
+      "sha256": "135n5p1maz6622pw81dgsqzsz675x5gwq3mghp4w6jbgiyjjphmj",
       "depends": ["Biobase", "IDPmisc", "KernSmooth", "MASS", "RColorBrewer", "flowCore", "hexbin", "lattice", "latticeExtra"]
     },
     "flowWorkspace": {
       "name": "flowWorkspace",
-      "version": "4.18.0",
-      "sha256": "0mjf3kzsmrrlg5asam96kjj8kqv12wn9xqbmf9pywgr5k6c045i7",
+      "version": "4.20.0",
+      "sha256": "1jrbi87zy11ls40d0c9gmdfd9ab53182ip3brg1gvgnr6sz930vx",
       "depends": ["BH", "Biobase", "BiocGenerics", "DelayedArray", "RBGL", "RProtoBufLib", "Rgraphviz", "Rhdf5lib", "S4Vectors", "XML", "cpp11", "cytolib", "data_table", "dplyr", "flowCore", "ggplot2", "graph", "matrixStats", "ncdfFlow", "scales"]
     },
     "flowcatchR": {
       "name": "flowcatchR",
-      "version": "1.40.0",
-      "sha256": "1czl7cccxd27y5cxwikdqkd79i1qd17lyb225ryhygpjbl6b84b3",
+      "version": "1.42.0",
+      "sha256": "069j7xw0hkyg3c45gra8wlz76msngby2iga3q390m5kiwa9z7za4",
       "depends": ["BiocParallel", "EBImage", "abind", "colorRamps", "plotly", "shiny"]
     },
     "fmcsR": {
       "name": "fmcsR",
-      "version": "1.48.0",
-      "sha256": "1zd5frijcxyv9k3v5irzrzx7wvhlwx6c395r2pai37pxzdxr1m4a",
+      "version": "1.50.0",
+      "sha256": "0js75zd5hp53lvmlidj14mb28mj7mvy34mmwvn2md5na41dns5ny",
       "depends": ["BiocGenerics", "ChemmineR", "RUnit"]
     },
     "fmrs": {
       "name": "fmrs",
-      "version": "1.16.0",
-      "sha256": "0b6sm1k3ancnzjhnd2gmwfmi5jq4g9ai63prn3364dmbmgkwp894",
+      "version": "1.18.0",
+      "sha256": "1p1c4gfm7w676pfqhq9z0d9m5k5mbzdvnsjh8mwxv75a0sa0fdvx",
       "depends": ["survival"]
     },
     "fobitools": {
       "name": "fobitools",
-      "version": "1.14.0",
-      "sha256": "11s02q3jj8z66jkx4v4c48656vkiaiwqb9064y07kiajj28ckvpy",
+      "version": "1.16.0",
+      "sha256": "18mwca5hh95dhbkgwc4ginmy67amh8dl62zyxa2np2wxl9wsqafg",
       "depends": ["RecordLinkage", "clisymbols", "crayon", "dplyr", "fgsea", "ggplot2", "ggraph", "magrittr", "ontologyIndex", "purrr", "stringr", "textclean", "tictoc", "tidygraph", "tidyr", "vroom"]
     },
     "frenchFISH": {
       "name": "frenchFISH",
-      "version": "1.18.0",
-      "sha256": "11cmb0fp7mj73rbqmh8qfm0zmdr1jz1w1wy5w670p6hxc882qmih",
+      "version": "1.20.0",
+      "sha256": "1l6ikm1k176h8qqh8hjd5hk39p6wbh46l08kn64srfwrin0m1jxg",
       "depends": ["MCMCpack", "NHPoisson"]
     },
     "frma": {
       "name": "frma",
-      "version": "1.58.0",
-      "sha256": "14x36pgq4w76whg8c3gzkrmyn5b0rav7gqrlz8j2673j5gijkqq6",
+      "version": "1.60.0",
+      "sha256": "00ln0hzlmja4i9vd6h3sjyp3k0lz4hpd2kn56j9gqgja7f0npj79",
       "depends": ["Biobase", "BiocGenerics", "DBI", "MASS", "affy", "oligo", "oligoClasses", "preprocessCore"]
     },
     "frmaTools": {
       "name": "frmaTools",
-      "version": "1.58.0",
-      "sha256": "0fszdna6n3nhdqzvxarby7zrcwv3c61p3cvw8sjr18v7qmwxahic",
+      "version": "1.60.0",
+      "sha256": "1iilympv6mmyjldw0lr3qcj8bv6i2g6dpvwbb5a9k6dd52p4mrzi",
       "depends": ["Biobase", "DBI", "affy", "preprocessCore"]
     },
     "funOmics": {
       "name": "funOmics",
-      "version": "1.0.0",
-      "sha256": "0xybpr3iclpazyjf405y5qvvg18n038rmmg3v4234cym9gymf8c6",
+      "version": "1.2.0",
+      "sha256": "0c3666b01skpvj1wfwk3l4rgkfbmrw60q5b92wxzd79gp322kqi6",
       "depends": ["AnnotationDbi", "KEGGREST", "NMF", "dplyr", "org_Hs_eg_db", "pathifier", "stringr"]
     },
     "funtooNorm": {
       "name": "funtooNorm",
-      "version": "1.30.0",
-      "sha256": "13qz1icxpkdk0kssdh9svk71r850crrf2x7lc3sxiphcg71x83jz",
+      "version": "1.32.0",
+      "sha256": "1mfsr7p0x6khha29js0y3jj1w447f3p9fsxi1kyx8gp7pd1bdmv3",
       "depends": ["GenomeInfoDb", "IlluminaHumanMethylation450kanno_ilmn12_hg19", "IlluminaHumanMethylation450kmanifest", "matrixStats", "minfi", "pls"]
     },
     "gCrisprTools": {
       "name": "gCrisprTools",
-      "version": "2.12.0",
-      "sha256": "08kd2p1mvh69ayk11xrv4vz1wsmvav7yhqpshda14sg2sdmhb9ac",
+      "version": "2.14.0",
+      "sha256": "0vmwd6hz1w5gfbkzc1isizxqy77dlxly71lqr92qvzykv9b59zk1",
       "depends": ["Biobase", "ComplexHeatmap", "RobustRankAggreg", "SummarizedExperiment", "ggplot2", "limma", "rmarkdown"]
     },
     "gDNAx": {
       "name": "gDNAx",
-      "version": "1.4.1",
-      "sha256": "0f2k563lzbbdb5wf9hw0ljfrra3dizsvcis4nzqfgqaz5ppdrckw",
+      "version": "1.6.0",
+      "sha256": "1zvippq7i4jrp0jsjcfgq64ghvnxnp7csx284zhyb2gghqgfad6w",
       "depends": ["AnnotationDbi", "AnnotationHub", "BiocGenerics", "BiocParallel", "Biostrings", "GenomeInfoDb", "GenomicAlignments", "GenomicFeatures", "GenomicFiles", "GenomicRanges", "IRanges", "RColorBrewer", "Rsamtools", "S4Vectors", "SummarizedExperiment", "bitops", "cli", "matrixStats", "plotrix"]
     },
     "gDR": {
       "name": "gDR",
-      "version": "1.4.1",
-      "sha256": "1lpv6a5a1qaspa8b57z20856viwbhsspi04cl0rmbjfaar1mnlb1",
+      "version": "1.6.0",
+      "sha256": "0pd05qqn49qs4n2lx3rn6pqyqifyc2012p4ba1vgsky77y5jhz12",
       "depends": ["gDRcore", "gDRimport", "gDRutils"]
     },
     "gDRcore": {
       "name": "gDRcore",
-      "version": "1.4.4",
-      "sha256": "0h942jaqa7336nqyw79ab4skq789y12g2rcpncvdbwvbwy48jkyx",
+      "version": "1.6.0",
+      "sha256": "02zja1gslhvhdqs48nlm71c5bzbzl1lmlkpgqgqj4yws2n0drv42",
       "depends": ["BiocParallel", "BumpyMatrix", "MultiAssayExperiment", "S4Vectors", "SummarizedExperiment", "checkmate", "data_table", "futile_logger", "gDRutils", "purrr", "stringr"]
     },
     "gDRimport": {
       "name": "gDRimport",
-      "version": "1.4.6",
-      "sha256": "1xyzlqcb62cvfbv3s27f3skg0qjwnpfbzk6jkkznll7p7j369p9i",
+      "version": "1.6.0",
+      "sha256": "09ww37jgwl77njf9m89sb769f05da4mvnj2kkdxan7x9wjdsxyxq",
       "depends": ["BumpyMatrix", "CoreGx", "MultiAssayExperiment", "PharmacoGx", "S4Vectors", "SummarizedExperiment", "XML", "assertthat", "checkmate", "data_table", "futile_logger", "gDRutils", "magrittr", "openxlsx", "readxl", "rio", "stringi", "tibble", "yaml"]
     },
     "gDRstyle": {
       "name": "gDRstyle",
-      "version": "1.4.3",
-      "sha256": "0m792pvxymzc1c0l7qncm85br8agss97r7q2vmkzqq1lsm6cpywr",
+      "version": "1.6.0",
+      "sha256": "1xbjfn0sk9jn4q8652dbg6wd0xg9n75i8gyrdf2kzv0xrgwwcmcm",
       "depends": ["BiocCheck", "BiocManager", "BiocStyle", "checkmate", "desc", "git2r", "lintr", "pkgbuild", "rcmdcheck", "remotes", "rjson", "withr", "yaml"]
     },
     "gDRutils": {
       "name": "gDRutils",
-      "version": "1.4.10",
-      "sha256": "0pn248fc96q9m25p2pl8zvg14wg5b7a00ilf308159d22x8ap9d0",
+      "version": "1.6.0",
+      "sha256": "099l59gm0g7q6rnhbp9vyimaw17blp65krp40z2r1nxd6rglr0k0",
       "depends": ["BiocParallel", "BumpyMatrix", "MultiAssayExperiment", "S4Vectors", "SummarizedExperiment", "checkmate", "data_table", "drc", "jsonlite", "jsonvalidate", "stringr"]
     },
     "gINTomics": {
       "name": "gINTomics",
-      "version": "1.2.0",
-      "sha256": "03p2xym6b5wk06dby3s7hzd1gkmqygdm50mk9hs3na5qnqfjg57y",
-      "depends": ["AnnotationDbi", "BiocGenerics", "BiocParallel", "ComplexHeatmap", "DT", "GenomicFeatures", "GenomicRanges", "InteractiveComplexHeatmap", "MASS", "MultiAssayExperiment", "OmnipathR", "RColorBrewer", "ReactomePA", "SummarizedExperiment", "TxDb_Hsapiens_UCSC_hg38_knownGene", "TxDb_Mmusculus_UCSC_mm10_knownGene", "biomaRt", "callr", "circlize", "clusterProfiler", "dplyr", "edgeR", "ggplot2", "ggridges", "ggtree", "ggvenn", "gtools", "limma", "org_Hs_eg_db", "org_Mm_eg_db", "plotly", "plyr", "randomForest", "reshape2", "shiny", "shiny_gosling", "shinydashboard", "stringi", "stringr", "visNetwork"]
+      "version": "1.4.0",
+      "sha256": "04b1ksazr3l1b1k5rylmswzlfgz5xixgds2n10a1yiqwbbcjkn2p",
+      "depends": ["AnnotationDbi", "BiocGenerics", "BiocParallel", "ComplexHeatmap", "DT", "GenomicFeatures", "GenomicRanges", "InteractiveComplexHeatmap", "MASS", "MethylMix", "MultiAssayExperiment", "OmnipathR", "RColorBrewer", "ReactomePA", "SummarizedExperiment", "TxDb_Hsapiens_UCSC_hg38_knownGene", "TxDb_Mmusculus_UCSC_mm10_knownGene", "biomaRt", "callr", "circlize", "clusterProfiler", "dplyr", "edgeR", "ggplot2", "ggridges", "ggtree", "ggvenn", "gtools", "limma", "org_Hs_eg_db", "org_Mm_eg_db", "plotly", "plyr", "randomForest", "reshape2", "shiny", "shiny_gosling", "shinydashboard", "shinyjs", "stringi", "stringr", "visNetwork"]
     },
     "gaga": {
       "name": "gaga",
-      "version": "2.52.0",
-      "sha256": "12p2bnazsl2nvr5i6nmh5rr3kycmbzfc5wvbx9lwl327qsfvmdfd",
+      "version": "2.54.0",
+      "sha256": "1nx98853d9waqxx7vh64fxxp4704jk443l8vbfvsypbqhk5qd5bb",
       "depends": ["Biobase", "EBarrays", "coda", "mgcv"]
     },
     "gage": {
       "name": "gage",
-      "version": "2.56.0",
-      "sha256": "06kd8cklhqp8w2iqli427k072wg0z2hd08y8c61ds5rkqhk7m13d",
+      "version": "2.58.0",
+      "sha256": "0fnc53iplws7qwx3hg66b9im8g50bsb7v22dkhd8xvrsgbnn0ydr",
       "depends": ["AnnotationDbi", "GO_db", "KEGGREST", "graph"]
     },
     "garfield": {
       "name": "garfield",
-      "version": "1.34.0",
-      "sha256": "177xjy55abf4jgzy22k72lkwcsql3vfrb0znn6ajg8v562aa18f7",
+      "version": "1.36.0",
+      "sha256": "0ri0iay0rmckfb59sanch9df9k65bwwvpvaa95vb7wyjsp0fzsmn",
       "depends": []
     },
     "gatom": {
       "name": "gatom",
-      "version": "1.4.0",
-      "sha256": "1gqnb7s4z5h5yyzlq8yw3jcksr0nw28hz9ciq9yzs7zfqpwc3ib3",
+      "version": "1.6.0",
+      "sha256": "0a8r9k2aly0lhb9yfq0sc4pmgkrgycgsgcdi1nh3izj34w1q953h",
       "depends": ["BioNet", "GGally", "XML", "data_table", "ggplot2", "htmltools", "htmlwidgets", "igraph", "intergraph", "mwcsr", "network", "plyr", "pryr", "shinyCyJS", "sna"]
     },
     "gcapc": {
       "name": "gcapc",
-      "version": "1.30.0",
-      "sha256": "0ylxnb4k86dv3pbp0w9rs2h9nvzlg19hrryxvk1j9qn08d5rf3gm",
+      "version": "1.32.0",
+      "sha256": "056cwamgjf43nkd5sbp5dya78a11x7v54bl6g9c7mh9p8pccjwk3",
       "depends": ["BSgenome", "BiocGenerics", "Biostrings", "GenomeInfoDb", "GenomicAlignments", "GenomicRanges", "IRanges", "MASS", "Rsamtools", "S4Vectors", "matrixStats"]
     },
     "gcatest": {
       "name": "gcatest",
-      "version": "2.6.0",
-      "sha256": "0nnd2gwankxha19j98h9bm558pi15vmanw0n1hzypch70z0kf2xd",
+      "version": "2.8.0",
+      "sha256": "1cwc9sshjzv3brasvc9ka30zmg8nrmkwz5ab61bgkx43a28f9ddh",
       "depends": ["lfa"]
     },
     "gcrma": {
       "name": "gcrma",
-      "version": "2.78.0",
-      "sha256": "0v397nmmm6zy5pipzgz81fhkygg4hz173dvm28cm4813pjrq7gsa",
+      "version": "2.80.0",
+      "sha256": "0c49gwx1jdvp2kb58iwlvxr0j2yav04hc7v4gkbvmdc77fk8bslm",
       "depends": ["Biobase", "BiocManager", "Biostrings", "XVector", "affy", "affyio"]
     },
     "gdsfmt": {
       "name": "gdsfmt",
-      "version": "1.42.1",
-      "sha256": "058qh3vbxj9ix8fn995l66ynjzd40lxs9qr1vq7v2fxbmy4rzc0q",
+      "version": "1.44.0",
+      "sha256": "1zp7ydzg492ifnlypc0ypfi6a0jq6c1gv5ckwcwzwmqfwavk5jfq",
       "depends": []
     },
     "geNetClassifier": {
       "name": "geNetClassifier",
-      "version": "1.46.0",
-      "sha256": "1qfakvirq5k5ypia1dfq4fwfmp9p9294bqp3s5w2a73z6ypincp2",
+      "version": "1.48.0",
+      "sha256": "1x2q78nvinrj7j72z12cl9jx2cv3klpq7hrqr2r7jianjw6prhqc",
       "depends": ["Biobase", "EBarrays", "e1071", "minet"]
     },
     "gemini": {
       "name": "gemini",
-      "version": "1.20.0",
-      "sha256": "1r2kfavdiizhl6ah2mmrrh20daswygr24viw5kig0hvrjc3c74hl",
+      "version": "1.22.0",
+      "sha256": "0c2g357j9kap9fs5s4yd0jvwdinvlbj41q1rcyzibbw22b7gi6li",
       "depends": ["dplyr", "ggplot2", "magrittr", "mixtools", "pbmcapply", "scales"]
     },
     "gemma_R": {
       "name": "gemma.R",
-      "version": "3.2.1",
-      "sha256": "1c3b838b6i8bg9lspgwvhlg1xwfazk3nszdc7v0cgjx2jg9rnwnh",
+      "version": "3.4.0",
+      "sha256": "1m54sxrwkd89fgw2qyq4b8jx0wm50plishxdy5jkk65xvxqh1crh",
       "depends": ["Biobase", "R_utils", "S4Vectors", "SummarizedExperiment", "assertthat", "base64enc", "bit64", "data_table", "digest", "glue", "httr", "jsonlite", "kableExtra", "lubridate", "magrittr", "memoise", "rappdirs", "rlang", "stringr", "tibble", "tidyr"]
     },
     "genArise": {
       "name": "genArise",
-      "version": "1.82.0",
-      "sha256": "0hj3ar1c8v66lib42bbs0y4w9spihhzklnn4fbbhx4xpgi015p1q",
+      "version": "1.84.0",
+      "sha256": "1yaq0ka093wml2z5xpxkq34s28ry9yh2as4dpkgc6wjd4cw4jy2c",
       "depends": ["locfit", "tkrplot", "xtable"]
     },
     "geneAttribution": {
       "name": "geneAttribution",
-      "version": "1.32.0",
-      "sha256": "012prq4mlx2knpf8z811fgqcwk2fvjn2cgnashs5ql457c9aw4x1",
+      "version": "1.34.0",
+      "sha256": "0i1whgj0n1n92ciw0iha9xf4pwapf8hfgn4nw2yn3x0jq5cm2id5",
       "depends": ["BiocGenerics", "GenomeInfoDb", "GenomicFeatures", "GenomicRanges", "IRanges", "org_Hs_eg_db", "rtracklayer"]
     },
     "geneClassifiers": {
       "name": "geneClassifiers",
-      "version": "1.30.0",
-      "sha256": "0vdpvf70i3svb12kd9caa64nkpsszcx48xj3l4rxcfi1vz90473q",
+      "version": "1.32.0",
+      "sha256": "0gckcfsjciia99qaxpy32i2brdsswkxdvgf5idl34a4dd775qj1z",
       "depends": ["Biobase", "BiocGenerics"]
     },
     "geneRecommender": {
       "name": "geneRecommender",
-      "version": "1.78.0",
-      "sha256": "1g7imxpswf6gnp37jp8llh2mh3r93915s2z21766bhsj6mm40cik",
+      "version": "1.80.0",
+      "sha256": "0yz81hdxcx1q41am5i3m5dvzpmzjh12ahjibk6z2m2srpyx52a9n",
       "depends": ["Biobase"]
     },
     "geneRxCluster": {
       "name": "geneRxCluster",
-      "version": "1.42.0",
-      "sha256": "1x7ir32fa8ykgrvq2ssmbxc052npzmyp6lzgz9m2kmaka1mikgh7",
+      "version": "1.44.0",
+      "sha256": "1d5r41y5wgza7jmjhcmyzk5zsnby9x12r2cb7fw4xrmycmmr3f56",
       "depends": ["GenomicRanges", "IRanges"]
     },
     "geneXtendeR": {
       "name": "geneXtendeR",
-      "version": "1.32.0",
-      "sha256": "1wns3qgp0vj22azl9pd4y8yvld84180mjha15h50ayflz6mx7xna",
+      "version": "1.34.0",
+      "sha256": "19biavls97s80zhxcl0dhyw6x7jawhxgvvjkasspimzryj34944f",
       "depends": ["AnnotationDbi", "BiocStyle", "GO_db", "RColorBrewer", "SnowballC", "data_table", "dplyr", "networkD3", "org_Rn_eg_db", "rtracklayer", "tm", "wordcloud"]
     },
     "genefilter": {
       "name": "genefilter",
-      "version": "1.88.0",
-      "sha256": "1c5mi7g5l501x8l0cd27cvqpwfki740yxj9598sgvgmd8v8aczyd",
+      "version": "1.90.0",
+      "sha256": "0zdwa8sm91fpmnmq2r726a8ihmwg8k7pi17v9cwv7bvimlkzngnc",
       "depends": ["AnnotationDbi", "Biobase", "MatrixGenerics", "annotate", "survival"]
+    },
+    "genefu": {
+      "name": "genefu",
+      "version": "2.40.0",
+      "sha256": "0cxxlyk3grc2kjagnlmxc7svbq1qkq4572c2zlmkjhcf62abci1b",
+      "depends": ["AIMS", "amap", "biomaRt", "iC10", "iC10TrainingData", "impute", "limma", "mclust", "survcomp"]
     },
     "geneplast": {
       "name": "geneplast",
-      "version": "1.32.0",
-      "sha256": "0ad0wc844vamzlwllizs783pbgr4r0jywhrgsxnd9h3l3fka4qnv",
+      "version": "1.34.0",
+      "sha256": "1la7h15w3d8v4b297r772spff301kbr51jib6a952rg10knsi897",
       "depends": ["ape", "data_table", "igraph", "snow"]
     },
     "geneplotter": {
       "name": "geneplotter",
-      "version": "1.84.0",
-      "sha256": "1yvq6wa27q6r6m5zi9m9qqzqgxrndwybgz056yc5gpbngp1c2va7",
+      "version": "1.86.0",
+      "sha256": "13a8rn620d56wwfi0zskqxm2dkv65ly6xfv512gymcglxc359d95",
       "depends": ["AnnotationDbi", "Biobase", "BiocGenerics", "RColorBrewer", "annotate", "lattice"]
     },
     "genoCN": {
       "name": "genoCN",
-      "version": "1.58.0",
-      "sha256": "0ij9pjsw8p083vkvvjck849iixxvilcw8mkjfdr2inqh1lwdd46l",
+      "version": "1.59.0",
+      "sha256": "1fyyq6759p7pz8ajgkn08clpvygm8b25jlf8m3sgrvw62kwcilxl",
       "depends": []
     },
     "genomation": {
       "name": "genomation",
-      "version": "1.38.0",
-      "sha256": "17vwkw85936hdxw503gjd4l7js5pzv9zvcscvmhaasnfck1l9y48",
+      "version": "1.40.0",
+      "sha256": "0wvvx4h4d52wk1mxqjfih95w3x6y6y4qzdlxqsh3b66ad63l3pd6",
       "depends": ["BSgenome", "Biostrings", "GenomeInfoDb", "GenomicAlignments", "GenomicRanges", "IRanges", "Rcpp", "Rsamtools", "S4Vectors", "data_table", "ggplot2", "gridBase", "impute", "matrixStats", "plotrix", "plyr", "readr", "reshape2", "rtracklayer", "seqPattern"]
     },
     "genomeIntervals": {
       "name": "genomeIntervals",
-      "version": "1.62.0",
-      "sha256": "022ka0hjq05659i4xzibqdnj9fahxmgpfqiw4z03xibc3vdz6fsw",
+      "version": "1.64.0",
+      "sha256": "1zahjzxi8m9kv9g2g9dxs4fmhcmvwcvksa4js3zzfyrbgx7j517l",
       "depends": ["BiocGenerics", "GenomeInfoDb", "GenomicRanges", "IRanges", "S4Vectors", "intervals"]
     },
     "genomes": {
       "name": "genomes",
-      "version": "3.36.0",
-      "sha256": "146rap0lbv8kwm8kpqkd6gp8qm7fl6dps0fyx3xpm4fbmynrsq5v",
+      "version": "3.38.0",
+      "sha256": "1ix8nlwz1q88i1qfl60nsii355k98garnz4zzh3gnmjfd5drypdp",
       "depends": ["curl", "readr"]
     },
     "genomicInstability": {
       "name": "genomicInstability",
-      "version": "1.12.0",
-      "sha256": "1rxmvgy5dwi4hqzva42v1f4nlfn91svzsxqc67rldlx9avp7nqj1",
+      "version": "1.14.0",
+      "sha256": "05f30zqj331qiphfdl6vr9zb075jzxpkmzrs9dblqh5b7m198j1l",
       "depends": ["SummarizedExperiment", "checkmate", "mixtools"]
     },
     "geomeTriD": {
       "name": "geomeTriD",
-      "version": "1.0.1",
-      "sha256": "08k117bhqbshxma4as44l107qncfa65cyha2f8i7y1xrakyrcsrl",
-      "depends": ["BiocGenerics", "GenomeInfoDb", "GenomicRanges", "IRanges", "InteractionSet", "MASS", "Matrix", "S4Vectors", "htmlwidgets", "igraph", "plotrix", "rgl", "rjson", "scales", "trackViewer"]
+      "version": "1.2.0",
+      "sha256": "02a1jy2p04ls17j453xf211pr7fq0a9nfg3m4710dfiyl0dx4h14",
+      "depends": ["BiocGenerics", "GenomeInfoDb", "GenomicRanges", "IRanges", "InteractionSet", "MASS", "Matrix", "RANN", "S4Vectors", "dbscan", "htmlwidgets", "igraph", "plotrix", "rgl", "rjson", "scales", "trackViewer"]
     },
     "gep2pep": {
       "name": "gep2pep",
-      "version": "1.26.0",
-      "sha256": "1nfj8x2py6xi06lchbykp26gwx0114x31wb5q7g1vzc34hkmf2f4",
+      "version": "1.28.0",
+      "sha256": "10lxc4qlkc8brcd4wvp0s27b2hvja5aygfyw8rnpl83a1zy7ayvg",
       "depends": ["Biobase", "GSEABase", "XML", "digest", "foreach", "iterators", "repo", "rhdf5"]
     },
     "getDEE2": {
       "name": "getDEE2",
-      "version": "1.16.2",
-      "sha256": "0xc95r3j4bbk8a537hj9jjykjja22axv5gh7b12i305dvzjxrk8v",
+      "version": "1.18.0",
+      "sha256": "1d134sw87gianypnymgkwqr5pqq7rrnqwml43mglpnk4jrx8xgpi",
       "depends": ["SummarizedExperiment", "htm2txt"]
     },
     "geva": {
       "name": "geva",
-      "version": "1.14.0",
-      "sha256": "0qas6mlfm84b9w8s9gg7pp4wmv4sqpvg2kyrapjj1si8a337rs5l",
+      "version": "1.16.0",
+      "sha256": "1lwacqif40xj636y8qvbm40jgiw1hf3avp1frchcacbxr2fxg6ki",
       "depends": ["dbscan", "fastcluster", "matrixStats"]
+    },
+    "geyser": {
+      "name": "geyser",
+      "version": "1.0.0",
+      "sha256": "04s28nbrlgwc0v59dpakmvb823qvz62lbiz2hg98b46l7cb6lwq9",
+      "depends": ["BiocStyle", "ComplexHeatmap", "DT", "SummarizedExperiment", "bslib", "dplyr", "ggbeeswarm", "ggplot2", "htmltools", "magrittr", "shiny", "tibble", "tidyr", "tidyselect"]
     },
     "gg4way": {
       "name": "gg4way",
-      "version": "1.4.0",
-      "sha256": "0is9ff59bb97y52s6ivm83cmpm7gvbr6s4z9phbxv8c6zkcbdfr6",
+      "version": "1.6.0",
+      "sha256": "1igh50yhkj86va1wbx3jzyqxp83cr4sqdgi3n90295hfxaxxa609",
       "depends": ["DESeq2", "dplyr", "edgeR", "ggplot2", "ggrepel", "glue", "janitor", "limma", "magrittr", "purrr", "rlang", "scales", "stringr", "tibble", "tidyr"]
     },
     "ggbio": {
       "name": "ggbio",
-      "version": "1.54.0",
-      "sha256": "1p9ja262rnvdf5gmbspkrkwvbdv4la0321m92c0l78wj3mc9y1zh",
+      "version": "1.56.0",
+      "sha256": "1vdnwcq90awh2g48xirgsha07w33kqvi73mz6f3c6896abmz7p9w",
       "depends": ["AnnotationDbi", "AnnotationFilter", "BSgenome", "Biobase", "BiocGenerics", "Biostrings", "GGally", "GenomeInfoDb", "GenomicAlignments", "GenomicFeatures", "GenomicRanges", "Hmisc", "IRanges", "OrganismDbi", "Rsamtools", "S4Vectors", "SummarizedExperiment", "VariantAnnotation", "biovizBase", "ensembldb", "ggplot2", "gridExtra", "gtable", "reshape2", "rlang", "rtracklayer", "scales"]
     },
     "ggcyto": {
       "name": "ggcyto",
-      "version": "1.34.0",
-      "sha256": "0a74lb36482djxfr77akyqqa7wnj9y3g4fkn8ain2gsbb3l6kcbk",
+      "version": "1.36.0",
+      "sha256": "0pdbp05vv9n7dal1bmdkvb0p9vb4lixk19wr2k93kpj3bkc0dzaz",
       "depends": ["RColorBrewer", "data_table", "flowCore", "flowWorkspace", "ggplot2", "gridExtra", "hexbin", "ncdfFlow", "plyr", "rlang", "scales"]
     },
     "ggkegg": {
       "name": "ggkegg",
-      "version": "1.4.1",
-      "sha256": "0aqbxypqj63y02jxn3086mdkgxnh7f1zk0afd1w5spd3dymw3fpb",
+      "version": "1.6.0",
+      "sha256": "1cqg5inir80vwhzzd3jc7xs4j4nc7yy0lkiql6qviivrv0zs3yqj",
       "depends": ["BiocFileCache", "XML", "data_table", "dplyr", "ggplot2", "ggraph", "gtable", "igraph", "magick", "patchwork", "shadowtext", "stringr", "tibble", "tidygraph"]
     },
     "ggmanh": {
       "name": "ggmanh",
-      "version": "1.10.0",
-      "sha256": "1dd0k2b84m4nn67a5vpd6s25dfqi6dw6dxll5l0snhc84czn59d3",
+      "version": "1.12.0",
+      "sha256": "1kig1r2lbnkvs5y4xcs1z4m2gvkfly27bjf8ahpvbij6yyvgmydj",
       "depends": ["RColorBrewer", "SeqArray", "dplyr", "gdsfmt", "ggplot2", "ggrepel", "magrittr", "paletteer", "pals", "rlang", "scales", "tidyr"]
     },
     "ggmsa": {
       "name": "ggmsa",
-      "version": "1.12.0",
-      "sha256": "1bs81d3ml0nyi1sh5s3p2pm96hgqxm3cayndid0z6wzwig3wkqhg",
+      "version": "1.14.0",
+      "sha256": "0hd5vvx3p767q2fxp4rwq5ds348ki29b0qkmk67mmlflh8cz8p8f",
       "depends": ["Biostrings", "R4RNA", "RColorBrewer", "aplot", "dplyr", "ggalt", "ggforce", "ggplot2", "ggtree", "magrittr", "seqmagick", "statebins", "tidyr"]
     },
     "ggsc": {
       "name": "ggsc",
-      "version": "1.4.0",
-      "sha256": "15r13xg9kpa3sazw8hcbanaadzzq1lq69vam2ccq703vrrwjj89d",
+      "version": "1.6.0",
+      "sha256": "1xqrd0ghkav7wpb1s4wb42ic2h313varf3b4w0bqnaly3r05h9wr",
       "depends": ["RColorBrewer", "Rcpp", "RcppArmadillo", "RcppParallel", "Seurat", "SingleCellExperiment", "SummarizedExperiment", "cli", "dplyr", "ggfun", "ggplot2", "rlang", "scales", "scattermore", "tibble", "tidydr", "tidyr", "yulab_utils"]
     },
     "ggseqalign": {
       "name": "ggseqalign",
-      "version": "1.0.0",
-      "sha256": "0v0cssd2g7zn7d30z7w5lkcb2hk5kxfj7x3b9hw0c1mf545qn7bv",
+      "version": "1.2.0",
+      "sha256": "0k3p0rj5kx7rl35wrxzq334gkfls5bhx5j6lvn53j4snncipd2r1",
       "depends": ["dplyr", "ggplot2", "pwalign"]
     },
     "ggspavis": {
       "name": "ggspavis",
-      "version": "1.12.0",
-      "sha256": "0plm5g24inm82akwni2rjiixyihr9f6p5mlc5xg4hx2s721y9j1k",
+      "version": "1.14.0",
+      "sha256": "0wr3fw5f1kccm9mq14xbbjy0wx35ngvd52iw44285si23kh61sqk",
       "depends": ["RColorBrewer", "SingleCellExperiment", "SpatialExperiment", "SummarizedExperiment", "ggplot2", "ggrepel", "ggside", "scales"]
     },
     "ggtree": {
       "name": "ggtree",
-      "version": "3.14.0",
-      "sha256": "0ki9cap34jbf2xa9xkddfmaj8lmf5vc6b3a0w03q3z8c465v06g5",
+      "version": "3.16.0",
+      "sha256": "06wvqh66c0gf4xc9c65qr75w0rl99aqc4c4hks55axzb5q84yg6s",
       "depends": ["ape", "aplot", "cli", "dplyr", "ggfun", "ggplot2", "magrittr", "purrr", "rlang", "scales", "tidyr", "tidytree", "treeio", "yulab_utils"]
     },
     "ggtreeDendro": {
       "name": "ggtreeDendro",
-      "version": "1.8.0",
-      "sha256": "08q7nn819wsynm18nm8azl123j7fbwj05r9qch3igc5bcvzbwsf5",
+      "version": "1.10.0",
+      "sha256": "0jg2604wib9mdq88avmzndbjymhhzg0l9ig6j1hlv9fcgv62n2q1",
       "depends": ["ggplot2", "ggtree", "tidytree"]
     },
     "ggtreeExtra": {
       "name": "ggtreeExtra",
-      "version": "1.16.0",
-      "sha256": "1xlwz45zcr51r7n2yc2ffxz0p4xgwhnka868crg17f9d9g6phhdr",
+      "version": "1.18.0",
+      "sha256": "1dp6is7sqz88lbcxjn0khw6qm5szqad74yr0jbv3axd025nv2rp5",
       "depends": ["cli", "ggnewscale", "ggplot2", "ggtree", "magrittr", "rlang", "tidytree"]
     },
     "ggtreeSpace": {
       "name": "ggtreeSpace",
-      "version": "1.2.0",
-      "sha256": "0maahk7h4pxrxy9p7gxv8nqng98sl67j6869s78bqqc832wa1z7c",
+      "version": "1.4.0",
+      "sha256": "0imkzs139xr8385cn6629xa6ral87w8w522rb4jfqglkiykf9zrh",
       "depends": ["GGally", "ape", "dplyr", "ggplot2", "ggtree", "interp", "phytools", "rlang", "tibble", "tidyr", "tidyselect"]
     },
     "ginmappeR": {
       "name": "ginmappeR",
-      "version": "1.2.3",
-      "sha256": "0h6zzrxs3fd65a2qwbm1yiw7niwaa51avgy4fvcsbrlz8jd4vh0q",
+      "version": "1.4.0",
+      "sha256": "0a93nllavx3jpyr233p2qr72560mglkc2if657xlr99j7237z2bm",
       "depends": ["KEGGREST", "UniProt_ws", "XML", "cachem", "httr", "jsonlite", "memoise", "rentrez", "rvest"]
     },
     "girafe": {
       "name": "girafe",
-      "version": "1.58.0",
-      "sha256": "0mzd11zdm11nhv80sz6hgs8m4z30vmfc4l0ryr2za78v8f16yd0q",
+      "version": "1.60.0",
+      "sha256": "06cfbmr8y8xi3z3dl92w0ljl6w4px2m9nr28yp71i9yswa39j107",
       "depends": ["Biobase", "BiocGenerics", "Biostrings", "IRanges", "Rsamtools", "S4Vectors", "ShortRead", "genomeIntervals", "intervals", "pwalign"]
     },
     "glmGamPoi": {
       "name": "glmGamPoi",
-      "version": "1.18.0",
-      "sha256": "141drlbgld05npk1bay7pcng7xmm43y26559qs8mxy9432cpzx9n",
-      "depends": ["BiocGenerics", "DelayedArray", "DelayedMatrixStats", "HDF5Array", "MatrixGenerics", "Rcpp", "RcppArmadillo", "SingleCellExperiment", "SparseArray", "SummarizedExperiment", "beachmat", "matrixStats", "rlang", "vctrs"]
+      "version": "1.20.0",
+      "sha256": "0mfwhlj3mli7c5iabd90gbdzc22cvqq2wh26l3bqxjv5im07hgmx",
+      "depends": ["BiocGenerics", "DelayedArray", "DelayedMatrixStats", "HDF5Array", "Matrix", "MatrixGenerics", "Rcpp", "RcppArmadillo", "S4Vectors", "SingleCellExperiment", "SparseArray", "SummarizedExperiment", "assorthead", "beachmat", "matrixStats", "rlang", "vctrs"]
     },
     "glmSparseNet": {
       "name": "glmSparseNet",
-      "version": "1.24.0",
-      "sha256": "0ph7q1b80kmyjgb7kwi6mnjxrychaljsjlb1ab6bnbjwnrwm7d18",
+      "version": "1.26.0",
+      "sha256": "1fai7mkh4rspc2k7n09wwbxq03ap0d67ij3zwlbda2gfr997c88b",
       "depends": ["Matrix", "MultiAssayExperiment", "SummarizedExperiment", "TCGAutils", "biomaRt", "checkmate", "dplyr", "forcats", "futile_logger", "ggplot2", "glmnet", "glue", "httr", "lifecycle", "readr", "rlang", "survminer"]
     },
     "globalSeq": {
       "name": "globalSeq",
-      "version": "1.34.0",
-      "sha256": "1vv34jsrnifma9x2yds0ndmg43y50jh6gm8ax2lsasyzjpixkqmx",
+      "version": "1.36.0",
+      "sha256": "1vpdrbbx82hr467dns4fgkjx3bm2hkp9w69xnb9ji74d8pzpcnj7",
       "depends": []
     },
     "globaltest": {
       "name": "globaltest",
-      "version": "5.60.0",
-      "sha256": "1gi62ynkyvrzi6m691206wrlprid028h1rj1p725k4myi5fh06jr",
+      "version": "5.62.0",
+      "sha256": "0ra53iisn0ccb4l5icwrzrdkk4vzhpkr1pz2i7gi4iryyxlzbgf5",
       "depends": ["AnnotationDbi", "Biobase", "annotate", "survival"]
     },
     "gmapR": {
       "name": "gmapR",
-      "version": "1.48.0",
-      "sha256": "08ws3xifis7gchasbpcmvwz2nwi8any532vgyfh2wxg4wibzd0c9",
-      "depends": ["BSgenome", "Biobase", "BiocGenerics", "BiocParallel", "Biostrings", "GenomeInfoDb", "GenomicAlignments", "GenomicFeatures", "GenomicRanges", "IRanges", "Rsamtools", "S4Vectors", "VariantAnnotation", "rtracklayer"]
+      "version": "1.50.0",
+      "sha256": "0y2bw13vmnh752vakcnaqqwgx4sf1vkizcn1km98s1c8p10c45dv",
+      "depends": ["BSgenome", "Biobase", "BiocGenerics", "BiocIO", "BiocParallel", "Biostrings", "GenomeInfoDb", "GenomicAlignments", "GenomicFeatures", "GenomicRanges", "IRanges", "Rsamtools", "S4Vectors", "VariantAnnotation", "rtracklayer"]
     },
     "gmoviz": {
       "name": "gmoviz",
-      "version": "1.18.0",
-      "sha256": "025i9lsq0bjd8dwx4h8izg3pfbb1bxbdsfpfi5gkkzcvlbgcvc9q",
+      "version": "1.20.0",
+      "sha256": "0kbw83sif16g4316m1hb16426xv7wch4wj2ggiyi6srd445d1ykj",
       "depends": ["BiocGenerics", "Biostrings", "ComplexHeatmap", "GenomeInfoDb", "GenomicAlignments", "GenomicFeatures", "GenomicRanges", "IRanges", "Rsamtools", "S4Vectors", "circlize", "colorspace", "gridBase", "pracma", "rtracklayer"]
     },
     "goProfiles": {
       "name": "goProfiles",
-      "version": "1.68.0",
-      "sha256": "1lqsr1gqs8ikzspbi0g1smllkrm2ydlfi50in6ymyizkk3s8cz3g",
+      "version": "1.70.0",
+      "sha256": "06fgri975nnqad5mdppfara2w7fhpy0w8jfakz4mbg5n80spk770",
       "depends": ["AnnotationDbi", "Biobase", "CompQuadForm", "GO_db", "stringr"]
     },
     "goSTAG": {
       "name": "goSTAG",
-      "version": "1.30.0",
-      "sha256": "1wr5w1y41xqh6xsr3bf0cgz5lnlslcc1cqc4w01jh1j12hd6r7m7",
+      "version": "1.32.0",
+      "sha256": "1zp6lgxcy8c3lvwxq3grxw2zk5ilnijlan5yfhydmy2b4vjp7naf",
       "depends": ["AnnotationDbi", "GO_db", "biomaRt", "memoise"]
     },
     "goSorensen": {
       "name": "goSorensen",
-      "version": "1.8.0",
-      "sha256": "0gv7wls9xg6lbbhz29rdlfwvh1d90xzls0cnz6s2bi3f55vz7pwg",
+      "version": "1.10.0",
+      "sha256": "0zrwhsqi2gjf1v3m5np1shnqfa8gj9kkzlpnpmdc0clarhxa1089",
       "depends": ["clusterProfiler", "goProfiles", "org_Hs_eg_db", "stringr"]
     },
     "goTools": {
       "name": "goTools",
-      "version": "1.80.0",
-      "sha256": "0f3079d1hb6rr8iyp53dvbl9vx8iznqrjczgbfwz0jq4csyfiv05",
+      "version": "1.82.0",
+      "sha256": "0jcydnsjh9xacm3yazkjj493xyv54v6im9zp8kbk29a167fdd7qh",
       "depends": ["AnnotationDbi", "GO_db"]
     },
     "goseq": {
       "name": "goseq",
-      "version": "1.58.0",
-      "sha256": "1paya44vvzvbv0mr0vky4sjvmaqx8y4n5p457vxy2b8b3l086p45",
+      "version": "1.60.0",
+      "sha256": "08ds2zaqkv7r9qcn8wnd994k94ifj848kg9q9swyq5gm8sg8sbn0",
       "depends": ["AnnotationDbi", "BiasedUrn", "BiocGenerics", "GO_db", "GenomeInfoDb", "GenomicFeatures", "geneLenDataBase", "mgcv", "rtracklayer"]
     },
     "gpls": {
       "name": "gpls",
-      "version": "1.78.0",
-      "sha256": "1h8n4h8c0yax6295acxsiwnawhw495jlfn7wcw8d04za2xf9r0np",
+      "version": "1.80.0",
+      "sha256": "1nzjm4h7xm9hvz62nmi57agwprrbdk8z4nfg4z0vx85cjrrz1k9h",
       "depends": []
     },
     "gpuMagic": {
       "name": "gpuMagic",
-      "version": "1.22.0",
-      "sha256": "0h2fl3i4p1v4vnq481np8vfh0rzqxgip1xla3mmbv4s973761fh6",
+      "version": "1.23.0",
+      "sha256": "0skgw46i3419i1bsinhkl12f1jv5gf2bxjr7j7ml5g7azypq61ha",
       "depends": ["BiocGenerics", "Deriv", "DescTools", "Rcpp", "digest", "pryr", "stringr"]
     },
     "granulator": {
       "name": "granulator",
-      "version": "1.14.0",
-      "sha256": "038v9vg77czlm31lb6fs4g4yghlhs0c8vqkqdfmdj82i8jq66bcm",
+      "version": "1.16.0",
+      "sha256": "0ycwj878nyf8vc131781abvpz5dmyhdprflidw6gz5ywz16l7538",
       "depends": ["MASS", "cowplot", "dplyr", "dtangle", "e1071", "epiR", "ggplot2", "ggplotify", "limSolve", "magrittr", "nnls", "pheatmap", "purrr", "rlang", "tibble", "tidyr"]
     },
     "graper": {
       "name": "graper",
-      "version": "1.22.0",
-      "sha256": "18y2g6df4c22fbcw3x7yjj6qiy94pxc42x25bg93rqs42bg3n9qn",
+      "version": "1.23.0",
+      "sha256": "1xaa9656ng3fs94qhn761rg6ac4z5rypm1rvw5p4sbs487mdv0rs",
       "depends": ["BH", "Matrix", "Rcpp", "RcppArmadillo", "cowplot", "ggplot2", "matrixStats"]
     },
     "graph": {
       "name": "graph",
-      "version": "1.84.1",
-      "sha256": "19s5bzpbc5m99k7cvfl90ndy7pcwi9z42g45b6f9vh417k4r2and",
+      "version": "1.86.0",
+      "sha256": "0rzkz0nq4yzyr2165rw0grng3y21zyf36bgaa6l4hf5lzinik7mc",
       "depends": ["BiocGenerics"]
     },
     "graphite": {
       "name": "graphite",
-      "version": "1.52.0",
-      "sha256": "0ayqhz94qri62m0rs1x7q59s7wl4winqlahrwwd0k8qylgz9yx6b",
+      "version": "1.54.0",
+      "sha256": "0d0y8i2sswfkkdi0r9r28f4f41hp7qxxf5fxml39i5119bpkzzc5",
       "depends": ["AnnotationDbi", "graph", "httr", "purrr", "rappdirs", "rlang"]
     },
     "groHMM": {
       "name": "groHMM",
-      "version": "1.40.3",
-      "sha256": "0zx9xlrqaq11bnfcrchcg0kdbq4dcw8sx7zbxq2g715h89zihp1c",
+      "version": "1.42.0",
+      "sha256": "12b50lcsal9dmsgvfsccwa9w9h4askrfppfmfs9f99piyiavsvzz",
       "depends": ["GenomeInfoDb", "GenomicAlignments", "GenomicRanges", "IRanges", "MASS", "S4Vectors", "rtracklayer"]
     },
     "gscreend": {
       "name": "gscreend",
-      "version": "1.20.0",
-      "sha256": "07li76fv4zkmnbfm1ifzark65fj395bzsqsjdknhxyqpzcy6dyq9",
+      "version": "1.22.0",
+      "sha256": "0agcdswr2caislakgn5hk97p4jrmjp8k4ndfvhlhm3g42gpvxwca",
       "depends": ["BiocParallel", "SummarizedExperiment", "fGarch", "nloptr"]
     },
     "gsean": {
       "name": "gsean",
-      "version": "1.26.0",
-      "sha256": "0n8x95ii0pykh887mr3a6780qqsjyxwpc23y4paz4pdn9y0wppk6",
+      "version": "1.28.0",
+      "sha256": "0hgk1jdp8qrjkh0x91d0d8l7jhsmmnhppn3jfr08gwwnjsmkkvr1",
       "depends": ["PPInfer", "fgsea"]
     },
     "gtrellis": {
       "name": "gtrellis",
-      "version": "1.38.0",
-      "sha256": "1cf98aric80hz6jqriyk8m1cr4d9pxsjv7pixss2qsp797qvf87z",
+      "version": "1.40.0",
+      "sha256": "1a0v1ks87rly0x8hw3x1qpkyjc4dadi6bnlrwfqkrx8m7nnzxjp9",
       "depends": ["GenomicRanges", "GetoptLong", "IRanges", "circlize"]
     },
     "gwascat": {
       "name": "gwascat",
-      "version": "2.38.0",
-      "sha256": "1dh9av1b7df88l08y682aqmmmq5adrsh6bfc7a9rb4f6rcdzpadc",
-      "depends": ["AnnotationDbi", "AnnotationHub", "BiocFileCache", "Biostrings", "GenomeInfoDb", "GenomicFeatures", "GenomicRanges", "IRanges", "S4Vectors", "VariantAnnotation", "readr", "snpStats"]
+      "version": "2.40.0",
+      "sha256": "048h1i0i6wm1rsnn6gcc83wf3bagwvbphqi7rbchkws8rn3828v9",
+      "depends": ["AnnotationDbi", "AnnotationHub", "BiocFileCache", "Biostrings", "GenomeInfoDb", "GenomicFeatures", "GenomicRanges", "IRanges", "S4Vectors", "VariantAnnotation", "data_table", "readr", "snpStats", "tibble"]
     },
     "gwasurvivr": {
       "name": "gwasurvivr",
-      "version": "1.24.0",
-      "sha256": "1qj5w4a4vc3pmzwh6jmv5g7wv31h4zn1j2p33gav9379lm5ys3z6",
+      "version": "1.26.0",
+      "sha256": "0m41pyq86v5x6bdpiq7rh395m34bcmp92c2pjcmr5vl885dg2qh8",
       "depends": ["GWASTools", "SNPRelate", "SummarizedExperiment", "VariantAnnotation", "matrixStats", "survival"]
     },
     "gypsum": {
       "name": "gypsum",
-      "version": "1.2.0",
-      "sha256": "1qyb90r5qji9r0hy986891dyjqmryyszjp2v27q054mimwbgwskk",
+      "version": "1.4.0",
+      "sha256": "1mjlhn0026nfx4z7s4mdxd27b26vp5rklfqm2fksjizlid34h8fx",
       "depends": ["filelock", "httr2", "jsonlite", "rappdirs"]
+    },
+    "h5mread": {
+      "name": "h5mread",
+      "version": "1.0.0",
+      "sha256": "14cqk68qb3wsdyr40cdc4rg3g413m5zxccfkgc7s0x53klf9z2sn",
+      "depends": ["BiocGenerics", "IRanges", "Rhdf5lib", "S4Arrays", "S4Vectors", "SparseArray", "rhdf5", "rhdf5filters"]
     },
     "h5vc": {
       "name": "h5vc",
-      "version": "2.40.1",
-      "sha256": "06xn9k6kk4qasxaqd5q7n9r9ka03n56837dfcsqjni4jp7jx063r",
+      "version": "2.42.0",
+      "sha256": "19m73bmcv51v3kxa2i6khwpz39gfyf18ajnzikv91x1la9d347mw",
       "depends": ["BatchJobs", "BiocParallel", "Biostrings", "GenomeInfoDb", "GenomicRanges", "IRanges", "Rhtslib", "Rsamtools", "S4Vectors", "abind", "ggplot2", "gridExtra", "h5vcData", "reshape", "rhdf5"]
     },
     "hapFabia": {
       "name": "hapFabia",
-      "version": "1.48.0",
-      "sha256": "0l4i555mbv4bq95j7c6zqzg8f9v8165a96jdaplgp5f60zmvsik6",
+      "version": "1.50.0",
+      "sha256": "1qg4128q340q3zfzlyby1kpbslnk6pqd34rzp3c3xn6d56dkq4zp",
       "depends": ["Biobase", "fabia"]
     },
     "hca": {
       "name": "hca",
-      "version": "1.14.0",
-      "sha256": "0vjsgqlhhkiyvfqnfmw9sc05p3dvj7z662wg81p4q6sp8gylh156",
+      "version": "1.16.0",
+      "sha256": "1b2fj61m9h3h8ccly4y1ishr3ivrszpwc5j8rkkxy43nwmmv1r2p",
       "depends": ["BiocFileCache", "DT", "digest", "dplyr", "httr", "jsonlite", "miniUI", "readr", "shiny", "tibble", "tidyr"]
     },
     "hdxmsqc": {
       "name": "hdxmsqc",
-      "version": "1.2.0",
-      "sha256": "0f2qjywgs843y3mdl7kh3pf3fy88b03yjbkgrn1m1rwmpbnh8jkg",
+      "version": "1.4.0",
+      "sha256": "0vhy1qfjh99c3z49r4smhxij49ji3arqlv77w4kbdp3ac4wfwisb",
       "depends": ["BiocStyle", "MsCoreUtils", "QFeatures", "S4Vectors", "Spectra", "dplyr", "ggplot2", "knitr", "tidyr"]
     },
     "heatmaps": {
       "name": "heatmaps",
-      "version": "1.30.0",
-      "sha256": "0xq6dbl4mylvlr0hcgmw8qnbvpxvvdczdyw7iw1mcmj4rn5yyblb",
+      "version": "1.32.0",
+      "sha256": "0midacxd3k8hvvymgy8k3v5cm7b8hb3rph258agkkr3dyxlpb2dm",
       "depends": ["BiocGenerics", "Biostrings", "EBImage", "GenomeInfoDb", "GenomicRanges", "IRanges", "KernSmooth", "Matrix", "RColorBrewer", "plotrix"]
     },
     "hermes": {
       "name": "hermes",
-      "version": "1.10.0",
-      "sha256": "00aprldg8xb1340f06rcliwic1dlnksmb4l9yxd3lmwq944flbdy",
+      "version": "1.12.0",
+      "sha256": "0n3vninb333dj1yk5x3zd0xpra0cwdswl5bda6y6k7xzi6asa4vr",
       "depends": ["Biobase", "BiocGenerics", "ComplexHeatmap", "DESeq2", "EnvStats", "GenomicRanges", "IRanges", "MultiAssayExperiment", "R6", "Rdpack", "S4Vectors", "SummarizedExperiment", "assertthat", "biomaRt", "checkmate", "circlize", "dplyr", "edgeR", "forcats", "ggfortify", "ggplot2", "ggrepel", "lifecycle", "limma", "magrittr", "matrixStats", "purrr", "rlang", "tidyr"]
     },
     "hiAnnotator": {
       "name": "hiAnnotator",
-      "version": "1.40.0",
-      "sha256": "1imvh4gmczpx8agd2iq1aincjnp27pglchf9jcy9nslv6rxlvzlc",
+      "version": "1.42.0",
+      "sha256": "17c6v1w4lqiafvyfswf1p2wijzihawgazflwcviiq7dvx5qb0k6z",
       "depends": ["BSgenome", "GenomicRanges", "dplyr", "foreach", "ggplot2", "iterators", "rtracklayer", "scales"]
     },
     "hiReadsProcessor": {
       "name": "hiReadsProcessor",
-      "version": "1.42.0",
-      "sha256": "05jmkwnfq89yrf6vx26chblbaisnqyhpbfa8x32hmdvjva70pb7p",
+      "version": "1.44.0",
+      "sha256": "0xql5p20cqhwb5j13l643lshhrns45n4hg15x8lbk24r2zmb8azi",
       "depends": ["BiocGenerics", "BiocParallel", "Biostrings", "GenomicAlignments", "GenomicRanges", "dplyr", "hiAnnotator", "pwalign", "readxl", "sonicLength"]
     },
     "hicVennDiagram": {
       "name": "hicVennDiagram",
-      "version": "1.4.0",
-      "sha256": "0k9i0ax6y2a9d408r9ppm9v6xnyzhvy1bvyk02mw7rm7xb4ygbbs",
+      "version": "1.6.0",
+      "sha256": "1ijzplniw4sm3bw62sfl7wr7ydbpdrq859iyxz9rsbxfmbkrclzd",
       "depends": ["ComplexUpset", "GenomeInfoDb", "GenomicRanges", "IRanges", "InteractionSet", "S4Vectors", "eulerr", "ggplot2", "htmlwidgets", "reshape2", "rtracklayer", "svglite"]
     },
     "hierGWAS": {
       "name": "hierGWAS",
-      "version": "1.36.0",
-      "sha256": "1x2nk77g0ypgs9ba61s7wgsymn15pl1jcyc905zz7np30gmw3hg5",
+      "version": "1.38.0",
+      "sha256": "0539jn026704hcn2zdi3srszf1wahsxb5ph79jl7m2hx8hns05zr",
       "depends": ["fastcluster", "fmsb", "glmnet"]
     },
     "hierinf": {
       "name": "hierinf",
-      "version": "1.24.0",
-      "sha256": "1f3ph3n94kqgddlhc8vnmxm1a67avq2nvf6vmic8mxkkpkqrj6vz",
+      "version": "1.26.0",
+      "sha256": "10d5g0jcjidj4p4rajkg4f45nhgyqbwa6rlpbhwiljjk24lryjin",
       "depends": ["fmsb", "glmnet"]
     },
     "hipathia": {
       "name": "hipathia",
-      "version": "3.6.0",
-      "sha256": "0h7c1jvfvxglxjrwhl8a6psw53wchc49vxb8j1qj7gzvkw8s849a",
+      "version": "3.8.0",
+      "sha256": "0lplbzcxgb1x5y5rqxr2jbl3a5fg7xh26p2i96mx39mmz8xvwnz0",
       "depends": ["AnnotationHub", "DelayedArray", "MetBrewer", "MultiAssayExperiment", "S4Vectors", "SummarizedExperiment", "coin", "dplyr", "ggplot2", "ggpubr", "igraph", "limma", "matrixStats", "preprocessCore", "reshape2", "servr", "tibble", "visNetwork"]
     },
     "hmdbQuery": {
       "name": "hmdbQuery",
-      "version": "1.26.0",
-      "sha256": "02kmb7gsmc1m5rfp1423m788f4l4013nk7zdckn2ydmp9385c9ga",
+      "version": "1.28.0",
+      "sha256": "0qd610p0cksa1l3vbmrfzxszvrpbc2b4q24537dq7cbkf7vrwdri",
       "depends": ["S4Vectors", "XML"]
     },
     "hoodscanR": {
       "name": "hoodscanR",
-      "version": "1.4.0",
-      "sha256": "12882rrmz407m3pz86jp6576pj0739nvgcdjc1db46y9lqwvmmmn",
+      "version": "1.6.0",
+      "sha256": "02xp81p1x8h2hykr3g70zm7ig86ljjz3rxsiy1p7j9xcp3fbkzjw",
       "depends": ["ComplexHeatmap", "RANN", "Rcpp", "SpatialExperiment", "SummarizedExperiment", "circlize", "ggplot2", "knitr", "rlang", "rmarkdown", "scico"]
     },
     "hopach": {
       "name": "hopach",
-      "version": "2.66.0",
-      "sha256": "15brfhyavqdfdpippy0pl93rpppxsmmmi1j5xxkl3ynhz3s0lcj1",
+      "version": "2.68.0",
+      "sha256": "1p6cjcs0jws31v53kys3az4hlln92mr1wq711n71p2xmxj3bs69s",
       "depends": ["Biobase", "BiocGenerics", "cluster"]
     },
     "hpar": {
       "name": "hpar",
-      "version": "1.48.0",
-      "sha256": "0b3m2krlmvfjcwb0f6y5gxwdi55hizzps1cp7imgx1mqgsv5gjya",
+      "version": "1.50.0",
+      "sha256": "1r12x855l91jpcxllfink2dzw5gkpx5laq0krgn09rcbp87bm5zj",
       "depends": ["ExperimentHub"]
     },
     "hummingbird": {
       "name": "hummingbird",
-      "version": "1.16.0",
-      "sha256": "1scwjab7cc522rqs24633bxg1nl3vg2f2i60kcvzyard2n6j5f92",
+      "version": "1.18.0",
+      "sha256": "0k9rvgfmgj33n2qzdz8b9mp1nxnsf9kk6k3qin5shiacdfa97ir3",
       "depends": ["GenomicRanges", "IRanges", "Rcpp", "SummarizedExperiment"]
     },
     "hypeR": {
       "name": "hypeR",
-      "version": "2.4.0",
-      "sha256": "129lmbq271q45ggafa6c69vybssnv61a3789hj7caq0fax4ds8zv",
+      "version": "2.5.0",
+      "sha256": "1c4ag9k8f91xyz3b57qrykj8kn467fh31lh41xw7vh1w7kwb0vjb",
       "depends": ["BiocStyle", "R6", "dplyr", "ggforce", "ggplot2", "htmltools", "httr", "igraph", "kableExtra", "magrittr", "msigdbr", "openxlsx", "purrr", "reactable", "reshape2", "rlang", "rmarkdown", "scales", "shiny", "stringr", "visNetwork"]
     },
     "hyperdraw": {
       "name": "hyperdraw",
-      "version": "1.58.0",
-      "sha256": "0p98gicscijllmhb302jca1z04xvm9rcrsnz429c3d8rckz3asr9",
+      "version": "1.60.0",
+      "sha256": "1dq35dlcifqdkgh3nrry3h5rx3q948wvlw9g3kn3v7wy15lklh33",
       "depends": ["Rgraphviz", "graph", "hypergraph"]
     },
     "hypergraph": {
       "name": "hypergraph",
-      "version": "1.78.0",
-      "sha256": "1928iia8l2sanirzb22i67n71zsnbps0qbdsf6ll7zpvs2vcmd5c",
+      "version": "1.80.0",
+      "sha256": "10a7c319ikn9yznf3b7m5vdwbycbjdjb0nc9b6wjvarw3775d77i",
       "depends": ["graph"]
     },
     "iASeq": {
       "name": "iASeq",
-      "version": "1.50.0",
-      "sha256": "0wfd04xx7ma4qb4n71dx3svs02r0zjhaidz6943m7i1zm4qd1wzx",
+      "version": "1.52.0",
+      "sha256": "18xjfybwzqjgig2a7jhw2sbxq6f4893zj26dsfkzqljad3llvb02",
       "depends": []
     },
     "iBBiG": {
       "name": "iBBiG",
-      "version": "1.50.0",
-      "sha256": "0fcgcnb07m7llyngsmnnrw0337j4aijmwyqxiszxcyzrvmg6w6wf",
+      "version": "1.52.0",
+      "sha256": "10qg71bcw14wwla5vggb0q6m8cgmjvss792332qsvhhfvyxhz9ah",
       "depends": ["ade4", "biclust", "xtable"]
     },
     "iBMQ": {
       "name": "iBMQ",
-      "version": "1.46.0",
-      "sha256": "1miw0yrl29hmv7887achjjhibi6fsqgkmixacj3g7m9h6skj2zcl",
+      "version": "1.48.0",
+      "sha256": "0h916h1dgjmk4cd048rjccs76whm0p91byszfs6ynql4bzypdh0d",
       "depends": ["Biobase", "ggplot2"]
     },
     "iCARE": {
       "name": "iCARE",
-      "version": "1.34.0",
-      "sha256": "0a92sahiv5ccwdiqswx9fjry7gnspp8z4msiq1kc9hfys3cyb9wq",
+      "version": "1.36.0",
+      "sha256": "17l8v8qi0mj7r6zcnv1zhhysk6p5bfviafxdjm3pdzb3cx9x6kiy",
       "depends": ["Hmisc", "gtools", "plotrix"]
     },
     "iCNV": {
       "name": "iCNV",
-      "version": "1.26.0",
-      "sha256": "117ppsh2d7ziml9avyw6kjrb3rvl2ddbsv2l44bng0hfr7qwmbif",
+      "version": "1.28.0",
+      "sha256": "17gmfvpwm97ykpg2mwcp5ink8i6ry8bd0yi848xyb6q4s5i0yn7y",
       "depends": ["CODEX", "data_table", "dplyr", "fields", "ggplot2", "rlang", "tidyr", "truncnorm"]
     },
     "iCOBRA": {
       "name": "iCOBRA",
-      "version": "1.34.0",
-      "sha256": "0fhvzrp6q4kcx9xjy96iyra2z1yc4c2vagmnymzbj1gli4sl2idx",
+      "version": "1.36.0",
+      "sha256": "1dwrsjapgwh7q7q5qmy8k1iq5v5m2d3bz40jvnk7hqnm404qgzgf",
       "depends": ["DT", "ROCR", "UpSetR", "dplyr", "ggplot2", "limma", "markdown", "reshape2", "rlang", "scales", "shiny", "shinyBS", "shinydashboard"]
     },
     "iCheck": {
       "name": "iCheck",
-      "version": "1.36.0",
-      "sha256": "10pqglc77gj9adbzad9rljr723nnaf57ylqvnjzhl193c7k8j1d4",
+      "version": "1.38.0",
+      "sha256": "1722j96py7fyaf5cla6alky0d0cmps5rb57wjgnhhvv1c0lvvpbs",
       "depends": ["Biobase", "GeneSelectMMD", "MASS", "affy", "gplots", "limma", "lmtest", "lumi", "preprocessCore", "randomForest", "rgl", "scatterplot3d"]
     },
     "iChip": {
       "name": "iChip",
-      "version": "1.60.0",
-      "sha256": "1xbbrsdynwrs9p271siw7dvvyzvhlm1jrkfbgbkhp42kzg9ljx7q",
+      "version": "1.62.0",
+      "sha256": "0icv1nphpcznj18v5sk7yi3dhhk13x3q06yl87bwrswc6bzarqdf",
       "depends": ["limma"]
     },
     "iClusterPlus": {
       "name": "iClusterPlus",
-      "version": "1.42.0",
-      "sha256": "0ir2xshq4qmzyli9v14cmlk262px47ng5gd23r4sf6p065xnws6m",
+      "version": "1.44.0",
+      "sha256": "150g1903yiwn2314pvwp8dnm1ba69ckbx6668p1yx8kdiz13kvwj",
       "depends": []
     },
     "iGC": {
       "name": "iGC",
-      "version": "1.36.0",
-      "sha256": "1j2v2hv5j1xwbcm7z35l2mml2l2iwzl3dhda3590c33vmihl1dza",
+      "version": "1.38.0",
+      "sha256": "10qdwkqakhz7pjaqp1zla2mzg25gji99hx2mhhmpykq0999c0203",
       "depends": ["data_table", "plyr"]
     },
     "iNETgrate": {
       "name": "iNETgrate",
-      "version": "1.4.0",
-      "sha256": "1bb33ijrdjkyrzp0ws96rcbbyk8fl19l3x8h4xir6s7an1510bdj",
+      "version": "1.6.0",
+      "sha256": "02862s4wqzmxhyvbk7d854wlp0whsww7g2w2ngwr5s4n1ri190p0",
       "depends": ["BiocStyle", "GenomicRanges", "Homo_sapiens", "Pigengene", "Rfast", "SummarizedExperiment", "WGCNA", "caret", "glmnet", "gplots", "igraph", "matrixStats", "minfi", "survival", "tidyr", "tidyselect"]
     },
     "iPath": {
       "name": "iPath",
-      "version": "1.12.0",
-      "sha256": "003yyin2jh08p2n9miiq7kyvvxjzknj7r6gb4x8dvadn7w664mm1",
+      "version": "1.14.0",
+      "sha256": "0in8gcs669kcp397z5jishf26prgp86f7w86jwbdmi5j232xb9da",
       "depends": ["BiocParallel", "Rcpp", "RcppArmadillo", "ggplot2", "ggpubr", "matrixStats", "mclust", "survival", "survminer"]
     },
     "iSEE": {
       "name": "iSEE",
-      "version": "2.18.0",
-      "sha256": "1rc3yfnvqn7qm4sia9fgfx9pdsa795c64ns1gcxc0893mcx2vilx",
+      "version": "2.20.0",
+      "sha256": "0vd6cgp6kz4nidic04drx335gy3ivf5j8sm8s3j6jm7qjl7pjwp4",
       "depends": ["BiocGenerics", "ComplexHeatmap", "DT", "S4Vectors", "SingleCellExperiment", "SummarizedExperiment", "circlize", "colourpicker", "ggplot2", "ggrepel", "igraph", "listviewer", "mgcv", "rintrojs", "shiny", "shinyAce", "shinyWidgets", "shinydashboard", "shinyjs", "vipor", "viridisLite"]
     },
     "iSEEde": {
       "name": "iSEEde",
-      "version": "1.4.0",
-      "sha256": "0v45nrjr856zq5a811zmbwsdg3ym0jnyq6nv5npbpwb646qzaxhv",
+      "version": "1.6.0",
+      "sha256": "0hka6cq0jbxz8l7ymi85jwsqh9m8n1khwnngda8jx8w2y3snxgrl",
       "depends": ["DESeq2", "S4Vectors", "SummarizedExperiment", "edgeR", "iSEE", "shiny"]
     },
     "iSEEfier": {
       "name": "iSEEfier",
-      "version": "1.2.0",
-      "sha256": "1wfvbf6hka8ngah64sqrdkvi2vbshg0jcv3gz48mrk02xfm5lfrz",
+      "version": "1.4.0",
+      "sha256": "04gw4njrc3rb1c319s7qm26a42d5rww1pvy6h04cnah2vqa91j2y",
       "depends": ["BiocBaseUtils", "SingleCellExperiment", "SummarizedExperiment", "ggplot2", "iSEE", "iSEEu", "igraph", "rlang", "visNetwork"]
     },
     "iSEEhex": {
       "name": "iSEEhex",
-      "version": "1.8.0",
-      "sha256": "11w03h5b2j3qyql2ljxpllh60kk1dgizhihnamlr5cs903qwmw5c",
+      "version": "1.10.0",
+      "sha256": "16cl60f8h6qv31sry7plrh77636a38fsrx24rn3a57dyrrawyc10",
       "depends": ["SummarizedExperiment", "ggplot2", "hexbin", "iSEE", "shiny"]
     },
     "iSEEhub": {
       "name": "iSEEhub",
-      "version": "1.8.0",
-      "sha256": "0bc9b3vd9h5hvpqf4pffifd8cqnh21dckkpgjsv8k7w7y694r5n8",
+      "version": "1.10.0",
+      "sha256": "0rvviazpygr6qa5vqf1wfqgx07i0z9712j4zzmajmws1kc34gqk9",
       "depends": ["AnnotationHub", "BiocManager", "DT", "ExperimentHub", "S4Vectors", "SingleCellExperiment", "SummarizedExperiment", "iSEE", "rintrojs", "shiny", "shinydashboard", "shinyjs"]
     },
     "iSEEindex": {
       "name": "iSEEindex",
-      "version": "1.4.0",
-      "sha256": "08q6sal4vszdnrpz9zyqsfqi2ipha4qldlbknlvmxlpbx4icdb7j",
+      "version": "1.6.0",
+      "sha256": "0q1jdjxwnmg6jqgm6l5h25gk20yjg2lcvavaq9m9by7s9zwpc934",
       "depends": ["BiocFileCache", "DT", "SingleCellExperiment", "SummarizedExperiment", "iSEE", "paws_storage", "rintrojs", "shiny", "shinydashboard", "shinyjs", "stringr", "urltools"]
     },
     "iSEEpathways": {
       "name": "iSEEpathways",
-      "version": "1.4.0",
-      "sha256": "0p1vrz196kdq8z8wq5vvz7d5kghxkz6ahgdh8w1kycah5iq2plrq",
+      "version": "1.6.0",
+      "sha256": "1z150fbgx8z12ppnwr14g84mdrf133p7mavwvaynxs0lbfrjblzf",
       "depends": ["S4Vectors", "SummarizedExperiment", "ggplot2", "iSEE", "shiny", "shinyWidgets"]
     },
     "iSEEtree": {
       "name": "iSEEtree",
-      "version": "1.0.0",
-      "sha256": "0zwpdzwsxaa4j6ds8qpai6q5mhcfdi3pg3lgy28v52pnvys0l9ah",
-      "depends": ["S4Vectors", "SingleCellExperiment", "SummarizedExperiment", "TreeSummarizedExperiment", "iSEE", "mia", "miaViz", "shiny", "shinyWidgets"]
+      "version": "1.2.0",
+      "sha256": "150zlmzdx1y19zjmwqnnw6qk97z57lq52d7s599lkc9va51x23r4",
+      "depends": ["S4Vectors", "SingleCellExperiment", "SummarizedExperiment", "TreeSummarizedExperiment", "ape", "ggplot2", "ggtree", "iSEE", "mia", "miaViz", "purrr", "shiny", "shinyWidgets", "tidygraph"]
     },
     "iSEEu": {
       "name": "iSEEu",
-      "version": "1.18.0",
-      "sha256": "0dqws1y7is0ic5bc1rfkcsvmknkcg8nb9kxjfn3nlpiicv0g4411",
+      "version": "1.20.0",
+      "sha256": "09g67nkb3g1lln2nsx80nym6rp19w58rb98k0kz679z74rip7k9x",
       "depends": ["DT", "IRanges", "S4Vectors", "SingleCellExperiment", "SummarizedExperiment", "colourpicker", "ggplot2", "iSEE", "iSEEhex", "shiny", "shinyAce"]
     },
     "iSeq": {
       "name": "iSeq",
-      "version": "1.58.0",
-      "sha256": "00r776j1klf96f0qdj0b9h5fi2gnf0iscbnvbshiblla7cmirvky",
+      "version": "1.60.0",
+      "sha256": "1bc2nplnayn0m32sya1dlrima9i54vhk6fc1s2lsfcng4xwxcv7d",
       "depends": []
     },
     "iasva": {
       "name": "iasva",
-      "version": "1.24.0",
-      "sha256": "1bfhlljnnb3m42k9v75a66d46w1lg4lma3l6ldksimvx1g49yv5w",
+      "version": "1.26.0",
+      "sha256": "0d9hp6dckilv5rcjijampzdlcbp7kg3pzx9d4x31wzrbl8154lw3",
       "depends": ["BiocParallel", "SummarizedExperiment", "cluster", "irlba"]
     },
     "ibh": {
       "name": "ibh",
-      "version": "1.54.0",
-      "sha256": "19vqg4qsxdg0l5v93yqr2fgjjpjzmp4971a2x3jpvnbdbxfrlpw4",
+      "version": "1.56.0",
+      "sha256": "028d3kj24cyipbyw5l7ahxpllmigxpz13s5dhg71rhf6gbinxpk8",
       "depends": ["simpIntLists"]
     },
     "icetea": {
       "name": "icetea",
-      "version": "1.24.0",
-      "sha256": "1iykvznc7x3j035advjaxb72clp16pymc9hy6gl88v1z6i52l36b",
+      "version": "1.26.0",
+      "sha256": "0vdd65lw2c7ykqz4lica07k27iq21h7zgxkysjp4fbpysdplm2n1",
       "depends": ["BiocGenerics", "BiocParallel", "Biostrings", "DESeq2", "GenomicAlignments", "GenomicFeatures", "GenomicRanges", "IRanges", "Rsamtools", "S4Vectors", "ShortRead", "SummarizedExperiment", "TxDb_Dmelanogaster_UCSC_dm6_ensGene", "VariantAnnotation", "csaw", "edgeR", "ggplot2", "limma", "rtracklayer"]
     },
     "ideal": {
       "name": "ideal",
-      "version": "2.0.0",
-      "sha256": "0dlyhlyw7n8ncf1qzbcs28yy266ijfqdg27x6x2wsa794dpxm6fv",
+      "version": "2.2.0",
+      "sha256": "1hgc14pnlfa10h0fjaz4yz6rhm509rw5mwm8icdlgdryxqpgvmh5",
       "depends": ["AnnotationDbi", "BiocParallel", "DESeq2", "DT", "GO_db", "GOstats", "GenomicRanges", "IHW", "IRanges", "S4Vectors", "SummarizedExperiment", "UpSetR", "base64enc", "dplyr", "ggplot2", "ggrepel", "goseq", "gplots", "heatmaply", "knitr", "limma", "mosdef", "pheatmap", "plotly", "rentrez", "rintrojs", "rlang", "rmarkdown", "shiny", "shinyAce", "shinyBS", "shinydashboard", "stringr", "topGO"]
     },
     "idiogram": {
       "name": "idiogram",
-      "version": "1.82.0",
-      "sha256": "1ilsid362bwh1jqqhwfvn0qwpwc5l2hq2npcg2skq4p3bn9ds52w",
+      "version": "1.84.0",
+      "sha256": "1zadfim9yrv3b0jqbfgr0vn86rnn3di0qx1d3w9gb54ghd4281l0",
       "depends": ["Biobase", "annotate", "plotrix"]
     },
     "idpr": {
       "name": "idpr",
-      "version": "1.16.0",
-      "sha256": "1qq56ggp4wlydzi35fckp0mfb29hmy4lmxl5kdz7vfyfagr0r319",
+      "version": "1.18.0",
+      "sha256": "1sl1vyhx5sbrylaz1h9xrsn95rhhizx9r0y0lk0vciz0i1n2wqv8",
       "depends": ["Biostrings", "dplyr", "ggplot2", "jsonlite", "magrittr", "plyr", "rlang"]
     },
     "idr2d": {
       "name": "idr2d",
-      "version": "1.20.0",
-      "sha256": "0yz86bx0pvgj4rnjfj6ha08kjr0gg7l739w92xqdr7gz1qc94c8s",
+      "version": "1.22.0",
+      "sha256": "0hj15k2525nnb440wsqksbv7wk1ghi9szf0n5dypvgd15lswgsaz",
       "depends": ["GenomeInfoDb", "GenomicRanges", "IRanges", "dplyr", "futile_logger", "ggplot2", "idr", "magrittr", "reticulate", "scales", "stringr"]
     },
     "igvR": {
       "name": "igvR",
-      "version": "1.26.0",
-      "sha256": "172a6mmqs7vbjirpy8i88pnwmh0qi401wf9x7rbmfzz8jkakmpz3",
+      "version": "1.28.0",
+      "sha256": "0b6x3bmmanv046ddq2bxi0ggh79z983bsimpv6sfp6bzmnlm255s",
       "depends": ["BiocGenerics", "BrowserViz", "GenomicAlignments", "GenomicRanges", "RColorBrewer", "VariantAnnotation", "httpuv", "httr", "rtracklayer"]
     },
     "igvShiny": {
       "name": "igvShiny",
-      "version": "1.2.0",
-      "sha256": "0149knb7ff1ny4g15hk1h49ryfmxs7dfkfza41dqj25iknzza31y",
+      "version": "1.4.0",
+      "sha256": "1rjz6jl5xm3s3l84q9izgrzmvwfg2irfhqc1l78dw4qnkmalqmk4",
       "depends": ["BiocGenerics", "GenomeInfoDbData", "GenomicRanges", "checkmate", "futile_logger", "htmlwidgets", "httr", "jsonlite", "randomcoloR", "shiny"]
     },
     "illuminaio": {
       "name": "illuminaio",
-      "version": "0.48.0",
-      "sha256": "1czvan67l4ib0xw76a9qgcwa0x2vswv752nrslj9k9mhdav6syms",
+      "version": "0.50.0",
+      "sha256": "1azz7r90l9f7ns2p37qigwk45glq0p7rxkmgf939484iizkxq275",
       "depends": ["base64"]
+    },
+    "imageTCGA": {
+      "name": "imageTCGA",
+      "version": "1.0.0",
+      "sha256": "053q3wrqgq6j2wixjf23lysx9h4qbbww24856d9agjlgx5m6r20p",
+      "depends": ["DT", "bsicons", "bslib", "clipr", "dplyr", "ggplot2", "leaflet", "rlang", "shiny", "tidyr", "viridis"]
     },
     "imcRtools": {
       "name": "imcRtools",
-      "version": "1.12.0",
-      "sha256": "0p474plzgf2ngy877fi9d81mj7zla44wqzwan4y9znkp6vlmsikl",
+      "version": "1.14.0",
+      "sha256": "1118pdpi3fzkdl7k1q4q2m34r3hy7h72nsy48d4391ghdcf3hlmk",
       "depends": ["BiocNeighbors", "BiocParallel", "DT", "EBImage", "MatrixGenerics", "RTriangle", "S4Vectors", "SingleCellExperiment", "SpatialExperiment", "SummarizedExperiment", "abind", "concaveman", "cytomapper", "data_table", "distances", "dplyr", "ggplot2", "ggraph", "igraph", "magrittr", "pheatmap", "readr", "rlang", "scuttle", "sf", "stringr", "tidygraph", "tidyselect", "viridis", "vroom"]
     },
     "immApex": {
       "name": "immApex",
-      "version": "1.0.5",
-      "sha256": "1h1pqqaz9acmsa1x9051d5g8clxhdx2mm4qahczr45wj6bdia22w",
+      "version": "1.1.0",
+      "sha256": "08lscvphgz7v53rllvkm8g6avsdjkgypqiwpx7lnkwnzkvj76f16",
       "depends": ["SingleCellExperiment", "hash", "httr", "keras3", "magrittr", "matrixStats", "reticulate", "rvest", "stringi", "stringr", "tensorflow"]
     },
     "immunoClust": {
       "name": "immunoClust",
-      "version": "1.38.0",
-      "sha256": "1v6flzlf6xblinn072dayvnzbdjk5fqvzji05vh8gffy6xgsjf8k",
+      "version": "1.40.0",
+      "sha256": "1m2caghphf47kv358psz11ydc7k9vapgcqqq60vhqpplclg51ry2",
       "depends": ["flowCore", "lattice"]
     },
     "immunogenViewer": {
       "name": "immunogenViewer",
-      "version": "1.0.0",
-      "sha256": "1mczzpcbsbxs2f9zc0qg22kvh7c0lz4l8jsfk57g2867i9mng3xf",
+      "version": "1.1.1",
+      "sha256": "1nvpv7m9r498mf21qmxina045qfn0ld2gwha8cscnjyx7m3a514y",
       "depends": ["UniProt_ws", "ggplot2", "httr", "jsonlite", "patchwork"]
     },
     "immunotation": {
       "name": "immunotation",
-      "version": "1.14.0",
-      "sha256": "0v7ffiv3wzb2kbmd6raxacg7i26gimry6xpzzzr0agi8zjj8pfis",
+      "version": "1.16.0",
+      "sha256": "0ii5lhcwlr065kx7yjq3bby446i67msl4p3iyc9hxxbv4a8yqivf",
       "depends": ["curl", "ggplot2", "maps", "ontologyIndex", "readr", "rlang", "rvest", "stringr", "tidyr", "xml2"]
     },
     "impute": {
       "name": "impute",
-      "version": "1.80.0",
-      "sha256": "19w88r5c9c522jafl4bdxravphpxady3n8bkd17vngxvla9m257z",
+      "version": "1.82.0",
+      "sha256": "1pmhz101nwab2f0p1afmb87b16rgd62ym724x4q30ll6rv5nc85s",
       "depends": []
     },
     "infercnv": {
       "name": "infercnv",
-      "version": "1.22.0",
-      "sha256": "04ccxn2nzwjmcpbsxrksavrhjgbwv1zpc9i9dkyjsf0sirhn1mkf",
+      "version": "1.24.0",
+      "sha256": "0bix9cnb1bmbnjw5hfddl9hcg49j2gm9aaqr5sn2qf114by1pxr4",
       "depends": ["BiocGenerics", "HiddenMarkov", "Matrix", "RANN", "RColorBrewer", "Seurat", "SingleCellExperiment", "SummarizedExperiment", "ape", "argparse", "caTools", "coda", "coin", "digest", "doParallel", "dplyr", "edgeR", "fastcluster", "fitdistrplus", "foreach", "futile_logger", "future", "ggplot2", "gplots", "gridExtra", "igraph", "parallelDist", "phyclust", "reshape2", "rjags", "tidyr"]
     },
     "infinityFlow": {
       "name": "infinityFlow",
-      "version": "1.16.0",
-      "sha256": "1rfpw99hpry453k453m5ib9lvjcd25n1bqrsmc74a5s7xcc2gviv",
+      "version": "1.18.0",
+      "sha256": "03vx7k6q8w2amcv10y3d7a1cagzns8l1xk0a15hfqmyqygg8x700",
       "depends": ["Biobase", "flowCore", "generics", "gtools", "matlab", "pbapply", "png", "raster", "uwot", "xgboost"]
     },
     "intansv": {
       "name": "intansv",
-      "version": "1.46.0",
-      "sha256": "021mjg4ahfmivq6y6xxh9a745i52jjrwl2qhb2dr2k2fnn7k8f92",
+      "version": "1.48.0",
+      "sha256": "14lcya7w4mp8i1c6ynhphakbf12ypqyyv7m1l6qmpy83dhd4djlk",
       "depends": ["BiocGenerics", "GenomicRanges", "IRanges", "ggbio", "plyr"]
     },
     "interacCircos": {
       "name": "interacCircos",
-      "version": "1.16.0",
-      "sha256": "0abaa8m0pjsifhx0wnr5zz5vfi297wlp8h6gxq87z26k0djg2085",
+      "version": "1.18.0",
+      "sha256": "0j7d2l7a4jr2qwfkw2jx4bvg0flwgv1yaw5p3kz32dnlsdxwlzdl",
       "depends": ["RColorBrewer", "htmlwidgets", "plyr"]
     },
     "interactiveDisplay": {
       "name": "interactiveDisplay",
-      "version": "1.44.0",
-      "sha256": "1gqn93j7ysa34qgwv1166a51n817zm1pcghx7i7wjaiazbs9rlv9",
+      "version": "1.46.0",
+      "sha256": "0xx8rl1ifk631v39pmzi82zavi89m74p7pslgv2w40ms4fia9vgj",
       "depends": ["AnnotationDbi", "BiocGenerics", "Category", "RColorBrewer", "XML", "ggplot2", "gridSVG", "interactiveDisplayBase", "plyr", "reshape2", "shiny"]
     },
     "interactiveDisplayBase": {
       "name": "interactiveDisplayBase",
-      "version": "1.44.0",
-      "sha256": "1w39vn00armnka9sbgczc0madwc3hmcn4awcyl1xbq86q8danx11",
+      "version": "1.46.0",
+      "sha256": "1xnllqanpfc8dghbzcd63dsycdagb1q8bvqpqv2isal9gpycw6q8",
       "depends": ["BiocGenerics", "DT", "shiny"]
     },
     "ipdDb": {
       "name": "ipdDb",
-      "version": "1.24.0",
-      "sha256": "1xgzb184p9qn58ivd5jmbnxhyas18pzs8c8igkgyhn3dw4jd1a2z",
+      "version": "1.26.0",
+      "sha256": "1djzg748zj8hl2z64lbs9kzrxbn65c817sz3zpl0xb5w1y20r4hg",
       "depends": ["AnnotationDbi", "AnnotationHub", "Biostrings", "DBI", "GenomicRanges", "IRanges", "RSQLite", "assertthat"]
+    },
+    "islify": {
+      "name": "islify",
+      "version": "1.0.0",
+      "sha256": "0439qhcn4xhcwcpbh4f6s3hf6xzv3yp8jrlymrgmdj3zklkic4mn",
+      "depends": ["Matrix", "RBioFormats", "abind", "autothresholdr", "dbscan", "png", "tiff"]
     },
     "isobar": {
       "name": "isobar",
-      "version": "1.52.0",
-      "sha256": "0qw837cil704zlr0h5rip57fk29d1kikfh21pf84i8860j3170hq",
+      "version": "1.54.0",
+      "sha256": "0z6qf3lngwlpzxv2mwlblwh640ixpsdiarq7wfhyxlzmjazw69vc",
       "depends": ["Biobase", "biomaRt", "distr", "ggplot2", "plyr"]
     },
     "isomiRs": {
       "name": "isomiRs",
-      "version": "1.34.0",
-      "sha256": "0yx5n6k0x7brjwrjin4ilir8ly11qpbdm0fyv9zqjalqdfdx6czw",
+      "version": "1.36.0",
+      "sha256": "1yfp3x1jjy6ss670n04l4wpj3wgk48wazkzwdwjwmp7dsamdc25n",
       "depends": ["AnnotationDbi", "Biobase", "BiocGenerics", "DEGreport", "DESeq2", "GGally", "GenomicRanges", "IRanges", "RColorBrewer", "S4Vectors", "SummarizedExperiment", "broom", "cluster", "cowplot", "dplyr", "ggplot2", "gplots", "gridExtra", "gtools", "limma", "readr", "reshape", "rlang", "stringr", "tibble", "tidyr"]
     },
     "iterativeBMA": {
       "name": "iterativeBMA",
-      "version": "1.64.0",
-      "sha256": "1pjcnzgs8dpysbma0wbnxzzs9vwwnzkkg30qsg1b1ra34b3b27ii",
+      "version": "1.66.0",
+      "sha256": "0p449d50l8qi67hfzkqvb4cc3gx9l6vw2xqi9s4ymbikrj73rzyg",
       "depends": ["BMA", "Biobase", "leaps"]
     },
     "iterativeBMAsurv": {
       "name": "iterativeBMAsurv",
-      "version": "1.64.0",
-      "sha256": "13q2zk47wnnnmddc15apdn343cll9bj3ya8lgpn14hnqz00a0av4",
+      "version": "1.66.0",
+      "sha256": "1lhmw5h19j0s5n5srpp1q1yl274rq682yx2nw63wvgwlnzl0xm57",
       "depends": ["BMA", "leaps", "survival"]
     },
     "ivygapSE": {
       "name": "ivygapSE",
-      "version": "1.28.0",
-      "sha256": "0s44x3cbc60rg9i0v2ilizimfghncs8d4pck173klvxknipadik8",
+      "version": "1.30.0",
+      "sha256": "078jm05dc6xmdhb9m3pqz8hr7fz5i0aqdyf2g8n3n3jjmhl45s9m",
       "depends": ["S4Vectors", "SummarizedExperiment", "UpSetR", "ggplot2", "hwriter", "plotly", "shiny", "survival", "survminer"]
+    },
+    "jazzPanda": {
+      "name": "jazzPanda",
+      "version": "1.0.0",
+      "sha256": "0wskp62qny21r6mfa8qa9bxhand3hzz80zbkwsmjm56ba7930cm9",
+      "depends": ["BiocParallel", "BumpyMatrix", "SpatialExperiment", "caret", "doParallel", "dplyr", "foreach", "glmnet", "magrittr", "spatstat_geom"]
     },
     "karyoploteR": {
       "name": "karyoploteR",
-      "version": "1.32.0",
-      "sha256": "0cr1lb6na4s3ggh5516sclg08n74kvifgb5yyy1mijzryf9yrzcl",
+      "version": "1.33.0",
+      "sha256": "0qb6wr88j65v5qxibc1kz6w928388clzcldn43206fpxp0imj0fg",
       "depends": ["AnnotationDbi", "GenomeInfoDb", "GenomicFeatures", "GenomicRanges", "IRanges", "Rsamtools", "S4Vectors", "VariantAnnotation", "bamsignals", "bezier", "biovizBase", "digest", "memoise", "regioneR", "rtracklayer"]
     },
     "katdetectr": {
       "name": "katdetectr",
-      "version": "1.8.0",
-      "sha256": "1dslvwfqgpd3wahr1kkf02dan6kyy3xyr47k1zqj1shrkiva6rlm",
+      "version": "1.10.0",
+      "sha256": "02dsxyxslqzyh57zf92wnlxlaw1nm9l7ykspkgbphsky4rchnd5q",
       "depends": ["BSgenome", "BSgenome_Hsapiens_UCSC_hg19", "BSgenome_Hsapiens_UCSC_hg38", "Biobase", "BiocParallel", "GenomeInfoDb", "GenomicRanges", "IRanges", "Rdpack", "S4Vectors", "VariantAnnotation", "changepoint", "changepoint_np", "checkmate", "dplyr", "ggplot2", "ggtext", "maftools", "plyranges", "rlang", "scales", "tibble", "tidyr"]
     },
     "kebabs": {
       "name": "kebabs",
-      "version": "1.40.0",
-      "sha256": "0i8jj2wjcpv02h8wrj7sbr5s4kgyvxq7yjc506w391am9z1qzai4",
+      "version": "1.42.0",
+      "sha256": "1nzy5jbh545x9pc4vk7q0vraq9576yzg03wisavag8y7pn4k8k8f",
       "depends": ["Biostrings", "IRanges", "LiblineaR", "Matrix", "Rcpp", "S4Vectors", "XVector", "apcluster", "e1071", "kernlab"]
     },
     "keggorthology": {
       "name": "keggorthology",
-      "version": "2.58.0",
-      "sha256": "0ca72gql95s5k6wk5yf1nnfwp29sqa4i1p4y5qwmpda5ikisi6hv",
+      "version": "2.60.0",
+      "sha256": "01l9mii8liqnp0ghz1im5icwmw7i2q0228axjiz2ifnxffcf18iw",
       "depends": ["AnnotationDbi", "DBI", "graph", "hgu95av2_db"]
     },
     "kissDE": {
       "name": "kissDE",
-      "version": "1.26.0",
-      "sha256": "1wccjy66gn1yivz52bgcfbs7f4vg12bav0n35ajcy0yz5pqw46xj",
+      "version": "1.28.0",
+      "sha256": "1wkmkwib59hlgdvcfjq46igcnmrxyrz3zpmn93bpk40is0n0yxyk",
       "depends": ["Biobase", "DESeq2", "DSS", "DT", "ade4", "aods3", "doParallel", "factoextra", "foreach", "ggplot2", "gplots", "matrixStats", "shiny", "shinycssloaders"]
     },
     "kmcut": {
       "name": "kmcut",
-      "version": "1.0.0",
-      "sha256": "00gjb7vrmww3yxlmpbjgbmacxl5nms8qfdibpnhs68wmshxnhlim",
+      "version": "1.2.0",
+      "sha256": "18rbr8m5clgr1r2sw5kzbc31ikv9ibgckaygv1z3z50fi8klgv6i",
       "depends": ["S4Vectors", "SummarizedExperiment", "doParallel", "foreach", "pracma", "survival"]
     },
     "knowYourCG": {
       "name": "knowYourCG",
-      "version": "1.2.5",
-      "sha256": "0djdi1d1qlifdil407vda7psy4ib5z29n43g2q1p3gwhwmqd06zh",
+      "version": "1.4.0",
+      "sha256": "0pvkvgwqc137f1jym6cqasfiy3ppf4llx5fggsv8ff8p1hak2x64",
       "depends": ["GenomicRanges", "IRanges", "S4Vectors", "dplyr", "ggplot2", "ggrepel", "magrittr", "reshape2", "rlang", "sesameData", "stringr", "tibble", "wheatmap"]
     },
     "koinar": {
       "name": "koinar",
-      "version": "1.0.2",
-      "sha256": "1w0ya1yvghhnn4zxh4khf7g09jlh6cjb9kcjag28yqqkf1l14pky",
+      "version": "1.2.0",
+      "sha256": "13jj9saqwrq7jcys973rcdiwk110b75jd4ijilhxhh4dhqc55kmr",
       "depends": ["httr", "jsonlite"]
-    },
-    "lapmix": {
-      "name": "lapmix",
-      "version": "1.72.0",
-      "sha256": "19bhb7654h8pivsf3qxv518zp02ijbvlhkb4d93nyanns3g7zqas",
-      "depends": ["Biobase"]
     },
     "ldblock": {
       "name": "ldblock",
-      "version": "1.36.0",
-      "sha256": "016ly2iz42a2shfj5vm270np77cgbl92jnkjrrswk1sgghyxxi9y",
+      "version": "1.38.0",
+      "sha256": "00yrl7yrwbx7f18g1y0kvyp9wqf95yqfx0ajm3karz123q5q3kpm",
       "depends": ["BiocGenerics", "Matrix", "httr", "rlang"]
     },
     "lefser": {
       "name": "lefser",
-      "version": "1.16.2",
-      "sha256": "18ww5cg08037xavls5m7z141wdk1j0ngqrqmd57a8nh77fs5lkca",
-      "depends": ["MASS", "S4Vectors", "SummarizedExperiment", "coin", "dplyr", "forcats", "ggplot2", "ggtree", "stringr", "testthat", "tibble", "tidyr"]
+      "version": "1.18.0",
+      "sha256": "19hxbx3yqdg96mb857029qvj0whd1fa7g6abq35prkxf60pld5qh",
+      "depends": ["BiocGenerics", "MASS", "S4Vectors", "SummarizedExperiment", "ape", "coin", "dplyr", "forcats", "ggplot2", "ggrepel", "ggtree", "mia", "purrr", "stringr", "testthat", "tibble", "tidyr", "tidyselect", "treeio"]
     },
     "lemur": {
       "name": "lemur",
-      "version": "1.4.0",
-      "sha256": "0gdfp0yyjzgs5qmzzpi2gm4jyyc96hvl85hl61g676rc87in07cv",
+      "version": "1.6.0",
+      "sha256": "1ad0dfmalphkfld7pr2h5kdhhpv5bw20sxfwldxd09dcgjsbfzyh",
       "depends": ["BiocGenerics", "BiocNeighbors", "DelayedMatrixStats", "HDF5Array", "Matrix", "MatrixGenerics", "Rcpp", "RcppArmadillo", "S4Vectors", "SingleCellExperiment", "SummarizedExperiment", "glmGamPoi", "harmony", "irlba", "limma", "matrixStats", "rlang", "vctrs"]
     },
     "les": {
       "name": "les",
-      "version": "1.56.0",
-      "sha256": "06xvl0kzp7sc7dyskcq2cfanz1jinxxa6m2npl2nmxwq1pfgm90h",
+      "version": "1.58.0",
+      "sha256": "1gqxjgw1ffqqqzzaplriymlavx3v193p3inffh7bwchq4z02ksb1",
       "depends": ["RColorBrewer", "boot", "fdrtool", "gplots"]
     },
     "levi": {
       "name": "levi",
-      "version": "1.24.0",
-      "sha256": "1mqriv4rf23kx173gd51w3bxjl09bs8n1nl6ps8ki2s63lan4l43",
+      "version": "1.26.0",
+      "sha256": "0awhv9zcy8jn0nxxcnk40w0yvjbg0xxhayvngqg89b7ja3jg1vfg",
       "depends": ["DT", "RColorBrewer", "Rcpp", "colorspace", "dplyr", "ggplot2", "httr", "igraph", "knitr", "reshape2", "rmarkdown", "shiny", "shinydashboard", "shinyjs", "testthat", "xml2"]
     },
     "lfa": {
       "name": "lfa",
-      "version": "2.6.0",
-      "sha256": "00lrspaayb03dq7j786ph52s1yp6chdzcvz9b62izycsvsfpy8z1",
+      "version": "2.8.0",
+      "sha256": "00x7vjhsqfdbqf9lkx3lz93cqahdcdjawmfyvzyvdwjfxrmajfhb",
       "depends": ["RSpectra", "corpcor"]
     },
     "limma": {
       "name": "limma",
-      "version": "3.62.2",
-      "sha256": "0xdlgzk439b2qv7313ha1968m1z2071adwnmrjiiya0ray861fva",
+      "version": "3.64.0",
+      "sha256": "1c06l6g4c5p1h4nbgkvk31hhlgi8r0bjpgf4f8bgdx4ah9fncga5",
       "depends": ["statmod"]
     },
     "limmaGUI": {
       "name": "limmaGUI",
-      "version": "1.82.0",
-      "sha256": "1zqdm1hh4vh10shvdx2nrxp6dshicd1w5a0qblhjfy4wdba18jgz",
+      "version": "1.84.0",
+      "sha256": "1jixz7ilwg45aarzxf6zba169i947jdx3kabg0gb4ggzizjqrx22",
       "depends": ["R2HTML", "limma", "tkrplot", "xtable"]
+    },
+    "limpa": {
+      "name": "limpa",
+      "version": "1.0.0",
+      "sha256": "1j1qflnzw2zdqvash8dkxmbki635fk9w37iy0kc7j21bylq63krc",
+      "depends": ["data_table", "limma", "statmod"]
     },
     "limpca": {
       "name": "limpca",
-      "version": "1.2.0",
-      "sha256": "04cl6b2086azwri44ij266v6865xpld3v54nhjkm67bm89z5bcas",
+      "version": "1.4.0",
+      "sha256": "0dv8ncklx9pmwx4z9kfaa7ivxi4cd2pbdprjf1a17jvg2a9x4qsk",
       "depends": ["S4Vectors", "SummarizedExperiment", "doParallel", "dplyr", "ggplot2", "ggrepel", "ggsci", "plyr", "reshape2", "stringr", "tibble", "tidyr", "tidyverse"]
     },
     "lineagespot": {
       "name": "lineagespot",
-      "version": "1.10.0",
-      "sha256": "1yll19q8fmajpv56zwrdcc9sp3yjvymqdsbmbhysp7fkd3cpxkmm",
+      "version": "1.12.0",
+      "sha256": "1n6x12ihigvz53av5gc1cw94fz45jiczawmvggykra1999k0f1yc",
       "depends": ["MatrixGenerics", "SummarizedExperiment", "VariantAnnotation", "data_table", "httr", "stringr"]
     },
     "lionessR": {
       "name": "lionessR",
-      "version": "1.20.0",
-      "sha256": "06shxn831j06qr96fdw9m0s5ng5r2gd2g3105g0cj0vz0d3plxaj",
+      "version": "1.22.0",
+      "sha256": "1d0biddlzh237zwi72njf876rv0nhjmxfpyf9dfnvxcbz6hhiq0a",
       "depends": ["S4Vectors", "SummarizedExperiment"]
     },
     "lipidr": {
       "name": "lipidr",
-      "version": "2.20.0",
-      "sha256": "03k22sk8scxnb070p2ildp9fx2i1birhjfiqkspshzwwp8nsq0ij",
+      "version": "2.22.0",
+      "sha256": "1qrjixl9wqvzxjkr06sqca356n6a1457ib9czmyhv4ga1khdz3m9",
       "depends": ["S4Vectors", "SummarizedExperiment", "data_table", "dplyr", "fgsea", "forcats", "ggplot2", "imputeLCMD", "limma", "magrittr", "rlang", "ropls", "tidyr"]
     },
     "lisaClust": {
       "name": "lisaClust",
-      "version": "1.14.4",
-      "sha256": "11aqjzkchy1zmajgkw85yq2qx0ff2r803rk3a32wfkj8h5nbs02z",
-      "depends": ["BiocGenerics", "BiocParallel", "S4Vectors", "SingleCellExperiment", "SpatialExperiment", "SummarizedExperiment", "class", "concaveman", "data_table", "dplyr", "ggplot2", "pheatmap", "purrr", "spatstat_explore", "spatstat_geom", "spatstat_random", "spicyR", "testthat", "tidyr"]
+      "version": "1.16.0",
+      "sha256": "1pzdv5ivv75bhmjpsi3sagxc8w7zs9lsj5d5ildydsmifpfplab0",
+      "depends": ["BiocGenerics", "BiocParallel", "S4Vectors", "SingleCellExperiment", "SpatialExperiment", "SummarizedExperiment", "class", "concaveman", "data_table", "dplyr", "ggplot2", "lifecycle", "pheatmap", "purrr", "rlang", "simpleSeg", "spatstat_explore", "spatstat_geom", "spatstat_random", "spicyR", "tidyr"]
     },
     "lmdme": {
       "name": "lmdme",
-      "version": "1.48.0",
-      "sha256": "1sg0kvgg33hkpv1fxbibpz0p1126c1izw9jq4133i932pzl5gx5s",
+      "version": "1.50.0",
+      "sha256": "1l1kwsp3lf5r3x7pwqa7j1s3f5w61zc3hxwpgbjkfd86vv6c129w",
       "depends": ["limma", "pls", "stemHypoxia"]
     },
     "loci2path": {
       "name": "loci2path",
-      "version": "1.26.0",
-      "sha256": "02g25ipim6v6xl6cpdrard9rbp3yz52yvkb0jrisjmxpr0ab07mn",
+      "version": "1.28.0",
+      "sha256": "1iwkwcxi593zyikjizs43li7f6r402m8a0m6n6b8a7f2nlblibzx",
       "depends": ["BiocParallel", "GenomicRanges", "RColorBrewer", "S4Vectors", "data_table", "pheatmap", "wordcloud"]
     },
     "logicFS": {
       "name": "logicFS",
-      "version": "2.26.0",
-      "sha256": "07sh012j904pv8hgs4h1kknwg76bympv5g2dhal86xmnllzn2sqr",
+      "version": "2.28.0",
+      "sha256": "1vps8qa10svfk5hxrj6xn9fmrbqn9mvph7rb1r419zr9z0p8nz4a",
       "depends": ["LogicReg", "mcbiopi", "survival"]
     },
     "lpNet": {
       "name": "lpNet",
-      "version": "2.38.0",
-      "sha256": "1c23mc2dswzvgmnnlk3vxlg5qzhj6jbi49dyn87nh6ywb5zcm51c",
+      "version": "2.40.0",
+      "sha256": "02w8r6myyqbynynxmrzpjhxxdb8m04p9yxw7b4rmmi45052yamzd",
       "depends": ["KEGGgraph", "lpSolve"]
     },
     "lpsymphony": {
       "name": "lpsymphony",
-      "version": "1.34.0",
-      "sha256": "0w4rwj2vprpayijjwlqrximxlr8dnc1zs9pmr2wil7r76zvxlf94",
+      "version": "1.36.0",
+      "sha256": "1p1527hk52ca1qrsz0my887m01fq8zbnzs2z9hllpfgq633vissq",
       "depends": []
     },
     "lumi": {
       "name": "lumi",
-      "version": "2.58.0",
-      "sha256": "14bmwkbv9zppwql085g01m1q2wncmnb4q8gid5mwgdpr2gnkfwib",
+      "version": "2.60.0",
+      "sha256": "11j5jssdbip94njn2hbg2vk4wj2vn8vqnkr0i4dkd8vq1p40ps90",
       "depends": ["AnnotationDbi", "Biobase", "DBI", "GenomicFeatures", "GenomicRanges", "KernSmooth", "MASS", "RSQLite", "affy", "annotate", "lattice", "methylumi", "mgcv", "nleqslv", "preprocessCore"]
     },
     "lute": {
       "name": "lute",
-      "version": "1.2.0",
-      "sha256": "019cm45ahhqrrbj8bi8qdiajzp5238rc4ak8qlpnz1gf6y8zsbzm",
+      "version": "1.4.0",
+      "sha256": "1f1i083aqhls9xf7hynb1xlk5r9ksm5jzy9l971ikh97jyxfwx22",
       "depends": ["Biobase", "BiocGenerics", "S4Vectors", "SingleCellExperiment", "SummarizedExperiment", "dplyr", "ggplot2", "scran"]
     },
     "m6Aboost": {
       "name": "m6Aboost",
-      "version": "1.12.0",
-      "sha256": "1r16yiq2banqks4jxvn9x8cfcsm1g8gr3hgjx0wzsy1cmwfw20x1",
+      "version": "1.14.0",
+      "sha256": "1rdi20nwd4j1bqckhlyj8gc8pzrviwww7q3lh1h6hrc20lf8ckrz",
       "depends": ["BSgenome", "Biostrings", "ExperimentHub", "GenomicRanges", "IRanges", "S4Vectors", "adabag", "dplyr", "rtracklayer"]
     },
     "mBPCR": {
       "name": "mBPCR",
-      "version": "1.60.0",
-      "sha256": "1yrvavhhi2nc6g6arzcxy92dxywsmi4smg3hksyjp9yc0pajdv4j",
+      "version": "1.62.0",
+      "sha256": "0swrs3x5yq6z63mwn0gzixacilb51nxzwgj9nnllhcl9kf8wmqxd",
       "depends": ["Biobase", "GWASTools", "oligoClasses"]
     },
     "mCSEA": {
       "name": "mCSEA",
-      "version": "1.26.2",
-      "sha256": "1y6ppaahz9v73xniq3p0y4vphgx71nn6mz214v51560rsahgyhdq",
+      "version": "1.28.0",
+      "sha256": "0j1yrdl9im2s8xfzb57km43v2613k8h6hq29ypxqm6g4x95nhpqf",
       "depends": ["GenomicFeatures", "GenomicRanges", "Gviz", "Homo_sapiens", "IRanges", "S4Vectors", "SummarizedExperiment", "biomaRt", "fgsea", "ggplot2", "limma", "mCSEAdata"]
     },
     "maCorrPlot": {
       "name": "maCorrPlot",
-      "version": "1.76.0",
-      "sha256": "1nqxjgcp038b8qwbssd25ca40rzq769psrsvllwlmlns1gf8ml3z",
+      "version": "1.78.0",
+      "sha256": "1brq3mpa2wvzvp89cpwy8gr1b3yx63gq6avdavgkhpd2rfspyk2b",
       "depends": ["lattice"]
     },
     "maPredictDSC": {
       "name": "maPredictDSC",
-      "version": "1.44.0",
-      "sha256": "1xrigbg2np1c54jny5897d2g85js2ckbccqhz5frh1a6ai3cmpjj",
+      "version": "1.46.0",
+      "sha256": "0xygg4gfjs4ydq35855kailrcwm4w9fn9k9qm5fbncaybz79xzdw",
       "depends": ["AnnotationDbi", "LungCancerACvsSCCGEO", "MASS", "ROC", "ROCR", "affy", "caret", "class", "e1071", "gcrma", "hgu133plus2_db", "limma"]
     },
     "maSigPro": {
       "name": "maSigPro",
-      "version": "1.78.0",
-      "sha256": "134s42mmxy6563fplc9kn5ca1cbki9mnx0v3qms8jnrycglqw6yg",
+      "version": "1.80.0",
+      "sha256": "02vz1c9k3kgr8n7682sf040b693f46i75zxk4df5n31fvfwm91d7",
       "depends": ["Biobase", "MASS", "mclust", "venn"]
+    },
+    "maaslin3": {
+      "name": "maaslin3",
+      "version": "1.0.0",
+      "sha256": "14x7kblx19ibdclgj9qsy01w1d916xk88hhf7f4rqf2zl242vrck",
+      "depends": ["BiocGenerics", "RColorBrewer", "SummarizedExperiment", "TreeSummarizedExperiment", "dplyr", "ggnewscale", "ggplot2", "lme4", "lmerTest", "logging", "multcomp", "optparse", "patchwork", "pbapply", "plyr", "rlang", "scales", "survival", "tibble"]
     },
     "made4": {
       "name": "made4",
-      "version": "1.80.0",
-      "sha256": "0z40f2bxnakplq3xx221fk51m830dixc7nfll4xw1r3g2pg1iraq",
+      "version": "1.82.0",
+      "sha256": "0gzb8zw1npz04s5aihvnnch64ywgdfp1djxvy3a363kjl9wbiyrf",
       "depends": ["Biobase", "RColorBrewer", "SummarizedExperiment", "ade4", "gplots", "scatterplot3d"]
     },
     "maftools": {
       "name": "maftools",
-      "version": "2.22.0",
-      "sha256": "0vdqasrb4j7cvp66df2fvjbdi65480zrdzbbv057nlkvq1h4m3p3",
+      "version": "2.24.0",
+      "sha256": "16i7v706n1pi2p1n7jsd3wvx7j429f2n9gyfy2f2xxpm9h9bzvl7",
       "depends": ["DNAcopy", "RColorBrewer", "Rhtslib", "data_table", "pheatmap", "survival", "zlibbioc"]
     },
     "magpie": {
       "name": "magpie",
-      "version": "1.6.0",
-      "sha256": "1zvkh41sis8w22xca1vn4ip15s98al1jfkg125idxbdj03y2lvzy",
+      "version": "1.8.0",
+      "sha256": "0rswjhicyn0yvc9pifyslpbxgqb2c5nv3kmzzs4crsygri2g16ax",
       "depends": ["AnnotationDbi", "BiocParallel", "DESeq2", "GenomicFeatures", "GenomicRanges", "IRanges", "Matrix", "RColorBrewer", "Rsamtools", "S4Vectors", "TRESS", "aod", "matrixStats", "openxlsx", "reshape2", "rtracklayer"]
     },
     "magrene": {
       "name": "magrene",
-      "version": "1.8.0",
-      "sha256": "17pasmfbp0vby6a27gqbj7c563ms4x6c7q3j4mlijmv894ldqvzn",
+      "version": "1.10.0",
+      "sha256": "11b535p06ivk2c40nq42q7jrfrpbv2x7qlyjybvd7fh9zfy9r7kp",
       "depends": ["BiocParallel"]
     },
     "makecdfenv": {
       "name": "makecdfenv",
-      "version": "1.82.0",
-      "sha256": "08d33iqbgczw4w63s5nrjzwy059mqzgcr9s1g59irgplr9szjiar",
-      "depends": ["Biobase", "affy", "affyio", "zlibbioc"]
+      "version": "1.84.0",
+      "sha256": "1wjlqh7q46slgnpzvij6gajgkcp4acqs146z365l22ywkm7b90q5",
+      "depends": ["Biobase", "affy", "affyio"]
     },
     "mapscape": {
       "name": "mapscape",
-      "version": "1.30.0",
-      "sha256": "0lc0an3lag8jjcvqkqaws28j5qs40rbx1fhxs4xmcyi268971xdy",
+      "version": "1.32.0",
+      "sha256": "0qzhc56hn4231kqf7l4m7drzbvw15hmmskn9fzgcbx81ak1qba35",
       "depends": ["base64enc", "htmlwidgets", "jsonlite", "stringr"]
     },
     "mariner": {
       "name": "mariner",
-      "version": "1.6.0",
-      "sha256": "1nasspyjsd8r11l2jsnrdxlr507b4zjzfv0sq8rf2j1mfn7ygn9m",
+      "version": "1.8.0",
+      "sha256": "0ym4fqndjhq28daq7bbvghz7a3i3812sgjai7hdfd45xvfhz91ia",
       "depends": ["BiocGenerics", "BiocManager", "BiocParallel", "DelayedArray", "GenomeInfoDb", "GenomicRanges", "HDF5Array", "IRanges", "InteractionSet", "RColorBrewer", "S4Vectors", "SummarizedExperiment", "abind", "assertthat", "colourvalues", "data_table", "dbscan", "glue", "magrittr", "plotgardener", "plyranges", "progress", "purrr", "rhdf5", "rlang", "strawr"]
     },
     "marr": {
       "name": "marr",
-      "version": "1.16.0",
-      "sha256": "132dh34w5lh56mmzb055l59wjchf2yvlbcw1jvs065q8i0aldgfy",
+      "version": "1.18.0",
+      "sha256": "1c21kssvg1ifs0ycsspssg38q3grl3ci2n676h0qb7hgx4138xqb",
       "depends": ["Rcpp", "S4Vectors", "SummarizedExperiment", "dplyr", "ggplot2", "magrittr", "rlang"]
     },
     "marray": {
       "name": "marray",
-      "version": "1.84.0",
-      "sha256": "0j4hib9x4zr40k6gs911vvj766b7f46n15jpq8p2lv89jrh8wa99",
+      "version": "1.86.0",
+      "sha256": "1ryj4rhikgc3997yasmll5zbbyh7x7qdfigyjadg18zsmghqbnjx",
       "depends": ["limma"]
     },
     "martini": {
       "name": "martini",
-      "version": "1.26.0",
-      "sha256": "1qfqd7f1zjha7rjs3cdbbhwys0z0v1lhbi79qyqphdp7ipdjzz00",
+      "version": "1.28.0",
+      "sha256": "1wvlicmf472imy32v4r6jjwaw8g1ggpcppjb1i2fwgfxp249b7a4",
       "depends": ["Matrix", "Rcpp", "RcppEigen", "igraph", "memoise", "snpStats"]
     },
     "maser": {
       "name": "maser",
-      "version": "1.24.0",
-      "sha256": "0vpi1qdkscnxxbfx3py8szw9429wc4vkwls9b4w1zq1zrvvzbaig",
+      "version": "1.26.0",
+      "sha256": "1qfiyjgjixw5iv077nk1c6biwwxj7jfykqvvn295gf69qahsvy4g",
       "depends": ["BiocGenerics", "DT", "GenomeInfoDb", "GenomicRanges", "Gviz", "IRanges", "data_table", "dplyr", "ggplot2", "reshape2", "rtracklayer"]
     },
     "maskBAD": {
       "name": "maskBAD",
-      "version": "1.50.0",
-      "sha256": "0h89xfw4747iszxhcfh9j428z49p869vhgj77a3ahjzgq1z7gd9k",
+      "version": "1.52.0",
+      "sha256": "1lw7r5r5z6qbj9j88wfyixy652a8wh10lkkcjx62039zsmdqgs8m",
       "depends": ["affy", "gcrma"]
     },
     "massiR": {
       "name": "massiR",
-      "version": "1.42.0",
-      "sha256": "0bm8qbaxlpm5gb3asx9gc06civnvf4ljkg0vnldikriiyi3dhl22",
+      "version": "1.44.0",
+      "sha256": "0fq97ig43432yfk40sa734jxdmd0birriffjrjbh9xqrhyg03m1j",
       "depends": ["Biobase", "cluster", "diptest", "gplots"]
     },
     "mastR": {
       "name": "mastR",
-      "version": "1.6.0",
-      "sha256": "1a0z450vdsf00ccrrrd04l9ndp9arf8vszn5ammscqcj409vaz3i",
+      "version": "1.8.0",
+      "sha256": "16zcqcbn3s7jrff5mlr3p07k0ngg6whcpijk849nn483sflzsr45",
       "depends": ["AnnotationDbi", "Biobase", "GSEABase", "Matrix", "SeuratObject", "SingleCellExperiment", "SummarizedExperiment", "dplyr", "edgeR", "ggplot2", "ggpubr", "limma", "msigdb", "org_Hs_eg_db", "patchwork", "tidyr"]
     },
     "matchBox": {
       "name": "matchBox",
-      "version": "1.48.0",
-      "sha256": "1yz90l4grhvvx6m3cpcxkdxmgs6paa355qgf3ad4j5g8nym318pn",
+      "version": "1.50.0",
+      "sha256": "0pyv16ymi5zj2hrlva8jdif42v1zkhn411k401mvqhscvpjs4z8q",
       "depends": []
     },
     "matter": {
       "name": "matter",
-      "version": "2.8.0",
-      "sha256": "1bycdzggnbrhi34w733s6jxlshxsny8qmy4h1ad2p7css14g2xkk",
+      "version": "2.10.0",
+      "sha256": "0wb3iq390by21dgxy8ca9bh3schdfmf04800rn860lkiimivh2xj",
       "depends": ["BH", "BiocGenerics", "BiocParallel", "Matrix", "ProtGenerics", "digest", "irlba"]
     },
     "mbQTL": {
       "name": "mbQTL",
-      "version": "1.6.0",
-      "sha256": "0whrhcw4w1f3fbf8nk0wny1d06z7v6brmih1l9z0xk5024qmaxli",
+      "version": "1.8.0",
+      "sha256": "03pkbw1xwvf7cdvghaly08vdgyql78qyf6fsmhn6dl082ab09fx2",
       "depends": ["MatrixEQTL", "broom", "dplyr", "ggplot2", "metagenomeSeq", "pheatmap", "readxl", "stringr", "tidyr"]
     },
     "mbkmeans": {
       "name": "mbkmeans",
-      "version": "1.22.0",
-      "sha256": "0alm36lj0p541wyrk85ddyk8g4sscip54532i8pkb6a8mclp9cp3",
+      "version": "1.24.0",
+      "sha256": "0ipb03c0k5w1y4bdm9fcpg1qih74phwwwmfqldabshbwhkkaw4rp",
       "depends": ["BiocParallel", "ClusterR", "DelayedArray", "Matrix", "Rcpp", "RcppArmadillo", "Rhdf5lib", "S4Vectors", "SingleCellExperiment", "SummarizedExperiment", "beachmat", "benchmarkme"]
     },
     "mdp": {
       "name": "mdp",
-      "version": "1.26.0",
-      "sha256": "1v01qhl9hk8bwar5ghfd11rwl8wpwcqm8phjxblxf963cgzxycry",
+      "version": "1.28.0",
+      "sha256": "1yy6g5xvm15r7h7p4yz30sf0a86kyy2xhfkcdhpdis0qhpsfvdx1",
       "depends": ["ggplot2", "gridExtra"]
     },
     "mdqc": {
       "name": "mdqc",
-      "version": "1.68.0",
-      "sha256": "0vxplgmfhp0g8v080h0rwvkzhq3gq1956p4jngkrz4nmpynzdfd7",
+      "version": "1.70.0",
+      "sha256": "0x25jq8380rqgq04d1rjnvs5lb91gizwzfnj1i08gqiwb2b2ma6d",
       "depends": ["MASS", "cluster"]
     },
     "megadepth": {
       "name": "megadepth",
-      "version": "1.16.0",
-      "sha256": "1cay30y7cc6lpikcp4ncx69zjg4kyn152z5b8fhw159n6cb1z19n",
+      "version": "1.18.0",
+      "sha256": "05b3vish9vx1a1pwqayc52hdqb5kimnpzn1kg8qv5979xjbs9s75",
       "depends": ["GenomicRanges", "cmdfun", "dplyr", "fs", "magrittr", "readr", "xfun"]
     },
     "memes": {
       "name": "memes",
-      "version": "1.14.0",
-      "sha256": "0g1dpyyn5lnzy13h65m6wfnp4bsf7qs1jlc62qmjfq7aifw0hpxq",
+      "version": "1.16.0",
+      "sha256": "1ivvnrnlz9239m2mvx804q1jli3rqzkagvhkjfi5m14v8rbb1zrc",
       "depends": ["Biostrings", "GenomicRanges", "cmdfun", "dplyr", "ggplot2", "ggseqlogo", "magrittr", "matrixStats", "patchwork", "processx", "purrr", "readr", "rlang", "tibble", "tidyr", "universalmotif", "usethis", "xml2"]
     },
     "meshes": {
       "name": "meshes",
-      "version": "1.32.0",
-      "sha256": "0kjdwydkrnf0sbigwjp017350b432d151m2jg5ghwmrdw9a5fa2b",
+      "version": "1.34.0",
+      "sha256": "1alqbcwi0ig5jfji1hi6m291y0ifm22j87nlkh2csb99fcs1j24f",
       "depends": ["AnnotationDbi", "AnnotationHub", "DOSE", "GOSemSim", "MeSHDbi", "enrichplot", "yulab_utils"]
     },
     "meshr": {
       "name": "meshr",
-      "version": "2.12.0",
-      "sha256": "0mwcir939fqbydx5wf8aiiyrw69n5bcsaw1md9m61q9xfz99p9cl",
+      "version": "2.14.0",
+      "sha256": "0cnmzz3ap6173410qa1qcy7xbcdr8ajzmdi6iykq0ahzyfdbnz6d",
       "depends": ["BiocGenerics", "BiocStyle", "Category", "MeSHDbi", "RSQLite", "S4Vectors", "fdrtool", "knitr", "markdown", "rmarkdown"]
     },
     "messina": {
       "name": "messina",
-      "version": "1.42.0",
-      "sha256": "0341hblfhgnz18j0jlkwvkvapyvybs0sap8hgmvl3zh1yd7mff3l",
+      "version": "1.44.0",
+      "sha256": "0kgdya5miyrylwh743m4d0vb1x984wa8bw53vqws0xf768fsn2fk",
       "depends": ["Rcpp", "foreach", "ggplot2", "plyr", "survival"]
     },
     "metaCCA": {
       "name": "metaCCA",
-      "version": "1.34.0",
-      "sha256": "173g1my2b3p6q2hixwpc6p9wgqz1hph6m5k0d2fs8s9mg90f9p90",
+      "version": "1.36.0",
+      "sha256": "0x5lx3dwq50z1qx9njdirvxz6aiis9n0agdnzb2z9c2yc8c0vzdz",
       "depends": []
     },
     "metaMS": {
       "name": "metaMS",
-      "version": "1.42.0",
-      "sha256": "1fw4381jsfniwifrljwb2hfxfi537ial1a5x66gcc8xnr9cfzgls",
+      "version": "1.44.0",
+      "sha256": "1xlss98wk95khfld03jf9abljj80q1mys856y6gz63xr6759szsv",
       "depends": ["BiocGenerics", "CAMERA", "Matrix", "robustbase", "xcms"]
     },
     "metaSeq": {
       "name": "metaSeq",
-      "version": "1.46.0",
-      "sha256": "0ivmzci7gpkz9linwcm57c5kw08kd3k8gi826r5x6a65rnznqqpg",
+      "version": "1.48.0",
+      "sha256": "0svwvswj16nj2kswdgskwwam9w7vdkljn2hyyjawqwg0982llfim",
       "depends": ["NOISeq", "Rcpp", "snow"]
     },
     "metabCombiner": {
       "name": "metabCombiner",
-      "version": "1.16.0",
-      "sha256": "1vn41x25kxzcam5r43ik4q2xdy6h2j3rkqryr8hslbassbn0yq2h",
+      "version": "1.18.0",
+      "sha256": "0c2sspf2hq1malpz1yvqzb7i99bplixlmb4ymj8y6msycqdjldzp",
       "depends": ["S4Vectors", "caret", "dplyr", "matrixStats", "mgcv", "rlang", "tidyr"]
     },
     "metabinR": {
       "name": "metabinR",
-      "version": "1.8.0",
-      "sha256": "0q79qmrfa4yhnv45nqlx2nd94lj4992kmrj3w8sx2s8j3qfqf0c8",
+      "version": "1.10.0",
+      "sha256": "072fb1rrr5bjl543y6ivb6rkw8f61wpw5cxv3cq07hghmik2k0q1",
       "depends": ["rJava"]
     },
     "metabolomicsWorkbenchR": {
       "name": "metabolomicsWorkbenchR",
-      "version": "1.16.0",
-      "sha256": "0qajw2lpmp8b8j24m0cp88c39k6v1y10d5q1zl27gx4cqklgrijc",
+      "version": "1.18.0",
+      "sha256": "1yk4ddcwqi72aq1jr7gj9c862g6fy82i0s7rx8a6y8nfigd1nvqd",
       "depends": ["MultiAssayExperiment", "SummarizedExperiment", "data_table", "httr", "jsonlite", "struct"]
     },
     "metabomxtr": {
       "name": "metabomxtr",
-      "version": "1.40.0",
-      "sha256": "0pl0ilcx32njxdv4i9gly5gfvna1wndv6jnz2c72q60w8ayak7rv",
+      "version": "1.42.0",
+      "sha256": "0h3yyq5f96z0qdmd16ard00sznyqiiv5nzz08x83y2br9vapfnx0",
       "depends": ["Biobase", "BiocParallel", "Formula", "ggplot2", "multtest", "optimx", "plyr"]
     },
     "metagene2": {
       "name": "metagene2",
-      "version": "1.22.0",
-      "sha256": "14nrzk9d94sl4k67kx79wlk5kd4vd7c1lyzjlps7lpqv2717hylz",
+      "version": "1.24.0",
+      "sha256": "00xnp9h2avmr5x8njangxgf1qa09rllxqlbnzs3vmcagl9d58yih",
       "depends": ["BiocParallel", "GenomeInfoDb", "GenomicAlignments", "GenomicRanges", "IRanges", "R6", "Rsamtools", "data_table", "dplyr", "ggplot2", "magrittr", "purrr", "reshape2", "rtracklayer"]
     },
     "metagenomeSeq": {
       "name": "metagenomeSeq",
-      "version": "1.48.1",
-      "sha256": "1x6ycxrhpl4wgpaih9wpp0w7phnq6crgvyh93hs1gfmgybwmmlhs",
+      "version": "1.50.0",
+      "sha256": "1xbyc6pd7q6pr6f86x0i5i3pfgd2i8z62zb4h1mpb3ypr12icacj",
       "depends": ["Biobase", "Matrix", "RColorBrewer", "Wrench", "foreach", "glmnet", "gplots", "limma", "matrixStats"]
     },
     "metahdep": {
       "name": "metahdep",
-      "version": "1.64.0",
-      "sha256": "01cyv9n0d3p7silkxdyqqfdkww22hfw138bpxfh1sqgbyi9iwk8r",
+      "version": "1.66.0",
+      "sha256": "051jjcyww8m5dfk4ssvr2fvf9mym2nfsw27vmbz0cwd64kfv35cn",
       "depends": []
     },
     "metapod": {
       "name": "metapod",
-      "version": "1.14.0",
-      "sha256": "1ysdgnyzn5n2fazmx2az5kk30n10xla3l9xhrik3mmmif0ix0p8l",
+      "version": "1.16.0",
+      "sha256": "1hw8inkl6cxyf36cynwhcp1qxb8ls9w54gwwjf9ibsqpqw7in0ay",
       "depends": ["Rcpp"]
     },
     "metapone": {
       "name": "metapone",
-      "version": "1.12.0",
-      "sha256": "1mhs96j6mwkdlf4h1g068fn2m3p2dif6m026k1wafhips24pindh",
+      "version": "1.14.0",
+      "sha256": "1dc91jw9mw08wpa2flnprxn6vnv0rwc4wbfm6wr9fws5gwyxdnhv",
       "depends": ["BiocParallel", "fdrtool", "fgsea", "fields", "ggplot2", "ggrepel", "markdown"]
     },
     "metaseqR2": {
       "name": "metaseqR2",
-      "version": "1.18.0",
-      "sha256": "0h5zkjck6l6dxf80flsnln525ykvxsalmmdzgbpcn22yd9fkj3zl",
+      "version": "1.20.0",
+      "sha256": "16c0ic6mc48b7m2l96gy6m7qqfdpyp1nps82597zwbg6f3s53y2m",
       "depends": ["ABSSeq", "Biobase", "BiocGenerics", "BiocParallel", "Biostrings", "DESeq2", "DSS", "DT", "EDASeq", "GenomeInfoDb", "GenomicAlignments", "GenomicFeatures", "GenomicRanges", "IRanges", "MASS", "Matrix", "NBPSeq", "RSQLite", "Rsamtools", "S4Vectors", "SummarizedExperiment", "VennDiagram", "biomaRt", "corrplot", "edgeR", "genefilter", "gplots", "harmonicmeanp", "heatmaply", "htmltools", "httr", "jsonlite", "lattice", "limma", "locfit", "log4r", "magrittr", "pander", "qvalue", "rmarkdown", "rmdformats", "rtracklayer", "stringr", "survcomp", "txdbmaker", "vsn", "yaml", "zoo"]
     },
     "methInheritSim": {
       "name": "methInheritSim",
-      "version": "1.28.0",
-      "sha256": "1bj7kk0lz1gq62l5mr4m3zzpdpxjs32h6znpa2f68h78mjp5r3hl",
+      "version": "1.30.0",
+      "sha256": "1idnf3qwsymqhxn1sqjjmjf0w6fps519vla72r3493amipz8sb1l",
       "depends": ["BiocGenerics", "GenomeInfoDb", "GenomicRanges", "IRanges", "S4Vectors", "methylKit", "msm"]
     },
     "methimpute": {
       "name": "methimpute",
-      "version": "1.28.0",
-      "sha256": "09pgfwsga5whqhdp898h35zfwway8x3y7dbv2aaf2ad3d4k5rqly",
+      "version": "1.30.0",
+      "sha256": "04xidhw65jylc5gya5s2yjmbi5af2akvnsphpms0j5pnaiissfnm",
       "depends": ["Biostrings", "GenomeInfoDb", "GenomicRanges", "IRanges", "Rcpp", "data_table", "ggplot2", "minpack_lm", "reshape2"]
     },
     "methodical": {
       "name": "methodical",
-      "version": "1.2.0",
-      "sha256": "0w93w55r8k5fyhkq5rg2qqz5yamz0ziwm6idm68ykv1xh15f3fgw",
+      "version": "1.4.0",
+      "sha256": "0ybnr5pbmlrpsk19yz04c1iais6mklcq7xcrbs0c9wc5r0yxmidp",
       "depends": ["AnnotationHub", "BSgenome", "BSgenome_Hsapiens_UCSC_hg19", "BSgenome_Hsapiens_UCSC_hg38", "BiocCheck", "BiocManager", "BiocParallel", "BiocStyle", "Biostrings", "DelayedArray", "ExperimentHub", "GenomeInfoDb", "GenomicRanges", "HDF5Array", "IRanges", "MatrixGenerics", "R_utils", "RcppRoll", "S4Vectors", "SummarizedExperiment", "TumourMethData", "annotatr", "cowplot", "data_table", "devtools", "dplyr", "foreach", "ggplot2", "knitr", "rcmdcheck", "remotes", "rhdf5", "rtracklayer", "scales", "tibble", "tidyr", "usethis"]
     },
     "methrix": {
       "name": "methrix",
-      "version": "1.20.0",
-      "sha256": "08rr73ns82chcds25xihqj1cz44wicmvqlcij6agv1rd4gv2wqgf",
+      "version": "1.22.0",
+      "sha256": "03cbhjia2ivycf7ac7bj70haa790b2f23z5kk0i0514cg421pm69",
       "depends": ["BSgenome", "DelayedArray", "DelayedMatrixStats", "GenomicRanges", "HDF5Array", "IRanges", "S4Vectors", "SummarizedExperiment", "data_table", "ggplot2", "matrixStats", "rtracklayer"]
     },
     "methyLImp2": {
       "name": "methyLImp2",
-      "version": "1.2.0",
-      "sha256": "0drbwi9xdz32cm8pzaknm76mrwqc1m720gm8l44cnsh0ph9g7ilg",
+      "version": "1.4.0",
+      "sha256": "1aaqrckxfpp9vfhj7fi19y924xrn8bcr24gpignkjfv4czxv89fh",
       "depends": ["BiocParallel", "ChAMPdata", "SummarizedExperiment", "corpcor"]
     },
     "methylCC": {
       "name": "methylCC",
-      "version": "1.20.0",
-      "sha256": "082ybsdqg5nhpkkw93b39ac1p5k6hkk62kbrl49xfna0qw7hqdaj",
+      "version": "1.22.0",
+      "sha256": "0s8f1yj1qd648cxd3wxzjzbv0z7csrxsdhy6g3p5shn8piplqxk5",
       "depends": ["Biobase", "FlowSorted_Blood_450k", "GenomicRanges", "IRanges", "IlluminaHumanMethylation450kanno_ilmn12_hg19", "IlluminaHumanMethylation450kmanifest", "S4Vectors", "bsseq", "bumphunter", "dplyr", "genefilter", "magrittr", "minfi", "plyranges", "quadprog"]
     },
     "methylGSA": {
       "name": "methylGSA",
-      "version": "1.24.0",
-      "sha256": "1cb9sl3cgn726iq6p0ki02vpypmpazcb0bxcnvd2f6bkyr7xigq7",
+      "version": "1.26.0",
+      "sha256": "0bpas0zl4rf4gfvcp38y3v2cnlpc2a4n39ani1f7k91s5lvylkxx",
       "depends": ["AnnotationDbi", "BiocParallel", "GO_db", "IlluminaHumanMethylation450kanno_ilmn12_hg19", "IlluminaHumanMethylationEPICanno_ilm10b4_hg19", "RobustRankAggreg", "clusterProfiler", "ggplot2", "missMethyl", "org_Hs_eg_db", "reactome_db", "shiny", "stringr"]
     },
     "methylInheritance": {
       "name": "methylInheritance",
-      "version": "1.30.0",
-      "sha256": "01vigk36bv2pzqj0pf2m99wvq1jlpg4vgxhy9vaz29xxyi4y47bc",
+      "version": "1.32.0",
+      "sha256": "0dpq5vgb4zrj2pcwi0m8ykjvn0xr7hr4r0raksn8bgh0qyhn7mnf",
       "depends": ["BiocParallel", "GenomicRanges", "IRanges", "S4Vectors", "ggplot2", "gridExtra", "methylKit", "rebus"]
     },
     "methylKit": {
       "name": "methylKit",
-      "version": "1.32.0",
-      "sha256": "1niblg067819p8mldnlkf7xd8g3k89q6wcj095idlkcna06xj3d1",
-      "depends": ["GenomeInfoDb", "GenomicRanges", "IRanges", "KernSmooth", "R_utils", "Rcpp", "Rhtslib", "Rsamtools", "S4Vectors", "data_table", "emdbook", "fastseg", "gtools", "limma", "mclust", "mgcv", "qvalue", "rtracklayer", "zlibbioc"]
+      "version": "1.34.0",
+      "sha256": "09dc8h2w6xjkphfd82368lv9iq3yr46iiz05ixjjvlzvn772wqwd",
+      "depends": ["GenomeInfoDb", "GenomicRanges", "IRanges", "KernSmooth", "R_utils", "Rcpp", "Rhtslib", "Rsamtools", "S4Vectors", "data_table", "emdbook", "fastseg", "gtools", "limma", "mclust", "mgcv", "qvalue", "rtracklayer"]
     },
     "methylMnM": {
       "name": "methylMnM",
-      "version": "1.44.0",
-      "sha256": "1zqc7vkad0pma2hngaanxv0g3hzfy8hjgq4bp65mrjd34skr3r6q",
+      "version": "1.46.0",
+      "sha256": "1cls27s2qv18gggm1awz75ranng21w8rabs8cwj6spb11z5d5kzz",
       "depends": ["edgeR", "statmod"]
     },
     "methylPipe": {
       "name": "methylPipe",
-      "version": "1.40.0",
-      "sha256": "0dn2fb216y8f1mklrl6fhbkb6df9qr9ild92rdh9k0fzga8n6xhk",
+      "version": "1.41.0",
+      "sha256": "0i28n2ibjfjvvnanngkld37ykpygl6dbx21g53yi8hrrbv69406p",
       "depends": ["BiocGenerics", "Biostrings", "GenomeInfoDb", "GenomicAlignments", "GenomicRanges", "Gviz", "IRanges", "Rsamtools", "S4Vectors", "SummarizedExperiment", "data_table", "gplots", "marray"]
     },
     "methylSig": {
       "name": "methylSig",
-      "version": "1.18.0",
-      "sha256": "0fa43yblryn765v32l3i9imlshailip0vgdh9rzp3hhadfs9yaq3",
+      "version": "1.20.0",
+      "sha256": "1ndsffrslk2m96f17mqpckd9igl3zva6r4xarxk89i3gl52y0xz1",
       "depends": ["DSS", "DelayedArray", "DelayedMatrixStats", "GenomeInfoDb", "GenomicRanges", "IRanges", "S4Vectors", "bsseq"]
     },
     "methylclock": {
       "name": "methylclock",
-      "version": "1.12.0",
-      "sha256": "0853l4wpvjp2a86mjww4gwpb07i0v4j4m3j5y79nvi8iximz5kmp",
+      "version": "1.14.0",
+      "sha256": "1cyibj79zy3syqr2icqiddxphs1f4j24qihc8q96akj5ip7pisv6",
       "depends": ["Biobase", "ExperimentHub", "PerformanceAnalytics", "RPMM", "Rcpp", "devtools", "dplyr", "dynamicTreeCut", "ggplot2", "ggpmisc", "ggpubr", "gridExtra", "impute", "methylclockData", "minfi", "planet", "preprocessCore", "quadprog", "tibble", "tidyr", "tidyverse"]
     },
     "methylscaper": {
       "name": "methylscaper",
-      "version": "1.14.0",
-      "sha256": "1sp73xyy48jr9m41j743srvqif07lh5km8svb28357lng2pdp3ym",
+      "version": "1.16.0",
+      "sha256": "03896whn173rrzc7y4bxn8mljnqw3m9b3nm63jl5yv32x7scpkmw",
       "depends": ["BiocParallel", "Biostrings", "Rfast", "SummarizedExperiment", "data_table", "pwalign", "seqinr", "seriation", "shiny", "shinyFiles", "shinyjs"]
     },
     "methylumi": {
       "name": "methylumi",
-      "version": "2.52.0",
-      "sha256": "15lc81qdvjk6mr74h59gr2bxq9alj1wjady2h0j7rhq0p7rim754",
+      "version": "2.54.0",
+      "sha256": "1vxmwbhqsqjqgscw13094nz9y4izmi1a78b3i8npjwnxn330l9jk",
       "depends": ["AnnotationDbi", "Biobase", "BiocGenerics", "FDb_InfiniumMethylation_hg19", "GenomeInfoDb", "GenomicFeatures", "GenomicRanges", "IRanges", "S4Vectors", "SummarizedExperiment", "annotate", "genefilter", "ggplot2", "illuminaio", "lattice", "matrixStats", "minfi", "reshape2", "scales"]
     },
     "mfa": {
       "name": "mfa",
-      "version": "1.28.0",
-      "sha256": "196yxm19imkraph1l7yp2pras7hi0yvlxk0xlxr08ikn6pszks2f",
+      "version": "1.30.0",
+      "sha256": "0zgwf9sxgn0xb103f94zkd96264fjb7cshbwmbardlz74wvrjd87",
       "depends": ["Biobase", "MCMCglmm", "MCMCpack", "Rcpp", "coda", "dplyr", "ggmcmc", "ggplot2", "magrittr", "tibble"]
     },
     "mgsa": {
       "name": "mgsa",
-      "version": "1.54.0",
-      "sha256": "0jdv22xdkq2qgm17m8fsazshgpf0mvf44a46694qwn0y6pqm6rpy",
+      "version": "1.56.0",
+      "sha256": "0i8pncx71v58db7dpyibjkq938h4d4vmixyiy2pl4bjl4b0g081y",
       "depends": ["gplots"]
     },
     "miQC": {
       "name": "miQC",
-      "version": "1.14.0",
-      "sha256": "1mm5529h0xzj2lr61n49gl1x9hvrnwx10jlwgbb95cknyazn1dm6",
+      "version": "1.16.0",
+      "sha256": "0jdks2ra8v8lf46akyb9cchwhq7l457z1da2zfkw4kmrhbjdv4zc",
       "depends": ["SingleCellExperiment", "flexmix", "ggplot2"]
     },
     "miRBaseConverter": {
       "name": "miRBaseConverter",
-      "version": "1.30.0",
-      "sha256": "0nf24hkziq25xn1sikcgj4wfmggl51ndyfq3dxn9sdizdc5a087g",
+      "version": "1.32.0",
+      "sha256": "1hivi18pmmf3y6w89ha2030gyq746bl42xmma159n2dn57svbwv7",
       "depends": []
     },
     "miRLAB": {
       "name": "miRLAB",
-      "version": "1.36.0",
-      "sha256": "0rw6rav765b9slw9p4ghjxp1b6x4s7f47q01nz6sav39193139gc",
+      "version": "1.38.0",
+      "sha256": "1nksyiixwb8331phw07jgwbcbqw1flix10gi1yqn24cdg2q7k5qp",
       "depends": ["Category", "GOstats", "Hmisc", "InvariantCausalPrediction", "RCurl", "SummarizedExperiment", "TCGAbiolinks", "ctc", "dplyr", "energy", "entropy", "glmnet", "gplots", "httr", "impute", "limma", "org_Hs_eg_db", "pcalg", "stringr"]
     },
     "miRNAmeConverter": {
       "name": "miRNAmeConverter",
-      "version": "1.34.0",
-      "sha256": "15cyqd9vskx9ik0rc43s4cga8svlfqjil2mnj39gfd4sn4j9mxm6",
+      "version": "1.36.0",
+      "sha256": "0vl9g12gjf0zgw9vxl0hnrm4d16cmcb67dd0alzhrdhz015c50wa",
       "depends": ["AnnotationDbi", "DBI", "miRBaseVersions_db", "reshape2"]
     },
     "miRNApath": {
       "name": "miRNApath",
-      "version": "1.66.0",
-      "sha256": "0mkhwyw2xg4b2bh2mnqwnl5qgm3iywwlf3imvczk2w9lkd9ld60j",
+      "version": "1.68.0",
+      "sha256": "0w9j0dp295153cvbmpkhs5n7nw3g4f6wpwkyp0qqipqi8n24hmzb",
       "depends": []
     },
     "miRNAtap": {
       "name": "miRNAtap",
-      "version": "1.40.0",
-      "sha256": "0cigbnhd7025dnbnrjygxi494rdway499kg33mc62smxh39l1l8m",
+      "version": "1.42.0",
+      "sha256": "1aj7cm1sxc1s3c8m17bzprg1nafr1b7rgqhc7kn696gi20w8gqcd",
       "depends": ["AnnotationDbi", "DBI", "RSQLite", "plyr", "sqldf", "stringr"]
     },
     "miRSM": {
       "name": "miRSM",
-      "version": "2.2.0",
-      "sha256": "1zxsjm7yv1rndz709x6irdv29qjhi9h2g3c9b1y3hbh83yl1fcwx",
+      "version": "2.4.0",
+      "sha256": "0vkb5f9nycaijbk3ydalxc5f26l92iaxw69qywg99br7wl1kjxdv",
       "depends": ["BiBitR", "BicARE", "Biobase", "DOSE", "GFA", "GSEABase", "MCL", "MatrixCorrelation", "NMF", "PMA", "Rcpp", "ReactomePA", "SOMbrero", "SummarizedExperiment", "WGCNA", "biclust", "clusterProfiler", "dbscan", "dynamicTreeCut", "energy", "fabia", "flashClust", "iBBiG", "igraph", "isa2", "linkcomm", "mclust", "org_Hs_eg_db", "ppclust", "rqubic", "s4vd", "subspace"]
     },
     "miRcomp": {
       "name": "miRcomp",
-      "version": "1.36.0",
-      "sha256": "0nvjyiixk934hlmr33agw0crhs3kds981pzzfn4k1jy01hzgqc62",
+      "version": "1.38.0",
+      "sha256": "1rndl30dybmp4abpswizd1bhqy66j4fqq8gdxllr4cnajz2759yr",
       "depends": ["Biobase", "KernSmooth", "miRcompData"]
     },
     "miRspongeR": {
       "name": "miRspongeR",
-      "version": "2.10.0",
-      "sha256": "10r1rh2nvzwpz0wj2qr2mzzq4yqda6svhqq09ic7bhzzxxfk3qlp",
+      "version": "2.12.0",
+      "sha256": "1lxd782xrdvd68h13795142930nrvkcg3h1b06h1x39573gs34dr",
       "depends": ["DOSE", "MCL", "Rcpp", "ReactomePA", "SPONGE", "clusterProfiler", "corpcor", "doParallel", "foreach", "igraph", "linkcomm", "org_Hs_eg_db", "survival"]
     },
     "mia": {
       "name": "mia",
-      "version": "1.14.0",
-      "sha256": "1qf7dd9s66xmxsfv422cikrimyqiaqz71qc6yav119a9mbp8arpd",
-      "depends": ["BiocGenerics", "BiocParallel", "Biostrings", "DECIPHER", "DelayedArray", "DelayedMatrixStats", "DirichletMultinomial", "IRanges", "MASS", "MatrixGenerics", "MultiAssayExperiment", "S4Vectors", "SingleCellExperiment", "SummarizedExperiment", "TreeSummarizedExperiment", "ape", "bluster", "decontam", "dplyr", "mediation", "rbiom", "rlang", "scater", "scuttle", "tibble", "tidyr", "vegan"]
+      "version": "1.16.0",
+      "sha256": "0mhf6d4yw3qsxjlq1smsfb7ywhbknvzi01s3q1k9d005w7wk24ai",
+      "depends": ["BiocGenerics", "BiocParallel", "Biostrings", "DECIPHER", "DelayedArray", "DelayedMatrixStats", "DirichletMultinomial", "IRanges", "MASS", "MatrixGenerics", "MultiAssayExperiment", "Rcpp", "S4Vectors", "SingleCellExperiment", "SummarizedExperiment", "TreeSummarizedExperiment", "ape", "bluster", "decontam", "dplyr", "rbiom", "rlang", "scater", "scuttle", "stringr", "tibble", "tidyr", "vegan"]
+    },
+    "miaDash": {
+      "name": "miaDash",
+      "version": "1.0.0",
+      "sha256": "07dsqnbh9kv3p5h0hbzsfmw4cqwf6m16i0i04iz1prqx3qczlzis",
+      "depends": ["S4Vectors", "SingleCellExperiment", "SummarizedExperiment", "TreeSummarizedExperiment", "ape", "biomformat", "htmltools", "iSEE", "iSEEtree", "mia", "rintrojs", "scater", "shiny", "shinydashboard", "shinyjs", "vegan"]
     },
     "miaSim": {
       "name": "miaSim",
-      "version": "1.12.0",
-      "sha256": "1kaa09xanmgbyljjc1c0w2ckm6r73sn4ynqm3fr38zmss1wjsawg",
+      "version": "1.14.0",
+      "sha256": "02qnkrsjl0qs66w5jvzz4yiqxjbckwi6p5nijq37n2xdv5bcqk4g",
       "depends": ["MatrixGenerics", "S4Vectors", "SummarizedExperiment", "TreeSummarizedExperiment", "deSolve", "poweRlaw"]
     },
     "miaViz": {
       "name": "miaViz",
-      "version": "1.14.0",
-      "sha256": "1g4zbcl4158wjqwjbnw64l832k7jhy5x7z3jza8xvgsv6jzrfz91",
-      "depends": ["BiocGenerics", "BiocParallel", "DelayedArray", "DirichletMultinomial", "S4Vectors", "SingleCellExperiment", "SummarizedExperiment", "TreeSummarizedExperiment", "ape", "dplyr", "ggnewscale", "ggplot2", "ggraph", "ggrepel", "ggtree", "mia", "purrr", "rlang", "scater", "tibble", "tidygraph", "tidyr", "tidytext", "tidytree", "viridis"]
+      "version": "1.16.0",
+      "sha256": "005ny26n9w6l7dh0da5112h8g8fnridbsnn23rsphc45dbx9bz1a",
+      "depends": ["BiocGenerics", "BiocParallel", "DelayedArray", "DirichletMultinomial", "S4Vectors", "SingleCellExperiment", "SummarizedExperiment", "TreeSummarizedExperiment", "ape", "dplyr", "ggnewscale", "ggplot2", "ggraph", "ggrepel", "ggtree", "mia", "rlang", "scales", "scater", "tibble", "tidygraph", "tidyr", "tidytext", "tidytree", "viridis"]
     },
     "microRNA": {
       "name": "microRNA",
-      "version": "1.64.0",
-      "sha256": "1c9lqmrl7lmzr7r3174mw0dz070x3crlbay4rgnpml5jiqz0w6fm",
+      "version": "1.66.0",
+      "sha256": "14qc1xvldplxv1pxfaizd5hgvkzb6gybrvg54mfihp04c1laxhgf",
       "depends": ["Biostrings"]
     },
     "microSTASIS": {
       "name": "microSTASIS",
-      "version": "1.6.0",
-      "sha256": "1wvlx8w8ispcl2nsfjc3wl3fjy4gi9dqyikh3swi7vj9wzbkqn3y",
+      "version": "1.8.0",
+      "sha256": "1ixmd0srjndx43zsl183qzc1r4mhvm6cm2h5yshvijj4lhhgmfli",
       "depends": ["BiocParallel", "TreeSummarizedExperiment", "ggplot2", "ggside", "rlang", "stringr"]
     },
     "microbiome": {
       "name": "microbiome",
-      "version": "1.28.0",
-      "sha256": "1q78d71gpczgphv9adh8lz6lx1q0wbiv4pl59aqz6cvagx0kcza6",
+      "version": "1.30.0",
+      "sha256": "0l8538jg7rg8bag169ffbvhmb132y5rhn6s7a906jd2kf5fyx6ja",
       "depends": ["Biostrings", "Rtsne", "compositions", "dplyr", "ggplot2", "phyloseq", "reshape2", "scales", "tibble", "tidyr", "vegan"]
     },
     "microbiomeDASim": {
       "name": "microbiomeDASim",
-      "version": "1.20.0",
-      "sha256": "1hm8qfzcg0r2npb0nwnn0pki1y013nxy8bph113favznmi3c58lq",
+      "version": "1.22.0",
+      "sha256": "11lp6gdgvc6yg93ndxy50aya6apy6r5sxa13wx9p6bj9a0x7cnmg",
       "depends": ["Biobase", "MASS", "Matrix", "ggplot2", "metagenomeSeq", "mvtnorm", "pbapply", "phyloseq", "tmvtnorm"]
     },
     "microbiomeExplorer": {
       "name": "microbiomeExplorer",
-      "version": "1.16.0",
-      "sha256": "144agzs1l8w0vmsmhidz3sa2qqpyfy8894dgm2ya2i1f9jmnwkdb",
+      "version": "1.18.0",
+      "sha256": "195rmgpzjfr09anv2dbl5njnilylqlxl7q1isg42fvprqd4bf587",
       "depends": ["Biobase", "DESeq2", "DT", "RColorBrewer", "biomformat", "broom", "car", "dplyr", "forcats", "heatmaply", "knitr", "limma", "lubridate", "magrittr", "matrixStats", "metagenomeSeq", "plotly", "purrr", "readr", "reshape2", "rlang", "rmarkdown", "shiny", "shinyWidgets", "shinycssloaders", "shinydashboard", "shinyjs", "stringr", "tibble", "tidyr", "vegan"]
-    },
-    "microbiomeMarker": {
-      "name": "microbiomeMarker",
-      "version": "1.12.2",
-      "sha256": "0fkm2sqqsaa8kkdyp0j3zwx8lijgkgk4s45sir3s37an9yai2bp4",
-      "depends": ["ALDEx2", "ANCOMBC", "Biobase", "BiocGenerics", "BiocParallel", "Biostrings", "ComplexHeatmap", "DESeq2", "IRanges", "MASS", "S4Vectors", "biomformat", "caret", "coin", "dplyr", "edgeR", "ggplot2", "ggsignif", "ggtree", "limma", "magrittr", "metagenomeSeq", "multtest", "pROC", "patchwork", "phyloseq", "plotROC", "purrr", "rlang", "tibble", "tidyr", "tidytree", "vegan", "yaml"]
     },
     "midasHLA": {
       "name": "midasHLA",
-      "version": "1.14.0",
-      "sha256": "0yva9n4sg93g3skxaqv1156ccjflz8yg0xl896d661in2gxcr400",
+      "version": "1.16.0",
+      "sha256": "1cpmd8g0lmd567aqkzb1nidqz1qabrlsywwpdwxya0bdd45a8wz0",
       "depends": ["HardyWeinberg", "MultiAssayExperiment", "S4Vectors", "SummarizedExperiment", "assertthat", "broom", "dplyr", "formattable", "kableExtra", "knitr", "magrittr", "qdapTools", "rlang", "stringi", "tibble"]
     },
     "miloR": {
       "name": "miloR",
-      "version": "2.2.0",
-      "sha256": "1x7p6zjbif8wc4z8wqc472z69j3wbrbqbfq9sldj7v6cgfcflifd",
+      "version": "2.4.0",
+      "sha256": "0sx0i92zbgrnhbx8df48xkv46vp5xmswvrmzwl6vvggjdvk9sg6r",
       "depends": ["BiocGenerics", "BiocNeighbors", "BiocParallel", "BiocSingular", "Matrix", "MatrixGenerics", "RColorBrewer", "Rcpp", "RcppArmadillo", "RcppEigen", "RcppML", "S4Vectors", "SingleCellExperiment", "SummarizedExperiment", "cowplot", "dplyr", "edgeR", "ggbeeswarm", "ggplot2", "ggraph", "ggrepel", "gtools", "igraph", "irlba", "limma", "matrixStats", "numDeriv", "patchwork", "pracma", "stringr", "tibble", "tidyr"]
     },
     "mimager": {
       "name": "mimager",
-      "version": "1.30.0",
-      "sha256": "151rkn9rz89x15xh01dn6x48wvdx1wy4hgrwfancpjhq3vlbz0a2",
+      "version": "1.32.0",
+      "sha256": "1yb3wgc5ghw4k1sg8a9p00ff7dg4lbbghvp0mszagy1q7kllh9i1",
       "depends": ["Biobase", "BiocGenerics", "DBI", "S4Vectors", "affy", "affyPLM", "gtable", "oligo", "oligoClasses", "preprocessCore", "scales"]
     },
     "mina": {
       "name": "mina",
-      "version": "1.14.0",
-      "sha256": "04a0sdif70v0136vzq5p7dhd4z4sjmvnz2fd0bkhcpz7s566w2gp",
+      "version": "1.16.0",
+      "sha256": "1jbygw7gzqrirdkq3c0p5hz9hbmaybj5aqcd2pd75dcy6lnvyk0v",
       "depends": ["Hmisc", "MCL", "RSpectra", "Rcpp", "RcppArmadillo", "RcppParallel", "apcluster", "biganalytics", "bigmemory", "foreach", "ggplot2", "parallelDist", "plyr", "reshape2", "stringr"]
     },
     "minet": {
       "name": "minet",
-      "version": "3.64.0",
-      "sha256": "0laq82zi3ij8rdgv4cw6kcsbf0hrwy6v3hqr3v5x66lv8vnykp4p",
+      "version": "3.66.0",
+      "sha256": "1gbpi6nxla161zpmlpymvalchcgk4f97rz9kw49bnbr1lw8msa84",
       "depends": ["infotheo"]
     },
     "minfi": {
       "name": "minfi",
-      "version": "1.52.1",
-      "sha256": "13bajbcsm0rkw92c8pz1pxn07af5nf51qfff5p0n9chdi01k78dk",
+      "version": "1.54.0",
+      "sha256": "0nvsirsc6i3wax3bn9bc8n2qw1wfdjkvalqpfkmi6l35ilkksqd5",
       "depends": ["Biobase", "BiocGenerics", "BiocParallel", "Biostrings", "DelayedArray", "DelayedMatrixStats", "GEOquery", "GenomeInfoDb", "GenomicRanges", "HDF5Array", "IRanges", "MASS", "RColorBrewer", "S4Vectors", "SummarizedExperiment", "beanplot", "bumphunter", "data_table", "genefilter", "illuminaio", "lattice", "limma", "mclust", "nlme", "nor1mix", "preprocessCore", "quadprog", "reshape", "siggenes"]
     },
     "mirIntegrator": {
       "name": "mirIntegrator",
-      "version": "1.36.0",
-      "sha256": "0nzd6y95jlbal60axkfdrillghbzxa7vhwqb86hmb0g87hfzjmkw",
+      "version": "1.38.0",
+      "sha256": "05d5x4xzqz2bpi7wvbf8nx5x6cn24hmc4acq04b7g7fs3mj0zd2v",
       "depends": ["AnnotationDbi", "ROntoTools", "Rgraphviz", "ggplot2", "graph", "org_Hs_eg_db"]
     },
     "mirTarRnaSeq": {
       "name": "mirTarRnaSeq",
-      "version": "1.14.0",
-      "sha256": "1yww4mx117bh6xkdmxnvxsyy5rxy8p679qm1gha3vxd7fnxca4zf",
+      "version": "1.16.0",
+      "sha256": "0zlhkcip070xvmb58lqn61ajihcz8i7w2y5dpvxq0rm4hg5yhnbb",
       "depends": ["MASS", "R_utils", "assertthat", "caTools", "corrplot", "data_table", "dplyr", "ggplot2", "pheatmap", "pscl", "purrr", "reshape2", "viridis"]
     },
     "missMethyl": {
       "name": "missMethyl",
-      "version": "1.40.1",
-      "sha256": "0bcp57rdlrzkcwn3pa6wwka8gg8hqmmycwmi97x0jyri1pws97h9",
+      "version": "1.42.0",
+      "sha256": "10sb3800dvic1nhan3g3gsmhqa4mbk22fwiyz08gq97bka4g3adp",
       "depends": ["AnnotationDbi", "BiasedUrn", "Biobase", "BiocGenerics", "GO_db", "GenomicRanges", "IRanges", "IlluminaHumanMethylation450kanno_ilmn12_hg19", "IlluminaHumanMethylation450kmanifest", "IlluminaHumanMethylationEPICanno_ilm10b4_hg19", "IlluminaHumanMethylationEPICmanifest", "IlluminaHumanMethylationEPICv2anno_20a1_hg38", "IlluminaHumanMethylationEPICv2manifest", "S4Vectors", "SummarizedExperiment", "limma", "methylumi", "minfi", "org_Hs_eg_db", "ruv", "statmod", "stringr"]
     },
     "missRows": {
       "name": "missRows",
-      "version": "1.26.0",
-      "sha256": "09vjmb9p6xwxkz4y6mrzzvw4q8kc72rw9dwivafd55hn8l8410j5",
+      "version": "1.28.0",
+      "sha256": "0p979nxxwrzwn4pjxhy4hzrsa14j1y38sayinfzm6w04f9qhygdj",
       "depends": ["MultiAssayExperiment", "S4Vectors", "ggplot2", "gtools", "plyr"]
+    },
+    "mist": {
+      "name": "mist",
+      "version": "1.0.0",
+      "sha256": "1y1k3xz0di4g26hfplqv9cbnivmaws0wgxgz7qgyz2b27x13gkmw",
+      "depends": ["BiocGenerics", "BiocParallel", "MCMCpack", "Matrix", "S4Vectors", "SingleCellExperiment", "SummarizedExperiment", "car", "mvtnorm", "rlang", "rtracklayer"]
     },
     "mistyR": {
       "name": "mistyR",
-      "version": "1.14.0",
-      "sha256": "14jvn05faj2w344rn4297vc23y3q523rvqnkqg48c6sa3dw4gwp5",
+      "version": "1.16.0",
+      "sha256": "0wndy978qly0m9nk5q3ilycrk50198zbczxwsg8c2pm12i120fj1",
       "depends": ["R_utils", "assertthat", "caret", "deldir", "digest", "distances", "dplyr", "filelock", "furrr", "ggplot2", "purrr", "ranger", "readr", "ridge", "rlang", "rlist", "stringr", "tibble", "tidyr", "tidyselect", "withr"]
     },
     "mitch": {
       "name": "mitch",
-      "version": "1.18.4",
-      "sha256": "1w75lsa5ygzr67mr5kfj36z40qzyb2q04mbvwgsyappkqdkscd15",
-      "depends": ["GGally", "MASS", "beeswarm", "echarts4r", "ggplot2", "gplots", "gridExtra", "kableExtra", "knitr", "plyr", "reshape2", "rmarkdown"]
+      "version": "1.20.0",
+      "sha256": "1s7mqb4qxx2ylr966y0aj3m9slvcrxy5zxj77q7nfi256781lf4x",
+      "depends": ["GGally", "MASS", "beeswarm", "dplyr", "echarts4r", "ggplot2", "gplots", "gridExtra", "kableExtra", "knitr", "network", "plyr", "reshape2", "rmarkdown"]
     },
     "mitoClone2": {
       "name": "mitoClone2",
-      "version": "1.12.0",
-      "sha256": "0jsjjjgqnn380fg6v5336dvrcgkfjc4h1cv4y40srhx008f5g63y",
+      "version": "1.14.0",
+      "sha256": "1p7mg1cb8ma161hbhjpa7xcigszmzjwvgqv12gpadmn080z8lljm",
       "depends": ["GenomicRanges", "Rhtslib", "S4Vectors", "deepSNV", "ggplot2", "pheatmap", "reshape2"]
+    },
+    "mitology": {
+      "name": "mitology",
+      "version": "1.0.0",
+      "sha256": "1kvka6ma0ax74521w31nijz0nkq9dl56f76ab1i9h6pr3jaaddj3",
+      "depends": ["AnnotationDbi", "ComplexHeatmap", "ape", "circlize", "ggplot2", "ggtree", "magrittr", "org_Hs_eg_db", "scales"]
     },
     "mixOmics": {
       "name": "mixOmics",
-      "version": "6.30.0",
-      "sha256": "0bjwwjhcgbx27sm6ki3aag7jngmdsp3hr3hn58wkm492xa2hsimf",
+      "version": "6.32.0",
+      "sha256": "177wpgpd5przj4zfj9ylwr1xxlq9a2yjp6kjkca9h79r4mgba1sn",
       "depends": ["BiocParallel", "MASS", "RColorBrewer", "corpcor", "dplyr", "ellipse", "ggplot2", "ggrepel", "gridExtra", "gsignal", "igraph", "lattice", "matrixStats", "rARPACK", "reshape2", "rgl", "tidyr"]
     },
     "mnem": {
       "name": "mnem",
-      "version": "1.22.0",
-      "sha256": "0accy11xhqai777zb5c1b49k5fm8drng0jrwf467x7nvzwgkpfw9",
+      "version": "1.24.0",
+      "sha256": "077g7pmlx8qlj4hnn2xlyn1h0ydv0pxwjxc4jsmn7ni8hzcppi80",
       "depends": ["Linnorm", "Rcpp", "RcppEigen", "Rgraphviz", "cluster", "data_table", "e1071", "flexclust", "ggplot2", "graph", "lattice", "matrixStats", "naturalsort", "snowfall", "tsne", "wesanderson"]
     },
     "moanin": {
       "name": "moanin",
-      "version": "1.14.0",
-      "sha256": "0ppcjynl9mplsz3fwyj47lni6dv53y4avaqsavf885bp33dn85gb",
+      "version": "1.16.0",
+      "sha256": "1d79bx9a4wv1ybkxv918ga8bf1rlfmikii8ql70m25b73cacwl6k",
       "depends": ["ClusterR", "MASS", "NMI", "S4Vectors", "SummarizedExperiment", "edgeR", "limma", "matrixStats", "reshape2", "topGO", "viridis", "zoo"]
     },
     "mobileRNA": {
       "name": "mobileRNA",
-      "version": "1.2.0",
-      "sha256": "0f4g54fyjwiqcwfrsrfgb7414x9mk4mcxpsyd6j0bx704qjr743v",
+      "version": "1.4.0",
+      "sha256": "0a7kd7a2avkiba4aixyv8bvk7rha91g25hg16nbkikv5px1x7ssw",
       "depends": ["BiocGenerics", "Biostrings", "DESeq2", "GenomeInfoDb", "GenomicRanges", "IRanges", "RColorBrewer", "S4Vectors", "SimDesign", "SummarizedExperiment", "bioseq", "data_table", "dplyr", "edgeR", "ggplot2", "ggrepel", "pheatmap", "progress", "reticulate", "rlang", "rtracklayer", "scales", "tidyr", "tidyselect"]
     },
     "mogsa": {
       "name": "mogsa",
-      "version": "1.40.0",
-      "sha256": "131l0xs5gvjkih18h4jckmwmsz4r90cnrrxqnyfrrk9kbdcsb8jw",
+      "version": "1.42.0",
+      "sha256": "13zfxl0saqs57i29ymrpx46awjljihhhvkylj86hv35x4ly4hql5",
       "depends": ["Biobase", "BiocGenerics", "GSEABase", "cluster", "corpcor", "genefilter", "gplots", "graphite", "svd"]
     },
     "monaLisa": {
       "name": "monaLisa",
-      "version": "1.12.0",
-      "sha256": "0pylick07qkv421l068z6pdjgms0cmns49fh9m9lz9g4r4b9w31y",
-      "depends": ["BSgenome", "BiocGenerics", "BiocParallel", "Biostrings", "ComplexHeatmap", "GenomeInfoDb", "GenomicRanges", "IRanges", "RSQLite", "S4Vectors", "SummarizedExperiment", "TFBSTools", "XVector", "circlize", "glmnet", "stabs", "vioplot"]
+      "version": "1.14.0",
+      "sha256": "16rp6c0hcl0xmw08xpq649sdf5dgcn4s8394lq562rrbb51wvsg4",
+      "depends": ["BSgenome", "BiocGenerics", "BiocParallel", "Biostrings", "ComplexHeatmap", "GenomeInfoDb", "GenomicRanges", "IRanges", "RSQLite", "S4Vectors", "SummarizedExperiment", "TFBSTools", "XVector", "circlize", "cli", "ggplot2", "glmnet", "rlang", "stabs", "tidyr"]
     },
     "monocle": {
       "name": "monocle",
-      "version": "2.34.0",
-      "sha256": "1qxf83zblihxm3fs5zrzf1spzhnm332n6nbzbzaid69l7xmgl5x0",
+      "version": "2.36.0",
+      "sha256": "0lp75gdxizsap5shsavdiq6c0vlkaw81qsd4k8sna90hr7bziwv3",
       "depends": ["Biobase", "BiocGenerics", "DDRTree", "HSMMSingleCell", "MASS", "Matrix", "RANN", "Rcpp", "Rtsne", "VGAM", "biocViews", "cluster", "combinat", "dplyr", "fastICA", "ggplot2", "igraph", "irlba", "leidenbase", "limma", "matrixStats", "pheatmap", "plyr", "proxy", "reshape2", "slam", "stringr", "tibble", "viridis"]
     },
     "mosaics": {
       "name": "mosaics",
-      "version": "2.44.0",
-      "sha256": "0f2qnqzm76hhcq113bag4p2g2li8rf2afdskj4hki8n0mnzgqgnc",
+      "version": "2.46.0",
+      "sha256": "1ya14fdxbbcflhiknmx8ar29y1sbpdih9q8g381s4vlli3k3zgxk",
       "depends": ["GenomeInfoDb", "GenomicAlignments", "GenomicRanges", "IRanges", "MASS", "Rcpp", "Rsamtools", "S4Vectors", "lattice"]
     },
     "mosbi": {
       "name": "mosbi",
-      "version": "1.12.0",
-      "sha256": "09dp77ryr0cg1c8gj67a38s9y0pa7dlxrwjrvsi8vnkbn27ys712",
+      "version": "1.14.0",
+      "sha256": "160yz2bqx7rm8m90j282yr3dkaw3r1ckhnikb6zw4xkd7nwj3wkl",
       "depends": ["BH", "QUBIC", "RColorBrewer", "Rcpp", "RcppParallel", "akmbiclust", "biclust", "fabia", "igraph", "isa2", "xml2"]
     },
     "mosdef": {
       "name": "mosdef",
-      "version": "1.2.0",
-      "sha256": "0y2hniyb1y5hxlsm339059kb4n3l21fzb3xx112igsbk7zd0r258",
+      "version": "1.4.0",
+      "sha256": "1djl0sl9yr3kpz5mbrs23gwz2dc8cz3g7sv1ians804r53aalirz",
       "depends": ["AnnotationDbi", "DESeq2", "DT", "GO_db", "RColorBrewer", "S4Vectors", "SummarizedExperiment", "clusterProfiler", "ggforce", "ggplot2", "ggrepel", "goseq", "htmltools", "rlang", "scales", "topGO"]
     },
     "motifStack": {
       "name": "motifStack",
-      "version": "1.50.0",
-      "sha256": "0wkv0gjvk7p491c4zsg1hh61r3lhmjnif6nd2s63xwqm2qw6a4nx",
+      "version": "1.52.0",
+      "sha256": "1gd8rhdci6cskhxz6g5hyjx9rdpd5b6pacy5i8nk5yvqmg2jqwrn",
       "depends": ["Biostrings", "TFBSTools", "XML", "ade4", "ggplot2", "htmlwidgets"]
     },
     "motifTestR": {
       "name": "motifTestR",
-      "version": "1.2.1",
-      "sha256": "1ysqk2xsxry9jm78qzph8myyl0f1bab1lfwwazga8513ffxnn4xn",
+      "version": "1.4.0",
+      "sha256": "0qdivy6ci9xcjjwbkklh69rqhfrvi733r2jraw9cina8jiwff2q9",
       "depends": ["Biostrings", "GenomeInfoDb", "GenomicRanges", "IRanges", "S4Vectors", "ggplot2", "harmonicmeanp", "matrixStats", "patchwork", "rlang", "universalmotif"]
     },
     "motifbreakR": {
       "name": "motifbreakR",
-      "version": "2.20.0",
-      "sha256": "0308wqrcjzdfm38p9lqphz5h82k2zdzknvhviqzrvcqinzqjqy26",
+      "version": "2.22.0",
+      "sha256": "1kc9aqpx7006c5pz0i7l8qvp0vkng9f14r7z1wj67rb806qsd76f",
       "depends": ["BSgenome", "BiocFileCache", "BiocGenerics", "BiocParallel", "Biostrings", "DT", "GenomeInfoDb", "GenomicRanges", "Gviz", "IRanges", "MotifDb", "S4Vectors", "SummarizedExperiment", "TFMPvalue", "VariantAnnotation", "biomaRt", "bsicons", "bslib", "matrixStats", "motifStack", "pwalign", "rtracklayer", "shiny", "stringr", "vroom"]
     },
     "motifcounter": {
       "name": "motifcounter",
-      "version": "1.30.0",
-      "sha256": "1babir5nypi3h2rbqfgkawsv1mbhqkkx8q583cszpwyivyird1x1",
+      "version": "1.32.0",
+      "sha256": "19wfy5cn76x9v7sb3pglk3c7lw997cidmsl39hhdyxsm76nfy0cv",
       "depends": ["Biostrings"]
     },
     "motifmatchr": {
       "name": "motifmatchr",
-      "version": "1.28.0",
-      "sha256": "0a2hd7fld7q22kpllpq6zb79ivpfrrq1vz1v4fariar18800fjc2",
+      "version": "1.30.0",
+      "sha256": "0j0dx8v856l4bqz0v3n2kj4yvdq4ffkfr5vsh5mwj09vbacjqzgf",
       "depends": ["BSgenome", "Biostrings", "GenomeInfoDb", "GenomicRanges", "IRanges", "Matrix", "Rcpp", "RcppArmadillo", "Rsamtools", "S4Vectors", "SummarizedExperiment", "TFBSTools"]
     },
     "mpra": {
       "name": "mpra",
-      "version": "1.28.0",
-      "sha256": "04bbx660bq3fx27dzf5cl33plsg6ndyxv31pa0ind3ma4zzxa47m",
+      "version": "1.30.0",
+      "sha256": "0kv0y4yjykn1vbkv55697f1zfx7ddh4kf9cs44n72lgrffmkkndh",
       "depends": ["BiocGenerics", "S4Vectors", "SummarizedExperiment", "limma", "scales", "statmod"]
     },
     "msImpute": {
       "name": "msImpute",
-      "version": "1.16.0",
-      "sha256": "0jizwv0jsc9kq22dm4df8fr50d1d4avx9syrj39fixmvajgk8x9a",
+      "version": "1.18.0",
+      "sha256": "1f05avwrxfbr4jf14x23w9zay74lnwfji82vbkjdsaxxsx3rwnw6",
       "depends": ["FNN", "data_table", "dplyr", "limma", "matrixStats", "mvtnorm", "pdist", "reticulate", "scran", "softImpute", "tidyr"]
     },
     "msPurity": {
       "name": "msPurity",
-      "version": "1.32.0",
-      "sha256": "0pnb415v401l98brl61bnzxdl4d89psl1jr4cx4imdp7brixfhbl",
+      "version": "1.34.0",
+      "sha256": "1q20wrlzb51ri3sz70zxw65gg538jqvrl42hmrk8d2h1yl6ipxvm",
       "depends": ["DBI", "RSQLite", "Rcpp", "dbplyr", "doSNOW", "dplyr", "fastcluster", "foreach", "ggplot2", "magrittr", "mzR", "plyr", "reshape2", "stringr"]
     },
     "msa": {
       "name": "msa",
-      "version": "1.38.0",
-      "sha256": "0v65pfhl19zi0dc2avzpxq7dygknlr2y44wkir6wmvn8m7jppjlg",
+      "version": "1.40.0",
+      "sha256": "0cfxdyynnzb06cv9mghsbpkrqi66yrcfy4crzfwlszdxf5ixdqyb",
       "depends": ["BiocGenerics", "Biostrings", "IRanges", "Rcpp", "S4Vectors"]
     },
     "msgbsR": {
       "name": "msgbsR",
-      "version": "1.30.0",
-      "sha256": "08g8xv3l6a0hxirrgrdsjrgdcrkinraws7bg9yv6dv43a1yabpqp",
+      "version": "1.32.0",
+      "sha256": "1j77bc05slhgznwmg6lym9vzk61dvhjd2iisksz1yn635cflfryp",
       "depends": ["BSgenome", "GenomeInfoDb", "GenomicAlignments", "GenomicFeatures", "GenomicRanges", "IRanges", "R_utils", "Rsamtools", "S4Vectors", "SummarizedExperiment", "easyRNASeq", "edgeR", "ggbio", "ggplot2", "plyr"]
     },
     "mslp": {
       "name": "mslp",
-      "version": "1.8.0",
-      "sha256": "0z7igxk2rswznilvsbgxvy6ga7g8fd7i7schgg21bcfy1c0jly4f",
+      "version": "1.10.0",
+      "sha256": "1za9q8hmia7d8f795v7v53n4vadpyk8irmsszna3va6kk0ir1fby",
       "depends": ["RankProd", "data_table", "doRNG", "fmsb", "foreach", "magrittr", "org_Hs_eg_db", "pROC", "randomForest"]
     },
     "msmsEDA": {
       "name": "msmsEDA",
-      "version": "1.44.0",
-      "sha256": "0i3ivq14jjc2v9d8v536s55w211bh67v39qzl2prringrwncq418",
+      "version": "1.46.0",
+      "sha256": "1qxksn69zp1whxajwzdprpns9r1aq66hkgp9knc8nd2jk5y8arla",
       "depends": ["MASS", "MSnbase", "RColorBrewer", "gplots"]
     },
     "msmsTests": {
       "name": "msmsTests",
-      "version": "1.44.0",
-      "sha256": "0pwz1hzrniqdgcxbd361w4rf5brjgb4wwz5jlny2vfnigb6v1mmd",
+      "version": "1.46.0",
+      "sha256": "0vy90ki0fcyszry21m53yf1rpa59y80m9y1sjbhkcn0qxwplf593",
       "depends": ["MSnbase", "edgeR", "msmsEDA", "qvalue"]
+    },
+    "mspms": {
+      "name": "mspms",
+      "version": "1.0.0",
+      "sha256": "0bcjyw5d3l9f2h9157acxpjfn2shpgv4191p6880j77s5vi20xb5",
+      "depends": ["QFeatures", "SummarizedExperiment", "dplyr", "ggplot2", "ggpubr", "ggseqlogo", "heatmaply", "limma", "magrittr", "purrr", "readr", "rlang", "rstatix", "stringr", "tibble", "tidyr"]
     },
     "msqrob2": {
       "name": "msqrob2",
-      "version": "1.14.1",
-      "sha256": "0kwfvmcngwzxm38837lp1jpd20k4cag638q4p7gz9c98qff1rkln",
+      "version": "1.16.0",
+      "sha256": "0ik80pmwzyaaz287hab3nfivag4pzd1qkngc91vlmx21x0r4nzss",
       "depends": ["BiocParallel", "MASS", "Matrix", "MultiAssayExperiment", "QFeatures", "SummarizedExperiment", "codetools", "limma", "lme4", "purrr"]
     },
     "multiClust": {
       "name": "multiClust",
-      "version": "1.36.0",
-      "sha256": "0l1a9kajam5zl95j5yvjkjiblmg8wcsvna562drw5nh4lanldsk5",
+      "version": "1.38.0",
+      "sha256": "0hm1hpjaf5rnxzxlxpxhwsz3xdx2n1yvw5ljk7f2mslbphnbfmb6",
       "depends": ["amap", "cluster", "ctc", "dendextend", "mclust", "survival"]
     },
     "multiGSEA": {
       "name": "multiGSEA",
-      "version": "1.16.2",
-      "sha256": "1d7l7mlw03sq5yj5dhxanm31m0gy7ix7ddbzq2kv3lpr56rdgqjx",
+      "version": "1.18.0",
+      "sha256": "0mxl9lgwv9gxb671fynhkl3mj9d5j6df2j9yr2w1g7bgp80hw434",
       "depends": ["AnnotationDbi", "dplyr", "fgsea", "graphite", "magrittr", "metaboliteIDmapping", "metap", "rappdirs", "rlang"]
     },
     "multiHiCcompare": {
       "name": "multiHiCcompare",
-      "version": "1.24.0",
-      "sha256": "19z0f0dihfdvdw063a5728hm7wgh2brxp9hvv8b7y04q07ywd1cc",
+      "version": "1.26.0",
+      "sha256": "00gw159yyas5b8122z096rgiyr215i9c35way67s73h2zl8jbrs7",
       "depends": ["BiocParallel", "GenomeInfoDb", "GenomeInfoDbData", "GenomicRanges", "HiCcompare", "aggregation", "data_table", "dplyr", "edgeR", "pbapply", "pheatmap", "qqman"]
     },
     "multiMiR": {
       "name": "multiMiR",
-      "version": "1.28.0",
-      "sha256": "0ihj8zlw6g5hv6amrqqkzln8kd7lvhny4z15y4nc2rz7bf5kcsyy",
+      "version": "1.30.0",
+      "sha256": "0f64qmiv6kq6md4clyk369pp8zyzyygxw8wllrwmyik8y9zqfsxz",
       "depends": ["AnnotationDbi", "BiocGenerics", "RCurl", "XML", "dplyr", "purrr", "tibble"]
     },
     "multiWGCNA": {
       "name": "multiWGCNA",
-      "version": "1.4.0",
-      "sha256": "0lv1hxd23iglmk952y4lf75i50fp5jmb6iwbd3k617i4q3gxam8v",
+      "version": "1.6.0",
+      "sha256": "0p14v9kdg105jlglcm24h0mvrn7f4x7r4k1la3l5wlyk17jga24q",
       "depends": ["SummarizedExperiment", "WGCNA", "cowplot", "data_table", "dcanr", "dplyr", "flashClust", "ggalluvial", "ggplot2", "ggrepel", "igraph", "patchwork", "readr", "reshape2", "scales", "stringr"]
     },
     "multicrispr": {
       "name": "multicrispr",
-      "version": "1.16.1",
-      "sha256": "0kyvmas6kni5x51pwfin7z6m67bg9lhaisqyxf0mcsgwiwz263n8",
+      "version": "1.18.0",
+      "sha256": "1q6s3rr6w66gykfh304sk3mw6ja8hxpszikvjyxjz1liyzqmarwr",
       "depends": ["BSgenome", "BiocGenerics", "Biostrings", "CRISPRseek", "GenomeInfoDb", "GenomicFeatures", "GenomicRanges", "Rbowtie", "data_table", "ggplot2", "karyoploteR", "magrittr", "plyranges", "reticulate", "rtracklayer", "stringi", "tidyr", "tidyselect"]
     },
     "multiscan": {
       "name": "multiscan",
-      "version": "1.66.0",
-      "sha256": "11vkd45kvxkrahkzwrl1xfhy4rhqdr5kmnnf82rzk40mi1j70dyf",
+      "version": "1.68.0",
+      "sha256": "0zq5gd4x28ilh70bdd535w2sgdssw6ddgnljah74fbjmxjj9q2p2",
       "depends": ["Biobase"]
     },
     "multistateQTL": {
       "name": "multistateQTL",
-      "version": "1.2.2",
-      "sha256": "0qmvs0z3b87y21q285qabkpf3lbcw94c6axdg8xd9k9k7lz1ihbq",
+      "version": "2.0.0",
+      "sha256": "1b4is7chha5w4ivvk5w5rpl7033bb0r8m72baz553dzrhzp8imvc",
       "depends": ["ComplexHeatmap", "QTLExperiment", "S4Vectors", "SummarizedExperiment", "circlize", "collapse", "data_table", "dplyr", "fitdistrplus", "ggplot2", "mashr", "matrixStats", "tidyr", "viridis"]
     },
     "multtest": {
       "name": "multtest",
-      "version": "2.62.0",
-      "sha256": "00gs0mb371x5aj9wa8infwfpmg3iqyz0bgmn6gk9mcfl9rf6xkfk",
+      "version": "2.64.0",
+      "sha256": "0fcqz532n7p2ip2awm9if4yn39z0mgwcjl7p0gyhp79nlv6fcdmr",
       "depends": ["Biobase", "BiocGenerics", "MASS", "survival"]
     },
     "mumosa": {
       "name": "mumosa",
-      "version": "1.14.0",
-      "sha256": "0m7l0sn5npsvwcvpnsl61w8sgbnyanqdrz76chifzd9j7ydwwxqi",
+      "version": "1.16.0",
+      "sha256": "0scdf663lwpz1hzcz5kbh28x4vvkqrdvhhwf523l3h7mlyqrwgqx",
       "depends": ["BiocGenerics", "BiocNeighbors", "BiocParallel", "BiocSingular", "DelayedArray", "DelayedMatrixStats", "IRanges", "Matrix", "S4Vectors", "ScaledMatrix", "SingleCellExperiment", "SummarizedExperiment", "batchelor", "beachmat", "igraph", "metapod", "scran", "scuttle", "uwot"]
     },
     "muscat": {
       "name": "muscat",
-      "version": "1.20.0",
-      "sha256": "04kni9lv04dsnam71dw3ib2jmjfrrndj9432igf5aj22l4wlxbc3",
+      "version": "1.22.0",
+      "sha256": "1gbh93xb82k16wjwavpf8bfzb5fy5i4rpq5a174cjzi9idndjsra",
       "depends": ["BiocParallel", "ComplexHeatmap", "DESeq2", "Matrix", "S4Vectors", "SingleCellExperiment", "SummarizedExperiment", "blme", "data_table", "dplyr", "edgeR", "ggplot2", "glmmTMB", "limma", "lme4", "lmerTest", "matrixStats", "progress", "purrr", "rlang", "scales", "scater", "sctransform", "scuttle", "variancePartition", "viridis"]
     },
     "muscle": {
       "name": "muscle",
-      "version": "3.48.0",
-      "sha256": "0q172f0bwpr5cc1madba8rj258kbjdw32s171y01gkb9jgqn60n3",
+      "version": "3.50.0",
+      "sha256": "03inf7jdmm03rgliwr4y80zpmbkl5aki6z475ayr8b2dbqvpy4f2",
       "depends": ["Biostrings"]
     },
     "musicatk": {
       "name": "musicatk",
-      "version": "2.0.0",
-      "sha256": "173dzy60b3avndz9hywqfm22hpgsq14gdxkxm2glna9qd5sqw2al",
+      "version": "2.2.0",
+      "sha256": "1sgxl4ar4ql3ajmpay1jgcid1yppmvvclic8gjhfp62im3blhib5",
       "depends": ["BSgenome", "BSgenome_Hsapiens_UCSC_hg19", "BSgenome_Hsapiens_UCSC_hg38", "BSgenome_Mmusculus_UCSC_mm10", "BSgenome_Mmusculus_UCSC_mm9", "Biostrings", "ComplexHeatmap", "GenomeInfoDb", "GenomicFeatures", "GenomicRanges", "IRanges", "MASS", "MCMCprecision", "Matrix", "NMF", "S4Vectors", "SummarizedExperiment", "TxDb_Hsapiens_UCSC_hg19_knownGene", "TxDb_Hsapiens_UCSC_hg38_knownGene", "VariantAnnotation", "cluster", "conclust", "data_table", "decompTumor2Sig", "dplyr", "factoextra", "ggplot2", "ggpubr", "ggrepel", "gridExtra", "gtools", "maftools", "magrittr", "matrixTests", "philentropy", "plotly", "rlang", "scales", "shiny", "stringi", "stringr", "tibble", "tidyr", "tidyverse", "topicmodels", "uwot"]
     },
     "mygene": {
       "name": "mygene",
-      "version": "1.42.0",
-      "sha256": "0a60g3i4f6mprd4rf9pw093lr9qlnr067pipncl9chabsy9fzkhl",
+      "version": "1.44.0",
+      "sha256": "18wk3ks222pwamq62pyfjwwrpkkj842p79wsnjbvx6km0fqycr16",
       "depends": ["GenomicFeatures", "Hmisc", "S4Vectors", "httr", "jsonlite", "plyr", "sqldf", "txdbmaker"]
     },
     "myvariant": {
       "name": "myvariant",
-      "version": "1.36.0",
-      "sha256": "1vmmlkqx4cjhsx126lq4ax8s4qwfl5jqwiwm12i5aqxp9k28586z",
+      "version": "1.38.0",
+      "sha256": "1kl4cndr9a5ri7zxl274z6d6a7584wx2hbkq7yhvz0ikhqdv9gp4",
       "depends": ["GenomeInfoDb", "Hmisc", "S4Vectors", "VariantAnnotation", "httr", "jsonlite", "magrittr", "plyr"]
     },
     "mzID": {
       "name": "mzID",
-      "version": "1.44.0",
-      "sha256": "0lf7w65v01mc7cawlsbjagbrhlh6jpy6ah7pbjgyvy5s0axlzgp2",
+      "version": "1.46.0",
+      "sha256": "0xsk7g3jyqw75lpfa3rw2gg2xg648acrb0klyksb9cac2mhpl4w2",
       "depends": ["ProtGenerics", "XML", "doParallel", "foreach", "iterators", "plyr"]
     },
     "mzR": {
       "name": "mzR",
-      "version": "2.40.0",
-      "sha256": "1vqd9arlhvhw58jk2r343x6dqbv85ckgzjk04hi3pb6w5z0yvks4",
+      "version": "2.42.0",
+      "sha256": "0sm6scdrswxv67yz2kg5n4n4354j9pxxq0bzc6jgkh0y97k6vw9r",
       "depends": ["Biobase", "BiocGenerics", "ProtGenerics", "Rcpp", "Rhdf5lib", "ncdf4"]
     },
     "ncGTW": {
       "name": "ncGTW",
-      "version": "1.20.0",
-      "sha256": "1y1sc6qv5s2x0zg4wpvjflvzzi6zy4h0kvwds1j1kd9wm0ck9z6c",
+      "version": "1.22.0",
+      "sha256": "008l82ganh0zljmh98q5gq0k44qzilsb4qwnybi7dk8mjbh0pksf",
       "depends": ["BiocParallel", "Rcpp", "xcms"]
     },
     "ncRNAtools": {
       "name": "ncRNAtools",
-      "version": "1.16.0",
-      "sha256": "07kcwcf94vnm7byagnb4dkn1xpdimkp73vnglxh8d12s46vdpvcl",
+      "version": "1.17.0",
+      "sha256": "0nhif4rdamxg01yg7vc6rx8kgp79pg4g6f4jfjawsrbs9bs4gwib",
       "depends": ["GenomicRanges", "IRanges", "S4Vectors", "ggplot2", "httr", "xml2"]
     },
     "ncdfFlow": {
       "name": "ncdfFlow",
-      "version": "2.52.1",
-      "sha256": "1sqpifafyrnxln062pn3cvwxkmmxf9xzx5zsjb8i4bhxgkhrh7vh",
+      "version": "2.54.0",
+      "sha256": "0b4vriw7msvl0pv7m7wpx3gqg10pfdj6vnclawx2v3zarqbl2ny0",
       "depends": ["BH", "Biobase", "BiocGenerics", "Rhdf5lib", "cpp11", "flowCore"]
     },
     "ndexr": {
       "name": "ndexr",
-      "version": "1.28.0",
-      "sha256": "0m6hzx0nk2bq9l40mnjil1vjqys9lvgflifp8gnk3skiw2ddjrsm",
+      "version": "1.30.0",
+      "sha256": "0m1scmqpsha05pixlkq8a5xsfhbvml7knal8wqxvb9x0rzvizqiy",
       "depends": ["RCX", "httr", "jsonlite", "plyr", "tidyr"]
     },
     "nearBynding": {
       "name": "nearBynding",
-      "version": "1.16.0",
-      "sha256": "0q5bpfvrb8qvklwc6zhvdrj0rq58p0gpqc08j7cgxhllkmiacisw",
+      "version": "1.18.0",
+      "sha256": "0wh4j84i4vr51kjy9p2p6s3l48xz9vmh4zffqvf655w00n5kmi9a",
       "depends": ["BiocGenerics", "GenomeInfoDb", "GenomicRanges", "R_utils", "Rsamtools", "S4Vectors", "TxDb_Hsapiens_UCSC_hg19_knownGene", "TxDb_Hsapiens_UCSC_hg38_knownGene", "dplyr", "ggplot2", "gplots", "magrittr", "matrixStats", "plyranges", "rlang", "rtracklayer", "transport"]
     },
     "nempi": {
       "name": "nempi",
-      "version": "1.14.0",
-      "sha256": "16abvgv4vjbppkh41fsbjscxqjjfi0g8mqb8jf7k0psrvvfs0wg4",
+      "version": "1.16.0",
+      "sha256": "0kc2ndb7a3nhk64z9pnivrkrhmjskf9xb4aq7b0kig1f5pwf25b8",
       "depends": ["e1071", "epiNEM", "matrixStats", "mnem", "naturalsort", "nnet", "randomForest"]
     },
     "netSmooth": {
       "name": "netSmooth",
-      "version": "1.26.0",
-      "sha256": "0pwnzapfv4c39zggzfylxp7lz7hid3483qq1wdphz99nf796x3hm",
+      "version": "1.28.0",
+      "sha256": "13i75cdy8w9xixxlm1zkhdpcp5v15n1dc3qp4af6q9jz8a7m1qh7",
       "depends": ["DelayedArray", "HDF5Array", "Matrix", "SingleCellExperiment", "SummarizedExperiment", "cluster", "clusterExperiment", "data_table", "entropy", "scater"]
-    },
-    "netZooR": {
-      "name": "netZooR",
-      "version": "1.10.0",
-      "sha256": "11rq1lhxhwij6wik087wmnzk8aswhmmf3yzcpiljxbk8szsm8np7",
-      "depends": ["AnnotationDbi", "Biobase", "GO_db", "GOstats", "MASS", "Matrix", "RCy3", "STRINGdb", "assertthat", "data_table", "doParallel", "dplyr", "foreach", "ggdendro", "ggplot2", "gplots", "igraph", "matrixStats", "matrixcalc", "nnet", "org_Hs_eg_db", "pandaR", "penalized", "reshape", "reshape2", "reticulate", "tidyr", "vegan", "viridisLite", "yarn"]
     },
     "netboost": {
       "name": "netboost",
-      "version": "2.14.0",
-      "sha256": "036n93rrcv1b892xmijdvg6slla6h6hmf28rq1cr5fabcjzx6vf5",
+      "version": "2.16.0",
+      "sha256": "1wlcwvksf5a4ypk1l3lzpik84m83xjcvgg92pfjv28w2n2bi4im6",
       "depends": ["BiocStyle", "R_utils", "Rcpp", "RcppParallel", "WGCNA", "colorspace", "dynamicTreeCut", "impute"]
     },
     "nethet": {
       "name": "nethet",
-      "version": "1.38.0",
-      "sha256": "11kyawxhzwda4n14h1hgvbvzbxl1khxn3ssrwhncdd3fmlkd67hx",
+      "version": "1.40.0",
+      "sha256": "1r9hsgnhmhy2zfha5dqlazdjb4826bl4kw3gr6p4rpzw8f7vp3yl",
       "depends": ["CompQuadForm", "GSA", "GeneNet", "ICSNP", "ggm", "ggplot2", "glasso", "glmnet", "huge", "limma", "mclust", "multtest", "mvtnorm", "network"]
     },
     "netprioR": {
       "name": "netprioR",
-      "version": "1.32.0",
-      "sha256": "15v33ckc58r9yars5wpbm32pvlsdwnc5a6wnalkg72xjr5s1vqjy",
+      "version": "1.34.0",
+      "sha256": "0i521c4453vdraj6mljpk621zx5avrddz3mpy032wiqsbqlkxknd",
       "depends": ["Matrix", "doParallel", "dplyr", "foreach", "ggplot2", "gridExtra", "pROC", "sparseMVN"]
     },
     "netresponse": {
       "name": "netresponse",
-      "version": "1.66.0",
-      "sha256": "0xaikq96ip8g7xhsljr0z849aqj30sfdh4zdqxvabwbkh0ygxl8k",
+      "version": "1.68.0",
+      "sha256": "03my3rhbl2v6x2d4h0iyc97dck3c79l8lwlp1r2hglr878n8hbld",
       "depends": ["BiocStyle", "RColorBrewer", "Rgraphviz", "ggplot2", "graph", "igraph", "mclust", "minet", "plyr", "qvalue", "reshape2", "rmarkdown"]
     },
     "ngsReports": {
       "name": "ngsReports",
-      "version": "2.8.0",
-      "sha256": "01mgah5b8741y9pqrww9ikwmw823xr5i00jsjbazmhr82h2ksm4z",
+      "version": "2.10.0",
+      "sha256": "1b9ngp2s3xlws0p65qj290ysrgkffrfifxhh70d1l61hxcdvq9gq",
       "depends": ["BiocGenerics", "Biostrings", "checkmate", "dplyr", "forcats", "ggdendro", "ggplot2", "jsonlite", "lifecycle", "lubridate", "patchwork", "plotly", "reshape2", "rlang", "rmarkdown", "scales", "stringr", "tibble", "tidyr", "tidyselect", "zoo"]
     },
     "nipalsMCIA": {
       "name": "nipalsMCIA",
-      "version": "1.4.4",
-      "sha256": "0z0l0ylbz2by3mvp1bj6wdwsqjk4zhhflvyfbxgvch1jisz3dbcy",
+      "version": "1.6.0",
+      "sha256": "02vzhshbv6zk6iriqkypy5hyca1ncpadf5629q2jjz5ry27zlgjy",
       "depends": ["ComplexHeatmap", "MultiAssayExperiment", "RSpectra", "SummarizedExperiment", "dplyr", "fgsea", "ggplot2", "pracma", "rlang", "scales"]
     },
     "nnNorm": {
       "name": "nnNorm",
-      "version": "2.70.0",
-      "sha256": "1cr3ddbrfjhlqxjm43knmmmw8xzx9j2j1kkkxd1cj1nh86v3hn5n",
+      "version": "2.72.0",
+      "sha256": "0g43lyri5mzk6r755rc1gf2vz18g8x51ang9f9svjr0yf34zrspp",
       "depends": ["marray", "nnet"]
     },
     "nnSVG": {
       "name": "nnSVG",
-      "version": "1.10.2",
-      "sha256": "1v0dz95n0i2l39x55z4wgychyls67iifr54viqv3mzqkvcpk7f81",
+      "version": "1.12.0",
+      "sha256": "13lvwhfxrdfp00h7b8j6swnayyxly8gcicwhdmam4d30vpqgf711",
       "depends": ["BRISC", "BiocParallel", "Matrix", "SingleCellExperiment", "SpatialExperiment", "SummarizedExperiment", "matrixStats"]
+    },
+    "nondetects": {
+      "name": "nondetects",
+      "version": "2.37.1",
+      "sha256": "0xy5hbysrssrglxzlqmrcp5dxqndj062nnmxpw466hy6khn743p4",
+      "depends": ["Biobase", "HTqPCR", "arm", "limma", "mvtnorm"]
     },
     "normalize450K": {
       "name": "normalize450K",
-      "version": "1.34.0",
-      "sha256": "1hlj8habzbsmxdia5aw3khpl12v4zchchs8nk4mmvvhwa81lr326",
+      "version": "1.36.0",
+      "sha256": "1ga00yhznki6gw532bzz9bkgbak39lq4yfplnry3wja0930xw3v3",
       "depends": ["Biobase", "illuminaio", "quadprog"]
     },
     "normr": {
       "name": "normr",
-      "version": "1.32.0",
-      "sha256": "00rng96zpa0bp2j39ysvh6wf87pbbkxkaby651h8a3pl20bfs3s1",
+      "version": "1.34.0",
+      "sha256": "15f465yxmcp7lxv5rjaji99jqa84s4f9k2vjfj0qdc9fmijxq3l8",
       "depends": ["GenomeInfoDb", "GenomicRanges", "IRanges", "Rcpp", "bamsignals", "qvalue", "rtracklayer"]
     },
     "npGSEA": {
       "name": "npGSEA",
-      "version": "1.42.0",
-      "sha256": "17gn5axgplx935s9f4y1m21nxagkpdd29rvmrxc0qya6a8zfriy3",
+      "version": "1.44.0",
+      "sha256": "1lkpvbizdq0wzdfn30vcynfhx01wch1yki3zzzkqgjgyhsjaqfn1",
       "depends": ["Biobase", "BiocGenerics", "GSEABase"]
     },
     "nuCpos": {
       "name": "nuCpos",
-      "version": "1.24.0",
-      "sha256": "0wsxwdwjf6fm2p92jnd1fs99mxchfdqpm1qa7q61g1l2xjsmjhpw",
+      "version": "1.26.0",
+      "sha256": "1swkykv34aalwhk6wr6d4ja1h9yl1rx6ys3f81vk6r1wsqi1rs9l",
       "depends": []
     },
     "nucleR": {
       "name": "nucleR",
-      "version": "2.38.0",
-      "sha256": "0y63jh1d3ms4jpgvig64af64gandbn632fzibfjpyj015zyaamg8",
+      "version": "2.40.0",
+      "sha256": "1n0nxqx7hnnn74wp3l02bfl2fkc1c4ak0lnyh7cd45018ygs76fd",
       "depends": ["Biobase", "BiocGenerics", "Biostrings", "GenomeInfoDb", "GenomicRanges", "IRanges", "Rsamtools", "S4Vectors", "ShortRead", "dplyr", "ggplot2", "magrittr"]
     },
     "nucleoSim": {
       "name": "nucleoSim",
-      "version": "1.34.0",
-      "sha256": "02fv54fb9qqmicyr8hkrr6rd9gg74wdg05v2k6gdmp9cph37dcqb",
+      "version": "1.36.0",
+      "sha256": "1hydk3ay021g6m94i217prrb54r8prh14idflljjjrqx3jpf57ma",
       "depends": ["IRanges", "S4Vectors"]
     },
     "nullranges": {
       "name": "nullranges",
-      "version": "1.12.0",
-      "sha256": "0kv1jgdsaj65g1j848clszbnf0zwlpq75sxm4xal5ai4llx16206",
+      "version": "1.14.0",
+      "sha256": "1458p8r4mmfvp75xi3j47d615dx285sy32vr0hjhvwqfwkkz3p8d",
       "depends": ["GenomeInfoDb", "GenomicRanges", "IRanges", "InteractionSet", "S4Vectors", "data_table", "ggplot2", "ggridges", "plyranges", "progress", "rlang", "scales"]
     },
     "occugene": {
       "name": "occugene",
-      "version": "1.66.0",
-      "sha256": "1igpk8prnczlfvmcypn5n619lw18bx2bhbqdjwdfsm11j95sgp07",
+      "version": "1.68.0",
+      "sha256": "0y5wj927gy938vnv5irj9n1a12rfbfq2m2q3zpny0rd390bdpxmc",
       "depends": []
     },
     "octad": {
       "name": "octad",
-      "version": "1.8.0",
-      "sha256": "1ns496avsxifmar9v3056gsxav3dlmdhmnzf4kclqlkkb78r21nb",
+      "version": "1.9.0",
+      "sha256": "1w4nc2n1a93268bg3l3bhas48bsr6hlp5g4947xryr3b4dgc6dxb",
       "depends": ["AnnotationHub", "Biobase", "DESeq2", "EDASeq", "ExperimentHub", "GSVA", "RUVSeq", "Rfast", "S4Vectors", "data_table", "dplyr", "edgeR", "foreach", "ggplot2", "htmlwidgets", "httr", "limma", "magrittr", "octad_db", "plotly", "qpdf", "reshape2", "rhdf5"]
     },
     "odseq": {
       "name": "odseq",
-      "version": "1.34.0",
-      "sha256": "1z8zxjfyq3v0rb1p4m1jrl1x0lcjmchyl6a7g08cn4a5n7wkhdr0",
+      "version": "1.36.0",
+      "sha256": "08yr4448ij8jh6kzxq9sn7zv2xp0cjzvlllzz47x18v0py466vp8",
       "depends": ["kebabs", "mclust", "msa"]
     },
     "oligo": {
       "name": "oligo",
-      "version": "1.70.0",
-      "sha256": "0z7y8sicap04alkqrzqdjiq7jnmk5mf9h1ki4622hw5wf0gjiark",
-      "depends": ["Biobase", "BiocGenerics", "Biostrings", "DBI", "RSQLite", "affxparser", "affyio", "ff", "oligoClasses", "preprocessCore", "zlibbioc"]
+      "version": "1.72.0",
+      "sha256": "1f57jzfsrz3fx3z0w97pgipcrjspw08y32v4r7r22yiywlxbksa2",
+      "depends": ["Biobase", "BiocGenerics", "Biostrings", "DBI", "RSQLite", "affxparser", "affyio", "bit", "ff", "oligoClasses", "preprocessCore"]
     },
     "oligoClasses": {
       "name": "oligoClasses",
-      "version": "1.68.0",
-      "sha256": "01zcbrk1yxv6jzainw4hc2c20mzg4ji8l8svbyncch39f3n6agb7",
+      "version": "1.70.0",
+      "sha256": "04357ab8jx7vqj8k82q6j05z74pwayvgmxb8r1rw67zq6z6v6r02",
       "depends": ["Biobase", "BiocGenerics", "BiocManager", "Biostrings", "DBI", "GenomicRanges", "IRanges", "RSQLite", "S4Vectors", "SummarizedExperiment", "affyio", "ff", "foreach"]
     },
     "omXplore": {
       "name": "omXplore",
-      "version": "1.0.0",
-      "sha256": "05wamijib8f8i2kljcfrkkqaxaz3n71sprmr58wadpgfwh0j2zqw",
-      "depends": ["DT", "FactoMineR", "MSnbase", "MultiAssayExperiment", "PSMatch", "RColorBrewer", "SummarizedExperiment", "dendextend", "dplyr", "factoextra", "gplots", "highcharter", "htmlwidgets", "shiny", "shinyBS", "shinyjqui", "shinyjs", "tibble", "tidyr", "vioplot", "visNetwork"]
+      "version": "1.2.0",
+      "sha256": "1bqjd858vv4rzpfcsxql9dfbcq3b80l5xfkf81zj9ygmfhwz6hn9",
+      "depends": ["DT", "FactoMineR", "MSnbase", "MultiAssayExperiment", "PSMatch", "RColorBrewer", "SummarizedExperiment", "bs4Dash", "dendextend", "dplyr", "factoextra", "gplots", "highcharter", "htmlwidgets", "nipals", "shiny", "shinyBS", "shinyjqui", "shinyjs", "thematic", "tibble", "tidyr", "vioplot", "visNetwork", "waiter"]
     },
     "omada": {
       "name": "omada",
-      "version": "1.8.0",
-      "sha256": "1zxhp0yikp27ni020m1i6h10wkczwq03szi88rkjz2zb24bm8gf3",
+      "version": "1.10.0",
+      "sha256": "13ywxl0z6nklga23r8lhdnk1zpcd6c62jr5giy9j72hp42c6dvva",
       "depends": ["Rcpp", "clValid", "diceR", "dplyr", "fpc", "genieclust", "ggplot2", "glmnet", "kernlab", "pdfCluster", "reshape"]
     },
     "omicRexposome": {
       "name": "omicRexposome",
-      "version": "1.28.0",
-      "sha256": "18iagcd6ylqh6x6kc32m3lzhb0q164a7ylj8fhbjcn4h5qx04c70",
+      "version": "1.30.0",
+      "sha256": "0km7bg018i5g0l98ygrw0f4m753h0l1klgjkbnsv6wnyy7xqczaf",
       "depends": ["Biobase", "MultiDataSet", "PMA", "SmartSVA", "SummarizedExperiment", "ggplot2", "ggrepel", "gridExtra", "isva", "limma", "omicade4", "rexposome", "stringr", "sva"]
     },
     "omicade4": {
       "name": "omicade4",
-      "version": "1.46.0",
-      "sha256": "0c9ga5pg521w15zakwa0pw52yahj80x59lq5ziq294mj05fjmx32",
+      "version": "1.48.0",
+      "sha256": "0rr2mnhilb5badrp3flb2sv39f9365i30kb5053lif0gc5m7r5rg",
       "depends": ["Biobase", "ade4", "made4"]
     },
     "omicplotR": {
       "name": "omicplotR",
-      "version": "1.26.0",
-      "sha256": "08v57k5bdssz2p4bqxk62fg2wvaviflnzmsas4izzas4zagnabci",
+      "version": "1.28.0",
+      "sha256": "1vbarxn0p2n2mdr6vdadw6xv2lb4pp6nvlmyii7r9rxhbbp88wi7",
       "depends": ["ALDEx2", "DT", "compositions", "jsonlite", "knitr", "matrixStats", "rmarkdown", "shiny", "vegan", "zCompositions"]
     },
     "omicsPrint": {
       "name": "omicsPrint",
-      "version": "1.26.0",
-      "sha256": "0a7k75gylzmbrlzvafa4iv48krn239980x02jp32plm6vf0r3iac",
+      "version": "1.28.0",
+      "sha256": "1w8birg6p9vw59sl1q5za5nrnwfjcb88sbn6afc9g9vz8y5v85wz",
       "depends": ["MASS", "MultiAssayExperiment", "RaggedExperiment", "SummarizedExperiment", "matrixStats"]
     },
     "omicsViewer": {
       "name": "omicsViewer",
-      "version": "1.10.0",
-      "sha256": "06sf3h3ajzyp572fkc7nhc5cha6djsfk86jfbclbpyn7q1mkqfim",
+      "version": "1.12.0",
+      "sha256": "137cjryzwgkl91qjm85q1rk6hn5xz6y8m046wmdlxk7aq6pjw9bf",
       "depends": ["Biobase", "DT", "Matrix", "RColorBrewer", "ROCR", "RSQLite", "S4Vectors", "SummarizedExperiment", "beeswarm", "curl", "drc", "fastmatch", "fgsea", "flatxml", "ggplot2", "ggseqlogo", "htmlwidgets", "httr", "matrixStats", "networkD3", "openxlsx", "plotly", "psych", "reshape2", "shiny", "shinyWidgets", "shinybusy", "shinycssloaders", "shinyjs", "shinythemes", "stringr", "survival", "survminer"]
     },
     "ompBAM": {
       "name": "ompBAM",
-      "version": "1.10.0",
-      "sha256": "124i599k1ikxhz3xlzlz82rikmfff6f0c73cldi8cgy6qsqkwwf1",
+      "version": "1.12.0",
+      "sha256": "0i9szx0b4xq94k0vzb1dqwrb3b25hx54d1l8dkk75hdscb0rbjp2",
       "depends": ["Rcpp"]
     },
     "oncomix": {
       "name": "oncomix",
-      "version": "1.28.0",
-      "sha256": "1w311rrnvpx8fkvdyhjvjdcyfslwfah840ci9cq54m934rjxajgg",
+      "version": "1.30.0",
+      "sha256": "1yps1188z3bm4phhmj3hcb1bf4qgq8g552c42jxcvfprkrphabzd",
       "depends": ["RColorBrewer", "SummarizedExperiment", "ggplot2", "ggrepel", "mclust"]
     },
     "oncoscanR": {
       "name": "oncoscanR",
-      "version": "1.8.0",
-      "sha256": "0n7x3m52xigafl4hj3szl5p592c8j90snkyz9gvfg4xa150n6hmj",
+      "version": "1.10.0",
+      "sha256": "1bshhqzxqpydgvwj7bb609fvw54133h01z1mi26z4nxwkdark9vw",
       "depends": ["GenomicRanges", "IRanges", "S4Vectors", "magrittr", "readr"]
     },
     "onlineFDR": {
       "name": "onlineFDR",
-      "version": "2.14.0",
-      "sha256": "0kajxc6ggw61n6yfg6vfimqwkd1djp4bb5azd2a097mz1d5wyrmq",
+      "version": "2.16.0",
+      "sha256": "1nn51bykaciy2crnrm5z1b4rpx8083hxjxzcjx1q4fylwfxpr9hj",
       "depends": ["Rcpp", "RcppProgress", "progress"]
     },
     "ontoProc": {
       "name": "ontoProc",
-      "version": "2.0.0",
-      "sha256": "0vxya3p8gzb74z4jiniidibbhwcjpjpl4rarhgj40zj2fh25873r",
+      "version": "2.2.0",
+      "sha256": "0xk5gvbf8jkkkxjcmgycprr8hngl4s005id1n9qhmxfzjad99bjh",
       "depends": ["AnnotationHub", "Biobase", "BiocFileCache", "DT", "R_utils", "Rgraphviz", "S4Vectors", "SummarizedExperiment", "basilisk", "dplyr", "graph", "httr", "igraph", "magrittr", "ontologyIndex", "ontologyPlot", "reticulate", "shiny"]
     },
     "openCyto": {
       "name": "openCyto",
-      "version": "2.18.0",
-      "sha256": "07n5vv5jl34lc0l7ix952vararf6zwz3f64w1p32xnnkzvszpmiw",
+      "version": "2.20.0",
+      "sha256": "18z446ggvrmgicnyyfg1qd3xp62rz29125dfwrihz325px8rjsiy",
       "depends": ["BH", "Biobase", "BiocGenerics", "RBGL", "RColorBrewer", "cpp11", "data_table", "flowClust", "flowCore", "flowViz", "flowWorkspace", "graph", "ncdfFlow"]
     },
     "openPrimeR": {
       "name": "openPrimeR",
-      "version": "1.28.0",
-      "sha256": "18axx1r9vfwy5mwb1cg5l2hpghqwlx50qgqgvhplkg5khg7388ns",
+      "version": "1.29.0",
+      "sha256": "0r8cxhvr3mszv2l33v9cfi7i7vmk5bsg5lnr0bi7zc00zihjj20f",
       "depends": ["BiocGenerics", "Biostrings", "DECIPHER", "GenomicRanges", "Hmisc", "IRanges", "RColorBrewer", "S4Vectors", "XML", "ape", "digest", "dplyr", "foreach", "ggplot2", "lpSolveAPI", "magrittr", "openxlsx", "plyr", "pwalign", "reshape2", "scales", "seqinr", "stringdist", "stringr", "uniqtag"]
     },
     "oposSOM": {
       "name": "oposSOM",
-      "version": "2.24.0",
-      "sha256": "00m15lqyb1w84zbhg11imw2ji0adaflwimxdfrgnr7acjw5mic9x",
+      "version": "2.26.0",
+      "sha256": "07c4832hb5ib4cqj8sqsacw5r4vqnv2q6vphi0v7c5nd95jc8crx",
       "depends": ["Biobase", "RCurl", "Rcpp", "RcppParallel", "XML", "ape", "biomaRt", "fastICA", "fdrtool", "graph", "igraph", "pixmap", "png", "scatterplot3d", "tsne"]
     },
     "oppar": {
       "name": "oppar",
-      "version": "1.34.0",
-      "sha256": "1h7i524lmhddbhj99jyn7a1m352r8s39pqxyc0gl285vajag2r0d",
+      "version": "1.36.0",
+      "sha256": "16i4bzjsdgiyha3j7n81dqgmj8z6f20qzcv73jrs4i7a9s83ah7s",
       "depends": ["Biobase", "GSEABase", "GSVA"]
     },
     "oppti": {
       "name": "oppti",
-      "version": "1.20.0",
-      "sha256": "09cjf0vzgixklmppsf8r9hplq7m8njrw81yhgy07ygwk78mx0glq",
+      "version": "1.21.0",
+      "sha256": "0v7hy9qy3mjx8sj3rvs23sy38r8nfgr4d4na4k8h65y2mi8xfqnp",
       "depends": ["RColorBrewer", "devtools", "ggplot2", "knitr", "limma", "parallelDist", "pheatmap", "reshape"]
     },
     "optimalFlow": {
       "name": "optimalFlow",
-      "version": "1.18.0",
-      "sha256": "07rws3yrqk6v7i7abq3gv55zhbnrncw6012g51p0n0k87klhwlsi",
+      "version": "1.20.0",
+      "sha256": "0abr0c8x92d9p3q4k8a53ij355xz6pjp3yx1f5dqxhq12by4f7zr",
       "depends": ["Rfast", "dbscan", "doParallel", "dplyr", "ellipse", "flowMeans", "foreach", "optimalFlowData", "randomForest", "rgl", "rlang", "robustbase", "transport"]
     },
     "orthogene": {
       "name": "orthogene",
-      "version": "1.12.0",
-      "sha256": "0jwf7ylw6i25xv4b01lz6k993hnln3v81rqqnqf5n4mi76ifk0yg",
+      "version": "1.14.0",
+      "sha256": "0v6y1ih476spnvmbhnrbwiglpcapcg7a61min8jib89prhsqhvbi",
       "depends": ["DelayedArray", "Matrix", "babelgene", "data_table", "dplyr", "ggplot2", "ggpubr", "ggtree", "gprofiler2", "grr", "homologene", "jsonlite", "patchwork", "repmis"]
     },
     "orthos": {
       "name": "orthos",
-      "version": "1.4.0",
-      "sha256": "13z4f1h5niaclmd0zn6lq3y1j2nnq4kb1l5kxak2kabhqj13ap2n",
+      "version": "1.6.0",
+      "sha256": "0f742pna8d3iys5sgyzwj1hlj00hqjsgnnzs1pj8rbk1clzdwipp",
       "depends": ["AnnotationHub", "BiocParallel", "DelayedArray", "ExperimentHub", "HDF5Array", "S4Vectors", "SummarizedExperiment", "basilisk", "colorspace", "cowplot", "dplyr", "ggplot2", "ggpubr", "ggrepel", "ggsci", "keras", "orthosData", "plyr", "reticulate", "rlang", "tensorflow", "tidyr"]
     },
     "pRoloc": {
       "name": "pRoloc",
-      "version": "1.46.1",
-      "sha256": "0h1b9hqqc386fl3rzr9v21c84333qh6gcp3jamhai975qb1dnmjq",
-      "depends": ["Biobase", "BiocGenerics", "BiocParallel", "FNN", "LaplacesDemon", "MASS", "MLInterfaces", "MSnbase", "RColorBrewer", "Rcpp", "RcppArmadillo", "biomaRt", "caret", "class", "coda", "dendextend", "e1071", "ggplot2", "gtools", "hexbin", "kernlab", "knitr", "lattice", "mclust", "mixtools", "mvtnorm", "nnet", "plyr", "proxy", "randomForest", "sampling", "scales"]
+      "version": "1.48.0",
+      "sha256": "10mr8k1zvh80ah142zzw0x31b34f0563ydg46mcmwh9q2k45ms3v",
+      "depends": ["Biobase", "BiocGenerics", "BiocParallel", "FNN", "LaplacesDemon", "MASS", "MLInterfaces", "MSnbase", "RColorBrewer", "Rcpp", "RcppArmadillo", "biomaRt", "caret", "class", "coda", "colorspace", "dendextend", "e1071", "ggplot2", "gtools", "hexbin", "kernlab", "knitr", "lattice", "mclust", "mixtools", "mvtnorm", "nnet", "plyr", "proxy", "randomForest", "sampling", "scales"]
     },
     "pRolocGUI": {
       "name": "pRolocGUI",
-      "version": "2.16.0",
-      "sha256": "0yfc1sz2scdwpisbvqlg3amnhbzn9kqbir3hcib7w96m5raxlg5l",
+      "version": "2.18.0",
+      "sha256": "1094vsjxknkj9w30zikllb7kb0w8k7l7nb4agjisabc3dzsk9jwc",
       "depends": ["Biobase", "BiocGenerics", "DT", "MSnbase", "colorspace", "colourpicker", "dplyr", "ggplot2", "pRoloc", "scales", "shiny", "shinyWidgets", "shinydashboard", "shinydashboardPlus", "shinyhelper", "shinyjs"]
     },
     "packFinder": {
       "name": "packFinder",
-      "version": "1.18.0",
-      "sha256": "0ll3849za23jrq9hly8b05dlx664l62x0yk7775yh7k8i76cmp5p",
+      "version": "1.20.0",
+      "sha256": "02bf2454nspyndz79xk1s9g452q5aswivb7p1njxrfscm73hr4g7",
       "depends": ["Biostrings", "GenomicRanges", "IRanges", "S4Vectors", "ape", "kmer"]
     },
     "padma": {
       "name": "padma",
-      "version": "1.16.0",
-      "sha256": "0v9jnrqc93779gf1znbd9yx97k2v6098xhzxn3qf4z1j13p4r4xf",
+      "version": "1.18.0",
+      "sha256": "0lxfsq6smdnldj649yz9wz695qhpwc3a5by3jhb7i130ng2xz2dc",
       "depends": ["FactoMineR", "MultiAssayExperiment", "S4Vectors", "SummarizedExperiment"]
     },
     "pageRank": {
       "name": "pageRank",
-      "version": "1.16.0",
-      "sha256": "1mhpr1m95351a6r1sfb2alraf6i9jxmyas1i69l5vx5ccgc8322m",
+      "version": "1.18.0",
+      "sha256": "134yd2gl84yj3sa8xb9xsijv454wq8w1xvs13nkf0lvcq3szw192",
       "depends": ["GenomicRanges", "igraph", "motifmatchr"]
     },
     "paircompviz": {
       "name": "paircompviz",
-      "version": "1.44.0",
-      "sha256": "05qq1jxlb86ry5xyfcv3yjas98v8qsxwz53p5gqgxygxzk1lings",
+      "version": "1.46.0",
+      "sha256": "0flb0i3j35r7a3xl99vc6xn4lkwa5mdvs2l6mly8d8kpbqlcz2w2",
       "depends": ["Rgraphviz"]
     },
     "pairedGSEA": {
       "name": "pairedGSEA",
-      "version": "1.6.0",
-      "sha256": "16kf9jahdb234gf8n83q623nsni67l4zmqh12mfir970l3galkzr",
-      "depends": ["BiocParallel", "DESeq2", "DEXSeq", "S4Vectors", "SummarizedExperiment", "aggregation", "fgsea", "ggplot2", "limma", "sva"]
+      "version": "1.8.0",
+      "sha256": "07rcdk8z8lz108rcn6hhyp8j068kcpiszqh402p68kfij3rp40yn",
+      "depends": ["BiocParallel", "DESeq2", "DEXSeq", "S4Vectors", "SummarizedExperiment", "aggregation", "fgsea", "ggplot2", "limma", "msigdbr", "showtext", "sva"]
     },
     "pairkat": {
       "name": "pairkat",
-      "version": "1.12.0",
-      "sha256": "1y1zjhh90kwlmdkzrbv63n0m0j3pl7nvsjzrrbhrz9lyiigrzw7v",
+      "version": "1.14.0",
+      "sha256": "1mz12l5dp56yv4j6risnxzrjcva2f9rhii0ssz7nig92c25qnqby",
       "depends": ["CompQuadForm", "KEGGREST", "SummarizedExperiment", "data_table", "igraph", "magrittr", "tibble"]
     },
     "pandaR": {
       "name": "pandaR",
-      "version": "1.38.0",
-      "sha256": "07w702788cxq26fk7jj346nqa58mc4pncs3fcv5sx8p6z5a785kz",
+      "version": "1.40.0",
+      "sha256": "05s525kndwb86lhkq3ja8aywgazvr0k246gi47602bgi7g2byli2",
       "depends": ["Biobase", "BiocGenerics", "RUnit", "ggplot2", "hexbin", "igraph", "matrixStats", "plyr", "reshape"]
     },
     "panelcn_mops": {
       "name": "panelcn.mops",
-      "version": "1.28.0",
-      "sha256": "10zqj21k8k4qz4f83cy4xfdkdk672i8jjrj16plnhlx67xl520qa",
+      "version": "1.30.0",
+      "sha256": "02zfcb5bjz5nmi85pwxm7wr3wnapq6l9abfn8ps263w9gnm55si4",
       "depends": ["GenomeInfoDb", "GenomicRanges", "IRanges", "Rsamtools", "S4Vectors", "cn_mops"]
     },
     "panp": {
       "name": "panp",
-      "version": "1.76.0",
-      "sha256": "03shbp9izf8q7fvdcb6fyi9ybgbmjxmmzvyvl8acgvx2r6gsmqjp",
+      "version": "1.78.0",
+      "sha256": "04qf5188flaaypdf22ysqhpcjpj2vp1lc4n2hx4rc3s4lxv2pff4",
       "depends": ["Biobase", "affy"]
     },
     "parglms": {
       "name": "parglms",
-      "version": "1.38.0",
-      "sha256": "1gmrfbd4rha4zrxi8bskai1i32ccjn1ws315camb8qfpxr3wfb4n",
+      "version": "1.40.0",
+      "sha256": "0cbcbngfl5r4srjib7ihnxycgvvr9kz5q53d17wkagsmqvfvgmvv",
       "depends": ["BatchJobs", "BiocGenerics", "doParallel", "foreach"]
     },
     "parody": {
       "name": "parody",
-      "version": "1.64.0",
-      "sha256": "08vaqnrgkqxb99xjmgja3hs6r7n0z9chmykw6kjv6fgg914qlf2d",
+      "version": "1.66.0",
+      "sha256": "055m8f3h7gdpdxl31bwky9y3xdlazd0wx4mjyll7zbww0lkil1rj",
       "depends": []
     },
     "partCNV": {
       "name": "partCNV",
-      "version": "1.4.0",
-      "sha256": "196h4h4mr3ikp5rh3h3jcny7zda06hmx7ckwcbvildskhpyisarc",
+      "version": "1.6.0",
+      "sha256": "0p8ci8c9rw30kcrcrc4pkzvkcnsdn1w2ph4zx8lzfwz0lsy62qha",
       "depends": ["AnnotationHub", "BiocStyle", "GenomicRanges", "Seurat", "SingleCellExperiment", "data_table", "depmixS4", "magrittr"]
+    },
+    "pathMED": {
+      "name": "pathMED",
+      "version": "1.0.0",
+      "sha256": "1l30vx82bi27zcyvd1cjspa09l219bxq2llz088gx8ilc222bxfj",
+      "depends": ["BiocParallel", "FactoMineR", "GSVA", "caret", "caretEnsemble", "decoupleR", "dplyr", "factoextra", "ggplot2", "magrittr", "matrixStats", "metrica", "pbapply", "reshape2", "singscore", "stringi"]
     },
     "pathRender": {
       "name": "pathRender",
-      "version": "1.74.0",
-      "sha256": "00nmvykh3s5lq6n7ggjbz4qisbpbf9lj76fbzabkblnb5xcbsvx4",
+      "version": "1.76.0",
+      "sha256": "19z5gpfnv9c1rq4gdm3g7giwpipcrayac37cnjw5apxy81klqdpg",
       "depends": ["AnnotationDbi", "RColorBrewer", "Rgraphviz", "cMAP", "graph"]
     },
     "pathifier": {
       "name": "pathifier",
-      "version": "1.44.0",
-      "sha256": "16y1630jkl20zh5p13zr1h8aygmkbx60p9z9rxdci6dalv6b3yrb",
+      "version": "1.46.0",
+      "sha256": "1hh63mrm90981xd7vyhlfr1bsxb4jkvl48x4bp38alfmnih75kmv",
       "depends": ["R_oo", "princurve"]
     },
     "pathlinkR": {
       "name": "pathlinkR",
-      "version": "1.2.0",
-      "sha256": "0jmxmwfdz7gvqgvanr5pxp9da2y9jpaq1n7gxyfgy5g5d0bfbahq",
+      "version": "1.4.0",
+      "sha256": "1wn1h64vgs8vc9knjw0f57ssqvdxyspq09v492y9yjz2j3d1zaid",
       "depends": ["ComplexHeatmap", "circlize", "clusterProfiler", "dplyr", "fgsea", "ggforce", "ggplot2", "ggpubr", "ggraph", "ggrepel", "igraph", "purrr", "sigora", "stringr", "tibble", "tidygraph", "tidyr", "vegan", "visNetwork"]
     },
     "pathview": {
       "name": "pathview",
-      "version": "1.46.0",
-      "sha256": "0j7r239qvcb36025if4lqqjzxajfdjggp3cdy0h7yqziijz12kq8",
+      "version": "1.48.0",
+      "sha256": "096nf0p69jyj5ih09r1azz3ia5dzjj2n871kfmmm80sdzi1qs04g",
       "depends": ["AnnotationDbi", "KEGGREST", "KEGGgraph", "Rgraphviz", "XML", "graph", "org_Hs_eg_db", "png"]
     },
     "pathwayPCA": {
       "name": "pathwayPCA",
-      "version": "1.22.0",
-      "sha256": "0r345sxbxak67f3qgv78vnrcky8lv0fypr2cppqa3bc9sybqvg00",
+      "version": "1.24.0",
+      "sha256": "1ksga0fz3pxd7kax3sngbfps3vr0kihc06b0fwnf37hgqs0svyzv",
       "depends": ["lars", "survival"]
     },
     "pcaExplorer": {
       "name": "pcaExplorer",
-      "version": "3.0.0",
-      "sha256": "1i5qzbwdgi59izgppz63mvddiph7qv48h75243capxqfhbcqkq1g",
+      "version": "3.2.0",
+      "sha256": "0scm0f8j85q74fscj77pgpkcysy3vhmz4mhxw5yhvf89gw5z6z92",
       "depends": ["AnnotationDbi", "DESeq2", "DT", "GO_db", "GOstats", "GenomicRanges", "IRanges", "NMF", "S4Vectors", "SummarizedExperiment", "base64enc", "biomaRt", "genefilter", "ggplot2", "ggrepel", "heatmaply", "knitr", "limma", "mosdef", "pheatmap", "plotly", "plyr", "rmarkdown", "scales", "shiny", "shinyAce", "shinyBS", "shinydashboard", "threejs", "tidyr", "topGO"]
     },
     "pcaMethods": {
       "name": "pcaMethods",
-      "version": "1.98.0",
-      "sha256": "02p9ax76wm4rfkz9hmrf95xvq91ckha689qkg6lpwgb8f81wga7j",
+      "version": "2.0.0",
+      "sha256": "10rzf1anac8za7v71s5sliw1dvvazsa8m3vxwf23h053yzndfx84",
       "depends": ["Biobase", "BiocGenerics", "MASS", "Rcpp"]
     },
     "pdInfoBuilder": {
       "name": "pdInfoBuilder",
-      "version": "1.70.0",
-      "sha256": "0jg5hlib0i46mgkza9rhj95assii6h7gcyl7mgknxyki2bhiz7dc",
+      "version": "1.72.0",
+      "sha256": "1rqsvp66xqvwh2axai2063yd1gdqdfb3pd0zw7hrjhw4f97hagmz",
       "depends": ["Biobase", "BiocGenerics", "Biostrings", "DBI", "IRanges", "RSQLite", "S4Vectors", "affxparser", "oligo", "oligoClasses"]
     },
     "peakPantheR": {
       "name": "peakPantheR",
-      "version": "1.20.0",
-      "sha256": "14pi3qjkikd35nfz3pmpljjr7yxv6136vwv6bhbd05jk37r6dia6",
+      "version": "1.22.0",
+      "sha256": "04ixkcnwhb3677099wx58sjrdg2v6gmr592i916gskfzkk40pk62",
       "depends": ["DT", "MSnbase", "XML", "bslib", "doParallel", "foreach", "ggplot2", "gridExtra", "lubridate", "minpack_lm", "mzR", "pracma", "scales", "shiny", "shinycssloaders", "stringr", "svglite"]
     },
     "peco": {
       "name": "peco",
-      "version": "1.18.0",
-      "sha256": "1fir0w1w7x3789gckjyw096vylg61vafhgf34nvq1l4nl0ddai0h",
+      "version": "1.20.0",
+      "sha256": "11a85jrzpkw1rfmzjzx7cw41vvqa883qss7i8fy5qap01rsks3wn",
       "depends": ["SingleCellExperiment", "SummarizedExperiment", "assertthat", "circular", "conicfit", "doParallel", "foreach", "genlasso", "scater"]
     },
     "pengls": {
       "name": "pengls",
-      "version": "1.12.0",
-      "sha256": "0b75c4l4j9pw2bjfnnln8bwxq5k7ah3bans9pn8yf4gf71j1vls6",
+      "version": "1.14.0",
+      "sha256": "06ivyncvlrvrw48dkzvx6q81jq5m3nv9p2vif338a6jbh732qppb",
       "depends": ["BiocParallel", "glmnet", "nlme"]
     },
     "pepStat": {
       "name": "pepStat",
-      "version": "1.40.0",
-      "sha256": "14rc4kdjazx99665fj10wj5cmbcmg8m4rmaq09xbvbz65rcjsd5j",
+      "version": "1.42.0",
+      "sha256": "1ka22y3lkzsvpxxxpi9fdn9lgngwlh2b5gpijng2nfqazppam9x0",
       "depends": ["Biobase", "GenomicRanges", "IRanges", "data_table", "fields", "ggplot2", "limma", "plyr"]
     },
     "pepXMLTab": {
       "name": "pepXMLTab",
-      "version": "1.40.0",
-      "sha256": "124h7pfi4da2svl9mxard32cpc3nz6fqdj776vv1q9mdz23wppq7",
+      "version": "1.42.0",
+      "sha256": "0j2qp5alanyjxjhwgclw6p2danvh6kkblxzp3ibfk3c02qha7sf3",
       "depends": ["XML"]
     },
     "periodicDNA": {
       "name": "periodicDNA",
-      "version": "1.16.0",
-      "sha256": "1i581w88yd3qr4hp8m0dhbasxr3qgd2yz01mxdhiydrkf06hckd4",
+      "version": "1.18.0",
+      "sha256": "175lysjyjgw7md5ch0q09k41ak28f3f4lxiv8gnq4ds5f7p9chi8",
       "depends": ["BSgenome", "BiocParallel", "Biostrings", "GenomeInfoDb", "GenomicRanges", "IRanges", "S4Vectors", "cowplot", "ggplot2", "magrittr", "rtracklayer", "zoo"]
     },
     "pfamAnalyzeR": {
       "name": "pfamAnalyzeR",
-      "version": "1.6.0",
-      "sha256": "1d14nhi4gndg8gr4fk4yvfnjcvin9rndram0xhnjrkia166p1msx",
+      "version": "1.8.0",
+      "sha256": "0q5gcq5rm6az62mlhpbg6rawszdpckc5w5kl53bda9gfdcl6bi4l",
       "depends": ["dplyr", "magrittr", "readr", "stringr", "tibble"]
     },
     "pgca": {
       "name": "pgca",
-      "version": "1.30.0",
-      "sha256": "0d0y609cjys6m754r8vnnxwf19c8yd9ngrasv4nyzjxknzii71k9",
+      "version": "1.32.0",
+      "sha256": "12kmjzsasr3y2ghk101bwjx48nls5axr2ggl4agg57zw0231rfgb",
       "depends": []
     },
     "pgxRpi": {
       "name": "pgxRpi",
-      "version": "1.2.3",
-      "sha256": "1fql64bxlmkfl1z8gz8hk54npd1wghf6lxxw2rzgm7m5d4b9y7lx",
+      "version": "1.4.0",
+      "sha256": "00vfcr86bjni28n1zllv3s7vkgq8r155l07jl9qfyqjgh5w61y3b",
       "depends": ["GenomicRanges", "S4Vectors", "SummarizedExperiment", "attempt", "circlize", "dplyr", "future", "future_apply", "ggplot2", "httr", "lubridate", "survival", "survminer", "yaml"]
     },
     "phantasus": {
       "name": "phantasus",
-      "version": "1.26.0",
-      "sha256": "01z7vr54ji89wbwv1cc1icscw06x8lxxnhiyjls0rslccwiprr1g",
+      "version": "1.27.0",
+      "sha256": "1fl0inzxvsr5cbwpbz2kmn4lh04pafg6w1dpgl24b6v6qdjdn0n1",
       "depends": ["AnnotationDbi", "Biobase", "DESeq2", "GEOquery", "Matrix", "Rook", "XML", "apeglm", "assertthat", "ccaPP", "config", "curl", "data_table", "edgeR", "fgsea", "fs", "ggplot2", "gtable", "htmltools", "httpuv", "httr", "jsonlite", "limma", "opencpu", "phantasusLite", "pheatmap", "protolite", "rhdf5", "rhdf5client", "scales", "stringr", "svglite", "tidyr", "yaml"]
     },
     "phantasusLite": {
       "name": "phantasusLite",
-      "version": "1.4.0",
-      "sha256": "13nnsm7bkpirakyn5k9pz730jjj9ddiwppmk9x0rmfbqchnj8n1g",
+      "version": "1.5.0",
+      "sha256": "15cczgjziq0x30y9rk9chlj9a5sl767p3dc9sn8vsr5gvabiij8y",
       "depends": ["Biobase", "data_table", "httr", "rhdf5client", "stringr"]
     },
     "phenoTest": {
       "name": "phenoTest",
-      "version": "1.54.0",
-      "sha256": "111qdiqkzrmcy1lw2961icm55hfgfb6x5h2vddswk4pvj7ylwhqr",
+      "version": "1.56.0",
+      "sha256": "1gzi5mk4z99a4g60wp5rlzbrfbj57h0wn05a06lqprzvc4r6100i",
       "depends": ["AnnotationDbi", "BMA", "Biobase", "Category", "GSEABase", "Heatplus", "Hmisc", "annotate", "biomaRt", "ellipse", "genefilter", "ggplot2", "gplots", "hgu133a_db", "hopach", "limma", "mgcv", "survival", "xtable"]
     },
     "phenomis": {
       "name": "phenomis",
-      "version": "1.8.0",
-      "sha256": "02pdhaawhiyzhf89b0xgvh85kr8ih31zqm3158v45f5fim4k6ach",
+      "version": "1.10.0",
+      "sha256": "08zlqipfr5mnw2f3xslchbws2s9irwnsjbkb09zkn6ckddykjfb1",
       "depends": ["Biobase", "MultiAssayExperiment", "MultiDataSet", "PMCMRplus", "RColorBrewer", "SummarizedExperiment", "VennDiagram", "biodb", "biodbChebi", "data_table", "futile_logger", "ggplot2", "ggrepel", "htmlwidgets", "igraph", "limma", "plotly", "ranger", "ropls", "tibble", "tidyr"]
     },
     "phenopath": {
       "name": "phenopath",
-      "version": "1.30.0",
-      "sha256": "1kg4x01xp7j3klpqz24fihzhi9sy9dz4i4073zijwb4rvy661jf3",
+      "version": "1.32.0",
+      "sha256": "17l0av4hpcam3qs6rwsrd8a3195k2gxp5nqw1hcicz9vjsr6a9zv",
       "depends": ["Rcpp", "SummarizedExperiment", "dplyr", "ggplot2", "tibble", "tidyr"]
     },
     "philr": {
       "name": "philr",
-      "version": "1.32.0",
-      "sha256": "1ian38y69ng5xi928msp57maf0gr5bb57wnbfifpjdyvz7sinp8q",
+      "version": "1.34.0",
+      "sha256": "1gqzw8hfvgkcds80fmv0dr9hgyq1qqq21rmg4d1hrm91h0m29wma",
       "depends": ["ape", "ggplot2", "ggtree", "phangorn", "tidyr"]
     },
     "phosphonormalizer": {
       "name": "phosphonormalizer",
-      "version": "1.30.0",
-      "sha256": "1lpnfvw5krfipz2k96mfdg848d3xyjj71qzzlgnh6xmxiaimabbc",
+      "version": "1.32.0",
+      "sha256": "03bnqkmn4b34cj987i4sd90bgwffy38vgzid9fnacr701ybnc6c9",
       "depends": ["matrixStats", "plyr"]
     },
     "phyloseq": {
       "name": "phyloseq",
-      "version": "1.50.0",
-      "sha256": "0s64xz2svqrdypi5nkf3yilvv66a3g6yq6321c4sk23qm6341b5n",
+      "version": "1.52.0",
+      "sha256": "0yrfskwv5vah20ynrpxxk4fizxc2z8j86lkhldwd4yfkwkc1nsir",
       "depends": ["Biobase", "BiocGenerics", "Biostrings", "ade4", "ape", "biomformat", "cluster", "data_table", "foreach", "ggplot2", "igraph", "multtest", "plyr", "reshape2", "scales", "vegan"]
     },
     "piano": {
       "name": "piano",
-      "version": "2.22.0",
-      "sha256": "037xgsb57gc1ysb0p1nsb9mhfv7lgry3anza0znyhb3wbnjzz1q4",
+      "version": "2.24.0",
+      "sha256": "116fy2jmgy73fh080w6rzfzb0m2icvl8k5z2vcc3mf6p43kpkf2w",
       "depends": ["Biobase", "BiocGenerics", "DT", "fgsea", "gplots", "htmlwidgets", "igraph", "marray", "relations", "scales", "shiny", "shinydashboard", "shinyjs", "visNetwork"]
     },
     "pickgene": {
       "name": "pickgene",
-      "version": "1.78.0",
-      "sha256": "1h3wih2rs05hx4h1iccj14cj6nw2xlc1dqcfqm3inn040qvr9ig3",
+      "version": "1.80.0",
+      "sha256": "1vg4bc2sf2d8rgps4qlv5nzj4p7p55hwhp657vgwc3famhd9ickj",
       "depends": ["MASS"]
     },
     "pipeComp": {
       "name": "pipeComp",
-      "version": "1.16.0",
-      "sha256": "1hmi2fbnzd1pzilm4ca3gzmfnv0dbil77ml9a8x7hf3bqac398ww",
+      "version": "1.18.0",
+      "sha256": "1bryavymna9sfx40fwrgr6s5pf0rarxdq7ydik3nr56r3fx06y6j",
       "depends": ["BiocParallel", "ComplexHeatmap", "Matrix", "RColorBrewer", "Rtsne", "S4Vectors", "Seurat", "SingleCellExperiment", "SummarizedExperiment", "aricode", "circlize", "clue", "cluster", "cowplot", "dplyr", "ggplot2", "intrinsicDimension", "knitr", "matrixStats", "randomcoloR", "reshape2", "scales", "scater", "scran", "uwot", "viridisLite"]
     },
     "pipeFrame": {
       "name": "pipeFrame",
-      "version": "1.22.0",
-      "sha256": "089vbqwk6i5zg3bdkqr63ndkgj3sd8ac999423bqpkc2cfg9p6cm",
+      "version": "1.24.0",
+      "sha256": "0qckysswmfbw6gqq9a7fln9c6m97z310a7x9j5l8a8kpbzn6hn7m",
       "depends": ["BSgenome", "Biostrings", "GenomeInfoDb", "digest", "magrittr", "rmarkdown", "visNetwork"]
     },
     "planet": {
       "name": "planet",
-      "version": "1.14.0",
-      "sha256": "1vnz03gppcklywix2mkyxqz8ivx71kkl8kdn72da7720jp45hb86",
+      "version": "1.16.0",
+      "sha256": "0347kl1x7f7sm4szsqnjl8ahnxfhr6zmzvchsyp223svvsdzf5hq",
       "depends": ["dplyr", "magrittr", "tibble"]
     },
     "planttfhunter": {
       "name": "planttfhunter",
-      "version": "1.6.0",
-      "sha256": "0r0s1lys5nqdnl38xkkf1ir1pczmqb14ciy2irabbs4d2ni43bdl",
+      "version": "1.8.0",
+      "sha256": "0wnwm31fzfzg710217kcbhq1gd2d9187qb3p6ghxksbl15wg1cx8",
       "depends": ["Biostrings", "SummarizedExperiment"]
     },
     "plasmut": {
       "name": "plasmut",
-      "version": "1.4.0",
-      "sha256": "1jah13a4mgvqg6p3jw9f9jz6rgjwga9nfg0yilcmc933iv8zri2k",
+      "version": "1.6.0",
+      "sha256": "0igv0f8x3sxnw9ryi8hvci7l36qv8xqxr9gh2byrz6giwhiis2gp",
       "depends": ["dplyr", "tibble"]
     },
     "plgem": {
       "name": "plgem",
-      "version": "1.78.0",
-      "sha256": "1d2v7wqcdabr2903pi36il0hhkq1fr2fw0b8gznn89yyfgwq9k4a",
+      "version": "1.80.0",
+      "sha256": "0mc4kpbnvbs5a1bgrnmwa58kfbdpx3a7sacjacnn1k44s6smdmbw",
       "depends": ["Biobase", "MASS"]
     },
     "plier": {
       "name": "plier",
-      "version": "1.76.0",
-      "sha256": "0jcr8drnnscrimdn81qh7gmv7p4f62wzji2yb0s2v83526ly7xjy",
+      "version": "1.78.0",
+      "sha256": "0vacscadv6adi3qgb3zcjb7380i9ygp2pv1mbclfkr855xfwfqz4",
       "depends": ["Biobase", "affy"]
     },
     "plotGrouper": {
       "name": "plotGrouper",
-      "version": "1.24.0",
-      "sha256": "10mbgk8klsmm8dwhi27kqgx2jqdb7wrh1xqczq31da461nk1pb85",
+      "version": "1.26.0",
+      "sha256": "0485m3hd0lckq2mp99l6aa6w0mg8nvjnp3774k3ch4xp5cx5cds6",
       "depends": ["Hmisc", "colourpicker", "dplyr", "egg", "ggplot2", "ggpubr", "gridExtra", "gtable", "magrittr", "readr", "readxl", "rlang", "scales", "shiny", "shinythemes", "stringr", "tibble", "tidyr"]
     },
     "plotgardener": {
       "name": "plotgardener",
-      "version": "1.12.0",
-      "sha256": "0vfw431z7plqlxnmaxgy61gg499b4p38bbb61axaipppldvf87rl",
+      "version": "1.14.0",
+      "sha256": "13dg2rr8wy4mvjwc66cl7xs8fhs3hbbhy2x4fjd89nkpihfn14c7",
       "depends": ["GenomeInfoDb", "GenomicRanges", "IRanges", "RColorBrewer", "Rcpp", "curl", "data_table", "dplyr", "ggplotify", "glue", "plyranges", "purrr", "rhdf5", "rlang", "strawr", "withr"]
     },
     "plyinteractions": {
       "name": "plyinteractions",
-      "version": "1.4.0",
-      "sha256": "0mw7kbsy21fxbhi0biq8x84i0lvlads0f84mvqg5ycsl641484sp",
+      "version": "1.6.0",
+      "sha256": "1gspylz6d3jlynf4waqsi4ra28jsvc7202fgv17i21yd7mcx7v0w",
       "depends": ["BiocGenerics", "GenomeInfoDb", "GenomicRanges", "IRanges", "InteractionSet", "S4Vectors", "dplyr", "plyranges", "rlang", "tibble", "tidyselect"]
     },
     "plyranges": {
       "name": "plyranges",
-      "version": "1.26.0",
-      "sha256": "0ai6p7q4iva420wnm0008p1vivd72gc1anwhzzsmy14bxr52rwbx",
+      "version": "1.28.0",
+      "sha256": "08iif4rllnshp3xzsk8y08c3jnpk2k4bbnf6f7rsx2q4sgvnlcpn",
       "depends": ["BiocGenerics", "GenomeInfoDb", "GenomicAlignments", "GenomicRanges", "IRanges", "Rsamtools", "S4Vectors", "dplyr", "magrittr", "rlang", "rtracklayer", "tidyselect"]
     },
     "plyxp": {
       "name": "plyxp",
-      "version": "1.0.0",
-      "sha256": "1q8hidnqrw3b6is2ngld5m3idz4ibkwjfqjdm90slqdsbr79bx8l",
+      "version": "1.2.0",
+      "sha256": "16hjdwzv792il9dhqi3g8h0lb805hsj7mcj23lksxgxxwb9jl4zb",
       "depends": ["S4Vectors", "S7", "SummarizedExperiment", "cli", "dplyr", "glue", "pillar", "purrr", "rlang", "tibble", "tidyr", "tidyselect", "vctrs"]
     },
     "pmm": {
       "name": "pmm",
-      "version": "1.38.0",
-      "sha256": "0nrp23hnk74il7m9v5nv1fn6ihfryghq5h3p9j86zyllxp08jvda",
+      "version": "1.40.0",
+      "sha256": "145jpp9fh7m1aw1rc1wdvg4a6s0aws9f48vz6p770n9x0s6nc1la",
       "depends": ["lme4"]
     },
     "pmp": {
       "name": "pmp",
-      "version": "1.18.0",
-      "sha256": "0kk0fn0q844xl5z4kjx2yygwrckkqw45zvkg84kxc0pn8ab77dq0",
+      "version": "1.20.0",
+      "sha256": "0404ap89a74s8a1p9k98c44ai189jgh987l89b78jh9cgi4bs2k6",
       "depends": ["S4Vectors", "SummarizedExperiment", "ggplot2", "impute", "matrixStats", "missForest", "pcaMethods", "reshape2"]
     },
     "podkat": {
       "name": "podkat",
-      "version": "1.38.0",
-      "sha256": "14rfw680n8jlmppm657wiwv4axrqsyhc7w5mkk2yl7qcw5c84ii5",
+      "version": "1.40.0",
+      "sha256": "0vg46rjs6k7byvchhfs541p083v4klp1n7gci2q0ny6yckr0fc4w",
       "depends": ["BSgenome", "Biobase", "BiocGenerics", "Biostrings", "GenomeInfoDb", "GenomicRanges", "IRanges", "Matrix", "Rcpp", "Rhtslib", "Rsamtools"]
+    },
+    "poem": {
+      "name": "poem",
+      "version": "1.0.0",
+      "sha256": "0vnfm324qwzrwcxpsyi7vj85bq56x0a49x29vggkpdnnw91i52fh",
+      "depends": ["BiocNeighbors", "BiocParallel", "Matrix", "SpatialExperiment", "SummarizedExperiment", "aricode", "bluster", "clevr", "clue", "cluster", "elsa", "fclust", "igraph", "matrixStats", "mclustcomp", "pdist", "sp", "spdep"]
     },
     "pogos": {
       "name": "pogos",
-      "version": "1.26.0",
-      "sha256": "02mkx2p8l6nh05bcayl0klv8zy7zys0bpf0bq80nz1cs7509ggz0",
+      "version": "1.28.0",
+      "sha256": "19jsl6993zq5nl32zhkjsa6kwmn2ggzbhmbysmxq8al7vavpgyb0",
       "depends": ["S4Vectors", "ggplot2", "httr", "ontoProc", "rjson", "shiny"]
     },
     "powerTCR": {
       "name": "powerTCR",
-      "version": "1.26.0",
-      "sha256": "0xkqzh0bkji5acca3xcc68xqryyxvizgka5nabbw5w14zhrnymx5",
+      "version": "1.28.0",
+      "sha256": "06xbsbvhafm442b1kjyw1k05nap4wpwcdipgiclkb972nlmrm1i4",
       "depends": ["VGAM", "cubature", "doParallel", "evmix", "foreach", "magrittr", "purrr", "truncdist", "vegan"]
     },
     "ppcseq": {
       "name": "ppcseq",
-      "version": "1.14.0",
-      "sha256": "0f5vrp3q5vj4hvm6gm1452biq6dbpg7pkcw8s3gy6dv0ixizinzy",
+      "version": "1.16.0",
+      "sha256": "0wxzkhky14hz02k85ghvq6qcjs5j95yi716sqw1b9j7aifb6c9wv",
       "depends": ["BH", "Rcpp", "RcppEigen", "RcppParallel", "StanHeaders", "benchmarkme", "dplyr", "edgeR", "foreach", "ggplot2", "lifecycle", "magrittr", "purrr", "rlang", "rstan", "rstantools", "tibble", "tidybayes", "tidyr"]
     },
     "pqsfinder": {
       "name": "pqsfinder",
-      "version": "2.22.0",
-      "sha256": "0rxz4zg7lmn9q9mxi1h2wf9w4f05lg3889nbq2dip5xzs75p7fa4",
+      "version": "2.24.0",
+      "sha256": "0az362s402w0khcsb5zn2hza60q0kpdmcn86dci8kfv0xn340msr",
       "depends": ["BH", "Biostrings", "GenomicRanges", "IRanges", "Rcpp", "S4Vectors"]
     },
     "pram": {
       "name": "pram",
-      "version": "1.22.0",
-      "sha256": "0j74w5z2nnbacjq50x9v8qp0k078a0qy7n2wwy9j3wh0sr3j6k17",
+      "version": "1.24.0",
+      "sha256": "0dzq90wziq0mksb1q4kiphgqq3f1pzx1za5ldwz47cndsccimmhq",
       "depends": ["BiocGenerics", "BiocParallel", "GenomeInfoDb", "GenomicAlignments", "GenomicRanges", "IRanges", "Rsamtools", "S4Vectors", "data_table", "rtracklayer"]
     },
     "prebs": {
       "name": "prebs",
-      "version": "1.46.0",
-      "sha256": "11b5fzagvd935bi0j6415qq1gp4jmk471h2g78skya2004r5fkwr",
+      "version": "1.48.0",
+      "sha256": "092hc5pppcqshjp4497rz0z84lb811if9ra18dsh5ggs9p79d114",
       "depends": ["Biobase", "GenomeInfoDb", "GenomicAlignments", "GenomicRanges", "IRanges", "RPA", "S4Vectors", "affy"]
     },
     "preciseTAD": {
       "name": "preciseTAD",
-      "version": "1.16.0",
-      "sha256": "1brn1813nrgh5l3np7lfsdn02r1aw0xrjmxaly2cwbrblycnp41f",
+      "version": "1.18.0",
+      "sha256": "14qq3zgrfac7ysj2jclcig0dfhj8rc8cwvxpbby75akwm1024qw5",
       "depends": ["GenomicRanges", "IRanges", "ModelMetrics", "PRROC", "S4Vectors", "caret", "cluster", "dbscan", "doSNOW", "e1071", "foreach", "gtools", "pROC", "pbapply", "rCGH", "randomForest"]
     },
     "preprocessCore": {
       "name": "preprocessCore",
-      "version": "1.68.0",
-      "sha256": "0qpvyg5wjgf1bf1h2mripbsn03by3nap0561kk8qsxg4q71bdnah",
+      "version": "1.70.0",
+      "sha256": "062ymdjc48580yv1kl36p0prvffk8qcf5ypsvdvdqikxfp6ayrvp",
       "depends": []
     },
     "primirTSS": {
       "name": "primirTSS",
-      "version": "1.24.0",
-      "sha256": "07s212lh2mjfr91zh7w5avwdb3fjb4fkrm5kc8x55rcf84qm30db",
+      "version": "1.26.0",
+      "sha256": "0h188r0a16cfd8482jpa1qk33hj9l9f5gp3hlsb2hbfyg6l4ib36",
       "depends": ["BSgenome_Hsapiens_UCSC_hg38", "BiocGenerics", "Biostrings", "GenomicRanges", "GenomicScores", "Gviz", "IRanges", "JASPAR2018", "R_utils", "S4Vectors", "TFBSTools", "dplyr", "phastCons100way_UCSC_hg38", "purrr", "rtracklayer", "shiny", "stringr", "tibble", "tidyr"]
     },
     "proActiv": {
       "name": "proActiv",
-      "version": "1.16.0",
-      "sha256": "1mpq6mjwyfng339m9nq6n68h7llj0483wjqqmss7vbnhfgj2q84w",
+      "version": "1.18.0",
+      "sha256": "0x4lgd3rv0r4dj4b0rfpafj1sznd56h8mf99x8rava9lhv2j94jm",
       "depends": ["AnnotationDbi", "BiocParallel", "DESeq2", "GenomeInfoDb", "GenomicAlignments", "GenomicFeatures", "GenomicRanges", "IRanges", "S4Vectors", "SummarizedExperiment", "data_table", "dplyr", "ggplot2", "gplots", "rlang", "scales", "tibble", "txdbmaker"]
     },
     "proBAMr": {
       "name": "proBAMr",
-      "version": "1.40.0",
-      "sha256": "15fl3691hipzxm1zxjnjif9z7brnbq71dq6vc8zdr4w458m1zngj",
+      "version": "1.42.0",
+      "sha256": "0cywq08np6lxbbs1nc2grgcq99g184855zq1jg3xj3ah3qfgj9r8",
       "depends": ["AnnotationDbi", "Biostrings", "GenomicFeatures", "GenomicRanges", "IRanges", "rtracklayer", "txdbmaker"]
     },
     "proDA": {
       "name": "proDA",
-      "version": "1.20.0",
-      "sha256": "1l1wz66dnyv9kpfkw529641ixz8j2b3ynqj5b883nc8ch850ppba",
+      "version": "1.22.0",
+      "sha256": "19hd93xpvl4fxdcwr7p4xr2frqna2i02bjxk4wqa3v6x9d904sm2",
       "depends": ["BiocGenerics", "S4Vectors", "SummarizedExperiment", "extraDistr"]
     },
     "procoil": {
       "name": "procoil",
-      "version": "2.34.0",
-      "sha256": "0wfmh3fn87c1cl2cqc92202xbbw6as5r4x0i8k4cz7nac11lfiz6",
+      "version": "2.36.0",
+      "sha256": "0iwkngssiavx6fvx6w9g56hr6yrfn2j4k2j0lzhwzb1pjq2wwdv4",
       "depends": ["Biostrings", "S4Vectors", "kebabs"]
     },
     "profileScoreDist": {
       "name": "profileScoreDist",
-      "version": "1.34.0",
-      "sha256": "19qyxazgxix3llaxl5nvypwsazgkacg9svplzlnl031gqf0qg6ya",
+      "version": "1.36.0",
+      "sha256": "1700vq8lmhkza6g092szblbcfvb5wi93a319zlz3r7jzlsycqjna",
       "depends": ["BiocGenerics", "Rcpp"]
     },
     "profileplyr": {
       "name": "profileplyr",
-      "version": "1.22.0",
-      "sha256": "0ahwxyic7b39sc09zfhany8zg64n83izkwyqj95krdzdfr823m5c",
+      "version": "1.24.0",
+      "sha256": "0a31h9jcksn0a5wfjayaybqdpx5m4qycapzmx9dk5hgijdkfmy09",
       "depends": ["BiocGenerics", "BiocParallel", "ChIPseeker", "ComplexHeatmap", "EnrichedHeatmap", "GenomeInfoDb", "GenomicFeatures", "GenomicRanges", "IRanges", "R_utils", "Rsamtools", "S4Vectors", "SummarizedExperiment", "TxDb_Hsapiens_UCSC_hg19_knownGene", "TxDb_Hsapiens_UCSC_hg38_knownGene", "TxDb_Mmusculus_UCSC_mm10_knownGene", "TxDb_Mmusculus_UCSC_mm9_knownGene", "circlize", "dplyr", "ggplot2", "magrittr", "org_Hs_eg_db", "org_Mm_eg_db", "pheatmap", "rGREAT", "rjson", "rlang", "rtracklayer", "soGGi", "tidyr", "tiff"]
     },
     "progeny": {
       "name": "progeny",
-      "version": "1.28.0",
-      "sha256": "0ysxjady2cc3rijc3m2izd48zwm039scbk1h51z0926hyqg56h9c",
+      "version": "1.30.0",
+      "sha256": "1xxh46d9x2n1naw3m8nn3kdxpjv75mmlpgbpflfhyasf9p67qkjg",
       "depends": ["Biobase", "decoupleR", "dplyr", "ggplot2", "ggrepel", "gridExtra", "reshape2", "tidyr"]
     },
     "projectR": {
       "name": "projectR",
-      "version": "1.22.0",
-      "sha256": "0z16qahb2rvxad99y9lychlz2am4w4alpa2ypjmd1f7x2c46skj4",
-      "depends": ["Matrix", "MatrixModels", "NMF", "RColorBrewer", "ROCR", "cluster", "cowplot", "dplyr", "fgsea", "ggalluvial", "ggplot2", "ggrepel", "limma", "msigdbr", "reshape2", "scales", "tsne", "umap", "viridis"]
+      "version": "1.24.0",
+      "sha256": "14gi5b1mwmnsdvfbly2k0agdv8kax0vlb9vgrf2qa12ds8nhxkvs",
+      "depends": ["Matrix", "MatrixModels", "NMF", "RColorBrewer", "ROCR", "SingleCellExperiment", "cluster", "cowplot", "dplyr", "fgsea", "ggalluvial", "ggplot2", "ggrepel", "limma", "msigdbr", "reshape2", "scales", "tsne", "umap", "viridis"]
     },
     "protGear": {
       "name": "protGear",
-      "version": "1.10.0",
-      "sha256": "0nhx40i7mh5y0yd2crlshxq0844yfvjakpdgd86w9y3c7879bs69",
+      "version": "1.12.0",
+      "sha256": "0gnm22iybssn4d3vajbnb67065ahnprsdpsa0n8k85f3xbi0mv34",
       "depends": ["Biobase", "FactoMineR", "GGally", "Kendall", "MASS", "data_table", "dplyr", "factoextra", "flexdashboard", "genefilter", "ggplot2", "ggpubr", "gtools", "htmltools", "knitr", "limma", "magrittr", "pheatmap", "plotly", "plyr", "purrr", "readr", "remotes", "rlang", "rmarkdown", "shiny", "shinydashboard", "styler", "tibble", "tidyr", "vsn"]
     },
     "proteinProfiles": {
       "name": "proteinProfiles",
-      "version": "1.46.0",
-      "sha256": "192qhqlxln53zwcc1i1x3fg0brngphm183j6nx8bjgxhx0vqky40",
+      "version": "1.48.0",
+      "sha256": "0ylqnpg3drabx2ysv4larvwq93hcwzqk78g04iwbgzrmq87mcl0n",
       "depends": []
     },
     "psichomics": {
       "name": "psichomics",
-      "version": "1.32.0",
-      "sha256": "1792pbwypd8v8dfqfc5n1s21k2kqky3j9gvzldnxsd20y8wfha2s",
+      "version": "1.34.0",
+      "sha256": "12g9x7jyx8pkbp0l47sqzvpshifaiqqbzsr1zp7d4m0iqjgm1wyh",
       "depends": ["AnnotationDbi", "AnnotationHub", "BiocFileCache", "DT", "R_utils", "Rcpp", "Rfast", "SummarizedExperiment", "XML", "cluster", "colourpicker", "data_table", "digest", "dplyr", "edgeR", "fastICA", "fastmatch", "ggplot2", "ggrepel", "highcharter", "htmltools", "httr", "jsonlite", "limma", "pairsD3", "plyr", "purrr", "recount", "reshape2", "shiny", "shinyBS", "shinyjs", "stringr", "survival", "xtable"]
     },
     "ptairMS": {
       "name": "ptairMS",
-      "version": "1.14.0",
-      "sha256": "0q445dmspnyzvk1a8ygwdap3s0lmii6arcmg7bfjz111bcsfkgqn",
+      "version": "1.16.0",
+      "sha256": "1rca11p9fklq6x69kd34rwans5m068k4nrafddl3171a972aikhb",
       "depends": ["Biobase", "DT", "Hmisc", "MSnbase", "Rcpp", "bit64", "chron", "data_table", "doParallel", "enviPat", "foreach", "ggplot2", "ggpubr", "gridExtra", "minpack_lm", "plotly", "rhdf5", "rlang", "scales", "shiny", "shinyscreenshot", "signal"]
     },
     "puma": {
       "name": "puma",
-      "version": "3.48.0",
-      "sha256": "0wpfiza6cr2pvf098gyls19r3q72dah30knrg4n4pwnl55p8mvdl",
+      "version": "3.50.0",
+      "sha256": "0kvhq7xvldg2s5ib51gbl6ji3xczgzl9rhixrrygxkrffrwjql8b",
       "depends": ["Biobase", "affy", "affyio", "mclust", "oligo", "oligoClasses"]
     },
     "pvac": {
       "name": "pvac",
-      "version": "1.54.0",
-      "sha256": "0c77rmpr3x9sjjmq3wwb1azms5a7dgjlvvrwmmd0i1bp928ksl6v",
+      "version": "1.56.0",
+      "sha256": "03ny0gjx107w26l0hkd2n9gpkdni0y42f0iz87jfqpks0l3sfyk2",
       "depends": ["Biobase", "affy"]
     },
     "pvca": {
       "name": "pvca",
-      "version": "1.46.0",
-      "sha256": "1n3gn0bdbpgwkgkbcp5655sx9k8rw7a6pr7z7hfxx6nd7i5gnzg2",
+      "version": "1.48.0",
+      "sha256": "0phqz3rhns83p49zz1n1h72hi501gq9z98kz8hxc3rrcinbxmq2w",
       "depends": ["Biobase", "Matrix", "lme4", "vsn"]
     },
     "pwalign": {
       "name": "pwalign",
-      "version": "1.2.0",
-      "sha256": "1i01xhg8sjz9gx5pqaq8wam9r13l8m9n9pf1aiavjif20gd0rz3b",
+      "version": "1.4.0",
+      "sha256": "1v4iicyr37fb5whx8qrslqy7rvnydvvjb5dhf78vfq7q47497363",
       "depends": ["BiocGenerics", "Biostrings", "IRanges", "S4Vectors", "XVector"]
     },
     "qPLEXanalyzer": {
       "name": "qPLEXanalyzer",
-      "version": "1.24.0",
-      "sha256": "03n1mq5jgbhy6jnw65l9j6dy22s2wx4djnygc002fylzh9vglp9p",
+      "version": "1.26.0",
+      "sha256": "1mjkbzdqb8ksnwsi3fm8nj2rf3zi8lpr02dl6igpk5hav26gmq2z",
       "depends": ["Biobase", "BiocGenerics", "Biostrings", "IRanges", "MSnbase", "RColorBrewer", "assertthat", "dplyr", "ggdendro", "ggplot2", "limma", "magrittr", "preprocessCore", "purrr", "readr", "rlang", "scales", "stringr", "tibble", "tidyr", "tidyselect"]
     },
     "qckitfastq": {
       "name": "qckitfastq",
-      "version": "1.22.0",
-      "sha256": "0hpixpb4xxpdwh7v3x2hapri137mavzcq020qfhclrlf5a0gwhjc",
+      "version": "1.24.0",
+      "sha256": "16lcg42jclw24nk1k9bxy7vm3qj5vyqny99b0ixm0ilda6wkl1f7",
       "depends": ["RSeqAn", "Rcpp", "data_table", "dplyr", "ggplot2", "magrittr", "reshape2", "rlang", "seqTools", "zlibbioc"]
     },
     "qcmetrics": {
       "name": "qcmetrics",
-      "version": "1.44.0",
-      "sha256": "1bh9kr91r2svnrpcdyars8k2fsf35s5iqdzgmx1k8h0vyw0gs11j",
+      "version": "1.46.0",
+      "sha256": "0vqm62wsn3c8rk02dzlm6af0k238anrhhlj47qrkk28d8mchsjwc",
       "depends": ["Biobase", "S4Vectors", "knitr", "pander", "xtable"]
     },
     "qmtools": {
       "name": "qmtools",
-      "version": "1.10.0",
-      "sha256": "00d1cmcpin1j922ly5x1zwmfnss0psjq6i1mxkxmsqm5rjzrnw2a",
+      "version": "1.12.0",
+      "sha256": "1ipwy43w1cx208nrrg1kdnd7mnylrjq7zjyxgk616bsh7q65jzrv",
       "depends": ["MsCoreUtils", "SummarizedExperiment", "VIM", "ggplot2", "heatmaply", "igraph", "limma", "patchwork", "rlang", "scales"]
     },
     "qpcrNorm": {
       "name": "qpcrNorm",
-      "version": "1.64.0",
-      "sha256": "1m558ncz36qjsjd0l2zagr8i43f0fhjabkk2kcnil4n7b0hh13l5",
+      "version": "1.66.0",
+      "sha256": "0rlfswzkzwxmdfkyzg33ckfzwk9ylw7grjgsy4h3lca5nxf8xvq4",
       "depends": ["Biobase", "affy", "limma"]
     },
     "qpgraph": {
       "name": "qpgraph",
-      "version": "2.40.0",
-      "sha256": "1ydrja6rmvk57gamasgda86mjkk0c6yrhny4762m56xfwd6y9qs0",
+      "version": "2.42.0",
+      "sha256": "0p116qywrr4ngqkhc9darzqdii6saqs7yxn0pqadq52vivmilzqh",
       "depends": ["AnnotationDbi", "Biobase", "BiocParallel", "GenomeInfoDb", "GenomicFeatures", "GenomicRanges", "IRanges", "Matrix", "Rgraphviz", "S4Vectors", "annotate", "graph", "mvtnorm", "qtl"]
     },
     "qsea": {
       "name": "qsea",
-      "version": "1.32.0",
-      "sha256": "1ph05lavgy8xnz6dimbxy26bp23dw3bqf1kp0bkyxn94zvavwmy4",
+      "version": "1.34.0",
+      "sha256": "0alvx8kq3whi89nxgdk64gr1hndkdma4mhivvkm3v8l5v1cp9w98",
       "depends": ["BSgenome", "BiocGenerics", "BiocParallel", "Biostrings", "GenomeInfoDb", "GenomicRanges", "HMMcopy", "IRanges", "Rsamtools", "S4Vectors", "gtools", "limma", "rtracklayer", "zoo"]
     },
     "qsmooth": {
       "name": "qsmooth",
-      "version": "1.22.0",
-      "sha256": "1lky4adrz3iwn8f558hpikgk87b6d7zf018mf90mnarngpfn1d15",
+      "version": "1.24.0",
+      "sha256": "07bisfk8mx6aiylnkx7c6appwir9hrqnd5pms6q2hy3fc7lwsq3q",
       "depends": ["Hmisc", "SummarizedExperiment", "sva"]
     },
     "qsvaR": {
       "name": "qsvaR",
-      "version": "1.10.0",
-      "sha256": "05xx7kpwwyhx6b67q9pzm1wa7hcks2zf985gma5vw96maxf51mzk",
-      "depends": ["SummarizedExperiment", "ggplot2", "rlang", "sva", "tidyverse"]
+      "version": "1.12.0",
+      "sha256": "0cksc2rkg8cqa6dj23p368xj9415dff3c3fn0fnf263b8aql6kcw",
+      "depends": ["SummarizedExperiment", "dplyr", "ggplot2", "rlang", "sva"]
     },
     "quantiseqr": {
       "name": "quantiseqr",
-      "version": "1.14.0",
-      "sha256": "0iqxmiq7klpxnf3ih0qgpz666pjlhwmz9764amx7sx980fhra2xv",
+      "version": "1.16.0",
+      "sha256": "0gw1cy8m71qykvwy4pa2bg20r4gbpwlki7sar9d7cg20x5nwz22s",
       "depends": ["Biobase", "MASS", "SummarizedExperiment", "ggplot2", "limSolve", "preprocessCore", "rlang", "tidyr"]
     },
     "quantro": {
       "name": "quantro",
-      "version": "1.40.0",
-      "sha256": "0hkrpg2x7w8kgw8hblw0q178h5kb09yir1rg4jji1irbl4g1drck",
+      "version": "1.42.0",
+      "sha256": "18yixnla95ch595phf2dr7zpzg049bra8dhciawj0731rj158i73",
       "depends": ["Biobase", "RColorBrewer", "doParallel", "foreach", "ggplot2", "iterators", "minfi"]
     },
     "quantsmooth": {
       "name": "quantsmooth",
-      "version": "1.72.0",
-      "sha256": "0nrlkp5gqmhxq7n2cjg7nxkdnc7rbb4cl79dfham0ky97pwisi4p",
+      "version": "1.74.0",
+      "sha256": "19y817s9k86q79hmnj05573wrybglp5qzsywasn1h6hgvdnrd97h",
       "depends": ["quantreg"]
     },
     "qusage": {
       "name": "qusage",
-      "version": "2.40.0",
-      "sha256": "184ap7844dnhwfxx69ifvglyh2zk56zcdw9jl0izxqqgxinrw7ss",
+      "version": "2.42.0",
+      "sha256": "1jzfzsaw59iwb3k61ji9dpzl5bd4dfpmna8k0c359pv7c861310b",
       "depends": ["Biobase", "emmeans", "fftw", "limma", "nlme"]
     },
     "qvalue": {
       "name": "qvalue",
-      "version": "2.38.0",
-      "sha256": "0q9iafir09xnk2qgdaqhryd3y5kzcxcw9l0la1pnpanxdz2hl3i1",
+      "version": "2.40.0",
+      "sha256": "1ylmqdlsixwz3d31l6pwbifczadh98s5j7ff5gpps8k8wv8bbnlm",
       "depends": ["ggplot2", "reshape2"]
     },
     "r3Cseq": {
       "name": "r3Cseq",
-      "version": "1.52.0",
-      "sha256": "0siicyjr5zb9z1ymlasrnrvggcrnrpf9194s5qfhybasgai6a5jm",
+      "version": "1.54.0",
+      "sha256": "1zs6plfb0wpjim5bv5q0cw2am69frlz2vlk424m7i3142d144w6v",
       "depends": ["Biostrings", "GenomeInfoDb", "GenomicRanges", "IRanges", "RColorBrewer", "Rsamtools", "VGAM", "data_table", "qvalue", "rtracklayer", "sqldf"]
     },
     "rBLAST": {
       "name": "rBLAST",
-      "version": "1.2.0",
-      "sha256": "0249l734d0cky7wzbz3i9paz5aalrz7wmqa00prp1vj1drb73mig",
+      "version": "1.4.0",
+      "sha256": "14drh961jizyn0y0lp4xm2dcbxrp7z1xvv74fnlr3my60p3746aj",
       "depends": ["BiocFileCache", "Biostrings"]
     },
     "rBiopaxParser": {
       "name": "rBiopaxParser",
-      "version": "2.46.0",
-      "sha256": "0q9jsf5znfxs1647xp10f1mqam5k0jwfh9aniznfnymk2byhms90",
+      "version": "2.48.0",
+      "sha256": "0ggabwpsrs0dwim47p18brhyi51zmxkrjdnvpz8hpkmy570jljf6",
       "depends": ["XML", "data_table"]
     },
     "rCGH": {
       "name": "rCGH",
-      "version": "1.36.0",
-      "sha256": "07k2lw0a81flf3lx8dfzkrfysjmfj6xrjc3f6f7v526m3nip18xr",
+      "version": "1.38.0",
+      "sha256": "10lwvrmcc1nw7ci0bb20id32xs0f2wkbyjmqsck7rfiwfyccvg6h",
       "depends": ["AnnotationDbi", "DNAcopy", "GenomeInfoDb", "GenomicFeatures", "GenomicRanges", "IRanges", "TxDb_Hsapiens_UCSC_hg18_knownGene", "TxDb_Hsapiens_UCSC_hg19_knownGene", "TxDb_Hsapiens_UCSC_hg38_knownGene", "aCGH", "affy", "ggplot2", "lattice", "limma", "mclust", "org_Hs_eg_db", "plyr", "shiny"]
     },
     "rGADEM": {
       "name": "rGADEM",
-      "version": "2.54.0",
-      "sha256": "0lcsw14n3acxljx6zsrfh0hp3s6y0638jzzrh2f2p0jc9mj29b8y",
+      "version": "2.55.0",
+      "sha256": "1fjqvkayam7xpvvbdlz6nafgsrw46vgmbkl96mfvm4szclrxzs8g",
       "depends": ["BSgenome", "Biostrings", "GenomicRanges", "IRanges", "seqLogo"]
     },
     "rGREAT": {
       "name": "rGREAT",
-      "version": "2.8.0",
-      "sha256": "0rrnsfbbxxz6j1glp7bmffc4gwf0wwk5bw5lfy3rv8mwq2szgks9",
+      "version": "2.10.0",
+      "sha256": "1fhgwkyx11300aqvm2rz2gwqk3lh0blpdcqg439wi7ql3m0q5k9k",
       "depends": ["AnnotationDbi", "DT", "GO_db", "GenomeInfoDb", "GenomicFeatures", "GenomicRanges", "GetoptLong", "GlobalOptions", "IRanges", "RColorBrewer", "RCurl", "Rcpp", "S4Vectors", "TxDb_Hsapiens_UCSC_hg19_knownGene", "TxDb_Hsapiens_UCSC_hg38_knownGene", "circlize", "digest", "doParallel", "foreach", "org_Hs_eg_db", "progress", "rjson", "shiny"]
     },
     "rGenomeTracks": {
       "name": "rGenomeTracks",
-      "version": "1.12.0",
-      "sha256": "0fgib559zfjqwbgv42721pqrzbkgv88mzyf0a565rnymbzqg4azn",
+      "version": "1.14.0",
+      "sha256": "0j8p7k64djin5njrglw47j7ysfna7x5b45nchzrqk7zy20w5rdik",
       "depends": ["imager", "rGenomeTracksData", "reticulate"]
     },
     "rRDP": {
       "name": "rRDP",
-      "version": "1.40.0",
-      "sha256": "0al6yq0fcpc6b97wyz5qgbrbw4q78cvdkxzprmf0f3x4c9yw3f96",
+      "version": "1.42.0",
+      "sha256": "0s3k0hh62dl6lcfqgi2hm0x7v62vwq345gd1w1rirfbajzv775ks",
       "depends": ["Biostrings", "rJava"]
     },
     "rSWeeP": {
       "name": "rSWeeP",
-      "version": "1.18.0",
-      "sha256": "0lm61fxpfbcnbl15yk9nlnxv9lg3vmj05makcn3ljwwyr5xh60ng",
+      "version": "1.20.0",
+      "sha256": "1a2wzy1r7ifr1bzrxrbymj8f7353w9vg5vsh2ym1cimj6c89pln5",
       "depends": ["Biostrings", "doParallel", "foreach", "stringi"]
     },
     "rScudo": {
       "name": "rScudo",
-      "version": "1.22.0",
-      "sha256": "1vid2j7i3cq4b357mx57j840gc59wbg3yl5f748vjjsqkmj812gf",
+      "version": "1.24.0",
+      "sha256": "0agzx7fi36jwgklfz16rqzm9x9qmi5j5xz3hsh72lymzffmn5ca7",
       "depends": ["Biobase", "BiocGenerics", "S4Vectors", "SummarizedExperiment", "igraph", "stringr"]
     },
     "rTRM": {
       "name": "rTRM",
-      "version": "1.44.0",
-      "sha256": "1fqfb0nzh9nil8x7q1w08i156qx45f82y99hs9ndfq8rmcfiqw8j",
+      "version": "1.46.0",
+      "sha256": "1865zcx5gs09ysd047skz93b5rjf7l6yy764ld48p9m59al0h7ln",
       "depends": ["AnnotationDbi", "DBI", "RSQLite", "igraph"]
     },
     "rTRMui": {
       "name": "rTRMui",
-      "version": "1.44.0",
-      "sha256": "1dlivwfhzhdzn3gclg75pabswrydn1wap6izw0agdqj5pza5a9mp",
+      "version": "1.46.0",
+      "sha256": "1n3cz9v85c7wlqjsyyw60z8ly4jr393wphg9pksz44z87p048ygq",
       "depends": ["MotifDb", "org_Hs_eg_db", "org_Mm_eg_db", "rTRM", "shiny"]
     },
     "rWikiPathways": {
       "name": "rWikiPathways",
-      "version": "1.26.0",
-      "sha256": "025dd7w0fy6lbg56y5h2xqhax47p3kzsa90sac4fak3skaivg248",
+      "version": "1.28.0",
+      "sha256": "1rhs7mmn3q50ndkcr37smxqs7x8aq9imrp1ri5k2rmi82bhc805f",
       "depends": ["RCurl", "XML", "data_table", "dplyr", "httr", "lubridate", "purrr", "readr", "rjson", "stringr", "tidyr"]
     },
     "raer": {
       "name": "raer",
-      "version": "1.4.0",
-      "sha256": "07lsflgim5sd42lqczklzq22q1s14lsxsmjprkhq35kjp241f4wm",
+      "version": "1.6.0",
+      "sha256": "0dldr24abrdd2cl98m84pg2ziz2lcwi8f2n4xdf94iamzymck358",
       "depends": ["BSgenome", "BiocGenerics", "BiocParallel", "Biostrings", "GenomeInfoDb", "GenomicAlignments", "GenomicFeatures", "GenomicRanges", "IRanges", "Matrix", "Rhtslib", "Rsamtools", "S4Vectors", "SingleCellExperiment", "SummarizedExperiment", "cli", "rtracklayer"]
     },
     "rain": {
       "name": "rain",
-      "version": "1.40.0",
-      "sha256": "0656nmwz2v4vivgyw2yghsz513rz8xpb537z87hd3bsrcgbp9d7w",
+      "version": "1.42.0",
+      "sha256": "1vrqyr3px62hx8rbzfs51vrr81g75r2c3gz0c98gbp8pbfs7csjl",
       "depends": ["gmp", "multtest"]
     },
     "ramr": {
       "name": "ramr",
-      "version": "1.14.0",
-      "sha256": "0m2y2d28gqn1s4wv15m210i84p3c82vqbzayf5a92czfkzdm8w1z",
-      "depends": ["BiocGenerics", "EnvStats", "ExtDist", "GenomicRanges", "IRanges", "S4Vectors", "doParallel", "doRNG", "foreach", "ggplot2", "matrixStats", "reshape2"]
+      "version": "1.16.0",
+      "sha256": "0yh304barqgr4zc6kk6jrn2s3i0r1vqmfvci72315laanm4c8vd5",
+      "depends": ["BiocGenerics", "GenomeInfoDb", "GenomicRanges", "IRanges", "Rcpp", "S4Vectors", "data_table"]
     },
     "ramwas": {
       "name": "ramwas",
-      "version": "1.30.0",
-      "sha256": "0xz8np6rmjpm9al67nnvi7999m2znai7fvvgy9w40vqzzwrhi20i",
+      "version": "1.32.0",
+      "sha256": "1zycxy3rdg8nqs1jw7pdlydj7mnbm7ik9zxqmrmd5fbh2rjkqdp9",
       "depends": ["BiocGenerics", "Biostrings", "GenomicAlignments", "KernSmooth", "Rsamtools", "biomaRt", "digest", "filematrix", "glmnet"]
     },
     "randPack": {
       "name": "randPack",
-      "version": "1.52.0",
-      "sha256": "087n4h5l11z067i1zd6s2xhbxrp202yvazaj4rk2fyn52hq1vr5q",
+      "version": "1.54.0",
+      "sha256": "0n8zai797awci326j6ihx2x53y9ymyh7yj490ir1v03riifq3pmb",
       "depends": ["Biobase"]
     },
     "randRotation": {
       "name": "randRotation",
-      "version": "1.18.0",
-      "sha256": "1km777q9nlsmalv5m9vi9yw4y2q88g1f6b8f34sfgg80q9j3r2k5",
+      "version": "1.20.0",
+      "sha256": "19qhhf12x8z8wrdwvph9p9fx2ivzkk72n2mr97chj5n83wsxgvb4",
       "depends": ["Rdpack"]
     },
     "rawDiag": {
       "name": "rawDiag",
-      "version": "1.2.0",
-      "sha256": "0lzvd9wnhxanjajbwzm8wdan4gcnz9sxdya5p9gg4kpnvvvn0wx2",
+      "version": "1.4.0",
+      "sha256": "1944mgb1vx3y1vljm04x8ar640jjnsbdxqr0awwsd0ci99qjqw6i",
       "depends": ["BiocManager", "BiocParallel", "dplyr", "ggplot2", "hexbin", "htmltools", "rawrr", "reshape2", "rlang", "scales", "shiny"]
     },
     "rawrr": {
       "name": "rawrr",
-      "version": "1.14.0",
-      "sha256": "0lnwz3m7m5h27vqp6mirc26sxjx2px7dnym9b5v0vmmp181vz189",
+      "version": "1.16.0",
+      "sha256": "1g5d4mga7wb5ygj7dybz87sn88va3yigxy2hc1s8m5p9a1bl0vz6",
       "depends": []
     },
     "rbsurv": {
       "name": "rbsurv",
-      "version": "2.64.0",
-      "sha256": "195fw54b1j4bi2436dzpwkzpk4qw9dyvajx9lbrid5wji0rvvhjk",
+      "version": "2.66.0",
+      "sha256": "19qygdn3yx7a5jk2adqchpgw2jgznccg0hkp0wina7b0g8912jx0",
       "depends": ["Biobase", "survival"]
     },
     "rcellminer": {
       "name": "rcellminer",
-      "version": "2.28.0",
-      "sha256": "17h9c33rfi10rf3klkwna91i0kd131gcasnszy5mi7hcpjapykn2",
+      "version": "2.30.0",
+      "sha256": "14mn84ivyr6l2vlgdmkn9ycbvm5m53jwra5a4gmahhn3h96nsqjf",
       "depends": ["Biobase", "ggplot2", "gplots", "rcellminerData", "shiny", "stringr"]
     },
     "rebook": {
       "name": "rebook",
-      "version": "1.16.0",
-      "sha256": "1pl7pwdrccqzajb0n59sgxwy8z33hyp8p6qzsh3k6vl2ligw75sj",
+      "version": "1.18.0",
+      "sha256": "0xizyqw28bhgmg7s4a6jm1627z4iv3rglqczzwcfad152inyyypr",
       "depends": ["BiocStyle", "CodeDepends", "dir_expiry", "filelock", "knitr", "rmarkdown"]
     },
     "receptLoss": {
       "name": "receptLoss",
-      "version": "1.18.0",
-      "sha256": "1x0mwckvavl7p245qgx33a2n6zd7m6nzrsvp65hmzsqzcl8xc0fz",
+      "version": "1.20.0",
+      "sha256": "1b6lfs7dmizyvl1x21rf2h07pc04x7ains30zn64p8xrg6cxkfr9",
       "depends": ["SummarizedExperiment", "dplyr", "ggplot2", "magrittr", "tidyr"]
     },
     "reconsi": {
       "name": "reconsi",
-      "version": "1.18.0",
-      "sha256": "0221pxka1dcnf85ix3kp9k1izc73vgfwl42aqkl74hhkv14bk2d8",
+      "version": "1.20.0",
+      "sha256": "0w0wjv7l3jajlspvyrmngd5134bxfjvisjvmvbsl56l0ws7ib92c",
       "depends": ["Matrix", "ggplot2", "ks", "matrixStats", "phyloseq", "reshape2"]
     },
     "recount": {
       "name": "recount",
-      "version": "1.32.0",
-      "sha256": "0i512z370hrpgyddvgfd9mvcd0lhldbcs047q39brcf436a6glgs",
+      "version": "1.34.0",
+      "sha256": "0bwdid17vxzpxshb33c0kxfyqamb8jxsfl5v4pmlyscdv4lp3fhg",
       "depends": ["BiocParallel", "GEOquery", "GenomeInfoDb", "GenomicRanges", "IRanges", "RCurl", "S4Vectors", "SummarizedExperiment", "derfinder", "downloader", "rentrez", "rtracklayer"]
     },
     "recount3": {
       "name": "recount3",
-      "version": "1.16.0",
-      "sha256": "01xz4cgrwq3h15ikpl17f0103cqyx0p6vhlazahsn7k5dklp5ipr",
+      "version": "1.18.0",
+      "sha256": "1rzrkbi8wy94d08akrg7vzpv6a1jlpv4wjh2x1dr2pnsyx8lfnkc",
       "depends": ["BiocFileCache", "GenomicRanges", "Matrix", "R_utils", "S4Vectors", "SummarizedExperiment", "data_table", "httr", "rtracklayer", "sessioninfo"]
     },
     "recountmethylation": {
       "name": "recountmethylation",
-      "version": "1.16.0",
-      "sha256": "0idgifc0kywjvv6z6safga3168yz5837qsfjbakp23502zdkl904",
+      "version": "1.18.0",
+      "sha256": "06g3ahvcc5q33ngpk92vk1y1pqlnyazyg49jhv27580jvap64jmk",
       "depends": ["BiocFileCache", "DelayedMatrixStats", "HDF5Array", "RCurl", "R_utils", "S4Vectors", "basilisk", "minfi", "reticulate", "rhdf5"]
     },
     "recoup": {
       "name": "recoup",
-      "version": "1.34.0",
-      "sha256": "1fadqn6ddyvpl3a6115ixh8ikwz188pwph6i6j6y3nxaai97rmkm",
+      "version": "1.36.0",
+      "sha256": "020kb22ka0xxf430zdc7jwhhhq0djxskmaaqcr7a83vn6zn1r8z7",
       "depends": ["BiocGenerics", "Biostrings", "ComplexHeatmap", "GenomeInfoDb", "GenomicAlignments", "GenomicFeatures", "GenomicRanges", "IRanges", "RSQLite", "Rsamtools", "S4Vectors", "biomaRt", "circlize", "ggplot2", "httr", "rtracklayer", "stringr", "txdbmaker"]
     },
     "regionReport": {
       "name": "regionReport",
-      "version": "1.40.0",
-      "sha256": "0h13903lwxjdzm4mjid214z5pn9c1zqqsn3my1vr0xqzv3k4yiar",
+      "version": "1.42.0",
+      "sha256": "0ksqk3qnb0mv7rm5zli2n8gih3izd6crfwci8vv6vy7wmx1bgraz",
       "depends": ["BiocStyle", "DEFormats", "DESeq2", "GenomeInfoDb", "GenomicRanges", "RefManageR", "S4Vectors", "SummarizedExperiment", "derfinder", "knitr", "knitrBootstrap", "rmarkdown"]
     },
     "regionalpcs": {
       "name": "regionalpcs",
-      "version": "1.4.0",
-      "sha256": "000wygnnjw1x2jb73zrwgifc1w08vqwabhndzpk16aqc1wmv2nng",
+      "version": "1.6.0",
+      "sha256": "07c66bi8df6pl6biim16z108mv5zb5cr7xzifm41vbfj2cwyjkdp",
       "depends": ["GenomicRanges", "PCAtools", "dplyr", "tibble"]
     },
     "regioneR": {
       "name": "regioneR",
-      "version": "1.38.0",
-      "sha256": "1226wljfndqs11p61a79b0rm66jzwljzzi8w9lhx9g165jy3xxay",
+      "version": "1.39.0",
+      "sha256": "0fq8rcibsmh7vicw0p567w4847mpgj5wcc4gcsphym02hzl5ppqb",
       "depends": ["BSgenome", "Biostrings", "GenomeInfoDb", "GenomicRanges", "IRanges", "S4Vectors", "memoise", "rtracklayer"]
     },
     "regioneReloaded": {
       "name": "regioneReloaded",
-      "version": "1.8.0",
-      "sha256": "1jhfh6pgq6yq8czvx6razzswacb7m06pfci6apj86izal54zj8jj",
+      "version": "1.10.0",
+      "sha256": "0md9wyhnfcbh0l7nj75gj5wqbx58485f0n9pmcyj4v8hwwzf03z6",
       "depends": ["RColorBrewer", "Rtsne", "cluster", "ggplot2", "ggrepel", "regioneR", "reshape2", "scales", "umap"]
     },
     "regsplice": {
       "name": "regsplice",
-      "version": "1.32.0",
-      "sha256": "0jzmxl837wq7cf0jrff2py144qdk7mmypl2a93g6862k1zcgc9dk",
+      "version": "1.34.0",
+      "sha256": "1grlvjwan7c0fqjnmwwfm43jmc7w0n4kbmmw4nl5srgqm39xlyaq",
       "depends": ["S4Vectors", "SummarizedExperiment", "edgeR", "glmnet", "limma", "pbapply"]
     },
     "regutools": {
       "name": "regutools",
-      "version": "1.18.0",
-      "sha256": "1whamihnl3kamsjv9cqfdwvnzy8w6rxdc5xj6hv1g4w5x2sr7zvp",
+      "version": "1.20.0",
+      "sha256": "0sq41fn8c8s2xyk18lws5j7aqq89vw9vvhnc5w4r10avzrjx32f7",
       "depends": ["AnnotationDbi", "AnnotationHub", "BiocFileCache", "Biostrings", "DBI", "GenomicRanges", "Gviz", "IRanges", "RCy3", "RSQLite", "S4Vectors"]
     },
     "retrofit": {
       "name": "retrofit",
-      "version": "1.6.0",
-      "sha256": "0f8asr7573ra4vxp1s1fs1zr31r7sphzj7xpzk614llwacjyasvi",
+      "version": "1.8.0",
+      "sha256": "1hs4kyq2fzr1918fc6dp2pfr44bcx32aw6l40nahsipcr8jsz44p",
       "depends": ["Rcpp"]
     },
     "rexposome": {
       "name": "rexposome",
-      "version": "1.28.0",
-      "sha256": "0hhhdfjlqfrq7ginxy0rj2ih5m4wd1msgnrl4bangp7mm1d3m73r",
+      "version": "1.30.0",
+      "sha256": "15by861nxm5xdvq1lq214gff3a7flk2srrjywnwhll9h6n6m5r0g",
       "depends": ["Biobase", "FactoMineR", "Hmisc", "S4Vectors", "circlize", "corrplot", "ggplot2", "ggrepel", "ggridges", "glmnet", "gplots", "gridExtra", "gtools", "imputeLCMD", "lme4", "lsr", "mice", "pryr", "reshape2", "scales", "scatterplot3d", "stringr"]
     },
     "rfPred": {
       "name": "rfPred",
-      "version": "1.44.0",
-      "sha256": "10zr6ik6q1dxmczfh1kf12jydhk8lbcxc79m7j0334vdmd0szv45",
+      "version": "1.46.0",
+      "sha256": "008f4jy5cz9a9i8xfmwnjiyd9yplj9p9701xnfl70c330wzbh9pl",
       "depends": ["GenomeInfoDb", "GenomicRanges", "IRanges", "Rsamtools", "data_table"]
     },
     "rfaRm": {
       "name": "rfaRm",
-      "version": "1.18.0",
-      "sha256": "0d7f9jkiq6ddybkkysmrfrp8hll4nrxpk0hv6hgdjxrpx5wpw839",
+      "version": "1.19.0",
+      "sha256": "0ydz3j87bkydgiwz8y11kw5qpxc6ag90bdi3dmkd6ww7nrg8zg2b",
       "depends": ["Biostrings", "IRanges", "S4Vectors", "data_table", "httr", "jsonlite", "magick", "rsvg", "rvest", "stringi", "xml2"]
     },
     "rgoslin": {
       "name": "rgoslin",
-      "version": "1.10.0",
-      "sha256": "02c4kci5zyn1vdlg99pwq4skgivlp34ghj0ww4wxc94sc36kv0l5",
+      "version": "1.12.0",
+      "sha256": "0h9dxy13jv7mm47429k383a9mr73chh5yfv6blzcs6d31wgy69kp",
       "depends": ["Rcpp", "dplyr"]
     },
     "rgsepd": {
       "name": "rgsepd",
-      "version": "1.38.0",
-      "sha256": "11bs950drnwkan1mvhk9smx18gliwgkiw88dk7v21cg7qyh455aw",
+      "version": "1.40.0",
+      "sha256": "10x3xir9dfk78vqll55aharar6bj0r5kc1lrvi441qhj4jyzmjjk",
       "depends": ["AnnotationDbi", "DESeq2", "GO_db", "SummarizedExperiment", "biomaRt", "goseq", "gplots", "org_Hs_eg_db"]
     },
     "rhdf5": {
       "name": "rhdf5",
-      "version": "2.50.2",
-      "sha256": "1p3zkn6xdsy3rnwpfyw2r4w45klrhgws9gkg7zxbycscdz8fx9h3",
+      "version": "2.52.0",
+      "sha256": "1v243bhy2aq721fhsw3xhpqqmfax53yjvqn3783w8g1jas3q1w8z",
       "depends": ["Rhdf5lib", "rhdf5filters"]
     },
     "rhdf5client": {
       "name": "rhdf5client",
-      "version": "1.28.0",
-      "sha256": "15dnba73sabvv8p5kdx53g289s3dssy3nsq72c726nsikba8dqgq",
+      "version": "1.29.0",
+      "sha256": "1gss59axfvfirl1bsl7dr68m4admllpd8bc77l3qasp0dg804rc0",
       "depends": ["DelayedArray", "data_table", "httr", "rjson"]
     },
     "rhdf5filters": {
       "name": "rhdf5filters",
-      "version": "1.18.0",
-      "sha256": "1kf8w5bq20gwmry2dj46zhnbidpf94ldwpaix3arr4mjkxb7s9va",
+      "version": "1.20.0",
+      "sha256": "1dqpjv9zl00vxhvghnc54sic0z5z6d7jwlsybcf6qs002dkm9haz",
       "depends": ["Rhdf5lib"]
     },
     "rhinotypeR": {
       "name": "rhinotypeR",
-      "version": "1.0.0",
-      "sha256": "1ahag3dcal6mbfzy1kf2x1rj5znnpwl5107jz2xp8azcw18jidzw",
+      "version": "1.2.0",
+      "sha256": "0xp81bg6hw4bbdgb90ps5bin3qqvyn9b8r8nwj1wvvizg3sv70in",
       "depends": ["Biostrings"]
     },
     "riboSeqR": {
       "name": "riboSeqR",
-      "version": "1.40.0",
-      "sha256": "1xxar40bqmawz07h3l6r8m03cq65yymmcc9vyyk66c28yfr46crw",
+      "version": "1.42.0",
+      "sha256": "01rm4xjyh3q3slzm9gs3xifglh038if095vfg335xl2cwhpf6n4d",
       "depends": ["GenomeInfoDb", "GenomicRanges", "IRanges", "Rsamtools", "S4Vectors", "abind", "baySeq", "seqLogo"]
     },
     "ribor": {
       "name": "ribor",
-      "version": "1.18.0",
-      "sha256": "1153d770sw74xgrx9wd7d0a6yk8dhf16q1ck0d42gldkp2asrh83",
+      "version": "1.20.0",
+      "sha256": "18rhzvc6jkvi17zc5g8k3mk9kyiqldnxlq2d5s5rmxhgwfh4cjmf",
       "depends": ["S4Vectors", "dplyr", "ggplot2", "hash", "rhdf5", "rlang", "tidyr", "yaml"]
     },
     "ribosomeProfilingQC": {
       "name": "ribosomeProfilingQC",
-      "version": "1.18.0",
-      "sha256": "1845ra8zsdrf0z457n5vfhknyv7g591rrj9mw7f2bxqbgrijgqpm",
+      "version": "1.20.0",
+      "sha256": "0zjp5xdhfi5c3kp8f449fdjp3f0pcqc9xk6f2r5dydh9x6k9n66k",
       "depends": ["AnnotationDbi", "BSgenome", "BiocGenerics", "Biostrings", "EDASeq", "GenomeInfoDb", "GenomicAlignments", "GenomicFeatures", "GenomicRanges", "IRanges", "RUVSeq", "Rsamtools", "Rsubread", "S4Vectors", "XVector", "cluster", "ggExtra", "ggfittext", "ggplot2", "ggrepel", "motifStack", "rtracklayer", "scales", "txdbmaker"]
     },
     "rifi": {
       "name": "rifi",
-      "version": "1.10.0",
-      "sha256": "1apal2763n8bybcyrngd8zvxmkcp8sxgjj1dm4cn1jdaa51syzlq",
+      "version": "1.12.0",
+      "sha256": "1abcxjysgm0s6g1alr5qncqmnwvnxvbfk7n08gnlz9ifbvrcmp19",
       "depends": ["S4Vectors", "SummarizedExperiment", "car", "cowplot", "doMC", "dplyr", "egg", "foreach", "ggplot2", "nls2", "nnet", "reshape2", "rlang", "rtracklayer", "scales", "stringr", "tibble"]
     },
     "rifiComparative": {
       "name": "rifiComparative",
-      "version": "1.6.0",
-      "sha256": "06l3lvif5c0vl4hr2iiqmhaxp5c0fwvcy5g0jjynjb9w25b5nakb",
+      "version": "1.8.0",
+      "sha256": "1dw8aspwzd21q3y45qjbyan9im0xjx0223hkqpsdl423lf4cz9qa",
       "depends": ["DTA", "LSD", "S4Vectors", "SummarizedExperiment", "cowplot", "devtools", "doMC", "dplyr", "egg", "foreach", "ggplot2", "ggrepel", "nnet", "reshape2", "rlang", "rtracklayer", "scales", "stringr", "tibble", "writexl"]
+    },
+    "rigvf": {
+      "name": "rigvf",
+      "version": "1.0.0",
+      "sha256": "1imd47vcf3334ysna57dz2d2amgyhg179gl85mn1ry0m4aih1l42",
+      "depends": ["GenomeInfoDb", "GenomicRanges", "IRanges", "cachem", "dplyr", "httr2", "jsonlite", "memoise", "rjsoncons", "rlang", "tidyr", "whisker"]
     },
     "rmelting": {
       "name": "rmelting",
-      "version": "1.22.0",
-      "sha256": "08maaxhahqxfal1pdbsg665l7qzqiz9w6989ll45y3gx9zz1z3ql",
+      "version": "1.24.0",
+      "sha256": "0vsv2ja601chzm7zhk71sv6m5j0lwg6lq5j4r2g8ir76zwgxspjh",
       "depends": ["Rdpack", "rJava"]
     },
     "rmspc": {
       "name": "rmspc",
-      "version": "1.12.0",
-      "sha256": "0vqpkfa2lq8f484ihis283gdmda4x492m5hygfvz9y83lwb5syrm",
+      "version": "1.14.0",
+      "sha256": "0a4m34hda6f8q4nbd3b46pknyfpqd5pfpyz6yviicmdagb4v0jk7",
       "depends": ["BiocManager", "GenomicRanges", "processx", "rtracklayer", "stringr"]
     },
     "rnaEditr": {
       "name": "rnaEditr",
-      "version": "1.16.0",
-      "sha256": "165n04bh3g1sb15sfng9ax7bjb6zwy43xhdk9sgijrm7aj6p3cna",
+      "version": "1.18.0",
+      "sha256": "0vcyvd7vgc36qmk92si8s6s730j7zx8bsfq51r1i4sakq0w9mqa6",
       "depends": ["BiocGenerics", "GenomeInfoDb", "GenomicRanges", "IRanges", "S4Vectors", "bumphunter", "corrplot", "logistf", "plyr", "survival"]
     },
     "rnaseqcomp": {
       "name": "rnaseqcomp",
-      "version": "1.36.0",
-      "sha256": "01jx6vk334gfblz5a8dic12a8bi1fm2ybmzijk9cm0ny4d66n5sf",
+      "version": "1.38.0",
+      "sha256": "0b2kzf2qc3m9w6j8fwgzjd27gdqbb3wdhn6fhk9z0ccygy0hpz84",
       "depends": ["RColorBrewer"]
     },
     "roar": {
       "name": "roar",
-      "version": "1.42.0",
-      "sha256": "0mvb1vgjy6d3q9wh5a7a0s4cmy3hx15fl9fvh74yv5ywggp99n82",
+      "version": "1.44.0",
+      "sha256": "0f28p9x0cf80r087snzm2jbd49vsh4rx5b59gpcjp5cdl32ccnw9",
       "depends": ["BiocGenerics", "GenomeInfoDb", "GenomicAlignments", "GenomicRanges", "IRanges", "S4Vectors", "SummarizedExperiment", "rtracklayer"]
     },
     "roastgsa": {
       "name": "roastgsa",
-      "version": "1.4.0",
-      "sha256": "0jy7psw93cdb23rspqmvc389nff8g90c9s1qamv5q8j477a51p2l",
+      "version": "1.6.0",
+      "sha256": "0f47zmr2a598z1y9cx1ryp379gk6b6k0skaqva8fwkmxnkiisqm0",
       "depends": ["Biobase", "RColorBrewer", "ggplot2", "gplots", "limma"]
     },
     "rols": {
       "name": "rols",
-      "version": "3.2.0",
-      "sha256": "1shaxlh620l9p1bkmf6ps62xs81ksx6vvv3ynxlljcr7kgwgdjyn",
+      "version": "3.4.0",
+      "sha256": "1v6sp43j9ls4mxmfhzr3slq9kbhsnhwk7400i832yk1p7i0l9h4v",
       "depends": ["Biobase", "BiocGenerics", "httr2", "jsonlite"]
     },
     "ropls": {
       "name": "ropls",
-      "version": "1.38.0",
-      "sha256": "0f1qbpndil49d9friavzyhbfrp5176w2hrx79wp6b94afggil26h",
+      "version": "1.40.0",
+      "sha256": "04alj2md21bx2x3sx37gag08l9ax8kv2pj185a4h6010rj7jmkbv",
       "depends": ["Biobase", "MultiAssayExperiment", "MultiDataSet", "SummarizedExperiment", "ggplot2", "plotly"]
     },
     "rprimer": {
       "name": "rprimer",
-      "version": "1.10.0",
-      "sha256": "13mcw4wxffz1jcx1sbijdxx9qdd592b6frv728av1vk6rdqhycx3",
+      "version": "1.12.0",
+      "sha256": "0wc6k5vavw8sxbbv0jf4hfly23gigqw9kvhppi6fdkc9dnkrcs6q",
       "depends": ["Biostrings", "DT", "IRanges", "S4Vectors", "bslib", "ggplot2", "mathjaxr", "patchwork", "reshape2", "shiny", "shinyFeedback", "shinycssloaders"]
     },
     "rpx": {
       "name": "rpx",
-      "version": "2.14.1",
-      "sha256": "14gv8hxkm60032r5a4rfb4x06mxlhlz1idrf4pribnpmpjlq774w",
+      "version": "2.16.0",
+      "sha256": "0za17mjy5784hh5ypymldqc178piq7g7ddlc7bdzg8za3zm8y4i6",
       "depends": ["BiocFileCache", "RCurl", "curl", "jsonlite", "xml2"]
     },
     "rqt": {
       "name": "rqt",
-      "version": "1.32.0",
-      "sha256": "02c197p0al9ifc5l21p9f1dkk4cxaj3a4ml82l4rkc2s86ia8fin",
+      "version": "1.34.0",
+      "sha256": "068iz0xf4pxf9fj17264s0w5y3ch56nkmpym3hs69rdqjhkb1fd1",
       "depends": ["CompQuadForm", "Matrix", "RUnit", "SummarizedExperiment", "car", "glmnet", "metap", "pls", "ropls"]
     },
     "rqubic": {
       "name": "rqubic",
-      "version": "1.52.0",
-      "sha256": "18yx1nva368pvg1r02j5zxvjnqabsavcbr0v1gqbf6iklbm80mhg",
+      "version": "1.54.0",
+      "sha256": "0lcsqwjc1kjrn7ng719fy274hkf0sm7l0srp110105d0rzhzjiqg",
       "depends": ["Biobase", "BiocGenerics", "biclust"]
     },
     "rrvgo": {
       "name": "rrvgo",
-      "version": "1.18.0",
-      "sha256": "19y5cn3lp57p3biz442ml8i4fqpyjsv92a7zb5liwmcazbv7bgcq",
+      "version": "1.20.0",
+      "sha256": "04zdd1jpvn4qx3m28llyzldr64y081ini9k5xfi7pzs1jmk18dal",
       "depends": ["AnnotationDbi", "GOSemSim", "GO_db", "ggplot2", "ggrepel", "pheatmap", "shiny", "tm", "treemap", "umap", "wordcloud"]
     },
     "rsbml": {
       "name": "rsbml",
-      "version": "2.64.0",
-      "sha256": "0ygjcg7z0shajswp5bfavslq2b4hdxy30d7bb5i5a11kzxymwg3h",
+      "version": "2.66.0",
+      "sha256": "02qfdiwamlw6nds2lir2936zgs2gsv1rsnsvmsn2ld39i1i4vbg0",
       "depends": ["BiocGenerics", "graph"]
     },
     "rsemmed": {
       "name": "rsemmed",
-      "version": "1.16.0",
-      "sha256": "0f964j7q3xz5mmghvx5pinyrrgwgnddadzpsqb72nkz8vqaasbz3",
+      "version": "1.18.0",
+      "sha256": "0nkiygdcgr547b22zpwf5nan9al3cm3zsplga93g60ncjpc1bwkr",
       "depends": ["dplyr", "igraph", "magrittr", "stringr"]
     },
     "rtracklayer": {
       "name": "rtracklayer",
-      "version": "1.66.0",
-      "sha256": "0gh91rxahdh3ablngm094mnyrdrklm70cjlhwjwz2rydbr3a6dbg",
-      "depends": ["BiocGenerics", "BiocIO", "Biostrings", "GenomeInfoDb", "GenomicAlignments", "GenomicRanges", "IRanges", "Rsamtools", "S4Vectors", "XML", "XVector", "curl", "httr", "restfulr", "zlibbioc"]
+      "version": "1.68.0",
+      "sha256": "07lj0frvqaw062y0d5h52abklyw2ydnk3311a6ykwhhp0mvdskd2",
+      "depends": ["BiocGenerics", "BiocIO", "Biostrings", "GenomeInfoDb", "GenomicAlignments", "GenomicRanges", "IRanges", "Rsamtools", "S4Vectors", "XML", "XVector", "curl", "httr", "restfulr"]
     },
     "runibic": {
       "name": "runibic",
-      "version": "1.28.0",
-      "sha256": "1gqv3bkz9ngfdgg639xa6zg1ysmzkxm5pr78s86an4f3bs63xppr",
+      "version": "1.30.0",
+      "sha256": "18irwzjdvbswsdvwafpg8f265yywlavznwmv16h11xs4ydwy0pc0",
       "depends": ["Rcpp", "SummarizedExperiment", "biclust", "testthat"]
     },
     "sRACIPE": {
       "name": "sRACIPE",
-      "version": "1.22.0",
-      "sha256": "08aghppkc3ndrchqyw89zwi3524cr8ns35cm56ja48h7mby62chs",
-      "depends": ["BiocGenerics", "MASS", "RColorBrewer", "Rcpp", "S4Vectors", "SummarizedExperiment", "ggplot2", "gplots", "gridExtra", "htmlwidgets", "reshape2", "umap", "visNetwork"]
+      "version": "2.0.0",
+      "sha256": "1xhm32d4c8fy827nhrn33l56jd60v162mba16p5zhrww0db6m4iq",
+      "depends": ["BiocGenerics", "MASS", "RColorBrewer", "Rcpp", "S4Vectors", "SummarizedExperiment", "doFuture", "doRNG", "foreach", "future", "ggplot2", "gplots", "gridExtra", "htmlwidgets", "reshape2", "umap", "visNetwork"]
     },
     "sSNAPPY": {
       "name": "sSNAPPY",
-      "version": "1.10.0",
-      "sha256": "0gx89n2h9b4gw8v37ipd55m4xzm7jfmymmpg7bgjlkjr5zp0ws2p",
+      "version": "1.12.0",
+      "sha256": "0xb0biy2ni5g1hvvvgpn9nawwhk7dzj8nsdy451qji0g4nxkm60y",
       "depends": ["SummarizedExperiment", "dplyr", "edgeR", "ggforce", "ggplot2", "ggraph", "graphite", "gtools", "igraph", "magrittr", "org_Hs_eg_db", "pheatmap", "reshape2", "rlang", "stringr", "tibble", "tidyr"]
     },
     "sSeq": {
       "name": "sSeq",
-      "version": "1.44.0",
-      "sha256": "01q56h660akb7zs22cqc63z39fsldpgqd1gmn90qjwc6i6xafrcy",
+      "version": "1.46.0",
+      "sha256": "0308pqsbaqa0a5hamhnykq4423sgkmrmz1j78sbh63m7nvm3jr1n",
       "depends": ["RColorBrewer", "caTools"]
     },
     "safe": {
       "name": "safe",
-      "version": "3.46.0",
-      "sha256": "1rl8bxsbzqjb6kxrka2h6ggk1jkvnvlh2f7dkqmgkvv413anv6pb",
+      "version": "3.48.0",
+      "sha256": "05lgqw0c8rm9mrhm2hbr10paqvzibgrv3fg6zmp1jsl7ic787y5p",
       "depends": ["AnnotationDbi", "Biobase", "SparseM"]
     },
     "sagenhaft": {
       "name": "sagenhaft",
-      "version": "1.76.0",
-      "sha256": "0xpppp1mjdkcdh8qj81a3b4cbv9hfr292rh7fnz3hnhiwv8xhvz7",
+      "version": "1.78.0",
+      "sha256": "188qgkmw9j9whrm1lfgcdyjayiz3xm44ajh85hxw0crhj85sahg5",
       "depends": ["SparseM"]
     },
     "sampleClassifier": {
       "name": "sampleClassifier",
-      "version": "1.30.0",
-      "sha256": "0wg21fbhzsqdpfkg5mjsybfawms7cji3yvx9h1yqf5ql1yqy1vq3",
+      "version": "1.32.0",
+      "sha256": "18cmgpwwd54mkkpg13wjznbk71lp0bz1p5ics9mhxiq6vfw8i62l",
       "depends": ["MGFM", "MGFR", "annotate", "e1071", "ggplot2"]
     },
     "sangeranalyseR": {
       "name": "sangeranalyseR",
-      "version": "1.16.0",
-      "sha256": "0v39n8hj83dqy0nlf06wffka7qyy80fkgzf7p3bpd90j8y9j8cyn",
+      "version": "1.18.0",
+      "sha256": "1dy2n7d430b19lkl8104hmp9k3azl92j7n41h4a74155n0zsfy5v",
       "depends": ["BiocStyle", "Biostrings", "DECIPHER", "DT", "ape", "data_table", "excelR", "ggdendro", "gridExtra", "knitr", "logger", "openxlsx", "plotly", "pwalign", "reshape2", "rmarkdown", "sangerseqR", "seqinr", "shiny", "shinyWidgets", "shinycssloaders", "shinydashboard", "shinyjs", "stringr", "zeallot"]
     },
     "sangerseqR": {
       "name": "sangerseqR",
-      "version": "1.42.0",
-      "sha256": "1xvwlnyrs5w3aiapbiiq8dx71hf7803fywbqhg7nvqkdbls5iljd",
+      "version": "1.44.0",
+      "sha256": "116adlm2a82c5jsljpicsfq34yyks9jcnmn9qjbfb4s8arvq14fw",
       "depends": ["Biostrings", "pwalign", "shiny", "stringr"]
     },
     "sarks": {
       "name": "sarks",
-      "version": "1.18.0",
-      "sha256": "1cj0z5y54bkh06smc26r60mig8lgrdz4rcc7m5ji8f9jfvaqjshj",
+      "version": "1.20.0",
+      "sha256": "1b0szlwp7p5rcyvi4ndqxa0cdn5g89rxnfya6fg5arc93bdbgkq5",
       "depends": ["Biostrings", "IRanges", "binom", "cluster", "rJava"]
     },
     "saseR": {
       "name": "saseR",
-      "version": "1.2.0",
-      "sha256": "0k1n6rjpmrzwmrli5i97czm2vgz76i4dvrqnazqb6j6xpd5975il",
+      "version": "1.4.0",
+      "sha256": "0dndj7r195qwd0y9lm25wdk94b15gpimsck6i0v58nnfjldjgyds",
       "depends": ["ASpli", "BiocGenerics", "BiocParallel", "DESeq2", "DEXSeq", "GenomicAlignments", "GenomicFeatures", "GenomicRanges", "IRanges", "MASS", "MatrixGenerics", "PRROC", "S4Vectors", "SummarizedExperiment", "data_table", "dplyr", "edgeR", "igraph", "knitr", "limma", "pracma", "precrec", "rrcov"]
     },
     "satuRn": {
       "name": "satuRn",
-      "version": "1.14.0",
-      "sha256": "0rfh0zprl1gibcanjwp4sncjv5k660lhylbiaqwgri7n62jz7k9m",
+      "version": "1.16.0",
+      "sha256": "1vimbg778fph2rc95jq0z4ynz38d4cz9nj50iwrxz7j4arzndvg9",
       "depends": ["BiocParallel", "Matrix", "SummarizedExperiment", "boot", "ggplot2", "limma", "locfdr", "pbapply"]
     },
     "scAnnotatR": {
       "name": "scAnnotatR",
-      "version": "1.12.0",
-      "sha256": "0gra749fgcify2625gg1nbnqw328ddf98pplv8yaq4hn37a1s76j",
+      "version": "1.14.0",
+      "sha256": "1p3ws64rj4mraha4c9gw930g7r75n3g3r3m464l41cnli1w39fwi",
       "depends": ["AnnotationHub", "ROCR", "Seurat", "SingleCellExperiment", "SummarizedExperiment", "ape", "caret", "data_tree", "dplyr", "e1071", "ggplot2", "kernlab", "pROC"]
     },
     "scBFA": {
       "name": "scBFA",
-      "version": "1.20.0",
-      "sha256": "1gvr2rg8sacfg2lypiqkb6gd0qy7jy7aw9hypphq81pznmd1in27",
+      "version": "1.22.0",
+      "sha256": "08gy0rnpdgif942p5kw8rhgbfjfbz3c8j3ji7mhhlgr8dnqhbqfl",
       "depends": ["DESeq2", "MASS", "Matrix", "Seurat", "SingleCellExperiment", "SummarizedExperiment", "copula", "ggplot2", "zinbwave"]
     },
     "scBubbletree": {
       "name": "scBubbletree",
-      "version": "1.8.0",
-      "sha256": "1ym6zdxb6nkgb16y2caw432hx24kc10d0bdqq7fdmwj5lmdcwmhy",
+      "version": "1.10.0",
+      "sha256": "0wjafjxmv2hlmdc7hr381g3z2732429ixhlifj8gcz27j6m9g77g",
       "depends": ["BiocParallel", "Seurat", "ape", "dplyr", "ggplot2", "ggtree", "patchwork", "proxy", "reshape2", "scales"]
     },
     "scCB2": {
       "name": "scCB2",
-      "version": "1.16.0",
-      "sha256": "060ayarwf8aijppxw52h1kxrx8w06ws8ivdsr3645s26mri859p5",
+      "version": "1.18.0",
+      "sha256": "11vk83l923bnry1b18g7hap3k5rfi6ww46z556d8vxymjkcd4363",
       "depends": ["DropletUtils", "Matrix", "Seurat", "SingleCellExperiment", "SummarizedExperiment", "doParallel", "edgeR", "foreach", "iterators", "rhdf5"]
     },
     "scClassify": {
       "name": "scClassify",
-      "version": "1.18.0",
-      "sha256": "1c32lm6bgsqn16yzpzz70q7ypgqybv5w6cgqy99953zv18fgar05",
+      "version": "1.20.0",
+      "sha256": "1j1z715xr1sxb3vg528kqnch2vqnirl7mm4k8r2qiacq31jx10kg",
       "depends": ["BiocParallel", "Cepo", "Matrix", "S4Vectors", "cluster", "diptest", "ggplot2", "ggraph", "hopach", "igraph", "limma", "mgcv", "minpack_lm", "mixtools", "proxy", "proxyC", "statmod"]
     },
     "scDD": {
       "name": "scDD",
-      "version": "1.30.0",
-      "sha256": "1l47w55b1qlj589c84g9jmxah8bf8gspw30bl9mpppyjh2nihg8p",
+      "version": "1.32.0",
+      "sha256": "19kz0ivv9qypq7jg33rds5rcjr1mmqd19j3fsj842c5h3bydssph",
       "depends": ["BiocParallel", "EBSeq", "S4Vectors", "SingleCellExperiment", "SummarizedExperiment", "arm", "fields", "ggplot2", "mclust", "outliers", "scran"]
     },
     "scDDboost": {
       "name": "scDDboost",
-      "version": "1.8.0",
-      "sha256": "0lp4ficgglm7dfrnwhfvwn7ahmjrazszpb8yh61r90vhq7qq7cx3",
+      "version": "1.10.0",
+      "sha256": "1rxwm3l6mk0sgg478dbhjpd8dvp6nr934ml8k1wb651a1hz2zqcl",
       "depends": ["BH", "BiocParallel", "EBSeq", "Oscope", "Rcpp", "RcppEigen", "SingleCellExperiment", "SummarizedExperiment", "cluster", "ggplot2", "mclust"]
     },
     "scDataviz": {
       "name": "scDataviz",
-      "version": "1.16.0",
-      "sha256": "1ykvrk51w8bwyg4785r7mf4pjzs5aaks1dka1q1knx6hfybs8mjj",
+      "version": "1.18.0",
+      "sha256": "0d8dvnan7d1rwg18f32hajqcpix88wx6j2p0wx4cn3z584jn32ih",
       "depends": ["MASS", "RColorBrewer", "S4Vectors", "Seurat", "SingleCellExperiment", "corrplot", "flowCore", "ggplot2", "ggrepel", "matrixStats", "reshape2", "scales", "umap"]
     },
     "scDblFinder": {
       "name": "scDblFinder",
-      "version": "1.20.2",
-      "sha256": "140wlw2k9avhl8k895sa6n79xxmiy4q1066gz5kx0p5byxv0s36b",
+      "version": "1.22.0",
+      "sha256": "08nn6a3kina6l5b6m9q7jwkwzjw276k85ypsjhf04yi5nxxggy8s",
       "depends": ["BiocGenerics", "BiocNeighbors", "BiocParallel", "BiocSingular", "DelayedArray", "GenomeInfoDb", "GenomicRanges", "IRanges", "MASS", "Matrix", "Rsamtools", "S4Vectors", "SingleCellExperiment", "SummarizedExperiment", "bluster", "igraph", "rtracklayer", "scater", "scran", "scuttle", "xgboost"]
     },
     "scDesign3": {
       "name": "scDesign3",
-      "version": "1.4.0",
-      "sha256": "1mnwy3gficv3vkxv3anp3208mpxl67pay36bp7m8v9llaxd16kww",
+      "version": "1.6.0",
+      "sha256": "18b2xdhm4fgxj6f9kzp37v9xfa8p9yij88nar6gyvn6p04a8ar5f",
       "depends": ["BiocParallel", "Matrix", "SingleCellExperiment", "SummarizedExperiment", "coop", "dplyr", "gamlss", "gamlss_dist", "ggplot2", "irlba", "matrixStats", "mclust", "mgcv", "mvtnorm", "pbmcapply", "rvinecopulib", "sparseMVN", "tibble", "umap", "viridis"]
     },
     "scDiagnostics": {
       "name": "scDiagnostics",
-      "version": "1.0.0",
-      "sha256": "1b8hx5qvcmgx5n9asyqhr9lzx591cnd8i9cf3h5rg0ias2cy2bad",
+      "version": "1.2.0",
+      "sha256": "1b974j1a6670ln6qbl9p07cic6g0am1kpym539g7vrwlsg21sn1n",
       "depends": ["SingleCellExperiment", "SummarizedExperiment", "bluster", "cramer", "ggplot2", "ggridges", "isotree", "patchwork", "ranger", "rlang", "speedglm", "transport"]
     },
     "scDotPlot": {
       "name": "scDotPlot",
-      "version": "1.0.0",
-      "sha256": "013kng1z74akhffddh3dx6w28572nwl7zqi768w58czz44skzrj5",
+      "version": "1.2.0",
+      "sha256": "04mnm2l3gdrzqxlk47bjh00ac3d4qvpzaknd4x1gc8aq3zlplgn6",
       "depends": ["BiocGenerics", "Seurat", "SingleCellExperiment", "aplot", "cli", "dplyr", "ggplot2", "ggsci", "ggtree", "magrittr", "purrr", "rlang", "scales", "scater", "stringr", "tibble", "tidyr"]
     },
     "scFeatureFilter": {
       "name": "scFeatureFilter",
-      "version": "1.26.0",
-      "sha256": "0r137q81z2cdxid3f2wfljhj71dm9f8fawajz8fsb6pk8cc962hi",
+      "version": "1.28.0",
+      "sha256": "0kpjk6ylm9kxyaynjkd61y3gdgkh7415liw2azmymm641k3h1h7j",
       "depends": ["dplyr", "ggplot2", "magrittr", "rlang", "tibble"]
     },
     "scFeatures": {
       "name": "scFeatures",
-      "version": "1.6.0",
-      "sha256": "0rr5isjjvram7s0am3vvqvywnvsqb1lfccjfny60sy2k3mslv79m",
+      "version": "1.8.0",
+      "sha256": "0srvd9jayyy3793jmm7pcq70m4mhvdc9qhsszbnnl2qcd33wsnkv",
       "depends": ["AUCell", "BiocParallel", "DT", "DelayedArray", "DelayedMatrixStats", "EnsDb_Hsapiens_v79", "EnsDb_Mmusculus_v79", "GSVA", "MatrixGenerics", "Seurat", "SingleCellSignalR", "ape", "cli", "dplyr", "ensembldb", "glue", "gtools", "msigdbr", "proxyC", "reshape2", "rmarkdown", "spatstat_explore", "spatstat_geom", "tidyr"]
     },
     "scGPS": {
       "name": "scGPS",
-      "version": "1.20.0",
-      "sha256": "06hm6cckb78vr67rh39g32ys2phch99d5fw7iia0fm3014slfmfw",
+      "version": "1.22.0",
+      "sha256": "0j5b6jq3qafhsx240sinmcf8hrg7290x3l8mfcibjpq3mkrhv0h9",
       "depends": ["DESeq2", "Rcpp", "RcppArmadillo", "RcppParallel", "SingleCellExperiment", "SummarizedExperiment", "caret", "dplyr", "dynamicTreeCut", "fastcluster", "ggplot2", "glmnet", "locfit"]
     },
     "scHOT": {
       "name": "scHOT",
-      "version": "1.18.0",
-      "sha256": "03q9f2xg9va4pqpz0xva8mz8czlkn3r8z5vb33hz6agzncyp0pgf",
+      "version": "1.20.0",
+      "sha256": "0p7gz30j2d3zqfxhqw200aydxgqkqkbfxnc2gm09z4zlqk7156gx",
       "depends": ["BiocParallel", "IRanges", "Matrix", "S4Vectors", "SingleCellExperiment", "SummarizedExperiment", "ggforce", "ggplot2", "igraph", "reshape"]
+    },
+    "scHiCcompare": {
+      "name": "scHiCcompare",
+      "version": "1.0.0",
+      "sha256": "1cyhhacrvicz3870rpr4l4v0cpjfhphnqgiiqwxxl2qacqq45wr0",
+      "depends": ["BiocParallel", "HiCcompare", "data_table", "dplyr", "ggplot2", "gtools", "lattice", "mclust", "mice", "miceadds", "ranger", "rlang", "rstatix", "tidyr"]
     },
     "scMET": {
       "name": "scMET",
-      "version": "1.8.0",
-      "sha256": "07i2f9wf6nhnh288i66z846lcbb1n1j6gild64axxq48n1d0c2cm",
+      "version": "1.10.0",
+      "sha256": "1jrr9d5si7wgy07sg0z9qdr1zy9wkc2qks02viwfnwdz92kp9x6m",
       "depends": ["BH", "BiocStyle", "MASS", "Matrix", "Rcpp", "RcppEigen", "RcppParallel", "S4Vectors", "SingleCellExperiment", "StanHeaders", "SummarizedExperiment", "VGAM", "assertthat", "coda", "cowplot", "data_table", "dplyr", "ggplot2", "logitnorm", "matrixStats", "rstan", "rstantools", "viridis"]
     },
     "scMerge": {
       "name": "scMerge",
-      "version": "1.22.0",
-      "sha256": "1hyh3lv2fxgf9hdf7d1vqcp4w613614pfi64hb9am77k1znsb8sg",
+      "version": "1.24.0",
+      "sha256": "1j5jm3gxkaymzr1karwx2ym5q62xxvfwixgw15yvnbays3v0kj5k",
       "depends": ["BiocNeighbors", "BiocParallel", "BiocSingular", "DelayedArray", "DelayedMatrixStats", "M3Drop", "S4Vectors", "SingleCellExperiment", "SummarizedExperiment", "batchelor", "cluster", "cvTools", "distr", "igraph", "proxyC", "ruv", "scater", "scran"]
     },
     "scMitoMut": {
       "name": "scMitoMut",
-      "version": "1.2.0",
-      "sha256": "15fpbp9fk7xif8m63xsr1ddjac1lm1kq6qjs65a1a7gpfd7nxxnq",
-      "depends": ["RColorBrewer", "Rcpp", "RcppArmadillo", "data_table", "ggplot2", "magrittr", "pheatmap", "plyr", "readr", "rhdf5", "stringr", "zlibbioc"]
+      "version": "1.4.0",
+      "sha256": "1fhaf1ayy4b5z17jjbqj5yq0n1a06553cc5jklr7yynchqdl91a5",
+      "depends": ["RColorBrewer", "Rcpp", "RcppArmadillo", "data_table", "ggplot2", "magrittr", "pheatmap", "plyr", "readr", "rhdf5", "stringr"]
     },
     "scMultiSim": {
       "name": "scMultiSim",
-      "version": "1.2.0",
-      "sha256": "0lhhz45sdkx5s73dwg5zq098g232cr83xp4d80dszh9va21vxp8m",
+      "version": "1.4.0",
+      "sha256": "16vz69c55dmpcf4c38cv6j62mil8cpfym9714mg3hjq9alva5k2z",
       "depends": ["BiocParallel", "KernelKnn", "MASS", "Rtsne", "SummarizedExperiment", "ape", "assertthat", "crayon", "dplyr", "foreach", "ggplot2", "gplots", "igraph", "markdown", "matrixStats", "phytools", "rlang", "zeallot"]
     },
     "scPCA": {
       "name": "scPCA",
-      "version": "1.20.0",
-      "sha256": "1mx4dhwhz5rr1qalspd74p88cp6bnn63bmvz4agi6xyzxbx0spnr",
+      "version": "1.22.0",
+      "sha256": "095bymrqx8fxl4pjcd2sj81j7lrggnaqzng5zkj61skcs0nf34kk",
       "depends": ["BiocParallel", "DelayedArray", "Matrix", "MatrixGenerics", "RSpectra", "Rdpack", "ScaledMatrix", "assertthat", "cluster", "coop", "dplyr", "elasticnet", "kernlab", "matrixStats", "origami", "purrr", "sparsepca", "stringr", "tibble"]
     },
     "scPipe": {
       "name": "scPipe",
-      "version": "2.6.0",
-      "sha256": "08laknxbzkxr2nqwwv8mi8390rsjj9pc9s4kcy11lvr8fqwpckc7",
-      "depends": ["AnnotationDbi", "BiocGenerics", "Biostrings", "DropletUtils", "GGally", "GenomicAlignments", "GenomicRanges", "IRanges", "MASS", "Matrix", "MultiAssayExperiment", "Rcpp", "Rhtslib", "Rsamtools", "Rsubread", "S4Vectors", "SingleCellExperiment", "SummarizedExperiment", "basilisk", "biomaRt", "data_table", "dplyr", "flexmix", "ggplot2", "glue", "hash", "magrittr", "mclust", "org_Hs_eg_db", "org_Mm_eg_db", "purrr", "reshape", "reticulate", "rlang", "robustbase", "rtracklayer", "scales", "stringr", "testthat", "tibble", "tidyr", "vctrs", "zlibbioc"]
+      "version": "2.8.0",
+      "sha256": "13vqxd1p5pqbbbbcx9p5b4q21bs34sb31n9zbx1illrnwz5v484d",
+      "depends": ["AnnotationDbi", "BiocGenerics", "Biostrings", "DropletUtils", "GGally", "GenomicAlignments", "GenomicRanges", "IRanges", "MASS", "Matrix", "MultiAssayExperiment", "Rcpp", "Rhtslib", "Rsamtools", "Rsubread", "S4Vectors", "SingleCellExperiment", "SummarizedExperiment", "basilisk", "biomaRt", "data_table", "dplyr", "flexmix", "ggplot2", "glue", "hash", "magrittr", "mclust", "org_Hs_eg_db", "org_Mm_eg_db", "purrr", "reshape", "reticulate", "rlang", "robustbase", "rtracklayer", "scales", "stringr", "testthat", "tibble", "tidyr", "vctrs"]
+    },
+    "scQTLtools": {
+      "name": "scQTLtools",
+      "version": "0.99.12",
+      "sha256": "1h3gxgap384a1yj6w37xdq8alx2jsl7dikkn57cghk16grs4fl4p",
+      "depends": ["DESeq2", "GOSemSim", "Matrix", "SeuratObject", "SingleCellExperiment", "SummarizedExperiment", "VGAM", "biomaRt", "dplyr", "gamlss", "ggplot2", "limma", "magrittr", "patchwork", "progress", "stringr"]
     },
     "scRNAseqApp": {
       "name": "scRNAseqApp",
-      "version": "1.6.1",
-      "sha256": "1ahyzc3h9krypy8chjsj607sfmb5vvzf1wr623inz1125frws7cp",
-      "depends": ["ComplexHeatmap", "DBI", "DT", "GenomeInfoDb", "GenomicRanges", "IRanges", "RColorBrewer", "RSQLite", "RefManageR", "Rsamtools", "S4Vectors", "Seurat", "SeuratObject", "SingleCellExperiment", "bibtex", "bslib", "circlize", "colourpicker", "data_table", "ggdendro", "ggforce", "ggplot2", "ggrepel", "ggridges", "gridExtra", "htmltools", "jsonlite", "magrittr", "patchwork", "plotly", "rhdf5", "rtracklayer", "scales", "scrypt", "shiny", "shinyhelper", "shinymanager", "slingshot", "sortable", "xfun", "xml2"]
+      "version": "1.8.0",
+      "sha256": "0q6vlrxk5v463mvddcz42m747cv2z7kvzl3zbbx5823s1rk5syx4",
+      "depends": ["ComplexHeatmap", "DBI", "DT", "GenomeInfoDb", "GenomicRanges", "IRanges", "Matrix", "RColorBrewer", "RSQLite", "RefManageR", "Rsamtools", "S4Vectors", "Seurat", "SeuratObject", "SingleCellExperiment", "bibtex", "bslib", "circlize", "colourpicker", "data_table", "fs", "ggdendro", "ggforce", "ggplot2", "ggrepel", "ggridges", "gridExtra", "htmltools", "jsonlite", "magrittr", "patchwork", "plotly", "rhdf5", "rtracklayer", "scales", "scrypt", "shiny", "shinyhelper", "shinymanager", "slingshot", "sortable", "xfun", "xml2"]
     },
     "scReClassify": {
       "name": "scReClassify",
-      "version": "1.12.0",
-      "sha256": "0c95lijjd9775vrgg55wwms8wivivlwmqnia8vf0lsl6bi21a0yr",
+      "version": "1.14.0",
+      "sha256": "13xbcby3pc7f38af42sdq2nv57kr7sfzxprk70i8fs9jkajbxk5w",
       "depends": ["SingleCellExperiment", "SummarizedExperiment", "e1071", "randomForest"]
     },
     "scRecover": {
       "name": "scRecover",
-      "version": "1.22.0",
-      "sha256": "020zgypbfx0dznkxisak4wgiww331hvr58a1fcn05mwl6f40aqri",
+      "version": "1.24.0",
+      "sha256": "1g1yj2w3v5f5smh17qm7wk0r7cnx020iiya0dbvx6ziyhy6c5xyj",
       "depends": ["BiocParallel", "MASS", "Matrix", "SAVER", "bbmle", "doParallel", "foreach", "gamlss", "kernlab", "penalized", "preseqR", "pscl", "rsvd"]
     },
     "scRepertoire": {
       "name": "scRepertoire",
-      "version": "2.2.1",
-      "sha256": "0id62pkjyk48jxica8mfzb2mzwc5f1ijb7d5200grxzn453zsihm",
-      "depends": ["Rcpp", "S4Vectors", "SeuratObject", "SingleCellExperiment", "SummarizedExperiment", "VGAM", "assertthat", "cubature", "dplyr", "evmix", "ggalluvial", "ggdendro", "ggplot2", "ggraph", "hash", "iNEXT", "igraph", "lifecycle", "plyr", "purrr", "quantreg", "reshape2", "rjson", "rlang", "stringdist", "stringr", "tidygraph", "truncdist"]
+      "version": "2.4.0",
+      "sha256": "1lywcwh7zbjnfad2lxma5xxq33ah0kai65nxahls0lfk0j4xibyw",
+      "depends": ["Rcpp", "S4Vectors", "SeuratObject", "SingleCellExperiment", "SummarizedExperiment", "VGAM", "assertthat", "cubature", "dplyr", "evmix", "ggalluvial", "ggdendro", "ggplot2", "ggraph", "iNEXT", "igraph", "lifecycle", "plyr", "purrr", "quantreg", "reshape2", "rjson", "rlang", "stringdist", "stringr", "tidygraph", "truncdist"]
     },
     "scShapes": {
       "name": "scShapes",
-      "version": "1.12.0",
-      "sha256": "1a6rrbb4zg0x6sg0p15p8xa6kj3k506kx4zrh8vwa98iv04ni7sy",
+      "version": "1.14.0",
+      "sha256": "1m3kxysv96ir16d8rsnwsfprfq96r1iyh2ahl6c5jdn50zwycjv4",
       "depends": ["BiocParallel", "MASS", "Matrix", "VGAM", "dgof", "emdbook", "magrittr", "pscl"]
     },
     "scTGIF": {
       "name": "scTGIF",
-      "version": "1.20.0",
-      "sha256": "12kr33gbhd3xljyfi8jv1pyhk09i6p2ykcqvyb5r4g3b2k7drk77",
+      "version": "1.22.0",
+      "sha256": "0q4nz5vgawvlacgxai2p6v28qzh5766ypvd2wp348k2gzjdj91sv",
       "depends": ["Biobase", "BiocStyle", "GSEABase", "RColorBrewer", "Rcpp", "S4Vectors", "SingleCellExperiment", "SummarizedExperiment", "ggplot2", "igraph", "knitr", "msigdbr", "nnTensor", "plotly", "rmarkdown", "scales", "schex", "tagcloud", "tibble"]
     },
     "scTHI": {
       "name": "scTHI",
-      "version": "1.18.0",
-      "sha256": "173rlfl7cjcp9jhqkzl02rg9nynbgnc2ps0sxy4yrfpkw6272fb1",
+      "version": "1.20.0",
+      "sha256": "0b6vg445cags0vbxlbcqb5zchc6v2v2mf5jz70pxwjh68p3rwazn",
       "depends": ["BiocParallel", "Rtsne"]
     },
     "scTensor": {
       "name": "scTensor",
-      "version": "2.16.0",
-      "sha256": "0h91dxmsl6lsgbv0qaskl7nzk6n575p7di35m69n5abp5bb2r0ac",
+      "version": "2.17.0",
+      "sha256": "13sjq90kwj0a6lf7a3yn6h9a9dysdhka29xsbdxvd0vwmfifk1ph",
       "depends": ["AnnotationDbi", "AnnotationHub", "BiocManager", "BiocStyle", "Category", "DOSE", "GOstats", "MeSHDbi", "RSQLite", "ReactomePA", "S4Vectors", "SingleCellExperiment", "SummarizedExperiment", "abind", "ccTensor", "checkmate", "crayon", "ggplot2", "heatmaply", "igraph", "knitr", "meshr", "nnTensor", "outliers", "plotly", "plotrix", "rTensor", "reactome_db", "rmarkdown", "schex", "tagcloud", "visNetwork"]
     },
     "scTreeViz": {
       "name": "scTreeViz",
-      "version": "1.12.0",
-      "sha256": "1imsjlhpflqjqi89gpbw76s4vd04l3spas0hzpaznpypq3wkzglz",
+      "version": "1.14.0",
+      "sha256": "18df2058v3985j8w5hy9wp8xlf19zcdpbx3hxg7a6kh76hdxcx1h",
       "depends": ["Matrix", "Rtsne", "S4Vectors", "Seurat", "SingleCellExperiment", "SummarizedExperiment", "clustree", "data_table", "digest", "epivizr", "epivizrData", "epivizrServer", "ggplot2", "ggraph", "httr", "igraph", "scater", "scran", "sys"]
     },
     "scanMiR": {
       "name": "scanMiR",
-      "version": "1.12.0",
-      "sha256": "1qg9j82acg5ncx032pdh7ikwss0q4aa7ax64id3fyfqs3fi5z133",
+      "version": "1.14.0",
+      "sha256": "1s3k3hb4x666xczzilbb39nfir0z5sb30q0im0cfxibcjbgm5sps",
       "depends": ["BiocParallel", "Biostrings", "GenomeInfoDb", "GenomicRanges", "IRanges", "S4Vectors", "cowplot", "data_table", "ggplot2", "pwalign", "seqLogo", "stringi"]
     },
     "scanMiRApp": {
       "name": "scanMiRApp",
-      "version": "1.12.0",
-      "sha256": "00lxgnf00pjzjzy9z447afg94cxxvb5yghh0s4sxi60q8xcvdsd7",
+      "version": "1.14.0",
+      "sha256": "0xswhxnyigmm50wz4jdp0a1w8sjb6hyz7zgs30rcdiqk0fw8lfsz",
       "depends": ["AnnotationDbi", "AnnotationFilter", "AnnotationHub", "BiocParallel", "Biostrings", "DT", "GenomeInfoDb", "GenomicFeatures", "GenomicRanges", "IRanges", "Matrix", "S4Vectors", "data_table", "digest", "ensembldb", "fst", "ggplot2", "htmlwidgets", "plotly", "rintrojs", "rtracklayer", "scanMiR", "scanMiRData", "shiny", "shinycssloaders", "shinydashboard", "shinyjqui", "txdbmaker", "waiter"]
     },
     "scater": {
       "name": "scater",
-      "version": "1.34.0",
-      "sha256": "1b4sc5gi2wjcrfm78y0w7df2bb5sw6spjswhsss47shxy6m2vhh1",
+      "version": "1.36.0",
+      "sha256": "12rbjzwbxs78z62p6lfpgb241ah3c5ks6l1vgfz8ysfv5x7j3hpv",
       "depends": ["BiocGenerics", "BiocNeighbors", "BiocParallel", "BiocSingular", "DelayedArray", "Matrix", "MatrixGenerics", "RColorBrewer", "RcppML", "Rtsne", "S4Vectors", "SingleCellExperiment", "SparseArray", "SummarizedExperiment", "beachmat", "ggbeeswarm", "ggplot2", "ggrastr", "ggrepel", "pheatmap", "rlang", "scuttle", "uwot", "viridis"]
     },
     "scatterHatch": {
       "name": "scatterHatch",
-      "version": "1.12.0",
-      "sha256": "0l1lbr9nsb9mmh8n67p39lqmis4l1jb6x39xzlfcyw65sayq73pk",
+      "version": "1.14.0",
+      "sha256": "0r15vzncmrw52wc8lrv17c4g9sgs2923j3xxafn15k5xiyl3hlk3",
       "depends": ["ggplot2", "plyr", "spatstat_geom"]
     },
     "sccomp": {
       "name": "sccomp",
-      "version": "1.10.0",
-      "sha256": "1011rh6bx8vysgljj6z68d833gvprmd4slib1hdapscqhad01zp3",
-      "depends": ["SeuratObject", "SingleCellExperiment", "boot", "callr", "digest", "dplyr", "forcats", "fs", "ggplot2", "ggrepel", "glue", "instantiate", "lifecycle", "magrittr", "patchwork", "purrr", "readr", "rlang", "scales", "stringr", "tibble", "tidyr", "tidyselect", "withr"]
+      "version": "2.0.0",
+      "sha256": "0iy9rjzbdvabmcj09lp3jp495kqxi82513j8f2yfs2icqk41ilzd",
+      "depends": ["SingleCellExperiment", "boot", "crayon", "dplyr", "forcats", "ggplot2", "ggrepel", "glue", "instantiate", "lifecycle", "magrittr", "patchwork", "purrr", "readr", "rlang", "scales", "stringr", "tibble", "tidyr", "tidyselect"]
     },
     "scde": {
       "name": "scde",
-      "version": "2.34.0",
-      "sha256": "1chpic6rjp3vswbqjag11f202lfj3mf2ramqahl8fnzlfjzkb51y",
+      "version": "2.36.0",
+      "sha256": "09i6bzwasbv83d7hgq7ld4dn8pmipxlgpvzl69hc2cblzl18ffd8",
       "depends": ["BiocParallel", "Cairo", "MASS", "RColorBrewer", "RMTstat", "Rcpp", "RcppArmadillo", "Rook", "edgeR", "extRemes", "flexmix", "mgcv", "nnet", "pcaMethods", "quantreg", "rjson"]
     },
     "scds": {
       "name": "scds",
-      "version": "1.22.0",
-      "sha256": "18k3665pndd4vgn5a67kmwxc9jkbngspl20qgdxn3y1hph8mbjw5",
+      "version": "1.24.0",
+      "sha256": "10ylhdxgz6rj4di1xwayprxwfmm8q1w3z98f2012yd89jkqvnykx",
       "depends": ["Matrix", "S4Vectors", "SingleCellExperiment", "SummarizedExperiment", "dplyr", "pROC", "xgboost"]
     },
     "schex": {
       "name": "schex",
-      "version": "1.20.0",
-      "sha256": "01zlax3kx2zvab5bn2wdd5nilsagfrwhd15yzhyqpy2w2x6d00nw",
+      "version": "1.22.0",
+      "sha256": "1pay6f3vl5yl0xm70b4g05ck8yvh4p389rfabjn5drl0b43nb37q",
       "depends": ["SingleCellExperiment", "cluster", "concaveman", "dplyr", "entropy", "ggforce", "ggplot2", "hexbin", "rlang"]
     },
     "scider": {
       "name": "scider",
-      "version": "1.4.0",
-      "sha256": "0mldyb2rwcq2lf73lrkgmc8bg5hamp6r9zw9c0gdrq6fs3lwhk0a",
+      "version": "1.6.0",
+      "sha256": "08bp6yjxdkia0ykgyyapra02rz2qgq5z66pkg2pjppsis1k626cn",
       "depends": ["S4Vectors", "SpatialExperiment", "SummarizedExperiment", "ggplot2", "igraph", "isoband", "janitor", "knitr", "lwgeom", "pheatmap", "plotly", "rlang", "sf", "shiny", "spatstat_explore", "spatstat_geom"]
     },
     "scifer": {
       "name": "scifer",
-      "version": "1.8.1",
-      "sha256": "1f5s4hma2p4fvpspldrs52ry2kvy22gmylbyslid15cy4slx1knh",
+      "version": "1.10.0",
+      "sha256": "0c2qkqn36wd15a3gp9l7kn2g6nz4hkapwvwvv67gk1fp5kz36dyd",
       "depends": ["Biostrings", "DECIPHER", "basilisk", "basilisk_utils", "data_table", "dplyr", "flowCore", "ggplot2", "gridExtra", "here", "kableExtra", "knitr", "plyr", "reticulate", "rlang", "rmarkdown", "sangerseqR", "scales", "stringr", "tibble"]
     },
     "scmap": {
       "name": "scmap",
-      "version": "1.28.0",
-      "sha256": "16ajd19p8ybllm80sr7p6zv8jxs8y4r9cblgzy9f12bby2l71fbz",
+      "version": "1.30.0",
+      "sha256": "091n1703ngh50qkv1dynxszs0mqdawz8mm0n9mhsiiw38z4cg63d",
       "depends": ["Biobase", "BiocGenerics", "Rcpp", "RcppArmadillo", "S4Vectors", "SingleCellExperiment", "SummarizedExperiment", "dplyr", "e1071", "ggplot2", "googleVis", "matrixStats", "proxy", "randomForest", "reshape2"]
     },
     "scmeth": {
       "name": "scmeth",
-      "version": "1.26.0",
-      "sha256": "1fcxmb4wnj9108xswdkxq40a7g6whmizxkw9k4dr0ikdp7d24cwd",
+      "version": "1.28.0",
+      "sha256": "1zi5pa73qy5i0v6xma8la9l9hdh31yg6x1ha5m6i46g45wsh9bdc",
       "depends": ["AnnotationHub", "BSgenome", "Biostrings", "DT", "DelayedArray", "GenomeInfoDb", "GenomicRanges", "HDF5Array", "SummarizedExperiment", "annotatr", "bsseq", "knitr", "reshape2", "rmarkdown"]
     },
     "scone": {
       "name": "scone",
-      "version": "1.30.0",
-      "sha256": "0cmjyxkszidsjzhs6rqw5m7afmy4gw2rvajrm5wagnisk73bvz6i",
-      "depends": ["BiocParallel", "DelayedMatrixStats", "MatrixGenerics", "RColorBrewer", "RUVSeq", "SingleCellExperiment", "SummarizedExperiment", "aroma_light", "boot", "class", "cluster", "compositions", "diptest", "edgeR", "fpc", "gplots", "hexbin", "limma", "matrixStats", "mixtools", "rARPACK", "rhdf5", "sparseMatrixStats"]
+      "version": "1.32.0",
+      "sha256": "16nh3xnplh1zqx976ffpb967wsk89h4lny2pz7r1y2zdzs74la0a",
+      "depends": ["BiocParallel", "DelayedMatrixStats", "MatrixGenerics", "RColorBrewer", "RUVSeq", "SingleCellExperiment", "SparseArray", "SummarizedExperiment", "aroma_light", "boot", "class", "cluster", "compositions", "diptest", "edgeR", "fpc", "gplots", "hexbin", "limma", "matrixStats", "mixtools", "rARPACK", "rhdf5", "sparseMatrixStats"]
     },
     "scoreInvHap": {
       "name": "scoreInvHap",
-      "version": "1.28.0",
-      "sha256": "1awp2l4xfxnk36qcgig1fms39klk9ry5p3r4n5iqvs1qi7v5yma1",
+      "version": "1.30.0",
+      "sha256": "17mckzfw5aqyw2v1j02rm67d4dic9zdqiq9yz5nadmj4wvvg1259",
       "depends": ["BiocParallel", "Biostrings", "GenomicRanges", "SummarizedExperiment", "VariantAnnotation", "snpStats"]
     },
     "scoup": {
       "name": "scoup",
-      "version": "1.0.0",
-      "sha256": "10ajsp3pngwmy5php86cn6q2xf5nnrl44kqjmg17l9vn5jms5ybl",
+      "version": "1.2.0",
+      "sha256": "0231zmyp8iqmcmgrbhlqmfq6i55lhdg0wy6zgsq49l159ac043gs",
       "depends": ["Biostrings", "Matrix"]
     },
     "scp": {
       "name": "scp",
-      "version": "1.16.0",
-      "sha256": "0ld32imgw2qhc6gnjxbhd8q1nx5c9yvab3rqkgd48sm3kz43h3yh",
+      "version": "1.18.0",
+      "sha256": "0gljfvpn6rajppgk4jdnzdh90ghiasajkzyk1rxk61awp8wmlswl",
       "depends": ["IHW", "MsCoreUtils", "MultiAssayExperiment", "QFeatures", "RColorBrewer", "S4Vectors", "SingleCellExperiment", "SummarizedExperiment", "ggplot2", "ggrepel", "matrixStats", "metapod", "nipals"]
     },
     "scran": {
       "name": "scran",
-      "version": "1.34.0",
-      "sha256": "1gi5sv5bb7y8r95sr7cc01cy01j1ymc9piyjmriz0ybyh8flwyrv",
+      "version": "1.36.0",
+      "sha256": "0y2hcxri6w1jqg3hcmn5y3ys59q7nxxd0ynv1d66fwgblwbi856x",
       "depends": ["BH", "BiocGenerics", "BiocParallel", "BiocSingular", "DelayedArray", "Matrix", "MatrixGenerics", "Rcpp", "S4Arrays", "S4Vectors", "SingleCellExperiment", "SummarizedExperiment", "beachmat", "bluster", "dqrng", "edgeR", "igraph", "limma", "metapod", "scuttle", "statmod"]
     },
     "scrapper": {
       "name": "scrapper",
-      "version": "1.0.3",
-      "sha256": "0gvivdlrkbv3s8maz4iaxws3rmk1j80fjcgr7mkhnwxh1cavw0ai",
-      "depends": ["BiocNeighbors", "DelayedArray", "Rcpp", "assorthead", "beachmat", "igraph"]
+      "version": "1.2.0",
+      "sha256": "1jy0fajpcfxjpl8r3m229k4vhzhplziifqnzb181cahlglck10ls",
+      "depends": ["BiocNeighbors", "DelayedArray", "Rcpp", "Rigraphlib", "assorthead", "beachmat"]
     },
     "screenCounter": {
       "name": "screenCounter",
-      "version": "1.6.0",
-      "sha256": "0mnd2f5i41sx1qy96v5mf93bc5m4cwwc2kwn2q6hkbzxkb0rd5na",
-      "depends": ["BiocParallel", "Rcpp", "S4Vectors", "SummarizedExperiment", "zlibbioc"]
+      "version": "1.8.0",
+      "sha256": "0qiqjn2iiwrabfvg92czx5c15fv6pharywg4mdbf989k0k4ivq8c",
+      "depends": ["BiocParallel", "Rcpp", "S4Vectors", "SummarizedExperiment"]
     },
     "scruff": {
       "name": "scruff",
-      "version": "1.24.0",
-      "sha256": "1wnr7dqhc8ddss5nh3jdhqgzqnn44kfmy89mgdks8a6nbn1drvyr",
+      "version": "1.26.0",
+      "sha256": "0pqpz83lc9djjqnjanrg18mcbmgv979s15daz6ndb78l83k8v24r",
       "depends": ["AnnotationDbi", "BiocGenerics", "BiocParallel", "Biostrings", "GenomeInfoDb", "GenomicAlignments", "GenomicFeatures", "GenomicRanges", "Rsamtools", "Rsubread", "S4Vectors", "ShortRead", "SingleCellExperiment", "SummarizedExperiment", "data_table", "ggbio", "ggplot2", "ggthemes", "parallelly", "plyr", "rtracklayer", "scales", "stringdist", "txdbmaker"]
     },
     "scry": {
       "name": "scry",
-      "version": "1.18.0",
-      "sha256": "09l8w1b2n8kwhmn8373hfddj38gdddar0jfq0cz80kqb98xh3d37",
+      "version": "1.20.0",
+      "sha256": "07v96b4ydzil9d80gjpifs8dvd92273g32pp3pmzi386f569bxdw",
       "depends": ["BiocSingular", "DelayedArray", "Matrix", "SingleCellExperiment", "SummarizedExperiment", "glmpca"]
     },
     "scuttle": {
       "name": "scuttle",
-      "version": "1.16.0",
-      "sha256": "0h13a9pgsm3w324622qlp9nqpvq6gsjwcyd44d6w5yzrl9jcsliv",
+      "version": "1.18.0",
+      "sha256": "0y3fa8bvjpzv45z2kmxc1ii46yw2rrkam229na3107l1a1wg80iq",
       "depends": ["BiocGenerics", "BiocParallel", "DelayedArray", "GenomicRanges", "Matrix", "MatrixGenerics", "Rcpp", "S4Arrays", "S4Vectors", "SingleCellExperiment", "SparseArray", "SummarizedExperiment", "beachmat"]
     },
     "scviR": {
       "name": "scviR",
-      "version": "1.6.0",
-      "sha256": "0ylpvvfb5dvrh1bf9my8d24af1v3g5c50hvpmh9p54gazqpcqjwf",
+      "version": "1.8.0",
+      "sha256": "1m0p4l8s8bgsbmcd9qb0shax5fdhlk7j2g31vms8asypah0m9am0",
       "depends": ["BiocFileCache", "MatrixGenerics", "S4Vectors", "SingleCellExperiment", "SummarizedExperiment", "basilisk", "limma", "pheatmap", "reticulate", "scater", "shiny"]
     },
     "seahtrue": {
       "name": "seahtrue",
-      "version": "1.0.0",
-      "sha256": "1awprkfzqhp77rc6l432rm7ay7vx5ywgcw1am4xg7rgxlnm7yfz6",
+      "version": "1.2.0",
+      "sha256": "12klglc3sjp9qpkcrd7lhpk17f1fbsci5f8a89cnfp4rwmbqw7qh",
       "depends": ["RColorBrewer", "cli", "colorspace", "dplyr", "forcats", "ggplot2", "ggridges", "glue", "janitor", "logger", "lubridate", "purrr", "readr", "readxl", "rlang", "scales", "stringr", "tibble", "tidyr", "tidyxl", "validate"]
     },
     "sechm": {
       "name": "sechm",
-      "version": "1.14.0",
-      "sha256": "15xlssacx8cv6pn1kzv7zj0i9jqw2zi98h0vhqkj5iqyz30m6m65",
+      "version": "1.16.0",
+      "sha256": "0h1qc5qp1wv6qs9dy9wjs8xjdsqv933wxmpg71l80jwahixy3izp",
       "depends": ["ComplexHeatmap", "S4Vectors", "SummarizedExperiment", "circlize", "matrixStats", "randomcoloR", "seriation"]
     },
     "segmentSeq": {
       "name": "segmentSeq",
-      "version": "2.40.0",
-      "sha256": "08qk47m8yz467678qcjb7gvdpc7lksrgv14k3f1riwbjz4s2js1k",
+      "version": "2.42.0",
+      "sha256": "0smb0ch4ffj41gfr54wlk4lbxrdiywckjbb468x4ybgg4fd66my2",
       "depends": ["GenomeInfoDb", "GenomicRanges", "IRanges", "Rsamtools", "S4Vectors", "ShortRead", "abind", "baySeq"]
     },
     "segmenter": {
       "name": "segmenter",
-      "version": "1.12.0",
-      "sha256": "0sgagbabps2zh0wh5asw5r3yjlhh0ygs5cy5pqxh23p7v5yk9wsx",
+      "version": "1.13.0",
+      "sha256": "0z9f347xccp99r1xlic707kp48arswah4bvf2m26g3rs92asd2mn",
       "depends": ["ChIPseeker", "ComplexHeatmap", "GenomicRanges", "IRanges", "S4Vectors", "SummarizedExperiment", "bamsignals", "chromhmmData"]
     },
     "selectKSigs": {
       "name": "selectKSigs",
-      "version": "1.18.0",
-      "sha256": "0c4b4fk1nqas2chjllqds2a1iv2879c4vsg053m9hq8schv5x5dx",
+      "version": "1.20.0",
+      "sha256": "0cnif7xvljzl83v7k6ky827kpk5kd3r8lzz78iwrinp2mw1gpp48",
       "depends": ["HiLDA", "Rcpp", "gtools", "magrittr"]
     },
     "semisup": {
       "name": "semisup",
-      "version": "1.30.0",
-      "sha256": "1c0i163xsf0g0bsfjgcbj7vgw8jr55fxv1bcd4hn026sh4j5vkn9",
+      "version": "1.32.0",
+      "sha256": "0rjzk4zmvckxbmib7c094jkcs4ai3sj2i20cwqqig1hc6h95b6r9",
       "depends": ["VGAM"]
     },
     "seq_hotSPOT": {
       "name": "seq.hotSPOT",
-      "version": "1.6.0",
-      "sha256": "02mcwi2rp4dvvhz28gi50lr4anp7mxk8af1ivxkfbvpd2pj3xp4z",
+      "version": "1.8.0",
+      "sha256": "0lsd109g423bp3fgw5fkvxdvgqz7a8iljac2qjny1hxx9spvyygb",
       "depends": ["R_utils", "hash"]
     },
     "seq2pathway": {
       "name": "seq2pathway",
-      "version": "1.38.0",
-      "sha256": "1mq03f63qy9g2905wjmgdkf5c4m1b8a22yv2pnhqiqg9p7i3p0j8",
+      "version": "1.40.0",
+      "sha256": "1js23facw3z31fn4g8xrnxsvwfj4ij1spancl243wwnpdspw2vwy",
       "depends": ["GSA", "GenomicRanges", "WGCNA", "biomaRt", "nnet", "seq2pathway_data"]
     },
     "seqArchR": {
       "name": "seqArchR",
-      "version": "1.10.0",
-      "sha256": "1gw9qclal1ibiy09pbpz89m3ccgan24zi8m347zjc36zqwk9x51n",
+      "version": "1.12.0",
+      "sha256": "05i8ln6dbq46v4gnajmrfrnsi2y7mw22dzsmcbc6zni64c2r0186",
       "depends": ["BiocParallel", "Biostrings", "MASS", "Matrix", "cli", "cluster", "cvTools", "fpc", "ggplot2", "ggseqlogo", "matrixStats", "prettyunits", "reshape2", "reticulate"]
     },
     "seqArchRplus": {
       "name": "seqArchRplus",
-      "version": "1.6.0",
-      "sha256": "1i3v3w3hg09f8anz39d0pd124ymj1l1qd6bxyvgwmh8hfbcn5rcp",
+      "version": "1.8.0",
+      "sha256": "17pby4jz6422ndfkxzq19r7js01ai2mp4m6jn1dj622a16gvgkp4",
       "depends": ["BSgenome", "BiocParallel", "Biostrings", "ChIPseeker", "GenomeInfoDb", "GenomicRanges", "IRanges", "RColorBrewer", "S4Vectors", "cli", "clusterProfiler", "cowplot", "factoextra", "ggimage", "ggplot2", "gridExtra", "heatmaps", "magick", "scales", "seqArchR", "seqPattern"]
     },
     "seqCAT": {
       "name": "seqCAT",
-      "version": "1.28.0",
-      "sha256": "1k8850fzxl36hjjc9zmmby1vajhajicq3682d3cagssby2ha7mx1",
+      "version": "1.30.0",
+      "sha256": "0v5cq5zlz7i6rq2d4s4sjz0wi508i9i6v93kkzq998mcc1ycd7y7",
       "depends": ["GenomeInfoDb", "GenomicRanges", "IRanges", "S4Vectors", "SummarizedExperiment", "VariantAnnotation", "dplyr", "ggplot2", "rlang", "rtracklayer", "scales", "tidyr"]
     },
     "seqLogo": {
       "name": "seqLogo",
-      "version": "1.72.0",
-      "sha256": "0a5qndfdlsz38kwiijcshilwp6xiwlx0aqfx9ysw09a2kcb7hwww",
+      "version": "1.74.0",
+      "sha256": "0sahhfdwzj976jghxy9chm7pdyksb1ncncfj70c1asrmd1q6if6h",
       "depends": []
     },
     "seqPattern": {
       "name": "seqPattern",
-      "version": "1.38.0",
-      "sha256": "01dslqflyk7i30wlb2455xqq2zpyz91fg44q4fq6bbp9kj1npazm",
+      "version": "1.40.0",
+      "sha256": "1sjjvp87p0l9kzj27w3bfsp0ms1jqgw2b1isay9l21lkxc1v8y7x",
       "depends": ["Biostrings", "GenomicRanges", "IRanges", "KernSmooth", "plotrix"]
     },
     "seqTools": {
       "name": "seqTools",
-      "version": "1.40.0",
-      "sha256": "1in7dhcm08rnhsnp8hfcaviq821p97mj8dhjvggs1vf4w42s3l2l",
+      "version": "1.42.0",
+      "sha256": "0g9308wmrz9mkf8r1vg8pbz7z2bpcqd6invn30aka18r8kwcim7s",
       "depends": ["zlibbioc"]
     },
     "seqcombo": {
       "name": "seqcombo",
-      "version": "1.28.0",
-      "sha256": "09icq28w4lz3kvhhjx7kgf47y7bn60w39n3lwililzq3hr0arfhh",
+      "version": "1.30.0",
+      "sha256": "1kbx5y8cd8hvycjnqkxksr846ahfwfw31iwhbnp0hmnj88h5ckrf",
       "depends": ["ggplot2", "igraph", "yulab_utils"]
     },
     "seqsetvis": {
       "name": "seqsetvis",
-      "version": "1.26.0",
-      "sha256": "1kwww3kfx36ssvp4ynk11ls43rldc1yxflaiqp73rlbhs1r2sz2v",
+      "version": "1.28.0",
+      "sha256": "1q6mq04qz7h7pfsdb9g6bpvddc0izrml4231s4g3vpynxlbjjy1i",
       "depends": ["GenomeInfoDb", "GenomicAlignments", "GenomicRanges", "IRanges", "RColorBrewer", "Rsamtools", "S4Vectors", "UpSetR", "cowplot", "data_table", "eulerr", "ggplot2", "ggplotify", "limma", "pbapply", "pbmcapply", "png", "rtracklayer", "scales"]
     },
     "sesame": {
       "name": "sesame",
-      "version": "1.24.0",
-      "sha256": "0s7vybr0nd5wx1qjkmfqjkff4wp9qv5ibk2fckzpwlsd2jv3pzng",
+      "version": "1.26.0",
+      "sha256": "0kc5xs0cawxvp6qfrnppkaqx8s52j04cx6cypp05gykq8pyywpyn",
       "depends": ["BiocFileCache", "BiocParallel", "GenomeInfoDb", "GenomicRanges", "IRanges", "MASS", "S4Vectors", "SummarizedExperiment", "dplyr", "ggplot2", "preprocessCore", "readr", "reshape2", "sesameData", "stringr", "tibble", "wheatmap"]
     },
     "sevenC": {
       "name": "sevenC",
-      "version": "1.26.0",
-      "sha256": "1lci7mcmcgxly9izynrqs9dnam96ab2v4k95pqb6hh9dnllfa4xp",
+      "version": "1.28.0",
+      "sha256": "1r0ibaa29dlrz0zjszq7gnbk3dkis2djmzf8vkwqqncsfp1fm0dj",
       "depends": ["BiocGenerics", "GenomeInfoDb", "GenomicRanges", "IRanges", "InteractionSet", "S4Vectors", "boot", "data_table", "purrr", "readr", "rtracklayer"]
     },
     "sevenbridges": {
       "name": "sevenbridges",
-      "version": "1.36.0",
-      "sha256": "0ahg7dyp21k9hknlrbmb6njaikbwwpwsnncrjzni0zgwwqn57j8h",
+      "version": "1.38.0",
+      "sha256": "14c93pljg97rnrrcm45qgjfgdzhic02k13qc072lrdyr33imyh9c",
       "depends": ["S4Vectors", "curl", "data_table", "docopt", "httr", "jsonlite", "objectProperties", "stringr", "uuid", "yaml"]
     },
     "shiny_gosling": {
       "name": "shiny.gosling",
-      "version": "1.2.0",
-      "sha256": "1kak3dk8hra17xwsx35wqm8x40kp6lv6hwbpfxq9bd272v72rzkd",
+      "version": "1.4.0",
+      "sha256": "1as7hrs3kfwxlr9zykdm88gv985gdnmzlrb2hn9zcgsalika53in",
       "depends": ["digest", "fs", "htmltools", "jsonlite", "rjson", "rlang", "shiny", "shiny_react"]
+    },
+    "shinyDSP": {
+      "name": "shinyDSP",
+      "version": "1.0.0",
+      "sha256": "0nd1vl899rk8cia4fmjkbnfxnma5k4alq09hmb410pyzzzchvn07",
+      "depends": ["AnnotationHub", "BiocGenerics", "ComplexHeatmap", "DT", "ExperimentHub", "S4Vectors", "SingleCellExperiment", "SummarizedExperiment", "bsicons", "bslib", "circlize", "cowplot", "dplyr", "edgeR", "ggplot2", "ggpubr", "ggrepel", "htmltools", "limma", "magrittr", "pals", "readr", "scales", "scater", "shiny", "shinyWidgets", "shinycssloaders", "shinyjs", "shinyvalidate", "standR", "stringr", "tibble", "tidyr", "withr"]
     },
     "shinyMethyl": {
       "name": "shinyMethyl",
-      "version": "1.42.0",
-      "sha256": "1gbqyn55y1ybk4y67mj9vms6nzjhdx93ckrfyjkmispwra6drkmg",
+      "version": "1.44.0",
+      "sha256": "1z3ymzjy95qiv3cxgdvvjk98dilbpq218ffa8kdchh9synxwy9m5",
       "depends": ["Biobase", "BiocGenerics", "MatrixGenerics", "RColorBrewer", "htmltools", "minfi", "shiny"]
     },
     "shinyepico": {
       "name": "shinyepico",
-      "version": "1.14.0",
-      "sha256": "0sm09gd6bvpy88c4zc4mm5iibk2s7bf3v7r98c54ap9bgh8g04zv",
+      "version": "1.16.0",
+      "sha256": "1kpn4zhs0dqf7n1875cpphvhd6shdihrcay34x5a57d4xwyw76p4",
       "depends": ["DT", "GenomicRanges", "data_table", "doParallel", "dplyr", "foreach", "ggplot2", "gplots", "heatmaply", "limma", "minfi", "plotly", "reshape2", "rlang", "rmarkdown", "rtracklayer", "shiny", "shinyWidgets", "shinycssloaders", "shinyjs", "shinythemes", "statmod", "tidyr", "zip"]
     },
     "sigFeature": {
       "name": "sigFeature",
-      "version": "1.24.0",
-      "sha256": "1qpfv23ji0616afv5vdkw61q2li7gw0b9axsj6mrid6qakhv598r",
+      "version": "1.26.0",
+      "sha256": "01wq4nrgzd52jclablzl4hpzd4a0vd38kyk5xafxqns856icw68v",
       "depends": ["BiocParallel", "Matrix", "RColorBrewer", "SparseM", "SummarizedExperiment", "biocViews", "e1071", "nlme", "openxlsx", "pheatmap"]
     },
     "siggenes": {
       "name": "siggenes",
-      "version": "1.80.0",
-      "sha256": "0d9yy4mgljgwfv1p57zqwxp7csvmbqzfp46kay0rfmrdad3qzrq7",
+      "version": "1.82.0",
+      "sha256": "1riccriz288gwyjq1gv1gw162mk2qfx0in67dia4xy9q7p4krjz9",
       "depends": ["Biobase", "multtest", "scrime"]
     },
     "sights": {
       "name": "sights",
-      "version": "1.32.0",
-      "sha256": "007rgyj5gpqvb12lb941kqpg80pk9nawqam80n225ilp1wpifylm",
+      "version": "1.34.0",
+      "sha256": "1ipkmqx79j777frqi3l316jxbbd0a1npckwrj2x44jmhs4mzk4zj",
       "depends": ["MASS", "ggplot2", "lattice", "qvalue", "reshape2"]
     },
     "signatureSearch": {
       "name": "signatureSearch",
-      "version": "1.20.0",
-      "sha256": "11khc6aa7wcbk83z4d5n064pg246n18wrwlwhk51w4199nab01ih",
+      "version": "1.22.0",
+      "sha256": "0w8yz6z8pl0qy1nlmaygdmcl57k5bb9hnqglnbs2pr6krkvw9qgi",
       "depends": ["AnnotationDbi", "BiocGenerics", "BiocParallel", "DOSE", "DelayedArray", "ExperimentHub", "GSEABase", "HDF5Array", "Matrix", "RSQLite", "Rcpp", "SummarizedExperiment", "clusterProfiler", "data_table", "dplyr", "fastmatch", "fgsea", "ggplot2", "magrittr", "org_Hs_eg_db", "qvalue", "reactome_db", "readr", "reshape2", "rhdf5", "scales", "tibble", "visNetwork"]
     },
     "signeR": {
       "name": "signeR",
-      "version": "2.8.0",
-      "sha256": "1zxrszphm6c7xspwpknfq09qykx7kq5rr1xmkqblsw4xqp7lf8cs",
+      "version": "2.10.0",
+      "sha256": "0gp2r0r9bhm62zk5zxbwfz13dszsy2w4n24ldl8643mgjdi4fzwr",
       "depends": ["BSgenome", "BiocFileCache", "BiocGenerics", "Biostrings", "DT", "GenomeInfoDb", "GenomicRanges", "IRanges", "MASS", "NMF", "PMCMRplus", "RColorBrewer", "Rcpp", "RcppArmadillo", "VGAM", "VariantAnnotation", "ada", "bsplus", "class", "clue", "cowplot", "dplyr", "e1071", "future", "future_apply", "ggplot2", "ggpubr", "glmnet", "kknn", "listenv", "magrittr", "maxstat", "nloptr", "pROC", "pheatmap", "ppclust", "proxy", "pvclust", "randomForest", "readr", "reshape2", "rtracklayer", "scales", "shiny", "shinyWidgets", "shinycssloaders", "shinydashboard", "survival", "survivalAnalysis", "survminer", "tibble", "tidyr"]
+    },
+    "signifinder": {
+      "name": "signifinder",
+      "version": "1.10.0",
+      "sha256": "1kdlisb2ap7w1fblyqrnpmdn6q2w8vbxc2y4x80p9g75xgjsl8xa",
+      "depends": ["AnnotationDbi", "BiocGenerics", "ComplexHeatmap", "DGEobj_utils", "GSVA", "IRanges", "RColorBrewer", "SpatialExperiment", "SummarizedExperiment", "TxDb_Hsapiens_UCSC_hg19_knownGene", "TxDb_Hsapiens_UCSC_hg38_knownGene", "consensusOV", "cowplot", "dplyr", "ensembldb", "ggplot2", "ggridges", "magrittr", "matrixStats", "maxstat", "openair", "org_Hs_eg_db", "patchwork", "scales", "survival", "survminer", "viridis"]
     },
     "sigsquared": {
       "name": "sigsquared",
-      "version": "1.38.0",
-      "sha256": "1206vfsv77vhq8l6wigajk3w1k39gyn4rkjdxn7a4hb64s9lyhci",
+      "version": "1.40.0",
+      "sha256": "10vmbip6g5cqplhiypzrnxq9fb5vyl18y75c955v49jvhyi29sg9",
       "depends": ["Biobase", "survival"]
     },
     "simPIC": {
       "name": "simPIC",
-      "version": "1.2.0",
-      "sha256": "0hxvqr2ycjdldbsas4vnrnqkhb3lp4q0sdbrh96i40kvlqyf27fl",
+      "version": "1.4.0",
+      "sha256": "17chy5k314s876lpraga7981r1ny9ix30vjilnw69rxz18sdnp65",
       "depends": ["BiocGenerics", "Matrix", "S4Vectors", "SingleCellExperiment", "SummarizedExperiment", "actuar", "checkmate", "fitdistrplus", "matrixStats", "rlang", "scales", "scuttle"]
     },
     "similaRpeak": {
       "name": "similaRpeak",
-      "version": "1.38.0",
-      "sha256": "121ljckgdfd46f0ir1rsrwjxaxnygj22h9jj1nhz5iijk5v70rs5",
+      "version": "1.40.0",
+      "sha256": "0pi5drniv1chj83vbvpm14ssn3s36z9cn2623yv9sqylycyjgl6s",
       "depends": ["R6"]
     },
     "simona": {
       "name": "simona",
-      "version": "1.4.0",
-      "sha256": "13qkca6ch7ppdf1clgzgnygh9zb05163bm5a402pya7wbq2vkdzx",
+      "version": "1.6.0",
+      "sha256": "0d6zyjcrszyavpms883hjh68zwyq5hr0jh3lnhcy2zzkzlz857fd",
       "depends": ["ComplexHeatmap", "GetoptLong", "GlobalOptions", "Polychrome", "Rcpp", "S4Vectors", "circlize", "igraph", "matrixStats", "shiny", "xml2"]
     },
     "simpleSeg": {
       "name": "simpleSeg",
-      "version": "1.8.0",
-      "sha256": "0brm61896vaq7fhaqnnxdqhfc0qyihajbqvmakr8pfp8jhgbxzbh",
+      "version": "1.10.0",
+      "sha256": "03592r9swg2w2d81y4kkm8fw3ypnx9dnq6nnbqa7al9cs5d9if1v",
       "depends": ["BiocParallel", "EBImage", "S4Vectors", "SummarizedExperiment", "cytomapper", "spatstat_geom", "terra"]
     },
     "simplifyEnrichment": {
       "name": "simplifyEnrichment",
-      "version": "2.0.0",
-      "sha256": "04ww535snhd6j6syqfabhi5yrphzlv9ydmvvvxpx5f8x2cai1cp9",
+      "version": "2.2.0",
+      "sha256": "11d3hw43g54x0hind177imgj15n1xjsjcngfa5k1nyc14fv3n2wi",
       "depends": ["AnnotationDbi", "ComplexHeatmap", "GO_db", "GetoptLong", "GlobalOptions", "circlize", "clue", "cluster", "colorspace", "digest", "simona", "slam", "tm"]
     },
     "sincell": {
       "name": "sincell",
-      "version": "1.38.0",
-      "sha256": "1h4pbk42dhsqkim5r3nm1kd4qcfj2ab3yjrsy77hc0zwycsmkmr5",
+      "version": "1.40.0",
+      "sha256": "1y3ylnnbmryxsdwlbmb3848kzjzvfhdrq7qwmcwkvj4cnffygmgc",
       "depends": ["MASS", "Rcpp", "Rtsne", "TSP", "cluster", "entropy", "fastICA", "fields", "ggplot2", "igraph", "proxy", "reshape2", "scatterplot3d", "statmod"]
     },
     "singleCellTK": {
       "name": "singleCellTK",
-      "version": "2.16.1",
-      "sha256": "06bnm5wi1d2d6hb06n7plwhn59yjnk0gx7mdxbd0p3ifl2carqfd",
+      "version": "2.17.3",
+      "sha256": "10nr5g39vpw9crd97gxl0fx6bnpv67wijv2gh65j1kxni4z1n80c",
       "depends": ["AnnotationHub", "Biobase", "BiocParallel", "ComplexHeatmap", "DESeq2", "DT", "DelayedArray", "DelayedMatrixStats", "DropletUtils", "ExperimentHub", "GSEABase", "GSVA", "GSVAdata", "KernSmooth", "MAST", "Matrix", "ROCR", "R_utils", "Rtsne", "S4Vectors", "Seurat", "SingleCellExperiment", "SingleR", "SoupX", "SummarizedExperiment", "TENxPBMCData", "TSCAN", "TrajectoryUtils", "VAM", "anndata", "ape", "batchelor", "celda", "celldex", "circlize", "cluster", "colorspace", "colourpicker", "cowplot", "data_table", "dplyr", "eds", "enrichR", "ensembldb", "fields", "ggplot2", "ggplotify", "ggrepel", "ggtree", "gridExtra", "igraph", "limma", "magrittr", "matrixStats", "metap", "msigdbr", "multtest", "plotly", "plyr", "reshape2", "reticulate", "rlang", "rmarkdown", "scDblFinder", "scMerge", "scRNAseq", "scater", "scds", "scran", "scuttle", "shiny", "shinyalert", "shinycssloaders", "shinyjs", "stringr", "sva", "tibble", "tidyr", "tximport", "withr", "yaml", "zellkonverter", "zinbwave"]
     },
     "singscore": {
       "name": "singscore",
-      "version": "1.26.0",
-      "sha256": "1yzpmchvkyaca18bybbmf29amh8pilf213gnl8in6cc3nr50f3hv",
+      "version": "1.28.0",
+      "sha256": "122j7k42l5h1nvi91x7vgd8lnda7x353ygmvx3h98dxbxpacpvi4",
       "depends": ["Biobase", "BiocParallel", "GSEABase", "RColorBrewer", "S4Vectors", "SummarizedExperiment", "edgeR", "ggplot2", "ggrepel", "magrittr", "matrixStats", "plotly", "plyr", "reshape", "reshape2", "tidyr"]
     },
     "sitadela": {
       "name": "sitadela",
-      "version": "1.14.0",
-      "sha256": "0yr90jz4hibzwi29gji5f6jgi8hks6kah2zgij8y2kqv606a6by1",
+      "version": "1.16.0",
+      "sha256": "0gqr0c2npz97imhw7a20lx4qp3kdlwp9r4zmb3j8g4hdzxhy57kw",
       "depends": ["Biobase", "BiocGenerics", "Biostrings", "GenomeInfoDb", "GenomicFeatures", "GenomicRanges", "IRanges", "RSQLite", "Rsamtools", "S4Vectors", "biomaRt", "rtracklayer", "txdbmaker"]
     },
     "sitePath": {
       "name": "sitePath",
-      "version": "1.22.0",
-      "sha256": "1qpprf9pppdzhvfh75m9bsa1vwrwv0w6vhj090nx80r8agq3qrhv",
+      "version": "1.24.0",
+      "sha256": "18sjabmiiigwr4cz8b0hn415hcb12qgw5mgvdsay1al4djz33n2d",
       "depends": ["RColorBrewer", "Rcpp", "ape", "aplot", "ggplot2", "ggrepel", "ggtree", "gridExtra", "seqinr", "tidytree"]
     },
     "sizepower": {
       "name": "sizepower",
-      "version": "1.76.0",
-      "sha256": "1rkfg22a1css9wx2jx3pd8sq82dzyrgdr15kcdmx891p6g4bj1bp",
+      "version": "1.78.0",
+      "sha256": "0g776gfipp2gd1k7ad77vznwcydly7j5a350vk59dk75c8mxc84k",
       "depends": []
     },
     "sketchR": {
       "name": "sketchR",
-      "version": "1.2.0",
-      "sha256": "1p3m4bwj3fdm1bmj2q24figjch4j9xrjjqxg9i8a82hx6wiml0j2",
+      "version": "1.4.0",
+      "sha256": "0ykm74i292rdavdahhyb9gr92gc92pz8f49795klm1dfa3m50bzg",
       "depends": ["Biobase", "DelayedArray", "basilisk", "dplyr", "ggplot2", "reticulate", "rlang", "scales"]
     },
     "skewr": {
       "name": "skewr",
-      "version": "1.38.0",
-      "sha256": "1mhfjnai7lnpz2jhcwi2d4iiidzg6mbp0m73g1b2wibvni25r5p2",
+      "version": "1.40.0",
+      "sha256": "11mivap26raymy9xyxd5fk9abgdnfj0f91w2y8mychf63yp02fql",
       "depends": ["IlluminaHumanMethylation450kmanifest", "RColorBrewer", "S4Vectors", "methylumi", "minfi", "mixsmsn", "wateRmelon"]
     },
     "slalom": {
       "name": "slalom",
-      "version": "1.28.0",
-      "sha256": "10x92jv5vfygc6pl1j7mq31k6cic2mxsakqk05s59dvrpka3j960",
+      "version": "1.30.0",
+      "sha256": "03489wmi7yh23vgrvpwj4czaxvq757lnmi3kr9cv0mcqzgw2way1",
       "depends": ["BH", "GSEABase", "Rcpp", "RcppArmadillo", "SingleCellExperiment", "SummarizedExperiment", "ggplot2", "rsvd"]
     },
     "slingshot": {
       "name": "slingshot",
-      "version": "2.14.0",
-      "sha256": "0r9hhc23a3x9rm1ippx39llxfcagwbv70zn67wnyzvfyn93gbi3c",
+      "version": "2.16.0",
+      "sha256": "17s9rmd5dsw65cl218sxz5wg1ysqbwqmvcs3vyffl48j5mmsvqgm",
       "depends": ["S4Vectors", "SingleCellExperiment", "SummarizedExperiment", "TrajectoryUtils", "igraph", "matrixStats", "princurve"]
     },
     "smartid": {
       "name": "smartid",
-      "version": "1.2.0",
-      "sha256": "194h397rggyc5pvdcy3kfbmjvkiginirdrqm9sn4h0j0v7j0lzs4",
+      "version": "1.4.0",
+      "sha256": "02z5zh03p8kq0blfacl2a299mxq5zjqr05y1zmlc26zlvwp3kvbg",
       "depends": ["Matrix", "SummarizedExperiment", "dplyr", "ggplot2", "mclust", "mixtools", "sparseMatrixStats", "tidyr"]
     },
     "smoothclust": {
       "name": "smoothclust",
-      "version": "1.2.0",
-      "sha256": "09s025p5cz9nrfx8kq838labsda57fk4scb8rvv856wrqf4qrccb",
+      "version": "1.4.0",
+      "sha256": "1zb780asdxzpk6s7286r43zn77k9rnxcc1m02hz67a10nc1wsbxr",
       "depends": ["SpatialExperiment", "SummarizedExperiment", "sparseMatrixStats", "spdep"]
+    },
+    "smoppix": {
+      "name": "smoppix",
+      "version": "1.0.0",
+      "sha256": "0jv3rwq73apdh2dsafca95c2kl7lnm3dnrisahmk3afa31g85cs3",
+      "depends": ["BiocParallel", "Matrix", "Rcpp", "Rdpack", "SpatialExperiment", "SummarizedExperiment", "extraDistr", "ggplot2", "lme4", "lmerTest", "openxlsx", "scam", "spatstat_geom", "spatstat_model", "spatstat_random"]
     },
     "snapcount": {
       "name": "snapcount",
-      "version": "1.18.0",
-      "sha256": "1nfkrgkn64vzf169zsw9dyhrdz72gd9sybjhvcc0xfa7mmlr4vwg",
+      "version": "1.20.0",
+      "sha256": "1r7gzwrydn7b5bh34jsfy25mgppz4vrzgj1f4xbbwl43fd0np64q",
       "depends": ["GenomicRanges", "IRanges", "Matrix", "R6", "SummarizedExperiment", "assertthat", "data_table", "httr", "jsonlite", "magrittr", "purrr", "rlang", "stringr"]
     },
     "snifter": {
       "name": "snifter",
-      "version": "1.16.0",
-      "sha256": "0yy4a5hs1hk7a1vkm6kl4xsqa9a4669h527906r4inaia57mivwv",
+      "version": "1.18.0",
+      "sha256": "13xad95ai6ck5v0q0yx5w199byapy1sx1lkkz6j9d1s0sqsb979k",
       "depends": ["assertthat", "basilisk", "irlba", "reticulate"]
     },
     "snm": {
       "name": "snm",
-      "version": "1.54.0",
-      "sha256": "0ybp8yn6ng2hm751811sq5dm6siyx36khl5gc4qm9prwsi5hpp47",
+      "version": "1.56.0",
+      "sha256": "0hhq5818aicmyiq61l33xw0a7131zl3pzyg8v643va0a6bhfci99",
       "depends": ["corpcor", "lme4"]
     },
     "snpStats": {
       "name": "snpStats",
-      "version": "1.56.0",
-      "sha256": "01nijl7cnzbv7pk803nv1fgqgikamlzqcah98s7051bn9xbdn2j8",
+      "version": "1.58.0",
+      "sha256": "04p7dsyd1s9nxzg0fjwvxq7r1k94ncksbn0kk7s0ja8qq6lf8zgz",
       "depends": ["BiocGenerics", "Matrix", "survival", "zlibbioc"]
     },
     "soGGi": {
       "name": "soGGi",
-      "version": "1.38.0",
-      "sha256": "1f9r588dbm063lvxhs2sm5ig1nx5lh93pm8l08jinh999yscnvx6",
+      "version": "1.40.0",
+      "sha256": "1ibq880ccwyg9wi2w92la2lzkk8h0kg3sma8w6v7njh20fi983cx",
       "depends": ["BiocGenerics", "BiocParallel", "Biostrings", "GenomeInfoDb", "GenomicAlignments", "GenomicRanges", "IRanges", "Rsamtools", "S4Vectors", "SummarizedExperiment", "chipseq", "ggplot2", "preprocessCore", "reshape2", "rtracklayer"]
+    },
+    "sosta": {
+      "name": "sosta",
+      "version": "1.0.0",
+      "sha256": "1adj1s8xj9jrnacdwhsd2f4s03abp38qwpminv992lxs90m86m5k",
+      "depends": ["EBImage", "S4Vectors", "SingleCellExperiment", "SpatialExperiment", "SummarizedExperiment", "dplyr", "ggplot2", "patchwork", "rlang", "sf", "smoothr", "spatstat_explore", "spatstat_geom", "spatstat_random", "terra"]
     },
     "spaSim": {
       "name": "spaSim",
-      "version": "1.8.0",
-      "sha256": "03irk00qhzd0cja6sfq5xwi2b66az7y5mm7yny5r439c0kvq2mg3",
+      "version": "1.10.0",
+      "sha256": "1i8bi2x8q9zxg9z2wrhn8k2b6ywz5bypr9f9sml1sijwz7yr9f45",
       "depends": ["RANN", "SpatialExperiment", "SummarizedExperiment", "dplyr", "ggplot2", "spatstat_geom", "spatstat_random"]
+    },
+    "spacexr": {
+      "name": "spacexr",
+      "version": "1.0.0",
+      "sha256": "1pxwinam181g1lxdygjh7rw25h902nckybvj8937fqp91l6ays9c",
+      "depends": ["BiocFileCache", "BiocParallel", "Matrix", "SpatialExperiment", "SummarizedExperiment", "ggplot2", "httr", "memoise", "quadprog", "scatterpie"]
     },
     "sparrow": {
       "name": "sparrow",
-      "version": "1.12.0",
-      "sha256": "1ihw3anhjvqsgw41jfb8x6l9i64kr6z5gf4bzchy90x7vhjrfwrd",
+      "version": "1.14.0",
+      "sha256": "0vkx1917k7k63hj67dkbhmq69f0l07b0kba4mqh5syklqmgbxv9r",
       "depends": ["BiocGenerics", "BiocParallel", "BiocSet", "ComplexHeatmap", "DelayedMatrixStats", "GSEABase", "Matrix", "babelgene", "checkmate", "circlize", "data_table", "edgeR", "ggplot2", "irlba", "limma", "plotly", "viridis"]
     },
     "sparseMatrixStats": {
       "name": "sparseMatrixStats",
-      "version": "1.18.0",
-      "sha256": "0gmp2pwypl1bx0584xy2rv65fkk907g12k71jc76n94mk6lr1q75",
+      "version": "1.20.0",
+      "sha256": "1xds5h7scmas1fpanmyqk9mw1bv85hn7qfp27l577fjklyiyirvr",
       "depends": ["Matrix", "MatrixGenerics", "Rcpp", "matrixStats"]
     },
     "sparsenetgls": {
       "name": "sparsenetgls",
-      "version": "1.24.0",
-      "sha256": "0pga6x9farq59j7kz2ha0vmgkcqjrq8315m9f5xniic00ln7i2xd",
+      "version": "1.26.0",
+      "sha256": "13xbhznpcz0danvp0xl8km23sg87arjh7rx2g56829vi0v5jlh4x",
       "depends": ["MASS", "Matrix", "glmnet", "huge"]
     },
     "spatialDE": {
       "name": "spatialDE",
-      "version": "1.12.0",
-      "sha256": "0646sipx74dflil3rgypsi1rhjcx096zgaxm6a2xwr00vcz6r120",
+      "version": "1.13.0",
+      "sha256": "0dvb3wrbqsv15k1girvvjnzbap6svk3brdfshai4s3is00zhp188",
       "depends": ["Matrix", "SpatialExperiment", "SummarizedExperiment", "basilisk", "checkmate", "ggplot2", "ggrepel", "gridExtra", "reticulate", "scales"]
+    },
+    "spatialFDA": {
+      "name": "spatialFDA",
+      "version": "1.0.0",
+      "sha256": "0brc5cayav544bps9970yv488dc44gh471bpng0m284zwbxnxl94",
+      "depends": ["ExperimentHub", "SpatialExperiment", "SummarizedExperiment", "dplyr", "fda", "ggplot2", "magrittr", "patchwork", "purrr", "refund", "spatstat_explore", "spatstat_geom", "tidyr"]
     },
     "spatialHeatmap": {
       "name": "spatialHeatmap",
-      "version": "2.12.1",
-      "sha256": "0wyrg7lq4dbc3r4mvlphjfd4zif5r4yrnl9rxra028bwha4y0iva",
+      "version": "2.14.0",
+      "sha256": "1m4v5mfl2xzlwnvximj696dp852f17ivkpyxply02hapgmig0hjq",
       "depends": ["Matrix", "S4Vectors", "SingleCellExperiment", "SummarizedExperiment", "data_table", "dplyr", "edgeR", "genefilter", "ggplot2", "ggplotify", "grImport", "gridExtra", "igraph", "reshape2", "rsvg", "shiny", "shinydashboard", "spsComps", "tibble", "xml2"]
     },
     "spatialSimGP": {
       "name": "spatialSimGP",
-      "version": "1.0.0",
-      "sha256": "0j0csb2vdd0m96fyb334zc1j3lzhgyx1p6pimnmq0hqhb7m4pq8f",
+      "version": "1.2.0",
+      "sha256": "0p1svv3fc6jdlbbdwrzcv3rn48nkrj25h6swh18a1iibfhpyf91y",
       "depends": ["MASS", "SpatialExperiment", "SummarizedExperiment"]
     },
     "spatzie": {
       "name": "spatzie",
-      "version": "1.12.0",
-      "sha256": "1qvahba366b6gbmr3ljvzk6jx2i35k92gdxkk1az797r2igcxmpd",
+      "version": "1.14.0",
+      "sha256": "1jvz4szaqx1l7n87dd68mzpgpskxarpkg36qz0nx9x0d9xv4a9jd",
       "depends": ["BSgenome", "BiocGenerics", "GenomeInfoDb", "GenomicFeatures", "GenomicInteractions", "GenomicRanges", "IRanges", "MatrixGenerics", "S4Vectors", "SummarizedExperiment", "TFBSTools", "ggplot2", "matrixStats", "motifmatchr"]
     },
     "specL": {
       "name": "specL",
-      "version": "1.40.0",
-      "sha256": "0hkrr48idq7id198vya047bqi5p52rla3ll8y3xgxmddnaprqm0k",
+      "version": "1.42.0",
+      "sha256": "00hcfxazknvnabd70l17y7mrsiyxajd3hd193krzgdrnn2cc2ynv",
       "depends": ["DBI", "RSQLite", "protViz", "seqinr"]
     },
     "speckle": {
       "name": "speckle",
-      "version": "1.6.0",
-      "sha256": "1ir9k3ik32mvpzmwn6x6lv3dc03djm1sjpv9xhyygy320s00mh9p",
+      "version": "1.8.0",
+      "sha256": "0fq2z29rfzy0g4vmqhcc7rjjhk6g9n658nz3xpdmympmc0955aai",
       "depends": ["Seurat", "SingleCellExperiment", "edgeR", "ggplot2", "limma"]
     },
     "spicyR": {
       "name": "spicyR",
-      "version": "1.18.0",
-      "sha256": "1afi2m2cxk9axdips4vk1d3rs3ws8d784b40ix9m8l1c5p8v1qa4",
-      "depends": ["BiocParallel", "ClassifyR", "S4Vectors", "SingleCellExperiment", "SpatialExperiment", "SummarizedExperiment", "cli", "concaveman", "coxme", "data_table", "dplyr", "ggforce", "ggh4x", "ggnewscale", "ggplot2", "ggthemes", "lmerTest", "magrittr", "pheatmap", "rlang", "scam", "spatstat_explore", "spatstat_geom", "survival", "tibble", "tidyr"]
+      "version": "1.20.0",
+      "sha256": "14qx5kags6c0yfqpmgnc58kr2v986h29fvwjr7czgmnpd05199x5",
+      "depends": ["BiocParallel", "ClassifyR", "S4Vectors", "SingleCellExperiment", "SpatialExperiment", "SummarizedExperiment", "cli", "concaveman", "coxme", "data_table", "dplyr", "ggforce", "ggh4x", "ggnewscale", "ggplot2", "ggthemes", "lifecycle", "lmerTest", "magrittr", "pheatmap", "rlang", "scam", "simpleSeg", "spatstat_explore", "spatstat_geom", "survival", "tibble", "tidyr"]
     },
     "spikeLI": {
       "name": "spikeLI",
-      "version": "2.66.0",
-      "sha256": "1p5cz31l99j7fkxfgjdk7fz4i27dy8bb5w5rqn0d01qvh70xq6cf",
+      "version": "2.68.0",
+      "sha256": "0f44i5z2383v2xi7p15f947li0b63n2dmc42n27frk1g8113arrj",
       "depends": []
     },
     "spiky": {
       "name": "spiky",
-      "version": "1.12.0",
-      "sha256": "1kdjnkyh9f2paikhbhz46yzjqwz4390hw8al7m484ihvqwm961cq",
+      "version": "1.14.0",
+      "sha256": "1d2dmsfg8k59n3mdsjbic7sizhylmvphskwswk41d5wrxfpw40wj",
       "depends": ["BSgenome", "Biostrings", "BlandAltmanLeh", "GenomeInfoDb", "GenomicAlignments", "GenomicRanges", "IRanges", "Rsamtools", "S4Vectors", "bamlss", "ggplot2", "scales"]
     },
     "spillR": {
       "name": "spillR",
-      "version": "1.2.0",
-      "sha256": "1vx4l5ip98brm45bxrp9xwnb6h4gybkvrlz6c50yrqr85jrsih15",
+      "version": "1.4.0",
+      "sha256": "038i8jiwf7xavgzh4awffi3mp8rpcgismqdgjvaqbm4a6ijw3n82",
       "depends": ["CATALYST", "S4Vectors", "SummarizedExperiment", "dplyr", "ggplot2", "spatstat_univar", "tibble", "tidyr", "tidyselect"]
     },
     "spkTools": {
       "name": "spkTools",
-      "version": "1.62.0",
-      "sha256": "02n77lqw47hzcysqd5pyq4gmcns5jxn68ph9l639m6lxrsbgisj8",
+      "version": "1.64.0",
+      "sha256": "0zy0vlvms7g3syb3fzwhnnv4fwnm8i8z1xnnjsr5y77ck8fcm74d",
       "depends": ["Biobase", "RColorBrewer", "gtools"]
     },
     "splatter": {
       "name": "splatter",
-      "version": "1.30.0",
-      "sha256": "07klw1g0ww6fhxbl5a9kgbp7yck08s0fpyjrxkz5rdq5clvb08jk",
+      "version": "1.32.0",
+      "sha256": "1gdmzydahqqhb2s5n1xasqcxsg60zhsmbpy0vhflkm7n6d9cr04y",
       "depends": ["BiocGenerics", "BiocParallel", "S4Vectors", "SingleCellExperiment", "SummarizedExperiment", "checkmate", "crayon", "edgeR", "fitdistrplus", "locfit", "matrixStats", "rlang", "scuttle", "withr"]
     },
     "splineTimeR": {
       "name": "splineTimeR",
-      "version": "1.34.0",
-      "sha256": "0dqdm6f7hv6dvc0ha4014j0isng2fpwnfca6b6gk860ap7ayj79h",
+      "version": "1.36.0",
+      "sha256": "1zms4dn74l6liii23w2l48kq9qwkw0hl29fm6ds8vhyq21aglq25",
       "depends": ["Biobase", "FIs", "GSEABase", "GeneNet", "gtools", "igraph", "limma", "longitudinal"]
     },
     "splots": {
       "name": "splots",
-      "version": "1.72.0",
-      "sha256": "1byvkfrm05l1sjpjypd9z56in940nbj6r38gh3rhvz0fz61g520m",
+      "version": "1.74.0",
+      "sha256": "1c2gk9sj49bq4cbx820lzjv7xc5apr5b51x8b3j8rr20wlfw4sj7",
       "depends": ["RColorBrewer"]
     },
     "spoon": {
       "name": "spoon",
-      "version": "1.2.0",
-      "sha256": "0rw8rcnlyj4hg997kj66yjdqcnv6m0fsa3jc3fgzi4z1icgw06fp",
+      "version": "1.4.0",
+      "sha256": "047vz4bzhch1gik9j295xsj5b9q89fgpz3ml6s8gykp5jy1q4pyb",
       "depends": ["BRISC", "BiocParallel", "Matrix", "SpatialExperiment", "SummarizedExperiment", "nnSVG", "scuttle"]
     },
     "spqn": {
       "name": "spqn",
-      "version": "1.18.0",
-      "sha256": "1h93jr20r8pn1jym7hcf8z6c19aa6hcxzmksfmzvv6pd6plqh4x4",
+      "version": "1.20.0",
+      "sha256": "1b32mxiprh66fiddxz7m3ivmv1263b4xlxvpr2435zmlh9p0hajc",
       "depends": ["BiocGenerics", "SummarizedExperiment", "ggplot2", "ggridges", "matrixStats"]
     },
     "squallms": {
       "name": "squallms",
-      "version": "1.0.0",
-      "sha256": "1b08zp9jnbljhxdw079rlis9pqh9bi3cg3rb0c282rs04b2g5cdv",
+      "version": "1.2.0",
+      "sha256": "1pxr4d9mk430f9ag34gfl8vddpl6ax44q3zxfivl3is9m4153yvb",
       "depends": ["MSnbase", "MsExperiment", "RaMS", "caret", "data_table", "dplyr", "ggplot2", "keys", "plotly", "shiny", "tibble", "tidyr", "xcms"]
+    },
+    "srnadiff": {
+      "name": "srnadiff",
+      "version": "1.28.0",
+      "sha256": "0vxxavx8iqxygr61nnvsm6ggzd41z9fcpdw0lklvl1lpa300bg10",
+      "depends": ["BiocManager", "BiocParallel", "BiocStyle", "DESeq2", "GenomeInfoDb", "GenomicAlignments", "GenomicFeatures", "GenomicRanges", "Gviz", "IRanges", "Rcpp", "Rsamtools", "S4Vectors", "SummarizedExperiment", "edgeR", "rtracklayer"]
     },
     "ssPATHS": {
       "name": "ssPATHS",
-      "version": "1.20.0",
-      "sha256": "0gxf2snqgrlr90v7y6bcbjj4qcxda0pj77d7a9i4ihfy2alclfc6",
+      "version": "1.22.0",
+      "sha256": "08975xg8h2npsc85pba7a83n39ckw29pssnsw63a9s7h7m799vdc",
       "depends": ["MESS", "ROCR", "SummarizedExperiment", "dml"]
     },
     "sscu": {
       "name": "sscu",
-      "version": "2.36.0",
-      "sha256": "10igm6i7fry1iravil16a6nnb426xs2kz5gp96c0x1r6ii2s7v8z",
+      "version": "2.38.0",
+      "sha256": "1ywynv66shgbhszl6hkz092fnjnvmz59khhv9bcgfs3m7g7n8qjr",
       "depends": ["BiocGenerics", "Biostrings", "seqinr"]
     },
     "ssize": {
       "name": "ssize",
-      "version": "1.80.0",
-      "sha256": "18xprihcfxka323x9d1ny7rgxv37cwjjvmyn72f8l15p0041231s",
+      "version": "1.82.0",
+      "sha256": "0w3jgphxa0lqk8ak1s8ryfmkziknx8k0wi5f6y3syv6dags9xlmq",
       "depends": ["gdata", "xtable"]
     },
     "ssrch": {
       "name": "ssrch",
-      "version": "1.22.0",
-      "sha256": "1sbmjg48h06910vbcbwnwbwqvnjvpkyzi2ps8aj16ahpc0a62vi3",
+      "version": "1.24.0",
+      "sha256": "1q0skaym2qzkvrwrvjibkrfwwrixmdc5hcg38jfgv0mbw4k6l6jw",
       "depends": ["DT", "shiny"]
     },
     "ssviz": {
       "name": "ssviz",
-      "version": "1.40.0",
-      "sha256": "093jriz8i2faswzyyckrg8069469l4r845p8amhz7n0mybnck4rz",
+      "version": "1.42.0",
+      "sha256": "1k0d908wjz7m854fhc8j2mikxzq0vrwh6m1d7gn0x8wj944lq0kf",
       "depends": ["Biostrings", "RColorBrewer", "Rsamtools", "ggplot2", "reshape"]
     },
     "stJoincount": {
       "name": "stJoincount",
-      "version": "1.8.0",
-      "sha256": "1b101gsnw704agif9k15b1lyrpj59i0gwl9inwqgqjc867sh4qgq",
+      "version": "1.10.0",
+      "sha256": "1w482p12rcf982887fkz2zas8admi4jdxfblh4wyafjcklqjdz1b",
       "depends": ["Seurat", "SpatialExperiment", "SummarizedExperiment", "dplyr", "ggplot2", "magrittr", "pheatmap", "raster", "sp", "spdep"]
     },
     "stageR": {
       "name": "stageR",
-      "version": "1.28.0",
-      "sha256": "1rab6hcr8nwbpdlfy7c43dy66rwpj7vm0vvm95iislqrfjsc5pqi",
+      "version": "1.30.0",
+      "sha256": "0q4a26z6i3wvjjc0bhif9d3jf1h04bb091jg4and1ih7qfjvr89z",
       "depends": ["SummarizedExperiment"]
     },
     "standR": {
       "name": "standR",
-      "version": "1.10.0",
-      "sha256": "1j8vwh7vycryfnbdwrrayl2ddi93ss7z6nlrdd0r3qmvixwf7i3m",
+      "version": "1.12.0",
+      "sha256": "0k5jq5jr3yi36w32pcqh700s5i8iqnfjwn8kxp6mb0l8rnrpqrwl",
       "depends": ["Biobase", "BiocGenerics", "RUVSeq", "S4Vectors", "SingleCellExperiment", "SpatialExperiment", "SummarizedExperiment", "dplyr", "edgeR", "ggalluvial", "ggplot2", "limma", "mclustcomp", "patchwork", "readr", "rlang", "ruv", "tibble", "tidyr"]
     },
     "statTarget": {
       "name": "statTarget",
-      "version": "1.36.0",
-      "sha256": "13kl9jm2wiq7mii30p9qnl07v3j046819fq6692px9spciw20dvi",
+      "version": "1.38.0",
+      "sha256": "1scs6hpz1n9w36lgpl2hzyq53iif8g5w4xyln5bxfyysgsaq9gs2",
       "depends": ["ROC", "impute", "pdist", "pls", "plyr", "randomForest", "rrcov"]
     },
     "stepNorm": {
       "name": "stepNorm",
-      "version": "1.78.0",
-      "sha256": "1lbb790ih363g1gjgly7xfwq1jlz9623mz5ylls07imhb2g647kq",
+      "version": "1.80.0",
+      "sha256": "0jymh5jpkwzlihnrmbzxv12qdi0l3lqv7hp66bviixvl8waz182v",
       "depends": ["MASS", "marray"]
     },
     "strandCheckR": {
       "name": "strandCheckR",
-      "version": "1.24.0",
-      "sha256": "1iwf1wa6skk9k8j6wl7fdyxrsnv22fr4qjgarpy0qdr32njqc6f5",
-      "depends": ["BiocGenerics", "GenomeInfoDb", "GenomicAlignments", "GenomicRanges", "IRanges", "Rsamtools", "S4Vectors", "TxDb_Hsapiens_UCSC_hg38_knownGene", "dplyr", "ggplot2", "gridExtra", "magrittr", "reshape2", "rmarkdown", "stringr"]
+      "version": "1.26.0",
+      "sha256": "0iig82sx2h50gan3b3af79af8m32vfhxxr8q9c94dfmk3vyy0yck",
+      "depends": ["BiocGenerics", "GenomeInfoDb", "GenomicAlignments", "GenomicRanges", "IRanges", "Rsamtools", "S4Vectors", "TxDb_Hsapiens_UCSC_hg38_knownGene", "dplyr", "ggplot2", "gridExtra", "reshape2", "rlang", "stringr", "tidyselect"]
     },
     "struct": {
       "name": "struct",
-      "version": "1.18.0",
-      "sha256": "0wfv371waxvggy54mibr86n970mipf7nlyci147ainxbw7vbyzi0",
+      "version": "1.19.0",
+      "sha256": "16f0yqhwd6ih9d1hjckdgb98iqgkk03kx6cvwxi9ymwv8wi025dz",
       "depends": ["S4Vectors", "SummarizedExperiment", "knitr", "ontologyIndex", "rols"]
     },
     "structToolbox": {
       "name": "structToolbox",
-      "version": "1.18.2",
-      "sha256": "1qddpr9y5wn2ljp2ahiqsn2vpgn38s47f2kglywfk6amq45v6qd9",
+      "version": "1.20.0",
+      "sha256": "1wy0bw3a6q11w1fi4i17kswfjql9865rim1znhrmfq91vqndqldp",
       "depends": ["ggplot2", "ggthemes", "gridExtra", "scales", "sp", "struct"]
     },
     "subSeq": {
       "name": "subSeq",
-      "version": "1.36.0",
-      "sha256": "1vyfcph16ld4n8nvk1f05s8nfhzp55864950zr7g0q27mzblrdsw",
+      "version": "1.38.0",
+      "sha256": "1x65q9bjypsr7ph68q2wl0aqjwsh5xrjzs1c7zjpl0rxrwwm3p3r",
       "depends": ["Biobase", "data_table", "digest", "dplyr", "ggplot2", "magrittr", "qvalue", "tidyr"]
     },
     "supersigs": {
       "name": "supersigs",
-      "version": "1.14.0",
-      "sha256": "1yan41y4z6ngi8aiaszvdc7l579468129i3a18r5ww0xc09s0xjb",
+      "version": "1.16.0",
+      "sha256": "0l1mqpjv3qparkpraghbxxf2gf8i5mfllsgfyaaagx6bf4v6rxw9",
       "depends": ["Biostrings", "SummarizedExperiment", "assertthat", "caret", "dplyr", "rlang", "rsample", "tidyr"]
     },
     "surfaltr": {
       "name": "surfaltr",
-      "version": "1.12.0",
-      "sha256": "0dk1j6933lpzjy4h80rrqjxfjlbrmjk0yf5lf5k55daxxa7lfdl6",
+      "version": "1.14.0",
+      "sha256": "0lxgkzl3ygdv8s1f455fqzj77sljkqqxlp87pqan6pwcbapipl7a",
       "depends": ["Biostrings", "biomaRt", "dplyr", "ggplot2", "httr", "msa", "protr", "readr", "seqinr", "stringr", "testthat", "xml2"]
     },
     "survClust": {
       "name": "survClust",
-      "version": "1.0.0",
-      "sha256": "19311dcc82fm3a40bmaj2bsgckhrb164w542i17nvin48la9ha54",
+      "version": "1.2.0",
+      "sha256": "1yf74rbqbqz8pqkm3nld9l9a7jrz0scfc6cqxs1ji55yqjyhy4vw",
       "depends": ["MultiAssayExperiment", "Rcpp", "pdist", "survival"]
     },
     "survcomp": {
       "name": "survcomp",
-      "version": "1.56.0",
-      "sha256": "10dia4ys97kka23jrdkaih9sm6azqnbnks1inmw4gr8q8h9jy9x8",
+      "version": "1.58.0",
+      "sha256": "0ddxikvaihig2vvqcc3w223kvq7mrqmsswihr6x4rhs6f78v383h",
       "depends": ["KernSmooth", "SuppDists", "bootstrap", "ipred", "prodlim", "rmeta", "survival", "survivalROC"]
     },
     "survtype": {
       "name": "survtype",
-      "version": "1.22.0",
-      "sha256": "0b0nf19r3zg9abzb3blzj368l67zl3hkbyzhnwl8fqlankh30yj4",
+      "version": "1.24.0",
+      "sha256": "0qwwapqq8m0rdrgknyww59hmg8qn50dlngvz4a9hasxh4rnbph08",
       "depends": ["SummarizedExperiment", "clustvarsel", "pheatmap", "survival", "survminer"]
     },
     "sva": {
       "name": "sva",
-      "version": "3.54.0",
-      "sha256": "0syq6jsb6f2i3x47xr34n0k09bm1184sx0wnkh46v6jrfgbsh0qd",
+      "version": "3.56.0",
+      "sha256": "0l02ckbvvgxw266rxx7cbmsr436yr4jf43b18kbnpl666i3dlxix",
       "depends": ["BiocParallel", "edgeR", "genefilter", "limma", "matrixStats", "mgcv"]
     },
     "svaNUMT": {
       "name": "svaNUMT",
-      "version": "1.12.0",
-      "sha256": "1w355djqi9wzrk2b26hn23vn7kyszx261wsw02h85yl9gy16b4m9",
+      "version": "1.14.0",
+      "sha256": "12b5yfdlxk6bnkhhp67vlq2ias1rsyzq529a19cr2piz6wn5iw2s",
       "depends": ["BiocGenerics", "Biostrings", "GenomeInfoDb", "GenomicFeatures", "GenomicRanges", "S4Vectors", "StructuralVariantAnnotation", "VariantAnnotation", "assertthat", "dplyr", "pwalign", "rlang", "rtracklayer", "stringr"]
     },
     "svaRetro": {
       "name": "svaRetro",
-      "version": "1.12.0",
-      "sha256": "0k338zl5znhdw3dnal3603k5qqk4mhhpcama497zr9bpf9ccmqvh",
+      "version": "1.14.0",
+      "sha256": "0b2afyjrqwbyi2p8v07qgfimd234ycjk972y0jqnay1ryma84ql8",
       "depends": ["BiocGenerics", "Biostrings", "GenomeInfoDb", "GenomicFeatures", "GenomicRanges", "S4Vectors", "StructuralVariantAnnotation", "VariantAnnotation", "assertthat", "dplyr", "rlang", "rtracklayer", "stringr"]
     },
     "swfdr": {
       "name": "swfdr",
-      "version": "1.32.0",
-      "sha256": "10xjrdwja9mc1111jrkhlq76g7zx29gcnly27rhfd27vm5qpd2s5",
+      "version": "1.34.0",
+      "sha256": "12sqy09l95gidc7fcplhnacm7d0wx20yzddnphymxd0mh188qnmv",
       "depends": []
     },
     "switchBox": {
       "name": "switchBox",
-      "version": "1.42.0",
-      "sha256": "0czwps5dp1nk490nq3q3bm5ml934xaxil1c42cr61cvb15lv9giw",
+      "version": "1.44.0",
+      "sha256": "1w9nzcwrdxs042yyf1ic12crb5w8ylyyn35nd5xiicszyih9vwgg",
       "depends": ["gplots", "pROC"]
     },
     "switchde": {
       "name": "switchde",
-      "version": "1.32.0",
-      "sha256": "1k4fzbrbgb1zim2pwiccb73hd4nsk2gk9lp1zqb4kw0hcab0yl1a",
+      "version": "1.34.0",
+      "sha256": "0a97mlyhxnmv4ahnk2wbjngjy80c02yq2ch001j1vfpvp3jrk3y1",
       "depends": ["SingleCellExperiment", "SummarizedExperiment", "dplyr", "ggplot2"]
     },
     "synapsis": {
       "name": "synapsis",
-      "version": "1.12.0",
-      "sha256": "08hn4a73yw8vkdn122pdixa0q88py05lj0jryisn8yyw5ycsyk76",
+      "version": "1.14.0",
+      "sha256": "1253f4k4zw0cwcgkw492mf45m63pak6z40k1w6p5yaszn4nggib7",
       "depends": ["EBImage"]
     },
     "synapter": {
       "name": "synapter",
-      "version": "2.30.0",
-      "sha256": "1av9q8b0rp7l5y8mb8c385q0x91bfym679fm3zj35bwr0y615fqx",
+      "version": "2.31.0",
+      "sha256": "09jcnaw6mhcwk1mzysk3ryy6j11dasj3dkz7gajlgm855wcznkmp",
       "depends": ["Biobase", "Biostrings", "MSnbase", "RColorBrewer", "cleaver", "lattice", "multtest", "qvalue", "readr", "rmarkdown"]
     },
     "synergyfinder": {
       "name": "synergyfinder",
-      "version": "3.14.0",
-      "sha256": "0yj28q0z99y6lrjq73rpz4p5s1pqyq8wf9gbdy4xh62f9g3ji23k",
+      "version": "3.16.0",
+      "sha256": "0023giyw9jms8h6wx8fs1lkzq16q6i7x9kh222qxjrn7d75ccp5h",
       "depends": ["SpatialExtremes", "dplyr", "drc", "furrr", "future", "ggforce", "ggplot2", "ggrepel", "gstat", "kriging", "lattice", "magrittr", "metR", "mice", "nleqslv", "pbapply", "plotly", "purrr", "reshape2", "sp", "stringr", "tidyr", "tidyverse", "vegan"]
     },
     "synlet": {
       "name": "synlet",
-      "version": "2.6.0",
-      "sha256": "1li47g72g2naxx5vcx0h4amc7j07wn759id1w91xbamrh35s21cr",
+      "version": "2.8.0",
+      "sha256": "0zfwzblj1ch5ijc72ckslhhwiing005hzmkv0q0zd81rpyadpw5z",
       "depends": ["RColorBrewer", "RankProd", "data_table", "ggplot2", "magrittr", "patchwork"]
     },
     "syntenet": {
       "name": "syntenet",
-      "version": "1.8.1",
-      "sha256": "18bx1zaj4vdaw6hvxfnfqj78ssmdc4rcsm89bz4yl5vjqfljbam8",
+      "version": "1.10.0",
+      "sha256": "1zrycma4mdxlcfph478pfcllm0nbvs1qaw7smk2ik6khrs6d66l6",
       "depends": ["BiocParallel", "Biostrings", "GenomicRanges", "RColorBrewer", "Rcpp", "ggnetwork", "ggplot2", "igraph", "intergraph", "pheatmap", "rlang", "rtracklayer", "testthat"]
     },
     "systemPipeR": {
       "name": "systemPipeR",
-      "version": "2.12.0",
-      "sha256": "1f27vb03x1vmhi9nmizfzrvkyczhgrsgmc5fcf5xnyfmmhs97cnr",
+      "version": "2.14.0",
+      "sha256": "05zrcj46z3305hn6p2744w0ilsg7r2xxgm4y33pra0397ga43a13",
       "depends": ["BiocGenerics", "Biostrings", "GenomicRanges", "Rsamtools", "S4Vectors", "ShortRead", "SummarizedExperiment", "crayon", "ggplot2", "htmlwidgets", "magrittr", "stringr", "yaml"]
     },
     "systemPipeShiny": {
       "name": "systemPipeShiny",
-      "version": "1.16.0",
-      "sha256": "0a7d5qnb8brk4qh16ycn0p0qf5r96amfg0dg2da4g27i916rh1hy",
+      "version": "1.18.0",
+      "sha256": "0z459cr5jcnrirdjf8n4bzv1ai053vg1bq1vcn2v6ykavpghrk84",
       "depends": ["DT", "R6", "RSQLite", "assertthat", "bsplus", "crayon", "dplyr", "drawer", "ggplot2", "glue", "htmltools", "magrittr", "openssl", "plotly", "rlang", "rstudioapi", "shiny", "shinyAce", "shinyFiles", "shinyWidgets", "shinydashboard", "shinydashboardPlus", "shinyjqui", "shinyjs", "shinytoastr", "spsComps", "spsUtil", "stringr", "styler", "tibble", "vroom", "yaml"]
     },
     "systemPipeTools": {
       "name": "systemPipeTools",
-      "version": "1.14.0",
-      "sha256": "0bhj2vwngcika347bqyg4z9mghb7bc6d2h8ickdywlym8pzskvxc",
+      "version": "1.16.0",
+      "sha256": "0kmi6rj0cqdhpc673ai0knwzyvy7mvizjw33aw6hlnd2ry35iclj",
       "depends": ["DESeq2", "DT", "GGally", "Rtsne", "SummarizedExperiment", "ape", "dplyr", "ggplot2", "ggrepel", "ggtree", "glmpca", "magrittr", "pheatmap", "plotly", "tibble"]
     },
     "tLOH": {
       "name": "tLOH",
-      "version": "1.14.0",
-      "sha256": "1dkhjhxfpll8gjxjzbpqpjh1pxy029i3pgpz3940a03kxrydpczg",
+      "version": "1.16.0",
+      "sha256": "11yn96yb3i4kwqp41qdcgwj771xzdvrgwycdsxm83zycc38lqsdh",
       "depends": ["GenomicRanges", "MatrixGenerics", "VariantAnnotation", "bestNormalize", "data_table", "depmixS4", "dplyr", "ggplot2", "naniar", "purrr", "scales", "stringr"]
     },
     "tRNA": {
       "name": "tRNA",
-      "version": "1.24.0",
-      "sha256": "1s8gqk8fcdxk4cg4l3p2h8hlw5bxwr793p5kjjax8n1gdywxzkhr",
+      "version": "1.26.0",
+      "sha256": "1b39fyfg3kn0dadq1apq25rqmszf4mb58kz9jiq3fdss3sxl316j",
       "depends": ["BiocGenerics", "Biostrings", "GenomicRanges", "IRanges", "Modstrings", "S4Vectors", "Structstrings", "XVector", "ggplot2", "scales", "stringr"]
     },
     "tRNAdbImport": {
       "name": "tRNAdbImport",
-      "version": "1.24.0",
-      "sha256": "10w0grspgd0781z84fpiam6h92j1mvlplpg9arrhlax1fkk4xbyj",
+      "version": "1.26.0",
+      "sha256": "0ldrn67kjzjzndjyx3zx3a0s1dglkz2g57yrm5f9wg9gjdgqy44n",
       "depends": ["Biostrings", "GenomicRanges", "IRanges", "Modstrings", "S4Vectors", "Structstrings", "httr2", "stringr", "tRNA", "xml2"]
     },
     "tRNAscanImport": {
       "name": "tRNAscanImport",
-      "version": "1.26.0",
-      "sha256": "0751bzxn418vdpz6jblazw9wiwxmsgmp7b2n9h1c6hm26qvj3jb7",
+      "version": "1.28.0",
+      "sha256": "0zzkk6p7jw1z06faj55h8qqh0n8xm2x5i062f55b6nggfk5kam26",
       "depends": ["BSgenome", "BiocGenerics", "Biostrings", "GenomeInfoDb", "GenomicRanges", "IRanges", "Rsamtools", "S4Vectors", "Structstrings", "XVector", "rtracklayer", "stringr", "tRNA"]
     },
     "tRanslatome": {
       "name": "tRanslatome",
-      "version": "1.44.0",
-      "sha256": "0ns6ki18zzq58k78xc8f5qy2hciin2xjylgs6kq7z1hrf2a2ajfh",
+      "version": "1.46.0",
+      "sha256": "041f3p900nxgdgj3dlas7wjlr6ix5qck01ccmq15cm4bspb3fw0g",
       "depends": ["Biobase", "DESeq2", "GOSemSim", "Heatplus", "RankProd", "anota", "edgeR", "gplots", "limma", "org_Hs_eg_db", "plotrix", "topGO"]
     },
     "tadar": {
       "name": "tadar",
-      "version": "1.4.0",
-      "sha256": "1swf778qa0cd6mvxybg26yhlfpagqjnw4c07ww3az08nqlyj9qnc",
-      "depends": ["BiocGenerics", "GenomeInfoDb", "GenomicRanges", "Gviz", "IRanges", "MatrixGenerics", "Rsamtools", "S4Vectors", "VariantAnnotation", "ggplot2", "rlang"]
+      "version": "1.6.0",
+      "sha256": "0rnmsnd0k6psh69d11bcz2khx0ppqd92fn9lgnsayvx2kayayj50",
+      "depends": ["BiocGenerics", "GenomeInfoDb", "GenomicRanges", "Gviz", "IRanges", "MatrixGenerics", "Rsamtools", "S4Vectors", "VariantAnnotation", "ggplot2", "lifecycle", "rlang"]
     },
     "tanggle": {
       "name": "tanggle",
-      "version": "1.12.0",
-      "sha256": "0wa5lnj9fl1arpwadavclqqad1nqzlr6dwljyfijda9v5pjxb068",
+      "version": "1.14.0",
+      "sha256": "0v461653bm3sik6d1sy8ad87vkyl94yk60n3civ696j15mnk0rlx",
       "depends": ["ape", "ggplot2", "ggtree", "phangorn"]
     },
     "target": {
       "name": "target",
-      "version": "1.20.0",
-      "sha256": "1y628h6d886pxwvz6b1lpwk8r0yg45rpdnajsblq9lhyc0386hdd",
+      "version": "1.22.0",
+      "sha256": "00338jl5yw4g2g8kbkwaln7gxyvg21f4x61ng861ln3g4sad4c5v",
       "depends": ["BiocGenerics", "GenomicRanges", "IRanges", "matrixStats", "shiny"]
     },
     "tenXplore": {
       "name": "tenXplore",
-      "version": "1.28.0",
-      "sha256": "1xngd89im7pbf3v6lbca9c8y781lqwbf6pbnjy427yi54g65qwm0",
+      "version": "1.30.0",
+      "sha256": "0svqk2hcp3dkqa0r94yll17lzjxwnld5ci04k5fmjm28234770f0",
       "depends": ["AnnotationDbi", "BiocFileCache", "SummarizedExperiment", "matrixStats", "ontoProc", "org_Mm_eg_db", "shiny"]
+    },
+    "terapadog": {
+      "name": "terapadog",
+      "version": "1.0.0",
+      "sha256": "0kbbcylr8f99gp2877lcjk786zasvjbjgzgyyrd0zg26r7c4jwzh",
+      "depends": ["DESeq2", "KEGGREST", "biomaRt", "dplyr", "htmlwidgets", "plotly"]
     },
     "ternarynet": {
       "name": "ternarynet",
-      "version": "1.50.0",
-      "sha256": "0vasijm4m2v6px0vrh2vkddaxkmszappr2pahbbhd6fnbghr0dj4",
+      "version": "1.52.0",
+      "sha256": "0a33srg37npd4x8y80s397ca49vfaslmi0mkldabr5kfyp4gpgib",
       "depends": ["BiocParallel", "igraph"]
     },
     "terraTCGAdata": {
       "name": "terraTCGAdata",
-      "version": "1.10.0",
-      "sha256": "1zzlqrs630q47kfv6jd5mdm3c1zrv7sd68dd3l4qd1w2nn44pccq",
+      "version": "1.12.0",
+      "sha256": "0cf0ai3bdpz0xn2fk37lc1iyq3b2yk5k3f63hhhwya0k551liwll",
       "depends": ["AnVIL", "AnVILGCP", "BiocFileCache", "GenomicRanges", "MultiAssayExperiment", "RaggedExperiment", "S4Vectors", "TCGAutils", "dplyr", "readr", "tidyr"]
     },
     "tidyCoverage": {
       "name": "tidyCoverage",
-      "version": "1.2.0",
-      "sha256": "0aapvyrrqvnv1gdj63a5lzzprv9d14a6i07ggz1zjiw4yxdd86h8",
+      "version": "1.4.0",
+      "sha256": "0jhwcs7wda8wfl6904qw3yhlk2nd44i5klg78yxs57077jj63s52",
       "depends": ["BiocIO", "BiocParallel", "GenomeInfoDb", "GenomicRanges", "IRanges", "S4Vectors", "SummarizedExperiment", "cli", "dplyr", "fansi", "ggplot2", "pillar", "purrr", "rlang", "rtracklayer", "scales", "tidyr", "vctrs"]
     },
     "tidyFlowCore": {
       "name": "tidyFlowCore",
-      "version": "1.0.0",
-      "sha256": "0cp3a6ws5lngx1436viznbacr82jgwn7jrpcc4nj6jvx65sp34a3",
+      "version": "1.2.0",
+      "sha256": "18nfv2i0kwv12mam2cja8pfja8amgj9ap5lpvp42zqhvjskgms4c",
       "depends": ["Biobase", "dplyr", "flowCore", "ggplot2", "purrr", "rlang", "stringr", "tibble", "tidyr"]
     },
     "tidySingleCellExperiment": {
       "name": "tidySingleCellExperiment",
-      "version": "1.16.0",
-      "sha256": "1kj4a5dknx0a25w3z4rk8mjh68xd569p0mxx4jhms1pz517l5lc2",
+      "version": "1.18.0",
+      "sha256": "0dw33f55q4af03s7iahrs1hpgk5w5khxls5dp3w9y17gwdmk77qd",
       "depends": ["Matrix", "S4Vectors", "SingleCellExperiment", "SummarizedExperiment", "cli", "dplyr", "ellipsis", "fansi", "ggplot2", "lifecycle", "magrittr", "pillar", "pkgconfig", "purrr", "rlang", "stringr", "tibble", "tidyr", "tidyselect", "ttservice", "vctrs"]
     },
     "tidySpatialExperiment": {
       "name": "tidySpatialExperiment",
-      "version": "1.2.0",
-      "sha256": "04hyxlhyg4yfrybla3ibnsmy4cjvk1sb35s2c9xfbiq6qbphz6lw",
+      "version": "1.4.0",
+      "sha256": "1xzlsdna5wpkb68ij88rd30q19p9d2698xga98mypqh3amh84pib",
       "depends": ["BiocGenerics", "Matrix", "S4Vectors", "SingleCellExperiment", "SpatialExperiment", "SummarizedExperiment", "cli", "dplyr", "fansi", "ggplot2", "lifecycle", "magick", "pillar", "pkgconfig", "plotly", "purrr", "rlang", "shiny", "stringr", "tibble", "tidySingleCellExperiment", "tidygate", "tidyr", "tidyselect", "ttservice", "vctrs"]
     },
     "tidySummarizedExperiment": {
       "name": "tidySummarizedExperiment",
-      "version": "1.16.0",
-      "sha256": "0hjjjdsa6y7zl132403r442h946h012n8s2bv40sq6jsk8nkzcc7",
+      "version": "1.18.0",
+      "sha256": "19f0bawx84jhjkxhrywj09p9ibkr99ys8r5xishg30h7vmzcq083",
       "depends": ["S4Vectors", "SummarizedExperiment", "cli", "dplyr", "ellipsis", "fansi", "ggplot2", "lifecycle", "magrittr", "pillar", "pkgconfig", "purrr", "rlang", "stringr", "tibble", "tidyr", "tidyselect", "ttservice", "vctrs"]
     },
     "tidybulk": {
       "name": "tidybulk",
-      "version": "1.18.0",
-      "sha256": "1l1d3jvafc5mqwfsrkmvckhd47b8728mpxl6s02hy9jx2kwzscas",
+      "version": "1.20.0",
+      "sha256": "0mpinpa29f1rzcch9vwjfhifsmzf8if0dg2ahqzpri074ih29abz",
       "depends": ["GenomicRanges", "Matrix", "S4Vectors", "SummarizedExperiment", "crayon", "dplyr", "lifecycle", "magrittr", "preprocessCore", "purrr", "readr", "rlang", "scales", "stringi", "stringr", "tibble", "tidyr", "tidyselect", "ttservice"]
     },
     "tidyomics": {
       "name": "tidyomics",
-      "version": "1.2.0",
-      "sha256": "0x891j8p75icd9y4dv7k7gd8w12wpmrhp59lkf89wbsivprz0mkf",
+      "version": "1.4.0",
+      "sha256": "18imvbc8dcqn5iykp1gd73ndw39jyf8lymcafhlpswww9ibw2cb5",
       "depends": ["cli", "nullranges", "plyranges", "purrr", "rlang", "stringr", "tidySingleCellExperiment", "tidySummarizedExperiment", "tidybulk", "tidyseurat"]
     },
     "tidysbml": {
       "name": "tidysbml",
-      "version": "1.0.0",
-      "sha256": "1xi7mjsxcp7i655g9zxhvr1174xcqrhcn2b74p5xhhhf3i8cpza0",
+      "version": "1.2.0",
+      "sha256": "0yp08108r1njxg4dfvn7g9ccqxq0by2alxqdmy29j55ky482inz5",
       "depends": ["xml2"]
     },
     "tidytof": {
       "name": "tidytof",
-      "version": "1.0.0",
-      "sha256": "1yw4gz0y5yljj8rhnpmdsa02jg7v2rvag0syb1vmf1i43clq3zn3",
+      "version": "1.2.0",
+      "sha256": "13m028bm21j7404ncvpg7l7qvfkbvcnbrf4rp3xilyl5m6cyvidy",
       "depends": ["Rcpp", "RcppHNSW", "doParallel", "dplyr", "flowCore", "foreach", "ggplot2", "ggraph", "glmnet", "purrr", "readr", "recipes", "rlang", "stringr", "survival", "tibble", "tidygraph", "tidyr", "tidyselect", "yardstick"]
     },
     "tigre": {
       "name": "tigre",
-      "version": "1.60.0",
-      "sha256": "0l0rarssqqk3nn00nxwvhrwi0fsx3gw1pqqiyhvhn37x3c5svhgf",
+      "version": "1.62.0",
+      "sha256": "1mhlw8swf79rymbi6343bxls33czcnv97n59inv46vj5cmax5l2m",
       "depends": ["AnnotationDbi", "Biobase", "BiocGenerics", "DBI", "RSQLite", "annotate", "gplots"]
     },
     "tilingArray": {
       "name": "tilingArray",
-      "version": "1.84.0",
-      "sha256": "13n4myj46zfb7y42phqqy7rmavr8793qg4l8wr04b0634b3dv4jf",
+      "version": "1.86.0",
+      "sha256": "1j5b3400xfhzdffxrq08qk1sigr17r79v27f2iwpawn395vql9a2",
       "depends": ["Biobase", "RColorBrewer", "affy", "genefilter", "pixmap", "strucchange", "vsn"]
     },
     "timeOmics": {
       "name": "timeOmics",
-      "version": "1.18.0",
-      "sha256": "03q44x7nkc0ap78nliqzigsnb383r0hg38k9xmra7jbdsp55aqvi",
+      "version": "1.20.0",
+      "sha256": "00nrah03r01j1n26h2gfim0cwwpajv0k54pmf0dhgmxjy7dbsdqa",
       "depends": ["checkmate", "dplyr", "ggplot2", "ggrepel", "lmtest", "magrittr", "mixOmics", "plyr", "purrr", "stringr", "tibble", "tidyr"]
     },
     "timecourse": {
       "name": "timecourse",
-      "version": "1.78.0",
-      "sha256": "109pz2gm1jnm1lyqr2zjf82g1i0kdipr1h0j3pvlw4w47ccbrxbb",
+      "version": "1.80.0",
+      "sha256": "16w5h3mwzw9kbg4wiw2g9k2n5znx2lkrfd2scj9vp55v6px04kn3",
       "depends": ["Biobase", "MASS", "limma", "marray"]
     },
     "timescape": {
       "name": "timescape",
-      "version": "1.30.0",
-      "sha256": "0y7fdjp00jm0grhjvpvcfgs0ky18s31k8d450d2idf7qf3ac1592",
+      "version": "1.32.0",
+      "sha256": "11wm1ad2qfkiq78z3llk9i5114i10j3mg68r0wa34s90xx765s0k",
       "depends": ["dplyr", "gtools", "htmlwidgets", "jsonlite", "stringr"]
     },
     "tkWidgets": {
       "name": "tkWidgets",
-      "version": "1.84.0",
-      "sha256": "0s43wv4hg6g1x6li1w5zn4nvcyvhp013nh9p8b4b36mpij188lbj",
+      "version": "1.86.0",
+      "sha256": "0ssq1qzlw7bbk3rxbyjbwa0y03bmpbfqgih7bl3p1b5jnr3zv9z5",
       "depends": ["DynDoc", "widgetTools"]
     },
     "tomoda": {
       "name": "tomoda",
-      "version": "1.16.0",
-      "sha256": "03zfagn6bgcmwj55hbszxm9r5g2dcv971f5mr211jxkyiqsgs11c",
+      "version": "1.18.0",
+      "sha256": "01d8xrb35zaf0l4x8c28i1jy9yfwr5s9ngl4fxn67m2ncbg9wfpi",
       "depends": ["RColorBrewer", "Rtsne", "SummarizedExperiment", "ggplot2", "ggrepel", "reshape2", "umap"]
     },
     "tomoseqr": {
       "name": "tomoseqr",
-      "version": "1.10.0",
-      "sha256": "12brpr736165b323y7ysgajvab7y2cmfnpxvyh7fn2fa4hxvn43c",
+      "version": "1.12.0",
+      "sha256": "0w8wajmxy8gk3kviqq65n1v7rnrih4c5c4ppb79hlab698i2nn9c",
       "depends": ["BiocFileCache", "animation", "dplyr", "ggplot2", "plotly", "purrr", "readr", "shiny", "stringr", "tibble"]
     },
     "topGO": {
       "name": "topGO",
-      "version": "2.58.0",
-      "sha256": "1468m14b4hvabg2h14cbaayw34v4zmscn3fmmm37r4abamk7nh0m",
+      "version": "2.59.0",
+      "sha256": "025hsqkjzs07s62dqnh4navqp0iwz0kb59ibz83iamclbyyyxzxq",
       "depends": ["AnnotationDbi", "Biobase", "BiocGenerics", "DBI", "GO_db", "SparseM", "graph", "lattice", "matrixStats"]
     },
     "topconfects": {
       "name": "topconfects",
-      "version": "1.22.0",
-      "sha256": "186cyl0in6xrc3pmy4n0pihmsmg4a3q7xvk58iprmbcbymaws75c",
-      "depends": ["assertthat", "ggplot2"]
+      "version": "1.24.0",
+      "sha256": "1dn4b85jbgd9jbphaxq8ziabf7r02pfv6j42nvqhfnwwxcdfxi0w",
+      "depends": ["assertthat", "ggplot2", "scales"]
     },
     "topdownr": {
       "name": "topdownr",
-      "version": "1.28.0",
-      "sha256": "053s94yzw96vgs062v376spayr5k9m6nz05p0l5pszi7y4p2rfhb",
+      "version": "1.30.0",
+      "sha256": "1h6q9lqlk1h4bqww7hbhjgai3rwnhcnq946dad1xlhwdsw9yb22y",
       "depends": ["Biobase", "BiocGenerics", "Biostrings", "MSnbase", "Matrix", "PSMatch", "ProtGenerics", "S4Vectors", "ggplot2", "mzR"]
     },
     "tpSVG": {
       "name": "tpSVG",
-      "version": "1.2.0",
-      "sha256": "0kbfsi54y3pnk6pyy18pn5ra7ryyvqlala2vqjp2x7h71914pv9c",
+      "version": "1.4.0",
+      "sha256": "0cxd5q1jk5whkcg486gqq90rp203j6ng3ahzvrk8aw1wg4fjzz8z",
       "depends": ["BiocParallel", "MatrixGenerics", "SingleCellExperiment", "SpatialExperiment", "SummarizedExperiment", "mgcv"]
     },
     "trackViewer": {
       "name": "trackViewer",
-      "version": "1.42.0",
-      "sha256": "0qvan15w36ysby5688iz4kdimri2k16w318jgkynijiyg42i8y71",
+      "version": "1.44.0",
+      "sha256": "0x7048mf4i55sf6wr2b1ibpiw2jpw7bdd3w6n9m0dwirg0w487qf",
       "depends": ["AnnotationDbi", "BiocGenerics", "GenomeInfoDb", "GenomicAlignments", "GenomicFeatures", "GenomicRanges", "Gviz", "IRanges", "InteractionSet", "Rsamtools", "S4Vectors", "grImport", "htmlwidgets", "rhdf5", "rtracklayer", "scales", "strawr", "txdbmaker"]
     },
     "tracktables": {
       "name": "tracktables",
-      "version": "1.40.0",
-      "sha256": "1d43526h9bwm0lb2d1x4r94s023syykj7g2kkkij5qmxkzx5kwcn",
+      "version": "1.42.0",
+      "sha256": "10s4j4p6znqjd8bgkfis1mn75801gj2wh4zvj26r60h49dq52q6a",
       "depends": ["GenomicRanges", "IRanges", "RColorBrewer", "Rsamtools", "XML", "XVector", "stringr", "tractor_base"]
     },
     "tradeSeq": {
       "name": "tradeSeq",
-      "version": "1.20.0",
-      "sha256": "1wfq76g6mqf0gkqi9jxqb5va8v59k4ivbdm8d3plmpb6rd23n2ha",
+      "version": "1.22.0",
+      "sha256": "1vfz17rl3x777ssp0dlxxg4wb94703n31ibvxg56xbn1qvb8n0s1",
       "depends": ["Biobase", "BiocParallel", "MASS", "Matrix", "RColorBrewer", "S4Vectors", "SingleCellExperiment", "SummarizedExperiment", "TrajectoryUtils", "edgeR", "ggplot2", "igraph", "magrittr", "matrixStats", "mgcv", "pbapply", "princurve", "slingshot", "tibble", "viridis"]
     },
     "transcriptR": {
       "name": "transcriptR",
-      "version": "1.34.0",
-      "sha256": "00b4wgfvn8785l01vyx6n05l5lpngpk4gp5y2hpkcxrh49q19b45",
+      "version": "1.36.0",
+      "sha256": "182wynhpzh0ri8hxxbia4lnsr416z9j02cy4wcmw6s6wwxi6rw10",
       "depends": ["BiocGenerics", "GenomeInfoDb", "GenomicAlignments", "GenomicFeatures", "GenomicRanges", "IRanges", "Rsamtools", "S4Vectors", "caret", "chipseq", "e1071", "ggplot2", "pROC", "reshape2", "rtracklayer"]
     },
     "transcriptogramer": {
       "name": "transcriptogramer",
-      "version": "1.28.0",
-      "sha256": "047jiznbbdf436qampa9h1njmx1r76r26djmxd8p7sqi1md0gzpm",
+      "version": "1.30.0",
+      "sha256": "00vg9f563jv0wdhyiyw1nfx1v434hhbb6g2bl6r4hvpccfjz2f3s",
       "depends": ["RedeR", "biomaRt", "data_table", "doSNOW", "foreach", "ggplot2", "igraph", "limma", "progress", "snow", "tidyr", "topGO"]
     },
     "transformGamPoi": {
       "name": "transformGamPoi",
-      "version": "1.12.0",
-      "sha256": "0grd27xy0gq6375yxpb9pi6kjlkhbv9rwh5g7j90kb9r2jlfvx9m",
+      "version": "1.14.0",
+      "sha256": "0v6k2rppy64n80c5fpk9d1hvjsqklrzmyp5pq3qr6pxcsgg6d63d",
       "depends": ["DelayedArray", "HDF5Array", "Matrix", "MatrixGenerics", "Rcpp", "SummarizedExperiment", "glmGamPoi"]
     },
     "transite": {
       "name": "transite",
-      "version": "1.24.0",
-      "sha256": "17hxrw042dv8x7s1xx44awqcwvkmz5kpxz1yd9smlql6awc4wmda",
+      "version": "1.26.0",
+      "sha256": "0gy1vvvfhyfxjp1pjzbrkv1hk7skbps677128dk73vw615fiv73s",
       "depends": ["BiocGenerics", "Biostrings", "GenomicRanges", "Rcpp", "TFMPvalue", "dplyr", "ggplot2", "gridExtra", "scales"]
     },
     "transmogR": {
       "name": "transmogR",
-      "version": "1.2.0",
-      "sha256": "0aqlbf95k4cdsn0q0jahhmw0g64ydq5mgnlvpcd0z2qyrm842q1h",
-      "depends": ["BSgenome", "Biostrings", "GenomeInfoDb", "GenomicFeatures", "GenomicRanges", "IRanges", "S4Vectors", "SummarizedExperiment", "VariantAnnotation", "dplyr", "ggplot2", "jsonlite", "matrixStats", "rlang", "scales", "vroom"]
+      "version": "1.4.0",
+      "sha256": "0adpirsymal7pmv3kyzjayh16d21s7alsb69q4i3k90g0bva0f7q",
+      "depends": ["BSgenome", "Biostrings", "GenomeInfoDb", "GenomicFeatures", "GenomicRanges", "IRanges", "S4Vectors", "SummarizedExperiment", "VariantAnnotation", "data_table", "ggplot2", "jsonlite", "matrixStats", "rlang", "scales"]
     },
     "transomics2cytoscape": {
       "name": "transomics2cytoscape",
-      "version": "1.16.0",
-      "sha256": "1rpxqyabn8jsaldabycqq0r3j51il4rn58jvhszj03fjjqmpjxvy",
+      "version": "1.18.0",
+      "sha256": "0a3bnhknmj3kvkca2gssx7hv1ahiqzwdh9p8c0ijdi7ripqsv0cv",
       "depends": ["KEGGREST", "RCy3", "dplyr", "pbapply", "purrr", "tibble"]
     },
     "traseR": {
       "name": "traseR",
-      "version": "1.36.0",
-      "sha256": "1dbmrn078swhdcdkhjljvwq8qaznpmcjah9vs3irpm483xzs8ykm",
+      "version": "1.38.0",
+      "sha256": "15xl952af9gskph0jxcj625z5g14m4r38l56gynjhsjmj9hcnfrm",
       "depends": ["BSgenome_Hsapiens_UCSC_hg19", "GenomicRanges", "IRanges"]
     },
     "treeclimbR": {
       "name": "treeclimbR",
-      "version": "1.2.0",
-      "sha256": "19xwifrc3lml4250hqkzxq8cjkxyl4y179qvcpr3p2grlz5scm1g",
+      "version": "1.4.0",
+      "sha256": "1v7k9lzlymsc5gxchz68abx8g35l5h012cp7z640zdgz30r49v83",
       "depends": ["S4Vectors", "SummarizedExperiment", "TreeSummarizedExperiment", "ape", "diffcyt", "dirmult", "dplyr", "edgeR", "ggnewscale", "ggplot2", "ggtree", "rlang", "tibble", "tidyr", "viridis"]
     },
     "treeio": {
       "name": "treeio",
-      "version": "1.30.0",
-      "sha256": "0x1fd3422icp56ac01dn5nk5y04724sv80pb24fd993d426jj1xj",
+      "version": "1.32.0",
+      "sha256": "1fcr47cj4xqdscc6riyffw5a60iz5hrz87v0ajpi3nmbiab2xjpg",
       "depends": ["ape", "dplyr", "jsonlite", "magrittr", "rlang", "tibble", "tidytree", "yulab_utils"]
     },
     "treekoR": {
       "name": "treekoR",
-      "version": "1.14.0",
-      "sha256": "1xp7h3fmaryalnn8z7drlx4id1crmcw12cflcz40vvy86slwzvi6",
+      "version": "1.16.0",
+      "sha256": "100wzgh7bfq03k96k6k0m4xbxaas8fr04q18p5ppqrq4ywb9d0i8",
       "depends": ["SingleCellExperiment", "ape", "data_table", "diffcyt", "dplyr", "edgeR", "ggiraph", "ggplot2", "ggtree", "hopach", "lme4", "multcomp", "patchwork", "tidyr"]
     },
     "tricycle": {
       "name": "tricycle",
-      "version": "1.14.0",
-      "sha256": "1q9vn0gq67kkg6f4jyq05cg56qmwzl3xhiyhkgpvi1flrj9f8cpd",
+      "version": "1.16.0",
+      "sha256": "0s8ywy4rs9bpn3dm4mr4ml1i5c61121xzmq3n177bwsz83clkp3q",
       "depends": ["AnnotationDbi", "GenomicRanges", "IRanges", "RColorBrewer", "S4Vectors", "SingleCellExperiment", "SummarizedExperiment", "circular", "dplyr", "ggnewscale", "ggplot2", "scater", "scattermore"]
     },
     "trigger": {
       "name": "trigger",
-      "version": "1.52.0",
-      "sha256": "0wi37i7p8mah6hwb2fbpl8x5vnn11xkxq4rlvd8a96ni2gkwvdrn",
+      "version": "1.53.0",
+      "sha256": "1m1gwqjz8b72csygl0yp2jz3i9pv8yxgb3gk5s53bbh27wfh9hk8",
       "depends": ["corpcor", "qtl", "qvalue", "sva"]
     },
     "trio": {
       "name": "trio",
-      "version": "3.44.0",
-      "sha256": "17clz4c8jc6gbj1ry3i1bwfcxljlgr1f29cycnz9294nq9cc7qkv",
-      "depends": ["LogicReg", "siggenes", "survival"]
+      "version": "3.46.0",
+      "sha256": "05l4k349d7nwdbx7g89vl93sn6zqh66rxhjbaas3ffly611fycbd",
+      "depends": ["LogicReg", "data_table", "siggenes", "survival"]
     },
     "triplex": {
       "name": "triplex",
-      "version": "1.46.0",
-      "sha256": "1jxdzcpk5mssxii5y3x89myv762n0yirqlk52biifmfygwxjx10g",
+      "version": "1.48.0",
+      "sha256": "1iycda6qrhiqlq1zpih6mr4ch4cl1npjwxc9dz9j2n6043afz3sv",
       "depends": ["Biostrings", "GenomicRanges", "IRanges", "S4Vectors", "XVector"]
     },
     "tripr": {
       "name": "tripr",
-      "version": "1.12.0",
-      "sha256": "1dar4z6fs83rlipx0di144paghavwg10jrldffdhiqb4flfpvk4x",
+      "version": "1.14.0",
+      "sha256": "0isw18lfs9dz0i5qrkdsw3vprfrd7zcqvr5726hv24pwn2irf3yk",
       "depends": ["DT", "RColorBrewer", "config", "data_table", "dplyr", "golem", "gridExtra", "plot3D", "plotly", "plyr", "shiny", "shinyBS", "shinyFiles", "shinyjs", "stringdist", "stringr", "vegan"]
     },
     "ttgsea": {
       "name": "ttgsea",
-      "version": "1.14.0",
-      "sha256": "08a8rll0vr6k0yl9l52b4a2qmh1xdiwfjnnmma845ymn83q8yjxb",
+      "version": "1.16.0",
+      "sha256": "16b46a59r3rihx9w83pwqpicphk70dszri45jj0xrk4fx5kzqgzr",
       "depends": ["DiagrammeR", "data_table", "keras", "purrr", "stopwords", "text2vec", "textstem", "tm", "tokenizers"]
     },
     "tweeDEseq": {
       "name": "tweeDEseq",
-      "version": "1.52.0",
-      "sha256": "0av6qnv13aw6r5mp8wwgzssm3c5rbvdgbdxkfi7mxn2nyflvxi74",
+      "version": "1.54.0",
+      "sha256": "1xna9h9n7q8ay4a6xbbd293qhfq5vf59vls9vb21jb0zlwig2ikl",
       "depends": ["MASS", "Rcpp", "cqn", "edgeR", "limma"]
     },
     "twilight": {
       "name": "twilight",
-      "version": "1.82.0",
-      "sha256": "08f8krw8jj5dz6acyz4qc7xvg863qaqllscp6989g6hh4k31pbzk",
+      "version": "1.84.0",
+      "sha256": "0kamrxihicjy1n7kwyv8zfclprxysxcj9q04wpk8cwcr1yy34vqx",
       "depends": ["Biobase"]
     },
     "twoddpcr": {
       "name": "twoddpcr",
-      "version": "1.30.0",
-      "sha256": "0g3m3wj7vl54s3c2mdaz174s1hxl53x943v7nvm5h7sslnm3ns47",
+      "version": "1.32.0",
+      "sha256": "0f8xakjz0177d2ckzrsy0kbwa9f40rlwkf8492w0x3wz9z8f71pf",
       "depends": ["RColorBrewer", "S4Vectors", "class", "ggplot2", "hexbin", "scales", "shiny"]
     },
     "txcutr": {
       "name": "txcutr",
-      "version": "1.12.0",
-      "sha256": "1dxza2lk7r84sxvl917fgsasfiny0smyrmbn5sp2m92j2y186rnl",
+      "version": "1.14.0",
+      "sha256": "0p8wxnpbcvrbbmkx2fnsps8sv8f77a6zk1wv8d9lcsb5fxfd2s3m",
       "depends": ["AnnotationDbi", "BiocGenerics", "BiocParallel", "Biostrings", "GenomicFeatures", "GenomicRanges", "IRanges", "S4Vectors", "rtracklayer", "txdbmaker"]
     },
     "txdbmaker": {
       "name": "txdbmaker",
-      "version": "1.2.1",
-      "sha256": "09ix8lzc7rgkxnrk8s53ql0jd96h89wbqvqqpax1i7d5jw15lja6",
+      "version": "1.4.0",
+      "sha256": "0svbfb11hh7q97a5qfs89scs6m9viccky25p0xcxi4zd4m1z6p22",
       "depends": ["AnnotationDbi", "Biobase", "BiocGenerics", "BiocIO", "DBI", "GenomeInfoDb", "GenomicFeatures", "GenomicRanges", "IRanges", "RSQLite", "S4Vectors", "UCSC_utils", "biomaRt", "httr", "rjson", "rtracklayer"]
     },
     "tximeta": {
       "name": "tximeta",
-      "version": "1.24.0",
-      "sha256": "0s978mzq8pw1gj5j4j9yil0z1w5zx0msip11gkiq8wjyiipa6qg1",
+      "version": "1.26.0",
+      "sha256": "1h551lrrb04gww7j6db4399p086hk6igg1q7siqvc7p3l0mxw5bc",
       "depends": ["AnnotationDbi", "AnnotationHub", "BiocFileCache", "Biostrings", "GenomeInfoDb", "GenomicFeatures", "GenomicRanges", "IRanges", "Matrix", "S4Vectors", "SummarizedExperiment", "ensembldb", "jsonlite", "tibble", "txdbmaker", "tximport"]
     },
     "tximport": {
       "name": "tximport",
-      "version": "1.34.0",
-      "sha256": "1rrnldicisjf2cjkvnynlsr91illi6v6wfyqn20xb10p947cyckl",
+      "version": "1.36.0",
+      "sha256": "1ds2h7kmzj0r3sbj7g4w4h6j2vz7j2srbvz5wribdlpa611amqly",
       "depends": []
     },
     "uSORT": {
       "name": "uSORT",
-      "version": "1.32.0",
-      "sha256": "1qcww8jc5zgv92bwa4w6lqpzppmp0j46riz5dqv8cssqnqx48zwb",
+      "version": "1.34.0",
+      "sha256": "15hvv9vj9h2jsics6b4asbmjcm54jgqc3mgsgmgia4njr811a8vi",
       "depends": ["Biobase", "BiocGenerics", "Matrix", "RANN", "RSpectra", "VGAM", "cluster", "fpc", "gplots", "igraph", "monocle", "plyr"]
     },
     "uncoverappLib": {
       "name": "uncoverappLib",
-      "version": "1.16.0",
-      "sha256": "1i28jakbyafa20a7lwbfwks55n7r58caz8c6lzcz63zb5rxijwi9",
+      "version": "1.18.0",
+      "sha256": "1s4arjnwf4dq939a0k56al1lb7l02j20db58qsgys5jlmc79b5gq",
       "depends": ["BiocFileCache", "DT", "EnsDb_Hsapiens_v75", "EnsDb_Hsapiens_v86", "GenomicRanges", "Gviz", "Homo_sapiens", "OrganismDbi", "Rsamtools", "S4Vectors", "TxDb_Hsapiens_UCSC_hg19_knownGene", "TxDb_Hsapiens_UCSC_hg38_knownGene", "condformat", "markdown", "openxlsx", "org_Hs_eg_db", "processx", "rappdirs", "rlist", "shiny", "shinyBS", "shinyWidgets", "shinycssloaders", "shinyjs", "stringr"]
     },
     "unifiedWMWqPCR": {
       "name": "unifiedWMWqPCR",
-      "version": "1.42.0",
-      "sha256": "174dj0vkccabi89jf3ld39ksl6gds9q5kadyrqvvmnp5ic9h59wj",
+      "version": "1.44.0",
+      "sha256": "0dsk0nwlv2g717124rlw80w2ggmkp09mhsn1bwlz8v2yn52qzaj3",
       "depends": ["BiocGenerics", "limma"]
     },
     "universalmotif": {
       "name": "universalmotif",
-      "version": "1.24.2",
-      "sha256": "03wjwi3h6agdvp552cd8mlrlvjjb1wwi0z02yclh0jcxbrd7a90z",
+      "version": "1.26.0",
+      "sha256": "06mhw57ysdfysjyshxzhx6wbw78shni0xgb8ivwrdcf8c1sxkj0c",
       "depends": ["BiocGenerics", "Biostrings", "IRanges", "MASS", "MatrixGenerics", "Rcpp", "RcppThread", "S4Vectors", "ggplot2", "rlang", "yaml"]
     },
     "updateObject": {
       "name": "updateObject",
-      "version": "1.10.0",
-      "sha256": "1r195p39gcnlmcnp5x9mfkb8j53y1yh8rvh527xk54jd6wfd4w4w",
+      "version": "1.12.0",
+      "sha256": "1pwfm6zibi4bcjhqrgb9yz1ixw1kmd1lmgvcv8r1iwc0wvcrvk46",
       "depends": ["BiocGenerics", "S4Vectors", "digest"]
     },
     "variancePartition": {
       "name": "variancePartition",
-      "version": "1.36.3",
-      "sha256": "1xyki5lrpb5wbmgfn1qvkyc4912jv1wsm98njb5krqvvwff1z8hr",
+      "version": "1.38.0",
+      "sha256": "1kwlias43ga649xxm7mlb85s8br6d9sy2ihc31fmi4sx86c912yz",
       "depends": ["Biobase", "BiocParallel", "MASS", "Matrix", "Rdpack", "RhpcBLASctl", "aod", "corpcor", "fANCOVA", "ggplot2", "gplots", "iterators", "limma", "lme4", "lmerTest", "matrixStats", "pbkrtest", "remaCor", "reshape2", "rlang", "scales"]
     },
     "vbmp": {
       "name": "vbmp",
-      "version": "1.74.0",
-      "sha256": "09ib5j0cv5n6w8rvhj45hr0piwigszpjmi6kb81m2k8z7029sz28",
+      "version": "1.76.0",
+      "sha256": "107fdsascnkf2sddqg6n3ncc4b2qiknhx9s74lg05lbzr2p1i12q",
       "depends": []
     },
     "velociraptor": {
       "name": "velociraptor",
-      "version": "1.16.0",
-      "sha256": "1mp5sm5n2z3xkr3ivky4ask1ssncxfg6l30j7d0zd8amd5f7n8s0",
+      "version": "1.18.0",
+      "sha256": "0j9gi0p2jgqhzbyfdykwdsphyjg74phdz6fw1r92qz94fs2hpis3",
       "depends": ["BiocGenerics", "BiocParallel", "BiocSingular", "DelayedArray", "Matrix", "S4Vectors", "SingleCellExperiment", "SummarizedExperiment", "basilisk", "reticulate", "scuttle", "zellkonverter"]
     },
     "veloviz": {
       "name": "veloviz",
-      "version": "1.12.0",
-      "sha256": "1r7qgppq3dp985z46bsfs5dhxa93m5dlpxd7r6r2aiz5j9aw3agr",
+      "version": "1.14.0",
+      "sha256": "1n5xm73iygs8r3r75sibxinm32jh8609dy0ckghfzb0v4kliczcf",
       "depends": ["Matrix", "RSpectra", "Rcpp", "igraph", "mgcv"]
     },
     "vidger": {
       "name": "vidger",
-      "version": "1.26.0",
-      "sha256": "1n2d8awihp1hc6y0xa5gdplv2qbp5460lm4ylikvj2z6cyhfsxhh",
+      "version": "1.28.0",
+      "sha256": "048sdliqp19726crn1jq0cw67wm237wmcc9sn8qchii4d0fijc4z",
       "depends": ["Biobase", "DESeq2", "GGally", "RColorBrewer", "SummarizedExperiment", "edgeR", "ggplot2", "ggrepel", "knitr", "rmarkdown", "scales", "tidyr"]
     },
     "viper": {
       "name": "viper",
-      "version": "1.40.0",
-      "sha256": "0ms0v6hwwyy4n8l452zzdjzim3yiv22p0m6a36pipap976y2n0b7",
+      "version": "1.42.0",
+      "sha256": "090j9vvsi7876hhl15bkfasbicc2rndil6ji6v66b8vk86gdclaz",
       "depends": ["Biobase", "KernSmooth", "e1071", "mixtools"]
+    },
+    "visiumStitched": {
+      "name": "visiumStitched",
+      "version": "1.0.0",
+      "sha256": "1rg0bybpbzvxz4wbq0m9fgpbvcz99gdc3dg0rg3sm1shxx1s54xf",
+      "depends": ["BiocBaseUtils", "BiocGenerics", "DropletUtils", "Matrix", "S4Vectors", "SingleCellExperiment", "SpatialExperiment", "SummarizedExperiment", "dplyr", "imager", "pkgcond", "readr", "rjson", "spatialLIBD", "stringr", "tibble", "tidyr", "xml2"]
     },
     "vissE": {
       "name": "vissE",
-      "version": "1.14.0",
-      "sha256": "0xlv8qgjvl2wrqs4livkbysyj8bfg0fqdjvwvrbv4rrkggppbd35",
+      "version": "1.16.0",
+      "sha256": "0a1z4zjw740p6skm0pxvb7b7x5asdjk5dg2wa12nfc7im0a6nf41",
       "depends": ["GSEABase", "RColorBrewer", "ggforce", "ggplot2", "ggraph", "ggrepel", "ggwordcloud", "igraph", "msigdb", "plyr", "reshape2", "scales", "scico", "textstem", "tidygraph", "tm"]
     },
     "vsclust": {
       "name": "vsclust",
-      "version": "1.8.0",
-      "sha256": "0yi3ij0bphvmrshrf3m922ixw1xdgj2y0cj43dfaih9qf8jdw2fx",
+      "version": "1.10.0",
+      "sha256": "1kackwsy9fp5dk69s89kwdspngz6ak3blffkqx2aj1yj5sbqn6c4",
       "depends": ["MultiAssayExperiment", "Rcpp", "limma", "matrixStats", "qvalue", "shiny"]
     },
     "vsn": {
       "name": "vsn",
-      "version": "3.74.0",
-      "sha256": "0i0fghcrdgivm5amyx2clzqqx4yb3fq7s24v85jmclbsr8fnzm5q",
+      "version": "3.76.0",
+      "sha256": "0nv4v8j0bc7mnmd4y344rsry4wmg6rynlaablka8hb7njnq6gkh6",
       "depends": ["Biobase", "affy", "ggplot2", "lattice", "limma"]
     },
     "vtpnet": {
       "name": "vtpnet",
-      "version": "0.46.0",
-      "sha256": "0n353il4ip0v1khfvg9rljlghlgrgq3f4fdgr5rzzvcaxhfdghik",
+      "version": "0.48.0",
+      "sha256": "07fc511w8jk38blp4d81km8s71ffnshy6x8jjbfnx1vhfq4rjakj",
       "depends": ["GenomicRanges", "doParallel", "foreach", "graph", "gwascat"]
     },
     "vulcan": {
       "name": "vulcan",
-      "version": "1.28.0",
-      "sha256": "0pbfbmk009765m8bqlb27hwz7hrgbi6af5gffwm5ljk6zcg7d8hm",
+      "version": "1.30.0",
+      "sha256": "0pm8kflmm26yvzxb1npas98xpc0d04inzdaf9zgxj3283mdg0ymx",
       "depends": ["Biobase", "ChIPpeakAnno", "DESeq2", "DiffBind", "GenomicRanges", "S4Vectors", "TxDb_Hsapiens_UCSC_hg19_knownGene", "caTools", "csaw", "gplots", "locfit", "viper", "wordcloud", "zoo"]
     },
     "waddR": {
       "name": "waddR",
-      "version": "1.20.0",
-      "sha256": "01w57p09mm7fbx9w7swfy6zvryx31gpmj5jsp9mklij7ivd7wp4c",
+      "version": "1.22.0",
+      "sha256": "0vc1ryyn6pvgjgay57pa8sq9q4jmc6nld4v5pn1ix0jpjmysj0mv",
       "depends": ["BiocFileCache", "BiocParallel", "Rcpp", "RcppArmadillo", "SingleCellExperiment", "arm", "eva"]
     },
     "wateRmelon": {
       "name": "wateRmelon",
-      "version": "2.12.0",
-      "sha256": "0806qbnkxzmyhx80x5ib7qkggqvcpvsm51n9s1cfplzsd7d5jb7i",
+      "version": "2.14.0",
+      "sha256": "0qgya8cva2942mxvwcb53rrs2s8mivg6x4m537l5hk4zvlvz20ym",
       "depends": ["Biobase", "IlluminaHumanMethylation450kanno_ilmn12_hg19", "ROC", "illuminaio", "limma", "lumi", "matrixStats", "methylumi"]
     },
     "wavClusteR": {
       "name": "wavClusteR",
-      "version": "2.40.0",
-      "sha256": "0sgnp5s5lgvkpypcbypls6lnav81d10r3kzyw61bva5xn236vwyx",
+      "version": "2.42.0",
+      "sha256": "1y254sq86vwcs7nz6c9p16nbrpmnshsm1k2dqfgpw7y277fkd8a9",
       "depends": ["BiocGenerics", "Biostrings", "GenomicFeatures", "GenomicRanges", "Hmisc", "IRanges", "Rsamtools", "S4Vectors", "foreach", "ggplot2", "mclust", "rtracklayer", "seqinr", "stringr"]
     },
     "weaver": {
       "name": "weaver",
-      "version": "1.72.0",
-      "sha256": "0vqnrwv204mavggps48pjhazkz2hk4wj2hhjny88m5h3f1amb3hb",
+      "version": "1.74.0",
+      "sha256": "1fb15gnl6kkkv2q7abx9k15jyqagqpp36gy1zvkrv7cljl3735x5",
       "depends": ["codetools", "digest"]
     },
     "webbioc": {
       "name": "webbioc",
-      "version": "1.78.0",
-      "sha256": "0wvkbma50q6ibckhsimarc0qb0rr65ph85amxq2lihvc9w69b7p8",
+      "version": "1.80.0",
+      "sha256": "0w3gzkhxd928k563pfy45fkgrhrgmh0prvnq6128b0vs250s3qpy",
       "depends": ["Biobase", "BiocManager", "affy", "annaffy", "gcrma", "multtest", "qvalue", "vsn"]
     },
     "weitrix": {
       "name": "weitrix",
-      "version": "1.18.0",
-      "sha256": "0lvd6wf4bm5yxz9097hz18amx4kx5mm4lcj6nk8508qpnffz8pqs",
+      "version": "1.20.0",
+      "sha256": "1v11s901cnq2pj582a4j220g3z5l8b4qlxv0xhxzkah03b4vq6j4",
       "depends": ["BiocGenerics", "BiocParallel", "Ckmeans_1d_dp", "DelayedArray", "DelayedMatrixStats", "RhpcBLASctl", "S4Vectors", "SummarizedExperiment", "assertthat", "dplyr", "ggplot2", "glm2", "limma", "purrr", "reshape2", "rlang", "scales", "topconfects"]
     },
     "widgetTools": {
       "name": "widgetTools",
-      "version": "1.84.0",
-      "sha256": "0mi8xnwwlcdh3vj58fg69xbqv12k8xp5jbbd2kkrhcpcvkw0lnxb",
+      "version": "1.86.0",
+      "sha256": "1b7j4fh4cnvw31fkyyfz3k8vm1y2xdsdphcqwhgx74jd6z04pvrs",
       "depends": []
     },
     "wiggleplotr": {
       "name": "wiggleplotr",
-      "version": "1.30.0",
-      "sha256": "1p0x3zrp5hvrfh7cyxdxgniij3yjawrsm1pnz0sw75ps00kw3kpn",
+      "version": "1.32.0",
+      "sha256": "0ncldwkyy0pd97bgv9zps9xh4b2a6apzvy9jhm5n6wgrr0i01zq2",
       "depends": ["GenomeInfoDb", "GenomicRanges", "IRanges", "S4Vectors", "assertthat", "cowplot", "dplyr", "ggplot2", "purrr", "rtracklayer"]
     },
     "wpm": {
       "name": "wpm",
-      "version": "1.16.0",
-      "sha256": "0iax3qncywjfjyqhhj6m9wcfycaqk8yaywg29js387bjwscr2irc",
+      "version": "1.18.0",
+      "sha256": "1snwgkqi2pdwajx7maz14vipjgilxnslc59qgxaxjhfpr630i8yy",
       "depends": ["Biobase", "DT", "RColorBrewer", "SummarizedExperiment", "cli", "config", "dplyr", "ggplot2", "golem", "logging", "rlang", "shiny", "shinyWidgets", "shinycustomloader", "shinydashboard", "stringr"]
     },
     "wppi": {
       "name": "wppi",
-      "version": "1.14.0",
-      "sha256": "0vd90v88k1p5ljbdyd0s2qhsr4b2ja16w610ab41rxwpf62vmxgz",
+      "version": "1.16.0",
+      "sha256": "17rkfbhy0r22ayca4c7n8gr2kjgbj3r4gk1rh423cp566x0n7pcp",
       "depends": ["Matrix", "OmnipathR", "RCurl", "dplyr", "igraph", "logger", "magrittr", "progress", "purrr", "rlang", "tibble", "tidyr"]
+    },
+    "xCell2": {
+      "name": "xCell2",
+      "version": "1.0.0",
+      "sha256": "1hrq387m65sf9nkv6rf8khkwmsk58jmrayn8sxdbnw44pljcw2hk",
+      "depends": ["AnnotationHub", "BiocParallel", "Matrix", "Rfast", "SingleCellExperiment", "SummarizedExperiment", "dplyr", "magrittr", "minpack_lm", "ontologyIndex", "pracma", "progress", "quadprog", "readr", "singscore", "tibble"]
     },
     "xcms": {
       "name": "xcms",
-      "version": "4.4.0",
-      "sha256": "1i9xiilrwvnzkdbzrdnbsw0sbwplfaklbsk3wz8kzv87ivipybh5",
+      "version": "4.6.0",
+      "sha256": "1yf5x69f7m8bqassxzzhys7gbnvsyw79b13xlib156abyjvr5g2b",
       "depends": ["Biobase", "BiocGenerics", "BiocParallel", "IRanges", "MSnbase", "MassSpecWavelet", "MetaboCoreUtils", "MsCoreUtils", "MsExperiment", "MsFeatures", "ProtGenerics", "RColorBrewer", "S4Vectors", "Spectra", "SummarizedExperiment", "lattice", "mzR", "progress"]
     },
     "xcore": {
       "name": "xcore",
-      "version": "1.10.0",
-      "sha256": "11pam90f6q6f1lvjl54jdg8p9rd47pybdcl1xy7g0q1gyygdl6qs",
+      "version": "1.12.0",
+      "sha256": "1i17xqa5gyhhwa98dcfbc5nihwrql4ndpp7prcxvzwiahcgghxay",
       "depends": ["DelayedArray", "GenomicRanges", "IRanges", "Matrix", "MultiAssayExperiment", "S4Vectors", "edgeR", "foreach", "glmnet", "iterators", "magrittr"]
     },
     "xenLite": {
       "name": "xenLite",
-      "version": "1.0.0",
-      "sha256": "18nkq56gnb50i5a0wjqrlmdkp29qf5va5bkyjlvaz01gxrbx445g",
+      "version": "1.2.0",
+      "sha256": "1kc56xzjnl515933q3hhq1gfn111l9m7g629afw3zqrw9dh9j2q7",
       "depends": ["BiocFileCache", "EBImage", "HDF5Array", "Matrix", "S4Vectors", "SingleCellExperiment", "SpatialExperiment", "SummarizedExperiment", "TENxIO", "arrow", "dplyr", "ggplot2", "shiny"]
     },
     "xmapbridge": {
       "name": "xmapbridge",
-      "version": "1.64.0",
-      "sha256": "1r4n5lnps47qrl90m5mm0i3530l0r31hd7hsp2d004sgbmyak304",
+      "version": "1.66.0",
+      "sha256": "1vhvagfpicc35vp25hrf9v56rlqz5yzb4zg5jr01yx1vrz3fikgj",
       "depends": []
     },
     "yamss": {
       "name": "yamss",
-      "version": "1.32.0",
-      "sha256": "1rdqx69x4qqq6lnsk54rha8am51likxvlyqj4lk7rx5gg2390d5q",
+      "version": "1.34.0",
+      "sha256": "1kf7j77sws4al8xb4r9112k5cvix9xw70ikhyj2x49j8psg0y588",
       "depends": ["BiocGenerics", "EBImage", "IRanges", "Matrix", "S4Vectors", "SummarizedExperiment", "data_table", "limma", "mzR"]
     },
     "yarn": {
       "name": "yarn",
-      "version": "1.32.0",
-      "sha256": "0iy130bkx549jn9ki7zgmxw78md9l6rr98rwmv9jzv2a09bddl2c",
+      "version": "1.34.0",
+      "sha256": "1a73jnyz1961kk35s64wb5iz4asbvm59lkhdhvg6r310xb3yp1sz",
       "depends": ["Biobase", "RColorBrewer", "biomaRt", "downloader", "edgeR", "gplots", "limma", "matrixStats", "preprocessCore", "quantro", "readr"]
     },
     "zFPKM": {
       "name": "zFPKM",
-      "version": "1.28.0",
-      "sha256": "1hhlx7xqjlnm90j8hk5qypk225n4w38qsn2v4vdaar96z6lm2rnq",
+      "version": "1.30.0",
+      "sha256": "1ydh535r6x3r6ad0xxnn0iwq1v77xg8ik851gxqy6hnl6gscs1zb",
       "depends": ["SummarizedExperiment", "checkmate", "dplyr", "ggplot2", "tidyr"]
     },
     "zellkonverter": {
       "name": "zellkonverter",
-      "version": "1.16.0",
-      "sha256": "1y1z2vjw04aq139a9f43s4kwl8zbx734s593cm15g0yxjsdpcgxv",
+      "version": "1.18.0",
+      "sha256": "0w221y7mcn6i53lqrkvs00jl315z18hvvxrylg9rlvzmca9ac3ri",
       "depends": ["DelayedArray", "Matrix", "S4Vectors", "SingleCellExperiment", "SummarizedExperiment", "basilisk", "cli", "reticulate"]
     },
     "zenith": {
       "name": "zenith",
-      "version": "1.8.0",
-      "sha256": "1bxbnd8yv4n47g5y2dkk4rgaaqbkmzplh2f9drrjzcy3bmwmvlxx",
-      "depends": ["EnrichmentBrowser", "GSEABase", "Rdpack", "Rfast", "ggplot2", "limma", "msigdbr", "progress", "reshape2", "tidyr", "variancePartition"]
+      "version": "1.10.0",
+      "sha256": "0na9fx9h8a5c8h7fp8lm9pb6basdwz6y7gqq4bi2yfbpyk0k8dz4",
+      "depends": ["EnrichmentBrowser", "GSEABase", "Rdpack", "Rfast", "dplyr", "ggplot2", "limma", "msigdbr", "progress", "reshape2", "tidyr", "variancePartition"]
     },
     "zinbwave": {
       "name": "zinbwave",
-      "version": "1.28.0",
-      "sha256": "0z0414h470674g0w6y11i1mc06vrc075zdcyjjhsj1i8npwqym60",
+      "version": "1.30.0",
+      "sha256": "02rzf371kp7gkklw4yq08mmxkfj7fha2jc7qm00m1d3kwqancljj",
       "depends": ["BiocParallel", "Matrix", "SingleCellExperiment", "SummarizedExperiment", "edgeR", "genefilter", "softImpute"]
     },
     "zitools": {
       "name": "zitools",
-      "version": "1.0.0",
-      "sha256": "0cw83gm6q1d9jd20j8yk8k4vcx7q968winmvpf3pia4hyrc773pf",
+      "version": "1.2.0",
+      "sha256": "1wb4k0c4xxar3ncklvj96b41x15yj90jwbvrmlbqd559bhhqych3",
       "depends": ["BiocGenerics", "DESeq2", "MatrixGenerics", "RColorBrewer", "SummarizedExperiment", "VGAM", "dplyr", "ggplot2", "magrittr", "matrixStats", "phyloseq", "pscl", "reshape2", "tibble", "tidyr"]
     },
     "zlibbioc": {
       "name": "zlibbioc",
-      "version": "1.52.0",
-      "sha256": "0nz17g5dvj57c72csnpnfvylsq3z3c0qxvgsp7l2lcns9xc9rdnz",
+      "version": "1.54.0",
+      "sha256": "0ll3v5b9yk63rqiwm4g0dwan22mqkj2lv1b6czwghbpl1jpv2jrd",
       "depends": []
     },
     "ABAEnrichment": {
@@ -13590,13 +14040,6 @@
       "depends": ["dplyr", "httr", "memoise", "readr", "whisker"],
       "broken": true
     },
-    "BiocHail": {
-      "name": "BiocHail",
-      "version": "1.4.0",
-      "sha256": "1p8wkl31c7snv8l8zkmg2hf9pb2p0gif4gfgjia0npi91y2h5hfp",
-      "depends": ["BiocFileCache", "BiocGenerics", "basilisk", "dplyr", "reticulate"],
-      "broken": true
-    },
     "BiocInstaller": {
       "name": "BiocInstaller",
       "version": "1.20.3",
@@ -13651,6 +14094,13 @@
       "version": "1.2.1",
       "sha256": "0ncpa81ac6dzkhqnr56i4nzzipsmzy44n71z6sdhpa39rgdar2a7",
       "depends": ["ggplot2", "reshape"],
+      "broken": true
+    },
+    "CBEA": {
+      "name": "CBEA",
+      "version": "1.6.0",
+      "sha256": "1mbd62wakjn9pwhy2q2hfxkx09ny577a4j6lssnjj65jb3s7gjr6",
+      "depends": ["BiocParallel", "BiocSet", "Rcpp", "SummarizedExperiment", "TreeSummarizedExperiment", "dplyr", "fitdistrplus", "generics", "glue", "goftest", "lmom", "magrittr", "mixtools", "rlang", "tibble", "tidyr"],
       "broken": true
     },
     "CNPBayes": {
@@ -14185,13 +14635,6 @@
       "depends": ["BiocGenerics", "BiocParallel", "Biostrings", "Cairo", "GenomicAlignments", "GenomicFeatures", "GenomicRanges", "IRanges", "Rsamtools", "S4Vectors", "ShortRead", "VariantAnnotation", "VariantTools", "chipseq", "gmapR", "hwriter", "rtracklayer"],
       "broken": true
     },
-    "HTqPCR": {
-      "name": "HTqPCR",
-      "version": "1.24.0",
-      "sha256": "1bjnirp3ha5ymnv1xyh02d77w7gp36qk62gjfzkbsnhwbwajpdkx",
-      "depends": ["Biobase", "RColorBrewer", "affy", "gplots", "limma"],
-      "broken": true
-    },
     "HumanTranscriptomeCompendium": {
       "name": "HumanTranscriptomeCompendium",
       "version": "1.20.0",
@@ -14316,6 +14759,13 @@
       "version": "1.15.1",
       "sha256": "0742i3fxg2793lhgpxb4whh6mwvzd4bn86ykd0rv8sgilxyq5zsl",
       "depends": ["BH", "bigmemory", "BiocParallel", "Biostrings", "futile_logger", "GenomeInfoDb", "GenomicAlignments", "GenomicRanges", "GEOquery", "gtools", "InteractionSet", "intervals", "IRanges", "knitr", "plyr", "Rbowtie", "Rcpp", "Rsamtools", "rtracklayer", "S4Vectors", "ShortRead"],
+      "broken": true
+    },
+    "MAGeCKFlute": {
+      "name": "MAGeCKFlute",
+      "version": "2.9.0",
+      "sha256": "1m2yq73q9wwv5kfybgnkdb877dy539x9vpx713pr6xjpkqvksfiv",
+      "depends": ["Biobase", "DOSE", "clusterProfiler", "depmap", "enrichplot", "ggplot2", "ggrepel", "gridExtra", "msigdbr", "pathview", "reshape2"],
       "broken": true
     },
     "MCRestimate": {
@@ -14575,13 +15025,6 @@
       "version": "1.32.0",
       "sha256": "023dkbi3r1bs9wiihx3rcdc1dx5w21pfmk0n3n7zan4k5jkz4rwx",
       "depends": ["AnnotationDbi", "Biobase", "Category", "GO_db", "GSEABase", "KEGG_db", "SLGI", "ScISI", "annotate", "graph", "ppiData", "ppiStats"],
-      "broken": true
-    },
-    "PDATK": {
-      "name": "PDATK",
-      "version": "1.12.0",
-      "sha256": "079gdwh9m90r5b0p0szqv222sgdmjr6s3sz19l5xz0435r7h53nv",
-      "depends": ["BiocGenerics", "BiocParallel", "ConsensusClusterPlus", "CoreGx", "MatrixGenerics", "MultiAssayExperiment", "RColorBrewer", "S4Vectors", "SummarizedExperiment", "caret", "clusterRepro", "data_table", "dplyr", "genefu", "ggplot2", "ggplotify", "igraph", "matrixStats", "pROC", "piano", "plyr", "reportROC", "rlang", "scales", "survcomp", "survival", "survminer", "switchBox", "verification"],
       "broken": true
     },
     "PERFect": {
@@ -15109,13 +15552,6 @@
       "depends": ["R2HTML", "gplots", "signal"],
       "broken": true
     },
-    "TBSignatureProfiler": {
-      "name": "TBSignatureProfiler",
-      "version": "1.16.0",
-      "sha256": "1vjd9dwnr6m867d1ax6kwj4w5qs5y81fzrnnjl6xkl2ch3g48jpk",
-      "depends": ["ASSIGN", "BiocParallel", "ComplexHeatmap", "DESeq2", "DT", "GSVA", "RColorBrewer", "ROCit", "S4Vectors", "SummarizedExperiment", "edgeR", "gdata", "ggplot2", "magrittr", "reshape2", "rlang", "singscore"],
-      "broken": true
-    },
     "TCGAbiolinksGUI": {
       "name": "TCGAbiolinksGUI",
       "version": "1.23.0",
@@ -15212,13 +15648,6 @@
       "version": "1.18.0",
       "sha256": "0f7rzzckd69xbnism0v7jl0dly55lwj30nla7yj88qqalnb7ajzs",
       "depends": [],
-      "broken": true
-    },
-    "ViSEAGO": {
-      "name": "ViSEAGO",
-      "version": "1.18.0",
-      "sha256": "06cqx88vndmgxb7vhn7w0kwkxrsn8hy3a3mz591pj48f3z0q9w16",
-      "depends": ["AnnotationDbi", "AnnotationForge", "DT", "DiagrammeR", "GOSemSim", "GO_db", "RColorBrewer", "R_utils", "UpSetR", "biomaRt", "data_table", "dendextend", "dynamicTreeCut", "fgsea", "ggplot2", "heatmaply", "htmlwidgets", "igraph", "plotly", "processx", "scales", "topGO"],
       "broken": true
     },
     "XBSeq": {
@@ -15438,6 +15867,13 @@
       "depends": ["Biobase", "ICSNP", "IRanges", "MASS", "changepoint", "cluster"],
       "broken": true
     },
+    "chromstaR": {
+      "name": "chromstaR",
+      "version": "1.32.0",
+      "sha256": "071aipwk1awr71hvzflps49dzp83p12zm1pbyx4l8d2v3wbj0dlz",
+      "depends": ["BiocGenerics", "GenomeInfoDb", "GenomicAlignments", "GenomicRanges", "IRanges", "Rsamtools", "S4Vectors", "bamsignals", "chromstaRData", "doParallel", "foreach", "ggplot2", "mvtnorm", "reshape2"],
+      "broken": true
+    },
     "chromswitch": {
       "name": "chromswitch",
       "version": "1.22.0",
@@ -15492,13 +15928,6 @@
       "version": "1.5.0",
       "sha256": "09rk73sxqxsy0zq07n67jxqbzb1rlxlj0phg6987szdjwxmag6jc",
       "depends": ["AnnotationDbi", "Biobase", "BiocFileCache", "biomaRt", "clusterProfiler", "dbscan", "doParallel", "dplyr", "factoextra", "foreach", "fpc", "GEOquery", "ggplot2", "gridExtra", "org_Hs_eg_db", "org_Mm_eg_db", "pheatmap", "rlang", "Rtsne", "scales", "scater", "scran", "SingleCellExperiment", "stringr", "SummarizedExperiment"],
-      "broken": true
-    },
-    "consensusOV": {
-      "name": "consensusOV",
-      "version": "1.26.0",
-      "sha256": "0a2qrjid6a5yndkhd47km40qv2c3321xypr5mwlwsq5qp48x7vvq",
-      "depends": ["Biobase", "BiocParallel", "GSVA", "gdata", "genefu", "limma", "matrixStats", "randomForest"],
       "broken": true
     },
     "contiBAIT": {
@@ -15809,13 +16238,6 @@
       "depends": ["Biobase", "BiocGenerics", "Biostrings", "GenomeInfoDb", "GenomicFeatures", "GenomicRanges", "IRanges", "rtracklayer", "S4Vectors", "VariantAnnotation"],
       "broken": true
     },
-    "genefu": {
-      "name": "genefu",
-      "version": "2.2.0",
-      "sha256": "0q49hnxz59hack7j28haazia6qd5pkmgyq5jaypvaa3jnvcsfij7",
-      "depends": ["AIMS", "amap", "biomaRt", "iC10", "mclust", "survcomp"],
-      "broken": true
-    },
     "genoset": {
       "name": "genoset",
       "version": "1.24.0",
@@ -15933,6 +16355,13 @@
       "version": "1.18.0",
       "sha256": "0fjbxczwkn8f4p0h8dgi3vfn4qf9a650wmp01q20j7f0jsmmb06x",
       "depends": ["RBGL", "bgmm"],
+      "broken": true
+    },
+    "lapmix": {
+      "name": "lapmix",
+      "version": "1.72.0",
+      "sha256": "19bhb7654h8pivsf3qxv518zp02ijbvlhkb4d93nyanns3g7zqas",
+      "depends": ["Biobase"],
       "broken": true
     },
     "logitT": {
@@ -16075,6 +16504,13 @@
       "depends": ["SummarizedExperiment"],
       "broken": true
     },
+    "microbiomeMarker": {
+      "name": "microbiomeMarker",
+      "version": "1.12.2",
+      "sha256": "0fkm2sqqsaa8kkdyp0j3zwx8lijgkgk4s45sir3s37an9yai2bp4",
+      "depends": ["ALDEx2", "ANCOMBC", "Biobase", "BiocGenerics", "BiocParallel", "Biostrings", "ComplexHeatmap", "DESeq2", "IRanges", "MASS", "S4Vectors", "biomformat", "caret", "coin", "dplyr", "edgeR", "ggplot2", "ggsignif", "ggtree", "limma", "magrittr", "metagenomeSeq", "multtest", "pROC", "patchwork", "phyloseq", "plotROC", "purrr", "rlang", "tibble", "tidyr", "tidytree", "vegan", "yaml"],
+      "broken": true
+    },
     "mitoODE": {
       "name": "mitoODE",
       "version": "1.8.0",
@@ -16152,6 +16588,13 @@
       "depends": ["AnnotationDbi", "dplyr", "ggplot2", "GO_db", "gprofiler2", "igraph", "magrittr", "minet", "purrr", "RandomWalkRestartMH", "tibble", "tidyr"],
       "broken": true
     },
+    "netZooR": {
+      "name": "netZooR",
+      "version": "1.10.0",
+      "sha256": "11rq1lhxhwij6wik087wmnzk8aswhmmf3yzcpiljxbk8szsm8np7",
+      "depends": ["AnnotationDbi", "Biobase", "GO_db", "GOstats", "MASS", "Matrix", "RCy3", "STRINGdb", "assertthat", "data_table", "doParallel", "dplyr", "foreach", "ggdendro", "ggplot2", "gplots", "igraph", "matrixStats", "matrixcalc", "nnet", "org_Hs_eg_db", "pandaR", "penalized", "reshape", "reshape2", "reticulate", "tidyr", "vegan", "viridisLite", "yarn"],
+      "broken": true
+    },
     "netbenchmark": {
       "name": "netbenchmark",
       "version": "1.2.0",
@@ -16178,13 +16621,6 @@
       "version": "1.12.0",
       "sha256": "0zkf10iqiabsln1jxq0sypr43mrw6k82l3pdp5bg9kcv0bqqqy5k",
       "depends": ["BMA", "Rcpp", "RcppArmadillo", "RcppEigen"],
-      "broken": true
-    },
-    "nondetects": {
-      "name": "nondetects",
-      "version": "2.0.0",
-      "sha256": "0cyp7f90w9vcgwkg0mxrrpv28wihsgbynhq5kjk5hng9qfqjcyxg",
-      "depends": ["Biobase", "HTqPCR", "limma", "mvtnorm"],
       "broken": true
     },
     "nudge": {
@@ -16600,13 +17036,6 @@
       "depends": ["Biobase", "CGHbase", "MASS", "corpcor", "igraph", "marray", "mvtnorm", "penalized", "quadprog", "snowfall"],
       "broken": true
     },
-    "signifinder": {
-      "name": "signifinder",
-      "version": "1.6.0",
-      "sha256": "0r6acaqk7zaryy8ddpfischw08b6sml3cydrw8v9wys0rfv207pb",
-      "depends": ["AnnotationDbi", "BiocGenerics", "ComplexHeatmap", "DGEobj_utils", "GSVA", "IRanges", "RColorBrewer", "SpatialExperiment", "SummarizedExperiment", "TxDb_Hsapiens_UCSC_hg19_knownGene", "TxDb_Hsapiens_UCSC_hg38_knownGene", "consensusOV", "cowplot", "dplyr", "ensembldb", "ggplot2", "ggridges", "magrittr", "matrixStats", "maxstat", "openair", "org_Hs_eg_db", "patchwork", "sparrow", "survival", "survminer", "viridis"],
-      "broken": true
-    },
     "simpleaffy": {
       "name": "simpleaffy",
       "version": "2.46.0",
@@ -16689,13 +17118,6 @@
       "version": "1.44.0",
       "sha256": "074nzh18pj6dpk9bqh8id0j2vpaxvhi2ddrz6hnza381wzdgxdr3",
       "depends": ["mclust"],
-      "broken": true
-    },
-    "srnadiff": {
-      "name": "srnadiff",
-      "version": "1.24.0",
-      "sha256": "0gr754qb5gc0lh1r513yrfrys7q13a0kmbzmbx5m0p7wwp508mdg",
-      "depends": ["BiocManager", "BiocParallel", "BiocStyle", "DESeq2", "GenomeInfoDb", "GenomicAlignments", "GenomicFeatures", "GenomicRanges", "Gviz", "IRanges", "Rcpp", "Rsamtools", "S4Vectors", "SummarizedExperiment", "devtools", "edgeR", "rtracklayer"],
       "broken": true
     },
     "sscore": {

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -1753,6 +1753,13 @@ let
       postPatch = "patchShebangs configure";
     });
 
+    hypeR = old.hypeR.overrideAttrs (attrs: {
+      postPatch = ''
+        substituteInPlace NAMESPACE R/db_msig.R --replace-fail \
+        "msigdbr_show_species" "msigdbr_species"
+      '';
+    });
+
     alcyon = old.alcyon.overrideAttrs (attrs: {
       configureFlags = [
         "--enable-force-openmp"

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -421,6 +421,7 @@ let
       which
     ];
     audio = [ pkgs.portaudio ];
+    BayesChange = [ pkgs.gsl ];
     BayesSAE = [ pkgs.gsl ];
     BayesVarSel = [ pkgs.gsl ];
     BayesXsrc = with pkgs; [

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -787,6 +787,10 @@ let
       libtiff
       curl
     ];
+    fio = with pkgs; [
+      cargo
+      rustc
+    ];
     strawr = with pkgs; [ curl.dev ];
     string2path = [ pkgs.cargo ];
     terra = with pkgs; [
@@ -1731,6 +1735,10 @@ let
           'python_cmds <- c(python_cmds, file.path("${lib.getBin pkgs.python3}", "bin", "python3"))
            python_cmds[which(python_cmds != "")]'
       '';
+    });
+
+    fio = old.fio.overrideAttrs (attrs: {
+      postPatch = "patchShebangs configure";
     });
 
     alcyon = old.alcyon.overrideAttrs (attrs: {

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -795,7 +795,10 @@ let
       geos
     ];
     tok = [ pkgs.cargo ];
-    rshift = [ pkgs.cargo ];
+    rshift = with pkgs; [
+      cargo
+      rustc
+    ];
     arcgisutils = with pkgs; [
       cargo
       rustc
@@ -1714,6 +1717,10 @@ let
     });
 
     arcpbf = old.arcpbf.overrideAttrs (attrs: {
+      postPatch = "patchShebangs configure";
+    });
+
+    rshift = old.rshift.overrideAttrs (attrs: {
       postPatch = "patchShebangs configure";
     });
 

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -693,6 +693,7 @@ let
     ];
     rjags = [ pkgs.jags ];
     rJava = with pkgs; [
+      stripJavaArchivesHook
       zlib
       bzip2.dev
       icu

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -697,6 +697,7 @@ let
       bzip2.dev
       icu
       xz.dev
+      zstd.dev
       pcre.dev
       jdk
       libzip

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -542,6 +542,7 @@ let
       bzip2.dev
       xz.dev
     ];
+    HiCParser = [ pkgs.zlib ];
     yyjsonr = with pkgs; [ zlib.dev ];
     RNifti = with pkgs; [ zlib.dev ];
     RNiftyReg = with pkgs; [ zlib.dev ];

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -472,6 +472,7 @@ let
       ]
       ++ lib.optional stdenv.hostPlatform.isDarwin pkgs.llvmPackages.openmp;
     devEMF = with pkgs; [ xorg.libXft.dev ];
+    DEploid_utils = [ pkgs.zlib.dev ];
     diversitree = with pkgs; [
       gsl
       fftw

--- a/pkgs/development/r-modules/patches/rhdf5filters.patch
+++ b/pkgs/development/r-modules/patches/rhdf5filters.patch
@@ -1,13 +1,12 @@
 diff --git a/src/Makevars.in b/src/Makevars.in
-index 3e55470..656eae4 100644
 --- a/src/Makevars.in
 +++ b/src/Makevars.in
-@@ -15,7 +15,7 @@ export PKG_CXXPICFLAGS=@CXXPICFLAGS@
- export RANLIB=@RANLIB@
- export MAKE=@MAKE@
- export AR=@AR@
--export PKG_CPPFLAGS=@CPPFLAGS@ -I"@RHDF5_INCLUDE@"
-+export PKG_CPPFLAGS=@CPPFLAGS@
- export PKG_LDFLAGS=@LDFLAGS@
- 
+@@ -15,7 +15,7 @@ RANLIB := @RANLIB@
+ MAKE := @MAKE@
+ AR := @AR@
+-PKG_CPPFLAGS := @CPPFLAGS@ -I"@RHDF5_INCLUDE@"
++PKG_CPPFLAGS := @CPPFLAGS@
+ PKG_LDFLAGS := @LDFLAGS@
+ export
+
  all: copying $(SHLIB)


### PR DESCRIPTION
some vestigial  function name. I have little hope that this will be fixed upstream, last commit is 2 years old.

https://github.com/NixOS/nixpkgs/pull/399350

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
