### PR TITLE
openhue-cli: init at 0.18

### DIFF
--- a/pkgs/by-name/op/openhue-cli/package.nix
+++ b/pkgs/by-name/op/openhue-cli/package.nix
@@ -14,21 +14,28 @@ buildGoModule (finalAttrs: {
     owner = "openhue";
     repo = "openhue-cli";
     tag = finalAttrs.version;
-    hash = "sha256-yIPqjKIvYk2Y9BYieqrm5QvvAHnuImXEDbI1JOy0kBA=";
+    hash = "sha256-LSaHE3gdjpNea6o+D/JGvHtwvG13LbHv2pDcZhlIoEE=";
+    leaveDotGit = true;
+    postFetch = ''
+      cd "$out"
+      git rev-parse HEAD > $out/COMMIT
+      find "$out" -name .git -print0 | xargs -0 rm -rf
+    '';
   };
 
   vendorHash = "sha256-lqIzmtFtkfrJSrpic79Is0yGpnLUysPQLn2lp/Mh+u4=";
 
   env.CGO_ENABLED = 0;
 
-  rev = "c37f2a910173d8c9df42b40bd6efb583307a40cc";
-
   ldflags = [
     "-s"
     "-w"
     "-X main.version=${finalAttrs.version}"
-    "-X main.commit=${finalAttrs.rev}"
   ];
+
+  preBuild = ''
+    ldflags+=" -X main.commit=$(cat COMMIT)"
+  '';
 
   postInstall = ''
     mv $out/bin/openhue-cli $out/bin/openhue

--- a/pkgs/by-name/op/openhue-cli/package.nix
+++ b/pkgs/by-name/op/openhue-cli/package.nix
@@ -1,0 +1,54 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  versionCheckHook,
+  writableTmpDirAsHomeHook,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "openhue-cli";
+  version = "0.18";
+
+  src = fetchFromGitHub {
+    owner = "openhue";
+    repo = "openhue-cli";
+    tag = finalAttrs.version;
+    hash = "sha256-yIPqjKIvYk2Y9BYieqrm5QvvAHnuImXEDbI1JOy0kBA=";
+  };
+
+  vendorHash = "sha256-lqIzmtFtkfrJSrpic79Is0yGpnLUysPQLn2lp/Mh+u4=";
+
+  env.CGO_ENABLED = 0;
+
+  rev = "c37f2a910173d8c9df42b40bd6efb583307a40cc";
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X main.version=${finalAttrs.version}"
+    "-X main.commit=${finalAttrs.rev}"
+  ];
+
+  postInstall = ''
+    mv $out/bin/openhue-cli $out/bin/openhue
+  '';
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [
+    versionCheckHook
+    writableTmpDirAsHomeHook
+  ];
+  versionCheckProgram = "${placeholder "out"}/bin/openhue";
+  versionCheckProgramArg = "version";
+  versionCheckKeepEnvironment = [ "HOME" ];
+
+  meta = {
+    changelog = "https://github.com/openhue/openhue-cli/releases/tag/${finalAttrs.version}";
+    description = "CLI for interacting with Philips Hue smart lighting systems";
+    homepage = "https://github.com/openhue/openhue-cli";
+    mainProgram = "openhue";
+    maintainers = with lib.maintainers; [ madeddie ];
+    license = lib.licenses.asl20;
+  };
+})


### PR DESCRIPTION
openhue-cli is a small utility written in Go to interact with Philips Hue from the OpenHue Project https://www.openhue.io


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
