### PR TITLE
etcd_3_6: init 3.6.0-rc.4

### DIFF
--- a/pkgs/by-name/et/etcd_3_6/package.nix
+++ b/pkgs/by-name/et/etcd_3_6/package.nix
@@ -1,0 +1,113 @@
+{
+  lib,
+  buildGo123Module,
+  fetchFromGitHub,
+  symlinkJoin,
+  nixosTests,
+  k3s,
+}:
+
+let
+  # pinned buildGoModule to avoid checkphase errors, remove this when upgrading
+  buildGoModule = buildGo123Module;
+
+  version = "3.6.0-rc.4";
+  etcdSrcHash = "sha256-OGfokFjgSC97Hb9wHifIDevLDrronh/VDaUR8r2hNXU=";
+  etcdServerVendorHash = "sha256-TusJgTKn66D4LHr9Q9/V0jpJ3OR7g2t7T/JWQchWphk=";
+  etcdUtlVendorHash = "sha256-0yKBVwkhfkAc5f3uE2F93nHRJks7YvPQJNTFkdpBGO4=";
+  etcdCtlVendorHash = "sha256-lMsEadoK6u6gwj3Or/UaTjCy2eJHKjAhPLuA/LZwqLI=";
+
+  src = fetchFromGitHub {
+    owner = "etcd-io";
+    repo = "etcd";
+    rev = "v${version}";
+    hash = etcdSrcHash;
+  };
+
+  env = {
+    CGO_ENABLED = 0;
+  };
+
+  meta = with lib; {
+    description = "Distributed reliable key-value store for the most critical data of a distributed system";
+    license = licenses.asl20;
+    homepage = "https://etcd.io/";
+    maintainers = with maintainers; [ offline ];
+    platforms = platforms.darwin ++ platforms.linux;
+  };
+
+  etcdserver = buildGoModule {
+    pname = "etcdserver";
+
+    inherit
+      env
+      meta
+      src
+      version
+      ;
+
+    vendorHash = etcdServerVendorHash;
+
+    modRoot = "./server";
+
+    preInstall = ''
+      mv $GOPATH/bin/{server,etcd}
+    '';
+
+    # We set the GitSHA to `GitNotFound` to match official build scripts when
+    # git is unavailable. This is to avoid doing a full Git Checkout of etcd.
+    # User facing version numbers are still available in the binary, just not
+    # the sha it was built from.
+    ldflags = [ "-X go.etcd.io/etcd/api/v3/version.GitSHA=GitNotFound" ];
+  };
+
+  etcdutl = buildGoModule rec {
+    pname = "etcdutl";
+
+    inherit
+      env
+      meta
+      src
+      version
+      ;
+
+    vendorHash = etcdUtlVendorHash;
+
+    modRoot = "./etcdutl";
+  };
+
+  etcdctl = buildGoModule rec {
+    pname = "etcdctl";
+
+    inherit
+      env
+      meta
+      src
+      version
+      ;
+
+    vendorHash = etcdCtlVendorHash;
+
+    modRoot = "./etcdctl";
+  };
+in
+symlinkJoin {
+  name = "etcd-${version}";
+
+  inherit meta version;
+
+  passthru = {
+    inherit etcdserver etcdutl etcdctl;
+    tests = {
+      inherit (nixosTests) etcd etcd-cluster;
+      k3s = k3s.passthru.tests.etcd;
+    };
+    updateScript = ./update.sh;
+  };
+
+  paths = [
+    etcdserver
+    etcdutl
+    etcdctl
+  ];
+}

