### PR TITLE
doc/build-helpers: fix appimage example where postExtract is used

### DIFF
--- a/doc/build-helpers/images/appimagetools.section.md
+++ b/doc/build-helpers/images/appimagetools.section.md
@@ -114,12 +114,12 @@ appimageTools.wrapType2 {
   extraPkgs = pkgs: [ pkgs.at-spi2-core ];
 
   extraInstallCommands = ''
-    mv $out/bin/${pname}-${version} $out/bin/${pname}
+    mv $out/bin/irccloud-${version} $out/bin/irccloud
     install -m 444 -D ${appimageContents}/irccloud.desktop $out/share/applications/irccloud.desktop
     install -m 444 -D ${appimageContents}/usr/share/icons/hicolor/512x512/apps/irccloud.png \
       $out/share/icons/hicolor/512x512/apps/irccloud.png
     substituteInPlace $out/share/applications/irccloud.desktop \
-      --replace-fail 'Exec=AppRun' 'Exec=${pname}'
+      --replace-fail 'Exec=AppRun' 'Exec=irccloud'
   '';
 }
 ```
@@ -154,7 +154,7 @@ let
   appimageContents = appimageTools.extract {
     inherit pname version src;
     postExtract = ''
-      substituteInPlace $out/irccloud.desktop --replace-fail 'Exec=AppRun' 'Exec=${pname}'
+      substituteInPlace $out/irccloud.desktop --replace-fail 'Exec=AppRun' 'Exec=irccloud'
     '';
   };
 in
@@ -166,7 +166,7 @@ appimageTools.wrapAppImage {
   extraPkgs = pkgs: [ pkgs.at-spi2-core ];
 
   extraInstallCommands = ''
-    mv $out/bin/${pname}-${version} $out/bin/${pname}
+    mv $out/bin/irccloud-${version} $out/bin/irccloud
     install -m 444 -D ${appimageContents}/irccloud.desktop $out/share/applications/irccloud.desktop
     install -m 444 -D ${appimageContents}/usr/share/icons/hicolor/512x512/apps/irccloud.png \
       $out/share/icons/hicolor/512x512/apps/irccloud.png

--- a/doc/build-helpers/images/appimagetools.section.md
+++ b/doc/build-helpers/images/appimagetools.section.md
@@ -129,11 +129,16 @@ appimageTools.wrapType2 {
 The argument passed to `extract` can also contain a `postExtract` attribute, which allows you to execute additional commands after the files are extracted from the AppImage.
 `postExtract` must be a string with commands to run.
 
+:::{.warning}
+When specifying `postExtract`, you should use `appimageTools.wrapAppImage` instead of `appimageTools.wrapType2`.
+Otherwise `wrapType2` will extract the AppImage contents without respecting the `postExtract` instructions.
+:::
+
 :::{.example #ex-extracting-appimage-with-postextract}
 
 # Extracting an AppImage to install extra files, using `postExtract`
 
-This is a rewrite of [](#ex-extracting-appimage) to use `postExtract`.
+This is a rewrite of [](#ex-extracting-appimage) to use `postExtract` and `wrapAppImage`.
 
 ```nix
 { appimageTools, fetchurl }:
@@ -153,8 +158,10 @@ let
     '';
   };
 in
-appimageTools.wrapType2 {
-  inherit pname version src;
+appimageTools.wrapAppImage {
+  inherit pname version;
+
+  src = appimageContents;
 
   extraPkgs = pkgs: [ pkgs.at-spi2-core ];
 
@@ -164,6 +171,9 @@ appimageTools.wrapType2 {
     install -m 444 -D ${appimageContents}/usr/share/icons/hicolor/512x512/apps/irccloud.png \
       $out/share/icons/hicolor/512x512/apps/irccloud.png
   '';
+
+  # specify src archive for nix-update
+  passthru.src = src;
 }
 ```
 


### PR DESCRIPTION
At the moment the combination of `wrapType2` and `extract` with `postExtract` is a bit of a footgun, since the `postExtract` will not apply to the wrapType2 invocation.

Unfortunately using wrapAppImage means you need to add a passthru for src to make nix-update work. The example is fixed to do so.

## Things done

- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).