### PR TITLE
nolibc: init

### DIFF
--- a/pkgs/by-name/no/nolibc/package.nix
+++ b/pkgs/by-name/no/nolibc/package.nix
@@ -1,0 +1,66 @@
+{
+  lib,
+  stdenvNoLibc,
+  linuxHeaders,
+}:
+
+stdenvNoLibc.mkDerivation (finalAttrs: {
+  pname = "nolibc";
+
+  inherit (linuxHeaders) version src;
+
+  # Nolibc depends on these headers
+  propagatedBuildInputs = [ linuxHeaders ];
+
+  setSourceRoot = ''
+    sourceRoot=$(echo */tools/include/nolibc)
+  '';
+
+  makeFlags = [ "ARCH=${stdenvNoLibc.hostPlatform.linuxArch}" ];
+  makeTarget = [ "headers" ];
+
+  # The Makefile insists on installing to $(OUTPUT)/sysroot, so we satisfy
+  # their wish, use the default of current directory, and copy in installPhase.
+  installPhase = ''
+    runHook preInstall
+    mkdir -p "$out"
+    cp -r -t "$out" sysroot/*
+    runHook postInstall
+  '';
+
+  # {check,installCheck}Phase are disabled if cross, so we use our own phase
+  postPhases = [ "nolibcCheckPhase" ];
+
+  # For nolibcCheckPhase
+  hardeningDisable = [
+    "stackprotector" # Segfaults due to no TLS support
+  ];
+
+  nolibcCheckPhase =
+    ''
+      echo "Doing a compilation test"
+
+      cat > hello-world.c <<END
+      #include <stdio.h>
+
+      int main() { puts("Hello, world!"); }
+      END
+
+      $CC -Os -o hello-world \
+        -nostdlib -nostdinc -static -I "$out/include" \
+        hello-world.c \
+        ${lib.optionalString stdenvNoLibc.cc.isGNU "-lgcc"}
+    ''
+    + lib.optionalString (stdenvNoLibc.buildPlatform.canExecute stdenvNoLibc.hostPlatform) ''
+      echo "Doing a running test"
+      ./hello-world
+    '';
+
+  meta = {
+    description = "Libc alternative for minimal programs with very limited requirements";
+    homepage = "https://git.kernel.org/pub/scm/linux/kernel/git/nolibc/linux-nolibc.git";
+    license = lib.licenses.mit; # Actually LGPL-2.1 OR MIT
+    maintainers = with lib.maintainers; [ dramforever ];
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
## Description of changes

Nolibc is a tiny, header-only library providing minimal functionality, just barely enough to write some C programs ("we have libc at home"). One use is to provide some even tinier statically linked programs:

```console
$ cat hello.c
#include <stdio.h>
int main() { puts("hi"); }
$ stat --format='%n: %s bytes' hello-*
hello-musl: 17704 bytes
hello-nolibc: 8632 bytes
```

For reference, command lines used:
```
$ NIX_HARDENING_ENABLE= $CC -fno-asynchronous-unwind-tables -fno-ident -s -Os -nostdlib -nostdinc -static -o hello-nolibc hello.c -lgcc # stdenvNoLibc with buildInputs = [ nolibc ]
$ NIX_HARDENING_ENABLE= x86_64-unknown-linux-musl-gcc $CC -fno-asynchronous-unwind-tables -fno-ident -s -Os -static -o hello-musl hello.c # pkgsStatic.stdenv.cc
```

Another use is for building special-purpose userspace code that cannot use a normal libc. With nolibc we wouldn't have to reimplement a lot of random functions. Important symbols like `_start` are `__attribute__((weak))` for easy overriding, and it really has as little setup as possible:

```console
$ strace ./hello-nolibc >/dev/null
execve("./hello-nolibc", ["./hello-nolibc"], 0x7ffec03bfb60 /* 107 vars */) = 0
write(1, "hi", 2)                       = 2
write(1, "\n", 1)                       = 1
exit(0)                                 = ?
+++ exited with 0 +++
```

To test, use `-nostdlib -nostdinc -static ... -lgcc` when compiling (`-lgcc` not necessary with Clang)

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux (both `nolibc` and `pkgsCross.riscv64.nolibc`)
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
