### PR TITLE
codec2: fix pkg-config file, split outputs

### DIFF
--- a/pkgs/by-name/co/codec2/fix-pkg-config.patch
+++ b/pkgs/by-name/co/codec2/fix-pkg-config.patch
@@ -1,0 +1,13 @@
+diff --git a/codec2.pc.in b/codec2.pc.in
+index ecca704..94fca12 100644
+--- a/codec2.pc.in
++++ b/codec2.pc.in
+@@ -1,6 +1,5 @@
+-prefix=@CMAKE_INSTALL_PREFIX@
+-libdir=@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_LIBDIR@
+-includedir=@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_INCLUDEDIR@/codec2
++libdir=@CMAKE_INSTALL_LIBDIR@
++includedir=@CMAKE_INSTALL_INCLUDEDIR@/codec2
+ 
+ Name: codec2
+ Description: A speech codec for 2400 bit/s and below

--- a/pkgs/by-name/co/codec2/package.nix
+++ b/pkgs/by-name/co/codec2/package.nix
@@ -20,6 +20,11 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-69Mp4o3MgV98Fqfai4txv5jQw2WpoPuoWcwHsNAFPQM=";
   };
 
+  patches = [
+    # Fix nix-store path dupliucations
+    ./fix-pkg-config.patch
+  ];
+
   nativeBuildInputs = [
     cmake
     buildPackages.stdenv.cc # needs to build a C program to run at build time

--- a/pkgs/by-name/co/codec2/package.nix
+++ b/pkgs/by-name/co/codec2/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  testers,
   stdenv,
   buildPackages,
   fetchFromGitHub,
@@ -8,14 +9,14 @@
   lpcnetfreedv,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "codec2";
   version = "1.2.0";
 
   src = fetchFromGitHub {
     owner = "drowe67";
     repo = "codec2";
-    rev = "${version}";
+    rev = finalAttrs.version;
     hash = "sha256-69Mp4o3MgV98Fqfai4txv5jQw2WpoPuoWcwHsNAFPQM=";
   };
 
@@ -56,6 +57,8 @@ stdenv.mkDerivation rec {
       "-DLPCNET=ON"
     ];
 
+  passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+
   meta = with lib; {
     description = "Speech codec designed for communications quality speech at low data rates";
     homepage = "https://www.rowetel.com/codec2.html";
@@ -64,5 +67,6 @@ stdenv.mkDerivation rec {
     maintainers = with maintainers; [ markuskowa ];
     # generate_codebook only built for host platform
     broken = !stdenv.buildPlatform.canExecute stdenv.hostPlatform;
+    pkgConfigModules = [ "codec2" ];
   };
-}
+})


### PR DESCRIPTION
Fixes https://github.com/NixOS/nixpkgs/issues/403011

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
