### PR TITLE
cargo-leptos: 0.2.28 -> 0.2.32

### DIFF
--- a/pkgs/by-name/ca/cargo-leptos/dont-vendor-openssl-and-libgit2.patch
+++ b/pkgs/by-name/ca/cargo-leptos/dont-vendor-openssl-and-libgit2.patch
@@ -1,0 +1,112 @@
+diff --git a/Cargo.lock b/Cargo.lock
+index c133008..4f50554 100644
+--- a/Cargo.lock
++++ b/Cargo.lock
+@@ -515,7 +515,6 @@ dependencies = [
+  "liquid-lib",
+  "log",
+  "names",
+- "openssl",
+  "paste",
+  "path-absolutize",
+  "regex",
+@@ -533,7 +532,7 @@ dependencies = [
+ 
+ [[package]]
+ name = "cargo-leptos"
+-version = "0.2.31"
++version = "0.2.32"
+ dependencies = [
+  "anyhow",
+  "axum",
+@@ -1397,21 +1396,6 @@ version = "0.1.5"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+ 
+-[[package]]
+-name = "foreign-types"
+-version = "0.3.2"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+-dependencies = [
+- "foreign-types-shared",
+-]
+-
+-[[package]]
+-name = "foreign-types-shared"
+-version = "0.1.1"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+-
+ [[package]]
+ name = "form_urlencoded"
+ version = "1.2.1"
+@@ -2996,47 +2980,12 @@ dependencies = [
+  "portable-atomic",
+ ]
+ 
+-[[package]]
+-name = "openssl"
+-version = "0.10.71"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "5e14130c6a98cd258fdcb0fb6d744152343ff729cbfcb28c656a9d12b999fbcd"
+-dependencies = [
+- "bitflags 2.9.0",
+- "cfg-if",
+- "foreign-types",
+- "libc",
+- "once_cell",
+- "openssl-macros",
+- "openssl-sys",
+-]
+-
+-[[package]]
+-name = "openssl-macros"
+-version = "0.1.1"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+-dependencies = [
+- "proc-macro2",
+- "quote",
+- "syn 2.0.100",
+-]
+-
+ [[package]]
+ name = "openssl-probe"
+ version = "0.1.6"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
+ 
+-[[package]]
+-name = "openssl-src"
+-version = "300.4.2+3.4.1"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "168ce4e058f975fe43e89d9ccf78ca668601887ae736090aacc23ae353c298e2"
+-dependencies = [
+- "cc",
+-]
+-
+ [[package]]
+ name = "openssl-sys"
+ version = "0.9.106"
+@@ -3045,7 +2994,6 @@ checksum = "8bb61ea9811cc39e3c2069f40b8b8e2e70d8569b361f879786cc7ed48b777cdd"
+ dependencies = [
+  "cc",
+  "libc",
+- "openssl-src",
+  "pkg-config",
+  "vcpkg",
+ ]
+diff --git a/Cargo.toml b/Cargo.toml
+index e8a4792..c588d37 100644
+--- a/Cargo.toml
++++ b/Cargo.toml
+@@ -56,7 +56,7 @@ base64ct = { version = "1.6.0", features = ["alloc"] }
+ swc = "13.0.1"
+ swc_common = "6.1"
+ shlex = "1.3.0"
+-cargo-generate = { version = "0.22", features = ["vendored-openssl"] }
++cargo-generate = { version = "0.22", default-features = false }
+ wasm-opt = "0.116.1"
+ ignore = "0.4.23"
+ walkdir = "2.5"

--- a/pkgs/by-name/ca/cargo-leptos/package.nix
+++ b/pkgs/by-name/ca/cargo-leptos/package.nix
@@ -4,6 +4,9 @@
   lib,
   rustPlatform,
   stdenv,
+  pkg-config,
+  libgit2,
+  openssl,
 }:
 let
   inherit (darwin.apple_sdk.frameworks)
@@ -16,23 +19,36 @@ let
 in
 rustPlatform.buildRustPackage rec {
   pname = "cargo-leptos";
-  version = "0.2.28";
+  version = "0.2.32";
 
   src = fetchFromGitHub {
     owner = "leptos-rs";
     repo = "cargo-leptos";
     rev = "v${version}";
-    hash = "sha256-SjpfM963Zux+H5QhK8prvDLuI56fP5PqX5gcVbthRx4=";
+    hash = "sha256-sRfIRPs0hhFjMK9KQ4AUDSGTu1U8QIpVxsVhsWjY4fs=";
   };
 
-  useFetchCargoVendor = true;
-  cargoHash = "sha256-Da9ei4yAOfhSQmQgrUDZCmMeJXTfGnYhI1+L0JT/ECs=";
-
-  buildInputs = optionals isDarwin [
-    SystemConfiguration
-    Security
-    CoreServices
+  cargoPatches = [
+    ./dont-vendor-openssl-and-libgit2.patch
   ];
+
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-xh9fGtSxDsYvJbGV55Rf+8c+eI4dtc5a8QcoNq1SvbQ=";
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  buildInputs =
+    [
+      libgit2
+      openssl
+    ]
+    ++ optionals isDarwin [
+      SystemConfiguration
+      Security
+      CoreServices
+    ];
 
   # https://github.com/leptos-rs/cargo-leptos#dependencies
   buildFeatures = [ "no_downloads" ]; # cargo-leptos will try to install missing dependencies on its own otherwise


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Changed the features in a dependency (cargo-generate) to use the system openssl and libgit2.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
