### PR TITLE
clash-verge-rev: apply patches for security problems

### DIFF
--- a/pkgs/by-name/cl/clash-verge-rev/0001-core-validate-bin_path-to-prevent-RCE-in-start_clash.patch
+++ b/pkgs/by-name/cl/clash-verge-rev/0001-core-validate-bin_path-to-prevent-RCE-in-start_clash.patch
@@ -1,0 +1,72 @@
+From fff6494e26edce6bf8a5b4c40d9535f820608cc3 Mon Sep 17 00:00:00 2001
+From: Moraxyc <i@qaq.li>
+Date: Mon, 28 Apr 2025 16:43:29 +0800
+Subject: [PATCH 1/2] core: validate bin_path to prevent RCE in start_clash
+
+Add a security check in CoreManager::start_clash to ensure that the provided
+binary path (`bin_path`) must be located under the current executable's
+directory. This prevents potential remote code execution (RCE) attacks
+caused by arbitrary binary path injection.
+---
+ src/service/core.rs | 21 ++++++++++++++++++---
+ 1 file changed, 18 insertions(+), 3 deletions(-)
+
+diff --git a/src/service/core.rs b/src/service/core.rs
+index 84407a5..51081ed 100644
+--- a/src/service/core.rs
++++ b/src/service/core.rs
+@@ -7,6 +7,7 @@ use once_cell::sync::Lazy;
+ use std::{
+     collections::HashMap,
+     sync::{atomic::Ordering, Arc, Mutex},
++    env,
+ };
+ 
+ impl CoreManager {
+@@ -227,7 +228,7 @@ impl CoreManager {
+             .unwrap()
+             .running_pid
+             .load(Ordering::Relaxed) as u32;
+-        
++
+         match process::find_processes("verge-mihomo") {
+             Ok(pids) => {
+                 // 直接在迭代过程中过滤和终止
+@@ -248,18 +249,32 @@ impl CoreManager {
+                     })
+                     .filter(|&success| success)
+                     .count();
+-                    
++
+                 println!("Successfully stopped {} verge-mihomo processes", kill_count);
+             }
+             Err(e) => {
+                 eprintln!("Error finding verge-mihomo processes: {}", e);
+             }
+         }
+-        
++
+         Ok(())
+     }
+ 
+     pub fn start_clash(&self, body: StartBody) -> Result<(), String> {
++        {
++            let bin_path = std::path::Path::new(body.bin_path.as_str());
++            let current_exe = std::env::current_exe()
++                .map_err(|e| format!("Failed to get current exe path: {}", e))?;
++            let current_dir = current_exe.parent()
++                .ok_or("Failed to get current directory")?;
++
++            if !bin_path.starts_with(current_dir) {
++                return Err(format!(
++                    "Invalid binary path for clash kernel. It must be under: {}",
++                    current_dir.display()
++                ));
++            }
++        }
+         {
+             // Check clash & stop if needed
+             let is_running_clash = self
+-- 
+2.49.0
+

--- a/pkgs/by-name/cl/clash-verge-rev/0002-core-prevent-overwriting-existing-file-by-validating.patch
+++ b/pkgs/by-name/cl/clash-verge-rev/0002-core-prevent-overwriting-existing-file-by-validating.patch
@@ -1,0 +1,33 @@
+From b104778a608862789f2be400b9f13a92b1ec5b20 Mon Sep 17 00:00:00 2001
+From: Moraxyc <i@qaq.li>
+Date: Mon, 28 Apr 2025 21:38:02 +0800
+Subject: [PATCH 2/2] core: prevent overwriting existing file by validating its
+ existence
+
+Add a check to verify whether the specified `log_file` already exists before proceeding.
+If the file exists, return an error to prevent accidental or malicious overwriting of files.
+This enhances the security of log file handling by mitigating arbitrary file overwrite risks.
+---
+ src/service/core.rs | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/src/service/core.rs b/src/service/core.rs
+index 51081ed..a2c4f82 100644
+--- a/src/service/core.rs
++++ b/src/service/core.rs
+@@ -275,6 +275,12 @@ impl CoreManager {
+                 ));
+             }
+         }
++        {
++            let log_file = std::path::Path::new(body.log_file.as_str());
++            if log_file.exists() {
++                return Err(format!("Log file already exists: {}", log_file.display()));
++            }
++        }
+         {
+             // Check clash & stop if needed
+             let is_running_clash = self
+-- 
+2.49.0
+

--- a/pkgs/by-name/cl/clash-verge-rev/package.nix
+++ b/pkgs/by-name/cl/clash-verge-rev/package.nix
@@ -80,9 +80,6 @@ let
       bot-wxt1221
     ];
     platforms = lib.platforms.linux;
