### PR TITLE
Firefox: 137.0.2 -> 138.0; 128.9.0esr -> 128.10.0esr

### DIFF
--- a/pkgs/applications/networking/browsers/firefox-bin/release_sources.nix
+++ b/pkgs/applications/networking/browsers/firefox-bin/release_sources.nix
@@ -1,1859 +1,1859 @@
 {
-  version = "137.0.2";
+  version = "138.0";
   sources = [
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-x86_64/ach/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-x86_64/ach/firefox-138.0.tar.xz";
       locale = "ach";
       arch = "linux-x86_64";
-      sha256 = "beecaa5b4bad913c4a0eb465b52cc05dfbee39192c48c6c7f898e10358e3d15c";
+      sha256 = "0d840b4a5b9bf22901aec4e1fc15a96fe7cc5205280df9136cf2d7552cfebe60";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-x86_64/af/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-x86_64/af/firefox-138.0.tar.xz";
       locale = "af";
       arch = "linux-x86_64";
-      sha256 = "f90fc55ea0af175e42f2b172e009a80dee906e8787f0cf91c8f3288e2fc8bcf4";
+      sha256 = "1e445851928ab680f7fba8d3ac470d7697c8521be427838c578a76cd653269af";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-x86_64/an/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-x86_64/an/firefox-138.0.tar.xz";
       locale = "an";
       arch = "linux-x86_64";
-      sha256 = "10e9e64aeae0f4ee34f9788f9e93a6151c634cf88a231958f15e79642007649c";
+      sha256 = "e7fe02ca8e35bf5feba51d4c143da3b7ea7276b36170b6365e277e4946a457df";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-x86_64/ar/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-x86_64/ar/firefox-138.0.tar.xz";
       locale = "ar";
       arch = "linux-x86_64";
-      sha256 = "31157778a6d64e005e9c5ffacdd6186eacb49dcbb88c2ed2a17cc5e1c6b5a202";
+      sha256 = "cf2cd76b1e3823c98f178c2d15572e6cb0febf585688675186e0def43e1e1144";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-x86_64/ast/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-x86_64/ast/firefox-138.0.tar.xz";
       locale = "ast";
       arch = "linux-x86_64";
-      sha256 = "8bf67845e19e65e71255949b31894a16e1a4737ea69624f3b651922acdf3a991";
+      sha256 = "d5555ddaf7c57e3af30fe1c970042b4ffd14268480682f98eea6356ab95c189e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-x86_64/az/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-x86_64/az/firefox-138.0.tar.xz";
       locale = "az";
       arch = "linux-x86_64";
-      sha256 = "28668a4717564393bd3610d12dfcd03d539128715813a9722dd5ff36aa85f793";
+      sha256 = "255f90672043251a6258c016319ad66b160702e079a76238642c340cfa44ecae";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-x86_64/be/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-x86_64/be/firefox-138.0.tar.xz";
       locale = "be";
       arch = "linux-x86_64";
-      sha256 = "2cb5e2c4b7be6e417a7869deff5228093c7bb0f14b54ad984e01b6eec62bfbcb";
+      sha256 = "38e69ba4eb00f3d4570bbfb5651b4bf58ce97b759d62457e248cb5543a456ffd";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-x86_64/bg/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-x86_64/bg/firefox-138.0.tar.xz";
       locale = "bg";
       arch = "linux-x86_64";
-      sha256 = "ab615dce92062a74485390664b36b258673f0278fada067d2740c7e2f026606d";
+      sha256 = "eb7cf02e450dbcd2bbed2b7f9fdc5567f8aa046d0ca66fa2d85d96b6e436642f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-x86_64/bn/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-x86_64/bn/firefox-138.0.tar.xz";
       locale = "bn";
       arch = "linux-x86_64";
-      sha256 = "051cebd6cb5d0a9a88e696c51f9dd94098a296d689cfb7ad0eac0052191fa96b";
+      sha256 = "8dd05493d2fe529952602ebea40debe04eb5f899ce0ad1a9c6e4c0fba0a7e9a0";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-x86_64/br/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-x86_64/br/firefox-138.0.tar.xz";
       locale = "br";
       arch = "linux-x86_64";
-      sha256 = "c838bd817941b200663bcd52caf0a9d4d46abf30cbae7f5a1b1d0b76cda40d01";
+      sha256 = "1ef71bec6234eb8cf73307520ee54cb998877341868bc868cb1a8497fffc306b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-x86_64/bs/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-x86_64/bs/firefox-138.0.tar.xz";
       locale = "bs";
       arch = "linux-x86_64";
-      sha256 = "52965f3295bb13546afb93aada64ea60fbf2fc52a8c8f1fb92c818112247a81a";
+      sha256 = "f4fa4220faacaf5b5fbf9981d21290545dbb5dae2d88d4554d11072a4cf2a8b0";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-x86_64/ca-valencia/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-x86_64/ca-valencia/firefox-138.0.tar.xz";
       locale = "ca-valencia";
       arch = "linux-x86_64";
-      sha256 = "8dacc85a0df5826c811a5071f7ba7751953391db90dabc070d576b054e0efab9";
+      sha256 = "e19ab006c05b6dcdc8393d0dbd0876784a7099dfc28e35aea5ea201f2c05a7f7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-x86_64/ca/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-x86_64/ca/firefox-138.0.tar.xz";
       locale = "ca";
       arch = "linux-x86_64";
-      sha256 = "39df8279a724b0ad449680e4a3a6489aeac19d258f43a37e983624e71616fdcd";
+      sha256 = "250260b8700dd098e73ff027ae40c5fa22b0d68759ea23b831869cf0f4ba04db";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-x86_64/cak/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-x86_64/cak/firefox-138.0.tar.xz";
       locale = "cak";
       arch = "linux-x86_64";
-      sha256 = "e24fae206c2e8aa50f7a5664ad729a2daeedfefa626934db7492849e884f54e9";
+      sha256 = "f0d8a6f3f4f4539dbc33d281b8b78d86b28811e7ed73471d4bc8dc0632fce85e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-x86_64/cs/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-x86_64/cs/firefox-138.0.tar.xz";
       locale = "cs";
       arch = "linux-x86_64";
-      sha256 = "92e041159298ee79680c043bb7eff7bc7a502be2bf988336b466e831e48392a0";
+      sha256 = "23cbbec86c66c19a3a39c6badc331383cbef841a9dfe07eaad7225b7e46338e7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-x86_64/cy/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-x86_64/cy/firefox-138.0.tar.xz";
       locale = "cy";
       arch = "linux-x86_64";
-      sha256 = "9acd776ddd23d9f59845da6859cf517537fa686c54a5af91cd5301b8598d9a78";
+      sha256 = "046322354e4d75dc34c5954f10d6a2fde4a0e02255eddd2755395837c025a98c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-x86_64/da/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-x86_64/da/firefox-138.0.tar.xz";
       locale = "da";
       arch = "linux-x86_64";
-      sha256 = "367dd5650d7fa8289db6e629ad2f893fdf0c8ef2b0295ff9082654469764c448";
+      sha256 = "e1486e9409dbf8c95fdd4fbf0e85f6510f65e9646bc364c27ce28721c3e0cb5a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-x86_64/de/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-x86_64/de/firefox-138.0.tar.xz";
       locale = "de";
       arch = "linux-x86_64";
-      sha256 = "de7b400050dd88cc3fa6599bd23e7c03996e62dbd5a991b6c6d79b8df5261d34";
+      sha256 = "20a82b2ecf92c0f3882efccf61928e71ab20716c0244c5c3cd93b0ac424a1896";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-x86_64/dsb/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-x86_64/dsb/firefox-138.0.tar.xz";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha256 = "9dc0401a8dda643c052abc829a0491eb965f2f6afa62202bc44ba0781d665849";
+      sha256 = "001c084d8f49fb50849dab6a03bb40e13511cde4336c0b0f31e87e61c96ab129";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-x86_64/el/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-x86_64/el/firefox-138.0.tar.xz";
       locale = "el";
       arch = "linux-x86_64";
-      sha256 = "21495846c2d687de0547c162f1a12b9d5b6fe8a81bf704549bc24ec1dda915bf";
+      sha256 = "dad6de01d3ad4d8949756d6559482c44002a4f71f322473680fb90a6955421a3";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-x86_64/en-CA/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-x86_64/en-CA/firefox-138.0.tar.xz";
       locale = "en-CA";
       arch = "linux-x86_64";
-      sha256 = "e64ca18d51a12b16f3bc5a6a8e2059d3632db3bbd360be32db1e0f94b211971d";
+      sha256 = "42938a28b44f4c71bd1fc3d8f2daf6b5059fe2f93ecdaeefb13891a616de0a1c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-x86_64/en-GB/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-x86_64/en-GB/firefox-138.0.tar.xz";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha256 = "a36d27ac5649f9e8d11fc1c86f0032bb1c8cea17e1183a8abe5c6adfb4159b41";
+      sha256 = "9b9854e1c17b021e20f50158d2d27dc998aaba1619979a1487516dec018df47c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-x86_64/en-US/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-x86_64/en-US/firefox-138.0.tar.xz";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha256 = "3d6f07eddbd98ae96b55cd6ec95fcf18b61a139a0c68739c098954b5015c4b11";
+      sha256 = "a9b83684f6fa9eecf29c79119bab9239c4255ac53ce12126ced524cc8c7da758";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-x86_64/eo/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-x86_64/eo/firefox-138.0.tar.xz";
       locale = "eo";
       arch = "linux-x86_64";
-      sha256 = "56be98cccbbd9021c40c08b3d064f9d8aa570dc215b984afde2a197fcb0dc691";
+      sha256 = "f86543fbb58f4ae56e1c63cf6a1852c627cf84c40f0f885ae05e114d3b0a5cfd";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-x86_64/es-AR/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-x86_64/es-AR/firefox-138.0.tar.xz";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha256 = "5c0184473aa08c6b415a85bb375647079ba2b996e65d89ed953f95bb4a879427";
+      sha256 = "f2009cf76b44377cd9318341ed810286ae3dd65c76e81442f69fedf4bb15efac";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-x86_64/es-CL/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-x86_64/es-CL/firefox-138.0.tar.xz";
       locale = "es-CL";
       arch = "linux-x86_64";
-      sha256 = "d0e2ecc37ad129a191289df5159582125b9c64cbff9b6538041a9219a02493e0";
+      sha256 = "30b8bf6d8dcc97f0d30aea10d3689257674ad0df493e07d086bec172f4f5ff87";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-x86_64/es-ES/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-x86_64/es-ES/firefox-138.0.tar.xz";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha256 = "2c86ea5a8b186840fb9d2d0d113925c026fbfb75cbb8a8a644cf71773d7b87ed";
+      sha256 = "d16ecef3c1d700d15cec4f46d8a5a756e382b6d20a4d311d031e6f33d273d6a6";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-x86_64/es-MX/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-x86_64/es-MX/firefox-138.0.tar.xz";
       locale = "es-MX";
       arch = "linux-x86_64";
-      sha256 = "73db0f0059a10b3c6ea273f7682b0ce6089c454c62771fd3d9be1f218fd869a4";
+      sha256 = "6f609a838d7c56edc093e1c4398a5f715766728a90c9b3d4664834b635566906";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-x86_64/et/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-x86_64/et/firefox-138.0.tar.xz";
       locale = "et";
       arch = "linux-x86_64";
-      sha256 = "5ee0251ea53d042bb105a55f9092ac2d038be0cff7eb1c28cc91b03e14adf4ea";
+      sha256 = "c58a9dbf6ec4bf852cefbf4345a98e584753e4b5be8c1bbdbf3dc3e6b1d9604b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-x86_64/eu/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-x86_64/eu/firefox-138.0.tar.xz";
       locale = "eu";
       arch = "linux-x86_64";
-      sha256 = "7810a6f6eb9c35a5c59b73d00be32c409e241b1c727b3ed9b3c520cbfee5e5a9";
+      sha256 = "84be6adab2cbd5af19cdcde6ea441e2d70cacc92930dbd67c8ec5f2e5cda437f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-x86_64/fa/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-x86_64/fa/firefox-138.0.tar.xz";
       locale = "fa";
       arch = "linux-x86_64";
-      sha256 = "1f744113209da1109f185f87cebaed599717ee7249c11ae13e74c8723b461e19";
+      sha256 = "8017bd25562ae02f29a06e6a57c57f5dbdf56d09061119464d8cfcec7c0e1c3e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-x86_64/ff/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-x86_64/ff/firefox-138.0.tar.xz";
       locale = "ff";
       arch = "linux-x86_64";
-      sha256 = "39c0f8f91756b547d9ff2f6083822be971276c777fbbe64193bf0cf57a2db3c5";
+      sha256 = "9a2cdca8d457f560fc73440f987ea09aab945893bc2ceecb627b5c8fda25be72";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-x86_64/fi/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-x86_64/fi/firefox-138.0.tar.xz";
       locale = "fi";
       arch = "linux-x86_64";
-      sha256 = "7f42f7687ccb2b84192fe45d4ba1f7e466b61b4ead9f5440797f4dfa223e0219";
+      sha256 = "56f3abfef74f572319152aa394c8d39baf515aaad5f8d353b5476ca0c42b7bd1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-x86_64/fr/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-x86_64/fr/firefox-138.0.tar.xz";
       locale = "fr";
       arch = "linux-x86_64";
-      sha256 = "3160f543f7fed5b663799183fe32f0fc3050fb3f56c4b4db37b3436a2617c890";
+      sha256 = "965dd1e5b6c7f45662bf9604782d34bd7e50cb26f3f9656330f54af76d2b5128";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-x86_64/fur/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-x86_64/fur/firefox-138.0.tar.xz";
       locale = "fur";
       arch = "linux-x86_64";
-      sha256 = "8f20034bcdb30909f37c48aaeb9d67820f9f98c598e3243ce341256ee57989bd";
+      sha256 = "0e62c48e4f99eb611f56be1cda29dc4fa002b2d90d9861e96261ae8d3c87cb98";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-x86_64/fy-NL/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-x86_64/fy-NL/firefox-138.0.tar.xz";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha256 = "25c664b40db4e58a1929403a588fc022eb46408081ef77e5d2c6a04e3a59b294";
+      sha256 = "e360a8b43bcf43b58ed50548fcde92b71a20f91ca0f544d3d38ce21cd458c094";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-x86_64/ga-IE/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-x86_64/ga-IE/firefox-138.0.tar.xz";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha256 = "e9be2d8351ef1496b54d7a8e292b9ca38499da2613f8bf2fd229b3c3f487f8fe";
+      sha256 = "43f0133e418b1b5b39c84753a5b083bbed06a480e3159bf9726e2c79c3b62ed0";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-x86_64/gd/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-x86_64/gd/firefox-138.0.tar.xz";
       locale = "gd";
       arch = "linux-x86_64";
-      sha256 = "91b103ee7f1c20bcd08e1c5f6179af6d2191d63ec8256f4c7809cb1b655c5465";
+      sha256 = "9c2dc598f63ca6f146bf76a2ecdde4c65e7b53de1e6d017feb4929f91bb43a35";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-x86_64/gl/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-x86_64/gl/firefox-138.0.tar.xz";
       locale = "gl";
       arch = "linux-x86_64";
-      sha256 = "09ef5f1547fd5c01c6a16d42fb8b25775022b7a61b5dcea6df371e316b99a6a0";
+      sha256 = "72ef7fc75d8518883a5e44a4cb94adfbe9addfb1a655d1c2f9ccaaa9a0dbdef2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-x86_64/gn/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-x86_64/gn/firefox-138.0.tar.xz";
       locale = "gn";
       arch = "linux-x86_64";
-      sha256 = "5625564302b26eefd9a92b080e100da9d16cf69428780347acc474f1ec7f7dde";
+      sha256 = "7cb7c6bc3e0a201b243519a6cb7300f7a273de0ee64b3b77003fb4560f6d1216";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-x86_64/gu-IN/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-x86_64/gu-IN/firefox-138.0.tar.xz";
       locale = "gu-IN";
       arch = "linux-x86_64";
-      sha256 = "103c1f328af7cb66ebfc73f7ea276a12641a77bbc8f29f03c77e0b26b270e3c7";
+      sha256 = "72e8aa9058d2cc170cffe63d3884c1654fee5a7c6afdf895a033a42a285e8d81";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-x86_64/he/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-x86_64/he/firefox-138.0.tar.xz";
       locale = "he";
       arch = "linux-x86_64";
-      sha256 = "02caaf6ee7c071f69d25081ad49d6c6f4afb308739f824eb20cccf44e2b81ee9";
+      sha256 = "24c8d0f94f54a11466c4d1484fb1cf0ef13869b84f56570efd3a800ec5a8f8e5";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-x86_64/hi-IN/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-x86_64/hi-IN/firefox-138.0.tar.xz";
       locale = "hi-IN";
       arch = "linux-x86_64";
-      sha256 = "e952e6891ec10f77eb09351d0b5854b74fc7e923766f4d297b403f9fd608f55a";
+      sha256 = "b18f3a55b9304a80c627ad0101419365e60129957517aca82d3c0c52faad24b5";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-x86_64/hr/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-x86_64/hr/firefox-138.0.tar.xz";
       locale = "hr";
       arch = "linux-x86_64";
-      sha256 = "18669fb79b07c1b1777b5747cd4647ba2fe36e0bb56c768bbb146f601af8270a";
+      sha256 = "ef389a29ac6ebbca4d79a3d4e2e484ec2f283562b6cf72bd5cb32ec7f0a4f7d7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-x86_64/hsb/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-x86_64/hsb/firefox-138.0.tar.xz";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha256 = "6d61c8fd007974450128d1173b1ef3f78f2aaaf8f16610c383b7c48f1312871f";
+      sha256 = "02e044cd6dc27a3057c3444f5e4e48eada014150045e127fdd89efc460230fb2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-x86_64/hu/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-x86_64/hu/firefox-138.0.tar.xz";
       locale = "hu";
       arch = "linux-x86_64";
-      sha256 = "1dabfabeca87adda4639c1877cf4d129bcec083ab80856d94b5fe0046bbafe8d";
+      sha256 = "457cf2d3b5f9b9c90635f90ff7703e8657e7467818b4afc3a17de80cdcdf223c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-x86_64/hy-AM/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-x86_64/hy-AM/firefox-138.0.tar.xz";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha256 = "ee43ff0a3e54cfa51d2bdc8d96cfd5fe5f6de1e1ef194b4e40217220dc4bf88b";
+      sha256 = "35c5d069b678f239b218fdd7c14731a6f0678640bf851ef0b80ee461113d1ab3";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-x86_64/ia/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-x86_64/ia/firefox-138.0.tar.xz";
       locale = "ia";
       arch = "linux-x86_64";
-      sha256 = "5c743ee698b1fd9bfe149b86c1122ecde080e1f2e291bb23bbd0e96271833758";
+      sha256 = "4eaa70b5ee0b80da59961e9fb955690e4cac142a52735226b3469c5268f344c9";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-x86_64/id/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-x86_64/id/firefox-138.0.tar.xz";
       locale = "id";
       arch = "linux-x86_64";
-      sha256 = "608a487137164d1da3771c2573ad4cc8749fb031a4b77bbd514f1cda0f3c7fe9";
+      sha256 = "2e14932cfbb652d50da5a28258660d3041cb40ee2d4525147f3155ee917037c2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-x86_64/is/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-x86_64/is/firefox-138.0.tar.xz";
       locale = "is";
       arch = "linux-x86_64";
-      sha256 = "6b6d9f06ffbddd7a7308652ac3c71d98a98b45287c12592098fe270d4ecb4b85";
+      sha256 = "3810eb7fd380125f46ff329ee5a6ebb0ea0320f0203a6f1cca4915f0f62d694d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-x86_64/it/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-x86_64/it/firefox-138.0.tar.xz";
       locale = "it";
       arch = "linux-x86_64";
-      sha256 = "420f26340a6eeab042ca0566b165af6d6fde49a74c3da90249bda2855524331c";
+      sha256 = "44ba8bb3c4ef74afbdcf00f2172b3085eb0b737364f1342cb3d9453356a27d32";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-x86_64/ja/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-x86_64/ja/firefox-138.0.tar.xz";
       locale = "ja";
       arch = "linux-x86_64";
-      sha256 = "f4a1b396aed1397fd2cd39e637e0e9e5e96fa032f0a606632b8f8654bbfa74ee";
+      sha256 = "c7279fb1920c345f22bbb4232e53f915bef7b8c891acf672357597249625d795";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-x86_64/ka/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-x86_64/ka/firefox-138.0.tar.xz";
       locale = "ka";
       arch = "linux-x86_64";
-      sha256 = "2fc4581e5c324d69a5fdf8b7f361bb55efb039986aebf68fc800c480b193d8fc";
+      sha256 = "a9c77b593f464b99b60d51b4a5c96115925f8169c2804d60a9e989a4a11f4e34";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-x86_64/kab/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-x86_64/kab/firefox-138.0.tar.xz";
       locale = "kab";
       arch = "linux-x86_64";
-      sha256 = "9e93cd63bbf2c1f1e3fe61f8cced85bc9e73612d830bf3519ceb0becb74bb9bd";
+      sha256 = "602df00252c26398b5901352729532b5bafc4cd0f3f20d494501d0b5fbd02b43";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-x86_64/kk/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-x86_64/kk/firefox-138.0.tar.xz";
       locale = "kk";
       arch = "linux-x86_64";
-      sha256 = "c03aaed46d5039c7e221ee43a0929cd253d4c0ae61a2b8d0de8e2900d4915f33";
+      sha256 = "d24a3cf52369ba57fff4b9e7c4e72b828d050e21510113a6693a1e853846986a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-x86_64/km/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-x86_64/km/firefox-138.0.tar.xz";
       locale = "km";
       arch = "linux-x86_64";
-      sha256 = "8f1d4682280445e54f6b92753c15c69810c4e028342bc6b595a8d713ad55cdfb";
+      sha256 = "3798787509605fece208007f350f99c3e1dbe79aace1a7bdeb0c03d22ddd6bfc";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-x86_64/kn/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-x86_64/kn/firefox-138.0.tar.xz";
       locale = "kn";
       arch = "linux-x86_64";
-      sha256 = "caa3f0d6d0e68e62cc5a23d0f659207c5924ce48ddbc13a5476c5906e3cc0180";
+      sha256 = "8c439acac3feb23f63c64adc75cad647f2b376c9c7d4ceeef0f011dfafb9ffbb";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-x86_64/ko/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-x86_64/ko/firefox-138.0.tar.xz";
       locale = "ko";
       arch = "linux-x86_64";
-      sha256 = "66d548d1ff9cdcc667f0c37faeb32cc9edb054b592333bd674fb1c1cb3168cc7";
+      sha256 = "af61147731e999669a0679ec367041cc64e2049746753fb05f56e7efd189801c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-x86_64/lij/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-x86_64/lij/firefox-138.0.tar.xz";
       locale = "lij";
       arch = "linux-x86_64";
-      sha256 = "264b3f6415910d466222dfd84bade37e21e6f75783238702f0c67a6556d0a746";
+      sha256 = "edceb3ba5796ae06dd0a8be45fecc82d8c07d18fae27f9be8d0a724f3ca291f7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-x86_64/lt/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-x86_64/lt/firefox-138.0.tar.xz";
       locale = "lt";
       arch = "linux-x86_64";
-      sha256 = "cd9a4f271c0b46c97003e266ba4e63d13c2a3569462c7bc3b166d406d7e7a4e7";
+      sha256 = "67840d5a0f911ab41d41aa1e4c6d0242551654bb301ee9e442e23bbd1fad39bb";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-x86_64/lv/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-x86_64/lv/firefox-138.0.tar.xz";
       locale = "lv";
       arch = "linux-x86_64";
-      sha256 = "a566ac89ea6e23d0319358a23915d8918d3093e91f068241845ca00e48814950";
+      sha256 = "ab08f664c6969b842533ca49e4d03c66307d9bf1d94110b91cc6187034f34ff9";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-x86_64/mk/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-x86_64/mk/firefox-138.0.tar.xz";
       locale = "mk";
       arch = "linux-x86_64";
-      sha256 = "15716628a50e937051966ba40f8d222cc093dbce52118a1b31b53a20b73aae73";
+      sha256 = "ba0bb5ff5b1e067e5f14678a4b48c54eabee0793ca4de4755bcef9402913cb1d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-x86_64/mr/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-x86_64/mr/firefox-138.0.tar.xz";
       locale = "mr";
       arch = "linux-x86_64";
-      sha256 = "1828ecbbd62ac5f62ed9e589f5445ce74484cabdb6d4f0bb935f9e879b18dd28";
+      sha256 = "10f5fe1bb677a7dfe88171c9556edaf2e87d33ea320e556bedd858391a8988d2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-x86_64/ms/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-x86_64/ms/firefox-138.0.tar.xz";
       locale = "ms";
       arch = "linux-x86_64";
-      sha256 = "abd6d3fa9adeca6c7d9b657b6189d11692c93f2839b42aaca414005ec6e4002c";
+      sha256 = "ec9c7d119117052cf3c18137ca979bdfb91f3954c95c24140c0d4de0154ba8b2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-x86_64/my/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-x86_64/my/firefox-138.0.tar.xz";
       locale = "my";
       arch = "linux-x86_64";
-      sha256 = "17e4f5a61d397c6504b402fa55c07dcf9c0ba1ed0f58247844e24c592f8f00d7";
+      sha256 = "5fbdfdb253ad259fcad4e995648b2b45e9de10f1587d67a2871bb7d2c1c26432";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-x86_64/nb-NO/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-x86_64/nb-NO/firefox-138.0.tar.xz";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha256 = "23a4410cac5c240a588176af292bf180a9d86d1e176ea9d7a6314f1ba0d4fd13";
+      sha256 = "68c0209e4b7b2d7691c471fd979add2fb17397946f38d2755f4c2423f8d16a12";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-x86_64/ne-NP/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-x86_64/ne-NP/firefox-138.0.tar.xz";
       locale = "ne-NP";
       arch = "linux-x86_64";
-      sha256 = "20bd319f23d5ef6c6e809ac0ac40275b00f6a421f1c9541321e6cb3db57d9b86";
+      sha256 = "2dfee48281692b6e79ac1bd53209fe890f8f9c66824c6c1a61cfa2a636ac9d39";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-x86_64/nl/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-x86_64/nl/firefox-138.0.tar.xz";
       locale = "nl";
       arch = "linux-x86_64";
-      sha256 = "3068a8f1fe6e1196ff4033dd2ab7a1ed83598f7143e3205a783930b70f07f59a";
+      sha256 = "43a2a848ba4841ceeb8883664352ad088258af9054a75a805940311754ab084b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-x86_64/nn-NO/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-x86_64/nn-NO/firefox-138.0.tar.xz";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha256 = "9eb130e3b6a535f80bca06fbb9a171597ef81e233517a7b1d1f7e62057d73a64";
+      sha256 = "c4cd6f3e68235a0138998cdcadc90aaeecde656d006e0db80dd459228ae86241";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-x86_64/oc/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-x86_64/oc/firefox-138.0.tar.xz";
       locale = "oc";
       arch = "linux-x86_64";
-      sha256 = "3c690c47012838b6c168208e5fbfef734bcd67a20a04ed876b964551b31f1619";
+      sha256 = "00109d10e97748c4af4125a58051e1d3508c57a9e7eb28f8ec1f6474d6a6cc00";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-x86_64/pa-IN/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-x86_64/pa-IN/firefox-138.0.tar.xz";
       locale = "pa-IN";
       arch = "linux-x86_64";
-      sha256 = "1ebb99a285a91078914cc8f4a88a610f3bc87a5414339baf81debd08967015f7";
+      sha256 = "5263f58f9366a69e4a7b6ad8cf7fc41e215ff4f41f1b42ec8b83693304d2f648";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-x86_64/pl/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-x86_64/pl/firefox-138.0.tar.xz";
       locale = "pl";
       arch = "linux-x86_64";
-      sha256 = "c2e298ee00ac4909586a7648f699a138edf4b0bddd4a7d87dc693da6cf08494e";
+      sha256 = "3764e5660b2deecdc1b163b020b31ba507d3753bc4f90de5206cac54666e270a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-x86_64/pt-BR/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-x86_64/pt-BR/firefox-138.0.tar.xz";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha256 = "19a3bfbdbbb204d071eba03db03c74499cd8f0798c5a792bbdbcd163f72e9591";
+      sha256 = "f4da62c8563fe1301409418356ca7ec99d7bab68a7a4be19d07f14f45a45d33d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-x86_64/pt-PT/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-x86_64/pt-PT/firefox-138.0.tar.xz";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha256 = "89fe936d7db9a13e2a8f7a1c577e10ca0cd539533f605dbb1ecafbe4447791a5";
+      sha256 = "861f9974592fecb8d5750a263da0ad369caa392e219d3e53decb624b97208843";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-x86_64/rm/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-x86_64/rm/firefox-138.0.tar.xz";
       locale = "rm";
       arch = "linux-x86_64";
-      sha256 = "5f267228a3cfc5c05cc484f896989ab64af12d50bf7be3506d4a2e1a2c7d7c28";
+      sha256 = "b44fd78bbcec8858651ce08f0b528765390dcdc01812f810d227d459f9e7e337";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-x86_64/ro/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-x86_64/ro/firefox-138.0.tar.xz";
       locale = "ro";
       arch = "linux-x86_64";
-      sha256 = "850889178d295fbdf85859885fdd3fafd0bf3688f1e6d3593f25bf61477add69";
+      sha256 = "dd04c00b7d9d25d412e7685cf2a54d375350a90e3c8c6f0a2cadf32d1a3da59b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-x86_64/ru/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-x86_64/ru/firefox-138.0.tar.xz";
       locale = "ru";
       arch = "linux-x86_64";
-      sha256 = "842ae6709fb6d95a563f2c602f64bb4cabe7617c72f98d4e66e1a503f478d700";
+      sha256 = "a1220d1b48f966fa4642e3d9affded75908fba854a787629fca779f8f8cb8cf0";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-x86_64/sat/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-x86_64/sat/firefox-138.0.tar.xz";
       locale = "sat";
       arch = "linux-x86_64";
-      sha256 = "b5344a7047aa7172eeeee471560a9d096d6c4568397becb89f203a0305b9ca49";
+      sha256 = "ac5805dd69be75cb8355f77a3518aa9703633eb580275de4cd78c16da1b5e64d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-x86_64/sc/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-x86_64/sc/firefox-138.0.tar.xz";
       locale = "sc";
       arch = "linux-x86_64";
-      sha256 = "0a10cd229657bc13de2b66ded91a0cfab4a0556990773ec113e602a068a180c6";
+      sha256 = "1fc5034db7e4a3d386a7da6cf81106b68e716db1b4bd564a0fdab93b1b2c3f43";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-x86_64/sco/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-x86_64/sco/firefox-138.0.tar.xz";
       locale = "sco";
       arch = "linux-x86_64";
-      sha256 = "6c55328ac00248fcdbd83cee3cc74c10e7565df403d58e37fbf76f7051f08c6d";
+      sha256 = "87fa87652c0dc35c0f4b9450f2e06220c3ce587f77aeafef99d025bcab603cdc";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-x86_64/si/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-x86_64/si/firefox-138.0.tar.xz";
       locale = "si";
       arch = "linux-x86_64";
-      sha256 = "39c14ca97139645185a5db7f21ca2829992d232d12dafedd6fd234497c1064fb";
+      sha256 = "ba388c2068fee6da01b21d0f775f3f89d350a6da637244c5fefcc97ba8d8a9e1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-x86_64/sk/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-x86_64/sk/firefox-138.0.tar.xz";
       locale = "sk";
       arch = "linux-x86_64";
-      sha256 = "a36f404649816155d79f146e67a6f1fc14eb1042ad5bdb7d28f0bd236e30519f";
+      sha256 = "df6e772dbbec87d645c80a3e3d6e80c3c6e3bef201762e0525ec4067bce7f9dc";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-x86_64/skr/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-x86_64/skr/firefox-138.0.tar.xz";
       locale = "skr";
       arch = "linux-x86_64";
-      sha256 = "cb873d39badbaba3975d3046118508abb7bd0537da70115dd836aa4a70628780";
+      sha256 = "9c145865394d4d5abc0b0507792c6191bb217e4679776965d43bc631cf9de4c3";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-x86_64/sl/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-x86_64/sl/firefox-138.0.tar.xz";
       locale = "sl";
       arch = "linux-x86_64";
-      sha256 = "68ba260f053f9b8feb94b75b5246735cd564aa184846a83ad8126060144aaf96";
+      sha256 = "0319e9864bb133f414e6ae3204931291dcf8afb6b0d8dcda0122e40af3533528";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-x86_64/son/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-x86_64/son/firefox-138.0.tar.xz";
       locale = "son";
       arch = "linux-x86_64";
-      sha256 = "970108ab232bcb602034455c66f78b4f8a788858f5ab5dded9b7a01dfb0354bd";
+      sha256 = "4e702a808e15a336e97100e0db4be3c294ce2c65a65807be2fab888b5a639c64";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-x86_64/sq/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-x86_64/sq/firefox-138.0.tar.xz";
       locale = "sq";
       arch = "linux-x86_64";
-      sha256 = "bbde7cacd160ccc91188e5ad38695ee21a41c0b44c50c3b6634373b94ce248ba";
+      sha256 = "11fdedb99e83b9a4fa108f995ac404d5cc877b9077c0c8123672657b2dcdb02e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-x86_64/sr/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-x86_64/sr/firefox-138.0.tar.xz";
       locale = "sr";
       arch = "linux-x86_64";
-      sha256 = "2ab8b8ba12f67a90f83d465def67ed37c8e15600ab33f551194d8f3e0ece8908";
+      sha256 = "06e2cf8f88ab8de2fd2aa89eef4e80e3d44ba15499be4f60268fae775b66a0bc";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-x86_64/sv-SE/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-x86_64/sv-SE/firefox-138.0.tar.xz";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha256 = "f83b82ccdc8e725548f0b1704353c0cb917915d9894fa571f67e9756c7e5a2de";
+      sha256 = "765384d5974417c3968f98919c8fe83541a674ce7f83a660545acf88c94b4508";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-x86_64/szl/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-x86_64/szl/firefox-138.0.tar.xz";
       locale = "szl";
       arch = "linux-x86_64";
-      sha256 = "7ab8e2dd2bf279fddbaec1cf0361d61d7ad72e0c167b6f711ea41e9ea4d0c7d3";
+      sha256 = "db4fbe6af28cf0273eaed649b0369d635342fc73302f6adcd274f1464d6d7d5a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-x86_64/ta/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-x86_64/ta/firefox-138.0.tar.xz";
       locale = "ta";
       arch = "linux-x86_64";
-      sha256 = "b257832d007e99b94f3da729f230c60388725079a66d2e3f49784b7193fff9d1";
+      sha256 = "d878b53b7e962f9e90af4e74c715d11dcbc9509c98264216687214b2468e8f5f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-x86_64/te/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-x86_64/te/firefox-138.0.tar.xz";
       locale = "te";
       arch = "linux-x86_64";
-      sha256 = "b5c680211915b4ecfcd91bdb3f9cfd1289f9cfbebbce054333505dda69e5189e";
+      sha256 = "69a33c57575ee8ad9b5a43354ec499d8bf86e0a8504d0fffcbe57a3a886f7314";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-x86_64/tg/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-x86_64/tg/firefox-138.0.tar.xz";
       locale = "tg";
       arch = "linux-x86_64";
-      sha256 = "a7a1f542d781d000af042feb46d66e9ec190523ee1e13af062a85036dbcc80fe";
+      sha256 = "b9d28d2e1cacb993c8984a38b83e5267217b3f22f6221838548172316918af54";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-x86_64/th/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-x86_64/th/firefox-138.0.tar.xz";
       locale = "th";
       arch = "linux-x86_64";
-      sha256 = "dc122961f2b9616ffccda4f598dfeef25868667669eeee10925218ed6bf67860";
+      sha256 = "387214cbc3cc1ff63db9ae3133043fb84915596a9a4813c62f0ff1958373e867";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-x86_64/tl/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-x86_64/tl/firefox-138.0.tar.xz";
       locale = "tl";
       arch = "linux-x86_64";
-      sha256 = "a0bac76af6e5c828403abe673d8ea5f2f575772bb7ae58c333db1efeb5f424bc";
+      sha256 = "e670785d8f2a7c3064644c496b3e9ca644c9c31863bcebab0710a850cc98dc82";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-x86_64/tr/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-x86_64/tr/firefox-138.0.tar.xz";
       locale = "tr";
       arch = "linux-x86_64";
-      sha256 = "fbfab0605c2274cb3507a4f7160f44fe014c2d9d95fcc1b4624b9cc4cdbcb06f";
+      sha256 = "02b7b04453379c97d5c77b25f2b173c95c2023042b75cc63762c04de06e4229d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-x86_64/trs/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-x86_64/trs/firefox-138.0.tar.xz";
       locale = "trs";
       arch = "linux-x86_64";
-      sha256 = "1e6d9edab1241fdbcdcfad0c306e10abb6ef615beae0a1f66e3ebaecf8e2ddd9";
+      sha256 = "4e6b9fe3ceaad41fba91c8050aa5be689eb92c06a0144245746dce5d3cb014c5";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-x86_64/uk/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-x86_64/uk/firefox-138.0.tar.xz";
       locale = "uk";
       arch = "linux-x86_64";
-      sha256 = "c0ec2c2d0d184f2217024f59c7f0351294236d8fe46b09186e12ba6a23cc552a";
+      sha256 = "394e5f0ba508a6ff2d13a5861cb26606cdf95fa4ef4954303c48aeca34a48ce2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-x86_64/ur/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-x86_64/ur/firefox-138.0.tar.xz";
       locale = "ur";
       arch = "linux-x86_64";
-      sha256 = "c891825a53330fbf0469b48d040d8420c2418656a6c8f923c657a1940dfb8df5";
+      sha256 = "84110639e696725b997db708858e80248a9f070e723fa2729b1ab1de22113f13";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-x86_64/uz/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-x86_64/uz/firefox-138.0.tar.xz";
       locale = "uz";
       arch = "linux-x86_64";
-      sha256 = "9db81a1629ef38c87cd9ba79fce5b494b105d6bd355bbcb74cf9aa60e858c1a6";
+      sha256 = "7db0ae4c72daa632a4f83c11140d69ce2b8d3131b37b672579edd5dc296eaeac";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-x86_64/vi/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-x86_64/vi/firefox-138.0.tar.xz";
       locale = "vi";
       arch = "linux-x86_64";
-      sha256 = "9f66b43f327180015f65da572e7c8068545bd5b866edde25860bf5d2efe33493";
+      sha256 = "b7bc7feacdc5303a29cc134bec977d7b8a0e8477a0000ed71ff0f297231c2224";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-x86_64/xh/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-x86_64/xh/firefox-138.0.tar.xz";
       locale = "xh";
       arch = "linux-x86_64";
-      sha256 = "d58cd9a9a57912ea250703c2dc19190e3b1645bea41b5c595a5e452107a24138";
+      sha256 = "5f9462198c0d95bae32f3f82ea02e79fc0990fe2382703cf8a3a9201492fe12a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-x86_64/zh-CN/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-x86_64/zh-CN/firefox-138.0.tar.xz";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha256 = "661af2c1bf0caf217b07b581e62b8211061394d53a95d04c23124bce8e17a26d";
+      sha256 = "36e0499a7fe922252ffaf345f0a2b0d1185ed1be020d1734b4bc6b393fbca654";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-x86_64/zh-TW/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-x86_64/zh-TW/firefox-138.0.tar.xz";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha256 = "66f40de984319163e2a88cb89ba1befad243625e47b1b5ed4edf3925f8cc1904";
+      sha256 = "f6f482c11ecd685146b16714e26edef8b4c75fd61d4c7e6917b577d148e9b5f4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-i686/ach/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-i686/ach/firefox-138.0.tar.xz";
       locale = "ach";
       arch = "linux-i686";
-      sha256 = "6bd8e80ef6501332545c036ec49e2c83f9bb6116c82ab136de1db6504a99fb79";
+      sha256 = "c50b8859672a2488a16befacb1558fba5374f2811b28bd4c221f56a1721d9b8a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-i686/af/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-i686/af/firefox-138.0.tar.xz";
       locale = "af";
       arch = "linux-i686";
-      sha256 = "a9fb4d5437983b03c4c1582b3f5368f5a3831fad212cc3a484f6d7f67bb874fb";
+      sha256 = "bfb6b834572a50fc3bb60b8f0ffd3469d02165306ab014ecbd929e0a68a9e165";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-i686/an/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-i686/an/firefox-138.0.tar.xz";
       locale = "an";
       arch = "linux-i686";
-      sha256 = "a89e090bc7481b93795742a269f55fe0a5ead0bb4fb4d2b614beadb597312cbb";
+      sha256 = "dce05df47dce302c9504a49790887be3eb50b752b482c93f250f8247d9b0f711";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-i686/ar/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-i686/ar/firefox-138.0.tar.xz";
       locale = "ar";
       arch = "linux-i686";
-      sha256 = "8e9b9006a45034c0d4fb0a97fb35706380a1cf53af475db0d04d8939b2a56828";
+      sha256 = "0ddc73773d53e48be9bf8435a806cbd2bf0e6dc1f2d3cb93881fe0481f49002e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-i686/ast/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-i686/ast/firefox-138.0.tar.xz";
       locale = "ast";
       arch = "linux-i686";
-      sha256 = "09706bd734d7d011c1b3f2d7a989b1c17b2b4da651d46dff736a96dc905c2a4e";
+      sha256 = "25b3ff78e085e0fd7309da70dc6792f4a20430adde2954e0cc44fb25414379e2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-i686/az/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-i686/az/firefox-138.0.tar.xz";
       locale = "az";
       arch = "linux-i686";
-      sha256 = "7dc913b488ead99dd2e2df5acdd2e35ef2d30f169db4f001fadaab3d5e4f8198";
+      sha256 = "7e39d26d735ed7b53dfb3d1320c7bc84696de7533a61a2bea32ef90f51f28ad8";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-i686/be/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-i686/be/firefox-138.0.tar.xz";
       locale = "be";
       arch = "linux-i686";
-      sha256 = "da2d63d8e995733972df75916999af31343d803af600e2f0398a76d8ed288001";
+      sha256 = "dfd115d6fe7178ff4b30b10f4179c0e4851c8cc2c00c3aa8f1c87e2055c4f29a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-i686/bg/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-i686/bg/firefox-138.0.tar.xz";
       locale = "bg";
       arch = "linux-i686";
-      sha256 = "fec5e5cb24377287c0a5a7eb3c2951c0809e7fa445b1af1045207c6a91f1c72e";
+      sha256 = "40988936d16f557b41188ff2acc1c841b4ac0714ec3b3983ab532ce6de21680b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-i686/bn/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-i686/bn/firefox-138.0.tar.xz";
       locale = "bn";
       arch = "linux-i686";
-      sha256 = "8cac78572ae4ac693776d7dac2eeec5276b3c9e6207fa1d0151add065b973a57";
+      sha256 = "2ee86906fc6a97ad3eb06ac003904b84a242d73b1fd1f18d529f35349f27795c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-i686/br/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-i686/br/firefox-138.0.tar.xz";
       locale = "br";
       arch = "linux-i686";
-      sha256 = "9852eb309194eb9d8e26683ac93558b76c1f032905bbe5a411a097de6eccfc58";
+      sha256 = "a0259510acebd5f1c36f7e69b73939bbb6ec6b41f951a6a450154076913c303f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-i686/bs/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-i686/bs/firefox-138.0.tar.xz";
       locale = "bs";
       arch = "linux-i686";
-      sha256 = "539802406c5dbbe4f58f14dee7fc38c1638d2ac0d8d70ab65940410d8aa57e55";
+      sha256 = "27fbb387f0e835faf6c25d8408d86b12f5329abd0a9e803e3f6a6a5581b2e290";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-i686/ca-valencia/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-i686/ca-valencia/firefox-138.0.tar.xz";
       locale = "ca-valencia";
       arch = "linux-i686";
-      sha256 = "0f68cba87d9f02ee8149e98011a858c5c7266edba35a471b9f849d50479f5628";
+      sha256 = "ffdf7b354199187f759eae9462e4ce21e82d09811058ca4623b59ffc9bf13c4f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-i686/ca/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-i686/ca/firefox-138.0.tar.xz";
       locale = "ca";
       arch = "linux-i686";
-      sha256 = "3bc216ba5bb04c4222215c7a05667a95d9c7af179e410de5c690153192288709";
+      sha256 = "0249cc18225d32352e095808c4a8b05f3fd0421cb945bbf1efa956036f8fd69a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-i686/cak/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-i686/cak/firefox-138.0.tar.xz";
       locale = "cak";
       arch = "linux-i686";
-      sha256 = "117256281219b779648d4bf47cc8889cf655f55ba3173c68179fdd8a391136ea";
+      sha256 = "443b70f68c8ae949d30de9071ee646e8d777544fc6b2d213a5a7a28515155a99";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-i686/cs/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-i686/cs/firefox-138.0.tar.xz";
       locale = "cs";
       arch = "linux-i686";
-      sha256 = "e6005ef98e3a79677d0cc6339dd2b420b621a87e23aeec54162c886d52afcafa";
+      sha256 = "9170c77fd7e5868f766c32ebad98ee931b71e19fc864abbea25171fa5a9a2daa";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-i686/cy/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-i686/cy/firefox-138.0.tar.xz";
       locale = "cy";
       arch = "linux-i686";
-      sha256 = "a18b0a4ad2b51cc261f0ec445ec08becf1e3cf8e4337417f8c8581159c3f0e98";
+      sha256 = "0eacf9aee2b97654ceb86b575ce4267f18d01e7ed470e42a65670f14a25fe353";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-i686/da/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-i686/da/firefox-138.0.tar.xz";
       locale = "da";
       arch = "linux-i686";
-      sha256 = "42262804c5fc6f01e3fa7d17174bc4b59b55dfd818d9f2722730414365cbf28a";
+      sha256 = "71187f375b929a9d12138faa5665c8bb7d793e1e92ddbe7074d60f0e55f08814";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-i686/de/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-i686/de/firefox-138.0.tar.xz";
       locale = "de";
       arch = "linux-i686";
-      sha256 = "93ea70309ded5803a08b1e06bd73c574b9f0e7f6a2edc1062058640c3c63b67c";
+      sha256 = "ed68513eac978b484461ebe13e1469b6c1f39b063c49df621afd626ab9187436";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-i686/dsb/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-i686/dsb/firefox-138.0.tar.xz";
       locale = "dsb";
       arch = "linux-i686";
-      sha256 = "6f5fb42ea0c3da63eb9802ed44326a14476ab87382b58a13d47cb3d46708a11b";
+      sha256 = "d6046fb8011d4822e1806a400ac0df41acb89671ee24c339892f9d2bd5cbb3ad";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-i686/el/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-i686/el/firefox-138.0.tar.xz";
       locale = "el";
       arch = "linux-i686";
-      sha256 = "b372b973bb62d45b03addb100239fbbda28ea9f751b92f82f11e7e3134b92f14";
+      sha256 = "2b68ef2f9a0295cd9c193ddca2e4e5d152d429b2a7549d8fb837ccee13632db7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-i686/en-CA/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-i686/en-CA/firefox-138.0.tar.xz";
       locale = "en-CA";
       arch = "linux-i686";
-      sha256 = "dd4b0f753cae8f14a6a4190679c624abfa576c06c7a256a812b8f6c7a5304a79";
+      sha256 = "c084efadf9bfb19271af89841b698681d9d496d89a6bc5f54bc4b88aa5933037";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-i686/en-GB/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-i686/en-GB/firefox-138.0.tar.xz";
       locale = "en-GB";
       arch = "linux-i686";
-      sha256 = "7072319bdb505101719e6929d15f2a2eed0f47ace2a0072f909bd3aea713a493";
+      sha256 = "48068b6bfcf5f2ec10ab0148ec6cd8c0b012bf72874c7738a3e0580c5526b540";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-i686/en-US/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-i686/en-US/firefox-138.0.tar.xz";
       locale = "en-US";
       arch = "linux-i686";
-      sha256 = "0fbe76eb8941f979a5e9e2641e5161bc689045e19e5dcc31363e3297fce49864";
+      sha256 = "11f6a3c29fbcfdac0608716620f48ed42eaf3b68152de99b07a37c7709175346";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-i686/eo/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-i686/eo/firefox-138.0.tar.xz";
       locale = "eo";
       arch = "linux-i686";
-      sha256 = "fd303d27cc422c01df600b77862bdd5bb4ecb52754dcd165f333d7fa4f289b4d";
+      sha256 = "3448f794436119814deb1bcdca03c49ea4514cf767c9b0678b2f9b41f42d3f52";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-i686/es-AR/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-i686/es-AR/firefox-138.0.tar.xz";
       locale = "es-AR";
       arch = "linux-i686";
-      sha256 = "037f3c12d25fa776e3564e28da3779b5c9518c46ded00a0692cc7a2dd68da148";
+      sha256 = "a64f7bc723c317a18421650d310a6d2db0cee9bfca75bbc429a25158835a013c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-i686/es-CL/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-i686/es-CL/firefox-138.0.tar.xz";
       locale = "es-CL";
       arch = "linux-i686";
-      sha256 = "92b7a3e4894fdda35588f5ca6efd9729d9c9b1c5b698b5109b779f1c7db40934";
+      sha256 = "92c6b7ed42f4a45a53087bf7b578fb9301f14843d7ae64f33bb90ce59f759b48";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-i686/es-ES/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-i686/es-ES/firefox-138.0.tar.xz";
       locale = "es-ES";
       arch = "linux-i686";
-      sha256 = "b20df5f263481d681c8cb444aa2559638ce987e22f482d884bb993118a8600b0";
+      sha256 = "1cf6e9c6fbb61bb34ccaf9e27a117e783e91d9bd0024fb529cc43d27a15d7ecf";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-i686/es-MX/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-i686/es-MX/firefox-138.0.tar.xz";
       locale = "es-MX";
       arch = "linux-i686";
-      sha256 = "140ba8766d869d69e4b44a22b3727dfcc6d7bdd2f86bf04e97f48093af1a7d64";
+      sha256 = "be7adb9eef93b07e4b641c1940ebca49c0e61dd07ce62406fddf4af4631a6559";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-i686/et/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-i686/et/firefox-138.0.tar.xz";
       locale = "et";
       arch = "linux-i686";
-      sha256 = "77ac9a4e0679581b4d1de097bfe017e3641a24a2376a395e7c9f09e7d2df48fe";
+      sha256 = "4bef1a347a88cae8295e5f4a6b8b1496efdd6f86c5791481efe0c5c98f195721";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-i686/eu/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-i686/eu/firefox-138.0.tar.xz";
       locale = "eu";
       arch = "linux-i686";
-      sha256 = "352eb83d29fbe4139829a64131f8502b88f9dbfdc48027c2d324e7f74c1f48e9";
+      sha256 = "f55820753cd04ad6f05089037f504c7441da69f470076377075526bc6f99db83";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-i686/fa/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-i686/fa/firefox-138.0.tar.xz";
       locale = "fa";
       arch = "linux-i686";
-      sha256 = "b2e9193633d594624cbf9d04395375c51a0a0c0228ff3d9eae3d2d78461e0c1b";
+      sha256 = "d06a61485d2922f3bda8e7d005f5c98cf4687414b35b39d142e3d22699a870c2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-i686/ff/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-i686/ff/firefox-138.0.tar.xz";
       locale = "ff";
       arch = "linux-i686";
-      sha256 = "9881905e919886caae64568bc3287b07d432873b1b8c1f505828b2ad9abcee5a";
+      sha256 = "3f2384bf31b69896c7f9d5034e7c57ebebd535d1c611a4552365d1c3fbc4488a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-i686/fi/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-i686/fi/firefox-138.0.tar.xz";
       locale = "fi";
       arch = "linux-i686";
-      sha256 = "f9c778f78357eb88d9a95c5333b1b2707df93136f6ba1d61f0589b22df4264de";
+      sha256 = "d502aeb954c48388579447e6b8ec87504a90e56bc294a7b614b8625750539ee7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-i686/fr/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-i686/fr/firefox-138.0.tar.xz";
       locale = "fr";
       arch = "linux-i686";
-      sha256 = "57fe7ff08b26d81136bf1a5e785d0040f31f527afa8a6d30fd411df5da69fd1d";
+      sha256 = "457d35964003c91c69a78f94f81cae62614452db3ed61c12fb00e6cce39056a4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-i686/fur/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-i686/fur/firefox-138.0.tar.xz";
       locale = "fur";
       arch = "linux-i686";
-      sha256 = "9a4ecf9aa23cf03908ec9820b985ed68a5aa3227bde96cdd0cf28a5d80d8fbca";
+      sha256 = "911fcffde2ee68fd100b917b67be231ef7f3469257ed368ef48cca93ad454e02";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-i686/fy-NL/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-i686/fy-NL/firefox-138.0.tar.xz";
       locale = "fy-NL";
       arch = "linux-i686";
-      sha256 = "d5a3fda6f88468988f0c55eea9e6b724d7a013847f460edaf34abfc616842f6a";
+      sha256 = "0742bf5b7ac70887622fde562043f4da96ec32ef7aa0a20b5dccde9032477452";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-i686/ga-IE/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-i686/ga-IE/firefox-138.0.tar.xz";
       locale = "ga-IE";
       arch = "linux-i686";
-      sha256 = "d6765884e1537638d4b89c5d7f1d8d128f328c11feb0117f46b1b8cd592160c5";
+      sha256 = "e0e185a7757df478ad9dc111ca06368542682b12a59ef34fabe2aa869f406b9d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-i686/gd/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-i686/gd/firefox-138.0.tar.xz";
       locale = "gd";
       arch = "linux-i686";
-      sha256 = "fca8ee649de21a1311bde75effe6d62d0e9ad4884a72f421d19e80d29176cd38";
+      sha256 = "3baf88535c3dcd762be8afa29ccef68a4fe33c947b8d55fa24e612c760799fe2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-i686/gl/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-i686/gl/firefox-138.0.tar.xz";
       locale = "gl";
       arch = "linux-i686";
-      sha256 = "5fef17a9d4ff31ab3a78651538b0d4b9aae4ab99e33253b59000decf99e6077c";
+      sha256 = "f4ce6c023c5269b599226ad8275ad61c67b23eeba02920f9bf046e3d86ea14c8";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-i686/gn/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-i686/gn/firefox-138.0.tar.xz";
       locale = "gn";
       arch = "linux-i686";
-      sha256 = "dbd4351a166ce6cd82b68ce3cc05f6bd7fd88ffb5d1fd08b78d41ada40d78274";
+      sha256 = "53c63bd92137f0947f0a65b3411d86b94c9b2cb0aca8add8d19ebb28aea9f157";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-i686/gu-IN/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-i686/gu-IN/firefox-138.0.tar.xz";
       locale = "gu-IN";
       arch = "linux-i686";
-      sha256 = "f9f88b9949240c9ff8079d30ee3f69e2c755cdc1a3c8fe0fb2360b6eb5a05f76";
+      sha256 = "fec354379417b1e2222c2e0c5c7417e9c97bc7994500720ee2aacd0f5bcde0c2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-i686/he/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-i686/he/firefox-138.0.tar.xz";
       locale = "he";
       arch = "linux-i686";
-      sha256 = "6376acd80c908dcee26500149ecaefb6c8f3de729286a1a80d954e8e301c5520";
+      sha256 = "a87c2b76a8d9293f6b0a8b41e67ae1859535f23acda1c59bbf7de5635c69b3d7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-i686/hi-IN/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-i686/hi-IN/firefox-138.0.tar.xz";
       locale = "hi-IN";
       arch = "linux-i686";
-      sha256 = "e54ebdc31cda610d8dd360c1888b12e05810377217137e8a33473ae4dbc8ce52";
+      sha256 = "8c2018b267fd3c6c1c091f8bf5d0fe71974ee6b05ca745edb4bd44903bc328d6";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-i686/hr/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-i686/hr/firefox-138.0.tar.xz";
       locale = "hr";
       arch = "linux-i686";
-      sha256 = "44ae03c8515366e10c10237d46900c5098d2dbb15fd8a257967cdb0e72d71159";
+      sha256 = "43ec485c8f0ed3ecf504d191f1bb2ed6ed9b315bfc82adff0bce180ac7ac100b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-i686/hsb/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-i686/hsb/firefox-138.0.tar.xz";
       locale = "hsb";
       arch = "linux-i686";
-      sha256 = "a0d216082e4dd086ca7450a4b98e6a6b918008b963210ce5340fc7a276753214";
+      sha256 = "52f0d3a38b50c65a91ec6aad8f47f607cd179a61b67e424f909e5301f6e2a1f2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-i686/hu/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-i686/hu/firefox-138.0.tar.xz";
       locale = "hu";
       arch = "linux-i686";
-      sha256 = "5176c94a8a8e01e23ae67b56f2f6d9799c7da99bf81bd63db8f95d81e9329845";
+      sha256 = "5296a4c316fcc4be98206336d07158bf94fbe2d342556f4a6c2fe9c4b69c938d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-i686/hy-AM/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-i686/hy-AM/firefox-138.0.tar.xz";
       locale = "hy-AM";
       arch = "linux-i686";
-      sha256 = "44a2939795eb44c43a2c0188d03ca9d8b9516bc3e6500d5345eabc9e03ce7993";
+      sha256 = "596e09b27bbfc9b3872ada7981fbe0e9999dba3a38c39251cbbffa1a2e1318de";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-i686/ia/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-i686/ia/firefox-138.0.tar.xz";
       locale = "ia";
       arch = "linux-i686";
-      sha256 = "2d76f0b06db8e664c4e350ca7777f165ceaf62e35618e3489b22b39d1c382e57";
+      sha256 = "530ea7671409e6d49d547047bde79ea22f9704948acc1cb9daf3b605abaab8f7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-i686/id/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-i686/id/firefox-138.0.tar.xz";
       locale = "id";
       arch = "linux-i686";
-      sha256 = "ce088571dca27cfe88b0a5fd78dc00217f1c256f948e4b699185d604d0ccff3c";
+      sha256 = "be3ede0ea1b6f2c28af48f96d3aba92271c9b48401591aea93c98f68b6df066b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-i686/is/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-i686/is/firefox-138.0.tar.xz";
       locale = "is";
       arch = "linux-i686";
-      sha256 = "30d241557971e8baebef3f010dfd0ec9c1b7bb2e3c25fde88e4b7cab1640a93b";
+      sha256 = "ca3a933e2da9b2fca23ee8a05abc4220b774671f3f53dba321a92a778646b23f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-i686/it/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-i686/it/firefox-138.0.tar.xz";
       locale = "it";
       arch = "linux-i686";
-      sha256 = "7d32d531a5719f3b3638d9b7700ace76e2811336e81ff2a61d3bac42b9a43873";
+      sha256 = "884abd8e6d177f81625e956e3fcf72216ccb6c1488152c59ef386d6fbcb875fd";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-i686/ja/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-i686/ja/firefox-138.0.tar.xz";
       locale = "ja";
       arch = "linux-i686";
-      sha256 = "7e69d911b2b38156d0fd9310773f590363d3e976c2efe3e203afc6e842acaaf7";
+      sha256 = "203be1f5e4e6f1e13da3ac255e7e32f12b9486e77f929e530688208b3eb17be8";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-i686/ka/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-i686/ka/firefox-138.0.tar.xz";
       locale = "ka";
       arch = "linux-i686";
-      sha256 = "d154cd6896d6307768d8c81c393729c129274f0fe74e7250bd64b43f870d0a1e";
+      sha256 = "0e1b663de4a3bef122f61bf966e273252504f520b126b4d051ed3c867128f3ff";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-i686/kab/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-i686/kab/firefox-138.0.tar.xz";
       locale = "kab";
       arch = "linux-i686";
-      sha256 = "23eb6395ae2954e0c224102d52f6ca30b0e54c3da2be12ff4030577cfa04f204";
+      sha256 = "d8ded6e7c0d6059f40f5548991d8875cdc44acfb7c448175baf4aacd276b084a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-i686/kk/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-i686/kk/firefox-138.0.tar.xz";
       locale = "kk";
       arch = "linux-i686";
-      sha256 = "3ea3ad77da07f45b81459fc9144fdd17207c91d34f725a26409b3edcc6466022";
+      sha256 = "9ce2ddbc159fe998299995f3a53db5a9c9b5f81fb3e0c47754a85796224727d4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-i686/km/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-i686/km/firefox-138.0.tar.xz";
       locale = "km";
       arch = "linux-i686";
-      sha256 = "a6f688a41e7ce7e496a6754530c459394b0bf8977143a652e325294be8b0a72a";
+      sha256 = "b9a2dd4d8da2f5ddc353343e0bd4895b2a523e1400b2218b209bd1dc5e2930c9";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-i686/kn/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-i686/kn/firefox-138.0.tar.xz";
       locale = "kn";
       arch = "linux-i686";
-      sha256 = "6a4116a212ed7fd36c3af62ba8ee17eaa3209d9efe771386faed98a434f9fe88";
+      sha256 = "18b06baa3d5eabcba3cb59d6405a26a6ad17218ad8ab54980d2de87e2b01412d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-i686/ko/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-i686/ko/firefox-138.0.tar.xz";
       locale = "ko";
       arch = "linux-i686";
-      sha256 = "f1dec6feff907b033da4e2ae87d0b859f15d67a24b9c50fd260037dfb53de241";
+      sha256 = "185e66fd46f1b941140186fdc28f43daa58378fb55abe17ebdba0bfc4dd46a24";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-i686/lij/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-i686/lij/firefox-138.0.tar.xz";
       locale = "lij";
       arch = "linux-i686";
-      sha256 = "423e2be2c7e2a1a1696567bdb39a9e8f44ef489380652e036b4bdb2301b8928b";
+      sha256 = "a307af8df372e762be86d01898c7ecc52c7d1fb5dd8169a669b3cda23a1e8652";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-i686/lt/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-i686/lt/firefox-138.0.tar.xz";
       locale = "lt";
       arch = "linux-i686";
-      sha256 = "9cbec8ed732eccf4719d1c9e1d7b2d619cf9dc27de2b36a8913cc98ee49d9c9d";
+      sha256 = "98982e63dbdeb478074f888c936e67da5a2814d25b74292f86aa9f26cabc0963";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-i686/lv/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-i686/lv/firefox-138.0.tar.xz";
       locale = "lv";
       arch = "linux-i686";
-      sha256 = "a71dc31622a882a0963c92d0d2aa2522d1cb2a76340e481a53c8961fb49cd87f";
+      sha256 = "43ce28fa24b0d26c676e835b01c97a034f6652cac7e6bb89fabe6b92b38edf19";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-i686/mk/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-i686/mk/firefox-138.0.tar.xz";
       locale = "mk";
       arch = "linux-i686";
-      sha256 = "332f52aa6a9d85731dbc3d521a5956030ec78afc61420740763cabf76ef45fd0";
+      sha256 = "2bc779f1d2e7cf91f84203e8d401ebb6556c1da2e05f97887667134b763cb2be";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-i686/mr/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-i686/mr/firefox-138.0.tar.xz";
       locale = "mr";
       arch = "linux-i686";
-      sha256 = "ad6069e0b90f2da8c62c7ac5271856b63c14e8c93721a9e4e2fc90f693171583";
+      sha256 = "79d7c9b271eab0c0b75e05052f95a905c3219aa96010bcd829a4cc78470aafa0";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-i686/ms/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-i686/ms/firefox-138.0.tar.xz";
       locale = "ms";
       arch = "linux-i686";
-      sha256 = "d12b5497e1b6042096965968c56caf458a1a921e7743e960784330f9005b31d2";
+      sha256 = "4dd439d72b29f7fc507d82419f617ba1276d3fad7d2eb01ef94d6d64c5d878a1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-i686/my/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-i686/my/firefox-138.0.tar.xz";
       locale = "my";
       arch = "linux-i686";
-      sha256 = "0e891dbfb22d317650ab577590d65e914ed44fc19e0c1d04955c963a110c8fc8";
+      sha256 = "738b9875acd3dc02499f6642733fd3ed3380b4b202e62f54d76e2e96a8fea876";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-i686/nb-NO/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-i686/nb-NO/firefox-138.0.tar.xz";
       locale = "nb-NO";
       arch = "linux-i686";
-      sha256 = "7068c55600d901546ad5fb79d73b20099fcd30eda5dc7b6d88a14aa9c66afda2";
+      sha256 = "2f1c93ee8fda77a85f8dbf392bb6f6ba5cf2535b2b7fa167ba20965c4d9fb6db";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-i686/ne-NP/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-i686/ne-NP/firefox-138.0.tar.xz";
       locale = "ne-NP";
       arch = "linux-i686";
-      sha256 = "70024c0ac58c298098b4c478d1d8dcdcb1cc97b5c4491d0c4925a6e1f755d88b";
+      sha256 = "f72be80ea3354925b4d054795248fce86a71f066b23c0e79eabf1c84b7428d2a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-i686/nl/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-i686/nl/firefox-138.0.tar.xz";
       locale = "nl";
       arch = "linux-i686";
-      sha256 = "71ff5f4dd1496c38a18f8932bfa0a54f6b1cfe04d3c89e5e1893ffc8a5a64457";
+      sha256 = "467681a151fa36d923742ae66016d5fd047af2e6f29de36e168f760ae7ab141a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-i686/nn-NO/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-i686/nn-NO/firefox-138.0.tar.xz";
       locale = "nn-NO";
       arch = "linux-i686";
-      sha256 = "eaf2d4e35cd6b5801e0a7204a2fcb8d243cb51d8181bed4c3862392f6b080465";
+      sha256 = "0201acd21d1fe2f234c583b460700c3ac096a74ac22b1154f3901011c46ea54e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-i686/oc/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-i686/oc/firefox-138.0.tar.xz";
       locale = "oc";
       arch = "linux-i686";
-      sha256 = "d03833dc2b7fac5fd57bc5961c30e0854fac7cdb6203e6f8f36b928e9c70072e";
+      sha256 = "dc15c91da4b35b0c33d729156c6ad68b6711b41ce6bffdfd16cb11d8fe3e84f1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-i686/pa-IN/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-i686/pa-IN/firefox-138.0.tar.xz";
       locale = "pa-IN";
       arch = "linux-i686";
-      sha256 = "ca85fbc5f2cbcf1f1422ec2b368fc50808ac4f5da37df0e5ea17ddbceae0d369";
+      sha256 = "06eee6d3f287edc5e47e5a65b9c00a435d084e65a65271320f661a2d389fbd78";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-i686/pl/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-i686/pl/firefox-138.0.tar.xz";
       locale = "pl";
       arch = "linux-i686";
-      sha256 = "64df32727bf9828a1569549597922f7433597dd4cb7b3c25f93800ceacb0b96b";
+      sha256 = "8886e91d881290e3dbb6cf23feda408d4e9761b70d17b035c0b0c0e9771d72ec";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-i686/pt-BR/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-i686/pt-BR/firefox-138.0.tar.xz";
       locale = "pt-BR";
       arch = "linux-i686";
-      sha256 = "e610ba0462cf7fc5b66273e04677f49f48a360619709777f0abcf20ea5fbcb17";
+      sha256 = "20e8a11a04ed5e2ee6e06e8dc63c4df547306615eae8822bf6d6640e89803ae9";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-i686/pt-PT/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-i686/pt-PT/firefox-138.0.tar.xz";
       locale = "pt-PT";
       arch = "linux-i686";
-      sha256 = "39e0181b7ab03a583def142cec06edf80cc46bd041674341d4c78e6a4576658f";
+      sha256 = "19eeed508ce7c0352cf72e40f7ed554ac2b741ac514b47f7461ffab769b0f410";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-i686/rm/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-i686/rm/firefox-138.0.tar.xz";
       locale = "rm";
       arch = "linux-i686";
-      sha256 = "48b65adc7ddfc764bbc730e7cdb206b795047930a75d70e4a8fbe0dff629a6e4";
+      sha256 = "4ebf2d036205425fb7b209fe67c011d463e89a02bdf4032240017d9a17beb339";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-i686/ro/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-i686/ro/firefox-138.0.tar.xz";
       locale = "ro";
       arch = "linux-i686";
-      sha256 = "46d47766e1730248892b669f0196f02f03799ab00376eb2df6b75a023e93b7a2";
+      sha256 = "3de1aa887ed3cc3c085a2b206e1d3d4493b082f1a58baa505d80ee731030ff72";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-i686/ru/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-i686/ru/firefox-138.0.tar.xz";
       locale = "ru";
       arch = "linux-i686";
-      sha256 = "7cc61af8c366fa2ebd155157c0ae49bfc04a4fc356c1f05d9c0e9f9bbca36640";
+      sha256 = "cf1fefc409b226491b93b9a7ce9fb7ec536cde0c75a1511cb3c788d189ac43fe";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-i686/sat/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-i686/sat/firefox-138.0.tar.xz";
       locale = "sat";
       arch = "linux-i686";
-      sha256 = "d492c7cc824b9730b5b33bacab077fb4f54157c605c26138ed6010e1d7469d5d";
+      sha256 = "76c8e7357f216d231a9b559a7a6f9bbebca5dfca6d8dc0e77f6222b4611a25c4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-i686/sc/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-i686/sc/firefox-138.0.tar.xz";
       locale = "sc";
       arch = "linux-i686";
-      sha256 = "b0fcd6bc97c1e0c0528dcf2793f6a8e456249027e23e150658b23828f992e4b3";
+      sha256 = "8f7d3469ebdde396428ec41d443dfc798044073640c6c68ccb2c71b62c8ac2e3";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-i686/sco/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-i686/sco/firefox-138.0.tar.xz";
       locale = "sco";
       arch = "linux-i686";
-      sha256 = "84979d89742407b5204dfb58e07adfed9085483d86d706698f589a90eb6a720a";
+      sha256 = "37bbcef66b67a8cf3f8b3b87ded16922849e517dce4d599a696b3cb02dacfdc5";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-i686/si/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-i686/si/firefox-138.0.tar.xz";
       locale = "si";
       arch = "linux-i686";
-      sha256 = "d6b889dd2d9fa63a15f220ae11b748b704b9513f49cd07d9dab18ce3128a0d03";
+      sha256 = "8755436f7b41329ec7c7abe86c855e214679da48ceb9c0772011d560f6487e62";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-i686/sk/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-i686/sk/firefox-138.0.tar.xz";
       locale = "sk";
       arch = "linux-i686";
-      sha256 = "b2ef2b56a1f56fea0f2cde652e1059eae391e7ceb0b34d27a66afa68c0625225";
+      sha256 = "2617a91baff77823ff7d60209415fb390ad2a49733058f0a23efe01b137c2842";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-i686/skr/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-i686/skr/firefox-138.0.tar.xz";
       locale = "skr";
       arch = "linux-i686";
-      sha256 = "9193b12b0cc633b9dee2a26712af7bd8b165f90dbdf7b35685e79d3c7e87645a";
+      sha256 = "5e177e99c0ccf040e472501a081c1e805326e82e0120879e1aa0c0908965f3c7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-i686/sl/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-i686/sl/firefox-138.0.tar.xz";
       locale = "sl";
       arch = "linux-i686";
-      sha256 = "7123a14235a6de507c3ac5f3cd0b9407ba1af98baa9ab7f9ecfee82c95c3832a";
+      sha256 = "842982ad7b476a1d6fadbc1d67380347319c5130f18450b0b4057d5b24747ea6";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-i686/son/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-i686/son/firefox-138.0.tar.xz";
       locale = "son";
       arch = "linux-i686";
-      sha256 = "33824e97216a9db7bf85c45533a745231371f05d251768ed4ee7d015ba6b81ed";
+      sha256 = "1e0f5e5493b6c4bd67fd6fb4bc12c8c02e3bb0456014255e36a0729564e39fe7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-i686/sq/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-i686/sq/firefox-138.0.tar.xz";
       locale = "sq";
       arch = "linux-i686";
-      sha256 = "80c6c36754d1e1738144c2ee4647aad5b403ff26b62b864a5e84b8d9f179a887";
+      sha256 = "ccfc06ba1c2179e8eee5bab7e992cc3bd61b12265862ab041ae8da2aa9b8a88d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-i686/sr/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-i686/sr/firefox-138.0.tar.xz";
       locale = "sr";
       arch = "linux-i686";
-      sha256 = "fbba86e502fae0ab46ffdaff0baa082531a87757ab3609e77efdd0abb0298440";
+      sha256 = "762e5e956fa8e6769d37b40c90f7e84f0b314326d6490cd4f9fc817b660117fa";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-i686/sv-SE/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-i686/sv-SE/firefox-138.0.tar.xz";
       locale = "sv-SE";
       arch = "linux-i686";
-      sha256 = "39a0bdf1c6ef21a4a48639a41101695f22faec51b85663f9e09606d50384eaec";
+      sha256 = "e30862e277f8f8ebc9dd298c009ceafb8e01ca616aa646d9ad35ac4a14308cfd";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-i686/szl/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-i686/szl/firefox-138.0.tar.xz";
       locale = "szl";
       arch = "linux-i686";
-      sha256 = "8e4eede08305b83e289d5ba93a3604c788f058f77dcf6a7f588f9803b5043a24";
+      sha256 = "0a1f5c1e30c3dc37eead903c916fed4819dbb694e6baa0316d313b11f6ddc6a0";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-i686/ta/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-i686/ta/firefox-138.0.tar.xz";
       locale = "ta";
       arch = "linux-i686";
-      sha256 = "963adcdf8cf97cf75a7745545575403bfeb8378f0e14659e0453bd792e592692";
+      sha256 = "d04878c8ce3c794f2cf425b50ef02eb8a376ab6cea1561018b0abe55854276cf";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-i686/te/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-i686/te/firefox-138.0.tar.xz";
       locale = "te";
       arch = "linux-i686";
-      sha256 = "23de9f68b68907801f812e19c7b3498e8d4ef68ab60822012bbc07a80d83ca26";
+      sha256 = "3ec8f7bbed60527f3c0da75077d39ca61ee243195bfd0350088e78ab9451c9f8";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-i686/tg/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-i686/tg/firefox-138.0.tar.xz";
       locale = "tg";
       arch = "linux-i686";
-      sha256 = "1fe62a3eef2f67f39184e46d3bb4fdb7ed9b13a4e3aa677e396a55da3bdc86c4";
+      sha256 = "ed969fcac2200f210d3044d3ebb6cedcd102a79df560e766a9d8610cb7d1380e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-i686/th/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-i686/th/firefox-138.0.tar.xz";
       locale = "th";
       arch = "linux-i686";
-      sha256 = "2c540f3d1dd0977cc919e45fe14345282825ee6db8d7e2f2caf465b599e17519";
+      sha256 = "9b7efc332c1cb653caee9a25860bf881091a4f5ad95f8b2ddd177cd186cc6b45";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-i686/tl/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-i686/tl/firefox-138.0.tar.xz";
       locale = "tl";
       arch = "linux-i686";
-      sha256 = "b1f4924fb2c7fa7d10987ea450d478111c368f30d8ac706087d679f5920496ad";
+      sha256 = "8e0b498ab73c56bf962971b441f039a09670b8d52a358702b0cdb655b3d9d258";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-i686/tr/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-i686/tr/firefox-138.0.tar.xz";
       locale = "tr";
       arch = "linux-i686";
-      sha256 = "fe8e63dd6dd406efc7db8b5a20c7f0a7ddbbf568b055e7eb3572315916a6a587";
+      sha256 = "4d7e1af2ed8bd3a32eb3f5a15ab30680d4772c70c1b1da7b9a3538df2c534712";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-i686/trs/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-i686/trs/firefox-138.0.tar.xz";
       locale = "trs";
       arch = "linux-i686";
-      sha256 = "b6120eb10aa593bccb9ede568f8abbaf3ed8450f69c87e43c10939e3ce574f67";
+      sha256 = "79ae7512235d5480943f81e235aab55c3279aaa5876ec447897770033f6915e3";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-i686/uk/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-i686/uk/firefox-138.0.tar.xz";
       locale = "uk";
       arch = "linux-i686";
-      sha256 = "f3f95c23a52d6f41a6cae647910f71161670b48279558658fdc6cbe385531d86";
+      sha256 = "847c100603fc180157e96f53a7aac0d6bc8c6d94a04f81692f5ad1dc8812eb2a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-i686/ur/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-i686/ur/firefox-138.0.tar.xz";
       locale = "ur";
       arch = "linux-i686";
-      sha256 = "a1017d99f725ed9b56aa416181abd23556995c2aa8f5b30411c028f5058ad6fc";
+      sha256 = "a361f823b263cbec63199d59e0f92f029edf5845aee6bf859dbe0d48d2583b51";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-i686/uz/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-i686/uz/firefox-138.0.tar.xz";
       locale = "uz";
       arch = "linux-i686";
-      sha256 = "8e1dd3355bb37760805e8935b74ae5db21f7bc41c80417cc7c4d97c010cde8b8";
+      sha256 = "e31b8c83b334b8203ebe954909ca77a769c60fb9f50bfcee998a98b0264bae0c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-i686/vi/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-i686/vi/firefox-138.0.tar.xz";
       locale = "vi";
       arch = "linux-i686";
-      sha256 = "dea2d9319368d79fbb1313e762f36eb6df44c5b07aca21f95cf3dbdcc1a2f74f";
+      sha256 = "b501e35c5be81a82b3d6abab8eb18657ac4aa62d908467da4363623fb53f7894";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-i686/xh/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-i686/xh/firefox-138.0.tar.xz";
       locale = "xh";
       arch = "linux-i686";
-      sha256 = "d97760a305be1726ae37f9d1fa880ef637bff01410d2dfef6845fdb4f5ca6bee";
+      sha256 = "3e132fb7a439a83429f198b202b016c8156eb71d9b8e69bac9c0b23c08c24b3d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-i686/zh-CN/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-i686/zh-CN/firefox-138.0.tar.xz";
       locale = "zh-CN";
       arch = "linux-i686";
-      sha256 = "da927268e6e6b6dca431d9b061a8ea668ee84c92dc2dd7f1f33c6d78a8a4701c";
+      sha256 = "4becb86c83ec7000865dac34805bac4fd4377b34dd0634e22146f68e9dbf1b7f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-i686/zh-TW/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-i686/zh-TW/firefox-138.0.tar.xz";
       locale = "zh-TW";
       arch = "linux-i686";
-      sha256 = "4a32212cc25376729a3afa88745fcc2a02b2bdeb458985ab7d6c9f3c39c0fa0d";
+      sha256 = "ffe163d30b2793e9b0e09ff12230d8736bf95192aa828d2aab363bb9603bd907";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-aarch64/ach/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-aarch64/ach/firefox-138.0.tar.xz";
       locale = "ach";
       arch = "linux-aarch64";
-      sha256 = "83c98a0658180f32a5dde80ef6b0f2bccd08f4cdd78ef7c75c62bdf6f5048854";
+      sha256 = "c58053c0d52a3d7672f789dc510e715013e02767aacf554bd9795d4328bed414";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-aarch64/af/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-aarch64/af/firefox-138.0.tar.xz";
       locale = "af";
       arch = "linux-aarch64";
-      sha256 = "328a4d572bfa2e0abffeeda6e0e33ab4aa9490ff9e77006e030643ef722e6b04";
+      sha256 = "b18fb80cb55a747dd186e122bfec9a3b1afd215d5d02c4f0e090e018624033ed";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-aarch64/an/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-aarch64/an/firefox-138.0.tar.xz";
       locale = "an";
       arch = "linux-aarch64";
-      sha256 = "43f66d4a11b6a52699259b8c486d092f6bdba2f40360ac9b6cda808ef4b0d777";
+      sha256 = "9ec0948f25591002503880988faa467cc8ebeddd2ec5d83e1ebe90bf0853e296";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-aarch64/ar/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-aarch64/ar/firefox-138.0.tar.xz";
       locale = "ar";
       arch = "linux-aarch64";
-      sha256 = "b81361b991ca591c42369fcb46657147946afd42b42236ee6711c8d90999dddd";
+      sha256 = "211f455f92cbf51df73b4a9ce335a5c277d43f038ebbf70900f22beacd1c7939";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-aarch64/ast/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-aarch64/ast/firefox-138.0.tar.xz";
       locale = "ast";
       arch = "linux-aarch64";
-      sha256 = "5c00a758c52ed49ba56406adcbef1cef7f0e93b1066a0bac0000287fc38185c1";
+      sha256 = "faf470aafc75ea21ec784a72c0bb06e8003bb02e141f6f2031835d65bb7307eb";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-aarch64/az/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-aarch64/az/firefox-138.0.tar.xz";
       locale = "az";
       arch = "linux-aarch64";
-      sha256 = "3a73fd100fbc29167e758f2640e86f08dc3d0ec14d86cd762fbcd25d38a980f9";
+      sha256 = "ce9b579273a84612d85b1f29f518a7a31af2148c0ee9fd6bce7cdd9647558748";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-aarch64/be/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-aarch64/be/firefox-138.0.tar.xz";
       locale = "be";
       arch = "linux-aarch64";
-      sha256 = "d7452c789bc140e1bdae0969c222b6fd5a527a9cc1f355afb9ee8c86754d95e3";
+      sha256 = "3cc6fd7d85526248d2eb1100f63d20b60097b7a6bf969028236710525282c667";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-aarch64/bg/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-aarch64/bg/firefox-138.0.tar.xz";
       locale = "bg";
       arch = "linux-aarch64";
-      sha256 = "2efcdf2fd2f25e17a5e00b53909eb4d247c94f17b010a2a6fefe2c18bc7c5ac8";
+      sha256 = "ae70a834528e0df06f947b0121e9685e60344af8ad674b78761a247af77dd119";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-aarch64/bn/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-aarch64/bn/firefox-138.0.tar.xz";
       locale = "bn";
       arch = "linux-aarch64";
-      sha256 = "3bcbcc4fc238610b8fb689baa86302a37ec4ba9a232fb2a5987aa34bbea8dbbf";
+      sha256 = "8649ecb1f65f8bc3182bab45064e4fa55f3b7d6b7f4e5b480661be3e9c888054";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-aarch64/br/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-aarch64/br/firefox-138.0.tar.xz";
       locale = "br";
       arch = "linux-aarch64";
-      sha256 = "bbf23aa01a2b6f8a5eb16a42b20ac140b4db34850225c89068511ab8dfd4d313";
+      sha256 = "3d0e97ce39f207bd1d8f388535269b21acb455066126f21e8d12dafd8cd05c4c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-aarch64/bs/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-aarch64/bs/firefox-138.0.tar.xz";
       locale = "bs";
       arch = "linux-aarch64";
-      sha256 = "3377da320032a1856028d5147abc8ec097d99658485175b7d69631fd677777ae";
+      sha256 = "65cb431867a48b9dfba8cbaf14f08f7a6473b24be52216321917eae16c5e03c9";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-aarch64/ca-valencia/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-aarch64/ca-valencia/firefox-138.0.tar.xz";
       locale = "ca-valencia";
       arch = "linux-aarch64";
-      sha256 = "eefc516725cfbc86739bcb09354864db659b26be06ff55c8e11795b58e300486";
+      sha256 = "c84271b67863ba817ee4b69081465ce521f5c099f5d85ff699eb3613c90c4881";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-aarch64/ca/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-aarch64/ca/firefox-138.0.tar.xz";
       locale = "ca";
       arch = "linux-aarch64";
-      sha256 = "178168e1ddff1271ab3330439a73ed92ef476790022e835cb3b9c1bae1484807";
+      sha256 = "8cc578d306653a96042788eae5b2934843e6522a6a2e51d79ed6e223f389b76d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-aarch64/cak/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-aarch64/cak/firefox-138.0.tar.xz";
       locale = "cak";
       arch = "linux-aarch64";
-      sha256 = "09d2128a8defd03108b5df4853f097f653dd458126bfd64d905bf3beb82901d8";
+      sha256 = "4901c8c81fb37f634629f634f1918e149543f147b1ec2f612c65992a0dae4e11";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-aarch64/cs/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-aarch64/cs/firefox-138.0.tar.xz";
       locale = "cs";
       arch = "linux-aarch64";
-      sha256 = "e55d7a188d7058e86505a3a5b0ba0baa05ea510ab0a4e5e354a079ed20445769";
+      sha256 = "f7ff2f59afcf5527a9aa8531802f4ee57a8cce348ece7c6a6e4054d1096ef1cd";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-aarch64/cy/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-aarch64/cy/firefox-138.0.tar.xz";
       locale = "cy";
       arch = "linux-aarch64";
-      sha256 = "512d1a11ff9ae9b6c360c39ec25a9941a5bfba085ed6c87ceed1f46ca8c5eeb7";
+      sha256 = "35e041a9278ff05895db164fa24f77852155167c595bbae861d25bf6e756baae";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-aarch64/da/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-aarch64/da/firefox-138.0.tar.xz";
       locale = "da";
       arch = "linux-aarch64";
-      sha256 = "a6993017053fe771b0f80e863891f61402efe54b4c25eef3cba1f8b705932fa9";
+      sha256 = "948f206163e71f4898e21128689ef9385a6043999e9dd7790239631300d1441e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-aarch64/de/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-aarch64/de/firefox-138.0.tar.xz";
       locale = "de";
       arch = "linux-aarch64";
-      sha256 = "284b75f48b03ae46647c990d244714fa2508bdf0eebb025cfc6f77b473c3c213";
+      sha256 = "330eb18cefdce737d6ea17c3b70640821ece8c1536780b5ad3dd9ef14c8edb00";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-aarch64/dsb/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-aarch64/dsb/firefox-138.0.tar.xz";
       locale = "dsb";
       arch = "linux-aarch64";
-      sha256 = "7dc4e550dbcdc255f7440ac8817541ce203f6d3cd106b5a93c724f837bef49c0";
+      sha256 = "93454a6eb97f6cf671e11448cf45c9b54cfd0063a7cd6f5f35b8522b4b59c672";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-aarch64/el/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-aarch64/el/firefox-138.0.tar.xz";
       locale = "el";
       arch = "linux-aarch64";
-      sha256 = "e9ee787c182eee63a3a75a7388e3d9e66c43b6b991ecd11fb44e4b128f84abd5";
+      sha256 = "2db823a5c3574b3769be2e074209d42f4421456ad9e88a735a407f0409228f2e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-aarch64/en-CA/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-aarch64/en-CA/firefox-138.0.tar.xz";
       locale = "en-CA";
       arch = "linux-aarch64";
-      sha256 = "7f6468de90bcc429efdd18cab66ed8f5f40a5017b287bafa5ad0d73cfc960d90";
+      sha256 = "ccca0c1e74a3f4d2584634e557e3279724350001c22e810029e303692aaf9109";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-aarch64/en-GB/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-aarch64/en-GB/firefox-138.0.tar.xz";
       locale = "en-GB";
       arch = "linux-aarch64";
-      sha256 = "93fb4d652cfad022e0f915315d5b8b640c8a1dafaef07c685ce44991bd7c9ae3";
+      sha256 = "e29ebf16413b84c7fb453fecbcd7f936ed7761e869cbc149eb8211d4d32a839c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-aarch64/en-US/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-aarch64/en-US/firefox-138.0.tar.xz";
       locale = "en-US";
       arch = "linux-aarch64";
-      sha256 = "64550e9c1b93a41f0c407306935a9bae06113b4b68b9714fcc48e26f1e743008";
+      sha256 = "a4717c106b7294fb8557a7fb27db45e0648d185c9a85ef3d43e41c8b4d33a369";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-aarch64/eo/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-aarch64/eo/firefox-138.0.tar.xz";
       locale = "eo";
       arch = "linux-aarch64";
-      sha256 = "4b14d563c262f7b69b86c32e617da35bd264a6182d2e8932c3bb7d59556e310f";
+      sha256 = "ea174408daa8d52520d1a2e9591fc5bd0883ec9e892d0afbb70a459c17ccad75";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-aarch64/es-AR/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-aarch64/es-AR/firefox-138.0.tar.xz";
       locale = "es-AR";
       arch = "linux-aarch64";
-      sha256 = "82640ca874ec682fa9768389dacfd8ad02bb178038bebba4667cbeedaffd6f75";
+      sha256 = "18cd4b91a3c0922dd7cd0894a202a0420647d72fce43dd955c5c7f13fcfe8609";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-aarch64/es-CL/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-aarch64/es-CL/firefox-138.0.tar.xz";
       locale = "es-CL";
       arch = "linux-aarch64";
-      sha256 = "e86a2b1354d01986316a8cf27bc18da3242f9b0b03202a765162f49bee452804";
+      sha256 = "b1733607390441a1f515c129cf0506aa0db29c24531ce8e2b69800738da00364";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-aarch64/es-ES/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-aarch64/es-ES/firefox-138.0.tar.xz";
       locale = "es-ES";
       arch = "linux-aarch64";
-      sha256 = "8e276ebdd0b7b6e35bf0b79d497b6808eafd26c7e4a3118c27570dc806677bd1";
+      sha256 = "6e42587b45adf1221d89aecedf06a5dd130bbc81398bbf4c8369963adb69e5b1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-aarch64/es-MX/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-aarch64/es-MX/firefox-138.0.tar.xz";
       locale = "es-MX";
       arch = "linux-aarch64";
-      sha256 = "11982da816baa1bc4abdd8d3ef4754972069b70294f77346de7e5a915099cea3";
+      sha256 = "ca6d3e5524d14f915c265b03a6136069b99119e905c2e75375bd1d6e764dba8b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-aarch64/et/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-aarch64/et/firefox-138.0.tar.xz";
       locale = "et";
       arch = "linux-aarch64";
-      sha256 = "128b8ca9848c098b862bd4b6507be5279cbd08090b40fadb90a5798c35389850";
+      sha256 = "487a27bb404dbb76e5a0f5abe167c02ca221606ddc54ff7a91d071f54b112e92";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-aarch64/eu/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-aarch64/eu/firefox-138.0.tar.xz";
       locale = "eu";
       arch = "linux-aarch64";
-      sha256 = "9a81dad28340771985cc8535ae8df6bed190e42cf9d4544097240bb723c44816";
+      sha256 = "584e252b5ece4dc03b62a923649cbb54cbb41a6eca4ac090fb693afd9d27bf06";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-aarch64/fa/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-aarch64/fa/firefox-138.0.tar.xz";
       locale = "fa";
       arch = "linux-aarch64";
-      sha256 = "344584781dca139bb0a0a6c385e7ab0c7e08e6b2d2b3922b8fbfda780c3827db";
+      sha256 = "5d07a95fbb30a8d7cb8f6d8f7ce334cf77b5651d2213d94403cebd742a1036f3";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-aarch64/ff/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-aarch64/ff/firefox-138.0.tar.xz";
       locale = "ff";
       arch = "linux-aarch64";
-      sha256 = "28a93bce9b907843a6b92918d0c046e880318fc6f58afa91c31d6358e4f25f38";
+      sha256 = "417deb8c96f2c6fc9fd6438670265c4e464eaef552faaaf661c59396e36684d2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-aarch64/fi/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-aarch64/fi/firefox-138.0.tar.xz";
       locale = "fi";
       arch = "linux-aarch64";
-      sha256 = "36cf0b611b7a9273827a15684f8a10d95ec3b8ad744f9bdf7d0ad95f6e4f9d65";
+      sha256 = "7622ec05aa7d08679b671fa3ba11d14ad6557488afa899a82c37759b4d0c3967";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-aarch64/fr/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-aarch64/fr/firefox-138.0.tar.xz";
       locale = "fr";
       arch = "linux-aarch64";
-      sha256 = "3a051758d692de7619482f3ef5a684eb8b51a8020e2aa3ac9f97a7275734ac90";
+      sha256 = "8b6584f5176650a04ae04a437b7b007563cb7b0f508f582a3631083b12fe6a68";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-aarch64/fur/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-aarch64/fur/firefox-138.0.tar.xz";
       locale = "fur";
       arch = "linux-aarch64";
-      sha256 = "3df0b4425870fce071231a9df527f5f69bc93a1ab712ca925a930b1abc381520";
+      sha256 = "f1d2b1a4208b77ddda9a2cf85d10acb6e0bab617947fb1c25dc76671f5a61e54";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-aarch64/fy-NL/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-aarch64/fy-NL/firefox-138.0.tar.xz";
       locale = "fy-NL";
       arch = "linux-aarch64";
-      sha256 = "4d74316b43726fcf4d1d2b7d244009ee12663b4d21bd5294c2dfd2ce64c932ac";
+      sha256 = "9d85b49cc8561f22db6db6f2439d25e2d10a8b2716c223e78942d7c62dfb3374";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-aarch64/ga-IE/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-aarch64/ga-IE/firefox-138.0.tar.xz";
       locale = "ga-IE";
       arch = "linux-aarch64";
-      sha256 = "e4c40a092124592ef9293e55dc20f14d626e3041a56b08d58b03aa9b40b83ea6";
+      sha256 = "f134bbf1d11bef104fdc1e5dc5c6c8978359e04d77fbdf04aab2941c06e79ea4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-aarch64/gd/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-aarch64/gd/firefox-138.0.tar.xz";
       locale = "gd";
       arch = "linux-aarch64";
-      sha256 = "75aee9b07b56235eb1c7b22bf2ed200fa8be9d90d534204bfebc0055f0d66ab3";
+      sha256 = "b559b350de4704f447affed6660603cf6828ae67f739aec0a62f48423feaf8f1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-aarch64/gl/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-aarch64/gl/firefox-138.0.tar.xz";
       locale = "gl";
       arch = "linux-aarch64";
-      sha256 = "c9db02d58c7bb34ba943df89e085ded691b526dc8917465d7759128365961670";
+      sha256 = "4c10c4c0d54d0f92ec10c916e5c76621509b63e9e156681806a6118947e39fad";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-aarch64/gn/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-aarch64/gn/firefox-138.0.tar.xz";
       locale = "gn";
       arch = "linux-aarch64";
-      sha256 = "920b4af583ca3d667de856b52e2893555e7b81f147f83d2f3df5740cb876484c";
+      sha256 = "8320bca324c6ff26c0d86824df4686563b4151f35c5cefd5731ba491165aeddf";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-aarch64/gu-IN/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-aarch64/gu-IN/firefox-138.0.tar.xz";
       locale = "gu-IN";
       arch = "linux-aarch64";
-      sha256 = "fcb677e6f2a460641c5126dde4db82cbcf37aa19f8d900d94fc163026fd69e31";
+      sha256 = "56ef92214c554b1d04c31682881cdfc5bd2bb7f49a91966a779064270c5bc6de";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-aarch64/he/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-aarch64/he/firefox-138.0.tar.xz";
       locale = "he";
       arch = "linux-aarch64";
-      sha256 = "296f7ae7757220657a23e705a56ec96b39a79c715d9f8160495e9cd53d2d0684";
+      sha256 = "23f62247fa1fce1ae6090bb7350a569aaed0bbcdb479cadc65b9e15d7070d0d2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-aarch64/hi-IN/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-aarch64/hi-IN/firefox-138.0.tar.xz";
       locale = "hi-IN";
       arch = "linux-aarch64";
-      sha256 = "4141ed140509321799918a49f172a5d6f6dd39fe0d935def9a6cf1cbf288e7b6";
+      sha256 = "a1ea12f4af1b7fc1cbf2f73ba578d512be3634e2fbdd738e499cbc9eaac7f9fd";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-aarch64/hr/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-aarch64/hr/firefox-138.0.tar.xz";
       locale = "hr";
       arch = "linux-aarch64";
-      sha256 = "55e8e4e083be490ad5d9a0c217b2f62dfd2993065bcb9594e559f8b8d17d6014";
+      sha256 = "528fdb247d8f05579627b615cfd43f982f869a529f1c3931963f577aab2f4088";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-aarch64/hsb/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-aarch64/hsb/firefox-138.0.tar.xz";
       locale = "hsb";
       arch = "linux-aarch64";
-      sha256 = "a1ba8dd500cc94e5e79f50bd754ccb48f339d2f3ccf76c9ccb376587d33d344b";
+      sha256 = "b320ba86908069c29d2dead5fc13d5bc68c4080a9d586221dc41b0da4f5a551c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-aarch64/hu/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-aarch64/hu/firefox-138.0.tar.xz";
       locale = "hu";
       arch = "linux-aarch64";
-      sha256 = "eb9d5364b9a52bbc93a357b3a43c4e4633ae18c62e9765e4e7c209655f9515f9";
+      sha256 = "da08a408ed7b6769876cb5a6e087ee4520102c5a07ceb43cc26b86e84919c9a1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-aarch64/hy-AM/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-aarch64/hy-AM/firefox-138.0.tar.xz";
       locale = "hy-AM";
       arch = "linux-aarch64";
-      sha256 = "e3af59359d1a31fafc84e1afc4426d2cfb3c8c1b16d0e6cfb456f50e0bd6f297";
+      sha256 = "9cc70d0ed4d57500892723d40c76820331888ffae78c7df25e065e9c31ae7eb3";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-aarch64/ia/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-aarch64/ia/firefox-138.0.tar.xz";
       locale = "ia";
       arch = "linux-aarch64";
-      sha256 = "d6c4132d1acfe94e41dfa0e0c9ff155187cc734690e321e1aad7454f4c87362f";
+      sha256 = "39000fdd0b442904a4e23b4d7b13dfbd1d748867c9a91c1f86a8d6f59c13c8e2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-aarch64/id/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-aarch64/id/firefox-138.0.tar.xz";
       locale = "id";
       arch = "linux-aarch64";
-      sha256 = "a302440afcaff953687362b3104f991525cf0660673314ce29afe67d5fdb33ee";
+      sha256 = "b289f9da4ff46075e5b8d2251e2656d896517ebb3213dbc4eea03269cbdf4384";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-aarch64/is/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-aarch64/is/firefox-138.0.tar.xz";
       locale = "is";
       arch = "linux-aarch64";
-      sha256 = "37e735b006bde949b4d0b069535f2a12d75162ff68767a0b52f56189dc413d9c";
+      sha256 = "fa3f4108cad9d4fb91b50eb3f8f59e53f9ae97fa72624cbf3efaf73f4e9ff23b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-aarch64/it/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-aarch64/it/firefox-138.0.tar.xz";
       locale = "it";
       arch = "linux-aarch64";
-      sha256 = "b52dc0f59ad89dbf39641a26662f31132550a7faac1c044981e2571108d848ca";
+      sha256 = "71152f7f5b5986c57b92ec9f3e8c8cbe9bf813e809c52c05a67451b12c8bbbac";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-aarch64/ja/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-aarch64/ja/firefox-138.0.tar.xz";
       locale = "ja";
       arch = "linux-aarch64";
-      sha256 = "39c13d36be57b139f3352699fe136021a4b2cfca4fb0619653f36e3672a20634";
+      sha256 = "7d3ee171d1cac3bd04ba20991b69f129618f1fd27c38891430174f121dac572d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-aarch64/ka/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-aarch64/ka/firefox-138.0.tar.xz";
       locale = "ka";
       arch = "linux-aarch64";
-      sha256 = "3939ad0c47e6406832f0f8d47471f5b176722ea2a614e0ac9cde3da9bc5f7eec";
+      sha256 = "085f1384275121be89ea88eaf59427d0b5c9033dfa53f07f8444da2f259bac45";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-aarch64/kab/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-aarch64/kab/firefox-138.0.tar.xz";
       locale = "kab";
       arch = "linux-aarch64";
-      sha256 = "ebc2ecbf8962f041c6785cc1d61c06eb96209760d144071a5041f9671ec0305e";
+      sha256 = "85b81375c3345591611c70bc3d0e28a13dc1cfec620d77104c00ab2bd4fa73ea";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-aarch64/kk/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-aarch64/kk/firefox-138.0.tar.xz";
       locale = "kk";
       arch = "linux-aarch64";
-      sha256 = "2ec3d8b923302041f9ec3235e3554477adac04f28fcb2d6a7ec263f515bc6a91";
+      sha256 = "384bf77e90ba3504dc79a671d2687a1a6b0845e0c413e7aeb2d327c033fa413a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-aarch64/km/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-aarch64/km/firefox-138.0.tar.xz";
       locale = "km";
       arch = "linux-aarch64";
-      sha256 = "4f40825d57059c332d40b73812d68fa492d4c3d29538f21266ad7046e90ad1f6";
+      sha256 = "2fe8f8dc8aacadc4d1ddab6b4819f5be52b41d703507d43c4fd64be3c3eeba60";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-aarch64/kn/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-aarch64/kn/firefox-138.0.tar.xz";
       locale = "kn";
       arch = "linux-aarch64";
-      sha256 = "678bbdac704ae973a3f5beeba057f6e01b9754fc1f46f4a1d0aed409ba163ea8";
+      sha256 = "aefa78ae724025131cbe1b59fd5f7e8ba3013bfd7255cc2776a661b48436a29d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-aarch64/ko/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-aarch64/ko/firefox-138.0.tar.xz";
       locale = "ko";
       arch = "linux-aarch64";
-      sha256 = "2fbaa6d0665ff9f7021212c73e257663ac9c51f4eb0236a73fa177886e994ba3";
+      sha256 = "8690ffb4fbd1c80d8d578ba003e29045c22c94a68db81b7313f870349f560db4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-aarch64/lij/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-aarch64/lij/firefox-138.0.tar.xz";
       locale = "lij";
       arch = "linux-aarch64";
-      sha256 = "cebddf13d99c7e76d541f58679928509e69c5bdfc2325a0e9f8da870072dc404";
+      sha256 = "ce55a7bc098dfb522d6e18b0dfc9a79dd6b34831ff5c35219ab9b01eef2f0a1e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-aarch64/lt/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-aarch64/lt/firefox-138.0.tar.xz";
       locale = "lt";
       arch = "linux-aarch64";
-      sha256 = "7e885a7c1241741743353365fa32ab76ee6d0d69fddb61dbbf6723ec79734ab4";
+      sha256 = "c0d8a5ec22f9e381e90b3302a0df535a82dbfdd2ec4961d32b0e1cd2cb248446";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-aarch64/lv/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-aarch64/lv/firefox-138.0.tar.xz";
       locale = "lv";
       arch = "linux-aarch64";
-      sha256 = "fc4c0e3d75e74f1e82cfcfeea7739e815f6096435d1359c881e28bb552287c38";
+      sha256 = "34b634343d8aa0482d939208e8a5747144cb9ff41e28ff9abcb268c232986129";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-aarch64/mk/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-aarch64/mk/firefox-138.0.tar.xz";
       locale = "mk";
       arch = "linux-aarch64";
-      sha256 = "29dd72cb28db676474810343b31cee3a7720a0060c054f9f047ba7265509d0b0";
+      sha256 = "fe27d1978043a9fc1d75e3493e731e5e13b345bd86b88eb7c7c56540a648594b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-aarch64/mr/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-aarch64/mr/firefox-138.0.tar.xz";
       locale = "mr";
       arch = "linux-aarch64";
-      sha256 = "3bab9175a5589f5013d7bd6855090ecd6c26104f3a93830f76486e72cd1a676b";
+      sha256 = "0d4af6402471235b484cb7b71861ab677b6c436d092fac9b2e016f880c95bc58";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-aarch64/ms/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-aarch64/ms/firefox-138.0.tar.xz";
       locale = "ms";
       arch = "linux-aarch64";
-      sha256 = "d1d0e0cccb4a1d635533bb657e5800b1b3b7475e23313c6b69e5a56cde3787ec";
+      sha256 = "c9b780654d15e2f4feb2c455aee1d260264adb7e781cf28a807a152bb7987e1c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-aarch64/my/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-aarch64/my/firefox-138.0.tar.xz";
       locale = "my";
       arch = "linux-aarch64";
-      sha256 = "ab4a31865ba23c6d57f88df33790ee3cdb28084cdbeaa55361b8164d7e1799ee";
+      sha256 = "b10142155c7c5b81b8ca7187fd3d2b1c837c8f10b5e83e943f1e4c2768879cdc";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-aarch64/nb-NO/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-aarch64/nb-NO/firefox-138.0.tar.xz";
       locale = "nb-NO";
       arch = "linux-aarch64";
-      sha256 = "5b7657864a3e7934a151dac9d4470cd6d5ef6ba502033af3426d91f3172f19ae";
+      sha256 = "79dec266acad7e99696e2c7e7ee04f5ab92a0fa7450195cc2a0a35a5915e159f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-aarch64/ne-NP/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-aarch64/ne-NP/firefox-138.0.tar.xz";
       locale = "ne-NP";
       arch = "linux-aarch64";
-      sha256 = "279be4aaa18a4e8ad034d426bf1db0f4e0dbce458aadcce2f224f8e71a85ebf7";
+      sha256 = "c64f5212adecff867c7b4a1a09b8b278a53186a07975428b4a071d82bf5e1e1e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-aarch64/nl/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-aarch64/nl/firefox-138.0.tar.xz";
       locale = "nl";
       arch = "linux-aarch64";
-      sha256 = "b1865e95d259c0731eb268d9c690b47467966ddcd9419da11ce01a428da7d3ee";
+      sha256 = "6524eae972f44ffcebb6385851945e78d64498e7fa3236ef8f2e7c61d3891e04";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-aarch64/nn-NO/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-aarch64/nn-NO/firefox-138.0.tar.xz";
       locale = "nn-NO";
       arch = "linux-aarch64";
-      sha256 = "4b4b7d506fc2b6a9d30516d601ef2c6d0f1a060d342eadbe2761df869324be4f";
+      sha256 = "765de04d5039b5c80bb1546643a5e9b168a557f9d432d13370d0d7d5bee97e9e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-aarch64/oc/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-aarch64/oc/firefox-138.0.tar.xz";
       locale = "oc";
       arch = "linux-aarch64";
-      sha256 = "b4d4f94762d17d02fc91552a82599660ebb12ed66c06b3bdc790a65974fb164a";
+      sha256 = "d084615e8e98229e36cd9faed9009ab7c179509a6486c0923e0446e3f77e7c93";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-aarch64/pa-IN/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-aarch64/pa-IN/firefox-138.0.tar.xz";
       locale = "pa-IN";
       arch = "linux-aarch64";
-      sha256 = "f6ceddeb77967584e281452c95f9e8884dae38005edd9c320e560f7828faba20";
+      sha256 = "e3e6f5a6106890305960eae88c3cb7fdb1a3210781deb40d27f21b7c9aece64f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-aarch64/pl/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-aarch64/pl/firefox-138.0.tar.xz";
       locale = "pl";
       arch = "linux-aarch64";
-      sha256 = "0d3f871e4fe54e8c2f528b2badce7b5566d80dc7ff568a3726809205e34ef8f2";
+      sha256 = "15bad7bf562607c8efee84b201d4b76f8f84aace3b805135c0089021e749a82e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-aarch64/pt-BR/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-aarch64/pt-BR/firefox-138.0.tar.xz";
       locale = "pt-BR";
       arch = "linux-aarch64";
-      sha256 = "196fe614c0070bd2a637b0e5953a7774a276af1d31592a3d84391a0747a274a9";
+      sha256 = "ddd25f6a3fddefb7039932d4c8235183774aa774d139346e56ed495ba83ea2f1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-aarch64/pt-PT/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-aarch64/pt-PT/firefox-138.0.tar.xz";
       locale = "pt-PT";
       arch = "linux-aarch64";
-      sha256 = "cde0bf726f67b809cf85855c2d2387511faaf24ad4b7ad7bcfce72fb7edd1ecd";
+      sha256 = "f02f8dee0caa0a93909d61e2c7fa309473cf336ec0829bf745c911800605d1fd";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-aarch64/rm/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-aarch64/rm/firefox-138.0.tar.xz";
       locale = "rm";
       arch = "linux-aarch64";
-      sha256 = "17c5982f3ae655ce4a516185bf9fd02088f6640dc9920974e5e5cac07e360585";
+      sha256 = "3cdced6ecaa584217c27f89b0ace577a8bb1d4b7b122e26732031ac453715c73";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-aarch64/ro/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-aarch64/ro/firefox-138.0.tar.xz";
       locale = "ro";
       arch = "linux-aarch64";
-      sha256 = "050f8a2c4a9c659ae3330a54601eb0f19ab78b065bd21f5cbbe385fbd8effedc";
+      sha256 = "cde65b1932b57e147161be926b4556546e73e477b554fcb550507427032c5993";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-aarch64/ru/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-aarch64/ru/firefox-138.0.tar.xz";
       locale = "ru";
       arch = "linux-aarch64";
-      sha256 = "25480af2055ddcdf1ce22fde46ec1a90229766b49cd6af7dcc4b248b94d0db16";
+      sha256 = "a8224131ab23935b77951ed2656253d2aa12b7a8842565891e3b6ae2d105cd3e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-aarch64/sat/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-aarch64/sat/firefox-138.0.tar.xz";
       locale = "sat";
       arch = "linux-aarch64";
-      sha256 = "18776a933a267ccb809343ab0fb784549a4e8e5118bee1deefaf5e2f57355141";
+      sha256 = "ba3c28dede037b6f897301ddc529f26ee5bfed25d3d82e31e7d913a490990bfa";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-aarch64/sc/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-aarch64/sc/firefox-138.0.tar.xz";
       locale = "sc";
       arch = "linux-aarch64";
-      sha256 = "7112de709ffafdeb59f51356c59440e0ca69632f08ef5a82d1e98d1343c91bad";
+      sha256 = "fa3e46719e6da2cb8088746e1435b3af41428e34917f80efa9588134e6a210d6";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-aarch64/sco/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-aarch64/sco/firefox-138.0.tar.xz";
       locale = "sco";
       arch = "linux-aarch64";
-      sha256 = "558d6fd5ef23498c652bbc52c047067dabcdabc39843b9085e9e27395df4589d";
+      sha256 = "050c06547999b78fb157f3fe9def71fe53279ae49eba9d280fca939c005793a6";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-aarch64/si/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-aarch64/si/firefox-138.0.tar.xz";
       locale = "si";
       arch = "linux-aarch64";
-      sha256 = "f95450bf127ad55aa31e19a207b60414ccbaabb59b3f6083677851ecaeb5ea0c";
+      sha256 = "72ce0cf73d59d9d90b034bb91b23bb0d597f7d75a5bac717ea2d52ec3348579b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-aarch64/sk/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-aarch64/sk/firefox-138.0.tar.xz";
       locale = "sk";
       arch = "linux-aarch64";
-      sha256 = "d37bc3e866b8914a62d623d0a2cd4b10ef58f67c44c981c96bee7a49f79b591c";
+      sha256 = "e037ad02bb94740c94002b8ecf312f415be27b48d6bfe9002da9e234cd1ce815";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-aarch64/skr/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-aarch64/skr/firefox-138.0.tar.xz";
       locale = "skr";
       arch = "linux-aarch64";
-      sha256 = "adb29f7be1d73bf01a075d3557ceaf7e8d4b6f70f8615507a0d5b3956b989b4d";
+      sha256 = "eb06d7ea5dd4e0ca27f5edade7ed02972c17f9fb9a45eb00dd5281672eb66355";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-aarch64/sl/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-aarch64/sl/firefox-138.0.tar.xz";
       locale = "sl";
       arch = "linux-aarch64";
-      sha256 = "000fcee8722b648c825a394b43634e0b21797e9dcae555de85474ab1e564e4b3";
+      sha256 = "caa0a92321166873bd3478e1ee367a95c680d40bccc8577a35a62bb6bfe10671";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-aarch64/son/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-aarch64/son/firefox-138.0.tar.xz";
       locale = "son";
       arch = "linux-aarch64";
-      sha256 = "76428c1ed84f9ae04320cd0f665154ba1daa4c76cc739c91e4b2429409ccb4c6";
+      sha256 = "6ecfa50605909a23a5a3f1a4a40c834b93e8a3c531b74dadea6165017cd4940b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-aarch64/sq/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-aarch64/sq/firefox-138.0.tar.xz";
       locale = "sq";
       arch = "linux-aarch64";
-      sha256 = "3acea4f7ec3acf9782c64914f846eedaa98057523e3a96b2303b11936f0d7be1";
+      sha256 = "66882d7143a44726402f7a247a3865045606935174b8b254c9667255d9c54d43";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-aarch64/sr/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-aarch64/sr/firefox-138.0.tar.xz";
       locale = "sr";
       arch = "linux-aarch64";
-      sha256 = "d29a4f0e96bd749afe691bbbd3e197231e774ea955fa3e0855867882fb6b16cf";
+      sha256 = "f7a010c1ffc72fd972f693c8a015a4e777a00c8f30366918201a624352d0010b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-aarch64/sv-SE/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-aarch64/sv-SE/firefox-138.0.tar.xz";
       locale = "sv-SE";
       arch = "linux-aarch64";
-      sha256 = "480ee28f57c1816945f3164e277e0faeda21dbae6d1d9289ca7febf8c5a2707f";
+      sha256 = "29236d2081f9e98bb92ad3d1c1cfc224d9048a54f60f58dd8f9d820dc9005c53";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-aarch64/szl/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-aarch64/szl/firefox-138.0.tar.xz";
       locale = "szl";
       arch = "linux-aarch64";
-      sha256 = "224d204754ced7eb886f4ea01e4a3795612bb570b63e1a33994d163a2e8f7f65";
+      sha256 = "4a98d46c188d381cdc8cef382bfc1ae81a6500f7f39367e90b2cf660a127f938";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-aarch64/ta/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-aarch64/ta/firefox-138.0.tar.xz";
       locale = "ta";
       arch = "linux-aarch64";
-      sha256 = "d5b66b7f7a9e557904dbed23f1ac7ea67da5edaa8ee58f0904913b9578467736";
+      sha256 = "51ea257ab5216fae86f3f4b48fbfbb26c62acbcc1eddeb0e5da7b8b9689612e9";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-aarch64/te/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-aarch64/te/firefox-138.0.tar.xz";
       locale = "te";
       arch = "linux-aarch64";
-      sha256 = "b2194b5482dadbc3e2d5d40ae754319b697e71ab6438ddb001da5f0eb361d0ad";
+      sha256 = "451290435422dea8d2dbe3d2559120fa6d73a2e9fea495d1572cbd110710465a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-aarch64/tg/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-aarch64/tg/firefox-138.0.tar.xz";
       locale = "tg";
       arch = "linux-aarch64";
-      sha256 = "efd5eafd860e84a01a11fe74d6398353ecdb3a1d9bd0f1f64df9dad2a6d1921c";
+      sha256 = "a5667e252b0489d667322ec486296917844f453adf847dee5f703a348aeec964";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-aarch64/th/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-aarch64/th/firefox-138.0.tar.xz";
       locale = "th";
       arch = "linux-aarch64";
-      sha256 = "8f60f7a795789c5f3a62473e94a7e8f608dbb1d321920915bae2cd9ea56ff337";
+      sha256 = "df29e5d237c9e0f9164c6397fcb2a1628b5037bc8efac7797ba33ee1a6fd0d10";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-aarch64/tl/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-aarch64/tl/firefox-138.0.tar.xz";
       locale = "tl";
       arch = "linux-aarch64";
-      sha256 = "d897a83e5c0603cbe2085c205cc2637c521f5d0ef7edda20176913431c7dcf22";
+      sha256 = "0c6d178396efb2659a841d9f262b2b804a56ab17f5ef5e1ec23b7f4d9173dd5b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-aarch64/tr/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-aarch64/tr/firefox-138.0.tar.xz";
       locale = "tr";
       arch = "linux-aarch64";
-      sha256 = "0a10996f7f97f5d4999425ef91724db1eddc5d9edd871f27fc27600a15f00f63";
+      sha256 = "a7a2e7a6e164ab5d046b8b209775c8b7f3622592bb34525037a8109f2c369192";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-aarch64/trs/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-aarch64/trs/firefox-138.0.tar.xz";
       locale = "trs";
       arch = "linux-aarch64";
-      sha256 = "6df26c3141c55ef92a2ad72d33bd826353a3bd429b920c252494f5c350c73d53";
+      sha256 = "a105d958ff463a06668fb1dcd39ff8f7ae1238bd3be38f198364bc0621016416";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-aarch64/uk/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-aarch64/uk/firefox-138.0.tar.xz";
       locale = "uk";
       arch = "linux-aarch64";
-      sha256 = "554f7a2bf73e67872d28d391d2599bc51514cfb63bd078a692c275a2a0f1a357";
+      sha256 = "111a463c4f2890f10f0ae9a2f3f2a30a9219d8a498247783a02c09f803cb7b95";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-aarch64/ur/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-aarch64/ur/firefox-138.0.tar.xz";
       locale = "ur";
       arch = "linux-aarch64";
-      sha256 = "e2042d36e550ce3da7577e90a950b15a7ac939f1bac64b459e64f237c3361c5c";
+      sha256 = "3839730e85dec3cfbbb6a870d745184df6d3a672f321c512278780040d575643";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-aarch64/uz/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-aarch64/uz/firefox-138.0.tar.xz";
       locale = "uz";
       arch = "linux-aarch64";
-      sha256 = "2558a0e3c3cf9af31957d425cbb2837fc0b41aee3b90891049839fb70dc86743";
+      sha256 = "73f243483dae3d2b7480f4d345297b7cf7b4e7729c191173abbacf42ba3b2e36";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-aarch64/vi/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-aarch64/vi/firefox-138.0.tar.xz";
       locale = "vi";
       arch = "linux-aarch64";
-      sha256 = "7af8503745d6ea2630fad90e54952eeca80fd96d708ecc50dfec81be73618992";
+      sha256 = "45ee2bf35a41c6f5c48a81b641562ce2fac215bc8f9c8a48343937317dacfafd";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-aarch64/xh/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-aarch64/xh/firefox-138.0.tar.xz";
       locale = "xh";
       arch = "linux-aarch64";
-      sha256 = "a585215f881685de088461752644cac1269d69141e94e82707e9d17fb0416fd9";
+      sha256 = "c6c4c1107990da80a84f817e2df5918897537d0e64348ab32bd472456412a297";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-aarch64/zh-CN/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-aarch64/zh-CN/firefox-138.0.tar.xz";
       locale = "zh-CN";
       arch = "linux-aarch64";
-      sha256 = "854490e9a4a8442997b966b0eca8b8b884edd40407e2d58535fe4c50d6ee3922";
+      sha256 = "ad350ec5b982bd832615d59a6318be14f6ee9e5ff429add32004d93c7b1d6e98";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/137.0.2/linux-aarch64/zh-TW/firefox-137.0.2.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/138.0/linux-aarch64/zh-TW/firefox-138.0.tar.xz";
       locale = "zh-TW";
       arch = "linux-aarch64";
-      sha256 = "73371b02754ff6225db3298485a1b1fa97c8a5746dbd7ae037dff7be87364631";
+      sha256 = "2fa60016183e09e7264db195b7751c4b7281f2de52cfeb2726dd9b644025f927";
     }
   ];
 }

