### PR TITLE
python312Packages.pythreejs: init at 2.4.1

### DIFF
--- a/pkgs/development/python-modules/ipydatawidgets/default.nix
+++ b/pkgs/development/python-modules/ipydatawidgets/default.nix
@@ -40,6 +40,17 @@ buildPythonPackage rec {
     nbval
   ];
 
+  # Tests bind ports
+  __darwinAllowLocalNetworking = true;
+
+  pytestFlagsArray = [
+    # https://github.com/vidartf/ipydatawidgets/issues/62
+    "--deselect=ipydatawidgets/tests/test_ndarray_trait.py::test_dtype_coerce"
+
+    # https://github.com/vidartf/ipydatawidgets/issues/63
+    "--deselect=examples/test.ipynb::Cell\\\ 3"
+  ];
+
   meta = {
     description = "Widgets to help facilitate reuse of large datasets across different widgets";
     homepage = "https://github.com/vidartf/ipydatawidgets";

--- a/pkgs/development/python-modules/pythreejs/default.nix
+++ b/pkgs/development/python-modules/pythreejs/default.nix
@@ -1,0 +1,67 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+
+  jupyterlab,
+  setuptools,
+
+  ipywidgets,
+  ipydatawidgets,
+  numpy,
+  traitlets,
+}:
+
+buildPythonPackage rec {
+  pname = "pythreejs";
+  version = "2.4.2";
+  pyproject = true;
+
+  # github sources need to invoke npm, but no package-lock.json present:
+  # https://github.com/jupyter-widgets/pythreejs/issues/419
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-pWi/3Ew3l8TCM5FYko7cfc9vpKJnsI487FEh4geLW9Y=";
+  };
+
+  build-system = [
+    jupyterlab
+    setuptools
+  ];
+
+  # It seems pythonRelaxDeps doesn't work for these
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail "jupyterlab~=" "jupyterlab>="
+
+    # https://github.com/jupyter-widgets/pythreejs/pull/420
+    substituteInPlace setupbase.py \
+      --replace-fail "import pipes" "" \
+      --replace-fail "pipes.quote" "shlex.quote"
+  '';
+
+  # Don't run npm install, all files are already where they should be present.
+  # If we would run npm install, npm would detect package-lock.json is an old format,
+  # and try to fetch more metadata from the registry, which cannot work in the sandbox.
+  setupPyBuildFlags = [ "--skip-npm" ];
+
+  dependencies = [
+    ipywidgets
+    ipydatawidgets
+    numpy
+    traitlets
+  ];
+
+  # There are no tests
+  doCheck = false;
+
+  pythonImportsCheck = [ "pythreejs" ];
+
+  meta = {
+    description = "Interactive 3D graphics for the Jupyter Notebook and JupyterLab, using Three.js and Jupyter Widgets";
+    homepage = "https://github.com/jupyter-widgets/pythreejs";
+    changelog = "https://github.com/jupyter-widgets/pythreejs/releases/tag/${version}";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ flokli ];
+  };
+}

--- a/pkgs/development/python-modules/pythreejs/fix-re.error.patch
+++ b/pkgs/development/python-modules/pythreejs/fix-re.error.patch
@@ -1,0 +1,13 @@
+diff --git a/setupbase.py b/setupbase.py
+index 0ce0ac8..7762e23 100644
+--- a/setupbase.py
++++ b/setupbase.py
+@@ -659,7 +659,7 @@ def _translate_glob(pat):
+         translated_parts.append(_translate_glob_part(part))
+     os_sep_class = '[%s]' % re.escape(SEPARATORS)
+     res = _join_translated(translated_parts, os_sep_class)
+-    return '{res}\\Z(?ms)'.format(res=res)
++    return '(?ms){res}\\Z'.format(res=res)
+ 
+ 
+ def _join_translated(translated_parts, os_sep_class):

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -14363,6 +14363,8 @@ self: super: with self; {
 
   pythran = callPackage ../development/python-modules/pythran { inherit (pkgs.llvmPackages) openmp; };
 
+  pythreejs = callPackage ../development/python-modules/pythreejs { };
+
   pytibber = callPackage ../development/python-modules/pytibber { };
 
   pytikz-allefeld = callPackage ../development/python-modules/pytikz-allefeld { };


### PR DESCRIPTION
This adds [pythreejs](https://github.com/jupyter-widgets/pythreejs), providing interactive 3D graphics for the Jupyter Notebook and JupyterLab, using Three.js and Jupyter Widgets.

It also fixes the build failure in ipydatawidgets, a dependency.

I successfully ran the [`Animation.ipynb` example](https://github.com/jupyter-widgets/pythreejs/blob/master/examples/Animation.ipynb) on aarch64-linux.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
