### PR TITLE
python3Packages.langchain*: Add providers for deepseek, anthropic, perplexity, xai, mistralai, and fireworks-ai

### DIFF
--- a/pkgs/development/python-modules/langchain-anthropic/default.nix
+++ b/pkgs/development/python-modules/langchain-anthropic/default.nix
@@ -1,0 +1,75 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  nix-update-script,
+
+  # build-system
+  pdm-backend,
+
+  # dependencies
+  anthropic,
+  langchain-core,
+  pydantic,
+
+  # tests
+  langchain-tests,
+  pytest-asyncio,
+  pytestCheckHook,
+}:
+
+buildPythonPackage rec {
+  pname = "langchain-anthropic";
+  version = "0.3.12";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "langchain-ai";
+    repo = "langchain";
+    tag = "langchain-anthropic==${version}";
+    hash = "sha256-UpyACv1cVzvK4A1Up3R6PqVQahy9hAu0LoSkaEen6Sw=";
+  };
+
+  sourceRoot = "${src.name}/libs/partners/anthropic";
+
+  build-system = [ pdm-backend ];
+
+  dependencies = [
+    anthropic
+    langchain-core
+    pydantic
+  ];
+
+  pythonRelaxDeps = [
+    # Each component release requests the exact latest core.
+    # That prevents us from updating individual components.
+    "langchain-core"
+  ];
+
+  nativeCheckInputs = [
+    langchain-tests
+    pytest-asyncio
+    pytestCheckHook
+  ];
+
+  pytestFlagsArray = [ "tests/unit_tests" ];
+
+  pythonImportsCheck = [ "langchain_anthropic" ];
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [
+      "--version-regex"
+      "langchain-anthropic==([0-9.]+)"
+    ];
+  };
+
+  meta = {
+    changelog = "https://github.com/langchain-ai/langchain-anthropic/releases/tag/langchain-anthropic==${version}";
+    description = "Build LangChain applications with Anthropic";
+    homepage = "https://github.com/langchain-ai/langchain/tree/master/libs/partners/anthropic";
+    license = lib.licenses.mit;
+    maintainers = [
+      lib.maintainers.sarahec
+    ];
+  };
+}

--- a/pkgs/development/python-modules/langchain-core/update.sh
+++ b/pkgs/development/python-modules/langchain-core/update.sh
@@ -5,17 +5,23 @@ set -euo pipefail
 
 declare -ar packages=(
     langchain
+    langchain-anthropic
     langchain-azure-dynamic-sessions
     langchain-chroma
     langchain-community
     langchain-core
+    langchain-deepseek
+    langchain-fireworks
     langchain-groq
     langchain-huggingface
+    langchain-mistralai
     langchain-mongodb
     langchain-ollama
     langchain-openai
+    langchain-perplexity
     langchain-tests
     langchain-text-splitters
+    langchain-xai
 )
 
 tags=$(git ls-remote --tags --refs "https://github.com/langchain-ai/langchain" | cut --delimiter=/ --field=3-)

--- a/pkgs/development/python-modules/langchain-deepseek/default.nix
+++ b/pkgs/development/python-modules/langchain-deepseek/default.nix
@@ -1,0 +1,79 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  # build-system
+  pdm-backend,
+  poetry-core,
+
+  # dependencies
+  langchain-core,
+  langchain-openai,
+
+  # testing
+  langchain-tests,
+  pytestCheckHook,
+  pytest-asyncio,
+  syrupy,
+
+  # passthru
+  nix-update-script,
+}:
+
+buildPythonPackage rec {
+  pname = "langchain-deepseek";
+  version = "0.1.3";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "langchain-ai";
+    repo = "langchain";
+    tag = "langchain-deepseek==${version}";
+    hash = "sha256-nkL8QO1H29sA6g61Hgt7QrRAfwD3t+0m5JEHyPx8B7Y=";
+  };
+
+  sourceRoot = "${src.name}/libs/partners/deepseek";
+
+  build-system = [
+    pdm-backend
+    poetry-core
+  ];
+
+  pythonRelaxDeps = [
+    # Each component release requests the exact latest core.
+    # That prevents us from updating individual components.
+    "langchain-core"
+  ];
+
+  dependencies = [
+    langchain-core
+    langchain-openai
+  ];
+
+  nativeCheckInputs = [
+    langchain-tests
+    pytestCheckHook
+    pytest-asyncio
+    syrupy
+  ];
+
+  pytestFlagsArray = [ "tests/unit_tests" ];
+
+  pythonImportsCheck = [ "langchain_deepseek" ];
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [
+      "--version-regex"
+      "langchain-deepseek==([0-9.]+)"
+    ];
+  };
+
+  meta = {
+    changelog = "https://github.com/langchain-ai/langchain/releases/tag/langchain-deepseek==${version}";
+    description = "Integration package connecting DeepSeek and LangChain";
+    homepage = "https://github.com/langchain-ai/langchain/tree/master/libs/partners/deepseek";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ sarahec ];
+  };
+}

