### PR TITLE
galene-*: init

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -529,6 +529,7 @@ in
   ft2-clone = runTest ./ft2-clone.nix;
   legit = runTest ./legit.nix;
   mimir = runTest ./mimir.nix;
+  galene = discoverTests (import ./galene.nix);
   gancio = runTest ./gancio.nix;
   garage = handleTest ./garage { };
   gatus = runTest ./gatus.nix;

--- a/nixos/tests/galene.nix
+++ b/nixos/tests/galene.nix
@@ -3,14 +3,12 @@ let
   galeneTestGroupsDir = "/var/lib/galene/groups";
   galeneTestGroupFile = "galene-test-config.json";
   galenePort = 8443;
+  galeneTestGroupAdminName = "admin";
+  galeneTestGroupAdminPassword = "1234";
 in
 {
   basic = makeTest (
     { pkgs, lib, ... }:
-    let
-      galeneTestGroupAdminName = "admin";
-      galeneTestGroupAdminPassword = "1234";
-    in
     {
       name = "galene-works";
       meta = {
@@ -91,6 +89,122 @@ in
             machine.sleep(5)
             machine.wait_for_text(r"(Enable|Share|Screen)")
             machine.screenshot("galene-group-test-logged-in")
+      '';
+    }
+  );
+
+  file-transfer = makeTest (
+    { pkgs, lib, ... }:
+    {
+      name = "galene-file-transfer-works";
+      meta = {
+        inherit (pkgs.galene-file-transfer.meta) maintainers;
+        platforms = lib.platforms.linux;
+      };
+
+      nodes.machine =
+        { config, pkgs, ... }:
+        {
+          imports = [ ./common/x11.nix ];
+
+          services.xserver.enable = true;
+
+          environment = {
+            # https://galene.org/INSTALL.html
+            etc.${galeneTestGroupFile}.source = (pkgs.formats.json { }).generate galeneTestGroupFile {
+              op = [
+                {
+                  username = galeneTestGroupAdminName;
+                  password = galeneTestGroupAdminPassword;
+                }
+              ];
+              other = [ { } ];
+            };
+
+            systemPackages = with pkgs; [
+              firefox
+              galene-file-transfer
+            ];
+          };
+
+          services.galene = {
+            enable = true;
+            insecure = true;
+            httpPort = galenePort;
+            groupsDir = galeneTestGroupsDir;
+          };
+        };
+
+      enableOCR = true;
+
+      testScript = ''
+        machine.wait_for_x()
+
+        with subtest("galene starts"):
+            # Starts?
+            machine.wait_for_unit("galene")
+
+            # Keeps running after startup?
+            machine.sleep(10)
+            machine.wait_for_unit("galene")
+
+            # Reponds fine?
+            machine.succeed("curl -s -D - -o /dev/null 'http://localhost:${builtins.toString galenePort}' >&2")
+
+        machine.succeed("cp -v /etc/${galeneTestGroupFile} ${galeneTestGroupsDir}/test.json >&2")
+        machine.wait_until_succeeds("curl -s -D - -o /dev/null 'http://localhost:${builtins.toString galenePort}/group/test/' >&2")
+
+        with subtest("galene can join group"):
+            # Open site
+            machine.succeed("firefox --new-window 'http://localhost:${builtins.toString galenePort}/group/test/' >&2 &")
+            # Note: Firefox doesn't use a regular "-" in the window title, but "—" (Hex: 0xe2 0x80 0x94)
+            machine.wait_for_window("Test — Mozilla Firefox")
+            machine.send_key("ctrl-minus")
+            machine.send_key("ctrl-minus")
+            machine.send_key("alt-f10")
+            machine.wait_for_text(r"(Galène|Username|Password|Connect)")
+            machine.screenshot("galene-group-test-join")
+
+            # Log in as admin
+            machine.send_chars("${galeneTestGroupAdminName}")
+            machine.send_key("tab")
+            machine.send_chars("${galeneTestGroupAdminPassword}")
+            machine.send_key("ret")
+            machine.sleep(5)
+            # Close "Remember credentials?" FF prompt
+            machine.send_key("esc")
+            machine.sleep(5)
+            machine.wait_for_text(r"(Enable|Share|Screen)")
+            machine.screenshot("galene-group-test-logged-in")
+
+        with subtest("galene-file-transfer works"):
+            machine.succeed(
+                "galene-file-transfer "
+                + "-to '${galeneTestGroupAdminName}' "
+                + "-insecure 'http://localhost:${builtins.toString galenePort}/group/test/' "
+                + "${galeneTestGroupsDir}/test.json " # just try sending the groups file
+                + " >&2 &"
+            )
+            machine.sleep(5) # Give pop-up some time to appear
+            machine.wait_for_text(r"(offered to send us a file|Accept|Reject|disclose your IP)")
+            machine.screenshot("galene-file-transfer-dislogue")
+
+            # Focus on Accept button
+            machine.send_key("shift-tab")
+            machine.send_key("shift-tab")
+            machine.send_key("shift-tab")
+            machine.send_key("shift-tab")
+
+            # Accept download
+            machine.sleep(2)
+            machine.send_key("ret")
+
+            # Wait until complete & matching
+            machine.wait_until_succeeds(
+                "diff "
+                + "${galeneTestGroupsDir}/test.json " # original
+                + "/root/Downloads/test.json" # Received via file-transfer
+            )
       '';
     }
   );

--- a/nixos/tests/galene.nix
+++ b/nixos/tests/galene.nix
@@ -1,0 +1,97 @@
+let
+  makeTest = import ./make-test-python.nix;
+  galeneTestGroupsDir = "/var/lib/galene/groups";
+  galeneTestGroupFile = "galene-test-config.json";
+  galenePort = 8443;
+in
+{
+  basic = makeTest (
+    { pkgs, lib, ... }:
+    let
+      galeneTestGroupAdminName = "admin";
+      galeneTestGroupAdminPassword = "1234";
+    in
+    {
+      name = "galene-works";
+      meta = {
+        inherit (pkgs.galene.meta) maintainers;
+        platforms = lib.platforms.linux;
+      };
+
+      nodes.machine =
+        { config, pkgs, ... }:
+        {
+          imports = [ ./common/x11.nix ];
+
+          services.xserver.enable = true;
+
+          environment = {
+            # https://galene.org/INSTALL.html
+            etc.${galeneTestGroupFile}.source = (pkgs.formats.json { }).generate galeneTestGroupFile {
+              op = [
+                {
+                  username = galeneTestGroupAdminName;
+                  password = galeneTestGroupAdminPassword;
+                }
+              ];
+              other = [ { } ];
+            };
+
+            systemPackages = with pkgs; [
+              firefox
+            ];
+          };
+
+          services.galene = {
+            enable = true;
+            insecure = true;
+            httpPort = galenePort;
+            groupsDir = galeneTestGroupsDir;
+          };
+        };
+
+      enableOCR = true;
+
+      testScript = ''
+        machine.wait_for_x()
+
+        with subtest("galene starts"):
+            # Starts?
+            machine.wait_for_unit("galene")
+
+            # Keeps running after startup?
+            machine.sleep(10)
+            machine.wait_for_unit("galene")
+
+            # Reponds fine?
+            machine.succeed("curl -s -D - -o /dev/null 'http://localhost:${builtins.toString galenePort}' >&2")
+
+        machine.succeed("cp -v /etc/${galeneTestGroupFile} ${galeneTestGroupsDir}/test.json >&2")
+        machine.wait_until_succeeds("curl -s -D - -o /dev/null 'http://localhost:${builtins.toString galenePort}/group/test/' >&2")
+
+        with subtest("galene can join group"):
+            # Open site
+            machine.succeed("firefox --new-window 'http://localhost:${builtins.toString galenePort}/group/test/' >&2 &")
+            # Note: Firefox doesn't use a regular "-" in the window title, but "—" (Hex: 0xe2 0x80 0x94)
+            machine.wait_for_window("Test — Mozilla Firefox")
+            machine.send_key("ctrl-minus")
+            machine.send_key("ctrl-minus")
+            machine.send_key("alt-f10")
+            machine.wait_for_text(r"(Galène|Username|Password|Connect)")
+            machine.screenshot("galene-group-test-join")
+
+            # Log in as admin
+            machine.send_chars("${galeneTestGroupAdminName}")
+            machine.send_key("tab")
+            machine.send_chars("${galeneTestGroupAdminPassword}")
+            machine.send_key("ret")
+            machine.sleep(5)
+            # Close "Remember credentials?" FF prompt
+            machine.send_key("esc")
+            machine.sleep(5)
+            machine.wait_for_text(r"(Enable|Share|Screen)")
+            machine.screenshot("galene-group-test-logged-in")
+      '';
+    }
+  );
+}

--- a/pkgs/by-name/ga/galene-file-transfer/package.nix
+++ b/pkgs/by-name/ga/galene-file-transfer/package.nix
@@ -3,6 +3,7 @@
   buildGoModule,
   fetchFromGitHub,
   gitUpdater,
+  nixosTests,
   writeShellApplication,
   _experimental-update-script-combinators,
   galene,
@@ -31,6 +32,7 @@ buildGoModule (finalAttrs: {
   ];
 
   passthru = {
+    tests.vm = nixosTests.galene.file-transfer;
     updateScriptSrc = gitUpdater {
       rev-prefix = "galene-file-transfer-";
     };

--- a/pkgs/by-name/ga/galene-file-transfer/package.nix
+++ b/pkgs/by-name/ga/galene-file-transfer/package.nix
@@ -1,0 +1,73 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  gitUpdater,
+  writeShellApplication,
+  _experimental-update-script-combinators,
+  galene,
+  nix,
+  sd,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "galene-file-transfer";
+  version = "0.2";
+
+  src = fetchFromGitHub {
+    owner = "jech";
+    repo = "galene-file-transfer";
+    tag = "galene-file-transfer-${finalAttrs.version}";
+    hash = "sha256-T3OtEsHysAmHwvDIkxqXMKLqIeXEeX9uhEG4WFUgQL4=";
+  };
+
+  vendorHash = "sha256-Z2IYZtB2PAxJD8993reu+ldTG3LdPLNMbr9pP2NUBMA=";
+
+  strictDeps = true;
+
+  ldflags = [
+    "-s"
+    "-w"
+  ];
+
+  passthru = {
+    updateScriptSrc = gitUpdater {
+      rev-prefix = "galene-file-transfer-";
+    };
+    updateScriptVendor = writeShellApplication {
+      name = "update-galene-file-transfer-vendorHash";
+      runtimeInputs = [
+        nix
+        sd
+      ];
+      text = ''
+        export UPDATE_NIX_ATTR_PATH="''${UPDATE_NIX_ATTR_PATH:-galene-file-transfer}"
+
+        oldhash="$(nix-instantiate . --eval --strict -A "$UPDATE_NIX_ATTR_PATH.goModules.drvAttrs.outputHash" | cut -d'"' -f2)"
+        newhash="$(nix-build -A "$UPDATE_NIX_ATTR_PATH.goModules" --no-out-link 2>&1 | tail -n3 | grep 'got:' | cut -d: -f2- | xargs echo || true)"
+
+        if [ "$newhash" == "" ]; then
+          echo "No new vendorHash."
+          exit 0
+        fi
+
+        fname="$(nix-instantiate --eval -E "with import ./. {}; (builtins.unsafeGetAttrPos \"version\" $UPDATE_NIX_ATTR_PATH).file" | cut -d'"' -f2)"
+
+        ${sd.meta.mainProgram} --string-mode "$oldhash" "$newhash" "$fname"
+      '';
+    };
+    updateScript = _experimental-update-script-combinators.sequence [
+      finalAttrs.passthru.updateScriptSrc.command
+      (lib.getExe finalAttrs.passthru.updateScriptVendor)
+    ];
+  };
+
+  meta = {
+    description = "Command-line file transfer client for the Galene videoconferencing server";
+    homepage = "https://github.com/jech/galene-file-transfer";
+    changelog = "https://github.com/jech/galene-file-transfer/raw/${finalAttrs.src.rev}/CHANGES";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.linux;
+    inherit (galene.meta) maintainers;
+  };
+})

--- a/pkgs/by-name/ga/galene-ldap/package.nix
+++ b/pkgs/by-name/ga/galene-ldap/package.nix
@@ -1,0 +1,73 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  gitUpdater,
+  writeShellApplication,
+  _experimental-update-script-combinators,
+  galene,
+  nix,
+  sd,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "galene-ldap";
+  version = "0.2";
+
+  src = fetchFromGitHub {
+    owner = "jech";
+    repo = "galene-ldap";
+    tag = "galene-ldap-${finalAttrs.version}";
+    hash = "sha256-FXD90ishU3FBRj16tQx8wr+lSFl1dffNM1rU81Kfe1I=";
+  };
+
+  vendorHash = "sha256-i/pWXgcd01PgH1Q+WEm0gP1leTFBhqGxVGnl6c+J1aQ=";
+
+  strictDeps = true;
+
+  ldflags = [
+    "-s"
+    "-w"
+  ];
+
+  passthru = {
+    updateScriptSrc = gitUpdater {
+      rev-prefix = "galene-ldap-";
+    };
+    updateScriptVendor = writeShellApplication {
+      name = "update-galene-ldap-vendorHash";
+      runtimeInputs = [
+        nix
+        sd
+      ];
+      text = ''
+        export UPDATE_NIX_ATTR_PATH="''${UPDATE_NIX_ATTR_PATH:-galene-ldap}"
+
+        oldhash="$(nix-instantiate . --eval --strict -A "$UPDATE_NIX_ATTR_PATH.goModules.drvAttrs.outputHash" | cut -d'"' -f2)"
+        newhash="$(nix-build -A "$UPDATE_NIX_ATTR_PATH.goModules" --no-out-link 2>&1 | tail -n3 | grep 'got:' | cut -d: -f2- | xargs echo || true)"
+
+        if [ "$newhash" == "" ]; then
+          echo "No new vendorHash."
+          exit 0
+        fi
+
+        fname="$(nix-instantiate --eval -E "with import ./. {}; (builtins.unsafeGetAttrPos \"version\" $UPDATE_NIX_ATTR_PATH).file" | cut -d'"' -f2)"
+
+        ${sd.meta.mainProgram} --string-mode "$oldhash" "$newhash" "$fname"
+      '';
+    };
+    updateScript = _experimental-update-script-combinators.sequence [
+      finalAttrs.passthru.updateScriptSrc.command
+      (lib.getExe finalAttrs.passthru.updateScriptVendor)
+    ];
+  };
+
+  meta = {
+    description = "LDAP support for the Galene videoconferencing server";
+    homepage = "https://github.com/jech/galene-ldap";
+    changelog = "https://github.com/jech/galene-ldap/raw/${finalAttrs.src.rev}/CHANGES";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.linux;
+    inherit (galene.meta) maintainers;
+  };
+})

