### PR TITLE
faugus-launcher: init at 1.9.6

### DIFF
--- a/pkgs/by-name/fa/faugus-launcher/package.nix
+++ b/pkgs/by-name/fa/faugus-launcher/package.nix
@@ -1,0 +1,96 @@
+{
+  fetchFromGitHub,
+  gamemode,
+  gobject-introspection,
+  icoextract,
+  imagemagick,
+  lib,
+  libayatana-appindicator,
+  libcanberra-gtk3,
+  meson,
+  ninja,
+  nix-update-script,
+  python3Packages,
+  umu-launcher,
+  wrapGAppsHook3,
+  xdg-utils,
+}:
+
+python3Packages.buildPythonApplication rec {
+  pname = "faugus-launcher";
+  version = "1.9.6";
+  pyproject = false;
+
+  src = fetchFromGitHub {
+    owner = "Faugus";
+    repo = "faugus-launcher";
+    tag = version;
+    hash = "sha256-7brHeRwrH6MbRcGCb5qufU1PHLgg5fCfgLhvdCQr+ak=";
+  };
+
+  nativeBuildInputs = [
+    gobject-introspection
+    wrapGAppsHook3
+  ];
+
+  buildInputs = [
+    libayatana-appindicator
+  ];
+
+  build-system = [
+    meson
+    ninja
+  ];
+
+  dependencies = with python3Packages; [
+    filelock
+    pillow
+    psutil
+    pygobject3
+    requests
+    vdf
+  ];
+
+  postPatch = ''
+    substituteInPlace faugus_launcher.py \
+      --replace-fail "PathManager.find_binary('faugus-run')" "'$out/bin/.faugus-run-wrapped'" \
+      --replace-fail "PathManager.find_binary('faugus-proton-manager')" "'$out/bin/.faugus-proton-manager-wrapped'" \
+      --replace-fail "PathManager.user_data('faugus-launcher/umu-run')" "'${lib.getExe umu-launcher}'" \
+      --replace-fail 'Exec={faugus_run}' 'Exec=faugus-run'
+
+    substituteInPlace faugus_run.py \
+      --replace-fail "PathManager.find_binary('faugus-components')" "'$out/bin/.faugus-components-wrapped'" \
+      --replace-fail "PathManager.user_data('faugus-launcher/umu-run')" "'${lib.getExe umu-launcher}'" \
+      --replace-fail "PathManager.find_library('libgamemode.so.0')" "'${lib.getLib gamemode}/lib/libgamemode.so.0'" \
+      --replace-fail "PathManager.find_library('libgamemodeauto.so.0')" "'${lib.getLib gamemode}/lib/libgamemodeauto.so.0'"
+  '';
+
+  dontWrapGApps = true;
+
+  preFixup = ''
+    makeWrapperArgs+=(
+      "''${gappsWrapperArgs[@]}"
+      --suffix PATH : "${
+        lib.makeBinPath [
+          icoextract
+          imagemagick
+          libcanberra-gtk3
+          umu-launcher
+          xdg-utils
+        ]
+      }"
+    )
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Simple and lightweight app for running Windows games using UMU-Launcher";
+    homepage = "https://github.com/Faugus/faugus-launcher";
+    changelog = "https://github.com/Faugus/faugus-launcher/releases/tag/${version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ RoGreat ];
+    mainProgram = "faugus-launcher";
+    platforms = lib.platforms.linux;
+  };
+}


### PR DESCRIPTION
### [faugus-launcher](https://github.com/Faugus/faugus-launcher)

Simple and lightweight app for running Windows games using [UMU-Launcher](https://github.com/Open-Wine-Components/umu-launcher)

closes https://github.com/NixOS/nixpkgs/issues/325281 and closes https://github.com/NixOS/nixpkgs/issues/401569 (duplicate ).
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
