### PR TITLE
python312Packages.pyiceberg: 0.9.0 -> 0.9.1

### DIFF
--- a/pkgs/development/python-modules/pyiceberg/default.nix
+++ b/pkgs/development/python-modules/pyiceberg/default.nix
@@ -55,14 +55,14 @@
 
 buildPythonPackage rec {
   pname = "iceberg-python";
-  version = "0.9.0";
+  version = "0.9.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "apache";
     repo = "iceberg-python";
     tag = "pyiceberg-${version}";
-    hash = "sha256-PLxYe6MpKR6qILTNt0arujyx/nlVorwjhwokbXvdwb0=";
+    hash = "sha256-OUj8z/UOIcK0S4tf6Id52YHweNDfYnX6P4nChXrOxqY=";
   };
 
   patches = [
@@ -81,6 +81,10 @@ buildPythonPackage rec {
 
   # Prevents the cython build to fail silently
   env.CIBUILDWHEEL = "1";
+
+  pythonRelaxDeps = [
+    "rich"
+  ];
 
   dependencies = [
     cachetools
@@ -189,6 +193,10 @@ buildPythonPackage rec {
 
   disabledTests =
     [
+      # ModuleNotFoundError: No module named 'puresasl'
+      "test_create_hive_client_with_kerberos"
+      "test_create_hive_client_with_kerberos_using_context_manager"
+
       # Require unpackaged pyiceberg_core
       "test_bucket_pyarrow_transforms"
       "test_transform_consistency_with_pyarrow_transform"
@@ -219,34 +227,6 @@ buildPythonPackage rec {
       "test_partitioned_write"
       "test_token_200_w_oauth2_server_uri"
 
-      # TypeError: pyarrow.lib.large_list() takes no keyword argument
-      # From tests/io/test_pyarrow_stats.py:
-      "test_bounds"
-      "test_column_metrics_mode"
-      "test_column_sizes"
-      "test_metrics_mode_counts"
-      "test_metrics_mode_full"
-      "test_metrics_mode_non_default_trunc"
-      "test_metrics_mode_none"
-      "test_null_and_nan_counts"
-      "test_offsets"
-      "test_read_missing_statistics"
-      "test_record_count"
-      "test_value_counts"
-      "test_write_and_read_stats_schema"
-      # From tests/io/test_pyarrow.py:
-      "test_list_type_to_pyarrow"
-      "test_projection_add_column"
-      "test_projection_list_of_structs"
-      "test_read_list"
-      "test_schema_compatible_missing_nullable_field_nested"
-      "test_schema_compatible_nested"
-      "test_schema_mismatch_missing_required_field_nested"
-      "test_schema_to_pyarrow_schema_exclude_field_ids"
-      "test_schema_to_pyarrow_schema_include_field_ids"
-      # From tests/io/test_pyarrow_visitor.py
-      "test_round_schema_conversion_nested"
-
       # Hangs forever (from tests/io/test_pyarrow.py)
       "test_getting_length_of_file_gcs"
     ]
@@ -255,6 +235,11 @@ buildPythonPackage rec {
       "test_converting_an_outputfile_to_an_inputfile_gcs"
       "test_new_input_file_gcs"
       "test_new_output_file_gc"
+
+      # PermissionError: [Errno 13] Failed to open local file
+      # '/tmp/iceberg/warehouse/default.db/test_projection_partitions/metadata/00000-6c1c61a1-495f-45d3-903d-a2643431be91.metadata.json'
+      "test_identity_transform_column_projection"
+      "test_identity_transform_columns_projection"
     ];
 
   __darwinAllowLocalNetworking = true;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Diff: https://github.com/apache/iceberg-python/compare/refs/tags/pyiceberg-0.9.0...pyiceberg-0.9.1
Changelog: https://github.com/apache/iceberg-python/releases/tag/pyiceberg-0.9.1
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
