### PR TITLE
nixos/direnv: fix silent option... again

### DIFF
--- a/nixos/modules/programs/direnv.nix
+++ b/nixos/modules/programs/direnv.nix
@@ -26,6 +26,12 @@ in
 
     package = lib.mkPackageOption pkgs "direnv" { };
 
+    finalPackage = lib.mkOption {
+      type = lib.types.package;
+      readOnly = true;
+      description = "The wrapped direnv package.";
+    };
+
     enableBashIntegration = enabledOption ''
       Bash integration
     '';
@@ -92,18 +98,28 @@ in
   };
 
   config = lib.mkIf cfg.enable {
-
     programs = {
-      direnv.settings = lib.mkIf cfg.silent {
-        global = {
-          log_format = lib.mkDefault "-";
-          log_filter = lib.mkDefault "^$";
+      direnv = {
+        finalPackage = pkgs.symlinkJoin {
+          inherit (cfg.package) name;
+          paths = [ cfg.package ];
+          # direnv has a fish library which automatically sources direnv for some reason
+          postBuild = ''
+            rm -rf "$out/share/fish"
+          '';
+          meta.mainProgram = "direnv";
+        };
+        settings = lib.mkIf cfg.silent {
+          global = {
+            log_format = lib.mkDefault "-";
+            log_filter = lib.mkDefault "^$";
+          };
         };
       };
 
       zsh.interactiveShellInit = lib.mkIf cfg.enableZshIntegration ''
         if ${lib.boolToString cfg.loadInNixShell} || printenv PATH | grep -vqc '/nix/store'; then
-         eval "$(${lib.getExe cfg.package} hook zsh)"
+         eval "$(${lib.getExe cfg.finalPackage} hook zsh)"
         fi
       '';
 
@@ -111,14 +127,14 @@ in
       #$IN_NIX_SHELL for "nix-shell"
       bash.interactiveShellInit = lib.mkIf cfg.enableBashIntegration ''
         if ${lib.boolToString cfg.loadInNixShell} || [ -z "$IN_NIX_SHELL$NIX_GCROOT$(printenv PATH | grep '/nix/store')" ] ; then
-         eval "$(${lib.getExe cfg.package} hook bash)"
+         eval "$(${lib.getExe cfg.finalPackage} hook bash)"
         fi
       '';
 
       fish.interactiveShellInit = lib.mkIf cfg.enableFishIntegration ''
         if ${lib.boolToString cfg.loadInNixShell};
         or printenv PATH | grep -vqc '/nix/store';
-         ${lib.getExe cfg.package} hook fish | source
+         ${lib.getExe cfg.finalPackage} hook fish | source
         end
       '';
 
@@ -138,19 +154,10 @@ in
 
     environment = {
       systemPackages = [
-        # direnv has a fish library which automatically sources direnv for some reason
-        # I don't see any harm in doing this if we're sourcing it with fish.interactiveShellInit
-        (pkgs.symlinkJoin {
-          inherit (cfg.package) name;
-          paths = [ cfg.package ];
-          nativeBuildInputs = [ pkgs.makeBinaryWrapper ];
-          postBuild = ''
-            wrapProgram "$out/bin/direnv" \
-              --set-default 'DIRENV_CONFIG' '/etc/direnv'
-            rm -rf "$out/share/fish"
-          '';
-        })
+        cfg.finalPackage
       ];
+
+      variables.DIRENV_CONFIG = "/etc/direnv";
 
       etc = {
         "direnv/direnv.toml" = lib.mkIf (cfg.settings != { }) {


### PR DESCRIPTION
wrapping direnv with `DIRENV_CONFIG` was working... until it stopped.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
