### PR TITLE
dumphfdl: init at 1.6.1

### DIFF
--- a/pkgs/by-name/du/dumphfdl/package.nix
+++ b/pkgs/by-name/du/dumphfdl/package.nix
@@ -1,0 +1,68 @@
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  nix-update-script,
+  versionCheckHook,
+  cmake,
+  pkg-config,
+  libconfig,
+  liquid-dsp,
+  fftwSinglePrec,
+  glib,
+  soapysdr-with-plugins,
+  sqlite,
+  zeromq,
+  gperftools,
+  libacars,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "dumphfdl";
+  version = "1.6.1";
+
+  src = fetchFromGitHub {
+    owner = "szpajder";
+    repo = "dumphfdl";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-M4WjcGA15Kp+Hpp+I2Ndcx+oBqaGxEeQLTPcSlugLwQ=";
+  };
+
+  buildInputs = [
+    fftwSinglePrec
+    liquid-dsp
+    glib
+    libconfig
+    soapysdr-with-plugins
+    sqlite
+    zeromq
+    gperftools
+    libacars
+  ];
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    homepage = "https://github.com/szpajder/dumphfdl";
+    changelog = "https://github.com/szpajder/dumphfdl/releases/tag/v${finalAttrs.version}";
+    description = "Decoder for Multichannel HFDL aircraft communication";
+    longDescription = ''
+      HFDL (High Frequency Data Link) is a protocol used for radio communications
+      between aircraft and ground stations. It is used to carry ACARS and AOC messages as well as
+      CPDLC (Controller-Pilot Data Link Communications) and ADS-C.
+    '';
+    license = lib.licenses.gpl3Plus;
+    mainProgram = "dumphfdl";
+    maintainers = [ lib.maintainers.mafo ];
+    platforms = with lib.platforms; linux ++ darwin;
+    badPlatforms = lib.platforms.darwin;
+  };
+})


### PR DESCRIPTION
Init dumpfdl at 1.6.1
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
