### PR TITLE
python312Packages.ipywebrtc: init at 0.6.0

### DIFF
--- a/pkgs/development/python-modules/ipywebrtc/default.nix
+++ b/pkgs/development/python-modules/ipywebrtc/default.nix
@@ -1,0 +1,51 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  ipywidgets,
+  jupyter-packaging,
+  jupyterlab,
+  setuptools,
+}:
+
+buildPythonPackage rec {
+  pname = "ipywebrtc";
+  version = "0.6.0";
+  pyproject = true;
+
+  # Cannot fetch from github (and build javascript from source), as it fails with
+  # > Extensions require a devDependency on @jupyterlab/builder@^4.4.1, you have a dependency on 3.0.6
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-+Kw8wCs2M7WfOIrvZ5Yc/1f5ACj9MDuziGxjw9Yx2hM=";
+  };
+
+  build-system = [
+    jupyter-packaging
+    jupyterlab
+    setuptools
+  ];
+
+  # It seems pythonRelaxDeps doesn't work for these
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail "jupyter_packaging~=" "jupyter_packaging>=" \
+      --replace-fail "jupyterlab~=" "jupyterlab>="
+  '';
+
+  dependencies = [
+    ipywidgets
+  ];
+
+  # No tests
+  doCheck = false;
+
+  pythonImportsCheck = [ "ipywebrtc" ];
+
+  meta = {
+    description = "WebRTC and MediaStream API exposed in the Jupyter notebook/lab.";
+    homepage = "https://github.com/maartenbreddels/ipywebrtc";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ flokli ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6861,6 +6861,8 @@ self: super: with self; {
 
   ipyvuetify = callPackage ../development/python-modules/ipyvuetify { };
 
+  ipywebrtc = callPackage ../development/python-modules/ipywebrtc { };
+
   ipywidgets = callPackage ../development/python-modules/ipywidgets { };
 
   ipyxact = callPackage ../development/python-modules/ipyxact { };


### PR DESCRIPTION
This adds [`ipywebrtc`](https://github.com/maartenbreddels/ipywebrtc), WebRTC and MediaStream API exposed in the Jupyter notebook/lab.


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
