### PR TITLE
linux: fix compiler selection

### DIFF
--- a/pkgs/development/compilers/gcc/common/configure-flags.nix
+++ b/pkgs/development/compilers/gcc/common/configure-flags.nix
@@ -20,6 +20,7 @@
   enablePlugin,
   disableGdbPlugin ? !enablePlugin,
   enableShared,
+  targetPrefix,
 
   langC,
   langCC,
@@ -58,10 +59,6 @@ let
   crossMingw = (!lib.systems.equals targetPlatform hostPlatform) && targetPlatform.isMinGW;
   crossDarwin =
     (!lib.systems.equals targetPlatform hostPlatform) && targetPlatform.libc == "libSystem";
-
-  targetPrefix = lib.optionalString (
-    !lib.systems.equals stdenv.targetPlatform stdenv.hostPlatform
-  ) "${stdenv.targetPlatform.config}-";
 
   crossConfigureFlags =
     # Ensure that -print-prog-name is able to find the correct programs.

--- a/pkgs/development/compilers/gcc/common/meta.nix
+++ b/pkgs/development/compilers/gcc/common/meta.nix
@@ -1,4 +1,8 @@
-{ lib, version }:
+{
+  lib,
+  version,
+  targetPrefix,
+}:
 
 let
   inherit (lib)
@@ -24,5 +28,6 @@ in
 
   platforms = platforms.unix;
   teams = [ teams.gcc ];
+  mainProgram = "${targetPrefix}gcc";
 
 }

--- a/pkgs/development/compilers/gcc/default.nix
+++ b/pkgs/development/compilers/gcc/default.nix
@@ -119,6 +119,10 @@ let
     !lib.systems.equals targetPlatform hostPlatform
   ) "${targetPlatform.config}${stageNameAddon}-";
 
+  targetPrefix = lib.optionalString (
+    !lib.systems.equals stdenv.targetPlatform stdenv.hostPlatform
+  ) "${stdenv.targetPlatform.config}-";
+
   callFile = callPackageWith {
     # lets
     inherit
@@ -340,7 +344,7 @@ pipe
         "target"
       ];
 
-      configureFlags = callFile ./common/configure-flags.nix { };
+      configureFlags = callFile ./common/configure-flags.nix { inherit targetPrefix; };
 
       inherit targetConfig;
 
@@ -449,13 +453,14 @@ pipe
       inherit enableShared enableMultilib;
 
       meta = {
-        inherit (callFile ./common/meta.nix { })
+        inherit (callFile ./common/meta.nix { inherit targetPrefix; })
           homepage
           license
           description
           longDescription
           platforms
           teams
+          mainProgram
           ;
       }
       // optionalAttrs (!atLeast11) {

--- a/pkgs/development/compilers/zig/cc.nix
+++ b/pkgs/development/compilers/zig/cc.nix
@@ -14,7 +14,7 @@ in
 runCommand "zig-cc-${zig.version}"
   {
     pname = "zig-cc";
-    inherit (zig) version meta;
+    inherit (zig) version;
 
     nativeBuildInputs = [ makeWrapper ];
 
@@ -24,6 +24,10 @@ runCommand "zig-cc-${zig.version}"
     };
 
     inherit zig;
+
+    meta = zig.meta // {
+      mainProgram = "${targetPrefix}clang";
+    };
   }
   ''
     mkdir -p $out/bin

--- a/pkgs/os-specific/linux/kernel/common-config.nix
+++ b/pkgs/os-specific/linux/kernel/common-config.nix
@@ -525,7 +525,9 @@ let
         DRM_AMD_DC_DCN = lib.mkIf (with stdenv.hostPlatform; isx86 || isPower64) (
           whenBetween "5.11" "6.4" yes
         );
