### PR TITLE
libblake3: fix duplicate patch fields

### DIFF
--- a/pkgs/by-name/li/libblake3/package.nix
+++ b/pkgs/by-name/li/libblake3/package.nix
@@ -27,6 +27,12 @@ stdenv.mkDerivation (finalAttrs: {
       hash = "sha256-npCtM8nOFU8Tcu//IykjMs8aLU12d93+mIfKuxHkuaQ=";
       relative = "c";
     })
+    # build(cmake): Relax Clang frontend variant detection (BLAKE3-team/BLAKE3#477)
+    (fetchpatch {
+      url = "https://patch-diff.githubusercontent.com/raw/BLAKE3-team/BLAKE3/pull/477.patch";
+      hash = "sha256-kidCMGd/i9D9HLLTt7l1DbiU71sFTEyr3Vew4XHUHls=";
+      relative = "c";
+    })
   ];
 
   sourceRoot = finalAttrs.src.name + "/c";
@@ -36,15 +42,6 @@ stdenv.mkDerivation (finalAttrs: {
   propagatedBuildInputs = lib.optionals useTBB [
     # 2022.0 crashes on macOS at the moment
     tbb_2021_11
-  ];
-
-  patches = [
-    # build(cmake): Relax Clang frontend variant detection (BLAKE3-team/BLAKE3#477)
-    (fetchpatch {
-      url = "https://patch-diff.githubusercontent.com/raw/BLAKE3-team/BLAKE3/pull/477.patch";
-      hash = "sha256-kidCMGd/i9D9HLLTt7l1DbiU71sFTEyr3Vew4XHUHls=";
-      relative = "c";
-    })
   ];
 
   cmakeFlags = [


### PR DESCRIPTION
This PR fixes the duplicate `patch` fields which resulted from merging two separate PRs:

- https://github.com/NixOS/nixpkgs/pull/401250
- https://github.com/NixOS/nixpkgs/pull/402739

- Built on platform(s)
  - [x] x86_64-linux