--- a/pkgs/by-name/ga/galene-stt/package.nix
+++ b/pkgs/by-name/ga/galene-stt/package.nix
@@ -1,0 +1,91 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  gitUpdater,
+  writeShellApplication,
+  _experimental-update-script-combinators,
+  galene,
+  libopus,
+  nix,
+  pkg-config,
+  sd,
+  whisper-cpp,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "galene-stt";
+  version = "0.1";
+
+  src = fetchFromGitHub {
+    owner = "jech";
+    repo = "galene-stt";
+    tag = "galene-stt-${finalAttrs.version}";
+    hash = "sha256-uW1b5T+p7KGvqt+PlR9d7bo62V+URHniS45sZP/VuLQ=";
+  };
+
+  vendorHash = "sha256-UFOxo8jq+gxN1dkM2A/BQqtT9ggIp7qovFRLv3Q6Io0=";
+
+  # Not necessary, but feels cleaner to pull it in like that
+  postPatch = ''
+    substituteInPlace whisper.go \
+      --replace-fail 'cgo LDFLAGS: -lwhisper' 'cgo pkg-config: whisper'
+  '';
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  buildInputs = [
+    libopus
+    whisper-cpp
+  ];
+
+  ldflags = [
+    "-s"
+    "-w"
+  ];
+
+  passthru = {
+    updateScriptSrc = gitUpdater {
+      rev-prefix = "galene-stt-";
+    };
+    updateScriptVendor = writeShellApplication {
+      name = "update-galene-stt-vendorHash";
+      runtimeInputs = [
+        nix
+        sd
+      ];
+      text = ''
+        export UPDATE_NIX_ATTR_PATH="''${UPDATE_NIX_ATTR_PATH:-galene-stt}"
+
+        oldhash="$(nix-instantiate . --eval --strict -A "$UPDATE_NIX_ATTR_PATH.goModules.drvAttrs.outputHash" | cut -d'"' -f2)"
+        newhash="$(nix-build -A "$UPDATE_NIX_ATTR_PATH.goModules" --no-out-link 2>&1 | tail -n3 | grep 'got:' | cut -d: -f2- | xargs echo || true)"
+
+        if [ "$newhash" == "" ]; then
+          echo "No new vendorHash."
+          exit 0
+        fi
+
+        fname="$(nix-instantiate --eval -E "with import ./. {}; (builtins.unsafeGetAttrPos \"version\" $UPDATE_NIX_ATTR_PATH).file" | cut -d'"' -f2)"
+
+        ${sd.meta.mainProgram} --string-mode "$oldhash" "$newhash" "$fname"
+      '';
+    };
+    updateScript = _experimental-update-script-combinators.sequence [
+      finalAttrs.passthru.updateScriptSrc.command
+      (lib.getExe finalAttrs.passthru.updateScriptVendor)
+    ];
+  };
+
+  meta = {
+    description = "Speech-to-text support for Galene";
+    homepage = "https://github.com/jech/galene-stt";
+    changelog = "https://github.com/jech/galene-stt/raw/${finalAttrs.src.rev}/CHANGES";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.linux;
+    inherit (galene.meta) maintainers;
+  };
+})

