### PR TITLE
python313Packages.pyhealth: init at 1.1.6

### DIFF
--- a/pkgs/development/python-modules/litdata/default.nix
+++ b/pkgs/development/python-modules/litdata/default.nix
@@ -1,0 +1,68 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  boto3,
+  filelock,
+  lightning-utilities,
+  numpy,
+  obstore,
+  requests,
+  tifffile,
+  torch,
+  torchvision,
+  pytestCheckHook,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "litdata";
+  version = "0.2.63";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "Lightning-AI";
+    repo = "litdata";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-6wmMh1I41T4zI74QWl2nuiLE16RtQXRU2WIMpy4DU6w=";
+  };
+
+  build-system = [
+    setuptools
+  ];
+
+  dependencies = [
+    boto3
+    filelock
+    lightning-utilities
+    numpy
+    obstore
+    requests
+    tifffile
+    torch
+    torchvision
+  ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  pythonImportsCheck = [
+    "litdata"
+    "litdata.cli"
+    "litdata.cli.handler"
+    "litdata.debugger"
+    "litdata.processing"
+    "litdata.streaming"
+    "litdata.utilities"
+  ];
+
+  doCheck = false; # uses lightning_sdk; only available on PyPI
+
+  meta = {
+    description = "Speed up model training by fixing data loading";
+    homepage = "https://github.com/Lightning-AI/litdata";
+    changelog = "https://github.com/Lightning-AI/litData/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ bcdarwin ];
+    mainProgram = "litdata";
+  };
+})

--- a/pkgs/development/python-modules/pyhealth/default.nix
+++ b/pkgs/development/python-modules/pyhealth/default.nix
@@ -1,0 +1,118 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  # build-system
+  hatchling,
+
+  # dependencies
+  accelerate,
+  dask,
+  einops,
+  #linear-attention-transformer,
+  litdata,
+  mne,
+  more-itertools,
+  narwhals,
+  networkx,
+  numpy,
+  #ogb,
+  orjson,
+  pandas,
+  peft,
+  platformdirs,
+  polars,
+  pyarrow,
+  pydantic,
+  rdkit,
+  scikit-learn,
+  torch,
+  torchvision,
+  tqdm,
+  transformers,
+  urllib3,
+
+  # checkInputs
+  pytestCheckHook,
+  writableTmpDirAsHomeHook,
+
+  # optional-dependencies.nlp
+  rapidfuzz,
+  nltk,
+  rouge-score,
+}:
+
+buildPythonPackage rec {
+  pname = "pyhealth";
+  version = "2.0.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "sunlabuiuc";
+    repo = "PyHealth";
+    tag = "v${version}";
+    hash = "sha256-8JpDwtMmfdDLegeq6jNiiTh0MmLjefsfshPHB8d5jyY=";
+  };
+
+  build-system = [
+    hatchling
+  ];
+
+  dependencies = [
+    accelerate
+    dask
+    einops
+    #linear-attention-transformer
+    litdata
+    mne
+    more-itertools
+    narwhals
+    networkx
+    numpy
+    #ogb
+    orjson
+    pandas
+    peft
+    platformdirs
+    polars
+    pyarrow
+    pydantic
+    rdkit
+    scikit-learn
+    torch
+    torchvision
+    tqdm
+    transformers
+    urllib3
+  ] ++ dask.optional-dependencies.complete;
+
+  passthru.optional-dependencies.nlp = [
+    rapidfuzz
+    nltk
+    rouge-score
+  ];
+
+  pythonRelaxDeps = true;
+
+  # Nixpkgs rdkit does not create a -dist-info directory site-packages:
+  #pythonRemoveDeps = [ "rdkit" ];
+  pythonRemoveDeps = [ "rdkit" "ogb" "linear-attention-transformer" ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    writableTmpDirAsHomeHook
+  ];
+
+  # tries to write to $HOME
+  pythonImportsCheck = [
+    "pyhealth"
+  ];
+
+  meta = {
+    description = "Deep learning toolkit for healthcare applications";
+    homepage = "https://pyhealth.readthedocs.io";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ bcdarwin ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9580,6 +9580,8 @@ self: super: with self; {
 
   lit = callPackage ../development/python-modules/lit { };
 
+  litdata = callPackage ../development/python-modules/litdata { };
+
   litecli = callPackage ../development/python-modules/litecli { };
 
   litellm = callPackage ../development/python-modules/litellm { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -14718,6 +14718,8 @@ self: super: with self; {
 
   pyhdfe = callPackage ../development/python-modules/pyhdfe { };
 
+  pyhealth = callPackage ../development/python-modules/pyhealth { };
+
   pyheck = callPackage ../development/python-modules/pyheck { };
 
   pyhelty = callPackage ../development/python-modules/pyhelty { };


### PR DESCRIPTION
python313Packages.litdata: init at 0.2.63

Init pyhealth, a [package for deep learning for healthcare applications](https://pyhealth.readthedocs.io/).

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