-    knownVulnerabilities = [
-      "https://github.com/clash-verge-rev/clash-verge-rev/issues/3428"
-    ];
   };
 in
 stdenv.mkDerivation {
@@ -118,7 +115,7 @@ stdenv.mkDerivation {
     cp -r ${unwrapped}/share/* $out/share
     cp -r ${unwrapped}/bin/clash-verge $out/bin/clash-verge
     # This can't be symbol linked. It will find mihomo in its runtime path
-    ln -s ${service}/bin/clash-verge-service $out/bin/clash-verge-service
+    cp ${service}/bin/clash-verge-service $out/bin/clash-verge-service
     ln -s ${mihomo}/bin/mihomo $out/bin/verge-mihomo
     # people who want to use alpha build show override mihomo themselves. The alpha core entry was removed in clash-verge.
     ln -s ${v2ray-geoip}/share/v2ray/geoip.dat $out/lib/Clash\ Verge/resources/geoip.dat

--- a/pkgs/by-name/cl/clash-verge-rev/service.nix
+++ b/pkgs/by-name/cl/clash-verge-rev/service.nix
@@ -15,6 +15,19 @@ rustPlatform.buildRustPackage {
   src = src-service;
   sourceRoot = "${src-service.name}";
 
+  patches = [
+    # FIXME: remove until upstream fix these
+    # https://github.com/clash-verge-rev/clash-verge-rev/issues/3428
+
+    # Patch: Restrict bin_path in spawn_process to be under the clash-verge-service directory.
+    # This prevents arbitrary code execution by ensuring only trusted binaries from the Nix store are allowed to run.
+    ./0001-core-validate-bin_path-to-prevent-RCE-in-start_clash.patch
+
+    # Patch: Add validation to prevent overwriting existing files.
+    # This mitigates arbitrary file overwrite risks by ensuring a file does not already exist before writing.
+    ./0002-core-prevent-overwriting-existing-file-by-validating.patch
+  ];
+
   nativeBuildInputs = [
     pkg-config
   ];

--- a/pkgs/by-name/cl/clash-verge-rev/unwrapped.nix
+++ b/pkgs/by-name/cl/clash-verge-rev/unwrapped.nix
@@ -47,6 +47,12 @@ rustPlatform.buildRustPackage {
     mv tauri.linux.conf.json.2 tauri.linux.conf.json
     chmod 777 ../.cargo
     rm ../.cargo/config.toml
+
+    # As a side effect of patching the service to fix the arbitrary file overwrite issue,
+    # we also need to update the timestamp format in the filename to the second level.
+    # This ensures that the Clash kernel can still be restarted within one minute without problems.
+    substituteInPlace src/utils/dirs.rs \
+      --replace-fail '%Y-%m-%d-%H%M' '%Y-%m-%d-%H%M%S'
   '';
 
   nativeBuildInputs = [


### PR DESCRIPTION
This is a continuation of #402290

From a distribution perspective, these patches are about as much as we can do for now; further improvements will depend on changes upstream. When this PR was submitted, upstream had already released clash-verge-service [v1.0.6](https://github.com/clash-verge-rev/clash-verge-service/commit/06b522d2ccf37bdbc00e59687cc701c946166afe), which, however, did not substantially fix the existing issues.  Future upgrade work will be handled by @Bot-wxt1221.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
