### PR TITLE
karakeep: cleanup

### DIFF
--- a/pkgs/by-name/ka/karakeep/helpers/karakeep
+++ b/pkgs/by-name/ka/karakeep/helpers/karakeep
@@ -2,4 +2,4 @@
 set -eu -o pipefail
 KARAKEEP_LIB_PATH=
 NODEJS=
-exec "$NODEJS/bin/node" "$KARAKEEP_LIB_PATH/apps/cli/dist/index.mjs" "$@"
+exec "$NODEJS/bin/node" "$KARAKEEP_LIB_PATH/cli/index.mjs" "$@"

--- a/pkgs/by-name/ka/karakeep/helpers/migrate
+++ b/pkgs/by-name/ka/karakeep/helpers/migrate
@@ -2,9 +2,10 @@
 set -eu -o pipefail
 KARAKEEP_LIB_PATH=
 RELEASE=
+NODEJS=
 NODE_ENV=production
 
 [[ -d "$DATA_DIR" ]]	# Ensure DATA_DIR is defined and exists
 
 export RELEASE NODE_ENV
-exec "$KARAKEEP_LIB_PATH/node_modules/.bin/tsx" "$KARAKEEP_LIB_PATH/packages/db/migrate.ts" "$@"
+exec "$NODEJS/bin/node" "$KARAKEEP_LIB_PATH/db_migrations/index.js"

--- a/pkgs/by-name/ka/karakeep/helpers/start-web
+++ b/pkgs/by-name/ka/karakeep/helpers/start-web
@@ -8,4 +8,4 @@ NODE_ENV=production
 [[ -d "$DATA_DIR" ]]	# Ensure DATA_DIR is defined and exists
 
 export RELEASE NODE_ENV
-exec "$NODEJS/bin/node" "$KARAKEEP_LIB_PATH/apps/web/.next/standalone/apps/web/server.js"
+exec "$NODEJS/bin/node" "$KARAKEEP_LIB_PATH/web/apps/web/server.js"

--- a/pkgs/by-name/ka/karakeep/helpers/start-workers
+++ b/pkgs/by-name/ka/karakeep/helpers/start-workers
@@ -3,9 +3,9 @@ set -eu -o pipefail
 KARAKEEP_LIB_PATH=
 RELEASE=
 NODE_ENV=production
-NODE_PATH="$KARAKEEP_LIB_PATH/apps/workers"
+NODE_PATH="$KARAKEEP_LIB_PATH/workers"
 
 [[ -d "$DATA_DIR" ]]	# Ensure DATA_DIR is defined and exists
 
 export RELEASE NODE_ENV NODE_PATH
-exec "$KARAKEEP_LIB_PATH/node_modules/.bin/tsx" "$KARAKEEP_LIB_PATH/apps/workers/index.ts"
+exec "$KARAKEEP_LIB_PATH/node_modules/.bin/tsx" "$KARAKEEP_LIB_PATH/workers/index.ts"

--- a/pkgs/by-name/nc/ncc/package.nix
+++ b/pkgs/by-name/nc/ncc/package.nix
@@ -1,0 +1,44 @@
+{
+  fetchFromGitHub,
+  fetchYarnDeps,
+  lib,
+  nix-update-script,
+  nodejs,
+  stdenvNoCC,
+  yarnBuildHook,
+  yarnConfigHook,
+  yarnInstallHook,
+}:
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "ncc";
+  version = "0.38.3";
+
+  src = fetchFromGitHub {
+    owner = "vercel";
+    repo = "ncc";
+    rev = finalAttrs.version;
+    hash = "sha256-NW9o0I+pzA9nCXY0S13OsB33adI+D76PX/cjGZ+Ju6Q=";
+  };
+
+  yarnOfflineCache = fetchYarnDeps {
+    yarnLock = "${finalAttrs.src}/yarn.lock";
+    hash = "sha256-ZJOcWZH2h3Io6M5tzs8CUB4T1GZ5QQhjN4RbpHkJpZ4=";
+  };
+
+  nativeBuildInputs = [
+    yarnConfigHook
+    yarnBuildHook
+    yarnInstallHook
+    nodejs
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    homepage = "https://www.npmjs.com/package/@vercel/ncc";
+    description = "Simple CLI for compiling a Node.js module into a single file, together with all its dependencies, gcc-style";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.three ];
+    mainProgram = "ncc";
+  };
+})


### PR DESCRIPTION
**Not Ready for review:** `start-workers` is missing some necessary stuff

Cleanup and reduce the size of the Karakeep package. Instead of relying on copying `node_modules` we rely on compiled versions of the code. This change is meant to make the building more similar to Karakeep's [Dockerfile](https://github.com/karakeep-app/karakeep/blob/v0.23.2/docker/Dockerfile).

This change depends on https://github.com/NixOS/nixpkgs/pull/402099

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
