### PR TITLE
nexttrace: fix darwin build by adding -checklinkname=0 flag

### DIFF
--- a/pkgs/by-name/ne/nexttrace/package.nix
+++ b/pkgs/by-name/ne/nexttrace/package.nix
@@ -2,7 +2,6 @@
   lib,
   buildGoModule,
   fetchFromGitHub,
-  stdenv,
 }:
 
 buildGoModule rec {
@@ -23,6 +22,7 @@ buildGoModule rec {
     "-s"
     "-w"
     "-X github.com/nxtrace/NTrace-core/config.Version=v${version}"
+    "-checklinkname=0" # refers to https://github.com/nxtrace/NTrace-core/issues/247
   ];
 
   postInstall = ''
@@ -35,8 +35,5 @@ buildGoModule rec {
     license = licenses.gpl3Only;
     maintainers = with maintainers; [ sharzy ];
     mainProgram = "nexttrace";
-    # Broken on darwin for Go toolchain > 1.22, with error:
-    # 'link: github.com/nxtrace/NTrace-core/trace/internal: invalid reference to net.internetSocket'
-    broken = stdenv.hostPlatform.isDarwin;
   };
 }


### PR DESCRIPTION
The package was previously marked as broken on Darwin due to an issue with Go
toolchain > 1.22 throwing an error about invalid references to net.internetSocket.
This is fixed by adding the -checklinkname=0 linker flag, which disables the
link name checking that was causing the failure.

The broken attribute is now removed as the package builds successfully on Darwin.

Upstream fix: https://github.com/nxtrace/NTrace-core/commit/69588b0d14187ee00f48aa04e5617256148c3ecf


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
