### PR TITLE
ninja: refactor version,src

### DIFF
--- a/pkgs/by-name/ni/ninja/package.nix
+++ b/pkgs/by-name/ni/ninja/package.nix
@@ -17,26 +17,25 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "ninja";
-  version = lib.removePrefix "v" finalAttrs.src.rev;
-
-  src =
+  version =
     {
-      # TODO: Remove Ninja 1.11 as soon as possible.
-      "1.11" = fetchFromGitHub {
-        owner = "ninja-build";
-        repo = "ninja";
-        rev = "v1.11.1";
-        hash = "sha256-LvV/Fi2ARXBkfyA1paCRmLUwCh/rTyz+tGMg2/qEepI=";
-      };
-
-      latest = fetchFromGitHub {
-        owner = "ninja-build";
-        repo = "ninja";
-        rev = "v1.12.1";
-        hash = "sha256-RT5u+TDvWxG5EVQEYj931EZyrHUSAqK73OKDAascAwA=";
-      };
+      "1.11" = "1.11.1";
+      latest = "1.12.1";
     }
-    .${ninjaRelease} or (throw "Unsupported Ninja release: ${ninjaRelease}");
+    .${ninjaRelease};
+
+  src = fetchFromGitHub {
+    owner = "ninja-build";
+    repo = "ninja";
+    rev = "v${finalAttrs.version}";
+    hash =
+      {
+        # TODO: Remove Ninja 1.11 as soon as possible.
+        "1.11" = "sha256-LvV/Fi2ARXBkfyA1paCRmLUwCh/rTyz+tGMg2/qEepI=";
+        latest = "sha256-RT5u+TDvWxG5EVQEYj931EZyrHUSAqK73OKDAascAwA=";
+      }
+      .${ninjaRelease} or (throw "Unsupported Ninja release: ${ninjaRelease}");
+  };
 
   depsBuildBuild = [ buildPackages.stdenv.cc ];
 


### PR DESCRIPTION
This PR fixes a problem with `nix-prefetch` (and thus a number of update
scripts) where it would throw the following error when run in nixpkgs:
```
error: attribute 'rev' missing
at pkgs/by-name/ni/ninja/package.nix:19:34:
   18|   pname = "ninja";
   19|   version = lib.removePrefix "v" finalAttrs.src.rev;
     |                                  ^
```

This seems to be caused by an oversight where `nix-prefetch` overrides
`fetchFromGitHub` in a weird way, where `rev` is not returned, but so far this
is the only package that is triggering this bug. The related issue in
`nix-prefetch` is still unhandled, hence this change.

See: msteen/nix-prefetch#54 #403032

cc @thoughtpolice @bjornfor @orivej

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
