### PR TITLE
opshin: 0.24.1 -> 0.24.2

### DIFF
--- a/pkgs/by-name/op/opshin/package.nix
+++ b/pkgs/by-name/op/opshin/package.nix
@@ -4,9 +4,20 @@
   python3,
 }:
 
-python3.pkgs.buildPythonApplication rec {
+let
+  python3' = python3.override {
+    self = python3;
+    packageOverrides = (
+      final: prev: {
+        cbor2 = prev.cbor2WithoutCExtensions;
+      }
+    );
+  };
+in
+
+python3'.pkgs.buildPythonApplication rec {
   pname = "opshin";
-  version = "0.24.1";
+  version = "0.24.2";
 
   format = "pyproject";
 
@@ -14,10 +25,10 @@ python3.pkgs.buildPythonApplication rec {
     owner = "OpShin";
     repo = "opshin";
     tag = version;
-    hash = "sha256-+uuTEszA5p/qhvthM3Uje6yX3urbIUAKKfDZ4JXEYYQ=";
+    hash = "sha256-L0vWEXlghXssT9oUw5AYG3/4ALoB/NH90JV8Kdl2n30=";
   };
 
-  propagatedBuildInputs = with python3.pkgs; [
+  propagatedBuildInputs = with python3'.pkgs; [
     setuptools
     poetry-core
     uplc
@@ -26,11 +37,6 @@ python3.pkgs.buildPythonApplication rec {
     frozenlist2
     astunparse
     ordered-set
-  ];
-
-  pythonRelaxDeps = [
-    "pluthon"
-    "uplc"
   ];
 
   meta = with lib; {

--- a/pkgs/development/python-modules/cbor2/default.nix
+++ b/pkgs/development/python-modules/cbor2/default.nix
@@ -4,6 +4,8 @@
   fetchPypi,
   pythonOlder,
 
+  withCExtensions ? true,
+
   # build-system
   setuptools,
   setuptools-scm,
@@ -38,6 +40,14 @@ buildPythonPackage rec {
     pytest-cov-stub
     pytestCheckHook
   ];
+
+  env = lib.optionalAttrs (!withCExtensions) {
+    CBOR2_BUILD_C_EXTENSION = "0";
+  };
+
+  passthru = {
+    inherit withCExtensions;
+  };
 
   meta = with lib; {
     changelog = "https://github.com/agronholm/cbor2/releases/tag/${version}";

--- a/pkgs/development/python-modules/pluthon/default.nix
+++ b/pkgs/development/python-modules/pluthon/default.nix
@@ -12,7 +12,7 @@
 
 buildPythonPackage rec {
   pname = "pluthon";
-  version = "1.0.0";
+  version = "1.1.0";
 
   format = "pyproject";
 
@@ -20,7 +20,7 @@ buildPythonPackage rec {
     owner = "OpShin";
     repo = "pluthon";
     rev = version;
-    hash = "sha256-IYpkb/RXRu53HoeVKik7Jog5FyXwrWItrxSla9dN0s4=";
+    hash = "sha256-t8KWm2eBq6CzFPAWN9pgbpF62hvNNZWCpphJsY5T2OQ=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/pycardano/default.nix
+++ b/pkgs/development/python-modules/pycardano/default.nix
@@ -25,7 +25,7 @@
 }:
 
 let
-  cose_0_9_dev8 = cose.overridePythonAttrs (old: rec {
+  cose_0_9_dev8 = (cose.override { inherit cbor2; }).overridePythonAttrs (old: rec {
     version = "0.9.dev8";
     src = (
       old.src.override {
@@ -38,14 +38,14 @@ let
 in
 buildPythonPackage rec {
   pname = "pycardano";
-  version = "0.12.3";
+  version = "0.14.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "Python-Cardano";
     repo = "pycardano";
     tag = "v${version}";
-    hash = "sha256-jxgskdQ7Us+utndUgFYK7G2IW/e5QbeXytOsxQfFiJI=";
+    hash = "sha256-W5N254tND7mI0oR82YhMFWn4zVVs3ygYOqXOBMO3sXY=";
   };
 
   build-system = [
@@ -88,5 +88,9 @@ buildPythonPackage rec {
     homepage = "https://github.com/Python-Cardano/pycardano";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ t4ccer ];
+    # https://github.com/Python-Cardano/pycardano/blob/v0.13.2/Makefile#L26-L39
+    # cbor2 with C extensions fail tests due to differences in used sized vs unsized arrays
+    # more info: https://github.com/NixOS/nixpkgs/pull/402433#issuecomment-2916520286
+    broken = cbor2.withCExtensions; # consider overriding cbor2 with cbor2WithoutCExtensions
   };
 }

--- a/pkgs/development/python-modules/uplc/default.nix
+++ b/pkgs/development/python-modules/uplc/default.nix
@@ -8,14 +8,16 @@
   setuptools,
   poetry-core,
   frozendict,
+  cbor2WithoutCExtensions,
   cbor2,
   rply,
   pycardano,
+  uplc,
 }:
 
 buildPythonPackage rec {
   pname = "uplc";
-  version = "1.0.7";
+  version = "1.0.10";
 
   format = "pyproject";
 
@@ -23,7 +25,7 @@ buildPythonPackage rec {
     owner = "OpShin";
     repo = "uplc";
     tag = version;
-    hash = "sha256-xK2k0XLybWqyP5Qa2Oby8YBgiiswR++yVK7NPgpdSa0=";
+    hash = "sha256-Owo4W4jChrdYnz11BbWQdm2SiwFwOJlqjYutuRyjpxs=";
   };
 
   propagatedBuildInputs = [
@@ -37,7 +39,16 @@ buildPythonPackage rec {
     python-secp256k1-cardano
   ];
 
+  # Support cbor2 without C extensions
+  postPatch = lib.optionalString (!cbor2.withCExtensions) ''
+    substituteInPlace uplc/ast.py --replace-fail 'from _cbor2' 'from cbor2'
+  '';
+
   pythonImportsCheck = [ "uplc" ];
+
+  passthru.tests.withoutCExtensions = uplc.override {
+    cbor2 = cbor2WithoutCExtensions;
+  };
 
   meta = with lib; {
     description = "Python implementation of untyped plutus language core";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2282,6 +2282,10 @@ self: super: with self; {
 
   cbor2 = callPackage ../development/python-modules/cbor2 { };
 
+  cbor2WithoutCExtensions = callPackage ../development/python-modules/cbor2 {
+    withCExtensions = false;
+  };
+
   cccolutils = callPackage ../development/python-modules/cccolutils { krb5-c = pkgs.krb5; };
 
   cdcs = callPackage ../development/python-modules/cdcs { };


### PR DESCRIPTION
Bump `opshin` and dependencies

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
