### PR TITLE
Add Nixpkgs entrypoint lib, `<flake>.lib.nixpkgs.configure`, `(import <nixpkgs>).configure`

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -27,4 +27,7 @@ if !builtins ? nixVersion || builtins.compareVersions requiredVersion builtins.n
 
 else
 
-  import ./pkgs/top-level/impure.nix
+  import ./pkgs/abs/default.nix // {
+    /** Legacy Nixpkgs entrypoint */
+    __functor = _: import ./pkgs/top-level/impure.nix;
+  }

--- a/flake.nix
+++ b/flake.nix
@@ -94,7 +94,18 @@
               // builtins.removeAttrs args [ "modules" ]
             );
         }
-      );
+      ) // {
+        /**
+          This is the Nixpkgs entrypoint library, also known as `nixpkgs.lib.nixpkgs`.
+          Historically, the Nixpkgs package set has only been handled by means of `pkgs`, the conventional name for the return value of the function that produces a configured package set.
+          However, not everything that is specific to Nixpkgs is _relative_ to the _configured_ package set.
+
+          This library is specifically for un-configured things such as the `configure` function, which is used to produce the configured package set.
+          Other functions and values that relate to packages without referring to instantiated packages can be added here too.
+        */
+        # `nixpkgs` isn't part of the standard library `lib`, so it is intentionally not part of `lib.extend`.
+        nixpkgs = import ./pkgs/abs/default.nix;
+      };
 
       checks = forAllSystems (
         system:

--- a/pkgs/abs/default.nix
+++ b/pkgs/abs/default.nix
@@ -1,0 +1,57 @@
+let
+  lib = import ../../lib;
+  inherit (lib)
+    isString
+    removeAttrs
+    ;
+in
+{
+  /**
+    Configure the Nixpkgs package set.
+
+    By filling in parameters such as the platform, we obtain a constellation of
+    concrete, configured packages, as well as a set of functions that use the
+    configured package set.
+
+    # Inputs
+
+    - `hostPlatform`: The platform on which the built packages can run.
+    - `buildPlatform`: The platform that is used for building the packages.
+    - `overlays`: A list of overlays to apply to the package set.
+    - `crossOverlays`: A list of overlays to apply to the target packages only.
+    - ...: Other attributes should be among the [Nixpkgs configuration options](https://nixos.org/manual/nixpkgs/stable/#sec-config-options-reference).
+
+    # Outputs
+
+    The output is the package set commonly referred to as `pkgs`.
+    Besides many packages, notable attributes include:
+
+    - `_type`: A runtime type tag with value `"pkgs"`
+    - `lib`: The standard library
+    - `stdenv`: The standard build environment
+    - `testers`: Functions that produce derivations that fail to build if something is wrong.
+  */
+  # TODO: review copied `crossOverlays` doc: isn't it supposed to be "host packages only"? We don't even have "target" in this context.
+  configure = parameters@{ hostPlatform, ... }:
+    # For now, we convert the parameters to the format the legacy entrypoint expects.
+    let
+      # Nixpkgs didn't use to classify the platforms as configuration. (??!)
+      config = removeAttrs parameters [ "hostPlatform" "buildPlatform" "overlays" "crossOverlays" ];
+
+      # From what I understand, elaboration isn't necessarily idempotent or good.
+      # For now we'll just do the minimum.
+      elaborateSomewhat = platform: if isString platform then { system = platform; } else platform;
+
+      hostPlatform = elaborateSomewhat parameters.hostPlatform;
+      buildPlatform = elaborateSomewhat parameters.buildPlatform;
+
+      isCross = parameters?buildPlatform && ! lib.systems.equals hostPlatform buildPlatform;
+    in
+      import ../top-level/default.nix {
+        localSystem = elaborateSomewhat (if isCross then parameters.buildPlatform else parameters.hostPlatform);
+        ${if isCross then "crossSystem" else null} = elaborateSomewhat parameters.hostPlatform;
+        overlays = parameters.overlays or [ ];
+        crossOverlays = parameters.crossOverlays or [ ];
+        inherit config;
+      };
+}

--- a/pkgs/abs/tests.nix
+++ b/pkgs/abs/tests.nix
@@ -1,0 +1,30 @@
+# Run:
+#   nix-shell -p nix-unit -I nixpkgs=.
+#   nix-unit pkgs/abs/tests.nix
+#
+# See also pkgs/test/top-level/default.nix
+let
+  nixpkgs = import ./default.nix;
+
+  legacyEntrypoint = import ../..;
+in
+{
+  "test native invocation matches legacy entrypoint" = {
+    expr = (nixpkgs.configure {
+      hostPlatform.system = "x86_64-linux";
+    }).hello.outPath;
+    expected = (legacyEntrypoint {
+      localSystem.system = "x86_64-linux";
+    }).hello.outPath;
+  };
+  "test cross invocation matches legacy entrypoint" = {
+    expr = (nixpkgs.configure {
+      buildPlatform = "aarch64-linux";
+      hostPlatform = "x86_64-linux";
+    }).hello.outPath;
+    expected = (legacyEntrypoint {
+      localSystem.system = "aarch64-linux";
+      crossSystem.system = "x86_64-linux";
+    }).hello.outPath;
+  };
+}


### PR DESCRIPTION
- A clean entrypoint into Nixpkgs not too burdened by 20 years of history.
- Add a place for functions that don't depend on any configuration.
- This is a simpler alternative to https://github.com/NixOS/nixpkgs/pull/324614
- Related https://github.com/NixOS/nixpkgs/pull/398332
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
