### PR TITLE
androidenv: support linking "latest" version of all plugins (fixing NDK linking)

### DIFF
--- a/doc/languages-frameworks/android.section.md
+++ b/doc/languages-frameworks/android.section.md
@@ -50,6 +50,7 @@ let
     platformVersions = [
       "34"
       "35"
+      "latest"
     ];
     systemImageTypes = [ "google_apis_playstore" ];
     abiVersions = [
@@ -130,7 +131,8 @@ For each requested system image we can specify the following options:
   be included. Defaults to `armeabi-v7a` and `arm64-v8a`.
 
 Most of the function arguments have reasonable default settings, preferring the latest
-versions of tools when possible.
+versions of tools when possible. You can additionally specify "latest" for any plugin version
+that you do not care about, and just want the latest of.
 
 You can specify license names:
 

--- a/pkgs/development/mobile/androidenv/examples/shell.nix
+++ b/pkgs/development/mobile/androidenv/examples/shell.nix
@@ -45,11 +45,19 @@ let
   # The head unit only works on these platforms
   includeAuto = pkgs.stdenv.hostPlatform.isx86_64 || pkgs.stdenv.hostPlatform.isDarwin;
 
+  ndkVersions = [
+    "23.1.7779620"
+    "25.1.8937393"
+    "26.1.10909125"
+    "latest"
+  ];
+
   androidComposition = androidEnv.composeAndroidPackages {
     includeSources = true;
     includeSystemImages = false;
     includeEmulator = "if-supported";
     includeNDK = "if-supported";
+    inherit ndkVersions;
     useGoogleAPIs = true;
     useGoogleTVAddOns = true;
 
@@ -190,6 +198,12 @@ pkgs.mkShell rec {
               exit 1
             fi
           done
+
+          num_ndk_packages="$(echo "$installed_packages_section" | grep '^ndk;' | wc -l)"
+          if [ $num_ndk_packages -ne ${toString (pkgs.lib.length ndkVersions)} ]; then
+            echo "Invalid NDK package count: $num_ndk_packages"
+            exit 1
+          fi
 
           touch "$out"
         '';


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Fixes: https://github.com/NixOS/nixpkgs/pull/379534#issuecomment-2833444921

CC @NixOS/android. Fully backwards compatible change.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
