### PR TITLE
libsForQt5.polkit-qt: remove unused dependencies

### DIFF
--- a/pkgs/development/libraries/polkit-qt-1/default.nix
+++ b/pkgs/development/libraries/polkit-qt-1/default.nix
@@ -1,5 +1,4 @@
 {
-  stdenv,
   lib,
   mkDerivation,
   fetchurl,
@@ -7,10 +6,6 @@
   pkg-config,
   polkit,
   glib,
-  pcre,
-  libselinux,
-  libsepol,
-  util-linux,
 }:
 
 mkDerivation rec {
@@ -18,7 +13,7 @@ mkDerivation rec {
   version = "0.114.0";
 
   src = fetchurl {
-    url = "mirror://kde/stable/${pname}/${pname}-${version}.tar.xz";
+    url = "mirror://kde/stable/polkit-qt-1/polkit-qt-1-${version}.tar.xz";
     sha256 = "sha256-LrDyJEWIgpX/or+8DDaThHoPlzu2sMPkzOAhi+fjkH4=";
   };
 
@@ -27,21 +22,14 @@ mkDerivation rec {
     pkg-config
   ];
 
-  buildInputs =
-    [
-      glib
-      pcre
-      polkit
-    ]
-    ++ lib.optionals stdenv.hostPlatform.isLinux [
-      libselinux
-      libsepol
-      util-linux
-    ];
+  buildInputs = [
+    glib
+    polkit
+  ];
 
-  meta = with lib; {
+  meta = {
     description = "Qt wrapper around PolKit";
-    maintainers = with maintainers; [ ttuegel ];
-    platforms = platforms.linux;
+    maintainers = with lib.maintainers; [ ttuegel ];
+    platforms = lib.platforms.linux;
   };
 }


### PR DESCRIPTION
These were added in 1d8ffebb1133f1ec3802562868b8b103f27eba93, with little review or consideration, and no obvious reason. The qt6 variant does not require these dependencies, neither did the old qt4 or qt5 versions need them.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
