### PR TITLE
fleet: 4.67.1 -> 4.67.2, fleetctl: 4.67.1 -> 4.67.2 and keep in sync with fleet

### DIFF
--- a/pkgs/by-name/fl/fleet/package.nix
+++ b/pkgs/by-name/fl/fleet/package.nix
@@ -1,23 +1,21 @@
 {
   lib,
-  stdenv,
   fetchFromGitHub,
   buildGoModule,
-  writableTmpDirAsHomeHook,
   versionCheckHook,
 }:
 
 buildGoModule (finalAttrs: {
   pname = "fleet";
-  version = "4.67.1";
+  version = "4.67.2";
 
   src = fetchFromGitHub {
     owner = "fleetdm";
     repo = "fleet";
     tag = "fleet-v${finalAttrs.version}";
-    hash = "sha256-cZ0YTFcyPt7NMZUDZCdlVPTuhwRy7mTp7JCdINqiwOM=";
+    hash = "sha256-iMLD9M4EzXHRxvc5px9UcXEdjRIO1jm+hYwhaYaFON8=";
   };
-  vendorHash = "sha256-gFAotYho18Jn8MaFK6ShoMA1VLXVENcrASvHWZGFOFg=";
+  vendorHash = "sha256-UkdHwjCcxNX7maI4QClLm5WWaLXwGlEu80eZXVoYy60=";
 
   subPackages = [
     "cmd/fleet"
@@ -26,11 +24,6 @@ buildGoModule (finalAttrs: {
   ldflags = [
     "-X github.com/fleetdm/fleet/v4/server/version.appName=fleet"
     "-X github.com/fleetdm/fleet/v4/server/version.version=${finalAttrs.version}"
-  ];
-
-  doCheck = true;
-  nativeCheckInputs = [
-    writableTmpDirAsHomeHook
   ];
 
   doInstallCheck = true;

--- a/pkgs/by-name/fl/fleet/package.nix
+++ b/pkgs/by-name/fl/fleet/package.nix
@@ -46,6 +46,7 @@ buildGoModule (finalAttrs: {
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
       asauzeau
+      lesuisse
     ];
     mainProgram = "fleet";
   };

--- a/pkgs/by-name/fl/fleetctl/package.nix
+++ b/pkgs/by-name/fl/fleetctl/package.nix
@@ -1,44 +1,41 @@
 {
   lib,
   buildGoModule,
-  fetchFromGitHub,
+  fleet,
   writableTmpDirAsHomeHook,
   versionCheckHook,
   stdenv,
 }:
 
-buildGoModule rec {
-  pname = "fleectl";
-  version = "4.67.1";
+buildGoModule (finalAttrs: {
+  pname = "fleetctl";
 
-  src = fetchFromGitHub {
-    owner = "fleetdm";
-    repo = "fleet";
-    tag = "fleet-v${version}";
-    hash = "sha256-shaOPK7BbIDARopzGehlIA6aPdRiFRP9hrFRNO3kfGA=";
-  };
-  vendorHash = "sha256-UkdHwjCcxNX7maI4QClLm5WWaLXwGlEu80eZXVoYy60=";
+  inherit (fleet) version src vendorHash;
 
   subPackages = [
     "cmd/fleetctl"
   ];
 
   ldflags = [
-    "-X github.com/fleetdm/fleet/v4/server/version.appName=${pname}"
-    "-X github.com/fleetdm/fleet/v4/server/version.version=${version}"
+    "-X github.com/fleetdm/fleet/v4/server/version.appName=fleetctl"
+    "-X github.com/fleetdm/fleet/v4/server/version.version=${finalAttrs.version}"
   ];
 
   nativeCheckInputs = [
     writableTmpDirAsHomeHook
-    versionCheckHook
   ];
 
   # Try to access /var/empty/.goquery/history subfolders
   doCheck = !stdenv.hostPlatform.isDarwin;
+  doInstallCheck = !stdenv.hostPlatform.isDarwin;
+
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
 
   meta = {
     homepage = "https://github.com/fleetdm/fleet";
-    changelog = "https://github.com/fleetdm/fleet/releases/tag/fleet-v${version}";
+    changelog = "https://github.com/fleetdm/fleet/releases/tag/fleet-v${finalAttrs.version}";
     description = "CLI tool for managing Fleet";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
@@ -46,4 +43,4 @@ buildGoModule rec {
     ];
     mainProgram = "fleetctl";
   };
-}
+})


### PR DESCRIPTION
https://github.com/fleetdm/fleet/releases/tag/fleet-v4.67.2

Also fixes the hash mismatch because the src hash of a previous version was used.

`fleetctl` is now kept in sync with `fleet` since both tools are likely to be used together.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review pr 402876`

---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 2 packages built:</summary>
  <ul>
    <li>fleet</li>
    <li>fleetctl</li>
  </ul>
</details>

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
