### PR TITLE
citrix-workspace: 24.11.0.85 -> 25.03.0.066; citrix-workspace: mark 23.09 EOL 

### DIFF
--- a/pkgs/applications/networking/remote/citrix-workspace/generic.nix
+++ b/pkgs/applications/networking/remote/citrix-workspace/generic.nix
@@ -42,6 +42,7 @@
   cacert,
   systemd,
   libcxx,
+  sane-backends,
   symlinkJoin,
   libpulseaudio,
   pcsclite,
@@ -54,8 +55,6 @@
   libjson,
   libsecret,
   libcanberra-gtk3,
-  sane-backends,
-
   homepage,
   version,
   prefix,
@@ -175,6 +174,7 @@ stdenv.mkDerivation rec {
     openssl'
     pango
     pcsclite
+    sane-backends
     speex
     (lib.getLib systemd)
     stdenv.cc.cc

--- a/pkgs/applications/networking/remote/citrix-workspace/generic.nix
+++ b/pkgs/applications/networking/remote/citrix-workspace/generic.nix
@@ -87,6 +87,15 @@ let
     '';
   };
 
+  libxml2' = symlinkJoin {
+    name = "libxml2-backwards-compat";
+    nativeBuildInputs = [ makeWrapper ];
+    paths = [ (lib.getLib libxml2) ];
+    postBuild = ''
+      ln -sf $out/lib/libxml2.so $out/lib/libxml2.so.2
+    '';
+  };
+
 in
 
 stdenv.mkDerivation rec {
@@ -157,7 +166,7 @@ stdenv.mkDerivation rec {
     libsecret
     libsoup_2_4
     libvorbis
-    libxml2
+    libxml2'
     llvmPackages.libunwind
     libgbm
     nspr

--- a/pkgs/applications/networking/remote/citrix-workspace/sources.nix
+++ b/pkgs/applications/networking/remote/citrix-workspace/sources.nix
@@ -28,17 +28,6 @@ let
   # The latest versions can be found at https://www.citrix.com/downloads/workspace-app/linux/
   # x86 is unsupported past 23.11, see https://docs.citrix.com/en-us/citrix-workspace-app-for-linux/deprecation
   supportedVersions = lib.mapAttrs mkVersionInfo {
-    "23.09.0" = {
-      major = "23";
-      minor = "9";
-      patch = "0";
-      x64hash = "7b06339654aa27258d6dfa922828b43256e780b282d07109f452246c7aa27514";
-      x86hash = "95436fb289602cf31c65b7df89da145fc170233cb2e758a2f11116f15b57d382";
-      x64suffix = "24";
-      x86suffix = "24";
-      homepage = "https://www.citrix.com/downloads/workspace-app/legacy-workspace-app-for-linux/workspace-app-for-linux-latest9.html";
-    };
-
     "23.11.0" = {
       major = "23";
       minor = "11";
@@ -114,6 +103,7 @@ let
   unsupportedVersions = [
     "23.02.0"
     "23.07.0"
+    "23.09.0"
   ];
 in
 {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2550,7 +2550,6 @@ with pkgs;
   circus = with python310Packages; toPythonApplication circus;
 
   inherit (callPackage ../applications/networking/remote/citrix-workspace { })
-    citrix_workspace_23_09_0
     citrix_workspace_23_11_0
     citrix_workspace_24_02_0
     citrix_workspace_24_05_0


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
EOL Date https://www.citrix.com/support/product-lifecycle/workspace-app.html was 2025-03-28
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
