### PR TITLE
distrobuilder: 3.1 -> 3.2

### DIFF
--- a/pkgs/by-name/di/distrobuilder/nixos-generator.patch
+++ b/pkgs/by-name/di/distrobuilder/nixos-generator.patch
@@ -1,16 +1,16 @@
-diff --git a/distrobuilder/lxc.generator b/distrobuilder/lxc.generator
-index dc5b506..0265da8 100644
---- a/distrobuilder/lxc.generator
-+++ b/distrobuilder/lxc.generator
-@@ -21,16 +21,6 @@ is_incus_vm() {
- 	[ -e /dev/virtio-ports/org.linuxcontainers.incus ]
+diff --git c/distrobuilder/lxc.generator w/distrobuilder/lxc.generator
+index 5f854d3..927f2df 100644
+--- c/distrobuilder/lxc.generator
++++ w/distrobuilder/lxc.generator
+@@ -16,16 +16,6 @@ is_lxc_privileged_container() {
+ 	grep -qw 4294967295$ /proc/self/uid_map
  }
  
 -# is_in_path succeeds if the given file exists in on of the paths
 -is_in_path() {
 -	# Don't use $PATH as that may not include all relevant paths
 -	for path in /bin /sbin /usr/bin /usr/sbin /usr/local/bin /usr/local/sbin; do
--		[ -e "${path}/$1" ] && return 0
+-		[ -e "${path}/${1}" ] && return 0
 -	done
 -
 -	return 1
@@ -19,21 +19,23 @@ index dc5b506..0265da8 100644
  ## Fix functions
  # fix_ro_paths avoids udevd issues with /sys and /proc being writable
  fix_ro_paths() {
-@@ -42,38 +32,6 @@ fix_ro_paths() {
+@@ -47,41 +37,6 @@ fix_ro_run() {
  		EOF
  }
  
 -# fix_nm_link_state forces the network interface to a DOWN state ahead of NetworkManager starting up
 -fix_nm_link_state() {
--	[ -e "/sys/class/net/$1" ] || return 0
--	ip_path=
--	if [ -f /sbin/ip ]; then
--		ip_path=/sbin/ip
--	elif [ -f /bin/ip ]; then
--		ip_path=/bin/ip
+-	[ -e "/sys/class/net/${1}" ] || return 0
+-
+-	ip=
+-	if [ -f "/sbin/ip" ]; then
+-		ip="/sbin/ip"
+-	elif [ -f "/bin/ip" ]; then
+-		ip="/bin/ip"
 -	else
 -		return 0
 -	fi
+-
 -	cat <<-EOF > /run/systemd/system/network-device-down.service
 -		# This file was created by distrobuilder
 -		[Unit]
@@ -44,13 +46,14 @@ index dc5b506..0265da8 100644
 -		[Service]
 -		# do not turn off if there is a default route to 169.254.0.1, i.e. the device is a routed nic
 -		ExecCondition=/bin/sh -c '! /usr/bin/grep -qs 00000000.0100FEA9 /proc/net/route'
--		ExecStart=-${ip_path} link set $1 down
+-		ExecStart=-${ip} link set ${1} down
 -		Type=oneshot
 -		RemainAfterExit=true
 -
 -		[Install]
 -		WantedBy=default.target
 -		EOF
+-
 -	mkdir -p /run/systemd/system/default.target.wants
 -	ln -sf /run/systemd/system/network-device-down.service /run/systemd/system/default.target.wants/network-device-down.service
 -}
@@ -58,78 +61,105 @@ index dc5b506..0265da8 100644
  # fix_systemd_override_unit generates a unit specific override
  fix_systemd_override_unit() {
  	dropin_dir="/run/systemd/${1}.d"
-@@ -113,16 +71,7 @@ fix_systemd_mask() {
+@@ -122,16 +77,7 @@ fix_systemd_mask() {
  # fix_systemd_udev_trigger overrides the systemd-udev-trigger.service to match the latest version
  # of the file which uses "ExecStart=-" instead of "ExecStart=".
  fix_systemd_udev_trigger() {
--	cmd=
+-	udev=
 -	if [ -f /usr/bin/udevadm ]; then
--		cmd=/usr/bin/udevadm
+-		udev=/usr/bin/udevadm
 -	elif [ -f /sbin/udevadm ]; then
--		cmd=/sbin/udevadm
+-		udev=/sbin/udevadm
 -	elif [ -f /bin/udevadm ]; then
--		cmd=/bin/udevadm
+-		udev=/bin/udevadm
 -	else
 -		return 0
 -	fi
-+	cmd=udevadm
++	udev=/run/current-system/sw/bin/udevadm
  
  	mkdir -p /run/systemd/system/systemd-udev-trigger.service.d
  	cat <<-EOF > /run/systemd/system/systemd-udev-trigger.service.d/zzz-lxc-override.conf
-@@ -134,38 +83,13 @@ fix_systemd_udev_trigger() {
+@@ -143,52 +89,40 @@ fix_systemd_udev_trigger() {
  		EOF
  }
  
 -# fix_systemd_sysctl overrides the systemd-sysctl.service to use "ExecStart=-" instead of "ExecStart=".
 -fix_systemd_sysctl() {
--	cmd=/usr/lib/systemd/systemd-sysctl
--	! [ -e "${cmd}" ] && cmd=/lib/systemd/systemd-sysctl
+-	sysctl=/usr/lib/systemd/systemd-sysctl
+-	[ ! -e "${sysctl}" ] && sysctl=/lib/systemd/systemd-sysctl
+-
 -	mkdir -p /run/systemd/system/systemd-sysctl.service.d
 -	cat <<-EOF > /run/systemd/system/systemd-sysctl.service.d/zzz-lxc-override.conf
 -		# This file was created by distrobuilder
 -		[Service]
 -		ExecStart=
--		ExecStart=-${cmd}
+-		ExecStart=-${sysctl}
 -		EOF
 -}
 -
  ## Main logic
--# Nothing to do in Incus VM but deployed in case it is later converted to a container
--is_incus_vm && exit 0
- 
  # Exit immediately if not an Incus/LXC container
  is_lxc_container || exit 0
  
--# Check for NetworkManager
--nm_exists=0
--
--is_in_path NetworkManager && nm_exists=1
--
  # Determine systemd version
+-SYSTEMD=""
 -for path in /usr/lib/systemd/systemd /lib/systemd/systemd; do
 -	[ -x "${path}" ] || continue
--
--	systemd_version="$("${path}" --version | head -n1 | cut -d' ' -f2 | cut -d'~' -f1)"
++SYSTEMD="$(/run/current-system/sw/lib/systemd/systemd --version | head -n1 | cut -d' ' -f2 | cut -d'~' -f1)"
+ 
+-	SYSTEMD="$("${path}" --version | head -n1 | cut -d' ' -f2 | cut -d'~' -f1)"
 -	break
 -done
-+systemd_version="$(systemd --version | head -n1 | cut -d' ' -f2)"
  
- # Determine distro name and release
- ID=""
-@@ -196,7 +120,6 @@ fi
+-# Apply systemd overrides
+-if [ "${SYSTEMD}" -ge 244 ]; then
+-	fix_systemd_override_unit system/service
+-else
+-	# Setup per-unit overrides
+-	find /lib/systemd /etc/systemd /run/systemd /usr/lib/systemd -name "*.service" -type f | sed 's#/\(lib\|etc\|run\|usr/lib\)/systemd/##g'| while read -r service_file; do
+-		fix_systemd_override_unit "${service_file}"
+-	done
+-fi
+ 
+-# Workarounds for unprivileged containers.
+-if ! is_lxc_privileged_container; then
+-	fix_ro_paths systemd-networkd.service
+-	fix_ro_paths systemd-resolved.service
++
++# Overriding some systemd features is only needed if security.nesting=false
++# in which case, /dev/.lxc will be missing
++# Adding this conditional back for NixOS as we do not have the reported
++# problems, and the overrides could reduce potential service hardening
++if [ ! -d /dev/.lxc ]; then
++  # Apply systemd overrides
++  if [ "${SYSTEMD}" -ge 244 ]; then
++    fix_systemd_override_unit system/service
++  else
++    # Setup per-unit overrides
++    find /lib/systemd /etc/systemd /run/systemd /usr/lib/systemd -name "*.service" -type f | sed 's#/\(lib\|etc\|run\|usr/lib\)/systemd/##g'| while read -r service_file; do
++      fix_systemd_override_unit "${service_file}"
++    done
++  fi
++
++  # Workarounds for unprivileged containers.
++  if ! is_lxc_privileged_container; then
++    fix_ro_paths systemd-networkd.service
++    fix_ro_paths systemd-resolved.service
++  fi
+ fi
  
  # Ignore failures on some units.
  fix_systemd_udev_trigger
 -fix_systemd_sysctl
  
- # Mask some units.
- fix_systemd_mask dev-hugepages.mount
-@@ -226,11 +149,6 @@ if [ -d /etc/udev ]; then
+ # Fix issues with /run not being writable.
+ fix_ro_run systemd-nsresourced.service
+@@ -221,11 +155,6 @@ if [ -d /etc/udev ]; then
  		EOF
  fi
  
 -# Workarounds for NetworkManager in containers
--if [ "${nm_exists}" -eq 1 ]; then
+-if is_in_path NetworkManager; then
 -	fix_nm_link_state eth0
 -fi
 -

--- a/pkgs/by-name/di/distrobuilder/package.nix
+++ b/pkgs/by-name/di/distrobuilder/package.nix
@@ -10,6 +10,7 @@
   gnutar,
   hivex,
   makeWrapper,
+  nix-update-script,
   nixosTests,
   pkg-config,
   squashfsTools,
@@ -35,16 +36,15 @@ let
 in
 buildGoModule rec {
   pname = "distrobuilder";
-  version = "3.1";
+  version = "3.2";
 
-  vendorHash = "sha256-3oHLvOdHbOdaL2FTo+a5HmayNi/i3zoAsU/du9h1N30=";
+  vendorHash = "sha256-nlqapWxuSZlbt22F3Y9X1uXFxJHvEoUBZDl078x8ZnA=";
 
   src = fetchFromGitHub {
     owner = "lxc";
     repo = "distrobuilder";
-    rev = "refs/tags/distrobuilder-${version}";
-    sha256 = "sha256-cIzIoLQmg1kgI1QRAmFh/ca88PJBW2yIY92BKHKwTMk=";
-    fetchSubmodules = false;
+    tag = "distrobuilder-${version}";
+    sha256 = "sha256-aDCx2WGAKdTNf0uMzwxG0AUmbuuWBFPYzNyycKklYOY=";
   };
 
   buildInputs = bins;
@@ -67,6 +67,8 @@ buildGoModule rec {
     };
 
     generator = callPackage ./generator.nix { inherit src version; };
+
+    updateScript = nix-update-script { };
   };
 
   meta = {


### PR DESCRIPTION
https://discuss.linuxcontainers.org/t/distrobuilder-3-2-has-been-released/23385

Also rebased generator patch

Closes #396165

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
