### PR TITLE
python3Packages.mypy-extensions: 1.0.0 -> 1.1.0

### DIFF
--- a/pkgs/development/python-modules/mypy/extensions.nix
+++ b/pkgs/development/python-modules/mypy/extensions.nix
@@ -2,41 +2,41 @@
   lib,
   fetchFromGitHub,
   buildPythonPackage,
-  typing,
+  flit-core,
   pytestCheckHook,
   pythonAtLeast,
-  pythonOlder,
 }:
 
 buildPythonPackage rec {
   pname = "mypy-extensions";
-  version = "1.0.0";
+  version = "1.1.0";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "python";
     repo = "mypy_extensions";
-    rev = version;
-    hash = "sha256-gOfHC6dUeBE7SsWItpUHHIxW3wzhPM5SuGW1U8P7DD0=";
+    tag = version;
+    hash = "sha256-HNAFsWX4tU9hfZkKxLNJn1J+H3uTesQflbRPlo3GQ4k=";
   };
 
-  propagatedBuildInputs = lib.optional (pythonOlder "3.5") typing;
+  dependencies = [ flit-core ];
 
   # make the testsuite run with pytest, so we can disable individual tests
   nativeCheckInputs = [ pytestCheckHook ];
 
   pytestFlagsArray = [ "tests/testextensions.py" ];
 
-  disabledTests = lib.optionals (pythonAtLeast "3.11") [
-    # https://github.com/python/mypy_extensions/issues/24
-    "test_typeddict_errors"
+  disabledTests = lib.optionals (pythonAtLeast "3.14") [
+    # https://github.com/python/mypy_extensions/issues/65
+    "test_py36_class_syntax_usage"
   ];
 
   pythonImportsCheck = [ "mypy_extensions" ];
 
-  meta = with lib; {
+  meta = {
     description = "Experimental type system extensions for programs checked with the mypy typechecker";
     homepage = "https://www.mypy-lang.org";
-    license = licenses.mit;
-    maintainers = with maintainers; [ lnl7 ];
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ lnl7 ];
   };
 }


### PR DESCRIPTION
Changelog: https://github.com/python/mypy_extensions/compare/1.0.0...1.1.0

The `test_py36_class_syntax_usage` test currently fails on Python 3.14. It has been disabled for now.

Upstream replaced their `setup.py` why `pyproject.toml` in 6d9c7b756486a654e795095d393bf8206cd11dea [2]. The nix package has been adjusted accordingly.
In the same commit, upstream deprecated Python 3.7 support, and nixpkgs doesn't ship 3.5 or older anymore. This means the conditional checking for 3.5 or older can be dropped.

Upstream also implicitly dropped python 2 support: The now-required flit-core does not support python 2.

The test failure on python 3.11+ [3] was fixed upstream in cd8b0c9c9561d806db4644d772e4ab43279d3d1a [4].

[1] https://github.com/python/mypy_extensions/issues/65
[2] https://github.com/python/mypy_extensions/commit/6d9c7b756486a654e795095d393bf8206cd11dea
[3] https://github.com/python/mypy_extensions/issues/24
[4] https://github.com/python/mypy_extensions/pull/28/commits/cd8b0c9c9561d806db4644d772e4ab43279d3d1a

Due to the fact this breaks on Python 2.7, i am not exactly sure whether this is acceptable in freeze month, and what the exact impact is. I did however confirm `resholve` and `gimp` (2.x) are independent from `mypy` on py 27 and still build.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
