### PR TITLE
python312Packages.jupyter-book: 1.0.3 -> 1.0.4

### DIFF
--- a/pkgs/development/python-modules/jupyter-book/default.nix
+++ b/pkgs/development/python-modules/jupyter-book/default.nix
@@ -1,11 +1,11 @@
 {
   lib,
+  stdenv,
   buildPythonPackage,
   fetchFromGitHub,
-  pythonOlder,
 
   # build-system
-  flit-core,
+  hatchling,
 
   # dependencies
   click,
@@ -34,25 +34,27 @@
   pytestCheckHook,
   sphinx-inline-tabs,
   texsoup,
+  writableTmpDirAsHomeHook,
 }:
 
 buildPythonPackage rec {
   pname = "jupyter-book";
-  version = "1.0.3";
+  version = "1.0.4";
   pyproject = true;
-
-  disabled = pythonOlder "3.9";
 
   src = fetchFromGitHub {
     owner = "jupyter-book";
     repo = "jupyter-book";
     tag = "v${version}";
-    hash = "sha256-MBSf2/+4+efWHJ530jdezeh5OLTtUZlAEOl5SqoWOuE=";
+    hash = "sha256-04I9mzJMXCpvMiOeMD/Bg8FiymkRgHf/Yo9C1VcyTsw=";
   };
 
-  build-system = [ flit-core ];
+  build-system = [ hatchling ];
 
-  pythonRelaxDeps = [ "myst-parser" ];
+  pythonRelaxDeps = [
+    "myst-parser"
+    "sphinx"
+  ];
 
   dependencies = [
     click
@@ -87,27 +89,37 @@ buildPythonPackage rec {
     pytestCheckHook
     sphinx-inline-tabs
     texsoup
+    writableTmpDirAsHomeHook
   ];
 
-  preCheck = ''
-    export HOME=$TMPDIR
-  '';
+  disabledTests =
+    [
+      # touch the network
+      "test_create_from_cookiecutter"
 
-  disabledTests = [
-    # touch the network
-    "test_create_from_cookiecutter"
-    # flaky?
-    "test_execution_timeout"
-    # require texlive
-    "test_toc"
-    "test_toc_latex_parts"
-    "test_toc_latex_urllink"
-    # WARNING: Executing notebook failed: CellExecutionError [mystnb.exec]
-    "test_build_dirhtml_from_template"
-    "test_build_from_template"
-    "test_build_page"
-    "test_build_singlehtml_from_template"
-  ];
+      # flaky?
+      "test_execution_timeout"
+
+      # require texlive
+      "test_toc"
+      "test_toc_latex_parts"
+      "test_toc_latex_urllink"
+
+      # AssertionError: assert 'There was an error in building your book' in '1'
+      "test_build_errors"
+
+      # WARNING: Executing notebook failed: CellExecutionError [mystnb.exec]
+      "test_build_dirhtml_from_template"
+      "test_build_from_template"
+      "test_build_page"
+      "test_build_singlehtml_from_template"
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [
+      # pytest.PytestUnraisableExceptionWarning: Exception ignored in: <sqlite3.Connection object at 0x115dcc9a0>
+      # ResourceWarning: unclosed database in <sqlite3.Connection object at 0x115dcc9a0>
+      "test_clean_html_latex"
+      "test_clean_latex"
+    ];
 
   disabledTestPaths = [
     # require texlive


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Diff: https://github.com/jupyter-book/jupyter-book/compare/refs/tags/v1.0.3...refs/tags/v1.0.4
Changelog: https://github.com/jupyter-book/jupyter-book/blob/refs/tags/v1.0.4/CHANGELOG.md
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
