### PR TITLE
[staging-next] haskell.compiler.*: fix stack overrun in freeHaskellFunPtr on 32bit platforms 

### DIFF
--- a/pkgs/development/compilers/ghc/common-hadrian.nix
+++ b/pkgs/development/compilers/ghc/common-hadrian.nix
@@ -279,6 +279,17 @@
           includes = [ "configure.ac" ];
           hash = "sha256-L3FQvcm9QB59BOiR2g5/HACAufIG08HiT53EIOjj64g=";
         })
+      ]
+      # Fixes stack overrun in rts which crashes an process whenever
+      # freeHaskellFunPtr is called with nixpkgs' hardening flags.
+      # https://gitlab.haskell.org/ghc/ghc/-/issues/25485
+      # https://gitlab.haskell.org/ghc/ghc/-/merge_requests/13599
+      ++ lib.optionals (lib.versionOlder version "9.13") [
+        (fetchpatch {
+          name = "ghc-rts-adjustor-fix-i386-stack-overrun.patch";
+          url = "https://gitlab.haskell.org/ghc/ghc/-/commit/39bb6e583d64738db51441a556d499aa93a4fc4a.patch";
+          sha256 = "0w5fx413z924bi2irsy1l4xapxxhrq158b5gn6jzrbsmhvmpirs0";
+        })
       ];
 
     stdenv = stdenvNoCC;

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -2302,6 +2302,15 @@ self: super:
   # Overwrite the build cores
   raaz = disableParallelBuilding super.raaz;
 
+  # Test suite uses SHA as a point of comparison which doesn't
+  # succeeds its own test suite on 32bit:
+  # https://github.com/GaloisInc/SHA/issues/16
+  cryptohash-sha256 =
+    if pkgs.stdenv.hostPlatform.is32bit then
+      dontCheck super.cryptohash-sha256
+    else
+      super.cryptohash-sha256;
+
   # https://github.com/andreymulik/sdp/issues/3
   sdp = disableLibraryProfiling super.sdp;
   sdp-binary = disableLibraryProfiling super.sdp-binary;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

I've tested that the patch to all GHC versions and tested the issue observed with ghci/isocline with GHC 9.6.7. Doesn't give us pandoc yet which is still blocked on bsb-http-chunked which I'll look into next.

cc @K900 @vcunat 

What is the rebuild situation at the moment? Should we restrict this patch to 32bit on -next at least to prevent a huge rebuild?

