### PR TITLE
python312Packages.spsdk: 2.5.0 -> 2.6.1

### DIFF
--- a/pkgs/development/python-modules/spsdk-mcu-link/default.nix
+++ b/pkgs/development/python-modules/spsdk-mcu-link/default.nix
@@ -1,0 +1,80 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+
+  # build-system
+  setuptools,
+
+  # dependencies
+  hidapi,
+  pyusb,
+
+  # tests
+  click,
+  pytestCheckHook,
+  spsdk,
+  writableTmpDirAsHomeHook,
+
+  # passthru
+  spsdk-mcu-link,
+}:
+
+buildPythonPackage rec {
+  pname = "spsdk-mcu-link";
+  version = "0.6.0";
+  pyproject = true;
+
+  # Latest tag missing on GitHub
+  src = fetchPypi {
+    pname = "spsdk_mcu_link";
+    inherit version;
+    hash = "sha256-x+aOfFdD0+IfDT7LA2QlYqR7kMOwPfvlMCcZvOYnM0Q=";
+  };
+
+  build-system = [
+    setuptools
+  ];
+
+  pythonRemoveDeps = [
+    # unpackaged
+    "libusb_package"
+    "wasmtime"
+  ];
+
+  pythonRelaxDeps = [
+    "pyusb"
+  ];
+
+  dependencies = [
+    hidapi
+    pyusb
+  ];
+
+  nativeCheckInputs = [
+    click
+    pytestCheckHook
+    spsdk
+    writableTmpDirAsHomeHook
+  ];
+
+  # Cyclic dependency with spsdk
+  doCheck = false;
+
+  passthru.tests = {
+    pytest = spsdk-mcu-link.overridePythonAttrs {
+      pythonImportsCheck = [
+        "spsdk_mcu_link"
+      ];
+
+      doCheck = true;
+    };
+  };
+
+  meta = {
+    description = "Debugger probe plugin for SPSDK supporting LPC-Link/MCU-Link from NXP";
+    homepage = "https://pypi.org/project/spsdk-mcu-link";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ GaetanLepage ];
+  };
+}

--- a/pkgs/development/python-modules/spsdk-pyocd/default.nix
+++ b/pkgs/development/python-modules/spsdk-pyocd/default.nix
@@ -1,0 +1,71 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+
+  # build-system
+  setuptools,
+
+  # dependencies
+  pyocd,
+  pyocd-pemicro,
+  spsdk,
+
+  # tests
+  pytestCheckHook,
+  writableTmpDirAsHomeHook,
+
+  # passthru
+  spsdk-pyocd,
+}:
+
+buildPythonPackage rec {
+  pname = "spsdk-pyocd";
+  version = "0.3.1";
+  pyproject = true;
+
+  # Latest tag missing on GitHub
+  src = fetchPypi {
+    pname = "spsdk_pyocd";
+    inherit version;
+    hash = "sha256-yVQtX2T1l0TmFwaZDSFCXMuoFxTalfOr3b4CCTeteKI=";
+  };
+
+  build-system = [
+    setuptools
+  ];
+
+  dependencies = [
+    pyocd
+  ];
+
+  optional-dependencies = {
+    pemicro = [
+      pyocd-pemicro
+    ];
+  };
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    spsdk
+    writableTmpDirAsHomeHook
+  ];
+
+  # Cyclic dependency with spsdk
+  doCheck = false;
+
+  passthru.tests = {
+    pytest = spsdk-pyocd.overridePythonAttrs {
+      pythonImportsCheck = [ "spsdk_pyocd" ];
+
+      doCheck = true;
+    };
+  };
+
+  meta = {
+    description = "Debugger probe plugin for SPSDK";
+    homepage = "https://pypi.org/project/spsdk-pyocd";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ GaetanLepage ];
+  };
+}

--- a/pkgs/development/python-modules/spsdk/default.nix
+++ b/pkgs/development/python-modules/spsdk/default.nix
@@ -27,12 +27,16 @@
   packaging,
   platformdirs,
   prettytable,
+  pyasn1,
   pyocd,
   pyserial,
   requests,
   ruamel-yaml,
   sly,
+  spsdk-mcu-link,
+  spsdk-pyocd,
   typing-extensions,
+  x690,
 
   # tests
   ipykernel,
@@ -40,26 +44,25 @@
   pytestCheckHook,
   voluptuous,
   versionCheckHook,
+  writableTmpDirAsHomeHook,
 }:
 
 buildPythonPackage rec {
   pname = "spsdk";
-  version = "2.5.0";
+  version = "2.6.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "nxp-mcuxpresso";
     repo = "spsdk";
     tag = "v${version}";
-    hash = "sha256-Ua32c6hNjwfjsQIugiqtRL50AvOrPgqyKoG1Lb0NVqE=";
+    hash = "sha256-AdW19Zf5TZ6hChXbW9dLGcMpFTQOT1wrPzEqaSfWzDE=";
   };
 
   postPatch = ''
     substituteInPlace pyproject.toml \
