### PR TITLE
python3Packages.langchain-mistralai: init at 0.2.10

### DIFF
--- a/pkgs/development/python-modules/langchain-core/update.sh
+++ b/pkgs/development/python-modules/langchain-core/update.sh
@@ -11,6 +11,7 @@ declare -ar packages=(
     langchain-core
     langchain-groq
     langchain-huggingface
+    langchain-mistralai
     langchain-mongodb
     langchain-ollama
     langchain-openai

--- a/pkgs/development/python-modules/langchain-mistralai/default.nix
+++ b/pkgs/development/python-modules/langchain-mistralai/default.nix
@@ -1,0 +1,79 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  nix-update-script,
+
+  # build-system
+  pdm-backend,
+
+  # dependencies
+  langchain-core,
+  tokenizers,
+  httpx,
+  httpx-sse,
+  pydantic,
+
+  # tests
+  langchain-tests,
+  pytest-asyncio,
+  pytestCheckHook,
+}:
+
+buildPythonPackage rec {
+  pname = "langchain-mistralai";
+  version = "0.2.10";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "langchain-ai";
+    repo = "langchain";
+    tag = "langchain-mistralai==${version}";
+    hash = "sha256-1oH9GRvjYv/YzedKXeWgw5nwNgMQ9mSNkmZ2xwPekXc=";
+  };
+
+  sourceRoot = "${src.name}/libs/partners/mistralai";
+
+  build-system = [ pdm-backend ];
+
+  dependencies = [
+    langchain-core
+    tokenizers
+    httpx
+    httpx-sse
+    pydantic
+  ];
+
+  pythonRelaxDeps = [
+    # Each component release requests the exact latest core.
+    # That prevents us from updating individual components.
+    "langchain-core"
+  ];
+
+  nativeCheckInputs = [
+    langchain-tests
+    pytest-asyncio
+    pytestCheckHook
+  ];
+
+  pytestFlagsArray = [ "tests/unit_tests" ];
+
+  pythonImportsCheck = [ "langchain_mistralai" ];
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [
+      "--version-regex"
+      "langchain-mistralai==([0-9.]+)"
+    ];
+  };
+
+  meta = {
+    changelog = "https://github.com/langchain-ai/langchain-mistralai/releases/tag/langchain-mistralai==${version}";
+    description = "Build LangChain applications with mistralai";
+    homepage = "https://github.com/langchain-ai/langchain/tree/master/libs/partners/mistralai";
+    license = lib.licenses.mit;
+    maintainers = [
+      lib.maintainers.sarahec
+    ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7536,6 +7536,8 @@ self: super: with self; {
 
   langchain-huggingface = callPackage ../development/python-modules/langchain-huggingface { };
 
+  langchain-mistralai = callPackage ../development/python-modules/langchain-mistralai { };
+
   langchain-mongodb = callPackage ../development/python-modules/langchain-mongodb { };
 
   langchain-ollama = callPackage ../development/python-modules/langchain-ollama { };


### PR DESCRIPTION
* Adds Mistral AI support to langchain
  * homepage: https://github.com/langchain-ai/langchain/tree/master/libs/partners/mistralai
  * changelog: https://github.com/langchain-ai/langchain/releases/tag/langchain-mistralai%3D%3D0.2.10
* Adds to update script

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [x] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
