### PR TITLE
gitSetupHook: init

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2505.section.md
+++ b/nixos/doc/manual/release-notes/rl-2505.section.md
@@ -622,6 +622,11 @@
 
 - A toggle has been added under `users.users.<name>.enable` to allow toggling individual users conditionally. If set to false, the user account will not be created.
 
+- New hooks were added:
+  - `writableTmpDirAsHomeHook`: This setup hook ensures that the directory specified by the `HOME` environment variable is writable.
+  - `addBinToPathHook`: This setup hook checks if the `bin/` directory exists in the `$out` output path and, if so, adds it to the `PATH` environment variable.
+  - `gitSetupHook`: This setup hook sets up a valid Git configuration, including the `user.name` and `user.email` fields.
+
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
 
 ```{=include=} sections

--- a/pkgs/by-name/gi/gitSetupHook/gitSetupHook.sh
+++ b/pkgs/by-name/gi/gitSetupHook/gitSetupHook.sh
@@ -1,0 +1,10 @@
+# shellcheck shell=bash
+
+gitSetup () {
+    GIT_CONFIG_GLOBAL=$(mktemp -t gitconfig.XXXXXX)
+    export GIT_CONFIG_GLOBAL
+    @gitMinimal@ config --global user.name GitSetupHook
+    @gitMinimal@ config --global user.email GitSetupHook@nixpkgs.invalid
+}
+
+postHooks+=(gitSetup)

--- a/pkgs/by-name/gi/gitSetupHook/package.nix
+++ b/pkgs/by-name/gi/gitSetupHook/package.nix
@@ -1,0 +1,14 @@
+{
+  lib,
+  gitMinimal,
+  makeSetupHook,
+}:
+
+makeSetupHook {
+  name = "gitSetupHook";
+
+  substitutions = {
+    gitMinimal = lib.getExe gitMinimal;
+  };
+
+} ./gitSetupHook.sh


### PR DESCRIPTION
This PR:

- add a new hook `gitSetupHook` which initialize the git `user.mail` and `user.name`
- update a couple of derivation by using that new hook

Note: the hook uses a hook substitution for `gitMinimal` so that the user is still able to customize the version of git in use in `nativeCheckInputs`. 

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
