### PR TITLE
python3Packages.pytest-tap: 3.3 → 3.5

### DIFF
--- a/pkgs/development/python-modules/pytest-tap/default.nix
+++ b/pkgs/development/python-modules/pytest-tap/default.nix
@@ -2,6 +2,8 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+  fetchpatch,
+  hatchling,
   pythonOlder,
   pytest,
   tappy,
@@ -10,28 +12,34 @@
 
 buildPythonPackage rec {
   pname = "pytest-tap";
-  version = "3.3";
-  format = "setuptools";
+  version = "3.5";
+  pyproject = true;
 
-  disabled = pythonOlder "3.6";
+  disabled = pythonOlder "3.9";
 
   src = fetchFromGitHub {
     owner = "python-tap";
     repo = "pytest-tap";
     rev = "v${version}";
-    sha256 = "R0RSdKTyJYGq+x0+ut4pJEywTGNgGp/ps36ZaH5dyY4=";
+    hash = "sha256-IuVtH1hrynbFDmz7IZ6vef9bAwl8L1eqR9WYQVL6CCA=";
   };
+
+  patches = [
+    (fetchpatch {
+      # see https://github.com/python-tap/pytest-tap/pull/105
+      name = "missing-package-in-wheel.patch";
+      url = "https://github.com/python-tap/pytest-tap/commit/056a44a632b1af19d9ba4b5044768bde3dd6a764.patch";
+      hash = "sha256-P52NqgXtnO2SthDwVbT+NVPeBNhjGS/8Vsbe/WLCc3A=";
+    })
+  ];
+
+  build-system = [ hatchling ];
 
   buildInputs = [ pytest ];
 
   propagatedBuildInputs = [ tappy ];
 
   nativeCheckInputs = [ pytestCheckHook ];
-
-  disabledTests = [
-    # Fixed in 4ed0138bf659c348b6dfb8bb701ae1989625d3d8 and hopefully in next release
-    "test_unittest_expected_failure"
-  ];
 
   pythonImportsCheck = [ "pytest_tap" ];
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

---
Build fails with
```
warning: The interpretation of store paths arguments ending in `.drv` recently changed. If this command is now failing try again with '/nix/store/pvj2bhchp17k46s1851bg9lnfwrx4p0l-python3.12-pytest-tap-3.5.drv^*'
Sourcing python-remove-tests-dir-hook
Sourcing python-catch-conflicts-hook.sh
Sourcing python-remove-bin-bytecode-hook.sh
Sourcing pypa-build-hook
Using pypaBuildPhase
Sourcing python-runtime-deps-check-hook
Using pythonRuntimeDepsCheckHook
Sourcing pypa-install-hook
Using pypaInstallPhase
Sourcing python-imports-check-hook.sh
Using pythonImportsCheckPhase
Sourcing python-namespaces-hook
Sourcing python-catch-conflicts-hook.sh
Sourcing pytest-check-hook
/nix/store/lbw329diypjdljmc229l9h6zd51drp2v-pytest-check-hook/nix-support/setup-hook: line 41: warning: command substitution: 1 unterminated here-document
Using pytestCheckPhase
Running phase: unpackPhase
@nix { "action": "setPhase", "phase": "unpackPhase" }
unpacking source archive /nix/store/rbdhg56aci9dm2hb0h9n5k2j7ky79v6b-source
source root is source
setting SOURCE_DATE_EPOCH to timestamp 315619200 of file "source/uv.lock"
Running phase: patchPhase
@nix { "action": "setPhase", "phase": "patchPhase" }
Running phase: updateAutotoolsGnuConfigScriptsPhase
@nix { "action": "setPhase", "phase": "updateAutotoolsGnuConfigScriptsPhase" }
Running phase: configurePhase
@nix { "action": "setPhase", "phase": "configurePhase" }
no configure script, doing nothing
Running phase: buildPhase
@nix { "action": "setPhase", "phase": "buildPhase" }
Executing pypaBuildPhase
Creating a wheel...
pypa build flags: --no-isolation --outdir dist/ --wheel
* Getting build dependencies for wheel...
* Building wheel...
Successfully built pytest_tap-3.5-py3-none-any.whl
Finished creating a wheel...
Finished executing pypaBuildPhase
Running phase: pythonRuntimeDepsCheckHook
@nix { "action": "setPhase", "phase": "pythonRuntimeDepsCheckHook" }
Executing pythonRuntimeDepsCheck
Checking runtime dependencies for pytest_tap-3.5-py3-none-any.whl
Finished executing pythonRuntimeDepsCheck
Running phase: installPhase
@nix { "action": "setPhase", "phase": "installPhase" }
Executing pypaInstallPhase
Successfully installed pytest_tap-3.5-py3-none-any.whl
Finished executing pypaInstallPhase
Running phase: pythonOutputDistPhase
@nix { "action": "setPhase", "phase": "pythonOutputDistPhase" }
Executing pythonOutputDistPhase
Finished executing pythonOutputDistPhase
Running phase: fixupPhase
@nix { "action": "setPhase", "phase": "fixupPhase" }
shrinking RPATHs of ELF executables and libraries in /nix/store/yqp0czhsdxyhnirgl509xm8v7sv7nd6s-python3.12-pytest-tap-3.5
checking for references to /build/ in /nix/store/yqp0czhsdxyhnirgl509xm8v7sv7nd6s-python3.12-pytest-tap-3.5...
patching script interpreter paths in /nix/store/yqp0czhsdxyhnirgl509xm8v7sv7nd6s-python3.12-pytest-tap-3.5
stripping (with command strip and flags -S -p) in  /nix/store/yqp0czhsdxyhnirgl509xm8v7sv7nd6s-python3.12-pytest-tap-3.5/lib
shrinking RPATHs of ELF executables and libraries in /nix/store/gycd0m8sdzqrgpg5amqq5fx3gcky5n14-python3.12-pytest-tap-3.5-dist
checking for references to /build/ in /nix/store/gycd0m8sdzqrgpg5amqq5fx3gcky5n14-python3.12-pytest-tap-3.5-dist...
patching script interpreter paths in /nix/store/gycd0m8sdzqrgpg5amqq5fx3gcky5n14-python3.12-pytest-tap-3.5-dist
Executing pythonRemoveTestsDir
Finished executing pythonRemoveTestsDir
Running phase: installCheckPhase
@nix { "action": "setPhase", "phase": "installCheckPhase" }
no Makefile or custom installCheckPhase, doing nothing
Running phase: pythonCatchConflictsPhase
@nix { "action": "setPhase", "phase": "pythonCatchConflictsPhase" }
Running phase: pythonRemoveBinBytecodePhase
@nix { "action": "setPhase", "phase": "pythonRemoveBinBytecodePhase" }
Running phase: pythonImportsCheckPhase
@nix { "action": "setPhase", "phase": "pythonImportsCheckPhase" }
Executing pythonImportsCheckPhase
Check whether the following modules can be imported: pytest_tap
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "<string>", line 1, in <lambda>
  File "/nix/store/fqm9bqqlmaqqr02qbalm1bazp810qfiw-python3-3.12.9/lib/python3.12/importlib/__init__.py", line 90, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen importlib._bootstrap>", line 1387, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1360, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1324, in _find_and_load_unlocked
ModuleNotFoundError: No module named 'pytest_tap'
```