### PR TITLE
[24.11] signal-desktop-bin(x86_64-linux; aarch64-linux; darwin): 7.47.0 -> 7.52.0; signal-desktop-bin: replace apple emoji sheets

### DIFF
--- a/pkgs/by-name/si/signal-desktop/copy-noto-emoji.py
+++ b/pkgs/by-name/si/signal-desktop/copy-noto-emoji.py
@@ -55,37 +55,12 @@ def emoji_to_noto_name(emoji: str) -> str:
     )
 
 
-def emoji_to_emoji_data_name(emoji: str) -> str:
-    r"""Return the npm emoji-data emoji name of an emoji.
-
-    emoji-data emoji names are hyphen‐minus‐separated Unicode scalar
-    values, represented in lowercase big‐endian hex padded to at least
-    four digits.
-
-    >>> emoji_to_emoji_data_name("😶‍🌫️")
-    '1f636-200d-1f32b-fe0f'
-    >>> emoji_to_emoji_data_name("\U0001f636\u200d\U0001f32b\ufe0f")
-    '1f636-200d-1f32b-fe0f'
-    """
-    return "-".join(f"{ord(scalar_value):04x}" for scalar_value in emoji)
-
-
 def _main() -> None:
     noto_png_path, asar_root = (Path(arg) for arg in sys.argv[1:])
     asar_root = asar_root.absolute()
 
     out_path = asar_root / "images" / "nixpkgs-emoji"
     out_path.mkdir(parents=True)
-
-    emoji_data_out_path = (
-        asar_root
-        / "node_modules"
-        / "emoji-datasource-apple"
-        / "img"
-        / "apple"
-        / "64"
-    )
-    emoji_data_out_path.mkdir(parents=True)
 
     jumbomoji_json_path = asar_root / "build" / "jumbomoji.json"
     with jumbomoji_json_path.open() as jumbomoji_json_file:
@@ -106,10 +81,6 @@ def _main() -> None:
                     file=sys.stderr,
                 )
                 continue
-
-            (
-                emoji_data_out_path / f"{emoji_to_emoji_data_name(emoji)}.png"
-            ).symlink_to(out_path / emoji)
 
     print(out_path.relative_to(asar_root))
 

--- a/pkgs/by-name/si/signal-desktop/generic.nix
+++ b/pkgs/by-name/si/signal-desktop/generic.nix
@@ -43,6 +43,7 @@
   at-spi2-core,
   libappindicator-gtk3,
   mesa,
+  libwebp,
   # Runtime dependencies:
   systemd,
   libnotify,
@@ -86,6 +87,15 @@ let
       runHook postInstall
     '';
   });
