### PR TITLE
programs.nextflow: init

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -262,6 +262,7 @@
   ./programs/nbd.nix
   ./programs/neovim.nix
   ./programs/nethoscope.nix
+  ./programs/nextflow.nix
   ./programs/nexttrace.nix
   ./programs/nh.nix
   ./programs/nix-index.nix

--- a/nixos/modules/programs/nextflow.nix
+++ b/nixos/modules/programs/nextflow.nix
@@ -1,0 +1,28 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.programs.nextflow;
+in
+{
+  options.programs.nextflow = {
+    enable = lib.mkEnableOption "Nextflow";
+
+    package = lib.mkPackageOption pkgs "nextflow" { };
+  };
+
+  config = lib.mkIf cfg.enable {
+    environment.systemPackages = [
+      cfg.package
+    ];
+    services.envfs.enable = true;
+  };
+
+  meta = {
+    maintainers = with lib.maintainers; [ rollf ];
+  };
+}

--- a/pkgs/by-name/ne/nextflow/package.nix
+++ b/pkgs/by-name/ne/nextflow/package.nix
@@ -10,7 +10,6 @@
   gnused,
   gawk,
   coreutils,
-  bash,
   testers,
   nixosTests,
 }:
@@ -36,17 +35,6 @@ stdenv.mkDerivation (finalAttrs: {
     makeWrapper
     gradle
   ];
-
-  postPatch = ''
-    # Nextflow invokes the constant "/bin/bash" (not as a shebang) at
-    # several locations so we fix that globally. However, when running inside
-    # a container, we actually *want* "/bin/bash". Thus the global fix needs
-    # to be reverted for this specific use case.
-    substituteInPlace modules/nextflow/src/main/groovy/nextflow/executor/BashWrapperBuilder.groovy \
-      --replace-fail "['/bin/bash'," "['${bash}/bin/bash'," \
-      --replace-fail "if( containerBuilder ) {" "if( containerBuilder ) {
-                launcher = launcher.replaceFirst(\"/nix/store/.*/bin/bash\", \"/bin/bash\")"
-  '';
 
   mitmCache = gradle.fetchDeps {
     inherit (finalAttrs) pname;


### PR DESCRIPTION
This PR adds a new module `programs.nextflow`. This modules installs `nextflow` (the package) and - crucially - allows to run an unpatched version of Nextflow (the software). This is achieved by using `services.envfs.enable = true;` which solves all `/bin/bash`-doesn't-exist problems with Nextflow. I had tried to solve the problem upstream but that did not work. A good summary about that journey is found [here](https://github.com/nextflow-io/nextflow/pull/5696#issuecomment-2607740437).

Fixes https://github.com/NixOS/nixpkgs/issues/350183 but patching needs to be removed from the package definition (as done here in this PR as of writing). The test suite has been updated to cover this scenario.

There are, however, alternatives to the proposal of this PR:

0) This PR here as is. Pro: Just works. Contra: Can't really install `nextflow` (the package) as is anymore on NixOS, one needs to use `programs.nextfow` (or have `services.envfs.enable = true;` set independently).

1) Instead of adding `programs.nextflow`, we might stick to the original patched-based approach. We could condense the upstream changes that I had suggested into a single patch which would allow us to run Nextflow as before but fixing the "tracing scenario" (see linked issue above). This is more pure (because we do not rely on the existence of `/bin/bash` as enabled by envfs) and also would allow people to install `nextflow` the package as is, i.e. without having to use `programs.nextflow`. OTOH, it would create maintenance burden, esp. when upstream changes (for example, if this upstream [PR](https://github.com/nextflow-io/nextflow/pull/5696) would get merged).

2) We could go back to the old approach of using `buildFHSEnv` (see for example here at [23.05](https://github.com/NixOS/nixpkgs/blob/nixos-23.05/pkgs/development/interpreters/nextflow/default.nix)). Here, no patching is needed and no envfs neither. I think this is the least favorable option because it would (again) prevent certain use case (ex: use `nextflow.overrideAttrs()` to pin a certain nextflow version).

<<< EDIT 2025-05-06 BEGIN <<<
3) Go back to the upstream project and try to convince them that `/usr/bin/env -S bash` is a thing. Though, there are numerous PR/issues already around that topic.
<<< EDIT 2025-05-06 END <<<

I am undecided between 0) and 1).

TODO if 0) gets chosen:
* [ ] Add release note about `program.nextflow`
* [ ] Somehow make people aware that they should not use `environment.systemPackages = [pkgs.nextflow];` but rather `programs.nextflow.enable = true;` instead. I don't know how to do this; I envision some kind of warning in the package definition itself.

TODO if 1) gets chosen:
* [ ] Re-apply patching (including changes so that the "tracing scenario" is covered
* [ ] Remove `programs.nextflow` again


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
