### PR TITLE
libsupermesh: init at 2025.3.0

### DIFF
--- a/pkgs/by-name/li/libsupermesh/package.nix
+++ b/pkgs/by-name/li/libsupermesh/package.nix
@@ -1,0 +1,77 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  validatePkgConfig,
+  gfortran,
+  mpi,
+  cmake,
+  ninja,
+  libspatialindex,
+  mpiCheckPhaseHook,
+  testers,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "libsupermesh";
+  version = "2025.3.0";
+
+  src = fetchFromGitHub {
+    owner = "firedrakeproject";
+    repo = "libsupermesh";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-RKBi89bUhkbRATaSB8629D+/NeYE3YNDIMEGzSK8z04=";
+  };
+
+  strictDeps = true;
+
+  outputs = [
+    "out"
+    "dev"
+  ];
+
+  nativeBuildInputs = [
+    mpi
+    gfortran
+    cmake
+    ninja
+    validatePkgConfig
+  ];
+
+  cmakeFlags = [
+    (lib.cmakeBool "BUILD_SHARED_LIBS" (!stdenv.hostPlatform.isStatic))
+  ];
+
+  buildInputs = [
+    libspatialindex
+    gfortran.cc.lib
+  ];
+
+  __darwinAllowLocalNetworking = true;
+
+  nativeCheckInputs = [ mpiCheckPhaseHook ];
+
+  # On aarch64-darwin platform, the test program segfault at the line
+  # https://github.com/firedrakeproject/libsupermesh/blob/09af7c9a3beefc715fbdc23e46fdc96da8169ff6/src/tests/test_parallel_p1_inner_product_2d.F90#L164
+  # in defining the lambda subroutine pack_data_b with variable field_b.
+  # This error is test source and compiler related and does not indicate broken functionality of libsupermesh.
+  doCheck = !(stdenv.hostPlatform.system == "aarch64-darwin");
+
+  passthru = {
+    tests = {
+      pkg-config = testers.hasPkgConfigModules {
+        package = finalAttrs.finalPackage;
+      };
+    };
+  };
+
+  meta = {
+    homepage = "https://github.com/firedrakeproject/libsupermesh";
+    description = "Parallel supermeshing library";
+    changelog = "https://github.com/firedrakeproject/libsupermesh/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.lgpl2Plus;
+    platforms = lib.platforms.unix;
+    maintainers = with lib.maintainers; [ qbisi ];
+    pkgConfigModules = [ "libsupermesh" ];
+  };
+})

--- a/pkgs/development/python-modules/libsupermesh/default.nix
+++ b/pkgs/development/python-modules/libsupermesh/default.nix
@@ -1,0 +1,48 @@
+{
+  lib,
+  pkgs,
+  buildPythonPackage,
+  fetchFromGitHub,
+  scikit-build-core,
+  gfortran,
+  cmake,
+  ninja,
+  mpi,
+  libspatialindex,
+  rtree,
+}:
+
+buildPythonPackage rec {
+  inherit (pkgs.libsupermesh)
+    pname
+    version
+    src
+    meta
+    ;
+  pyproject = true;
+
+  build-system = [
+    scikit-build-core
+  ];
+
+  nativeBuildInputs = [
+    gfortran
+    cmake
+    ninja
+    mpi
+  ];
+
+  dontUseCmakeConfigure = true;
+
+  buildInputs = [
+    libspatialindex
+    gfortran.cc.lib
+  ];
+
+  dependencies = [
+    rtree
+  ];
+
+  # Only build tests if not built by scikit-build-core
+  doCheck = false;
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7912,6 +7912,8 @@ self: super: with self; {
 
   libsoundtouch = callPackage ../development/python-modules/libsoundtouch { };
 
+  libsupermesh = callPackage ../development/python-modules/libsupermesh { };
+
   libthumbor = callPackage ../development/python-modules/libthumbor { };
 
   libtmux = callPackage ../development/python-modules/libtmux { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
