### PR TITLE
mfcl3730cdn{lpr,cupswrapper}: init at 1.0.2-0

### DIFF
--- a/pkgs/by-name/mf/mfcl3730cdncupswrapper/package.nix
+++ b/pkgs/by-name/mf/mfcl3730cdncupswrapper/package.nix
@@ -1,0 +1,65 @@
+{
+  coreutils,
+  dpkg,
+  fetchurl,
+  gnugrep,
+  gnused,
+  lib,
+  makeWrapper,
+  mfcl3730cdnlpr,
+  perl,
+  stdenv,
+}:
+
+stdenv.mkDerivation rec {
+  model = "mfcl3730cdn";
+  pname = "${model}lpr";
+  version = "1.0.2-0";
+
+  src = fetchurl {
+    url = "https://download.brother.com/welcome/dlf103931/${model}pdrv-${version}.i386.deb";
+    sha256 = "1b3pyfl2w4aa9mpi56szi0mhd0qbw7fgmspbrmkywprgwcvvgdjm";
+  };
+
+  unpackPhase = "dpkg-deb -x $src $out";
+
+  nativeBuildInputs = [
+    dpkg
+    makeWrapper
+  ];
+
+  dontBuild = true;
+
+  installPhase = ''
+    basedir="${mfcl3730cdnlpr}/opt/brother/Printers/${model}"
+    dir="$out/opt/brother/Printers/${model}"
+    substituteInPlace $dir/cupswrapper/brother_lpdwrapper_${model} \
+      --replace /usr/bin/perl ${perl}/bin/perl \
+      --replace "basedir =~" "basedir = \"$basedir\"; #" \
+      --replace "PRINTER =~" "PRINTER = \"${model}\"; #"
+    wrapProgram $dir/cupswrapper/brother_lpdwrapper_${model} \
+      --prefix PATH : ${
+        lib.makeBinPath [
+          coreutils
+          gnugrep
+          gnused
+        ]
+      }
+    mkdir -p $out/lib/cups/filter
+    mkdir -p $out/share/cups/model
+    ln $dir/cupswrapper/brother_lpdwrapper_${model} $out/lib/cups/filter
+    ln $dir/cupswrapper/brother_${model}_printer_en.ppd $out/share/cups/model
+  '';
+
+  meta = with lib; {
+    description = "Brother MFC-L3730CDN CUPS wrapper driver";
+    homepage = "https://www.brother.com/";
+    license = licenses.gpl2Plus;
+    platforms = [
+      "i686-linux"
+      "x86_64-linux"
+    ];
+    maintainers = with maintainers; [ SchweGELBin ];
+    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
+  };
+}

--- a/pkgs/by-name/mf/mfcl3730cdnlpr/package.nix
+++ b/pkgs/by-name/mf/mfcl3730cdnlpr/package.nix
@@ -1,0 +1,65 @@
+{
+  coreutils,
+  dpkg,
+  fetchurl,
+  ghostscript,
+  gnugrep,
+  gnused,
+  lib,
+  makeWrapper,
+  perl,
+  pkgsi686Linux,
+  which,
+}:
+
+pkgsi686Linux.stdenv.mkDerivation rec {
+  model = "mfcl3730cdn";
+  pname = "${model}lpr";
+  version = "1.0.2-0";
+
+  src = fetchurl {
+    url = "https://download.brother.com/welcome/dlf103931/${model}pdrv-${version}.i386.deb";
+    sha256 = "1b3pyfl2w4aa9mpi56szi0mhd0qbw7fgmspbrmkywprgwcvvgdjm";
+  };
+
+  unpackPhase = "dpkg-deb -x $src $out";
+
+  nativeBuildInputs = [
+    dpkg
+    makeWrapper
+  ];
+
+  dontBuild = true;
+
+  installPhase = ''
+      dir="$out/opt/brother/Printers/${model}"
+      substituteInPlace $dir/lpd/filter_${model} \
+        --replace /usr/bin/perl ${perl}/bin/perl \
+        --replace "BR_PRT_PATH =~" "BR_PRT_PATH = \"$dir\"; #" \
+        --replace "PRINTER =~" "PRINTER = \"${model}\"; #"
+      wrapProgram $dir/lpd/filter_${model} \
+        --prefix PATH : ${
+          lib.makeBinPath [
+            coreutils
+            ghostscript
+            gnugrep
+            gnused
+            which
+          ]
+        }
+    patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
+      $dir/lpd/br${model}filter
+  '';
+
+  meta = with lib; {
+    description = "Brother MFC-L3730CDN LPR printer driver";
+    homepage = "https://www.brother.com/";
+    license = licenses.unfree;
+    platforms = [
+      "i686-linux"
+      "x86_64-linux"
+    ];
+    maintainers = with maintainers; [ SchweGELBin ];
+    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Added the LPR printing and CUPS wrapper driver.
I took inspiration from `pkgs/misc/cups/drivers/brother/mfcl3770cdw/default.nix` as those drivers have the same structure.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