--- a/pkgs/by-name/et/etcd_3_6/update.sh
+++ b/pkgs/by-name/et/etcd_3_6/update.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p curl gnugrep gnused jq nurl
+
+set -x -eu -o pipefail
+
+MAJOR_VERSION=3
+MINOR_VERSION=6
+
+ETCD_PATH="$(dirname "$0")"
+ETCD_VERSION_MAJOR_MINOR=${MAJOR_VERSION}.${MINOR_VERSION}
+ETCD_PKG_NAME=etcd_${MAJOR_VERSION}_${MINOR_VERSION}
+NIXPKGS_PATH="$(git rev-parse --show-toplevel)"
+
+LATEST_TAG=$(curl ${GITHUB_TOKEN:+" -u \":$GITHUB_TOKEN\""} \
+    --silent https://api.github.com/repos/etcd-io/etcd/releases \
+    | jq -r 'map(select(.prerelease == false))' \
+    | jq -r 'map(.tag_name)' \
+    | grep "v${ETCD_VERSION_MAJOR_MINOR}." \
+    | sed 's|[", ]||g' \
+    | sort -rV | head -n1 )
+
+LATEST_VERSION=$(echo ${LATEST_TAG} | sed 's/^v//')
+
+OLD_VERSION="$(nix-instantiate --eval -E "with import $NIXPKGS_PATH {}; \
+    $ETCD_PKG_NAME.version or (builtins.parseDrvName $ETCD_PKG_NAME.name).version" | tr -d '"')"
+
+if [ ! "$OLD_VERSION" = "$LATEST_VERSION" ]; then
+    echo "Attempting to update etcd from $OLD_VERSION to $LATEST_VERSION"
+    ETCD_SRC_HASH=$(nix-prefetch-url --quiet --unpack https://github.com/etcd-io/etcd/archive/refs/tags/${LATEST_TAG}.tar.gz)
+    ETCD_SRC_HASH=$(nix hash to-sri --type sha256 $ETCD_SRC_HASH)
+
+    setKV () {
+        sed -i "s|$1 = \".*\"|$1 = \"${2:-}\"|" "$ETCD_PATH/default.nix"
+    }
+
+    setKV version $LATEST_VERSION
+    setKV etcdSrcHash $ETCD_SRC_HASH
+
+    getAndSetVendorHash () {
+        local EMPTY_HASH="sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=" # Hash from lib.fakeHash
+        local VENDOR_HASH=$EMPTY_HASH
+        local PKG_KEY=$1
+        local INNER_PKG=$2
+
+        setKV $PKG_KEY $EMPTY_HASH
+
+        set +e
+        VENDOR_HASH=$(nurl -e "(import ${NIXPKGS_PATH}/. {}).$ETCD_PKG_NAME.passthru.$INNER_PKG.goModules")
+        set -e
+
+        if [ -n "${VENDOR_HASH:-}" ]; then
+            setKV $PKG_KEY $VENDOR_HASH
+        else
+            echo "Update failed. $PKG_KEY is empty."
+            exit 1
+        fi
+    }
+
+    getAndSetVendorHash etcdServerVendorHash etcdserver
+    getAndSetVendorHash etcdUtlVendorHash etcdutl
+    getAndSetVendorHash etcdCtlVendorHash etcdctl
+
+    # `git` flag here is to be used by local maintainers to speed up the bump process
+    if [ $# -eq 1 ] && [ "$1" = "git" ]; then
+        git switch -c "package-$ETCD_PKG_NAME-$LATEST_VERSION"
+        git add "$ETCD_PATH"/default.nix
+        git commit -m "$ETCD_PKG_NAME: $OLD_VERSION -> $LATEST_VERSION
+
+Release: https://github.com/etcd-io/etcd/releases/tag/$LATEST_TAG"
+    fi
+
+else
+    echo "etcd is already up-to-date at $OLD_VERSION"
+fi


### PR DESCRIPTION
etcd_3_6: init 3.6.0-rc.4

https://github.com/etcd-io/etcd/releases/tag/v3.6.0-rc.4

https://github.com/etcd-io/etcd/blob/main/CHANGELOG/CHANGELOG-3.6.md

Notes:
- This is a pre-release version. But this will automatically update fine once the release version lands. So what we are doing here is scaffolding and testing [package & update script] for it.

CC @dtomvan @offline @cafkafk @illustris

Pending:
- add shell completion