--- a/pkgs/development/python-modules/langchain-fireworks/default.nix
+++ b/pkgs/development/python-modules/langchain-fireworks/default.nix
@@ -1,0 +1,79 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  nix-update-script,
+
+  # build-system
+  pdm-backend,
+
+  # dependencies
+  aiohttp,
+  fireworks-ai,
+  langchain-core,
+  openai,
+  pydantic,
+
+  # tests
+  langchain-tests,
+  pytest-asyncio,
+  pytestCheckHook,
+}:
+
+buildPythonPackage rec {
+  pname = "langchain-fireworks";
+  version = "0.3.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "langchain-ai";
+    repo = "langchain";
+    tag = "langchain-fireworks==${version}";
+    hash = "sha256-OZou323FAk2I4YuQV7sllbzDwFQWy/90FK3gIHnEBd0=";
+  };
+
+  sourceRoot = "${src.name}/libs/partners/fireworks";
+
+  build-system = [ pdm-backend ];
+
+  dependencies = [
+    aiohttp
+    fireworks-ai
+    langchain-core
+    openai
+    pydantic
+  ];
+
+  pythonRelaxDeps = [
+    # Each component release requests the exact latest core.
+    # That prevents us from updating individual components.
+    "langchain-core"
+  ];
+
+  nativeCheckInputs = [
+    langchain-tests
+    pytest-asyncio
+    pytestCheckHook
+  ];
+
+  pytestFlagsArray = [ "tests/unit_tests" ];
+
+  pythonImportsCheck = [ "langchain_fireworks" ];
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [
+      "--version-regex"
+      "langchain-fireworks==([0-9.]+)"
+    ];
+  };
+
+  meta = {
+    changelog = "https://github.com/langchain-ai/langchain/releases/tag/langchain-fireworks==${version}";
+    description = "Build LangChain applications with Fireworks";
+    homepage = "https://github.com/langchain-ai/langchain/tree/master/libs/partners/fireworks";
+    license = lib.licenses.mit;
+    maintainers = [
+      lib.maintainers.sarahec
+    ];
+  };
+}

--- a/pkgs/development/python-modules/langchain-mistralai/default.nix
+++ b/pkgs/development/python-modules/langchain-mistralai/default.nix
@@ -1,0 +1,79 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  nix-update-script,
+
+  # build-system
+  pdm-backend,
+
+  # dependencies
+  langchain-core,
+  tokenizers,
+  httpx,
+  httpx-sse,
+  pydantic,
+
+  # tests
+  langchain-tests,
+  pytest-asyncio,
+  pytestCheckHook,
+}:
+
+buildPythonPackage rec {
+  pname = "langchain-mistralai";
+  version = "0.2.10";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "langchain-ai";
+    repo = "langchain";
+    tag = "langchain-mistralai==${version}";
+    hash = "sha256-1oH9GRvjYv/YzedKXeWgw5nwNgMQ9mSNkmZ2xwPekXc=";
+  };
+
+  sourceRoot = "${src.name}/libs/partners/mistralai";
+
+  build-system = [ pdm-backend ];
+
+  dependencies = [
+    langchain-core
+    tokenizers
+    httpx
+    httpx-sse
+    pydantic
+  ];
+
+  pythonRelaxDeps = [
+    # Each component release requests the exact latest core.
+    # That prevents us from updating individual components.
+    "langchain-core"
+  ];
+
+  nativeCheckInputs = [
+    langchain-tests
+    pytest-asyncio
+    pytestCheckHook
+  ];
+
+  pytestFlagsArray = [ "tests/unit_tests" ];
+
+  pythonImportsCheck = [ "langchain_mistralai" ];
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [
+      "--version-regex"
+      "langchain-mistralai==([0-9.]+)"
+    ];
+  };
+
+  meta = {
+    changelog = "https://github.com/langchain-ai/langchain-mistralai/releases/tag/langchain-mistralai==${version}";
+    description = "Build LangChain applications with mistralai";
+    homepage = "https://github.com/langchain-ai/langchain/tree/master/libs/partners/mistralai";
+    license = lib.licenses.mit;
+    maintainers = [
+      lib.maintainers.sarahec
+    ];
+  };
+}