--- a/pkgs/by-name/ga/galene/package.nix
+++ b/pkgs/by-name/ga/galene/package.nix
@@ -39,6 +39,7 @@ buildGoModule rec {
     changelog = "https://github.com/jech/galene/raw/galene-${version}/CHANGES";
     license = licenses.mit;
     platforms = platforms.linux;
+    teams = [ lib.teams.ngi ];
     maintainers = with maintainers; [
       rgrunbla
       erdnaxe

--- a/pkgs/by-name/ga/galene/package.nix
+++ b/pkgs/by-name/ga/galene/package.nix
@@ -2,6 +2,7 @@
   lib,
   fetchFromGitHub,
   buildGoModule,
+  nixosTests,
 }:
 
 buildGoModule rec {
@@ -32,6 +33,10 @@ buildGoModule rec {
     mkdir $static
     cp -r ./static $static
   '';
+
+  passthru = {
+    tests.vm = nixosTests.galene.basic;
+  };
 
   meta = with lib; {
     description = "Videoconferencing server that is easy to deploy, written in Go";


### PR DESCRIPTION
Packaging of these was requested for https://github.com/ngi-nix/projects/issues/33.

`galene-file-transfer`, and to some degree `galene-stream`, have been tested (and will continue being tested via VM tests). Ideally, it would be possible to set these up via the module system, but I think this'll need support for configuring Galène groups and members via the module system first.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
