### PR TITLE
satochip-utils: init at 0.4.0-beta

### DIFF
--- a/pkgs/by-name/sa/satochip-utils/package.nix
+++ b/pkgs/by-name/sa/satochip-utils/package.nix
@@ -1,0 +1,88 @@
+{
+  copyDesktopItems,
+  fetchFromGitHub,
+  imagemagick,
+  lib,
+  makeDesktopItem,
+  python3Packages,
+}:
+
+python3Packages.buildPythonApplication rec {
+  pname = "satochip-utils";
+  version = "0.4.0-beta";
+  pyproject = true;
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "Toporin";
+    repo = "Satochip-Utils";
+    tag = "v${version}";
+    hash = "sha256-QOnW06sfSPN7tgsAfJYySpY4/+53x1hmxFJK/9s9Jhc=";
+  };
+
+  build-system = [ python3Packages.setuptools ];
+
+  dependencies = with python3Packages; [
+    tkinter
+    customtkinter
+    pillow
+    mnemonic
+    pysatochip
+    pillow
+    pyscard
+    pyqrcode
+    pycryptotools
+    cbor2
+  ];
+
+  pythonRelaxDeps = [
+    "pillow"
+    "pysatochip"
+    "pyscard"
+    "pycryptotools"
+    "mnemonic"
+    "pyperclip"
+  ];
+
+  nativeBuildInputs = [
+    copyDesktopItems
+    imagemagick
+  ];
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "satochip-utils";
+      desktopName = "Satochip Utils";
+      comment = "GUI tool to configure your Satochip/Satodime/Seedkeeper card";
+      exec = "satochip-utils";
+      icon = "satochip-utils";
+      categories = [ "Utility" ];
+      terminal = false;
+    })
+  ];
+
+  postInstall = ''
+    mkdir -p $out/lib/satochip-utils
+    cp -r * $out/lib/satochip-utils/
+
+    mkdir -p $out/bin
+    makeWrapper ${python3Packages.python.interpreter} $out/bin/satochip-utils \
+      --set PYTHONPATH "$out/lib/satochip-utils:$PYTHONPATH" \
+      --add-flags "-m satochip_utils"
+
+    for size in 16 32 48 64 128 256; do
+      dir=$out/share/icons/hicolor/''${size}x''${size}/apps
+      mkdir -p $dir
+      convert satochip_utils.png -resize ''${size}x''${size} $dir/satochip-utils.png
+    done
+  '';
+
+  meta = {
+    description = "GUI tool to configure your Satochip/Satodime/Seedkeeper card";
+    homepage = "https://github.com/Toporin/Satochip-Utils";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.all;
+    maintainers = [ lib.maintainers.eymeric ];
+  };
+}

--- a/pkgs/development/python-modules/pycryptotools/default.nix
+++ b/pkgs/development/python-modules/pycryptotools/default.nix
@@ -1,0 +1,45 @@
+{
+  base58,
+  buildPythonPackage,
+  cashaddress,
+  fetchPypi,
+  lib,
+  pbkdf2,
+  pyperclip,
+  pythonRelaxDepsHook,
+  requests,
+  setuptools,
+}:
+
+buildPythonPackage rec {
+  pname = "pycryptotools";
+  version = "0.3.2";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-zfXHvEaSlDXAeKnmymytRt5Z6fBG/RH5R7j5ieg3rAU=";
+  };
+
+  build-system = [ setuptools ];
+
+  nativeBuildInputs = [ pythonRelaxDepsHook ];
+  pythonRelaxDeps = [ "requests" ]; # pycryptotools request requests~=2.32.3 which is older than the one in nixpkgs
+
+  dependencies = [
+    pbkdf2
+    requests
+    cashaddress
+    pyperclip
+    base58
+  ];
+
+  pythonImportsCheck = [ "pycryptotools" ];
+
+  meta = {
+    description = "Python library for Crypto coins signatures and transactions";
+    homepage = "https://pypi.org/project/pycryptotools/";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ eymeric ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -13558,6 +13558,8 @@ self: super: with self; {
 
   pycryptodomex = callPackage ../development/python-modules/pycryptodomex { };
 
+  pycryptotools = callPackage ../development/python-modules/pycryptotools { };
+
   pycsdr = callPackage ../development/python-modules/pycsdr { };
 
   pycsspeechtts = callPackage ../development/python-modules/pycsspeechtts { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -13977,6 +13977,8 @@ self: super: with self; {
 
   pycryptodomex = callPackage ../development/python-modules/pycryptodomex { };
 
+  pycryptotools = callPackage ../development/python-modules/pycryptotools { };
+
   pycsdr = callPackage ../development/python-modules/pycsdr { };
 
   pycsspeechtts = callPackage ../development/python-modules/pycsspeechtts { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -14606,6 +14606,8 @@ self: super: with self; {
 
   pycryptodomex = callPackage ../development/python-modules/pycryptodomex { };
 
+  pycryptotools = callPackage ../development/python-modules/pycryptotools { };
+
   pycsdr = callPackage ../development/python-modules/pycsdr { };
 
   pycsspeechtts = callPackage ../development/python-modules/pycsspeechtts { };


### PR DESCRIPTION
## Things done

Added satochip-utils and the deps pycryptotools

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
