### PR TITLE
treewide: unbreak with pythonRelaxDeps

### DIFF
--- a/pkgs/by-name/cl/clairvoyance/package.nix
+++ b/pkgs/by-name/cl/clairvoyance/package.nix
@@ -16,6 +16,8 @@ python3.pkgs.buildPythonApplication rec {
     hash = "sha256-CVXa2HvX7M0cwqnTeZVETg07j324ATQuMNreEgAC2QA=";
   };
 
+  pythonRelaxDeps = [ "rich" ];
+
   nativeBuildInputs = with python3.pkgs; [
     poetry-core
   ];

--- a/pkgs/by-name/me/memtree/package.nix
+++ b/pkgs/by-name/me/memtree/package.nix
@@ -17,6 +17,8 @@ python3Packages.buildPythonApplication {
     hash = "sha256-Ifp8hwkuyBw57fGer3GbDiJaRjL4TD3hzj+ecGXWqI0=";
   };
 
+  pythonRelaxDeps = [ "rich" ];
+
   nativeBuildInputs = with python3Packages; [
     poetry-core
   ];

--- a/pkgs/by-name/un/unblob/package.nix
+++ b/pkgs/by-name/un/unblob/package.nix
@@ -87,6 +87,8 @@ python3.pkgs.buildPythonApplication rec {
     "ubi-reader"
   ];
 
+  pythonRelaxDeps = [ "rich" ];
+
   pythonImportsCheck = [ "unblob" ];
 
   makeWrapperArgs = [

--- a/pkgs/development/python-modules/awswrangler/default.nix
+++ b/pkgs/development/python-modules/awswrangler/default.nix
@@ -21,6 +21,7 @@
   pythonOlder,
   redshift-connector,
   requests-aws4auth,
+  setuptools,
 }:
 
 buildPythonPackage rec {
@@ -37,7 +38,10 @@ buildPythonPackage rec {
     hash = "sha256-dIdNrfhBrfrzXmspw25yd/y6MbXRrLfDveCQk+AERV0=";
   };
 
-  pythonRelaxDeps = [ "packaging" ];
+  pythonRelaxDeps = [
+    "packaging"
+    "pyarrow"
+  ];
 
   build-system = [ poetry-core ];
 
@@ -54,6 +58,7 @@ buildPythonPackage rec {
     pymysql
     redshift-connector
     requests-aws4auth
+    setuptools
   ];
 
   optional-dependencies = {

--- a/pkgs/development/python-modules/bilibili-api-python/default.nix
+++ b/pkgs/development/python-modules/bilibili-api-python/default.nix
@@ -37,6 +37,7 @@ buildPythonPackage rec {
   pythonRelaxDeps = [
     "beautifulsoup4"
     "lxml"
+    "pillow"
   ];
 
   build-system = [

--- a/pkgs/development/python-modules/bloodyad/default.nix
+++ b/pkgs/development/python-modules/bloodyad/default.nix
@@ -28,6 +28,8 @@ buildPythonPackage rec {
     hash = "sha256-XqCP2GfS8hxlFU4Mndeh+7Ll2kXJ3Dei+AGp/oy0PUg=";
   };
 
+  pythonRelaxDeps = [ "cryptography" ];
+
   build-system = [ hatchling ];
 
   dependencies = [

--- a/pkgs/development/python-modules/datamodel-code-generator/default.nix
+++ b/pkgs/development/python-modules/datamodel-code-generator/default.nix
@@ -35,7 +35,10 @@ buildPythonPackage rec {
     hash = "sha256-CYNEpQFIWR7i7I7YJ5q/34KNhtQ7cjya97Z0fyeO5g8=";
   };
 
-  pythonRelaxDeps = [ "inflect" ];
+  pythonRelaxDeps = [
+    "inflect"
+    "isort"
+  ];
 
   build-system = [
     poetry-core

--- a/pkgs/development/python-modules/linien-common/default.nix
+++ b/pkgs/development/python-modules/linien-common/default.nix
@@ -31,7 +31,10 @@ buildPythonPackage rec {
 
   build-system = [ setuptools ];
 
-  pythonRelaxDeps = [ "importlib-metadata" ];
+  pythonRelaxDeps = [
+    "importlib-metadata"
+    "numpy"
+  ];
 
   dependencies = [
     importlib-metadata

--- a/pkgs/development/python-modules/mistral-common/default.nix
+++ b/pkgs/development/python-modules/mistral-common/default.nix
@@ -25,12 +25,10 @@ buildPythonPackage rec {
     hash = "sha256-CvQSSrCdFAl2HpHsYWgUdogtRvlBjuqJCNOcASIuD2s=";
   };
 
-  # relax dependencies
-  postPatch = ''
-    substituteInPlace pyproject.toml \
-      --replace-fail 'pillow = "^10.3.0"' 'pillow = ">=10.3.0"' \
-      --replace-fail 'tiktoken = "^0.7.0"' 'tiktoken = ">=0.7.0"' \
-  '';
+  pythonRelaxDeps = [
+    "pillow"
+    "tiktoken"
+  ];
 
   build-system = [ poetry-core ];
 

--- a/pkgs/development/python-modules/myfitnesspal/default.nix
+++ b/pkgs/development/python-modules/myfitnesspal/default.nix
@@ -31,6 +31,8 @@ buildPythonPackage rec {
     hash = "sha256-eE807M8qFDlSMAcE+GFJyve1YfmlWmB3ML9VJhMUeIE=";
   };
 
+  pythonRelaxDeps = [ "typing-extensions" ];
+
   nativeBuildInputs = [ setuptools ];
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/notifications-android-tv/default.nix
+++ b/pkgs/development/python-modules/notifications-android-tv/default.nix
@@ -23,6 +23,8 @@ buildPythonPackage rec {
     hash = "sha256-JUvxxVCiQtywAWU5AYnPm4SueIWIXkzLxPYveVXpc2E=";
   };
 
+  pythonRelaxDeps = [ "httpx" ];
+
   nativeBuildInputs = [ poetry-core ];
 
   propagatedBuildInputs = [ httpx ];

--- a/pkgs/development/python-modules/pygount/default.nix
+++ b/pkgs/development/python-modules/pygount/default.nix
@@ -22,6 +22,8 @@ buildPythonPackage rec {
     hash = "sha256-PFqcSnJoGL4bXFy3hu3Iurbb8QK1NqCDs8aJmMxP4Hc=";
   };
 
+  pythonRelaxDeps = [ "rich" ];
+
   nativeBuildInputs = [ poetry-core ];
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/sagemaker-core/default.nix
+++ b/pkgs/development/python-modules/sagemaker-core/default.nix
@@ -46,6 +46,7 @@ buildPythonPackage rec {
     "boto3"
     "importlib-metadata"
     "mock"
+    "rich"
   ];
 
   dependencies = [


### PR DESCRIPTION
fixes:

unblob https://hydra.nixos.org/build/295084325
python313Packages.sagemaker-core https://hydra.nixos.org/build/295064955
python313Packages.pygount https://hydra.nixos.org/build/295062331
python313Packages.notifications-android-tv https://hydra.nixos.org/build/295060264
python313Packages.mistral-common https://hydra.nixos.org/build/295058872
python313Packages.linien-common https://hydra.nixos.org/build/295058258
python313Packages.datamodel-code-generator https://hydra.nixos.org/build/295232106
python313Packages.bloodyad https://hydra.nixos.org/build/295052984
python313Packages.bilibili-api-python https://hydra.nixos.org/build/295052861
python313Packages.awswrangler https://hydra.nixos.org/build/295232019


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
