### PR TITLE
speedscope: init at 1.22.2

### DIFF
--- a/pkgs/by-name/sp/speedscope/fix-shebang.patch
+++ b/pkgs/by-name/sp/speedscope/fix-shebang.patch
@@ -1,0 +1,13 @@
+diff --git a/scripts/prepack.sh b/scripts/prepack.sh
+index 2172706..1f8f152 100755
+--- a/scripts/prepack.sh
++++ b/scripts/prepack.sh
+@@ -41,7 +41,7 @@ mkdir -p "$OUTDIR"
+ # Place info about the current commit into the build dir to easily identify releases
+ npm ls -depth -1 | head -n 1 | cut -d' ' -f 1 > "$OUTDIR"/release.txt
+ date >> "$OUTDIR"/release.txt
+-git rev-parse HEAD >> "$OUTDIR"/release.txt
++cp COMMIT "$OUTDIR"/release.txt
+ 
+ # Place a json schema for the file format into the build directory too
+ node scripts/generate-file-format-schema-json.js > "$OUTDIR"/file-format-schema.json

--- a/pkgs/by-name/sp/speedscope/package.nix
+++ b/pkgs/by-name/sp/speedscope/package.nix
@@ -1,0 +1,58 @@
+{
+  lib,
+  buildNpmPackage,
+  fetchFromGitHub,
+  versionCheckHook,
+}:
+
+buildNpmPackage rec {
+  pname = "speedscope";
+  version = "1.22.2";
+
+  src = fetchFromGitHub {
+    owner = "jlfwong";
+    repo = "speedscope";
+    tag = "v${version}";
+    hash = "sha256-JzlS5onVac1UKJUl1YYE7a3oWk2crMyuowea8a7UoOo=";
+
+    # scripts/prepack.sh wants to extract the git commit from .git
+    # We don't want to keep .git for reproducibility reasons, so save the commit
+    # to a file and patch the script.
+    leaveDotGit = true;
+    postFetch = ''
+      ( cd $out; git rev-parse HEAD > COMMIT )
+      rm -rf $out/.git
+    '';
+  };
+
+  npmDepsHash = "sha256-3LCixJJyz3O6xQxP0A/WyQXsDvkXpdo7KYNDoufZVS4=";
+
+  patches = [
+    ./fix-shebang.patch
+  ];
+
+  postConfigure = ''
+    patchShebangs scripts
+  '';
+
+  dontNpmBuild = true;
+
+  postFixup = ''
+    # Remove some dangling symlinks
+    rm $out/lib/node_modules/speedscope/node_modules/.bin/sshpk*
+  '';
+
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+  doInstallCheck = true;
+
+  meta = {
+    description = "Fast and interactive web-based viewer for performance profiles";
+    homepage = "https://github.com/jlfwong/speedscope";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.linux;
+    mainProgram = "speedscope";
+    maintainers = with lib.maintainers; [ thomasjm ];
+  };
+}


### PR DESCRIPTION
Speedscope is a fast, interactive web-based viewer for performance profiles. See https://github.com/jlfwong/speedscope and https://www.speedscope.app/.

Closes #337485.


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