-        DRM_AMD_DC_FP = whenAtLeast "6.4" yes;
+        # Not available when using clang
+        # See: https://github.com/torvalds/linux/blob/172a9d94339cea832d89630b89d314e41d622bd8/drivers/gpu/drm/amd/display/Kconfig#L14
+        DRM_AMD_DC_FP = lib.mkIf (!stdenv.cc.isClang) (whenAtLeast "6.4" yes);
         DRM_AMD_DC_HDCP = whenBetween "5.5" "6.4" yes;
         DRM_AMD_DC_SI = whenAtLeast "5.10" yes;
 

--- a/pkgs/os-specific/linux/kernel/common-flags.nix
+++ b/pkgs/os-specific/linux/kernel/common-flags.nix
@@ -1,0 +1,34 @@
+{
+  lib,
+  stdenv,
+  buildPackages,
+  extraMakeFlags ? [ ],
+}:
+# Absolute paths for compilers avoid any PATH-clobbering issues.
+[
+  #
+  # We use the unwrapped compiler, because the clang-wrapper doesn't like -target.
+  "CC=${lib.getExe stdenv.cc.cc}"
+  # The wrapper for ld.lld breaks linking the kernel. We use the unwrapped linker as workaround. See:
+  # https://github.com/NixOS/nixpkgs/issues/321667
+  "LD=${lib.getExe' stdenv.cc.bintools.bintools "${stdenv.cc.targetPrefix}ld"}"
+  "AR=${lib.getExe' stdenv.cc "${stdenv.cc.targetPrefix}ar"}"
+  "NM=${lib.getExe' stdenv.cc "${stdenv.cc.targetPrefix}nm"}"
+  "STRIP=${lib.getExe' stdenv.cc.bintools.bintools "${stdenv.cc.targetPrefix}strip"}"
+  "OBJCOPY=${lib.getExe' stdenv.cc "${stdenv.cc.targetPrefix}objcopy"}"
+  "OBJDUMP=${lib.getExe' stdenv.cc "${stdenv.cc.targetPrefix}objdump"}"
+  "READELF=${lib.getExe' stdenv.cc "${stdenv.cc.targetPrefix}readelf"}"
+  "HOSTCC=${lib.getExe' buildPackages.stdenv.cc "${buildPackages.stdenv.cc.targetPrefix}cc"}"
+  "HOSTCXX=${lib.getExe' buildPackages.stdenv.cc "${buildPackages.stdenv.cc.targetPrefix}c++"}"
+  "HOSTAR=${lib.getExe' buildPackages.stdenv.cc.bintools "${buildPackages.stdenv.cc.targetPrefix}ar"}"
+  "HOSTLD=${lib.getExe' buildPackages.stdenv.cc.bintools "${buildPackages.stdenv.cc.targetPrefix}ld"}"
+  "ARCH=${stdenv.hostPlatform.linuxArch}"
+  "CROSS_COMPILE=${stdenv.cc.targetPrefix}"
+]
+# Add the built in headers the kernel needs
+++ lib.optionals (stdenv.cc.isClang) [
+  "CFLAGS_MODULE=-I${lib.getLib stdenv.cc.cc}/lib/clang/${lib.versions.major stdenv.cc.cc.version}/include"
+  "CFLAGS_KERNEL=-I${lib.getLib stdenv.cc.cc}/lib/clang/${lib.versions.major stdenv.cc.cc.version}/include"
+]
+++ (stdenv.hostPlatform.linux-kernel.makeFlags or [ ])
+++ extraMakeFlags

--- a/pkgs/os-specific/linux/kernel/generic.nix
+++ b/pkgs/os-specific/linux/kernel/generic.nix
@@ -191,7 +191,7 @@ let
         ++ lib.optional (lib.versionAtLeast version "5.2") pahole
         ++ lib.optionals withRust [
           rust-bindgen
-          rustc
+          rustc.unwrapped
         ];
 
         RUST_LIB_SRC = lib.optionalString withRust rustPlatform.rustLibSrc;
@@ -201,11 +201,14 @@ let
         kernelBaseConfig =
           if defconfig != null then defconfig else stdenv.hostPlatform.linux-kernel.baseConfig;
 