--- a/pkgs/development/python-modules/langchain-perplexity/default.nix
+++ b/pkgs/development/python-modules/langchain-perplexity/default.nix
@@ -1,0 +1,77 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  nix-update-script,
+
+  # build-system
+  pdm-backend,
+
+  # dependencies
+  langchain-core,
+  openai,
+
+  # tests
+  langchain-tests,
+  pytest-asyncio,
+  pytest-cov,
+  pytest-mock,
+  pytestCheckHook,
+}:
+
+buildPythonPackage rec {
+  pname = "langchain-perplexity";
+  version = "0.1.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "langchain-ai";
+    repo = "langchain";
+    tag = "langchain-perplexity==${version}";
+    hash = "sha256-s20AnDsyLCzpG45QqgZp0WzlbdVrHNfpUQsMPUaF1qs=";
+  };
+
+  sourceRoot = "${src.name}/libs/partners/perplexity";
+
+  build-system = [ pdm-backend ];
+
+  dependencies = [
+    langchain-core
+    openai
+  ];
+
+  pythonRelaxDeps = [
+    # Each component release requests the exact latest core.
+    # That prevents us from updating individual components.
+    "langchain-core"
+  ];
+
+  nativeCheckInputs = [
+    langchain-tests
+    pytest-asyncio
+    pytest-cov
+    pytest-mock
+    pytestCheckHook
+  ];
+
+  pytestFlagsArray = [ "tests/unit_tests" ];
+
+  pythonImportsCheck = [ "langchain_perplexity" ];
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [
+      "--version-regex"
+      "langchain-perplexity==([0-9.]+)"
+    ];
+  };
+
+  meta = {
+    changelog = "https://github.com/langchain-ai/langchain-perplexity/releases/tag/langchain-perplexity==${version}";
+    description = "Build LangChain applications with Perplexity";
+    homepage = "https://github.com/langchain-ai/langchain/tree/master/libs/partners/perplexity";
+    license = lib.licenses.mit;
+    maintainers = [
+      lib.maintainers.sarahec
+    ];
+  };
+}

