### PR TITLE
python313Packages.meds: init at 0.4.1

### DIFF
--- a/pkgs/development/python-modules/flexible-schema/default.nix
+++ b/pkgs/development/python-modules/flexible-schema/default.nix
@@ -1,0 +1,53 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  setuptools-scm,
+  jsonschema,
+  pyarrow,
+  typing-extensions,
+  pytestCheckHook,
+  pytest-cov-stub,
+}:
+
+buildPythonPackage rec {
+  pname = "flexible-schema";
+  version = "0.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "Medical-Event-Data-Standard";
+    repo = "flexible_schema";
+    tag = version;
+    hash = "sha256-H5dnyaUDbNfA/EubX6UPteXB8dMeDMkvuJkl3SlPhRo=";
+  };
+
+  build-system = [
+    setuptools
+    setuptools-scm
+  ];
+
+  dependencies = [
+    jsonschema
+    pyarrow
+    typing-extensions
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    pytest-cov-stub
+  ];
+
+  pythonImportsCheck = [
+    "flexible_schema"
+  ];
+
+  meta = {
+    description = "Specify and validate schemas for PyArrow and JSON allowing optional columns, column re-ordering, and extra columns";
+    homepage = "https://flexible-schema.readthedocs.io";
+    changelog = "https://github.com/Medical-Event-Data-Standard/flexible_schema/releases/tag/${src.tag}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ bcdarwin ];
+  };
+}

--- a/pkgs/development/python-modules/meds-extract/default.nix
+++ b/pkgs/development/python-modules/meds-extract/default.nix
@@ -1,0 +1,81 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  setuptools-scm,
+  hydra-core,
+  meds,
+  meds-transforms,
+  numpy,
+  polars,
+  pyarrow,
+  universal-pathlib,
+  hydra-joblib-launcher,
+  meds-testing-helpers,
+  pytestCheckHook,
+  pytest-cov-stub,
+  pytest-notebook,
+}:
+
+buildPythonPackage rec {
+  pname = "meds-extract";
+  version = "0.5.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "mmcdermott";
+    repo = "MEDS_extract";
+    rev = version;
+    hash = "sha256-/cALKE+xoGlneMMl+QK6soGwMMK4WgGgL2F8UqquDsQ=";
+  };
+
+  build-system = [
+    setuptools
+    setuptools-scm
+  ];
+
+  dependencies = [
+    hydra-core
+    meds
+    meds-transforms
+    numpy
+    polars
+    pyarrow
+    universal-pathlib
+  ];
+
+  nativeCheckInputs = [
+    hydra-joblib-launcher
+    meds-testing-helpers
+    meds-transforms
+    pytestCheckHook
+    pytest-cov-stub
+    pytest-notebook
+  ];
+
+  preCheck = ''
+    rm -rf src/
+  '';
+
+  optional-dependencies = {
+    local_parallelism = [
+      hydra-joblib-launcher
+    ];
+    # Not in nixpkgs:
+    # slurm_parallelism = [
+    #   hydra-submitit-launcher
+    # ];
+  };
+
+  pythonImportsCheck = [
+    "MEDS_extract"
+  ];
+
+  meta = {
+    description = "Helpers to aid in building ETLs for MEDS datasets leveraging the MEDS-Transforms library";
+    homepage = "https://github.com/mmcdermott/MEDS_extract.git";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ bcdarwin ];
+  };
+}

