### PR TITLE
labels: add backport label for automatic browser updates

### DIFF
--- a/.github/labeler-no-sync.yml
+++ b/.github/labeler-no-sync.yml
@@ -7,6 +7,39 @@
       - any-glob-to-any-file:
         - .github/workflows/*
         - ci/**/*.*
+  - all:
+    - head-branch:
+      # r-ryantm's branches have this prefix.
+      - ^auto-update/
+    - changed-files:
+      - any-glob-to-any-file:
+        # Browser updates should always be backported.
+        - pkgs/applications/kde/angelfish.nix
+        - pkgs/applications/kde/falkon.nix
+        - pkgs/applications/kde/konqueror.nix
+        - pkgs/applications/networking/browsers/**/*
+        - pkgs/by-name/br/brave/**/*
+        # Added in December 2024, uncomment for 25.05
+        # - pkgs/by-name/ca/catalyst-browser/**/*
+        - pkgs/by-name/ch/chawan/**/*
+        - pkgs/by-name/di/dillo-plus/**/*
+        - pkgs/by-name/di/dillo/**/*
+        - pkgs/by-name/ed/edbrowse/**/*
+        - pkgs/by-name/ep/epiphany/**/*
+        - pkgs/by-name/go/google-chrome/**/*
+        - pkgs/by-name/ly/lynx/**/*
+        - pkgs/by-name/mi/microsoft-edge/**/*
+        - pkgs/by-name/mi/midori-unwrapped/**/*
+        - pkgs/by-name/mu/mullvad-browser/**/*
+        - pkgs/by-name/op/opera/**/*
+        - pkgs/by-name/to/tor-browser/**/*
+        - pkgs/by-name/vi/vimb-unwrapped/**/*
+        - pkgs/by-name/w3/w3m/**/*
+        - pkgs/desktops/lomiri/applications/morph-browser/**/*
+        - pkgs/development/libraries/webkitgtk/**/*
+        - pkgs/kde/gear/angelfish/**/*
+        - pkgs/kde/gear/falkon/**/*
+        - pkgs/kde/gear/konqueror/**/*
 
 "6.topic: policy discussion":
   - any:


### PR DESCRIPTION
Browser updates should always be backported for security reasons, so let's make our life a bit easier by adding the backport label for r-ryantm's PRs automatically.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
