### PR TITLE
zoom-us: allow to select xdg-desktop-portal packages

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -357,6 +357,7 @@
   ./programs/ydotool.nix
   ./programs/yubikey-touch-detector.nix
   ./programs/zmap.nix
+  ./programs/zoom-us.nix
   ./programs/zoxide.nix
   ./programs/zsh/oh-my-zsh.nix
   ./programs/zsh/zsh-autoenv.nix

--- a/nixos/modules/programs/zoom-us.nix
+++ b/nixos/modules/programs/zoom-us.nix
@@ -1,0 +1,63 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+{
+  options.programs.zoom-us = {
+    enable = lib.mkEnableOption "zoom.us video conferencing application";
+    package = lib.mkPackageOption pkgs "zoom-us" { };
+  };
+
+  config.environment.systemPackages = lib.mkIf config.programs.zoom-us.enable (
+    lib.singleton (
+      # The pattern here is to use the already-overridden value, or provide a default based on the
+      # configuration elsewhere.
+      config.programs.zoom-us.package.override (prev: {
+        # Support pulseaudio if it's enabled on the system.
+        pulseaudioSupport = prev.pulseaudioSupport or config.services.pulseaudio.enable;
+
+        # Support Plasma 6 desktop environment if it's enabled on the system.
+        plasma6XdgDesktopPortalSupport =
+          prev.plasma6XdgDesktopPortalSupport or config.services.desktopManager.plasma6.enable;
+
+        # Support Plasma 5 desktop environment if it's enabled on the system.
+        plasma5XdgDesktopPortalSupport =
+          prev.plasma5XdgDesktopPortalSupport or config.services.xserver.desktopManager.plasma5.enable;
+
+        # Support LXQT desktop environment if it's enabled on the system.
+        # There's also `config.services.xserver.desktopManager.lxqt.enable`
+        lxqtXdgDesktopPortalSupport = prev.lxqtXdgDesktopPortalSupport or config.xdg.portal.lxqt.enable;
+
+        # Support GNOME desktop environment if it's enabled on the system.
+        gnomeXdgDesktopPortalSupport =
+          prev.gnomeXdgDesktopPortalSupport or config.services.xserver.desktopManager.gnome.enable;
+
+        # Support Hyprland desktop for Wayland if it's enabled on the system.
+        hyprlandXdgDesktopPortalSupport =
+          prev.hyprlandXdgDesktopPortalSupport or config.programs.hyprland.enable;
+
+        # Support `wlroots` XDG desktop portal support if it's enabled.
+        wlrXdgDesktopPortalSupport = prev.wlrXdgDesktopPortalSupport or config.xdg.portal.wlr.enable;
+
+        # Support xapp XDG desktop portals if the Cinnamon desktop environment is enabled.
+        # The site claims that it's also used for Xfce4 and MATE; consider adding those to the
+        # default in the future.
+        xappXdgDesktopPortalSupport =
+          prev.xappXdgDesktopPortalSupport or config.services.xserver.desktopManager.cinnamon.enable;
+
+        # Finally, if the `xdg.portal.enable` option is set somehow, use the `targetPkgs` function
+        # to add those relevant packages in.
+        targetPkgs =
+          prev.targetPkgs or (
+            pkgs:
+            lib.optionals config.xdg.portal.enable (
+              [ pkgs.xdg-desktop-portal ] ++ config.xdg.portal.extraPortals
+            )
+          );
+      })
+    )
+  );
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1503,6 +1503,7 @@ in
   zipline = runTest ./zipline.nix;
   zoneminder = runTest ./zoneminder.nix;
   zookeeper = runTest ./zookeeper.nix;
+  zoom-us = runTest ./zoom-us.nix;
   zram-generator = runTest ./zram-generator.nix;
   zrepl = runTest ./zrepl.nix;
   zsh-history = runTest ./zsh-history.nix;

--- a/nixos/tests/zoom-us.nix
+++ b/nixos/tests/zoom-us.nix
@@ -1,0 +1,18 @@
+{ hostPkgs, lib, ... }:
+{
+  name = "zoom-us";
+
+  nodes.machine =
+    { pkgs, ... }:
+    {
+      imports = [ ./common/x11.nix ];
+      programs.zoom-us.enable = true;
+    };
+
+  testScript = ''
+    machine.succeed("which zoom")  # fail early if this is missing
+    machine.wait_for_x()
+    machine.execute("zoom >&2 &")
+    machine.wait_for_window("Zoom Workplace")
+  '';
+}

--- a/pkgs/by-name/zo/zoom-us/package.nix
+++ b/pkgs/by-name/zo/zoom-us/package.nix
@@ -6,6 +6,7 @@
   xar,
   cpio,
   callPackage,
+  nixosTests,
   buildFHSEnv,
 
   # Support pulseaudio by default
@@ -141,6 +142,7 @@ let
 
     passthru.updateScript = ./update.sh;
     passthru.tests.startwindow = callPackage ./test.nix { };
+    passthru.tests.nixos-module = nixosTests.zoom-us;
 
     meta = {
       homepage = "https://zoom.us/";

--- a/pkgs/by-name/zo/zoom-us/package.nix
+++ b/pkgs/by-name/zo/zoom-us/package.nix
@@ -5,10 +5,51 @@
   makeWrapper,
   xar,
   cpio,
-  pulseaudioSupport ? true,
-  xdgDesktopPortalSupport ? true,
   callPackage,
   buildFHSEnv,
+
+  # Support pulseaudio by default
+  pulseaudioSupport ? true,
+
+  # Whether to support XDG portals at all
+  xdgDesktopPortalSupport ? (
+    plasma6XdgDesktopPortalSupport
+    || plasma5XdgDesktopPortalSupport
+    || lxqtXdgDesktopPortalSupport
+    || gnomeXdgDesktopPortalSupport
+    || hyprlandXdgDesktopPortalSupport
+    || wlrXdgDesktopPortalSupport
+    || xappXdgDesktopPortalSupport
+  ),
+
+  # This is Plasma 6 (KDE) XDG portal support
+  plasma6XdgDesktopPortalSupport ? false,
+
+  # This is Plasma 5 (KDE) XDG portal support
+  plasma5XdgDesktopPortalSupport ? false,
+
+  # This is LXQT XDG portal support
+  lxqtXdgDesktopPortalSupport ? false,
+
+  # This is GNOME XDG portal support
+  gnomeXdgDesktopPortalSupport ? false,
+
+  # This is Hyprland XDG portal support
+  hyprlandXdgDesktopPortalSupport ? false,
+
+  # This is `wlroots` XDG portal support
+  wlrXdgDesktopPortalSupport ? false,
+
+  # This is Xapp XDG portal support, used for GTK and various Cinnamon/MATE/Xfce4 infrastructure.
+  xappXdgDesktopPortalSupport ? false,
+
+  # This function can be overridden to add in extra packages
+  targetPkgs ? pkgs: [ ],
+
+  # This list can be overridden to add in extra packages
+  # that are independent of the underlying package attrset
+  targetPkgsFixed ? [ ],
+
 }:
 
 let
@@ -179,17 +220,19 @@ let
       pkgs.libpulseaudio
       pkgs.pulseaudio
     ]