+
+  noto-emoji-sheet-32 = fetchurl {
+    url = "https://raw.githubusercontent.com/iamcal/emoji-data/refs/tags/v15.1.2/sheet_google_32.png";
+    hash = "sha256-S03NCTbvB5yeQl62WpLNjNGhjNErtgaOB6tAj/X8vPc=";
+  };
+  noto-emoji-sheet-64 = fetchurl {
+    url = "https://raw.githubusercontent.com/iamcal/emoji-data/refs/tags/v15.1.2/sheet_google_64.png";
+    hash = "sha256-kZYStR5xAuausSpOD6wJZRJZ1K6nPpweE3aYSgWntS4=";
+  };
 in
 stdenv.mkDerivation rec {
   inherit pname version;
@@ -124,7 +134,8 @@ stdenv.mkDerivation rec {
       asar extract "$out/${libdir}/resources/app.asar" $out/asar-contents
       rm -r \
         "$out/${libdir}/resources/app.asar"{,.unpacked} \
-        $out/asar-contents/node_modules/emoji-datasource-apple
+        $out/asar-contents/images/emoji-sheet-32.webp \
+        $out/asar-contents/images/emoji-sheet-64.webp
     '';
   };
 
@@ -136,6 +147,7 @@ stdenv.mkDerivation rec {
     # override doesn't preserve splicing https://github.com/NixOS/nixpkgs/issues/132651
     # Has to use `makeShellWrapper` from `buildPackages` even though `makeShellWrapper` from the inputs is spliced because `propagatedBuildInputs` would pick the wrong one because of a different offset.
     (buildPackages.wrapGAppsHook3.override { makeWrapper = buildPackages.makeShellWrapper; })
+    libwebp
   ];
 
   buildInputs = [
@@ -208,6 +220,10 @@ stdenv.mkDerivation rec {
     # Create required symlinks:
     ln -s libGLESv2.so "$out/lib/signal-desktop/libGLESv2.so.2"
 
+    # Compress the emoji sheets to webp, as signal expects webp images. The flags used are the same as those used upstream.
+    cwebp -progress -mt -preset icon -alpha_filter best -alpha_q 20 -pass 10 -q 75 ${noto-emoji-sheet-32} -o asar-contents/images/emoji-sheet-32.webp
+    cwebp -progress -mt -preset icon -alpha_filter best -alpha_q 20 -pass 10 -q 75 ${noto-emoji-sheet-64} -o asar-contents/images/emoji-sheet-64.webp
+
     # Copy the Noto Color Emoji PNGs into the ASAR contents. See `src`
     # for the motivation, and the script for the technical details.
     emojiPrefix=$(
@@ -270,6 +286,9 @@ stdenv.mkDerivation rec {
 
       # Various npm packages
       lib.licenses.free
+
+      lib.licenses.asl20 # noto-emoji
+      lib.licenses.mit # emoji-data
     ];
     maintainers = with lib.maintainers; [
       mic92

--- a/pkgs/by-name/si/signal-desktop/signal-desktop-aarch64.nix
+++ b/pkgs/by-name/si/signal-desktop/signal-desktop-aarch64.nix
@@ -1,7 +1,7 @@
 { callPackage }:
 callPackage ./generic.nix { } {
   pname = "signal-desktop";
-  version = "7.47.0-1";
+  version = "7.52.0";
 
   libdir = "usr/lib64/signal-desktop";
   bindir = "usr/bin";
@@ -10,6 +10,6 @@ callPackage ./generic.nix { } {
     bsdtar -xf $downloadedFile -C "$out"
   '';
 
-  url = "https://download.copr.fedorainfracloud.org/results/useidel/signal-desktop/fedora-42-aarch64/08795262-signal-desktop/signal-desktop-7.47.0-1.fc42.aarch64.rpm";
-  hash = "sha256-CDj9OX6OfEzbP8kusqnWN+MCPPEi9u2Hj1LkpsCg3vI=";
+  url = "https://download.copr.fedorainfracloud.org/results/useidel/signal-desktop/fedora-42-aarch64/08956500-signal-desktop/signal-desktop-7.52.0-1.fc42.aarch64.rpm";
+  hash = "sha256-kQbCkswCNRnz/K6KpZKJ55bCaM2YFL9wW+erVA+3Nok=";
 }

--- a/pkgs/by-name/si/signal-desktop/signal-desktop-darwin.nix
+++ b/pkgs/by-name/si/signal-desktop/signal-desktop-darwin.nix
@@ -6,11 +6,11 @@
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "signal-desktop";
-  version = "7.47.0";
+  version = "7.52.0";
 
   src = fetchurl {
     url = "https://updates.signal.org/desktop/signal-desktop-mac-universal-${finalAttrs.version}.dmg";
-    hash = "sha256-PP8D6D/DJiONJp0UNUSoy8zDwWGVWRRMsqfPTWQCgs8=";
+    hash = "sha256-GamsV4tWLEWbegUIrmZ4ZpAuRbfZzlxjnEy7FOo4q/E=";
   };
   sourceRoot = ".";
 

--- a/pkgs/by-name/si/signal-desktop/signal-desktop.nix
+++ b/pkgs/by-name/si/signal-desktop/signal-desktop.nix
@@ -1,12 +1,12 @@
 { callPackage }:
 callPackage ./generic.nix { } rec {
   pname = "signal-desktop";
-  version = "7.47.0";
+  version = "7.52.0";
 
   libdir = "opt/Signal";
   bindir = libdir;
   extractPkg = "dpkg-deb -x $downloadedFile $out";
 
   url = "https://updates.signal.org/desktop/apt/pool/s/signal-desktop/signal-desktop_${version}_amd64.deb";
-  hash = "sha256-rH1iuyVYoUNFvj2Z9DI5MXcX+sXjN2NSW2uaKafTO9M=";
+  hash = "sha256-SOe0BAEE5ljBb/OM3F7ejQQk8/KROFf7kfs/Gtp+bSY=";
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Manual backport of #400945. Adjusted several merge conflicts, because we don't have the from source build in 24.11 (yet?).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
