### PR TITLE
zabbix-cli: 3.1.3 -> 3.5.2, unbreak

### DIFF
--- a/pkgs/by-name/za/zabbix-cli/package.nix
+++ b/pkgs/by-name/za/zabbix-cli/package.nix
@@ -8,17 +8,15 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "zabbix-cli";
-  version = "3.1.3";
+  version = "3.5.2";
   pyproject = true;
 
   src = fetchFromGitHub {
-    owner = "usit-gd";
+    owner = "unioslo";
     repo = "zabbix-cli";
     tag = version;
-    hash = "sha256-hvLtc6owEOD29Y1oC7EmOOFp9P8hWOuj9N7qhtqkpks=";
+    hash = "sha256-Sgt3kVbyzNJCSVUYErHNOrgc7Jd3tIwYhwOESRPeAyw=";
   };
-
-  pythonRelaxDeps = [ "click-repl" ];
 
   build-system = with python3Packages; [
     hatchling
@@ -27,11 +25,11 @@ python3Packages.buildPythonApplication rec {
   dependencies =
     with python3Packages;
     [
-      click-repl
       httpx
       httpx.optional-dependencies.socks
       packaging
       platformdirs
+      prompt-toolkit
       pydantic
       requests
       rich
@@ -49,6 +47,7 @@ python3Packages.buildPythonApplication rec {
     freezegun
     inline-snapshot
     pytestCheckHook
+    pytest-httpserver
   ];
 
   # Otherwise tests will fail to create directory
@@ -64,11 +63,11 @@ python3Packages.buildPythonApplication rec {
     command = "HOME=$(mktemp -d) zabbix-cli --version";
   };
 
-  meta = with lib; {
+  meta = {
     description = "Command-line interface for Zabbix";
     homepage = "https://github.com/unioslo/zabbix-cli";
-    license = licenses.gpl3Plus;
+    license = lib.licenses.gpl3Plus;
     mainProgram = "zabbix-cli";
-    maintainers = [ maintainers.anthonyroussel ];
+    maintainers = [ lib.maintainers.anthonyroussel ];
   };
 }


### PR DESCRIPTION
https://github.com/unioslo/zabbix-cli/releases/tag/3.5.2
https://github.com/unioslo/zabbix-cli/compare/3.1.3...3.5.2

Also fixes https://hydra.nixos.org/build/294946173 (ZHF #403336)

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
