### PR TITLE
scsh: fix the build against `gcc-14`

### DIFF
--- a/pkgs/by-name/sc/scsh/gcc-14-p1.patch
+++ b/pkgs/by-name/sc/scsh/gcc-14-p1.patch
@@ -1,0 +1,33 @@
+https://github.com/scheme/scsh/pull/50.patch
+
+From edced224436fa70cd7d885fe65996b9c3cfd33d7 Mon Sep 17 00:00:00 2001
+From: Sergei Trofimovich <slyich@gmail.com>
+Date: Mon, 28 Apr 2025 22:40:31 +0100
+Subject: [PATCH] c/syscalls.c: add missing `<time.h>` icnlude
+
+Without the change the build fails for me as:
+
+    c/syscalls.c: In function 'sleep_until':
+    c/syscalls.c:711:18: error: implicit declaration of function 'time' [-Wimplicit-function-declaration]
+      711 |     time_t now = time(0);
+          |                  ^~~~
+    c/syscalls.c:41:1: note: 'time' is defined in header '<time.h>'; this is probably fixable by adding '#include <time.h>'
+       40 | #include "syscalls.h"
+      +++ |+#include <time.h>
+       41 |
+---
+ c/syscalls.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/c/syscalls.c b/c/syscalls.c
+index fe11e81..2be25a8 100644
+--- a/c/syscalls.c
++++ b/c/syscalls.c
+@@ -5,6 +5,7 @@
+ 
+ #include <stdio.h>
+ #include <stdlib.h>
++#include <time.h> /* for time() */
+ #include <sys/signal.h>
+ #include <signal.h>
+ #include <sys/types.h>

--- a/pkgs/by-name/sc/scsh/gcc-14-p2.patch
+++ b/pkgs/by-name/sc/scsh/gcc-14-p2.patch
@@ -1,0 +1,31 @@
+https://github.com/scheme/scsh/pull/51.patch
+
+From b2934abb68d6adab448f24787192c047e46cf17c Mon Sep 17 00:00:00 2001
+From: Sergei Trofimovich <slyich@gmail.com>
+Date: Mon, 28 Apr 2025 22:39:55 +0100
+Subject: [PATCH] configure.ac: add detection of `pty.h`
+
+Without the change the build on modern autoconf fails as:
+
+    c/tty.c: In function 'allocate_master':
+    c/tty.c:398:14: error: implicit declaration of function 'openpty'; did you mean 'openat'? [-Wimplicit-function-declaration]
+      398 |         rc = openpty (&master_fd, &slave_fd, NULL, NULL, NULL);
+          |              ^~~~~~~
+          |              openat
+---
+ configure.ac | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/configure.ac b/configure.ac
+index 99779dc..1cd8b22 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -32,7 +32,7 @@ CPPFLAGS="$CPPFLAGS -I$S48DIR/include"
+ # Checks for libraries.
+ 
+ # Checks for header files.
+-AC_CHECK_HEADERS([fcntl.h limits.h netdb.h sgtty.h stdlib.h string.h sys/ioctl.h sys/param.h sys/time.h termios.h unistd.h utime.h])
++AC_CHECK_HEADERS([fcntl.h limits.h netdb.h pty.h sgtty.h stdlib.h string.h sys/ioctl.h sys/param.h sys/time.h termios.h unistd.h utime.h])
+ 
+ dnl  We need the scheme48.h headers, so bomb out if we can't find them.
+ AC_CHECK_HEADERS([scheme48.h], [],

--- a/pkgs/by-name/sc/scsh/package.nix
+++ b/pkgs/by-name/sc/scsh/package.nix
@@ -19,6 +19,15 @@ stdenv.mkDerivation {
     fetchSubmodules = true;
   };
 
+  patches = [
+    # Fix the build against gcc-14:
+    # https://github.com/scheme/scsh/pull/50
+    ./gcc-14-p1.patch
+    # Fix the build against gcc-14:
+    # https://github.com/scheme/scsh/pull/51
+    ./gcc-14-p2.patch
+  ];
+
   nativeBuildInputs = [ autoreconfHook ];
   buildInputs = [ scheme48 ];
   configureFlags = [ "--with-scheme48=${scheme48}" ];


### PR DESCRIPTION
Without the change `scsh` build fails on `master` as https://hydra.nixos.org/build/294813946:

    c/syscalls.c: In function 'sleep_until':
    c/syscalls.c:711:18: error: implicit declaration of function 'time' []
      711 |     time_t now = time(0);
          |                  ^~~~


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
