### PR TITLE
codex: 0.1.2504161510 -> 0.1.2504251709; use `pnpm`

### DIFF
--- a/pkgs/by-name/co/codex/package.nix
+++ b/pkgs/by-name/co/codex/package.nix
@@ -1,24 +1,61 @@
 {
   lib,
-  buildNpmPackage,
+  stdenv,
   fetchFromGitHub,
+  nodejs_22, # Node ≥22 is required by codex-cli
+  pnpm_10,
+  makeBinaryWrapper,
   versionCheckHook,
 }:
 
-buildNpmPackage rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "codex";
-  version = "0.1.2504161510"; # from codex-cli/package.json
+  version = "0.1.2504251709"; # from codex-cli/package.json
 
   src = fetchFromGitHub {
     owner = "openai";
     repo = "codex";
-    rev = "b0ccca555685b1534a0028cb7bfdcad8fe2e477a";
-    hash = "sha256-WTnP6HZfrMjUoUZL635cngpfvvjrA2Zvm74T2627GwA=";
+    rev = "103093f79324482020490cb658cc1a696aece3bc";
+    hash = "sha256-GmMQi67HRanGKhiTKX8wgnpUbA1UwkPVe3siU4qC02Y=";
   };
 
-  sourceRoot = "${src.name}/codex-cli";
+  pnpmWorkspaces = [ "@openai/codex" ];
 
-  npmDepsHash = "sha256-riVXC7T9zgUBUazH5Wq7+MjU1FepLkp9kHLSq+ZVqbs=";
+  nativeBuildInputs = [
+    nodejs_22
+    pnpm_10.configHook
+    makeBinaryWrapper
+  ];
+
+  pnpmDeps = pnpm_10.fetchDeps {
+    inherit (finalAttrs)
+      pname
+      version
+      src
+      pnpmWorkspaces
+      ;
+    hash = "sha256-pPwHjtqqaG+Zqmq6x5o+WCT1H9XuXAqFNKMzevp7wTc=";
+  };
+
+  buildPhase = ''
+    runHook preBuild
+    pnpm --filter @openai/codex run build
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    dest=$out/lib/node_modules/@openai/codex
+    mkdir -p "$dest"
+    cp -r codex-cli/dist codex-cli/bin codex-cli/package.json "$dest"
+    cp LICENSE README.md "$dest"
+
+    mkdir -p $out/bin
+    makeBinaryWrapper ${nodejs_22}/bin/node $out/bin/codex --add-flags "$dest/bin/codex.js"
+
+    runHook postInstall
+  '';
 
   doInstallCheck = true;
   nativeInstallCheckInputs = [ versionCheckHook ];
@@ -30,4 +67,4 @@ buildNpmPackage rec {
     maintainers = [ lib.maintainers.malo ];
     mainProgram = "codex";
   };
-}
+})

--- a/pkgs/by-name/co/codex/package.nix
+++ b/pkgs/by-name/co/codex/package.nix
@@ -5,6 +5,7 @@
   nodejs_22, # Node ≥22 is required by codex-cli
   pnpm_10,
   makeBinaryWrapper,
+  installShellFiles,
   versionCheckHook,
 }:
 
@@ -25,6 +26,7 @@ stdenv.mkDerivation (finalAttrs: {
     nodejs_22
     pnpm_10.configHook
     makeBinaryWrapper
+    installShellFiles
   ];
 
   pnpmDeps = pnpm_10.fetchDeps {
@@ -53,6 +55,14 @@ stdenv.mkDerivation (finalAttrs: {
 
     mkdir -p $out/bin
     makeBinaryWrapper ${nodejs_22}/bin/node $out/bin/codex --add-flags "$dest/bin/codex.js"
+
+    # Install shell completions
+    ${lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+      $out/bin/codex completion bash > codex.bash
+      $out/bin/codex completion zsh > codex.zsh
+      $out/bin/codex completion fish > codex.fish
+      installShellCompletion codex.{bash,zsh,fish}
+    ''}
 
     runHook postInstall
   '';


### PR DESCRIPTION
Update to latest version and switch to using PNPM since `package-lock.json` was removed but `pnpm-lock.yaml` still exists in the source repository.

Closes: #400827

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
