### PR TITLE
karakeep: 0.23.2 -> 0.24.1

### DIFF
--- a/pkgs/by-name/ka/karakeep/package.nix
+++ b/pkgs/by-name/ka/karakeep/package.nix
@@ -15,13 +15,13 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "karakeep";
-  version = "0.23.2";
+  version = "0.24.1";
 
   src = fetchFromGitHub {
     owner = "karakeep-app";
     repo = "karakeep";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-Cm6e1XEmMHzQ3vODxa9+Yuwt+9zLvQ9S7jmwAozjA/k=";
+    hash = "sha256-eiDTNMB/CipAR3FkUqPUGYdTAC6lSxT9gRXPQJLx5YE=";
   };
 
   patches = [
@@ -30,7 +30,6 @@ stdenv.mkDerivation (finalAttrs: {
     ./patches/dont-lock-pnpm-version.patch
   ];
   postPatch = ''
-    ln -s ${inter}/share/fonts/truetype ./apps/landing/app/fonts
     ln -s ${inter}/share/fonts/truetype ./apps/web/app/fonts
   '';
 
@@ -52,7 +51,7 @@ stdenv.mkDerivation (finalAttrs: {
       '';
     };
 
-    hash = "sha256-HZb11CAbnlGSmP/Gxyjncd/RuIWkPv3GvwYs9QZ12Ss=";
+    hash = "sha256-2n61uKdT9Q1fobpHunRhC3Eql3fqsV+DcyaEGjYDOyY=";
   };
   buildPhase = ''
     runHook preBuild

--- a/pkgs/by-name/ka/karakeep/patches/dont-lock-pnpm-version.patch
+++ b/pkgs/by-name/ka/karakeep/patches/dont-lock-pnpm-version.patch
@@ -5,10 +5,10 @@ version to nixpkgs, we override this requirement and use the latest v9 release.
 ---
 --- a/package.json
 +++ b/package.json
-@@ -33,7 +33,7 @@
+@@ -32,7 +32,7 @@
      "turbo": "^2.1.2"
    },
-   "prettier": "@hoarder/prettier-config",
+   "prettier": "@karakeep/prettier-config",
 -  "packageManager": "pnpm@9.0.0-alpha.8+sha256.a433a59569b00389a951352956faf25d1fdf43b568213fbde591c36274d4bc30",
 +  "packageManager": "pnpm",
    "pnpm": {

--- a/pkgs/by-name/ka/karakeep/patches/use-local-font.patch
+++ b/pkgs/by-name/ka/karakeep/patches/use-local-font.patch
@@ -7,25 +7,6 @@ See similar patches:
  pkgs/by-name/ne/nextjs-ollama-llm-ui/0002-use-local-google-fonts.patch
 
 ---
---- a/apps/landing/app/layout.tsx
-+++ b/apps/landing/app/layout.tsx
-@@ -1,11 +1,14 @@
- import type { Metadata } from "next";
--import { Inter } from "next/font/google";
-+import localFont from 'next/font/local';
-
- import "@hoarder/tailwind-config/globals.css";
-
- import React from "react";
-
--const inter = Inter({ subsets: ["latin"] });
-+const inter = localFont({
-+  subsets: ["latin"],
-+  src: "./fonts/InterVariable.ttf",
-+});
-
- export const metadata: Metadata = {
-   title: "Hoarder",
 --- a/apps/web/app/layout.tsx
 +++ b/apps/web/app/layout.tsx
 @@ -1,5 +1,5 @@
@@ -33,15 +14,15 @@ See similar patches:
 -import { Inter } from "next/font/google";
 +import localFont from 'next/font/local';
 
- import "@hoarder/tailwind-config/globals.css";
+ import "@karakeep/tailwind-config/globals.css";
 
-@@ -13,7 +13,8 @@
+@@ -13,9 +13,10 @@ import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 
- import { clientConfig } from "@hoarder/shared/config";
+ import { clientConfig } from "@karakeep/shared/config";
 
 -const inter = Inter({
 +const inter = localFont({
-+  src: "./fonts/InterVariable.ttf",
    subsets: ["latin"],
    fallback: ["sans-serif"],
++  src: "./fonts/InterVariable.ttf",
  });


### PR DESCRIPTION
Changelog: https://github.com/karakeep-app/karakeep/releases/tag/v0.24.1

I have tested this on my own setup. This update does *not* create helpers for the MCP server introduced in [0.24.0](https://github.com/karakeep-app/karakeep/releases/tag/v0.24.0).

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
