### PR TITLE
feat: refactor hatch derivation to allow plugins

### DIFF
--- a/pkgs/by-name/ha/hatch/package.nix
+++ b/pkgs/by-name/ha/hatch/package.nix
@@ -1,183 +1,49 @@
-{
-  lib,
-  stdenv,
-  python3Packages,
-  fetchFromGitHub,
-  replaceVars,
-  git,
-  cargo,
-  versionCheckHook,
-  writableTmpDirAsHomeHook,
-  darwin,
-  nix-update-script,
-}:
+{ lib, python3 }:
+let
+  newPackageOverrides =
+    self: super:
+    {
+      hatch = self.callPackage ./unwrapped.nix { };
+    }
+    // (plugins self);
 
-python3Packages.buildPythonApplication rec {
-  pname = "hatch";
-  version = "1.14.1";
-  pyproject = true;
+  python = python3.override (old: {
+    self = python;
+    packageOverrides = lib.composeManyExtensions (
+      (if old ? packageOverrides then [ old.packageOverrides ] else [ ]) ++ [ newPackageOverrides ]
+    );
+  });
 
-  src = fetchFromGitHub {
-    owner = "pypa";
-    repo = "hatch";
-    tag = "hatch-v${version}";
-    hash = "sha256-101R5x4jAfMYrdE3OWWqGmkPWRI9rSMYr+Lye9NCbA4=";
-  };
-
-  patches = [ (replaceVars ./paths.patch { uv = lib.getExe python3Packages.uv; }) ];
-
-  build-system = with python3Packages; [
-    hatchling
-    hatch-vcs
-  ];
-
-  pythonRemoveDeps = [ "uv" ];
-
-  dependencies = with python3Packages; [
-    click
-    hatchling
-    httpx
-    hyperlink
-    keyring
-    packaging
-    pexpect
-    platformdirs
-    rich
-    shellingham
-    tomli-w
-    tomlkit
-    userpath
-    virtualenv
-    zstandard
-  ];
-
-  nativeCheckInputs =
-    with python3Packages;
-    [
-      binary
-      git
-      pytestCheckHook
-      pytest-mock
-      pytest-xdist
-      setuptools
-    ]
-    ++ [
-      cargo
-      versionCheckHook
-      writableTmpDirAsHomeHook
-    ]
-    ++ lib.optionals stdenv.hostPlatform.isDarwin [
-      darwin.ps
-    ];
-
-  versionCheckProgramArg = "--version";
-
-  pytestFlagsArray =
-    [
-      # AssertionError on the version metadata
-      # https://github.com/pypa/hatch/issues/1877
-      "--deselect=tests/backend/metadata/test_spec.py::TestCoreMetadataV21::test_all"
-      "--deselect=tests/backend/metadata/test_spec.py::TestCoreMetadataV21::test_license_expression"
-      "--deselect=tests/backend/metadata/test_spec.py::TestCoreMetadataV22::test_all"
-      "--deselect=tests/backend/metadata/test_spec.py::TestCoreMetadataV22::test_license_expression"
-      "--deselect=tests/backend/metadata/test_spec.py::TestCoreMetadataV23::test_all"
-      "--deselect=tests/backend/metadata/test_spec.py::TestCoreMetadataV23::test_license_expression"
-      "--deselect=tests/backend/metadata/test_spec.py::TestCoreMetadataV23::test_license_files"
-      "--deselect=tests/backend/metadata/test_spec.py::TestProjectMetadataFromCoreMetadata::test_license_files"
-    ]
-    ++ lib.optionals stdenv.hostPlatform.isDarwin [
-      # Dependency/versioning errors in the CLI tests, only seem to show up on Darwin
-      # https://github.com/pypa/hatch/issues/1893
-      "--deselect=tests/cli/env/test_create.py::test_sync_dependencies_pip"
-      "--deselect=tests/cli/env/test_create.py::test_sync_dependencies_uv"
-      "--deselect=tests/cli/project/test_metadata.py::TestBuildDependenciesMissing::test_no_compatibility_check_if_exists"
-      "--deselect=tests/cli/run/test_run.py::TestScriptRunner::test_dependencies"
-      "--deselect=tests/cli/run/test_run.py::TestScriptRunner::test_dependencies_from_tool_config"
-      "--deselect=tests/cli/run/test_run.py::test_dependency_hash_checking"
-      "--deselect=tests/cli/run/test_run.py::test_sync_dependencies"
-      "--deselect=tests/cli/run/test_run.py::test_sync_project_dependencies"
-      "--deselect=tests/cli/run/test_run.py::test_sync_project_features"
-      "--deselect=tests/cli/version/test_version.py::test_no_compatibility_check_if_exists"
-    ];
-
-  disabledTests =
-    [
-      # AssertionError: assert (1980, 1, 2, 0, 0, 0) == (2020, 2, 2, 0, 0, 0)
-      "test_default"
-      "test_editable_default"
-      "test_editable_default_extra_dependencies"
-      "test_editable_default_force_include"
-      "test_editable_default_force_include_option"
-      "test_editable_default_symlink"
-      "test_editable_exact"
-      "test_editable_exact_extra_dependencies"
-      "test_editable_exact_force_include"
-      "test_editable_exact_force_include_build_data_precedence"
-      "test_editable_exact_force_include_option"
-      "test_editable_pth"
-      "test_explicit_path"
-
-      # Loosen hatchling runtime version dependency
-      "test_core"
-      # New failing
-      "test_guess_variant"
-      "test_open"
-      "test_no_open"
-      "test_uv_env"
-      "test_pyenv"
-      "test_pypirc"
-      # Relies on FHS
-      # Could not read ELF interpreter from any of the following paths: /bin/sh, /usr/bin/env, /bin/dash, /bin/ls
-      "test_new_selected_python"
-    ]
-    ++ lib.optionals stdenv.hostPlatform.isDarwin [
-      # This test assumes it is running on macOS with a system shell on the PATH.
-      # It is not possible to run it in a nix build using a /nix/store shell.
-      # See https://github.com/pypa/hatch/pull/709 for the relevant code.
-      "test_populate_default_popen_kwargs_executable"
-
-      # Those tests fail because the final wheel is named '...2-macosx_11_0_arm64.whl' instead of
-      # '...2-macosx_14_0_arm64.whl'
-      "test_macos_archflags"
-      "test_macos_max_compat"
-
-      # https://github.com/pypa/hatch/issues/1942
-      "test_features"
-      "test_sync_dynamic_dependencies"
-    ]
-    ++ lib.optionals stdenv.hostPlatform.isAarch64 [ "test_resolve" ];
-
-  disabledTestPaths =
-    [
-      # ModuleNotFoundError: No module named 'hatchling.licenses.parse'
-      # https://github.com/pypa/hatch/issues/1850
-      "tests/backend/licenses/test_parse.py"
-      "tests/backend/licenses/test_supported.py"
-    ]
-    ++ lib.optionals stdenv.hostPlatform.isDarwin [
-      # AssertionError: assert [call('test h...2p32/bin/sh')] == [call('test h..., shell=True)]
-      # At index 0 diff:
-      #    call('test hatch-test.py3.10', shell=True, executable='/nix/store/b34ianga4diikh0kymkpqwmvba0mmzf7-bash-5.2p32/bin/sh')
-      # != call('test hatch-test.py3.10', shell=True)
-      "tests/cli/fmt/test_fmt.py"
-      "tests/cli/test/test_test.py"
-    ];
-
-  passthru = {
-    updateScript = nix-update-script {
-      extraArgs = [
-        "--version-regex"
-        "hatch-v([0-9.]+)"
-      ];
+  plugins =
+    ps: with ps; {
+      hatch-pip-compile = callPackage ./plugins/hatch-pip-compile.nix { };
     };
-  };
 
-  meta = {
-    description = "Modern, extensible Python project manager";
-    homepage = "https://hatch.pypa.io/latest/";
-    changelog = "https://github.com/pypa/hatch/blob/hatch-v${version}/docs/history/hatch.md";
-    license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ onny ];
-    mainProgram = "hatch";
-  };
-}
+  # selector is a function mapping pythonPackages to a list of plugins
+  # e.g. hatch.withPlugins (ps: with ps; [ hatch-pip-compile ])
+  withPlugins =
+    selector:
+    let
+      selected = selector (plugins python.pkgs);
+    in
+    python.pkgs.toPythonApplication (
+      python.pkgs.hatch.overridePythonAttrs (old: {
+        dependencies = old.dependencies ++ selected;
+
+        # save some build time when adding plugins by disabling tests
+        doCheck = selected == [ ];
+
+        # Propagating dependencies leaks them through $PYTHONPATH which causes issues
+        # when used in nix-shell.
+        postFixup = ''
+          rm $out/nix-support/propagated-build-inputs
+        '';
+
+        passthru = {
+          plugins = plugins python.pkgs;
+          inherit withPlugins python;
+        };
+      })
+    );
+in
+withPlugins (ps: [ ])

