### PR TITLE
[staging-next] Reanimate pandoc on i686

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -2602,7 +2602,28 @@ self: super:
   # Overly strict bounds on tasty-quickcheck (test suite) (< 0.11)
   hashable = doJailbreak super.hashable;
   # https://github.com/well-typed/cborg/issues/340
-  cborg = doJailbreak super.cborg;
+  cborg = lib.pipe super.cborg [
+    doJailbreak
+    # Fix build on 32-bit: https://github.com/well-typed/cborg/pull/322
+    (appendPatches (
+      lib.optionals pkgs.stdenv.hostPlatform.is32bit [
+        (pkgs.fetchpatch {
+          name = "cborg-i686-1.patch";
+          url = "https://github.com/well-typed/cborg/commit/a4757c46219afe6d235652ae642786f2e2977020.patch";
+          sha256 = "01n0x2l605x7in9hriz9asmzsfb5f8d6zkwgypckfj1r18qbs2hj";
+          includes = [ "**/Codec/CBOR/**" ];
+          stripLen = 1;
+        })
+        (pkgs.fetchpatch {
+          name = "cborg-i686-2.patch";
+          url = "https://github.com/well-typed/cborg/commit/94a856e4e544a5bc7f927cfb728de385d6260af4.patch";
+          sha256 = "03iz85gsll38q5bl3m024iv7yb1k5sisly7jvgf66zic8fbvkhcn";
+          includes = [ "**/Codec/CBOR/**" ];
+          stripLen = 1;
+        })
+      ]
+    ))
+  ];
   # Doesn't compile with tasty-quickcheck == 0.11 (see issue above)
   serialise = dontCheck super.serialise;
   # https://github.com/Bodigrim/data-array-byte/issues/1

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -3003,6 +3003,18 @@ self: super:
       url = "https://github.com/sjakobi/bsb-http-chunked/commit/689bf9ce12b8301d0e13a68e4a515c2779b62947.patch";
       sha256 = "sha256-ZdCXMhni+RGisRODiElObW5c4hKy2giWQmWnatqeRJo=";
     }))
+
+    # blaze-builder's code is missing the following fix, causing it to produce
+    # incorrect chunking on 32 bit platforms:
+    # https://github.com/sjakobi/bsb-http-chunked/commit/dde7c9fa33bb6e55b44c5f3e3024215475f64d4c
+    (overrideCabal (drv: {
+      testFlags =
+        drv.testFlags or [ ]
+        ++ lib.optionals pkgs.stdenv.hostPlatform.is32bit [
+          "-p"
+          "!/Identical output as Blaze/"
+        ];
+    }))
   ];
 
   # jailbreak to allow deepseq >= 1.5, https://github.com/jumper149/blucontrol/issues/3


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

I hate this ecosystem.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