-    ++ lib.optionals xdgDesktopPortalSupport [
-      pkgs.kdePackages.xdg-desktop-portal-kde
-      pkgs.lxqt.xdg-desktop-portal-lxqt
-      pkgs.plasma5Packages.xdg-desktop-portal-kde
-      pkgs.xdg-desktop-portal
+    ++ lib.optional xdgDesktopPortalSupport pkgs.xdg-desktop-portal
+    ++ lib.optional plasma6XdgDesktopPortalSupport pkgs.kdePackages.xdg-desktop-portal-kde
+    ++ lib.optional plasma5XdgDesktopPortalSupport pkgs.plasma5Packages.xdg-desktop-portal-kde
+    ++ lib.optional lxqtXdgDesktopPortalSupport pkgs.lxqt.xdg-desktop-portal-lxqt
+    ++ lib.optionals gnomeXdgDesktopPortalSupport [
       pkgs.xdg-desktop-portal-gnome
       pkgs.xdg-desktop-portal-gtk
-      pkgs.xdg-desktop-portal-hyprland
-      pkgs.xdg-desktop-portal-wlr
-      pkgs.xdg-desktop-portal-xapp
-    ];
+    ]
+    ++ lib.optional hyprlandXdgDesktopPortalSupport pkgs.xdg-desktop-portal-hyprland
+    ++ lib.optional wlrXdgDesktopPortalSupport pkgs.xdg-desktop-portal-wlr
+    ++ lib.optional xappXdgDesktopPortalSupport pkgs.xdg-desktop-portal-xapp
+    ++ targetPkgs pkgs
+    ++ targetPkgsFixed;
 
   # We add the `unpacked` zoom archive to the FHS env
   # and also bind-mount its `/opt` directory.


### PR DESCRIPTION
## Things done

Implement what's been proposed in https://github.com/NixOS/nixpkgs/pull/397036#discussion_r2068124261 .  It wants a *function* that returns a list, not a simple list of packages.  Please see the commit message for details.

Note: I cannot really test this as I'm not using xdg-desktop-portal at all.

Notifying discussion participants: @philiptaron @gvolpe

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc