### PR TITLE
breakpointHook: support FODs and non-sandboxed builds

### DIFF
--- a/pkgs/by-name/br/breakpointHook/attach.sh
+++ b/pkgs/by-name/br/breakpointHook/attach.sh
@@ -56,6 +56,10 @@ elif [ "$(echo "$pids" | wc -l)" -ne 1 ]; then
 fi
 pid="$(echo "$pids" | head -n1)"
 
+
+# get the build top level directory inside the sandbox (eg. /build)
+buildDir=$(getVar NIX_BUILD_TOP)
+
 # bash is needed to load the env vars, as we do not know the syntax of the debug shell.
 # bashInteractive is used instead of bash, as we depend on it anyways, due to it being
 #   the default debug shell
@@ -71,11 +75,11 @@ pwd="$(readlink /proc/$pid/cwd)"
 # If another shell is chosen via `debugShell`, it will only have simple env vars avaialable.
 exec nsenter --mount --ipc --uts --pid  --net --target "$pid" "$bashInteractive" -c "
   set -eu -o pipefail
-  source /build/env-vars
+  source \"$buildDir/env-vars\"
   cd \"$pwd\"
   if [ -n \"$debugShell\" ]; then
     exec \"$debugShell\"
   else
-    exec \"$bashInteractive\" --init-file /build/env-vars
+    exec \"$bashInteractive\" --init-file \"$buildDir/env-vars\"
   fi
 "


### PR DESCRIPTION
Remove the static reference to /build, instead evaluate NIX_BUILD_TOP

cc @mic92
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