-      --replace-fail "setuptools>=72.1,<74" "setuptools"
-
-    substituteInPlace setup.py \
-      --replace-fail "setuptools>=72.1,<74" "setuptools"
+      --replace-fail "setuptools>=72.1,<74" "setuptools" \
+      --replace-fail "setuptools_scm<8.2" "setuptools_scm"
   '';
 
   build-system = [
@@ -69,8 +72,12 @@ buildPythonPackage rec {
 
   pythonRelaxDeps = [
     "cryptography"
-    "requests"
+    "filelock"
+    "importlib-metadata"
     "packaging"
+    "prettytable"
+    "requests"
+    "setuptools_scm"
     "typing-extensions"
   ];
 
@@ -100,19 +107,19 @@ buildPythonPackage rec {
     packaging
     platformdirs
     prettytable
+    pyasn1
     pyocd
     pyserial
     requests
     ruamel-yaml
     sly
+    spsdk-mcu-link
+    spsdk-pyocd
     typing-extensions
+    x690
   ];
 
   pythonImportsCheck = [ "spsdk" ];
-
-  preInstallCheck = ''
-    export HOME="$(mktemp -d)"
-  '';
 
   nativeCheckInputs = [
     ipykernel
@@ -120,6 +127,7 @@ buildPythonPackage rec {
     pytestCheckHook
     voluptuous
     versionCheckHook
+    writableTmpDirAsHomeHook
   ];
   versionCheckProgramArg = "--version";
 
@@ -129,7 +137,7 @@ buildPythonPackage rec {
   ];
 
   meta = {
-    changelog = "https://github.com/nxp-mcuxpresso/spsdk/blob/${src.tag}/docs/release_notes.rst";
+    changelog = "https://github.com/nxp-mcuxpresso/spsdk/blob/v${version}/docs/release_notes.rst";
     description = "NXP Secure Provisioning SDK";
     homepage = "https://github.com/nxp-mcuxpresso/spsdk";
     license = lib.licenses.bsd3;

--- a/pkgs/development/python-modules/t61codec/default.nix
+++ b/pkgs/development/python-modules/t61codec/default.nix
@@ -1,0 +1,38 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  poetry-core,
+  pytestCheckHook,
+}:
+
+buildPythonPackage rec {
+  pname = "t61codec";
+  version = "2.0.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "exhuma";
+    repo = "t61codec";
+    tag = "v${version}";
+    hash = "sha256-PNUahn6NpNWdK3yhcQ23qb08lkZeNW61GosShLiyPc8=";
+  };
+
+  build-system = [
+    poetry-core
+  ];
+
+  pythonImportsCheck = [ "t61codec" ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  meta = {
+    description = "Python codec for T.61 strings";
+    homepage = "https://github.com/exhuma/t61codec";
+    changelog = "https://github.com/exhuma/t61codec/blob/v${version}/CHANGES.rst";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ GaetanLepage ];
+  };
+}

--- a/pkgs/development/python-modules/x690/default.nix
+++ b/pkgs/development/python-modules/x690/default.nix
@@ -1,0 +1,53 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  t61codec,
+  pytest-cov-stub,
+  pytestCheckHook,
+}:
+
+buildPythonPackage rec {
+  pname = "x690";
+  version = "1.0.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "exhuma";
+    repo = "x690";
+    tag = "v${version}";
+    hash = "sha256-yU4FABlTAFoj87SJXDA+sVCJT3pCbYxpTXp7Ja2ltGE=";
+  };
+
+  build-system = [
+    setuptools
+  ];
+
+  pythonRelaxDeps = [
+    "t61codec"
+  ];
+
+  dependencies = [
+    t61codec
+  ];
+
+  pythonImportsCheck = [ "x690" ];
+
+  nativeCheckInputs = [
+    pytest-cov-stub
+    pytestCheckHook
+  ];
+
+  disabledTests = [
+    # AssertionError: "<UnknownType 99 b'abc' TypeClass.APPLICATION/TypeNature.CONSTRUCTED/3>" != "<UnknownType 99 b'abc' application/constructed/3>"
+    "test_repr"
+  ];
+
+  meta = {
+    description = "Pure Python X.690 implementation";
+    homepage = "https://github.com/exhuma/x690";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ GaetanLepage ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -16437,6 +16437,8 @@ self: super: with self; {
 
   spsdk-mcu-link = callPackage ../development/python-modules/spsdk-mcu-link { };
 
+  spsdk-pyocd = callPackage ../development/python-modules/spsdk-pyocd { };
+
   spur = callPackage ../development/python-modules/spur { };
 
   spyder = callPackage ../development/python-modules/spyder { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -16435,6 +16435,8 @@ self: super: with self; {
 
   spsdk = callPackage ../development/python-modules/spsdk { };
 
+  spsdk-mcu-link = callPackage ../development/python-modules/spsdk-mcu-link { };
+
   spur = callPackage ../development/python-modules/spur { };
 
   spyder = callPackage ../development/python-modules/spyder { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -19025,6 +19025,8 @@ self: super: with self; {
 
   x256 = callPackage ../development/python-modules/x256 { };
 
+  x690 = callPackage ../development/python-modules/x690 { };
+
   xapian = callPackage ../development/python-modules/xapian { inherit (pkgs) xapian; };
 
   xarray = callPackage ../development/python-modules/xarray { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -16888,6 +16888,8 @@ self: super: with self; {
 
   sysv-ipc = callPackage ../development/python-modules/sysv-ipc { };
 
+  t61codec = callPackage ../development/python-modules/t61codec { };
+
   tabcmd = callPackage ../development/python-modules/tabcmd { };
 
   tableaudocumentapi = callPackage ../development/python-modules/tableaudocumentapi { };


### PR DESCRIPTION
- **python312Packages.t61codec: init at 2.0.0**
- **python312Packages.x690: init at 1.0.0**
- **python312Packages.spsdk-mcu-link: init at 0.6.0**
- **python312Packages.spsdk-pyocd: init at 0.3.1**
- **python312Packages.spsdk: 2.5.0 -> 2.6.1**


cc @frogamic @sbruder

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
