### PR TITLE
python3Packages.circus: build from source

### DIFF
--- a/pkgs/development/python-modules/circus/default.nix
+++ b/pkgs/development/python-modules/circus/default.nix
@@ -2,11 +2,10 @@
   lib,
   stdenv,
   buildPythonPackage,
-  fetchPypi,
+  fetchFromGitHub,
   flit-core,
   psutil,
   pytestCheckHook,
-  pythonOlder,
   pyyaml,
   pyzmq,
   tornado,
@@ -17,11 +16,11 @@ buildPythonPackage rec {
   version = "0.19.0";
   pyproject = true;
 
-  disabled = pythonOlder "3.7";
-
-  src = fetchPypi {
-    inherit pname version;
-    hash = "sha256-++alApmYrBI5sX6904JRrIsiYn0w5OxvaMsQIzkRsPQ=";
+  src = fetchFromGitHub {
+    owner = "circus-tent";
+    repo = "circus";
+    tag = version;
+    hash = "sha256-MiZXiGb6F8LAJLAdmEDBO8Y5cJxHJy7jMFi50Ac3Bsc=";
   };
 
   build-system = [ flit-core ];
@@ -43,42 +42,11 @@ buildPythonPackage rec {
   '';
 
   disabledTests = [
-    # these tests raise circus.tests.support.TimeoutException
-    "test_add_start"
-    "test_add"
-    "test_command_already_running"
-    "test_dummy"
-    "test_exits_within_graceful_timeout"
-    "test_full_stats"
-    "test_handler"
-    "test_handler"
-    "test_inherited"
-    "test_kills_after_graceful_timeout"
-    "test_launch_cli"
-    "test_max_age"
-    "test_reload_sequential"
-    "test_reload_uppercase"
-    "test_reload_wid_1_worker"
-    "test_reload_wid_4_workers"
-    "test_reload1"
-    "test_reload2"
-    "test_resource_watcher_max_cpu"
-    "test_resource_watcher_max_mem_abs"
+    # Depends on the build machine configuration
     "test_resource_watcher_max_mem"
-    "test_resource_watcher_min_cpu"
     "test_resource_watcher_min_mem_abs"
-    "test_resource_watcher_min_mem"
-    "test_set_before_launch"
-    "test_set_by_arbiter"
-    "test_signal"
-    "test_stdin_socket"
-    "test_stop_and_restart"
-    "test_stream"
-    "test_venv"
-    "test_watchdog_discovery_found"
-    "test_watchdog_discovery_not_found"
-    # this test requires socket communication
-    "test_plugins"
+    # Compares with magic string
+    "test_streams"
   ];
 
   pythonImportsCheck = [ "circus" ];


### PR DESCRIPTION
The build was showing up in [zero.hf](https://zero.hf) as broken. Turns out the PyPi package no longer contained tests. Switched this to build from source and updated the test settings to match.

@GaetanLepage Consider this an early ZHF gift

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [x] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
