### PR TITLE
python3Packages.fireworks-ai: init at 0.15.12

### DIFF
--- a/pkgs/development/python-modules/fireworks-ai/default.nix
+++ b/pkgs/development/python-modules/fireworks-ai/default.nix
@@ -1,0 +1,79 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+
+  # build-system
+  setuptools,
+  versioneer,
+
+  # dependencies
+  httpx,
+  httpx-ws,
+  httpx-sse,
+  pydantic,
+  pillow,
+
+  # optional dependencies
+  fastapi,
+  gitignore-parser,
+  openapi-spec-validator,
+  prance,
+  safetensors,
+  tabulate,
+  torch,
+  tqdm,
+}:
+
+buildPythonPackage rec {
+  pname = "fireworks-ai";
+  version = "0.15.12";
+  pyproject = true;
+
+  # no source available
+  src = fetchPypi {
+    pname = "fireworks_ai";
+    inherit version;
+    hash = "sha256-I4ClPZIkTGCP05j42XuXOA2Jnz/3EAkfS1CRe3URnsI=";
+  };
+
+  build-system = [
+    setuptools
+    versioneer
+  ];
+
+  dependencies = [
+    httpx
+    httpx-ws
+    httpx-sse
+    pydantic
+    pillow
+  ];
+
+  optional-dependencies = {
+    flumina = [
+      fastapi
+      gitignore-parser
+      openapi-spec-validator
+      prance
+      safetensors
+      tabulate
+      torch
+      tqdm
+    ];
+  };
+
+  # no tests available
+  doCheck = false;
+
+  pythonImportsCheck = [
+    "fireworks"
+  ];
+
+  meta = {
+    description = "Client library for the Fireworks.ai platform";
+    homepage = "https://pypi.org/project/fireworks-ai/";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ sarahec ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4930,6 +4930,8 @@ self: super: with self; {
 
   firetv = callPackage ../development/python-modules/firetv { };
 
+  fireworks-ai = callPackage ../development/python-modules/fireworks-ai { };
+
   first = callPackage ../development/python-modules/first { };
 
   fissix = callPackage ../development/python-modules/fissix { };


### PR DESCRIPTION
Built from latest PyPi. (No source available per a discussion with fireworks-ai's support).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [x] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
