### PR TITLE
pilot-link: unbreak on GCC 14

### DIFF
--- a/pkgs/by-name/pi/pilot-link/incompatible-pointer-type.patch
+++ b/pkgs/by-name/pi/pilot-link/incompatible-pointer-type.patch
@@ -1,0 +1,15 @@
+Index: pilot-link/src/pilot-read-todos.c
+===================================================================
+--- pilot-link/src/pilot-read-todos.c
++++ pilot-link/src/pilot-read-todos.c
+@@ -216,9 +216,9 @@
+ 				break;
+ 		}
+ 		else {
+ 			if (pi_file_read_record
+-			    (pif, i, (void *) &ptr, &len, &attr, &category,
++			    (pif, i, (void *) &ptr, (size_t *) &len, &attr, &category,
+ 			     0))
+ 				break;
+ 
+ 			pi_buffer_clear(recbuf);

--- a/pkgs/by-name/pi/pilot-link/package.nix
+++ b/pkgs/by-name/pi/pilot-link/package.nix
@@ -20,7 +20,7 @@
 
 stdenv.mkDerivation {
   pname = "pilot-link";
-  version = "0.12.3-unstable-2022-09-26";
+  version = "0.13.0-unstable-2022-09-26";
 
   src = fetchFromGitHub {
     owner = "desrod";
@@ -33,7 +33,10 @@ stdenv.mkDerivation {
   # https://github.com/desrod/pilot-link/issues/16
   # https://aur.archlinux.org/packages/pilot-link-git
   patches =
-    [ ./configure-checks.patch ]
+    [
+      ./configure-checks.patch
+      ./incompatible-pointer-type.patch
+    ]
     ++ lib.optionals enableConduits [ ./format-string-literals.patch ]
     ++ lib.optionals enableLibpng [ ./pilot-link-png14.patch ];
 
@@ -55,6 +58,8 @@ stdenv.mkDerivation {
     ++ lib.optionals enableConduits [ "--enable-conduits" ]
     ++ lib.optionals enableLibpng [ "--enable-libpng" ]
     ++ lib.optionals enableLibusb [ "--enable-libusb" ];
+
+  enableParallelBuilding = true;
 
   meta = {
     description = "Suite of tools for connecting to PalmOS handheld devices";


### PR DESCRIPTION
Include patch suggested in upstream discussions to fix pointer cast. Also, I noticed that the tool reports its version as 0.13.0.

- #388196

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
