### PR TITLE
age-plugin-1p: init at 0.1.0

### DIFF
--- a/pkgs/by-name/ag/age-plugin-1p/package.nix
+++ b/pkgs/by-name/ag/age-plugin-1p/package.nix
@@ -1,0 +1,33 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+}:
+
+buildGoModule rec {
+  pname = "age-plugin-1p";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "Enzime";
+    repo = "age-plugin-1p";
+    tag = "v${version}";
+    hash = "sha256-QYHHD7wOgRxRVkUOjwMz5DV8oxlb9mmb2K4HPoISguU=";
+  };
+
+  vendorHash = "sha256-WrdwhlaqciVEB2L+Dh/LEeSE7I3+PsOTW4c+0yOKzKY=";
+
+  ldflags = [
+    "-s"
+    "-w"
+  ];
+
+  meta = with lib; {
+    description = "Use SSH keys from 1Password with age";
+    mainProgram = "age-plugin-1p";
+    homepage = "https://github.com/Enzime/age-plugin-1p";
+    license = licenses.mit;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ Enzime ];
+  };
+}

--- a/pkgs/by-name/ag/age/package.nix
+++ b/pkgs/by-name/ag/age/package.nix
@@ -3,12 +3,13 @@
   buildGoModule,
   fetchFromGitHub,
   installShellFiles,
-  age-plugin-tpm,
+  age-plugin-fido2-hmac,
+  age-plugin-ledger,
   age-plugin-se,
   age-plugin-sss,
-  age-plugin-ledger,
+  age-plugin-tpm,
   age-plugin-yubikey,
-  age-plugin-fido2-hmac,
+  age-plugin-1p,
   makeWrapper,
   runCommand,
 }:
@@ -59,12 +60,13 @@ buildGoModule (final: {
   # group age plugins together
   passthru.plugins = {
     inherit
-      age-plugin-tpm
+      age-plugin-fido2-hmac
+      age-plugin-ledger
       age-plugin-se
       age-plugin-sss
-      age-plugin-ledger
+      age-plugin-tpm
       age-plugin-yubikey
-      age-plugin-fido2-hmac
+      age-plugin-1p
       ;
   };
 


### PR DESCRIPTION
[`age-plugin-1p`](https://github.com/Enzime/age-plugin-1p) is a plugin for age clients like [age](https://github.com/FiloSottile/age/) and [rage](https://github.com/str4d/rage) which allows you to use SSH keys stored inside 1Password.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
