### PR TITLE
ghostunnel: fix darwin build, skip included vendor directory

### DIFF
--- a/pkgs/by-name/gh/ghostunnel/package.nix
+++ b/pkgs/by-name/gh/ghostunnel/package.nix
@@ -44,7 +44,10 @@ buildGoModule rec {
     homepage = "https://github.com/ghostunnel/ghostunnel#readme";
     changelog = "https://github.com/ghostunnel/ghostunnel/releases/tag/v${version}";
     license = licenses.asl20;
-    maintainers = with maintainers; [ roberth ];
+    maintainers = with maintainers; [
+      roberth
+      mjm
+    ];
     mainProgram = "ghostunnel";
   };
 }

--- a/pkgs/by-name/gh/ghostunnel/package.nix
+++ b/pkgs/by-name/gh/ghostunnel/package.nix
@@ -4,6 +4,8 @@
   fetchFromGitHub,
   lib,
   nixosTests,
+  apple-sdk_12,
+  darwinMinVersionHook,
 }:
 
 buildGoModule rec {
@@ -17,16 +19,20 @@ buildGoModule rec {
     hash = "sha256-NnRm1HEdfK6WI5ntilLSwdR2B5czG5CIcMFzl2TzEds=";
   };
 
-  vendorHash = null;
+  vendorHash = "sha256-vP8OtjpYNMm1KkNfD3pmNrHh3HRy1GkzUbfLKWKhHbo=";
 
   deleteVendor = true;
 
-  # The certstore directory isn't recognized as a subpackage, but is when moved
-  # into the vendor directory.
-  postUnpack = ''
-    mkdir -p $sourceRoot/vendor/ghostunnel
-    mv $sourceRoot/certstore $sourceRoot/vendor/ghostunnel/
-  '';
+  buildInputs = lib.optionals stdenv.hostPlatform.isDarwin [
+    apple-sdk_12
+    (darwinMinVersionHook "12.0")
+  ];
+
+  # These tests don't exist for Linux, and on Darwin they attempt to use the macOS Keychain
+  # which doesn't work from a nix build. Presumably other platform implementations of the
+  # certstore would have similar issues, so it probably makes sense to skip them in
+  # general wherever they are available.
+  checkFlags = [ "-skip=^Test(ImportDelete|Signer|Certificate)(RSA|ECDSA|EC)$" ];
 
   passthru.tests = {
     nixos = nixosTests.ghostunnel;
@@ -34,7 +40,6 @@ buildGoModule rec {
   };
 
   meta = with lib; {
-    broken = stdenv.hostPlatform.isDarwin;
     description = "TLS proxy with mutual authentication support for securing non-TLS backend applications";
     homepage = "https://github.com/ghostunnel/ghostunnel#readme";
     changelog = "https://github.com/ghostunnel/ghostunnel/releases/tag/v${version}";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

- Stop using the vendor directory included in the repo, and remove the `postUnpack` stuff for the `certstore` package. The latter seemed to be messing up the Darwin build.
  - I didn't look too deeply into whether it could be made to work on Darwin while maintaining this. It seems to build fine on all platforms with a normal vendorHash.
- Add the macOS 12 SDK on Darwin, as ghostunnel uses a Security framework function that was first introduced in macOS 12.0.
  - Also update the deployment target to match, since it's not using `@available` annotations for it.
- Skip the tests in the `certstore` package, since they rely on interacting with the macOS keychain, which doesn't work within a nix build
- Add myself as a maintainer. Ghostunnel has become a critical piece of my homelab infra, so I'd like to take some responsibility for it continuing to be usable in Nixpkgs.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
