### PR TITLE
atomic-{cli,browser,server}: init at 0.40.0

### DIFF
--- a/pkgs/by-name/at/atomic-browser/package.nix
+++ b/pkgs/by-name/at/atomic-browser/package.nix
@@ -1,0 +1,54 @@
+{
+  lib,
+  stdenv,
+  nodejs,
+  fetchFromGitHub,
+  pnpm_9,
+  nix-update-script,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "atomic-browser";
+  version = "0.40.0";
+
+  src = fetchFromGitHub {
+    owner = "atomicdata-dev";
+    repo = "atomic-server";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-iZRKgRQL/+6RavFMWEugpd8+sWgXgE+itqak5BZe51s=";
+  };
+
+  sourceRoot = "source/browser";
+
+  pnpmDeps = pnpm_9.fetchDeps {
+    pname = finalAttrs.pname;
+    version = finalAttrs.version;
+    hash = "sha256-EurqNHOkUuu3bJ028Dz7y4ZWqKR46Vj798jbvDGA3g4=";
+  };
+
+  nativeBuildInputs = [
+    nodejs
+    pnpm_9.configHook
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  buildPhase = ''
+    pnpm run build
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    cp -R ./data-browser/dist/ $out/
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "GUI for viewing, editing and browsing Atomic Data";
+    homepage = "https://github.com/atomicdata-dev/atomic-server/tree/develop/browser";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.all;
+    teams = with lib.teams; [ ngi ];
+    maintainers = [ lib.maintainers.oluchitheanalyst ];
+  };
+})

--- a/pkgs/by-name/at/atomic-cli/package.nix
+++ b/pkgs/by-name/at/atomic-cli/package.nix
@@ -1,0 +1,24 @@
+{
+  lib,
+  runCommand,
+  atomic-server,
+}:
+
+runCommand "atomic-cli"
+  {
+    pname = "atomic-cli";
+    version = atomic-server.version;
+    meta = {
+      description = "Symlinked CLI tool for interacting with Atomic Data servers";
+      homepage = atomic-server.meta.homepage;
+      license = atomic-server.meta.license;
+      mainProgram = "atomic-cli";
+      maintainers = [ lib.maintainers.oluchitheanalyst ];
+      platforms = lib.platforms.all;
+      teams = with lib.teams; [ ngi ];
+    };
+  }
+  ''
+    mkdir -p "$out/bin"
+    ln -s "${atomic-server}/bin/atomic-cli" "$out/bin/atomic-cli"
+  ''

--- a/pkgs/by-name/at/atomic-server/package.nix
+++ b/pkgs/by-name/at/atomic-server/package.nix
@@ -18,18 +18,20 @@ rustPlatform.buildRustPackage (finalAttrs: {
     hash = "sha256-iZRKgRQL/+6RavFMWEugpd8+sWgXgE+itqak5BZe51s=";
   };
 
-  useFetchCargoVendor = true;
   cargoHash = "sha256-Lf3IjITpfAhPAznUNZyl1WJtWxNUmySPlzvsPHl7t68=";
 
   postUnpack = ''
     mkdir -p source/server/assets_tmp
     cp -r ${atomic-browser}/* source/server/assets_tmp
   '';
+
+  inputsFrom = [ atomic-browser ];
+
+  doCheck = false;
+
   passthru.updateScript = nix-update-script { };
 
   nativeBuildInputs = [ nasm ];
-
-  doCheck = false; # TODO(jl): broken upstream
 
   meta = {
     description = "Reference implementation for the Atomic Data specification";
@@ -38,8 +40,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
     platforms = lib.platforms.all;
     mainProgram = "atomic-server";
     teams = with lib.teams; [ ngi ];
-    maintainers = with lib.maintainers; [
-      oluchitheanalyst
-    ];
+    maintainers = [ lib.maintainers.oluchitheanalyst ];
   };
 })

--- a/pkgs/by-name/at/atomic-server/package.nix
+++ b/pkgs/by-name/at/atomic-server/package.nix
@@ -1,0 +1,45 @@
+{
+  lib,
+  fetchFromGitHub,
+  rustPlatform,
+  atomic-browser,
+  nix-update-script,
+  nasm,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "atomic-server";
+  version = "0.40.0";
+
+  src = fetchFromGitHub {
+    owner = "atomicdata-dev";
+    repo = "atomic-server";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-iZRKgRQL/+6RavFMWEugpd8+sWgXgE+itqak5BZe51s=";
+  };
+
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-Lf3IjITpfAhPAznUNZyl1WJtWxNUmySPlzvsPHl7t68=";
+
+  postUnpack = ''
+    mkdir -p source/server/assets_tmp
+    cp -r ${atomic-browser}/* source/server/assets_tmp
+  '';
+  passthru.updateScript = nix-update-script { };
+
+  nativeBuildInputs = [ nasm ];
+
+  doCheck = false; # TODO(jl): broken upstream
+
+  meta = {
+    description = "Reference implementation for the Atomic Data specification";
+    homepage = "https://docs.atomicdata.dev";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.all;
+    mainProgram = "atomic-server";
+    teams = with lib.teams; [ ngi ];
+    maintainers = with lib.maintainers; [
+      oluchitheanalyst
+    ];
+  };
+})


### PR DESCRIPTION
- Added and tested the Nix update script to make sure it works
- Added Myself to maintainers
- Added The Nix@NGI team
- Built both packages with ` nix-build -A "package-name" `
      **Package description**
` atomic-server ` references implementation for the Atomic Data specification
**Homepage**: https://docs.atomicdata.dev
**License**: MIT

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