-        makeFlags =
-          lib.optionals (
-            stdenv.hostPlatform.linux-kernel ? makeFlags
-          ) stdenv.hostPlatform.linux-kernel.makeFlags
-          ++ extraMakeFlags;
+        makeFlags = import ./common-flags.nix {
+          inherit
+            lib
+            stdenv
+            buildPackages
+            extraMakeFlags
+            ;
+        };
 
         postPatch = kernel.postPatch + ''
           # Patch kconfig to print "###" after every question so that

--- a/pkgs/os-specific/linux/kernel/generic.nix
+++ b/pkgs/os-specific/linux/kernel/generic.nix
@@ -236,6 +236,24 @@ let
             KERNEL_CONFIG="$buildRoot/kernel-config" AUTO_MODULES=$autoModules \
             PREFER_BUILTIN=$preferBuiltin BUILD_ROOT="$buildRoot" SRC=. MAKE_FLAGS="$makeFlags" \
             perl -w $generateConfig
+        ''
+        + lib.optionalString stdenv.cc.isClang ''
+          if ! grep -Fq CONFIG_CC_IS_CLANG=y $buildRoot/.config; then
+            echo "Kernel config didn't recognize the clang compiler?"
+            exit 1
+          fi
+        ''
+        + lib.optionalString stdenv.cc.bintools.isLLVM ''
+          if ! grep -Fq CONFIG_LD_IS_LLD=y $buildRoot/.config; then
+            echo "Kernel config didn't recognize the LLVM linker?"
+            exit 1
+          fi
+        ''
+        + lib.optionalString withRust ''
+          if ! grep -Fq CONFIG_RUST_IS_AVAILABLE=y $buildRoot/.config; then
+            echo "Kernel config didn't find Rust toolchain?"
+            exit 1
+          fi
         '';
 
         installPhase = "mv $buildRoot/.config $out";

--- a/pkgs/os-specific/linux/minimal-bootstrap/gcc/4.6.cxx.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/gcc/4.6.cxx.nix
@@ -102,6 +102,7 @@ bash.runCommand "${pname}-${version}"
       license = licenses.gpl3Plus;
       teams = [ teams.minimal-bootstrap ];
       platforms = platforms.unix;
+      mainProgram = "gcc";
     };
   }
   ''

--- a/pkgs/os-specific/linux/minimal-bootstrap/gcc/4.6.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/gcc/4.6.nix
@@ -84,6 +84,7 @@ bash.runCommand "${pname}-${version}"
       license = licenses.gpl3Plus;
       teams = [ teams.minimal-bootstrap ];
       platforms = platforms.unix;
+      mainProgram = "gcc";
     };
   }
   ''

--- a/pkgs/os-specific/linux/minimal-bootstrap/gcc/8.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/gcc/8.nix
@@ -101,6 +101,7 @@ bash.runCommand "${pname}-${version}"
       license = licenses.gpl3Plus;
       teams = [ teams.minimal-bootstrap ];
       platforms = platforms.unix;
+      mainProgram = "gcc";
     };
   }
   ''

--- a/pkgs/os-specific/linux/minimal-bootstrap/gcc/latest.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/gcc/latest.nix
@@ -100,6 +100,7 @@ bash.runCommand "${pname}-${version}"
       license = licenses.gpl3Plus;
       teams = [ teams.minimal-bootstrap ];
       platforms = platforms.unix;
+      mainProgram = "gcc";
     };
   }
   ''


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Based on #390631. Thank you @blitz for doing a good chunk of the work. And thanks to @zowoq for finding the fix for Rust. Best way to verify this is by building `pkgsLLVM.linux.configfile` and checking if `CONFIG_CC_IS_CLANG` is set, around that same area is should reference clang v19. Try building `linux.configfile` (non-`pkgsLLVM`) derivation and see if it references gcc still. Ofc, it's good to verify the full kernel build works. I tested both of these on my system and it works as expected.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
