### PR TITLE
kohighlights: init at 2.3.1.0

### DIFF
--- a/pkgs/by-name/ko/kohighlights/package.nix
+++ b/pkgs/by-name/ko/kohighlights/package.nix
@@ -1,0 +1,80 @@
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  python3,
+  python3Packages,
+  qt5,
+  makeWrapper,
+  copyDesktopItems,
+  makeDesktopItem,
+}:
+
+python3Packages.buildPythonApplication rec {
+  pname = "kohighlights";
+  version = "2.3.1.0";
+
+  src = fetchFromGitHub {
+    owner = "noembryo";
+    repo = "KoHighlights";
+    tag = "v${version}";
+    hash = "sha256-JxUVv2gq/AcNbikF5ix1KjbCILW3fQ1PBKMlrJH3lsk=";
+  };
+
+  dontWrapPythonPrograms = true;
+  dontBuild = true;
+  format = "other";
+
+  buildInputs =
+    [
+      qt5.qtbase
+    ]
+    ++ lib.optionals (stdenv.hostPlatform.isLinux) [
+      qt5.qtwayland
+    ];
+
+  nativeBuildInputs = [
+    qt5.wrapQtAppsHook
+    makeWrapper
+    copyDesktopItems
+  ];
+
+  dependencies = with python3Packages; [
+    pyside2
+    beautifulsoup4
+    packaging
+    requests
+    future
+  ];
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "kohighlights";
+      desktopName = "KoHighlights";
+      exec = meta.mainProgram;
+      comment = meta.description;
+      categories = [ "Utility" ];
+    })
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin $out/share/KoHighlights
+    cp -r * $out/share/KoHighlights
+    makeWrapper ${python3.interpreter} $out/bin/KoHighlights \
+      --add-flags "$out/share/KoHighlights/main.py" \
+      --set PYTHONPATH "${python3Packages.makePythonPath dependencies}"
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Utility for viewing and/or exporting KOReader's highlights";
+    homepage = "https://github.com/noembryo/KoHighlights";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ dtomvan ];
+    mainProgram = "KoHighlights";
+    platforms = lib.platforms.all;
+  };
+}

--- a/pkgs/by-name/ko/kohighlights/package.nix
+++ b/pkgs/by-name/ko/kohighlights/package.nix
@@ -75,6 +75,5 @@ python3Packages.buildPythonApplication rec {
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ dtomvan ];
     mainProgram = "KoHighlights";
-    platforms = lib.platforms.all;
   };
 }

--- a/pkgs/by-name/ko/kohighlights/package.nix
+++ b/pkgs/by-name/ko/kohighlights/package.nix
@@ -61,6 +61,7 @@ python3Packages.buildPythonApplication rec {
     runHook preInstall
 
     mkdir -p $out/bin $out/share/KoHighlights
+    rm -rf docs screens
     cp -r * $out/share/KoHighlights
     makeWrapper ${python3.interpreter} $out/bin/KoHighlights \
       --add-flags "$out/share/KoHighlights/main.py" \


### PR DESCRIPTION
Adds KoHighlights, `Utility for viewing and/or exporting KOReader's highlights`.

Fixes #402664

- Homepage URL: https://github.com/noembryo/KoHighlights
- License: MIT
- Platforms: linux

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
