### PR TITLE
knot-resolver: 5.7.4 -> 5.7.5

### DIFF
--- a/pkgs/servers/dns/knot-resolver/default.nix
+++ b/pkgs/servers/dns/knot-resolver/default.nix
@@ -36,11 +36,11 @@ let # un-indented, over the whole file
 
   unwrapped = stdenv.mkDerivation rec {
     pname = "knot-resolver";
-    version = "5.7.4";
+    version = "5.7.5";
 
     src = fetchurl {
       url = "https://secure.nic.cz/files/knot-resolver/${pname}-${version}.tar.xz";
-      hash = "sha256-a22m7PBoKAQa+tRN+iJ3gfCuNK0YOmZwCFCTVdGL2cg=";
+      sha256 = "80239cf9aa92599d9cbad4642dea5520b2ccfbc9c6f968886ea46179cb3cdf66";
     };
 
     outputs = [
@@ -69,13 +69,6 @@ let # un-indented, over the whole file
           substituteInPlace "$f" \
             --replace "ffi.load(" "ffi.load('${lib.getLib knot-dns}/lib/' .. "
         done
-      ''
-      # https://gitlab.nic.cz/knot/knot-resolver/-/issues/925
-      + ''
-        patch modules/http/meson.build <<EOF
-        @@ -22 +21,0 @@
-        -  ['http', files('http.test.lua')],
-        EOF
       ''
       # some tests have issues with network sandboxing, apparently
       + optionalString doInstallCheck ''

--- a/pkgs/servers/dns/knot-resolver/default.nix
+++ b/pkgs/servers/dns/knot-resolver/default.nix
@@ -27,8 +27,7 @@
   cacert,
   extraFeatures ? false, # catch-all if defaults aren't enough
 }:
-let # un-indented, over the whole file
-
+let
   result = if extraFeatures then wrapped-full else unwrapped;
 
   inherit (lib) optional optionals optionalString;
@@ -67,7 +66,7 @@ let # un-indented, over the whole file
         # Even though they should already be loaded and they're in RPATH, too.
         for f in daemon/lua/{kres,zonefile}.lua; do
           substituteInPlace "$f" \
-            --replace "ffi.load(" "ffi.load('${lib.getLib knot-dns}/lib/' .. "
+            --replace-fail "ffi.load(" "ffi.load('${lib.getLib knot-dns}/lib/' .. "
         done
       ''
       # some tests have issues with network sandboxing, apparently


### PR DESCRIPTION
https://gitlab.nic.cz/knot/knot-resolver/-/releases/v5.7.5#security


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
