### PR TITLE
pacparser: fix build on GCC 14

### DIFF
--- a/pkgs/by-name/pa/pacparser/fix-invalid-pointer-type.patch
+++ b/pkgs/by-name/pa/pacparser/fix-invalid-pointer-type.patch
@@ -1,0 +1,11 @@
+--- a/src/spidermonkey/js/src/jsapi.c
++++ b/src/spidermonkey/js/src/jsapi.c
+@@ -93,7 +93,7 @@
+ #ifdef HAVE_VA_LIST_AS_ARRAY
+ #define JS_ADDRESSOF_VA_LIST(ap) ((va_list *)(ap))
+ #else
+-#define JS_ADDRESSOF_VA_LIST(ap) (&(ap))
++#define JS_ADDRESSOF_VA_LIST(ap) ((va_list *)(&(ap)))
+ #endif
+ 
+ #if defined(JS_PARANOID_REQUEST) && defined(JS_THREADSAFE)

--- a/pkgs/by-name/pa/pacparser/package.nix
+++ b/pkgs/by-name/pa/pacparser/package.nix
@@ -4,21 +4,30 @@
   fetchFromGitHub,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "pacparser";
   version = "1.4.5";
 
   src = fetchFromGitHub {
     owner = "manugarg";
     repo = "pacparser";
-    rev = "v${version}";
-    sha256 = "sha256-X842+xPjM404aQJTc2JwqU4vq8kgyKhpnqVu70pNLks=";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-X842+xPjM404aQJTc2JwqU4vq8kgyKhpnqVu70pNLks=";
   };
+
+  patches = [
+    # jsapi.c:96:35: error: passing argument 5 of 'TryArgumentFormatter' from incompatible pointer type []
+    #   96 | #define JS_ADDRESSOF_VA_LIST(ap) (&(ap))
+    # suggested by https://github.com/manugarg/pacparser/issues/194#issuecomment-2262030966
+    ./fix-invalid-pointer-type.patch
+  ];
 
   makeFlags = [
     "NO_INTERNET=1"
     "PREFIX=${placeholder "out"}"
   ];
+
+  enableParallelBuilding = true;
 
   preConfigure = ''
     patchShebangs tests/runtests.sh
@@ -35,4 +44,4 @@ stdenv.mkDerivation rec {
     maintainers = with lib.maintainers; [ abbradar ];
     mainProgram = "pactester";
   };
-}
+})


### PR DESCRIPTION
Fix GCC 14 build by including the following patch: https://github.com/manugarg/pacparser/issues/194#issuecomment-2262030966

- #388196

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
