### PR TITLE
libnvidia-container: 1.17.2 -> 1.17.6

### DIFF
--- a/pkgs/by-name/li/libnvidia-container/package.nix
+++ b/pkgs/by-name/li/libnvidia-container/package.nix
@@ -30,14 +30,14 @@ let
     ];
   };
 in
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "libnvidia-container";
   version = "1.17.6";
 
   src = fetchFromGitHub {
     owner = "NVIDIA";
     repo = "libnvidia-container";
-    rev = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-kveP0Px9Fds7pS39aW+cqg2jtiQCMN2zG4GTGRqRrc0=";
   };
 
@@ -62,13 +62,13 @@ stdenv.mkDerivation rec {
 
   postPatch = ''
     sed -i \
-      -e 's/^REVISION ?=.*/REVISION = ${src.rev}/' \
+      -e 's/^REVISION ?=.*/REVISION = ${finalAttrs.src.tag}/' \
       -e 's/^COMPILER :=.*/COMPILER = $(CC)/' \
       mk/common.mk
 
     sed -i \
-      -e 's/^GIT_TAG ?=.*/GIT_TAG = ${version}/' \
-      -e 's/^GIT_COMMIT ?=.*/GIT_COMMIT = ${src.rev}/' \
+      -e 's/^GIT_TAG ?=.*/GIT_TAG = ${finalAttrs.version}/' \
+      -e 's/^GIT_COMMIT ?=.*/GIT_COMMIT = ${finalAttrs.src.tag}/' \
       versions.mk
 
     mkdir -p deps/src/nvidia-modprobe-${modprobeVersion}
@@ -105,7 +105,7 @@ stdenv.mkDerivation rec {
   postFixup = ''
     for lib in libnvidia-container libnvidia-container-go; do
       rm -f "$out/lib/$lib.so"
-      ln -s "$out/lib/$lib.so.${version}" "$out/lib/$lib.so.1"
+      ln -s "$out/lib/$lib.so.${finalAttrs.version}" "$out/lib/$lib.so.1"
       ln -s "$out/lib/$lib.so.1" "$out/lib/$lib.so"
     done
   '';
@@ -161,20 +161,20 @@ stdenv.mkDerivation rec {
       ];
     in
     ''
-      remove-references-to -t "${go}" $out/lib/libnvidia-container-go.so.${version}
+      remove-references-to -t "${go}" $out/lib/libnvidia-container-go.so.${finalAttrs.version}
       wrapProgram $out/bin/nvidia-container-cli --prefix LD_LIBRARY_PATH : ${libraryPath}
     '';
   disallowedReferences = [ go ];
 
-  meta = with lib; {
+  meta = {
     homepage = "https://github.com/NVIDIA/libnvidia-container";
     description = "NVIDIA container runtime library";
-    license = licenses.asl20;
-    platforms = platforms.linux;
+    license = lib.licenses.asl20;
+    platforms = lib.platforms.linux;
     mainProgram = "nvidia-container-cli";
-    maintainers = with maintainers; [
+    maintainers = with lib.maintainers; [
       cpcloud
       msanft
     ];
   };
-}
+})

--- a/pkgs/by-name/li/libnvidia-container/package.nix
+++ b/pkgs/by-name/li/libnvidia-container/package.nix
@@ -12,14 +12,11 @@
   makeWrapper,
   removeReferencesTo,
   replaceVars,
-  go_1_23,
   applyPatches,
   nvidia-modprobe,
+  go,
 }:
 let
-  # https://github.com/NVIDIA/libnvidia-container/pull/297
-  go = go_1_23;
-
   modprobeVersion = "550.54.14";
   patchedModprobe = applyPatches {
     src = nvidia-modprobe.src.override {
@@ -35,13 +32,13 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "libnvidia-container";
-  version = "1.17.2";
+  version = "1.17.6";
 
   src = fetchFromGitHub {
     owner = "NVIDIA";
     repo = "libnvidia-container";
     rev = "v${version}";
-    hash = "sha256-JmJKvAOEPyjVx2Frd0tAMBjnAUTMpMh1KBt6wr5RRmk=";
+    hash = "sha256-kveP0Px9Fds7pS39aW+cqg2jtiQCMN2zG4GTGRqRrc0=";
   };
 
   patches = [


### PR DESCRIPTION
https://github.com/NVIDIA/libnvidia-container/releases/tag/v1.17.6
https://github.com/NVIDIA/libnvidia-container/releases/tag/v1.17.5
https://github.com/NVIDIA/libnvidia-container/releases/tag/v1.17.4
https://github.com/NVIDIA/libnvidia-container/releases/tag/v1.17.3
https://github.com/NVIDIA/libnvidia-container/releases/tag/v1.17.2

Fixes [CVE-2024-0135](https://nvidia.custhelp.com/app/answers/detail/a_id/5599)
Fixes [CVE-2024-0136](https://nvidia.custhelp.com/app/answers/detail/a_id/5599)
Fixes [CVE-2024-0137](https://nvidia.custhelp.com/app/answers/detail/a_id/5599)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
