### PR TITLE
[Backport release-24.11] Backport 401250 to release 24.11

### DIFF
--- a/pkgs/by-name/li/libblake3/package.nix
+++ b/pkgs/by-name/li/libblake3/package.nix
@@ -27,6 +27,12 @@ stdenv.mkDerivation (finalAttrs: {
       hash = "sha256-npCtM8nOFU8Tcu//IykjMs8aLU12d93+mIfKuxHkuaQ=";
       relative = "c";
     })
+    # build(cmake): Relax Clang frontend variant detection (BLAKE3-team/BLAKE3#477)
+    (fetchpatch {
+      url = "https://patch-diff.githubusercontent.com/raw/BLAKE3-team/BLAKE3/pull/477.patch";
+      hash = "sha256-kidCMGd/i9D9HLLTt7l1DbiU71sFTEyr3Vew4XHUHls=";
+      relative = "c";
+    })
   ];
 
   sourceRoot = finalAttrs.src.name + "/c";
@@ -38,15 +44,6 @@ stdenv.mkDerivation (finalAttrs: {
   propagatedBuildInputs = lib.optionals useTBB [
     # 2022.0 crashes on macOS at the moment
     tbb_2021_11
-  ];
-
-  patches = [
-    # build(cmake): Relax Clang frontend variant detection (BLAKE3-team/BLAKE3#477)
-    (fetchpatch {
-      url = "https://patch-diff.githubusercontent.com/raw/BLAKE3-team/BLAKE3/pull/477.patch";
-      hash = "sha256-kidCMGd/i9D9HLLTt7l1DbiU71sFTEyr3Vew4XHUHls=";
-      relative = "c";
-    })
   ];
 
   cmakeFlags = [

--- a/pkgs/by-name/li/libblake3/package.nix
+++ b/pkgs/by-name/li/libblake3/package.nix
@@ -40,6 +40,15 @@ stdenv.mkDerivation (finalAttrs: {
     tbb_2021_11
   ];
 
+  patches = [
+    # build(cmake): Relax Clang frontend variant detection (BLAKE3-team/BLAKE3#477)
+    (fetchpatch {
+      url = "https://patch-diff.githubusercontent.com/raw/BLAKE3-team/BLAKE3/pull/477.patch";
+      hash = "sha256-kidCMGd/i9D9HLLTt7l1DbiU71sFTEyr3Vew4XHUHls=";
+      relative = "c";
+    })
+  ];
+
   cmakeFlags = [
     (lib.cmakeBool "BLAKE3_USE_TBB" useTBB)
     (lib.cmakeBool "BUILD_SHARED_LIBS" (!stdenv.hostPlatform.isStatic))

--- a/pkgs/development/libraries/tbb/2022_0.nix
+++ b/pkgs/development/libraries/tbb/2022_0.nix
@@ -34,11 +34,12 @@ stdenv.mkDerivation rec {
       url = "https://patch-diff.githubusercontent.com/raw/oneapi-src/oneTBB/pull/899.patch";
       hash = "sha256-kU6RRX+sde0NrQMKlNtW3jXav6J4QiVIUmD50asmBPU=";
     })
-  ];
-
-  cmakeFlags = [
-    # Skip tests to work around https://github.com/uxlfoundation/oneTBB/issues/1695
-    (lib.cmakeBool "TBB_TEST" (!stdenv.hostPlatform.isWindows))
+    # Fix tests on FreeBSD and Windows
+    (fetchpatch {
+      name = "fix-tbb-freebsd-and-windows-tests.patch";
+      url = "https://patch-diff.githubusercontent.com/raw/uxlfoundation/oneTBB/pull/1696.patch";
+      hash = "sha256-yjX2FkOK8bz29a/XSA7qXgQw9lxzx8VIgEBREW32NN4=";
+    })
   ];
 
   # Fix build with modern gcc

--- a/pkgs/development/libraries/tbb/2022_0.nix
+++ b/pkgs/development/libraries/tbb/2022_0.nix
@@ -36,6 +36,11 @@ stdenv.mkDerivation rec {
     })
   ];
 
+  cmakeFlags = [
+    # Skip tests to work around https://github.com/uxlfoundation/oneTBB/issues/1695
+    (lib.cmakeBool "TBB_TEST" (!stdenv.hostPlatform.isWindows))
+  ];
+
   # Fix build with modern gcc
   # In member function 'void std::__atomic_base<_IntTp>::store(__int_type, std::memory_order) [with _ITp = bool]',
   NIX_CFLAGS_COMPILE =
@@ -77,7 +82,7 @@ stdenv.mkDerivation rec {
       represents a higher-level, task-based parallelism that abstracts platform
       details and threading mechanisms for scalability and performance.
     '';
-    platforms = platforms.unix;
+    platforms = platforms.unix ++ platforms.windows;
     maintainers = with maintainers; [
       thoughtpolice
       tmarkus

--- a/pkgs/development/libraries/tbb/2022_0.nix
+++ b/pkgs/development/libraries/tbb/2022_0.nix
@@ -4,6 +4,7 @@
   fetchFromGitHub,
   fetchpatch,
   cmake,
+  ninja,
 }:
 
 stdenv.mkDerivation rec {
@@ -24,6 +25,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [
     cmake
+    ninja
   ];
 
   patches = [
@@ -60,6 +62,8 @@ stdenv.mkDerivation rec {
     substituteInPlace test/CMakeLists.txt \
       --replace-fail 'tbb_add_test(SUBDIR conformance NAME conformance_resumable_tasks DEPENDENCIES TBB::tbb)' ""
   '';
+
+  enableParallelBuilding = true;
 
   meta = with lib; {
     description = "Intel Thread Building Blocks C++ Library";

--- a/pkgs/development/libraries/tbb/default.nix
+++ b/pkgs/development/libraries/tbb/default.nix
@@ -44,11 +44,12 @@ stdenv.mkDerivation rec {
       url = "https://patch-diff.githubusercontent.com/raw/oneapi-src/oneTBB/pull/1193.patch";
       hash = "sha256-ZQbwUmuIZoGVBof8QNR3V8vU385e2X7EvU3+Fbj4+M8=";
     })
-  ];
-
-  cmakeFlags = [
-    # Skip tests to work around https://github.com/uxlfoundation/oneTBB/issues/1695
-    (lib.cmakeBool "TBB_TEST" (!stdenv.hostPlatform.isWindows))
+    # Fix tests on FreeBSD and Windows
+    (fetchpatch {
+      name = "fix-tbb-freebsd-and-windows-tests.patch";
+      url = "https://patch-diff.githubusercontent.com/raw/uxlfoundation/oneTBB/pull/1696.patch";
+      hash = "sha256-yjX2FkOK8bz29a/XSA7qXgQw9lxzx8VIgEBREW32NN4=";
+    })
   ];
 
   # Fix build with modern gcc

--- a/pkgs/development/libraries/tbb/default.nix
+++ b/pkgs/development/libraries/tbb/default.nix
@@ -34,6 +34,21 @@ stdenv.mkDerivation rec {
       url = "https://patch-diff.githubusercontent.com/raw/oneapi-src/oneTBB/pull/899.patch";
       hash = "sha256-kU6RRX+sde0NrQMKlNtW3jXav6J4QiVIUmD50asmBPU=";
     })
+    (fetchpatch {
+      name = "fix-tbb-mingw-compile.patch";
+      url = "https://patch-diff.githubusercontent.com/raw/oneapi-src/oneTBB/pull/1361.patch";
+      hash = "sha256-jVa4HQetZv0vImdv549MyTy6/8t9dy8m6YAmjPGNQ18=";
+    })
+    (fetchpatch {
+      name = "fix-tbb-mingw-link.patch";
+      url = "https://patch-diff.githubusercontent.com/raw/oneapi-src/oneTBB/pull/1193.patch";
+      hash = "sha256-ZQbwUmuIZoGVBof8QNR3V8vU385e2X7EvU3+Fbj4+M8=";
+    })
+  ];
+
+  cmakeFlags = [
+    # Skip tests to work around https://github.com/uxlfoundation/oneTBB/issues/1695
+    (lib.cmakeBool "TBB_TEST" (!stdenv.hostPlatform.isWindows))
   ];
 
   # Fix build with modern gcc
@@ -77,7 +92,7 @@ stdenv.mkDerivation rec {
       represents a higher-level, task-based parallelism that abstracts platform
       details and threading mechanisms for scalability and performance.
     '';
-    platforms = platforms.unix;
+    platforms = platforms.unix ++ platforms.windows;
     maintainers = with maintainers; [
       thoughtpolice
       tmarkus

--- a/pkgs/development/libraries/tbb/default.nix
+++ b/pkgs/development/libraries/tbb/default.nix
@@ -4,6 +4,7 @@
   fetchFromGitHub,
   fetchpatch,
   cmake,
+  ninja,
 }:
 
 stdenv.mkDerivation rec {
@@ -24,6 +25,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [
     cmake
+    ninja
   ];
 
   patches = [
@@ -60,6 +62,8 @@ stdenv.mkDerivation rec {
     substituteInPlace test/CMakeLists.txt \
       --replace 'conformance_resumable_tasks' ""
   '';
+
+  enableParallelBuilding = true;
 
   meta = with lib; {
     description = "Intel Thread Building Blocks C++ Library";


### PR DESCRIPTION
This PR backports the following to `release-24.11`

- https://github.com/NixOS/nixpkgs/pull/396676
- https://github.com/NixOS/nixpkgs/pull/401250
- https://github.com/NixOS/nixpkgs/pull/402869
