### PR TITLE
gomi: embed version information

### DIFF
--- a/pkgs/by-name/go/gomi/package.nix
+++ b/pkgs/by-name/go/gomi/package.nix
@@ -19,6 +19,15 @@ buildGoModule rec {
 
   subPackages = [ "." ];
 
+  # https://github.com/babarot/gomi/blob/v1.6.0/.goreleaser.yaml#L20-L22
+  ldflags = [
+    "-X main.version=v${version}"
+    # cd path/to/gomi; git switch -d "v${version}"; git show --format='%h' HEAD --quiet
+    "-X main.revision=da44e9f"
+    # cd path/to/gomi; git switch -d "v${version}"; date --date="@$(git show --format='%ct' HEAD --quiet)" --utc +'%Y-%m-%dT%H:%M:%SZ'
+    "-X main.buildDate=2025-03-17T05:38:26Z"
+  ];
+
   meta = {
     description = "Replacement for UNIX rm command";
     homepage = "https://github.com/b4b4r07/gomi";

--- a/pkgs/by-name/go/gomi/package.nix
+++ b/pkgs/by-name/go/gomi/package.nix
@@ -12,21 +12,31 @@ buildGoModule rec {
     owner = "b4b4r07";
     repo = "gomi";
     tag = "v${version}";
-    hash = "sha256-FZCvUG6lQH8CFivV/hbIgGQx4FCk1UtreiWXTQVi4+4=";
+    hash = "sha256-0C+us4GO8Jd51ATaaf0aRU3NnhmDvu0I3qDDXBoaiXU=";
+    # populate values that require us to use git. By doing this in postFetch we
+    # can delete .git afterwards and maintain better reproducibility of the src.
+    leaveDotGit = true;
+    postFetch = ''
+      cd $out
+      git show --format='%h' HEAD --quiet > ldflags_revision
+      date --utc --date="@$(git show --format='%ct' HEAD --quiet)" +'%Y-%m-%dT%H:%M:%SZ' > ldflags_buildDate
+      find . -type d -name .git -print0 | xargs -0 rm -rf
+    '';
   };
 
   vendorHash = "sha256-8aw81DKBmgNsQzgtHCsUkok5e5+LeAC8BUijwKVT/0s=";
 
   subPackages = [ "." ];
 
+  # Add version information fetched from the repository to ldflags.
   # https://github.com/babarot/gomi/blob/v1.6.0/.goreleaser.yaml#L20-L22
   ldflags = [
     "-X main.version=v${version}"
-    # cd path/to/gomi; git switch -d "v${version}"; git show --format='%h' HEAD --quiet
-    "-X main.revision=da44e9f"
-    # cd path/to/gomi; git switch -d "v${version}"; date --date="@$(git show --format='%ct' HEAD --quiet)" --utc +'%Y-%m-%dT%H:%M:%SZ'
-    "-X main.buildDate=2025-03-17T05:38:26Z"
   ];
+  preBuild = ''
+    ldflags+=" -X main.revision=$(cat ldflags_revision)"
+    ldflags+=" -X main.buildDate=$(cat ldflags_buildDate)"
+  '';
 
   meta = {
     description = "Replacement for UNIX rm command";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Summary

Embed version information on the binary as the pre-built binaries distributed in GitHub's release pages have.


### Results of `gomi --version`

#### Gomi built by Nix

```
$ gomi --version
gomi - a CLI trash manager
https://gomi.dev

version: (devel)
revision: unset
buildDate: unknown
```

#### Gomi distributed in GitHub's release page

https://github.com/babarot/gomi/releases/tag/v1.6.0

```
$ gomi --version
gomi - a CLI trash manager
https://gomi.dev

version: v1.6.0
revision: da44e9f
buildDate: 2025-03-17T05:38:26Z
```

#### Gomi built by Nix with this PR's change

```
$ result/bin/gomi --version
gomi - a CLI trash manager
https://gomi.dev

version: v1.6.0
revision: da44e9f
buildDate: 2025-03-17T05:38:26Z
```



## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
