### PR TITLE
kraken2: init at 2.1.5

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -338,6 +338,11 @@
     githubId = 7345998;
     name = "A1ca7raz";
   };
+  A1egator = {
+    name = "Alexander Thomas";
+    github = "A1egator";
+    githubId = 140679159;
+  };
   a1russell = {
     email = "adamlr6+pub@gmail.com";
     github = "a1russell";
@@ -3990,6 +3995,11 @@
     github = "CardboardTurkey";
     githubId = 34030186;
     keys = [ { fingerprint = "8BC7 74E4 A2EC 7507 3B61  A647 0BBB 1C8B 1C36 39EE"; } ];
+  };
+  cardealerT = {
+    name = "Timothy Cardillo";
+    github = "cardealerT";
+    githubId = 196286129;
   };
   carloscraveiro = {
     email = "carlos.craveiro@usp.br";

--- a/pkgs/by-name/kr/kraken2/package.nix
+++ b/pkgs/by-name/kr/kraken2/package.nix
@@ -1,0 +1,80 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  makeWrapper,
+  nix-update-script,
+  rsync,
+  perl,
+  wget,
+  zlib,
+  python3,
+  llvmPackages,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "kraken2";
+  version = "2.1.5";
+
+  src = fetchFromGitHub {
+    owner = "DerrickWood";
+    repo = "kraken2";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-9ZW29SXWzy/fZreOmNnjywwlaSReZXnqq+uzGsuWP2g=";
+  };
+
+  nativeBuildInputs = [
+    perl
+    makeWrapper
+  ];
+
+  buildInputs =
+    [ zlib.dev ]
+    # TODO: may mismatch LLVM version (#79818)
+    ++ lib.optionals stdenv.cc.isClang [ llvmPackages.openmp ];
+
+  installPhase = ''
+    runHook preInstall
+
+    substituteInPlace install_kraken2.sh \
+      --replace-fail ${lib.escapeShellArg ''KRAKEN2_DIR=$(perl -MCwd=abs_path -le 'print abs_path(shift)' "$1")''} 'KRAKEN2_DIR="$1"'
+    ./install_kraken2.sh "$out/libexec/kraken2"
+
+    mkdir -p $out/bin
+    ln -s $out/libexec/kraken2/kraken2 $out/bin
+    ln -s $out/libexec/kraken2/kraken2-build $out/bin
+    ln -s $out/libexec/kraken2/kraken2-inspect $out/bin
+    ln -s $out/libexec/kraken2/k2 $out/bin
+    for file in $out/libexec/kraken2/* ; do
+      if [ -x "$file" ] ; then
+        wrapProgram "$file" \
+          --prefix PATH : $out/libexec/kraken2:${
+            lib.makeBinPath [
+              wget
+              perl
+              rsync
+              python3
+            ]
+          }
+        fi
+      done
+
+    runHook postInstall
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "The second version of the Kraken taxonomic sequence classification system.";
+    homepage = "https://ccb.jhu.edu/software/kraken2/";
+    downloadPage = "https://github.com/DerrickWood/kraken2";
+    changelog = "https://github.com/DerrickWood/kraken2/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.unix;
+    maintainers = with lib.maintainers; [
+      cardealerT
+      A1egator
+      jbedo
+    ];
+  };
+})


### PR DESCRIPTION
## Description of Changes
Added kraken2 taxonomic sequence classification system to by-name/kr

homepage: https://ccb.jhu.edu/software/kraken2/

github: https://github.com/DerrickWood/kraken2

Also added cardealerT and A1egator to maintainers list

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