--- a/pkgs/development/python-modules/langchain-xai/default.nix
+++ b/pkgs/development/python-modules/langchain-xai/default.nix
@@ -1,0 +1,79 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  nix-update-script,
+
+  # build-system
+  pdm-backend,
+
+  # dependencies
+  aiohttp,
+  langchain-core,
+  langchain-openai,
+  requests,
+
+  # tests
+  langchain-tests,
+  pytest-asyncio,
+  pytest-mock,
+  pytestCheckHook,
+}:
+
+buildPythonPackage rec {
+  pname = "langchain-xai";
+  version = "0.2.3";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "langchain-ai";
+    repo = "langchain";
+    tag = "langchain-xai==${version}";
+    hash = "sha256-9pSwEHqh+WkHsjn7JNsyEy+U67ekTqAdHMAvAFanR8w=";
+  };
+
+  sourceRoot = "${src.name}/libs/partners/xai";
+
+  build-system = [ pdm-backend ];
+
+  dependencies = [
+    aiohttp
+    langchain-core
+    langchain-openai
+    requests
+  ];
+
+  pythonRelaxDeps = [
+    # Each component release requests the exact latest core.
+    # That prevents us from updating individual components.
+    "langchain-core"
+  ];
+
+  nativeCheckInputs = [
+    langchain-tests
+    pytest-asyncio
+    pytest-mock
+    pytestCheckHook
+  ];
+
+  pytestFlagsArray = [ "tests/unit_tests" ];
+
+  pythonImportsCheck = [ "langchain_xai" ];
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [
+      "--version-regex"
+      "langchain-xai==([0-9.]+)"
+    ];
+  };
+
+  meta = {
+    changelog = "https://github.com/langchain-ai/langchain-xai/releases/tag/langchain-xai==${version}";
+    description = "Build LangChain applications with X AI";
+    homepage = "https://github.com/langchain-ai/langchain/tree/master/libs/partners/xai";
+    license = lib.licenses.mit;
+    maintainers = [
+      lib.maintainers.sarahec
+    ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7540,6 +7540,8 @@ self: super: with self; {
 
   langchain-huggingface = callPackage ../development/python-modules/langchain-huggingface { };
 
+  langchain-mistralai = callPackage ../development/python-modules/langchain-mistralai { };
+
   langchain-mongodb = callPackage ../development/python-modules/langchain-mongodb { };
 
   langchain-ollama = callPackage ../development/python-modules/langchain-ollama { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7520,6 +7520,8 @@ self: super: with self; {
 
   langchain = callPackage ../development/python-modules/langchain { };
 
+  langchain-anthropic = callPackage ../development/python-modules/langchain-anthropic { };
+
   langchain-aws = callPackage ../development/python-modules/langchain-aws { };
 
   langchain-azure-dynamic-sessions =

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7552,6 +7552,8 @@ self: super: with self; {
 
   langchain-text-splitters = callPackage ../development/python-modules/langchain-text-splitters { };
 
+  langchain-xai = callPackage ../development/python-modules/langchain-xai { };
+
   langcodes = callPackage ../development/python-modules/langcodes { };
 
   langdetect = callPackage ../development/python-modules/langdetect { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7532,6 +7532,8 @@ self: super: with self; {
 
   langchain-core = callPackage ../development/python-modules/langchain-core { };
 
+  langchain-deepseek = callPackage ../development/python-modules/langchain-deepseek { };
+
   langchain-groq = callPackage ../development/python-modules/langchain-groq { };
 
   langchain-huggingface = callPackage ../development/python-modules/langchain-huggingface { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7536,6 +7536,8 @@ self: super: with self; {
 
   langchain-deepseek = callPackage ../development/python-modules/langchain-deepseek { };
 
+  langchain-fireworks = callPackage ../development/python-modules/langchain-fireworks { };
+
   langchain-groq = callPackage ../development/python-modules/langchain-groq { };
 
   langchain-huggingface = callPackage ../development/python-modules/langchain-huggingface { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7546,6 +7546,8 @@ self: super: with self; {
 
   langchain-openai = callPackage ../development/python-modules/langchain-openai { };
 
+  langchain-perplexity = callPackage ../development/python-modules/langchain-perplexity { };
+
   langchain-tests = callPackage ../development/python-modules/langchain-tests { };
 
   langchain-text-splitters = callPackage ../development/python-modules/langchain-text-splitters { };


### PR DESCRIPTION
Added multiple providers to Langchain:
* python3Packages.langchain-deepseek: init at 0.1.3
  * homepage: https://github.com/langchain-ai/langchain/tree/master/libs/partners/deepseek
  * changelog: https://github.com/langchain-ai/langchain/releases/tag/langchain-deepseek%3D%3D0.1.3
* python3Packages.langchain-anthropic: init at 0.3.12
  * homepage: https://github.com/langchain-ai/langchain/tree/master/libs/partners/anthropic
  * changelog: https://github.com/langchain-ai/langchain/releases/tag/langchain-anthropic%3D%3D0.3.12
* python3Packages.langchain-perplexity: init at 0.1.1
  * homepage: https://github.com/langchain-ai/langchain/tree/master/libs/partners/perplexity
  * changelog: https://github.com/langchain-ai/langchain/releases/tag/langchain-perplexity%3D%3D0.1.1
* python3Packages.langchain-xai: init at 0.2.3
  * homepage: https://github.com/langchain-ai/langchain/tree/master/libs/partners/xai
  * changelog: https://github.com/langchain-ai/langchain/releases/tag/langchain-xai%3D%3D0.2.3
* python3Packages.langchain-mistralai: init at 0.2.10
  * homepage: https://github.com/langchain-ai/langchain/tree/master/libs/partners/mistralai
  * changelog: https://github.com/langchain-ai/langchain/releases/tag/langchain-mistralai%3D%3D0.2.10
* python3Packages.langchain-fireworks: init at 0.3.0
  * homepage: https://github.com/langchain-ai/langchain/tree/master/libs/partners/fireworks
  * changelog: https://github.com/langchain-ai/langchain/releases/tag/langchain-fireworks%3D%3D0.3.0
* Add above to the bulk update script that runs when langchain-core is updated. 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [x] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
