### PR TITLE
python3Packages.fitparse: init at 1.2.0; garmin-grafana: init at 0.3.0

### DIFF
--- a/pkgs/by-name/ga/garmin-grafana/package.nix
+++ b/pkgs/by-name/ga/garmin-grafana/package.nix
@@ -1,0 +1,54 @@
+{
+  fetchFromGitHub,
+  python3Packages,
+  lib,
+}:
+python3Packages.buildPythonPackage rec {
+  pname = "garmin-grafana";
+  version = "0.3.0";
+
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "arpanghosh8453";
+    repo = "garmin-grafana";
+    tag = "v${version}";
+    hash = "sha256-nuVT6LK9KIs/FwUbdfI4xpKru4jfAyj1/vmk7ji43zk=";
+  };
+
+  build-system = with python3Packages; [
+    setuptools
+  ];
+
+  dependencies = with python3Packages; [
+    fitparse
+    garminconnect
+    influxdb
+    influxdb3-python
+    python-dotenv
+  ];
+
+  doCheck = false; # there are no tests
+
+  dontCheckRuntimeDeps = true;
+
+  postInstall = ''
+    install -Dt $out/share/grafana-dashboards -m644 Grafana_Dashboard/Garmin-Grafana-Dashboard.json
+  '';
+
+  passthru.grafana-dashboard = "${placeholder "out"}/share/grafana-dashboards/Garmin-Grafana-Dashboard.json";
+
+  meta = {
+    description = "Export Garmin data to InfluxDB";
+    longDescription = ''
+      A Python script to fetch Garmin health data and populate that in an InfluxDB database,
+      for visualizing long-term health trends with Grafana
+    '';
+    homepage = "https://github.com/arpanghosh8453/garmin-grafana";
+    changelog = "https://github.com/arpanghosh8453/garmin-grafana/releases/tag/v${version}";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ aciceri ];
+    mainProgram = "garmin-fetch";
+    platforms = lib.platforms.linux;
+  };
+}

--- a/pkgs/development/python-modules/fitparse/default.nix
+++ b/pkgs/development/python-modules/fitparse/default.nix
@@ -1,0 +1,40 @@
+{
+  buildPythonPackage,
+  fetchFromGitHub,
+  pytestCheckHook,
+  lib,
+  setuptools,
+}:
+buildPythonPackage rec {
+  pname = "fitparse";
+  version = "1.2.0";
+
+  pyproject = true;
+  build-system = [ setuptools ];
+
+  src = fetchFromGitHub {
+    owner = "dtcooper";
+    repo = "python-fitparse";
+    tag = "v${version}";
+    hash = "sha256-aO4djG9omc0jogalLitvT5i58cYKXqtvJ5WGBiCv448=";
+  };
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  disabledTests = [
+    "test_utils"
+  ];
+
+  pythonImportsCheck = [
+    "fitparse"
+  ];
+
+  meta = {
+    description = "Python library to parse ANT/Garmin .FIT files";
+    homepage = "https://pythonhosted.org/fitparse/";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ aciceri ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5384,6 +5384,8 @@ self: super: with self; {
 
   fitfile = callPackage ../development/python-modules/fitfile { };
 
+  fitparse = callPackage ../development/python-modules/fitparse { };
+
   fivem-api = callPackage ../development/python-modules/fivem-api { };
 
   fixerio = callPackage ../development/python-modules/fixerio { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Adding [garmin-grafana](https://github.com/arpanghosh8453/garmin-grafana) and `fitparse`, a dependency which was missing from nixpkgs.
Apparently `influxdb3-python` (already pacakged in nixpkgs) depends on `pyarrow` which is built without ORC, there is already [an issue](https://github.com/NixOS/nixpkgs/issues/212863) years old. I've tried enabling ORC in `pyarrow` without luck and at the end I chose to download `pyarrow` as prebuilt wheel, it's not optimal but it seems to work well.

I'm leaving this as a draft for a few days until the version `0.1.0` is out ([a few days according to the author](https://github.com/arpanghosh8453/garmin-grafana/pull/70#issuecomment-2842580019)). As soon as it's released I'll change the `rev` and mark it as ready.

I've tried running this both on `x86_64-linux` and `aarch64-linux`.

cc @arpanghosh8453

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [X] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