--- a/pkgs/applications/networking/browsers/firefox-bin/update.nix
+++ b/pkgs/applications/networking/browsers/firefox-bin/update.nix
@@ -29,7 +29,7 @@ writeScript "update-${pname}" ''
   HOME=`mktemp -d`
   export GNUPGHOME=`mktemp -d`
 
-  curl https://keys.openpgp.org/vks/v1/by-fingerprint/14F26682D0916CDD81E37B6D61B7B526D98F0353 | gpg --import -
+  curl https://keys.openpgp.org/vks/v1/by-fingerprint/09BEED63F3462A2DFFAB3B875ECB6497C1A20256 | gpg --import -
 
   tmpfile=`mktemp`
   url=${baseUrl}

--- a/pkgs/applications/networking/browsers/firefox/packages/firefox-esr-128.nix
+++ b/pkgs/applications/networking/browsers/firefox/packages/firefox-esr-128.nix
@@ -9,11 +9,11 @@
 
 buildMozillaMach rec {
   pname = "firefox";
-  version = "128.9.0esr";
+  version = "128.10.0esr";
   applicationName = "Firefox ESR";
   src = fetchurl {
     url = "mirror://mozilla/firefox/releases/${version}/source/firefox-${version}.source.tar.xz";
-    sha512 = "c0c8ac8374291cc93279064c73c17786c6f4fba7505ebc2cbd7a4ce7c82710620abdae7be15f60c43f9d10c3614fc9fd31f094e787105d528031c6f0510f7339";
+    sha512 = "c0f349cba626e6ec16ff0b52b7d21e05681acd1377fd1111992860f8079373f631ff997d833a3596c72a6d8c6e4f1d051927fa719f1d37a72553dcbd5348659c";
   };
 
   meta = {

--- a/pkgs/applications/networking/browsers/firefox/packages/firefox.nix
+++ b/pkgs/applications/networking/browsers/firefox/packages/firefox.nix
@@ -9,10 +9,10 @@
 
 buildMozillaMach rec {
   pname = "firefox";
-  version = "137.0.2";
+  version = "138.0";
   src = fetchurl {
     url = "mirror://mozilla/firefox/releases/${version}/source/firefox-${version}.source.tar.xz";
-    sha512 = "82140c4325233ea2e2f579088cebb98c0e8db8848b4018cff95d4ed42bf847049ed6520fc051d930ee267a5acb008908170825d381589da0d109ca04a61e1c24";
+    sha512 = "265eef505216f70d50ebb95a6b23983d0b70430320e7e2dcf497127890d7bbdff1c49c64790010c85b8e3fe0da5c90e95b2d44fb1adca64b1755428ccb2b91a2";
   };
 
   meta = {

--- a/pkgs/applications/networking/browsers/firefox/update.nix
+++ b/pkgs/applications/networking/browsers/firefox/update.nix
@@ -33,7 +33,7 @@ writeScript "update-${attrPath}" ''
   set -eux
   HOME=`mktemp -d`
   export GNUPGHOME=`mktemp -d`
-  curl https://keys.openpgp.org/vks/v1/by-fingerprint/14F26682D0916CDD81E37B6D61B7B526D98F0353 | gpg --import -
+  curl https://keys.openpgp.org/vks/v1/by-fingerprint/09BEED63F3462A2DFFAB3B875ECB6497C1A20256 | gpg --import -
 
   url=${baseUrl}
 


### PR DESCRIPTION
https://blog.mozilla.org/security/2025/04/01/updated-gpg-key-for-signing-firefox-releases-2/
https://www.mozilla.org/en-US/firefox/138.0/releasenotes/
https://www.mozilla.org/en-US/firefox/128.10.0/releasenotes/

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
