### PR TITLE
buildMozillaMach: default to beacondb for location data

### DIFF
--- a/pkgs/applications/networking/browsers/firefox/common.nix
+++ b/pkgs/applications/networking/browsers/firefox/common.nix
@@ -155,8 +155,6 @@ in
     !privacySupport && !stdenv.hostPlatform.isRiscV && !stdenv.hostPlatform.isMusl,
   curl,
   geolocationSupport ? !privacySupport,
-  googleAPISupport ? geolocationSupport,
-  mlsAPISupport ? geolocationSupport,
   webrtcSupport ? !privacySupport,
 
   # digital rights managemewnt
@@ -250,10 +248,10 @@ let
       }
     );
 
-  defaultPrefs = {
+  defaultPrefs = lib.optionalAttrs geolocationSupport {
     "geo.provider.network.url" = {
-      value = "https://location.services.mozilla.com/v1/geolocate?key=%MOZILLA_API_KEY%";
-      reason = "Use MLS by default for geolocation, since our Google API Keys are not working";
+      value = "https://api.beacondb.net/v1/geolocate";
+      reason = "We have no Google API keys and Mozilla Location Services were retired.";
     };
   };
 
@@ -472,22 +470,6 @@ buildStdenv.mkDerivation {
           ''
         }
       fi
-    ''
-    + lib.optionalString googleAPISupport ''
-      # Google API key used by Chromium and Firefox.
-      # Note: These are for NixOS/nixpkgs use ONLY. For your own distribution,
-      # please get your own set of keys at https://www.chromium.org/developers/how-tos/api-keys/.
-      echo "AIzaSyDGi15Zwl11UNe6Y-5XW_upsfyw31qwZPI" > $TMPDIR/google-api-key
-      # 60.5+ & 66+ did split the google API key arguments: https://bugzilla.mozilla.org/show_bug.cgi?id=1531176
-      configureFlagsArray+=("--with-google-location-service-api-keyfile=$TMPDIR/google-api-key")
-      configureFlagsArray+=("--with-google-safebrowsing-api-keyfile=$TMPDIR/google-api-key")
-    ''
-    + lib.optionalString mlsAPISupport ''
-      # Mozilla Location services API key
-      # Note: These are for NixOS/nixpkgs use ONLY. For your own distribution,
-      # please get your own set of keys at https://location.services.mozilla.com/api.
-      echo "dfd7836c-d458-4917-98bb-421c82d3c8a0" > $TMPDIR/mls-api-key
-      configureFlagsArray+=("--with-mozilla-api-keyfile=$TMPDIR/mls-api-key")
     ''
     + lib.optionalString (enableOfficialBranding && !stdenv.hostPlatform.is32bit) ''
       export MOZILLA_OFFICIAL=1

--- a/pkgs/applications/networking/browsers/firefox/common.nix
+++ b/pkgs/applications/networking/browsers/firefox/common.nix
@@ -248,12 +248,21 @@ let
       }
     );
 
-  defaultPrefs = lib.optionalAttrs geolocationSupport {
-    "geo.provider.network.url" = {
-      value = "https://api.beacondb.net/v1/geolocate";
-      reason = "We have no Google API keys and Mozilla Location Services were retired.";
-    };
-  };
+  defaultPrefs =
+    if geolocationSupport then
+      {
+        "geo.provider.network.url" = {
+          value = "https://api.beacondb.net/v1/geolocate";
+          reason = "We have no Google API keys and Mozilla Location Services were retired.";
+        };
+      }
+    else
+      {
+        "geo.provider.use_geoclue" = {
+          value = false;
+          reason = "Geolocation support has been disabled through the `geolocationSupport` package attribute.";
+        };
+      };
 
   defaultPrefsFile = pkgs.writeText "nixos-default-prefs.js" (
     lib.concatStringsSep "\n" (

--- a/pkgs/applications/networking/browsers/floorp/default.nix
+++ b/pkgs/applications/networking/browsers/floorp/default.nix
@@ -66,8 +66,7 @@
     privacySupport = true;
     webrtcSupport = true;
     enableOfficialBranding = false;
-    googleAPISupport = true;
-    mlsAPISupport = true;
+    geolocationSupport = true;
   }
 ).overrideAttrs
   (prev: {


### PR DESCRIPTION
Mozilla Location Services was retired and our Google API keys have not worked in years. This is also the new default for geoclue2 in nixpkgs.

https://beacondb.net/#firefox
same as #391845

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