--- a/pkgs/development/python-modules/meds-testing-helpers/default.nix
+++ b/pkgs/development/python-modules/meds-testing-helpers/default.nix
@@ -1,0 +1,68 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  setuptools-scm,
+  annotated-types,
+  hydra-core,
+  meds,
+  numpy,
+  polars,
+  pyarrow,
+  pytestCheckHook,
+  pytimeparse,
+  pytest-cov-stub,
+}:
+
+buildPythonPackage rec {
+  pname = "meds-testing-helpers";
+  version = "0.3.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "Medical-Event-Data-Standard";
+    repo = "meds_testing_helpers";
+    rev = version;
+    hash = "sha256-I9ohHNHi0GBe9agcKkGTuNtiWLuMle88hbRoODw9VnY=";
+  };
+
+  build-system = [
+    setuptools
+    setuptools-scm
+  ];
+
+  dependencies = [
+    annotated-types
+    hydra-core
+    meds
+    numpy
+    polars
+    pyarrow
+    pytimeparse
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    pytest-cov-stub
+  ];
+
+  # tests do not support being run from root of source tree;
+  # also, src/ contains some additional doctests but some fail on aarch64
+  # due to formatting width issues
+  preCheck = ''
+    export PATH=$out/bin:$PATH
+    cd tests/
+  '';
+
+  pythonImportsCheck = [
+    "meds_testing_helpers"
+  ];
+
+  meta = {
+    description = "Testing, benchmarking, and synthetic data generation helpers for MEDS tools, pipelines, and models";
+    homepage = "https://meds-testing-helpers.readthedocs.io";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ bcdarwin ];
+  };
+}

--- a/pkgs/development/python-modules/meds-transforms/default.nix
+++ b/pkgs/development/python-modules/meds-transforms/default.nix
@@ -1,0 +1,79 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  setuptools-scm,
+  filelock,
+  hydra-core,
+  meds,
+  meds-testing-helpers,
+  numpy,
+  polars,
+  pretty-print-directory,
+  pyarrow,
+  pytestCheckHook,
+  pytest-cov-stub,
+}:
+
+buildPythonPackage rec {
+  pname = "meds-transforms";
+  version = "0.6.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "mmcdermott";
+    repo = "MEDS_transforms";
+    tag = version;
+    hash = "sha256-72PQK0MUC3hEDclvvkgV+t6LipyiGWqYew9ik9TOJM4=";
+  };
+
+  build-system = [
+    setuptools
+    setuptools-scm
+  ];
+
+  dependencies = [
+    filelock
+    hydra-core
+    meds
+    meds-testing-helpers
+    numpy
+    polars
+    pretty-print-directory
+    pyarrow
+  ];
+
+  pythonRelaxDeps = [ "polars" ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    pytest-cov-stub
+  ];
+
+  pytestFlagsArray = [ "tests" ];
+
+  preCheck = ''
+    export PATH=$out/bin:$PATH
+  '';
+
+  disabledTests = [
+    # requires unpackaged optional dependencies
+    "test_example_pipeline_parallel"
+    # tries to run pip
+    "test_simple_example_pipeline"
+  ];
+
+  pythonImportsCheck = [
+    "MEDS_transforms"
+  ];
+
+  meta = {
+    description = "Simple set of Polars-based ETL and transformation functions for MEDS data";
+    homepage = "https://github.com/mmcdermott/MEDS_transforms";
+    changelog = "https://github.com/mmcdermott/MEDS_transforms/releases/tag/${src.tag}";
+    mainProgram = "MEDS_transform-pipeline";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ bcdarwin ];
+  };
+}

--- a/pkgs/development/python-modules/meds/default.nix
+++ b/pkgs/development/python-modules/meds/default.nix
@@ -1,0 +1,51 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  setuptools-scm,
+  flexible-schema,
+  jsonschema,
+  pyarrow,
+  typing-extensions,
+  pytestCheckHook,
+}:
+
+buildPythonPackage rec {
+  pname = "meds";
+  version = "0.4.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "Medical-Event-Data-Standard";
+    repo = "meds";
+    tag = version;
+    hash = "sha256-+HgKvtPH4X0YhlOR0YIROYL9hisNja2tGVDa1rc+q8k=";
+  };
+
+  build-system = [
+    setuptools
+    setuptools-scm
+  ];
+
+  dependencies = [
+    flexible-schema
+    jsonschema
+    pyarrow
+    typing-extensions
+  ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  pythonImportsCheck = [
+    "meds"
+  ];
+
+  meta = {
+    description = "Schema definitions and Python types for the Medical Event Data Standard";
+    homepage = "https://github.com/Medical-Event-Data-Standard/meds";
+    changelog = "https://github.com/Medical-Event-Data-Standard/meds/releases/tag/${src.tag}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ bcdarwin ];
+  };
+}

