### PR TITLE
Revert "Use mkImageMediaOverride for filesystem attributes of various images"

### DIFF
--- a/nixos/modules/installer/sd-card/sd-image.nix
+++ b/nixos/modules/installer/sd-card/sd-image.nix
@@ -185,7 +185,7 @@ in
   config = {
     hardware.enableAllHardware = true;
 
-    fileSystems = lib.mkImageMediaOverride {
+    fileSystems = {
       "/boot/firmware" = {
         device = "/dev/disk/by-label/${config.sdImage.firmwarePartitionName}";
         fsType = "vfat";

--- a/nixos/modules/virtualisation/azure-image.nix
+++ b/nixos/modules/virtualisation/azure-image.nix
@@ -113,7 +113,7 @@ in
       '';
     };
 
-    fileSystems = lib.mkImageMediaOverride {
+    fileSystems = {
       "/" = {
         device = "/dev/disk/by-label/${cfg.label}";
         inherit (cfg) label;

--- a/nixos/modules/virtualisation/digital-ocean-config.nix
+++ b/nixos/modules/virtualisation/digital-ocean-config.nix
@@ -39,7 +39,7 @@ with lib;
     in
     mkMerge [
       {
-        fileSystems."/" = lib.mkImageMediaOverride {
+        fileSystems."/" = lib.mkDefault {
           device = "/dev/disk/by-label/nixos";
           autoResize = true;
           fsType = "ext4";

--- a/nixos/modules/virtualisation/disk-image.nix
+++ b/nixos/modules/virtualisation/disk-image.nix
@@ -37,7 +37,7 @@ in
     boot.loader.systemd-boot.enable = lib.mkDefault cfg.efiSupport;
     boot.growPartition = lib.mkDefault true;
 
-    fileSystems = lib.mkImageMediaOverride {
+    fileSystems = {
       "/" = {
         device = "/dev/disk/by-label/nixos";
         autoResize = true;

--- a/nixos/modules/virtualisation/google-compute-config.nix
+++ b/nixos/modules/virtualisation/google-compute-config.nix
@@ -21,7 +21,7 @@ in
     ../profiles/qemu-guest.nix
   ];
 
-  fileSystems."/" = lib.mkImageMediaOverride {
+  fileSystems."/" = {
     fsType = "ext4";
     device = "/dev/disk/by-label/nixos";
     autoResize = true;

--- a/nixos/modules/virtualisation/hyperv-image.nix
+++ b/nixos/modules/virtualisation/hyperv-image.nix
@@ -73,17 +73,15 @@ in
       inherit config lib pkgs;
     };
 
-    fileSystems = lib.mkImageMediaOverride {
-      "/" = {
-        device = "/dev/disk/by-label/nixos";
-        autoResize = true;
-        fsType = "ext4";
-      };
+    fileSystems."/" = {
+      device = "/dev/disk/by-label/nixos";
+      autoResize = true;
+      fsType = "ext4";
+    };
 
-      "/boot" = {
-        device = "/dev/disk/by-label/ESP";
-        fsType = "vfat";
-      };
+    fileSystems."/boot" = {
+      device = "/dev/disk/by-label/ESP";
+      fsType = "vfat";
     };
 
     boot.growPartition = true;

--- a/nixos/modules/virtualisation/kubevirt.nix
+++ b/nixos/modules/virtualisation/kubevirt.nix
@@ -12,7 +12,7 @@
   ];
 
   config = {
-    fileSystems."/" = lib.mkImageMediaOverride {
+    fileSystems."/" = {
       device = "/dev/disk/by-label/nixos";
       fsType = "ext4";
       autoResize = true;

--- a/nixos/modules/virtualisation/linode-config.nix
+++ b/nixos/modules/virtualisation/linode-config.nix
@@ -1,8 +1,10 @@
 {
+  config,
   lib,
   pkgs,
   ...
 }:
+with lib;
 {
   imports = [ ../profiles/qemu-guest.nix ];
 
@@ -10,7 +12,7 @@
     enable = true;
 
     settings.PermitRootLogin = "prohibit-password";
-    settings.PasswordAuthentication = lib.mkDefault false;
+    settings.PasswordAuthentication = mkDefault false;
   };
 
   networking = {
@@ -32,13 +34,13 @@
     sysstat
   ];
 
-  fileSystems."/" = lib.mkImageMediaOverride {
+  fileSystems."/" = {
     fsType = "ext4";
     device = "/dev/sda";
     autoResize = true;
   };
 
-  swapDevices = lib.mkDefault [ { device = "/dev/sdb"; } ];
+  swapDevices = mkDefault [ { device = "/dev/sdb"; } ];
 
   # Enable LISH and Linode Booting w/ GRUB
   boot = {

--- a/nixos/modules/virtualisation/oci-common.nix
+++ b/nixos/modules/virtualisation/oci-common.nix
@@ -30,17 +30,15 @@ in
 
   boot.growPartition = true;
 
-  fileSystems = lib.mkImageMediaOverride {
-    "/" = {
-      device = "/dev/disk/by-label/nixos";
-      fsType = "ext4";
-      autoResize = true;
-    };
+  fileSystems."/" = {
+    device = "/dev/disk/by-label/nixos";
+    fsType = "ext4";
+    autoResize = true;
+  };
 
-    "/boot" = lib.mkIf cfg.efi {
-      device = "/dev/disk/by-label/ESP";
-      fsType = "vfat";
-    };
+  fileSystems."/boot" = lib.mkIf cfg.efi {
+    device = "/dev/disk/by-label/ESP";
+    fsType = "vfat";
   };
 
   boot.loader.efi.canTouchEfiVariables = false;

--- a/nixos/modules/virtualisation/openstack-config.nix
+++ b/nixos/modules/virtualisation/openstack-config.nix
@@ -33,22 +33,18 @@ in
   ];
 
   config = {
-    fileSystems."/" = mkIf (!cfg.zfs.enable) (
-      lib.mkImageMediaOverride {
-        device = "/dev/disk/by-label/nixos";
-        fsType = "ext4";
-        autoResize = true;
-      }
-    );
+    fileSystems."/" = mkIf (!cfg.zfs.enable) {
+      device = "/dev/disk/by-label/nixos";
+      fsType = "ext4";
+      autoResize = true;
+    };
 
-    fileSystems."/boot" = mkIf (cfg.efi || cfg.zfs.enable) (
-      lib.mkImageMediaOverride {
-        # The ZFS image uses a partition labeled ESP whether or not we're
-        # booting with EFI.
-        device = "/dev/disk/by-label/ESP";
-        fsType = "vfat";
-      }
-    );
+    fileSystems."/boot" = mkIf (cfg.efi || cfg.zfs.enable) {
+      # The ZFS image uses a partition labeled ESP whether or not we're
+      # booting with EFI.
+      device = "/dev/disk/by-label/ESP";
+      fsType = "vfat";
+    };
 
     boot.growPartition = true;
     boot.kernelParams = [ "console=tty1" ];

--- a/nixos/modules/virtualisation/openstack-options.nix
+++ b/nixos/modules/virtualisation/openstack-options.nix
@@ -70,14 +70,12 @@ in
           _: value: ((value.mount or null) != null)
         ) config.openstack.zfs.datasets;
       in
-      lib.mkImageMediaOverride (
-        lib.mapAttrs' (
-          dataset: opts:
-          lib.nameValuePair opts.mount {
-            device = dataset;
-            fsType = "zfs";
-          }
-        ) mountable
-      );
+      lib.mapAttrs' (
+        dataset: opts:
+        lib.nameValuePair opts.mount {
+          device = dataset;
+          fsType = "zfs";
+        }
+      ) mountable;
   };
 }

--- a/nixos/modules/virtualisation/proxmox-image.nix
+++ b/nixos/modules/virtualisation/proxmox-image.nix
@@ -306,13 +306,7 @@ with lib;
           ''
             ${vma}/bin/vma create "${config.image.baseName}.vma" \
               -c ${
-                cfgFile "qemu-server.conf" (
-                  (builtins.removeAttrs cfg.qemuConf [ "diskSize" ])
-                  // {
-                    inherit (config.virtualisation) diskSize;
-                  }
-                  // cfg.qemuExtraConf
-                )
+                cfgFile "qemu-server.conf" (cfg.qemuConf // cfg.qemuExtraConf)
               }/qemu-server.conf drive-virtio0=$diskImage
             rm $diskImage
             ${pkgs.zstd}/bin/zstd "${config.image.baseName}.vma"
@@ -352,16 +346,14 @@ with lib;
         ];
       };
 
-      fileSystems = lib.mkImageMediaOverride {
-        "/" = {
-          device = "/dev/disk/by-label/nixos";
-          autoResize = true;
-          fsType = "ext4";
-        };
-        "/boot" = lib.mkIf hasBootPartition {
-          device = "/dev/disk/by-label/ESP";
-          fsType = "vfat";
-        };
+      fileSystems."/" = {
+        device = "/dev/disk/by-label/nixos";
+        autoResize = true;
+        fsType = "ext4";
+      };
+      fileSystems."/boot" = lib.mkIf hasBootPartition {
+        device = "/dev/disk/by-label/ESP";
+        fsType = "vfat";
       };
 
       networking = mkIf cfg.cloudInit.enable {

--- a/nixos/modules/virtualisation/virtualbox-image.nix
+++ b/nixos/modules/virtualisation/virtualbox-image.nix
@@ -275,7 +275,7 @@ in
     };
 
     fileSystems =
-      lib.mkImageMediaOverride {
+      {
         "/" = {
           device = "/dev/disk/by-label/nixos";
           autoResize = true;

--- a/nixos/modules/virtualisation/vmware-image.nix
+++ b/nixos/modules/virtualisation/vmware-image.nix
@@ -83,17 +83,15 @@ in
       inherit config lib pkgs;
     };
 
-    fileSystems = lib.mkImageMediaOverride {
-      "/" = {
-        device = "/dev/disk/by-label/nixos";
-        autoResize = true;
-        fsType = "ext4";
-      };
+    fileSystems."/" = {
+      device = "/dev/disk/by-label/nixos";
+      autoResize = true;
+      fsType = "ext4";
+    };
 
-      "/boot" = {
-        device = "/dev/disk/by-label/ESP";
-        fsType = "vfat";
-      };
+    fileSystems."/boot" = {
+      device = "/dev/disk/by-label/ESP";
+      fsType = "vfat";
     };
 
     boot.growPartition = true;


### PR DESCRIPTION
Reverts NixOS/nixpkgs#397330

Reverting immediately because of the severity. The intended change from the original PR can be reintroduced in a more carefully reviewed and tested PR.

The change as it is now will break existing nixos deployments on all of these platforms. Any additional mounts defined in modules that import these will get shadowed. See [this](https://github.com/NixOS/nixpkgs/pull/397330#issuecomment-2837315239) for an example.