### PR TITLE
nixos/installation-cd-graphical-calamares-cosmic: init

### DIFF
--- a/nixos/modules/installer/cd-dvd/installation-cd-graphical-calamares-cosmic.nix
+++ b/nixos/modules/installer/cd-dvd/installation-cd-graphical-calamares-cosmic.nix
@@ -1,0 +1,71 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+{
+  imports = [ ./installation-cd-graphical-calamares.nix ];
+
+  isoImage.edition = lib.mkDefault "cosmic";
+  isoImage.configurationName = "COSMIC (Linux LTS)";
+
+  environment.pathsToLink = [ "/share/calamares" ];
+
+  services = {
+    desktopManager.cosmic.enable = true;
+    displayManager = {
+      # Greeter needs to be enabled to handle an idle logout and login
+      cosmic-greeter.enable = true;
+
+      # No need to have a lockscreen on an installer ISO, enable autologin
+      autoLogin = {
+        enable = true;
+        user = "nixos";
+      };
+    };
+  };
+
+  systemd.tmpfiles.rules =
+    let
+      desktopDir = "/home/nixos/Desktop";
+      filesInHomePerms = "0644 nixos users -";
+      dirsInHomePerms = "0755 nixos users - -";
+      CosmicAppList_favorites = "${pkgs.writeText "favorites" ''
+        [
+            "calamares",
+            "firefox",
+            "gparted",
+            "com.system76.CosmicFiles",
+            "com.system76.CosmicEdit",
+            "com.system76.CosmicTerm",
+            "com.system76.CosmicSettings",
+        ]''}";
+    in
+    [
+      # Need to create ${desktopDir} first or we get an ownership issue because
+      # otherwise ${desktopDir} gets the ownership of `root:root`.
+      "d ${desktopDir} ${dirsInHomePerms}"
+      "L+ ${desktopDir}/calamares.desktop ${filesInHomePerms} ${pkgs.calamares-nixos}/share/applications/calamares.desktop"
+      "L+ ${desktopDir}/firefox.desktop ${filesInHomePerms} ${pkgs.firefox}/share/applications/firefox.desktop"
+      "L+ ${desktopDir}/gparted.desktop ${filesInHomePerms} ${pkgs.gparted}/share/applications/gparted.desktop"
+      "L+ ${desktopDir}/nixos-manual.desktop ${filesInHomePerms} /run/current-system/sw/share/applications/nixos-manual.desktop"
+
+      # Same as ${desktopDir}, need to create all directories in the hierarchy
+      "d /home/nixos/.config ${dirsInHomePerms}"
+      "d /home/nixos/.config/cosmic ${dirsInHomePerms}"
+      "d /home/nixos/.config/cosmic/com.system76.CosmicAppList ${dirsInHomePerms}"
+      "d /home/nixos/.config/cosmic/com.system76.CosmicAppList/v1 ${dirsInHomePerms}"
+      "L+ /home/nixos/.config/cosmic/com.system76.CosmicAppList/v1/favorites ${filesInHomePerms} ${CosmicAppList_favorites}"
+    ];
+
+  specialisation = {
+    cosmic_latest_kernel.configuration =
+      { config, ... }:
+      {
+        imports = [ ./latest-kernel.nix ];
+        isoImage.configurationName = lib.mkForce "COSMIC (Linux ${config.boot.kernelPackages.kernel.version})";
+      };
+  };
+}


### PR DESCRIPTION
Soft dependency on https://github.com/NixOS/calamares-nixos-extensions/pull/56.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
