### PR TITLE
libiec61850: Add mbedtls support

### DIFF
--- a/pkgs/by-name/li/libiec61850/package.nix
+++ b/pkgs/by-name/li/libiec61850/package.nix
@@ -1,9 +1,11 @@
 {
   cmake,
+  mbedtls,
   lib,
   stdenv,
   fetchFromGitHub,
   gitUpdater,
+  withTls ? !stdenv.hostPlatform.isDarwin,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -19,7 +21,14 @@ stdenv.mkDerivation (finalAttrs: {
 
   separateDebugInfo = true;
 
+  cmakeFlags = lib.optionals withTls [
+    "-DCONFIG_USE_EXTERNAL_MBEDTLS_DYNLIB=ON"
+    "-DCONFIG_EXTERNAL_MBEDTLS_DYNLIB_PATH=${mbedtls}/lib"
+    "-DCONFIG_EXTERNAL_MBEDTLS_INCLUDE_PATH=${mbedtls}/include"
+  ];
+
   nativeBuildInputs = [ cmake ];
+  buildInputs = lib.optionals withTls [ mbedtls ];
 
   passthru.updateScript = gitUpdater { rev-prefix = "v"; };
 
@@ -27,7 +36,10 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Open-source library for the IEC 61850 protocols";
     homepage = "https://libiec61850.com/";
     license = lib.licenses.gpl3Only;
-    maintainers = with lib.maintainers; [ stv0g pjungkamp ];
+    maintainers = with lib.maintainers; [
+      stv0g
+      pjungkamp
+    ];
     platforms = lib.platforms.unix;
   };
 })

--- a/pkgs/by-name/li/libiec61850/package.nix
+++ b/pkgs/by-name/li/libiec61850/package.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Open-source library for the IEC 61850 protocols";
     homepage = "https://libiec61850.com/";
     license = lib.licenses.gpl3Only;
-    maintainers = with lib.maintainers; [ stv0g ];
+    maintainers = with lib.maintainers; [ stv0g pjungkamp ];
     platforms = lib.platforms.unix;
   };
 })


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

I want to use the experimental R-GOOSE and R-SV capabilities of `libiec61850`, but these rely on the `RSession` type which is only available if `libiec61850` is compiled with `mbedtls`.

I configured `cmake` to use the version of `mbedtls` packaged in Nixpkgs.

@stv0g Didn't you want to do something similar anyway? 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
