### PR TITLE
electron-fiddle: 0.36.6 -> 0.36.6-unstable-2025-07-17, bump electron

### DIFF
--- a/pkgs/by-name/el/electron-fiddle/package.nix
+++ b/pkgs/by-name/el/electron-fiddle/package.nix
@@ -1,13 +1,13 @@
 {
   buildFHSEnv,
-  electron_33,
+  electron_36,
   fetchFromGitHub,
   fetchYarnDeps,
   fetchurl,
   git,
   lib,
   makeDesktopItem,
-  nodejs_20,
+  nodejs,
   stdenvNoCC,
   util-linux,
   yarnBuildHook,
@@ -17,16 +17,16 @@
 
 let
   pname = "electron-fiddle";
-  version = "0.36.5";
-  electron = electron_33;
-  nodejs = nodejs_20;
+  version = "0.36.5-unstable-2025-07-17";
 
   src = fetchFromGitHub {
     owner = "electron";
     repo = "fiddle";
-    tag = "v${version}";
-    hash = "sha256-Fo7rXnufJ26WijnplWswdeCGJitkvTDboOggUfrz1Hw=";
+    rev = "0f3cd3007a336562a3c49ce95469022e6a729121"; # a revision that uses electron_36 instead of electron_33
+    hash = "sha256-1q8bDpEPrQNbngrGZj6/AQFFo06ED6uJ4Z/XVg6KNXw=";
   };
+
+  electron = electron_36;
 
   # As of https://github.com/electron/fiddle/pull/1316 this is fetched
   # from the network and has no stable hash.  Grab an old version from
@@ -42,7 +42,7 @@ let
 
     offlineCache = fetchYarnDeps {
       yarnLock = "${src}/yarn.lock";
-      hash = "sha256-eZ/g2cP6M0zWhF14go0sIC+UuzTo9Gl4KsPBGzJU3FQ=";
+      hash = "sha256-n6rzi4VohVaX+IIE1NITDsxXGyw0Z6Fx1WJb15YT9Sg=";
     };
 
     nativeBuildInputs = [


### PR DESCRIPTION
Related: https://github.com/NixOS/nixpkgs/pull/397918

Nodejs version doesn't matter that much, upstream just constrains it to be nodejs>=20

The electron version used by upstream is electron 33, which has been EOL for a while.

I bumped the package to a revision where they bumped the electron version to 36.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
