### PR TITLE
osm-gps-map: fix library propagation

### DIFF
--- a/pkgs/by-name/os/osm-gps-map/dont-require-libsoup.patch
+++ b/pkgs/by-name/os/osm-gps-map/dont-require-libsoup.patch
@@ -1,0 +1,13 @@
+diff --git a/osmgpsmap-1.0.pc.in b/osmgpsmap-1.0.pc.in
+index 86efb3c..da6d1a9 100644
+--- a/osmgpsmap-1.0.pc.in
++++ b/osmgpsmap-1.0.pc.in
+@@ -6,6 +6,7 @@ includedir=@includedir@
+ Name: @PACKAGE_NAME@
+ Description: Moving map widget using openstreet map data
+ Version: @PACKAGE_VERSION@
+-Requires: gtk+-3.0 libsoup-2.4
++Requires: gtk+-3.0
++Requires.private: libsoup-2.4
+ Libs: -L${libdir} -losmgpsmap-1.0
+ Cflags: -I${includedir}/osmgpsmap-1.0

--- a/pkgs/by-name/os/osm-gps-map/package.nix
+++ b/pkgs/by-name/os/osm-gps-map/package.nix
@@ -11,14 +11,21 @@
   stdenv,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "osm-gps-map";
   version = "1.2.0";
 
   src = fetchzip {
-    url = "https://github.com/nzjrs/osm-gps-map/releases/download/${version}/osm-gps-map-${version}.tar.gz";
+    url = "https://github.com/nzjrs/osm-gps-map/releases/download/${finalAttrs.version}/osm-gps-map-${finalAttrs.version}.tar.gz";
     sha256 = "sha256-ciw28YXhR+GC6B2VPC+ZxjyhadOk3zYGuOssSgqjwH0=";
   };
+
+  patches = [
+    # libsoup is only used internally
+    # it should only be listed as private requirement
+    # https://github.com/nzjrs/osm-gps-map/pull/108
+    ./dont-require-libsoup.patch
+  ];
 
   outputs = [
     "out"
@@ -35,15 +42,18 @@ stdenv.mkDerivation rec {
   buildInputs = [
     cairo
     glib
-    gtk3
     libsoup_2_4
   ];
 
-  meta = with lib; {
+  propagatedBuildInputs = [
+    gtk3
+  ];
+
+  meta = {
     description = "GTK widget for displaying OpenStreetMap tiles";
     homepage = "https://nzjrs.github.io/osm-gps-map";
-    license = licenses.gpl2Plus;
-    maintainers = with maintainers; [ hrdinka ];
-    platforms = platforms.linux ++ platforms.darwin;
+    license = lib.licenses.gpl2Plus;
+    maintainers = with lib.maintainers; [ hrdinka ];
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
   };
-}
+})


### PR DESCRIPTION
osm-gps-map does in fact not need to propagate libsoup. The only use of libsoup is `widget.c` [1],
which is irrelevant for the `.dev` output in nixpkgs.

On the contrary, any dependent not supplying
libsoup will not be able to use osm-gps-map (#402543).

gtk3 is listed in the requires too.
This only didn't explode yet because any
dependent of osm-gps-map also explicitly added gtk3.

broken since #399086
closes #402543 (fix)
closes #402569 (becomes unnecessary)

[1] https://github.com/nzjrs/osm-gps-map/blob/1.2.0/src/osm-gps-map-widget.c#L137


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