--- a/pkgs/by-name/ha/hatch/plugins/hatch-pip-compile.nix
+++ b/pkgs/by-name/ha/hatch/plugins/hatch-pip-compile.nix
@@ -1,0 +1,41 @@
+{
+  lib,
+  buildPythonPackage,
+  pythonOlder,
+  fetchFromGitHub,
+  hatchling,
+  click,
+  hatch,
+  pip-tools,
+  rich,
+}:
+buildPythonPackage rec {
+  pname = "hatch-pip-compile";
+  version = "1.11.3";
+  pyproject = true;
+
+  disabled = pythonOlder "3.8";
+
+  src = fetchFromGitHub {
+    owner = "juftin";
+    repo = "hatch-pip-compile";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-yZNkrdZJfFi8fdetG1Us6O5Yf+/ovWFJuRiIbjWHneE=";
+  };
+
+  build-system = [ hatchling ];
+
+  dependencies = [
+    click
+    hatch
+    pip-tools
+    rich
+  ];
+
+  meta = {
+    description = "hatch plugin to use pip-compile (or uv) to manage project dependencies and lockfiles";
+    homepage = "http://juftin.com/hatch-pip-compile/";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ ];
+  };
+}

--- a/pkgs/by-name/ha/hatch/unwrapped.nix
+++ b/pkgs/by-name/ha/hatch/unwrapped.nix
@@ -1,0 +1,183 @@
+{
+  lib,
+  stdenv,
+  python3Packages,
+  fetchFromGitHub,
+  replaceVars,
+  git,
+  cargo,
+  versionCheckHook,
+  writableTmpDirAsHomeHook,
+  darwin,
+  nix-update-script,
+}:
+
+python3Packages.buildPythonApplication rec {
+  pname = "hatch";
+  version = "1.14.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "pypa";
+    repo = "hatch";
+    tag = "hatch-v${version}";
+    hash = "sha256-101R5x4jAfMYrdE3OWWqGmkPWRI9rSMYr+Lye9NCbA4=";
+  };
+
+  patches = [ (replaceVars ./paths.patch { uv = lib.getExe python3Packages.uv; }) ];
+
+  build-system = with python3Packages; [
+    hatchling
+    hatch-vcs
+  ];
+
+  pythonRemoveDeps = [ "uv" ];
+
+  dependencies = with python3Packages; [
+    click
+    hatchling
+    httpx
+    hyperlink
+    keyring
+    packaging
+    pexpect
+    platformdirs
+    rich
+    shellingham
+    tomli-w
+    tomlkit
+    userpath
+    virtualenv
+    zstandard
+  ];
+
+  nativeCheckInputs =
+    with python3Packages;
+    [
+      binary
+      git
+      pytestCheckHook
+      pytest-mock
+      pytest-xdist
+      setuptools
+    ]
+    ++ [
+      cargo
+      versionCheckHook
+      writableTmpDirAsHomeHook
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [
+      darwin.ps
+    ];
+
+  versionCheckProgramArg = "--version";
+
+  pytestFlagsArray =
+    [
+      # AssertionError on the version metadata
+      # https://github.com/pypa/hatch/issues/1877
+      "--deselect=tests/backend/metadata/test_spec.py::TestCoreMetadataV21::test_all"
+      "--deselect=tests/backend/metadata/test_spec.py::TestCoreMetadataV21::test_license_expression"
+      "--deselect=tests/backend/metadata/test_spec.py::TestCoreMetadataV22::test_all"
+      "--deselect=tests/backend/metadata/test_spec.py::TestCoreMetadataV22::test_license_expression"
+      "--deselect=tests/backend/metadata/test_spec.py::TestCoreMetadataV23::test_all"
+      "--deselect=tests/backend/metadata/test_spec.py::TestCoreMetadataV23::test_license_expression"
+      "--deselect=tests/backend/metadata/test_spec.py::TestCoreMetadataV23::test_license_files"
+      "--deselect=tests/backend/metadata/test_spec.py::TestProjectMetadataFromCoreMetadata::test_license_files"
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [
+      # Dependency/versioning errors in the CLI tests, only seem to show up on Darwin
+      # https://github.com/pypa/hatch/issues/1893
+      "--deselect=tests/cli/env/test_create.py::test_sync_dependencies_pip"
+      "--deselect=tests/cli/env/test_create.py::test_sync_dependencies_uv"
+      "--deselect=tests/cli/project/test_metadata.py::TestBuildDependenciesMissing::test_no_compatibility_check_if_exists"
+      "--deselect=tests/cli/run/test_run.py::TestScriptRunner::test_dependencies"
+      "--deselect=tests/cli/run/test_run.py::TestScriptRunner::test_dependencies_from_tool_config"
+      "--deselect=tests/cli/run/test_run.py::test_dependency_hash_checking"
+      "--deselect=tests/cli/run/test_run.py::test_sync_dependencies"
+      "--deselect=tests/cli/run/test_run.py::test_sync_project_dependencies"
+      "--deselect=tests/cli/run/test_run.py::test_sync_project_features"
+      "--deselect=tests/cli/version/test_version.py::test_no_compatibility_check_if_exists"
+    ];
+
+  disabledTests =
+    [
+      # AssertionError: assert (1980, 1, 2, 0, 0, 0) == (2020, 2, 2, 0, 0, 0)
+      "test_default"
+      "test_editable_default"
+      "test_editable_default_extra_dependencies"
+      "test_editable_default_force_include"
+      "test_editable_default_force_include_option"
+      "test_editable_default_symlink"
+      "test_editable_exact"
+      "test_editable_exact_extra_dependencies"
+      "test_editable_exact_force_include"
+      "test_editable_exact_force_include_build_data_precedence"
+      "test_editable_exact_force_include_option"
+      "test_editable_pth"
+      "test_explicit_path"
+
+      # Loosen hatchling runtime version dependency
+      "test_core"
+      # New failing
+      "test_guess_variant"
+      "test_open"
+      "test_no_open"
+      "test_uv_env"
+      "test_pyenv"
+      "test_pypirc"
+      # Relies on FHS
+      # Could not read ELF interpreter from any of the following paths: /bin/sh, /usr/bin/env, /bin/dash, /bin/ls
+      "test_new_selected_python"
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [
+      # This test assumes it is running on macOS with a system shell on the PATH.
+      # It is not possible to run it in a nix build using a /nix/store shell.
+      # See https://github.com/pypa/hatch/pull/709 for the relevant code.
+      "test_populate_default_popen_kwargs_executable"
+
+      # Those tests fail because the final wheel is named '...2-macosx_11_0_arm64.whl' instead of
+      # '...2-macosx_14_0_arm64.whl'
+      "test_macos_archflags"
+      "test_macos_max_compat"
+
+      # https://github.com/pypa/hatch/issues/1942
+      "test_features"
+      "test_sync_dynamic_dependencies"
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isAarch64 [ "test_resolve" ];
+
+  disabledTestPaths =
+    [
+      # ModuleNotFoundError: No module named 'hatchling.licenses.parse'
+      # https://github.com/pypa/hatch/issues/1850
+      "tests/backend/licenses/test_parse.py"
+      "tests/backend/licenses/test_supported.py"
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [
+      # AssertionError: assert [call('test h...2p32/bin/sh')] == [call('test h..., shell=True)]
+      # At index 0 diff:
+      #    call('test hatch-test.py3.10', shell=True, executable='/nix/store/b34ianga4diikh0kymkpqwmvba0mmzf7-bash-5.2p32/bin/sh')
+      # != call('test hatch-test.py3.10', shell=True)
+      "tests/cli/fmt/test_fmt.py"
+      "tests/cli/test/test_test.py"
+    ];
+
+  passthru = {
+    updateScript = nix-update-script {
+      extraArgs = [
+        "--version-regex"
+        "hatch-v([0-9.]+)"
+      ];
+    };
+  };
+
+  meta = {
+    description = "Modern, extensible Python project manager";
+    homepage = "https://hatch.pypa.io/latest/";
+    changelog = "https://github.com/pypa/hatch/blob/hatch-v${version}/docs/history/hatch.md";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ onny ];
+    mainProgram = "hatch";
+  };
+}

--- a/pkgs/by-name/ha/hatch/unwrapped.nix
+++ b/pkgs/by-name/ha/hatch/unwrapped.nix
@@ -1,7 +1,7 @@
 {
   lib,
   stdenv,
-  python3Packages,
+  buildPythonApplication,
   fetchFromGitHub,
   replaceVars,
   git,
@@ -10,9 +10,31 @@
   writableTmpDirAsHomeHook,
   darwin,
   nix-update-script,
+  uv,
+  hatchling,
+  hatch-vcs,
+  click,
+  httpx,
+  hyperlink,
+  keyring,
+  packaging,
+  pexpect,
+  platformdirs,
+  rich,
+  shellingham,
+  tomli-w,
+  tomlkit,
+  userpath,
+  virtualenv,
+  zstandard,
+  binary,
+  pytestCheckHook,
+  pytest-mock,
+  pytest-xdist,
+  setuptools,
 }:
 
-python3Packages.buildPythonApplication rec {
+buildPythonApplication rec {
   pname = "hatch";
   version = "1.14.1";
   pyproject = true;
@@ -24,16 +46,16 @@ python3Packages.buildPythonApplication rec {
     hash = "sha256-101R5x4jAfMYrdE3OWWqGmkPWRI9rSMYr+Lye9NCbA4=";
   };
 
-  patches = [ (replaceVars ./paths.patch { uv = lib.getExe python3Packages.uv; }) ];
+  patches = [ (replaceVars ./paths.patch { uv = lib.getExe uv; }) ];
 
-  build-system = with python3Packages; [
+  build-system = [
     hatchling
     hatch-vcs
   ];
 
   pythonRemoveDeps = [ "uv" ];
 
-  dependencies = with python3Packages; [
+  dependencies = [
     click
     hatchling
     httpx
@@ -52,7 +74,7 @@ python3Packages.buildPythonApplication rec {
   ];
 
   nativeCheckInputs =
-    with python3Packages;
+
     [
       binary
       git


### PR DESCRIPTION
As per the hatch documentation, hatch plugings must be installed in the hatch environment itself: https://hatch.pypa.io/1.13/plugins/about/#hatch

This PR adds the ability to install plugins along with hatch. It is basically a copy-paste of how poetry does the same.

This also adds the hatch-pip-compile plugin.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
