### PR TITLE
mar1d: unbreak aarch64

### DIFF
--- a/pkgs/by-name/ma/mar1d/fix-aarch64.patch
+++ b/pkgs/by-name/ma/mar1d/fix-aarch64.patch
@@ -1,0 +1,45 @@
+diff --git a/src/parsing.c b/src/parsing.c
+index 8d97a7e..786a536 100644
+--- a/src/parsing.c
++++ b/src/parsing.c
+@@ -348,8 +348,8 @@ void io_getLevels(level** ls, char* fn){
+   memset(io_cs, 0, sizeof(color) * CHAR_MAX);
+   *ls = salloc(sizeof(level) * CHAR_MAX);
+   memset(*ls, 0, sizeof(level *) * CHAR_MAX);
+-  char c;
+-  char name = '\0';
++  int c;
++  int name = '\0';
+   while((c = fgetc(f)) != EOF){
+     if (c == 'C' || c == 'O' || c == 'L') {
+       name = fgetc(f);
+diff --git a/src/parsing.h b/src/parsing.h
+index d4be0a0..ae485ae 100644
+--- a/src/parsing.h
++++ b/src/parsing.h
+@@ -16,9 +16,9 @@ int io_getFont(bool**, char*);
+ 
+ void io_getColor(FILE*, color*);
+ 
+-void io_getLevel(FILE*, level*, obj[127]);
++void io_getLevel(FILE*, level*, obj[CHAR_MAX]);
+ 
+-void io_getObj(FILE*, obj*, char, color[127]);
++void io_getObj(FILE*, obj*, char, color[CHAR_MAX]);
+ 
+ // TODO: this is named terribly. There should be another function io_readLevels that's exposed. this should be private and take in FILE*
+ void io_getLevels(level**, char*);
+diff --git a/src/visual_sounds.c b/src/visual_sounds.c
+index 067e2e3..5e5cdc4 100644
+--- a/src/visual_sounds.c
++++ b/src/visual_sounds.c
+@@ -921,6 +921,9 @@ void vs_mainPlay(int snd) {
+ }
+ 
+ void vs_mainStop() {
++  if (vs_mainVisual == SND_none) {
++    return;
++  }
+   vs_sounds[vs_mainVisual].cur = NULL;
+   vs_mainVisual = SND_none;
+ }

--- a/pkgs/by-name/ma/mar1d/package.nix
+++ b/pkgs/by-name/ma/mar1d/package.nix
@@ -49,6 +49,8 @@ stdenv.mkDerivation (finalAttrs: {
       url = "https://github.com/Radvendii/MAR1D/commit/baf3269e90eca69f154a43c4c1ef14677a6300fd.patch";
       hash = "sha256-ybdLA2sO8e0J7w4roSdMWn72OkttD3y+cJ3ScuGiHCI=";
     })
+    # https://github.com/Radvendii/MAR1D/pull/5
+    ./fix-aarch64.patch
   ];
 
   meta = {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
fixes https://hydra.nixos.org/build/295012949
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