--- a/pkgs/development/python-modules/pretty-print-directory/default.nix
+++ b/pkgs/development/python-modules/pretty-print-directory/default.nix
@@ -1,0 +1,45 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  setuptools-scm,
+  pytestCheckHook,
+  pytest-cov-stub,
+}:
+
+buildPythonPackage rec {
+  pname = "pretty-print-directory";
+  version = "0.1.3";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "mmcdermott";
+    repo = "pretty-print-directory";
+    tag = version;
+    hash = "sha256-nX6xc9CaVur3zpaYLNXr+s34zFnYVU/ptIgucfo8nQQ=";
+  };
+
+  build-system = [
+    setuptools
+    setuptools-scm
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    pytest-cov-stub
+  ];
+
+  pytestFlagsArray = [ "tests" ];
+
+  pythonImportsCheck = [
+    "pretty_print_directory"
+  ];
+
+  meta = {
+    description = "Simple utility to pretty-print the contents of a directory";
+    homepage = "https://github.com/mmcdermott/pretty-print-directory";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ bcdarwin ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -12166,6 +12166,8 @@ self: super: with self; {
 
   pretty-errors = callPackage ../development/python-modules/pretty-errors { };
 
+  pretty-print-directory = callPackage ../development/python-modules/pretty-print-directory { };
+
   prettytable = callPackage ../development/python-modules/prettytable { };
 
   primecountpy = callPackage ../development/python-modules/primecountpy { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9211,6 +9211,8 @@ self: super: with self; {
 
   medpy = callPackage ../development/python-modules/medpy { };
 
+  meds = callPackage ../development/python-modules/meds { };
+
   medvol = callPackage ../development/python-modules/medvol { };
 
   meeko = callPackage ../development/python-modules/meeko { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5435,6 +5435,8 @@ self: super: with self; {
 
   flexcache = callPackage ../development/python-modules/flexcache { };
 
+  flexible-schema = callPackage ../development/python-modules/flexible-schema { };
+
   flexit-bacnet = callPackage ../development/python-modules/flexit-bacnet { };
 
   flexmock = callPackage ../development/python-modules/flexmock { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9215,6 +9215,8 @@ self: super: with self; {
 
   meds-testing-helpers = callPackage ../development/python-modules/meds-testing-helpers { };
 
+  meds-transforms = callPackage ../development/python-modules/meds-transforms { };
+
   medvol = callPackage ../development/python-modules/medvol { };
 
   meeko = callPackage ../development/python-modules/meeko { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9213,6 +9213,8 @@ self: super: with self; {
 
   meds = callPackage ../development/python-modules/meds { };
 
+  meds-extract = callPackage ../development/python-modules/meds-extract { };
+
   meds-testing-helpers = callPackage ../development/python-modules/meds-testing-helpers { };
 
   meds-transforms = callPackage ../development/python-modules/meds-transforms { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9213,6 +9213,8 @@ self: super: with self; {
 
   meds = callPackage ../development/python-modules/meds { };
 
+  meds-testing-helpers = callPackage ../development/python-modules/meds-testing-helpers { };
+
   medvol = callPackage ../development/python-modules/medvol { };
 
   meeko = callPackage ../development/python-modules/meeko { };


### PR DESCRIPTION
python313Packages.meds-extract: init at 0.5.0
python313Packages.meds-transforms: init at 0.6.1
python313Packages.meds-testing-helpers: init at 0.3.0
python313Packages.flexible-schema: init at 0.1
python313Packages.pretty-print-directory: init at 0.1.2

Init `meds`, a [Python implementation](https://github.com/Medical-Event-Data-Standard/meds) of the MEDS standard for medical event data. Also init `python313Packages.meds-{transforms,extract,testing-helpers}` and a couple utility packages (`python313Packages.{flexible-schema,pretty-print-directory}`.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
