### PR TITLE
octodns: 1.10.0 -> 1.11.0, octodns-providers.bind: 0.0.6 -> 0.0.7

### DIFF
--- a/pkgs/tools/networking/octodns/default.nix
+++ b/pkgs/tools/networking/octodns/default.nix
@@ -19,16 +19,16 @@ let
 in
 python3Packages.buildPythonApplication rec {
   pname = "octodns";
-  version = "1.10.0";
+  version = "1.11.0";
   pyproject = true;
 
-  disabled = python.pythonOlder "3.8";
+  disabled = python.pythonOlder "3.9";
 
   src = fetchFromGitHub {
     owner = "octodns";
     repo = "octodns";
     tag = "v${version}";
-    hash = "sha256-L3c4lYt/fgMctJFArc1XlR+hvpz10kcBcYYXajnNQr0=";
+    hash = "sha256-zCEfg6AAyclDBzSVQiGrE8Ol/9C7STq0VChepBt73GQ=";
   };
 
   build-system = with python3Packages; [
@@ -69,11 +69,11 @@ python3Packages.buildPythonApplication rec {
       '';
   };
 
-  meta = with lib; {
+  meta = {
     description = "Tools for managing DNS across multiple providers";
     homepage = "https://github.com/octodns/octodns";
     changelog = "https://github.com/octodns/octodns/blob/${src.rev}/CHANGELOG.md";
-    license = licenses.mit;
-    maintainers = teams.octodns.members;
+    license = lib.licenses.mit;
+    maintainers = lib.teams.octodns.members;
   };
 }

--- a/pkgs/tools/networking/octodns/providers/bind/package.nix
+++ b/pkgs/tools/networking/octodns/providers/bind/package.nix
@@ -11,16 +11,16 @@
 
 buildPythonPackage rec {
   pname = "octodns-bind";
-  version = "0.0.6";
+  version = "0.0.7";
   pyproject = true;
 
-  disabled = pythonOlder "3.8";
+  disabled = pythonOlder "3.9";
 
   src = fetchFromGitHub {
     owner = "octodns";
     repo = "octodns-bind";
     rev = "v${version}";
-    hash = "sha256-IxZr7Wds8wLfJg6rqCtJ59Sg/mCIJ1g9jDJ8CTM7O8w=";
+    hash = "sha256-cJbmGh0YNIu9fYH4It5SZG39ZsFoiOBERQXRd7kz8FY=";
   };
 
   nativeBuildInputs = [
@@ -40,11 +40,11 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
-  meta = with lib; {
-    description = " RFC compliant (Bind9) provider for octoDNS";
+  meta = {
+    description = "RFC compliant (Bind9) provider for octoDNS";
     homepage = "https://github.com/octodns/octodns-bind";
     changelog = "https://github.com/octodns/octodns-bind/blob/${src.rev}/CHANGELOG.md";
-    license = licenses.mit;
-    maintainers = teams.octodns.members;
+    license = lib.licenses.mit;
+    maintainers = lib.teams.octodns.members;
   };
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

* octodns: 1.1.0 -> 1.11.0
  * https://github.com/octodns/octodns/compare/v1.10.0...v1.11.0
* octodns-providers.bind: 0.0.6 -> 0.0.7

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
