### PR TITLE
texinfoInteractive: refactor XFAIL_TESTS

### DIFF
--- a/pkgs/development/tools/misc/texinfo/common.nix
+++ b/pkgs/development/tools/misc/texinfo/common.nix
@@ -67,10 +67,30 @@ stdenv.mkDerivation {
       patch -p1 -d gnulib < ${gnulib.passthru.longdouble-redirect-patch}
     '';
 
-  # ncurses is required to build `makedoc'
-  # this feature is introduced by the ./cross-tools-flags.patch
-  NATIVE_TOOLS_CFLAGS = if crossBuildTools then "-I${getDev buildPackages.ncurses}/include" else null;
-  NATIVE_TOOLS_LDFLAGS = if crossBuildTools then "-L${getLib buildPackages.ncurses}/lib" else null;
+  env =
+    {
+      XFAIL_TESTS = toString (
+        optionals stdenv.hostPlatform.isMusl [
+          # musl does not support locales.
+          "different_languages_gen_master_menu.sh"
+          "test_scripts/formatting_documentlanguage_cmdline.sh"
+          "test_scripts/layout_formatting_fr_info.sh"
+          "test_scripts/layout_formatting_fr.sh"
+          "test_scripts/layout_formatting_fr_icons.sh"
+        ]
+        ++ optionals (!stdenv.hostPlatform.isMusl && versionOlder version "7") [
+          # Test is known to fail on various locales on texinfo-6.8:
+          #   https://lists.gnu.org/r/bug-texinfo/2021-07/msg00012.html
+          "test_scripts/layout_formatting_fr_icons.sh"
+        ]
+      );
+    }
+    // lib.optionalAttrs crossBuildTools {
+      # ncurses is required to build `makedoc'
+      # this feature is introduced by the ./cross-tools-flags.patch
+      NATIVE_TOOLS_CFLAGS = "-I${getDev buildPackages.ncurses}/include";
+      NATIVE_TOOLS_LDFLAGS = "-L${getLib buildPackages.ncurses}/lib";
+    };
 
   strictDeps = true;
   enableParallelBuilding = true;
@@ -117,21 +137,6 @@ stdenv.mkDerivation {
   checkInputs = optionals (lib.versionAtLeast version "7.2") [ glibcLocales ];
 
   doCheck = interactive && !stdenv.hostPlatform.isDarwin && !stdenv.hostPlatform.isSunOS; # flaky
-
-  # musl does not support locales.
-  preCheck =
-    if interactive && stdenv.hostPlatform.isMusl then
-      ''
-        checkFlagsArray+=(XFAIL_TESTS="different_languages_gen_master_menu.sh test_scripts/formatting_documentlanguage_cmdline.sh test_scripts/layout_formatting_fr_info.sh test_scripts/layout_formatting_fr.sh test_scripts/layout_formatting_fr_icons.sh")
-      ''
-    else
-      null;
-
-  checkFlags = optionals (!stdenv.hostPlatform.isMusl && versionOlder version "7") [
-    # Test is known to fail on various locales on texinfo-6.8:
-    #   https://lists.gnu.org/r/bug-texinfo/2021-07/msg00012.html
-    "XFAIL_TESTS=test_scripts/layout_formatting_fr_icons.sh"
-  ];
 
   postFixup = optionalString crossBuildTools ''
     for f in "$out"/bin/{pod2texi,texi2any}; do


### PR DESCRIPTION
The previous code had to avoid a mass rebuild.  Clean it up.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
