### PR TITLE
nixos/tzupdate: Fix reference to non-existing attribute

### DIFF
--- a/nixos/modules/services/misc/tzupdate.nix
+++ b/nixos/modules/services/misc/tzupdate.nix
@@ -68,7 +68,6 @@ in
 
     systemd.timers.tzupdate = {
       enable = cfg.timer.enable;
-      interval = cfg.timer.interval;
       timerConfig = {
         OnStartupSec = "30s";
         OnCalendar = cfg.timer.interval;

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1389,6 +1389,7 @@ in
   tuxguitar = runTest ./tuxguitar.nix;
   twingate = runTest ./twingate.nix;
   typesense = handleTest ./typesense.nix { };
+  tzupdate = runTest ./tzupdate.nix;
   ucarp = handleTest ./ucarp.nix { };
   udisks2 = handleTest ./udisks2.nix { };
   ulogd = handleTest ./ulogd/ulogd.nix { };

--- a/nixos/tests/tzupdate.nix
+++ b/nixos/tests/tzupdate.nix
@@ -1,0 +1,22 @@
+{ lib, ... }:
+let
+  clientNodeName = "client";
+in
+{
+  name = "tzupdate";
+
+  # TODO: Test properly:
+  # - Add server node
+  # - Add client configuration to talk to the server node
+  # - Assert that the time zone changes appropriately
+  nodes.${clientNodeName} = {
+    services.tzupdate.enable = true;
+  };
+
+  testScript = ''
+    start_all()
+    ${clientNodeName}.wait_for_unit("multi-user.target")
+  '';
+
+  meta.maintainers = [ lib.maintainers.l0b0 ];
+}


### PR DESCRIPTION
Should detect issues like #402016, by using a `git bisect` script like this:

```bash
#!/usr/bin/env bash

set -o errexit

git show test-tzupdate:nixos/tests/all-tests.nix > nixos/tests/all-tests.nix
mkdir -p nixos/tests/tzupdate
git show test-tzupdate:nixos/tests/tzupdate/default.nix > nixos/tests/tzupdate/default.nix

nix-build --attr nixosTests.tzupdate || exit_code=$?
git checkout .
exit "${exit_code-0}"
```

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [x] Manual test in NixOS using [this technique](https://discourse.nixos.org/t/proper-way-of-applying-patch-to-system-managed-via-flake/21073/26?u=l0b0)
  - [x] [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
