### PR TITLE
openapi-down-convert: init at 0.14.1

### DIFF
--- a/pkgs/by-name/op/openapi-down-convert/package.nix
+++ b/pkgs/by-name/op/openapi-down-convert/package.nix
@@ -1,0 +1,45 @@
+{
+  lib,
+  fetchFromGitHub,
+  buildNpmPackage,
+  nodejs,
+  versionCheckHook,
+  nix-update-script,
+}:
+
+buildNpmPackage (finalAttrs: {
+  pname = "openapi-down-convert";
+  version = "0.14.1";
+
+  src = fetchFromGitHub {
+    owner = "apiture";
+    repo = "openapi-down-convert";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-8csxj2HfOb9agDmwNmksNaiQhRd+3D1tf0vWU2w+XWw=";
+  };
+
+  npmDepsHash = "sha256-5VgFAiphahDKz3ZhzNEdQOFxvhvDy+S/qOClqBgMzSg=";
+
+  postInstall = ''
+    find $out/lib -type f \( -name '*.ts' \) -delete
+    rm -r $out/lib/node_modules/@apiture/openapi-down-convert/node_modules/typescript
+    rm $out/lib/node_modules/@apiture/openapi-down-convert/node_modules/.bin/*
+  '';
+
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+  versionCheckProgramArg = "--version";
+  doInstallCheck = true;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Convert an OpenAPI 3.1.x document to OpenAPI 3.0.x format";
+    homepage = "https://github.com/apiture/openapi-down-convert";
+    changelog = "https://github.com/apiture/openapi-down-convert/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.isc;
+    maintainers = with lib.maintainers; [ fliegendewurst ];
+    mainProgram = "openapi-down-convert";
+  };
+})


### PR DESCRIPTION
https://github.com/apiture/openapi-down-convert

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).