### PR TITLE
python312Packages.pynvim-pp: unstable-2024-07-31 -> 0-unstable-2025-02-08, python312Packages.std2: 0-unstable-2024-09-02 -> 0-unstable-2025-02-06

### DIFF
--- a/pkgs/development/python-modules/pynvim-pp/default.nix
+++ b/pkgs/development/python-modules/pynvim-pp/default.nix
@@ -8,19 +8,21 @@
 
 buildPythonPackage {
   pname = "pynvim-pp";
-  version = "unstable-2024-07-31";
+  version = "0-unstable-2025-02-08";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "ms-jpq";
     repo = "pynvim_pp";
-    rev = "6d3c298b7eb9543bce7ab515b0a39f256c1d37ca";
-    hash = "sha256-W6YaxI/fa2HL6+FIBTTA+7K2Be02iuIfFFVO/hhYnpo=";
+    rev = "781f6beda5f5966857792af040d5e2ecff5467e4";
+    hash = "sha256-ggZqlaCP9WNECO+eRwi968EvQb8zuHCic6+9Zngsd24=";
   };
 
   build-system = [ setuptools ];
 
   dependencies = [ pynvim ];
+
+  pythonImportsCheck = [ "pynvim_pp" ];
 
   meta = {
     homepage = "https://github.com/ms-jpq/pynvim_pp";

--- a/pkgs/development/python-modules/std2/default.nix
+++ b/pkgs/development/python-modules/std2/default.nix
@@ -7,17 +7,19 @@
 
 buildPythonPackage {
   pname = "std2";
-  version = "0-unstable-2024-09-02";
+  version = "0-unstable-2025-02-06";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "ms-jpq";
     repo = "std2";
-    rev = "205d1f52e9b5438ef2b732c77e1144847cafa8d0";
-    hash = "sha256-WdUefadEk92cGnDI+KbQBpjg+d7KgI6bjlQlyhRRRFA=";
+    rev = "47fda91f8c8db9d5a8faa6f55d739d74afffc440";
+    hash = "sha256-n+6FxVQjzYhjQMJr+i+D8uSiVjI7HFkegxy5keVjKGs=";
   };
 
-  nativeBuildInputs = [ setuptools ];
+  build-system = [ setuptools ];
+
+  pythonImportsCheck = [ "std2" ];
 
   meta = {
     homepage = "https://github.com/ms-jpq/std2";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

- **python312Packages.pynvim-pp: unstable-2024-07-31 -> 0-unstable-2025-02-08**
- **python312Packages.std2: 0-unstable-2024-09-02 -> 0-unstable-2025-02-06**

---

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
