### PR TITLE
espanso: adding packages from espanso/hub as plugins

### DIFF
--- a/pkgs/by-name/es/espanso/plugins/accented-words/default.nix
+++ b/pkgs/by-name/es/espanso/plugins/accented-words/default.nix
@@ -1,0 +1,23 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkEspansoPlugin,
+}:
+mkEspansoPlugin {
+  pname = "accented-words";
+  version = "1.1.0";
+
+  src = fetchFromGitHub {
+    owner = "espanso";
+    repo = "hub";
+    rev = "d62bde95fc6f6cf90d4c23ee243922037c053def";
+    hash = "sha256-1cPtknrIi+9uTQt0pMaOBnY3C1GAGXPAA4fIgBh5Wgs=";
+  };
+
+  meta = {
+    description = "Automatically accent commonly accented words and proper nouns in English.";
+    homepage = "https://github.com/joshjhall/espanso-accented-words";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ delafthi ];
+  };
+}

--- a/pkgs/by-name/es/espanso/plugins/actually-all-emojis-spaces/default.nix
+++ b/pkgs/by-name/es/espanso/plugins/actually-all-emojis-spaces/default.nix
@@ -1,0 +1,22 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkEspansoPlugin,
+}:
+mkEspansoPlugin {
+  pname = "actually-all-emojis-spaces";
+  version = "1.3.0";
+
+  src = fetchFromGitHub {
+    owner = "espanso";
+    repo = "hub";
+    rev = "d62bde95fc6f6cf90d4c23ee243922037c053def";
+    hash = "sha256-1cPtknrIi+9uTQt0pMaOBnY3C1GAGXPAA4fIgBh5Wgs=";
+  };
+
+  meta = {
+    description = "An updated package providing all v.15 emojis - fetched from unicode.org";
+    homepage = "https://github.com/jobiewong/espanso-emojis";
+    maintainers = with lib.maintainers; [ delafthi ];
+  };
+}

--- a/pkgs/by-name/es/espanso/plugins/actually-all-emojis/default.nix
+++ b/pkgs/by-name/es/espanso/plugins/actually-all-emojis/default.nix
@@ -1,0 +1,22 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkEspansoPlugin,
+}:
+mkEspansoPlugin {
+  pname = "actually-all-emojis";
+  version = "1.3.0";
+
+  src = fetchFromGitHub {
+    owner = "espanso";
+    repo = "hub";
+    rev = "d62bde95fc6f6cf90d4c23ee243922037c053def";
+    hash = "sha256-1cPtknrIi+9uTQt0pMaOBnY3C1GAGXPAA4fIgBh5Wgs=";
+  };
+
+  meta = {
+    description = "An updated package providing all v.15 emojis - fetched from unicode.org";
+    homepage = "https://github.com/jobiewong/espanso-emojis";
+    maintainers = with lib.maintainers; [ delafthi ];
+  };
+}

--- a/pkgs/by-name/es/espanso/plugins/air-codes/default.nix
+++ b/pkgs/by-name/es/espanso/plugins/air-codes/default.nix
@@ -1,0 +1,23 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkEspansoPlugin,
+}:
+mkEspansoPlugin {
+  pname = "air-codes";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "espanso";
+    repo = "hub";
+    rev = "d62bde95fc6f6cf90d4c23ee243922037c053def";
+    hash = "sha256-1cPtknrIi+9uTQt0pMaOBnY3C1GAGXPAA4fIgBh5Wgs=";
+  };
+
+  meta = {
+    description = "A comprehensive package offering a database of airlines and airports' names, based on their IATA designators and codes.";
+    homepage = "https://github.com/cl3mcg/espanso-package-air-codes";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ delafthi ];
+  };
+}

--- a/pkgs/by-name/es/espanso/plugins/airport-codes/default.nix
+++ b/pkgs/by-name/es/espanso/plugins/airport-codes/default.nix
@@ -1,0 +1,21 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkEspansoPlugin,
+}:
+mkEspansoPlugin {
+  pname = "airport-codes";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "espanso";
+    repo = "hub";
+    rev = "d62bde95fc6f6cf90d4c23ee243922037c053def";
+    hash = "sha256-1cPtknrIi+9uTQt0pMaOBnY3C1GAGXPAA4fIgBh5Wgs=";
+  };
+
+  meta = {
+    description = "Quickly expand airport codes into their full city names.";
+    maintainers = with lib.maintainers; [ delafthi ];
+  };
+}

--- a/pkgs/by-name/es/espanso/plugins/albanian-accents/default.nix
+++ b/pkgs/by-name/es/espanso/plugins/albanian-accents/default.nix
@@ -1,0 +1,22 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkEspansoPlugin,
+}:
+mkEspansoPlugin {
+  pname = "albanian-accents";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "espanso";
+    repo = "hub";
+    rev = "a5b6dbc16fa52e717f92a3667323cfd8646b47e0";
+    hash = "sha256-QoQqI1cKgX9Xkl6u5t0TggrjiNsn0N+nZsRVGh812Mg=";
+  };
+
+  meta = {
+    description = "Useful for typing Albanian accented characters. Typically it is quite difficult to find an albanian keyboard. But in the end, there are just four accented characters, also, the \"w\" character is not part of our alfabet, and the replaces I'm using make sense for the characters getting replaced, and I can not find examples in english at least where they are used. So I hope this implementation will be helpful not only for me, but also for other . (e.g. ww + e -> ë and so on)";
+    homepage = "https://github.com/fnosi/espanso-hub/tree/albanian-accents";
+    maintainers = with lib.maintainers; [ delafthi ];
+  };
+}

--- a/pkgs/by-name/es/espanso/plugins/all-emojis/default.nix
+++ b/pkgs/by-name/es/espanso/plugins/all-emojis/default.nix
@@ -1,0 +1,22 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkEspansoPlugin,
+}:
+mkEspansoPlugin {
+  pname = "all-emojis";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "espanso";
+    repo = "hub";
+    rev = "d62bde95fc6f6cf90d4c23ee243922037c053def";
+    hash = "sha256-1cPtknrIi+9uTQt0pMaOBnY3C1GAGXPAA4fIgBh5Wgs=";
+  };
+
+  meta = {
+    description = "All emojis, with alt names, provided by gemoji";
+    homepage = "https://github.com/FoxxMD/espanso-all-emojis";
+    maintainers = with lib.maintainers; [ delafthi ];
+  };
+}

--- a/pkgs/by-name/es/espanso/plugins/alt-codes/default.nix
+++ b/pkgs/by-name/es/espanso/plugins/alt-codes/default.nix
@@ -1,0 +1,22 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkEspansoPlugin,
+}:
+mkEspansoPlugin {
+  pname = "alt-codes";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "espanso";
+    repo = "hub";
+    rev = "d62bde95fc6f6cf90d4c23ee243922037c053def";
+    hash = "sha256-1cPtknrIi+9uTQt0pMaOBnY3C1GAGXPAA4fIgBh5Wgs=";
+  };
+
+  meta = {
+    description = "Use Windows Alt codes with Espanso.";
+    homepage = "https://github.com/TheLastZombie/espanso-package-alt-codes";
+    maintainers = with lib.maintainers; [ delafthi ];
+  };
+}

--- a/pkgs/by-name/es/espanso/plugins/apl/default.nix
+++ b/pkgs/by-name/es/espanso/plugins/apl/default.nix
@@ -1,0 +1,21 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkEspansoPlugin,
+}:
+mkEspansoPlugin {
+  pname = "apl";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "espanso";
+    repo = "hub";
+    rev = "d62bde95fc6f6cf90d4c23ee243922037c053def";
+    hash = "sha256-1cPtknrIi+9uTQt0pMaOBnY3C1GAGXPAA4fIgBh5Wgs=";
+  };
+
+  meta = {
+    description = "A package for writing APL symbols based on Dyalog conventions";
+    maintainers = with lib.maintainers; [ delafthi ];
+  };
+}

--- a/pkgs/by-name/es/espanso/plugins/apple-symbols/default.nix
+++ b/pkgs/by-name/es/espanso/plugins/apple-symbols/default.nix
@@ -1,0 +1,23 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkEspansoPlugin,
+}:
+mkEspansoPlugin {
+  pname = "apple-symbols";
+  version = "1.0.0";
+
+  src = fetchFromGitHub {
+    owner = "espanso";
+    repo = "hub";
+    rev = "d62bde95fc6f6cf90d4c23ee243922037c053def";
+    hash = "sha256-1cPtknrIi+9uTQt0pMaOBnY3C1GAGXPAA4fIgBh5Wgs=";
+  };
+
+  meta = {
+    description = "Few more or less Apple specific symbols often used in technical writing";
+    homepage = "https://github.com/joshjhall/espanso-apple-symbols";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ delafthi ];
+  };
+}

--- a/pkgs/by-name/es/espanso/plugins/arrows-and-pointers/default.nix
+++ b/pkgs/by-name/es/espanso/plugins/arrows-and-pointers/default.nix
@@ -1,0 +1,21 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkEspansoPlugin,
+}:
+mkEspansoPlugin {
+  pname = "arrows-and-pointers";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "espanso";
+    repo = "hub";
+    rev = "d62bde95fc6f6cf90d4c23ee243922037c053def";
+    hash = "sha256-1cPtknrIi+9uTQt0pMaOBnY3C1GAGXPAA4fIgBh5Wgs=";
+  };
+
+  meta = {
+    description = "expanded set of arrows and pointers";
+    maintainers = with lib.maintainers; [ delafthi ];
+  };
+}

--- a/pkgs/by-name/es/espanso/plugins/arrows/default.nix
+++ b/pkgs/by-name/es/espanso/plugins/arrows/default.nix
@@ -1,0 +1,22 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkEspansoPlugin,
+}:
+mkEspansoPlugin {
+  pname = "arrows";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "espanso";
+    repo = "hub";
+    rev = "d62bde95fc6f6cf90d4c23ee243922037c053def";
+    hash = "sha256-1cPtknrIi+9uTQt0pMaOBnY3C1GAGXPAA4fIgBh5Wgs=";
+  };
+
+  meta = {
+    description = "Useful arrows and dashes";
+    homepage = "https://github.com/j6k4m8/espanso-arrows";
+    maintainers = with lib.maintainers; [ delafthi ];
+  };
+}

--- a/pkgs/by-name/es/espanso/plugins/ask-airia/default.nix
+++ b/pkgs/by-name/es/espanso/plugins/ask-airia/default.nix
@@ -1,0 +1,22 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkEspansoPlugin,
+}:
+mkEspansoPlugin {
+  pname = "ask-airia";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "espanso";
+    repo = "hub";
+    rev = "13eb7d6d7d242bbadfb43ed4284d6b46ba63ce11";
+    hash = "sha256-r0V24FeBiS8LRzbzMjLKJqitpoiOWnuynGMahmDYe3s=";
+  };
+
+  meta = {
+    description = "An Espanso package that enables users to quickly send prompts to Airia Agents.";
+    homepage = "https://github.com/carlescarles/ask-airia/edit/main/README.md";
+    maintainers = with lib.maintainers; [ delafthi ];
+  };
+}

--- a/pkgs/by-name/es/espanso/plugins/aspnetboilerplate-aspzerohub/default.nix
+++ b/pkgs/by-name/es/espanso/plugins/aspnetboilerplate-aspzerohub/default.nix
@@ -1,0 +1,22 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkEspansoPlugin,
+}:
+mkEspansoPlugin {
+  pname = "aspnetboilerplate-aspzerohub";
+  version = "0.1.1";
+
+  src = fetchFromGitHub {
+    owner = "espanso";
+    repo = "hub";
+    rev = "d62bde95fc6f6cf90d4c23ee243922037c053def";
+    hash = "sha256-1cPtknrIi+9uTQt0pMaOBnY3C1GAGXPAA4fIgBh5Wgs=";
+  };
+
+  meta = {
+    description = "A package to include aspnetboilerplate and aspnet zero shortcut code generation in espanso.";
+    homepage = "https://github.com/canmavi/aspboilerplate-aspzerohub";
+    maintainers = with lib.maintainers; [ delafthi ];
+  };
+}

--- a/pkgs/by-name/es/espanso/plugins/autocomplete-en/default.nix
+++ b/pkgs/by-name/es/espanso/plugins/autocomplete-en/default.nix
@@ -1,0 +1,22 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkEspansoPlugin,
+}:
+mkEspansoPlugin {
+  pname = "autocomplete-en";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "espanso";
+    repo = "hub";
+    rev = "d62bde95fc6f6cf90d4c23ee243922037c053def";
+    hash = "sha256-1cPtknrIi+9uTQt0pMaOBnY3C1GAGXPAA4fIgBh5Wgs=";
+  };
+
+  meta = {
+    description = "A package to autocomplete in espanso.";
+    homepage = "https://github.com/8-momo-8/autocomplete-en";
+    maintainers = with lib.maintainers; [ delafthi ];
+  };
+}

--- a/pkgs/by-name/es/espanso/plugins/base64-encoder-decoder/default.nix
+++ b/pkgs/by-name/es/espanso/plugins/base64-encoder-decoder/default.nix
@@ -1,0 +1,22 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkEspansoPlugin,
+}:
+mkEspansoPlugin {
+  pname = "base64-encoder-decoder";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "espanso";
+    repo = "hub";
+    rev = "d62bde95fc6f6cf90d4c23ee243922037c053def";
+    hash = "sha256-1cPtknrIi+9uTQt0pMaOBnY3C1GAGXPAA4fIgBh5Wgs=";
+  };
+
+  meta = {
+    description = "Espanso package for encode and decode clipboard content";
+    homepage = "https://github.com/WernerLuiz92/espanso-packages";
+    maintainers = with lib.maintainers; [ delafthi ];
+  };
+}

--- a/pkgs/by-name/es/espanso/plugins/basic-emojis/default.nix
+++ b/pkgs/by-name/es/espanso/plugins/basic-emojis/default.nix
@@ -1,0 +1,21 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkEspansoPlugin,
+}:
+mkEspansoPlugin {
+  pname = "basic-emojis";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "espanso";
+    repo = "hub";
+    rev = "d62bde95fc6f6cf90d4c23ee243922037c053def";
+    hash = "sha256-1cPtknrIi+9uTQt0pMaOBnY3C1GAGXPAA4fIgBh5Wgs=";
+  };
+
+  meta = {
+    description = "A package to include some basic emojis in espanso.";
+    maintainers = with lib.maintainers; [ delafthi ];
+  };
+}

--- a/pkgs/by-name/es/espanso/plugins/belarusian-letters/default.nix
+++ b/pkgs/by-name/es/espanso/plugins/belarusian-letters/default.nix
@@ -1,0 +1,22 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkEspansoPlugin,
+}:
+mkEspansoPlugin {
+  pname = "belarusian-letters";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "espanso";
+    repo = "hub";
+    rev = "d62bde95fc6f6cf90d4c23ee243922037c053def";
+    hash = "sha256-1cPtknrIi+9uTQt0pMaOBnY3C1GAGXPAA4fIgBh5Wgs=";
+  };
+
+  meta = {
+    description = "Type belarusian letters without layout switching";
+    homepage = "https://github.com/jahy/espanso-package-belarusian-letters";
+    maintainers = with lib.maintainers; [ delafthi ];
+  };
+}

--- a/pkgs/by-name/es/espanso/plugins/better-turkish/default.nix
+++ b/pkgs/by-name/es/espanso/plugins/better-turkish/default.nix
@@ -1,0 +1,22 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkEspansoPlugin,
+}:
+mkEspansoPlugin {
+  pname = "better-turkish";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "espanso";
+    repo = "hub";
+    rev = "d62bde95fc6f6cf90d4c23ee243922037c053def";
+    hash = "sha256-1cPtknrIi+9uTQt0pMaOBnY3C1GAGXPAA4fIgBh5Wgs=";
+  };
+
+  meta = {
+    description = "A package that provides (opinionatedly) intuitive triggers for the accented letters in the Turkish alphabet.";
+    homepage = "https://github.com/inan-hira/espanso-hub";
+    maintainers = with lib.maintainers; [ delafthi ];
+  };
+}

--- a/pkgs/by-name/es/espanso/plugins/better-typography/default.nix
+++ b/pkgs/by-name/es/espanso/plugins/better-typography/default.nix
@@ -1,0 +1,22 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkEspansoPlugin,
+}:
+mkEspansoPlugin {
+  pname = "better-typography";
+  version = "0.1.3";
+
+  src = fetchFromGitHub {
+    owner = "espanso";
+    repo = "hub";
+    rev = "d62bde95fc6f6cf90d4c23ee243922037c053def";
+    hash = "sha256-1cPtknrIi+9uTQt0pMaOBnY3C1GAGXPAA4fIgBh5Wgs=";
+  };
+
+  meta = {
+    description = "A package to help convert quotes into smart quotes.";
+    homepage = "https://github.com/jwliles/better-typography";
+    maintainers = with lib.maintainers; [ delafthi ];
+  };
+}

--- a/pkgs/by-name/es/espanso/plugins/bib-generator/default.nix
+++ b/pkgs/by-name/es/espanso/plugins/bib-generator/default.nix
@@ -1,0 +1,27 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkEspansoPlugin,
+  python3,
+}:
+mkEspansoPlugin {
+  pname = "bib-generator";
+  version = "1.0.0";
+
+  src = fetchFromGitHub {
+    owner = "espanso";
+    repo = "hub";
+    rev = "d62bde95fc6f6cf90d4c23ee243922037c053def";
+    hash = "sha256-1cPtknrIi+9uTQt0pMaOBnY3C1GAGXPAA4fIgBh5Wgs=";
+  };
+
+  buildInputs = [
+    python3
+  ];
+
+  meta = {
+    description = "Generate a BibTex entry by searching through DBLP";
+    homepage = "https://github.com/Xeophon/hub/tree/main/packages/bib-generator";
+    maintainers = with lib.maintainers; [ delafthi ];
+  };
+}

--- a/pkgs/by-name/es/espanso/plugins/blackboardletters/default.nix
+++ b/pkgs/by-name/es/espanso/plugins/blackboardletters/default.nix
@@ -1,0 +1,22 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkEspansoPlugin,
+}:
+mkEspansoPlugin {
+  pname = "blackboardletters";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "espanso";
+    repo = "hub";
+    rev = "d62bde95fc6f6cf90d4c23ee243922037c053def";
+    hash = "sha256-1cPtknrIi+9uTQt0pMaOBnY3C1GAGXPAA4fIgBh5Wgs=";
+  };
+
+  meta = {
+    description = "Blackboard or double-barred lettering in Espanso";
+    homepage = "https://github.com/j6k4m8/espanso-blackboard";
+    maintainers = with lib.maintainers; [ delafthi ];
+  };
+}

--- a/pkgs/by-name/es/espanso/plugins/brand-names/default.nix
+++ b/pkgs/by-name/es/espanso/plugins/brand-names/default.nix
@@ -1,0 +1,23 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkEspansoPlugin,
+}:
+mkEspansoPlugin {
+  pname = "brand-names";
+  version = "1.0.2";
+
+  src = fetchFromGitHub {
+    owner = "espanso";
+    repo = "hub";
+    rev = "d62bde95fc6f6cf90d4c23ee243922037c053def";
+    hash = "sha256-1cPtknrIi+9uTQt0pMaOBnY3C1GAGXPAA4fIgBh5Wgs=";
+  };
+
+  meta = {
+    description = "Automatically capitalize common brand and product names.";
+    homepage = "https://github.com/joshjhall/espanso-brand-names";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ delafthi ];
+  };
+}

--- a/pkgs/by-name/es/espanso/plugins/calc-macos/default.nix
+++ b/pkgs/by-name/es/espanso/plugins/calc-macos/default.nix
@@ -1,0 +1,22 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkEspansoPlugin,
+}:
+mkEspansoPlugin {
+  pname = "calc-macos";
+  version = "0.1.1";
+
+  src = fetchFromGitHub {
+    owner = "espanso";
+    repo = "hub";
+    rev = "d62bde95fc6f6cf90d4c23ee243922037c053def";
+    hash = "sha256-1cPtknrIi+9uTQt0pMaOBnY3C1GAGXPAA4fIgBh5Wgs=";
+  };
+
+  meta = {
+    description = "Espanso package for doing basic arithmetic in the shell.";
+    maintainers = with lib.maintainers; [ delafthi ];
+    platforms = lib.platforms.darwin;
+  };
+}

--- a/pkgs/by-name/es/espanso/plugins/calc/default.nix
+++ b/pkgs/by-name/es/espanso/plugins/calc/default.nix
@@ -1,0 +1,23 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkEspansoPlugin,
+}:
+mkEspansoPlugin {
+  pname = "calc";
+  version = "1.0.0";
+
+  src = fetchFromGitHub {
+    owner = "espanso";
+    repo = "hub";
+    rev = "d62bde95fc6f6cf90d4c23ee243922037c053def";
+    hash = "sha256-1cPtknrIi+9uTQt0pMaOBnY3C1GAGXPAA4fIgBh5Wgs=";
+  };
+
+  meta = {
+    description = "Matches to do basic arithmetic using your shell with Espanso version 2.1.0-alpha";
+    homepage = "https://github.com/UyCode/espanso-calc-new";
+    maintainers = with lib.maintainers; [ delafthi ];
+    platforms = lib.platforms.windows;
+  };
+}

--- a/pkgs/by-name/es/espanso/plugins/caron-letters/default.nix
+++ b/pkgs/by-name/es/espanso/plugins/caron-letters/default.nix
@@ -1,0 +1,21 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkEspansoPlugin,
+}:
+mkEspansoPlugin {
+  pname = "caron-letters";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "espanso";
+    repo = "hub";
+    rev = "d62bde95fc6f6cf90d4c23ee243922037c053def";
+    hash = "sha256-1cPtknrIi+9uTQt0pMaOBnY3C1GAGXPAA4fIgBh5Wgs=";
+  };
+
+  meta = {
+    description = "A package to insert caron letters";
+    maintainers = with lib.maintainers; [ delafthi ];
+  };
+}

--- a/pkgs/by-name/es/espanso/plugins/chemical-elements/default.nix
+++ b/pkgs/by-name/es/espanso/plugins/chemical-elements/default.nix
@@ -1,0 +1,21 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkEspansoPlugin,
+}:
+mkEspansoPlugin {
+  pname = "chemical-elements";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "espanso";
+    repo = "hub";
+    rev = "d62bde95fc6f6cf90d4c23ee243922037c053def";
+    hash = "sha256-1cPtknrIi+9uTQt0pMaOBnY3C1GAGXPAA4fIgBh5Wgs=";
+  };
+
+  meta = {
+    description = "A package containing all chemical elements and abreviations.";
+    maintainers = with lib.maintainers; [ delafthi ];
+  };
+}

--- a/pkgs/by-name/es/espanso/plugins/cht/default.nix
+++ b/pkgs/by-name/es/espanso/plugins/cht/default.nix
@@ -1,0 +1,26 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkEspansoPlugin,
+  curl,
+}:
+mkEspansoPlugin {
+  pname = "cht";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "espanso";
+    repo = "hub";
+    rev = "d62bde95fc6f6cf90d4c23ee243922037c053def";
+    hash = "sha256-1cPtknrIi+9uTQt0pMaOBnY3C1GAGXPAA4fIgBh5Wgs=";
+  };
+
+  buildInputs = [ curl ];
+
+  meta = {
+    description = "A package to get the code snippets from cht.sh.";
+    homepage = "https://github.com/bradyjoslin/espanso-package-cht";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ delafthi ];
+  };
+}

--- a/pkgs/by-name/es/espanso/plugins/clipboard-lower-upper-win/default.nix
+++ b/pkgs/by-name/es/espanso/plugins/clipboard-lower-upper-win/default.nix
@@ -1,0 +1,24 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkEspansoPlugin,
+}:
+mkEspansoPlugin {
+  pname = "clipboard-lower-upper-win";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "espanso";
+    repo = "hub";
+    rev = "d62bde95fc6f6cf90d4c23ee243922037c053def";
+    hash = "sha256-1cPtknrIi+9uTQt0pMaOBnY3C1GAGXPAA4fIgBh5Wgs=";
+  };
+
+  meta = {
+    description = "A simple espanso package to convert clipboard content to lower and upper case in Windows";
+    homepage = "https://github.com/saravanabalagi/espanso-clipboard-lower-upper-win";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ delafthi ];
+    platforms = lib.platforms.windows;
+  };
+}

--- a/pkgs/by-name/es/espanso/plugins/combining-characters/default.nix
+++ b/pkgs/by-name/es/espanso/plugins/combining-characters/default.nix
@@ -1,0 +1,23 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkEspansoPlugin,
+}:
+mkEspansoPlugin {
+  pname = "combining-characters";
+  version = "0.2.0";
+
+  src = fetchFromGitHub {
+    owner = "espanso";
+    repo = "hub";
+    rev = "d62bde95fc6f6cf90d4c23ee243922037c053def";
+    hash = "sha256-1cPtknrIi+9uTQt0pMaOBnY3C1GAGXPAA4fIgBh5Wgs=";
+  };
+
+  meta = {
+    description = "Modifies characters with a collection of symbols e.g.: à, â, a⃗, a̅, a⃜";
+    homepage = "https://github.com/jpmvferreira/espanso-mega-pack";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ delafthi ];
+  };
+}

--- a/pkgs/by-name/es/espanso/plugins/common-latex/default.nix
+++ b/pkgs/by-name/es/espanso/plugins/common-latex/default.nix
@@ -1,0 +1,22 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkEspansoPlugin,
+}:
+mkEspansoPlugin {
+  pname = "common-latex";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "espanso";
+    repo = "hub";
+    rev = "d62bde95fc6f6cf90d4c23ee243922037c053def";
+    hash = "sha256-1cPtknrIi+9uTQt0pMaOBnY3C1GAGXPAA4fIgBh5Wgs=";
+  };
+
+  meta = {
+    description = "A simple Latex snippets for basic math";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ delafthi ];
+  };
+}

--- a/pkgs/by-name/es/espanso/plugins/common-phrases/default.nix
+++ b/pkgs/by-name/es/espanso/plugins/common-phrases/default.nix
@@ -1,0 +1,22 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkEspansoPlugin,
+}:
+mkEspansoPlugin {
+  pname = "common-phrases";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "espanso";
+    repo = "hub";
+    rev = "d62bde95fc6f6cf90d4c23ee243922037c053def";
+    hash = "sha256-1cPtknrIi+9uTQt0pMaOBnY3C1GAGXPAA4fIgBh5Wgs=";
+  };
+
+  meta = {
+    description = "A package for most common phrases used in daily communication.";
+    homepage = "https://github.com/KarimAL-Shamy/common-phrases";
+    maintainers = with lib.maintainers; [ delafthi ];
+  };
+}

--- a/pkgs/by-name/es/espanso/plugins/contractions-en/default.nix
+++ b/pkgs/by-name/es/espanso/plugins/contractions-en/default.nix
@@ -1,0 +1,23 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkEspansoPlugin,
+}:
+mkEspansoPlugin {
+  pname = "contractions-en";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "espanso";
+    repo = "hub";
+    rev = "d62bde95fc6f6cf90d4c23ee243922037c053def";
+    hash = "sha256-1cPtknrIi+9uTQt0pMaOBnY3C1GAGXPAA4fIgBh5Wgs=";
+  };
+
+  meta = {
+    description = "This package adds apostrophes to your contractions.";
+    homepage = "https://github.com/sonofhypnos/espanso-contractions-en";
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [ delafthi ];
+  };
+}

--- a/pkgs/by-name/es/espanso/plugins/curl/default.nix
+++ b/pkgs/by-name/es/espanso/plugins/curl/default.nix
@@ -1,0 +1,23 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkEspansoPlugin,
+}:
+mkEspansoPlugin {
+  pname = "curl";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "espanso";
+    repo = "hub";
+    rev = "d62bde95fc6f6cf90d4c23ee243922037c053def";
+    hash = "sha256-1cPtknrIi+9uTQt0pMaOBnY3C1GAGXPAA4fIgBh5Wgs=";
+  };
+
+  meta = {
+    description = "An package to get curl command code snippets";
+    homepage = "https://github.com/zhangymPerson/espanso-package-curl";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ delafthi ];
+  };
+}

--- a/pkgs/by-name/es/espanso/plugins/currency-symbols/default.nix
+++ b/pkgs/by-name/es/espanso/plugins/currency-symbols/default.nix
@@ -1,0 +1,21 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkEspansoPlugin,
+}:
+mkEspansoPlugin {
+  pname = "currency-symbols";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "espanso";
+    repo = "hub";
+    rev = "d62bde95fc6f6cf90d4c23ee243922037c053def";
+    hash = "sha256-1cPtknrIi+9uTQt0pMaOBnY3C1GAGXPAA4fIgBh5Wgs=";
+  };
+
+  meta = {
+    description = "All the unicode currency symbols I could find";
+    maintainers = with lib.maintainers; [ delafthi ];
+  };
+}

--- a/pkgs/by-name/es/espanso/plugins/dadjoke/default.nix
+++ b/pkgs/by-name/es/espanso/plugins/dadjoke/default.nix
@@ -1,0 +1,26 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkEspansoPlugin,
+  curl,
+}:
+mkEspansoPlugin {
+  pname = "dadjoke";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "espanso";
+    repo = "hub";
+    rev = "d62bde95fc6f6cf90d4c23ee243922037c053def";
+    hash = "sha256-1cPtknrIi+9uTQt0pMaOBnY3C1GAGXPAA4fIgBh5Wgs=";
+  };
+
+  buildInputs = [ curl ];
+
+  meta = {
+    description = "A random dad joke every time";
+    homepage = "https://github.com/ivanovyordan/espanso-package-dadjoke";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ delafthi ];
+  };
+}

--- a/pkgs/by-name/es/espanso/plugins/date-offset/default.nix
+++ b/pkgs/by-name/es/espanso/plugins/date-offset/default.nix
@@ -1,0 +1,22 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkEspansoPlugin,
+}:
+mkEspansoPlugin {
+  pname = "date-offset";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "espanso";
+    repo = "hub";
+    rev = "d62bde95fc6f6cf90d4c23ee243922037c053def";
+    hash = "sha256-1cPtknrIi+9uTQt0pMaOBnY3C1GAGXPAA4fIgBh5Wgs=";
+  };
+
+  meta = {
+    description = "A package that uses the date-handling facilities of different scripting languages to return dates variably offset from today, as specified in a regex trigger.";
+    homepage = "https://github.com/smeech";
+    maintainers = with lib.maintainers; [ delafthi ];
+  };
+}

--- a/pkgs/by-name/es/espanso/plugins/default.nix
+++ b/pkgs/by-name/es/espanso/plugins/default.nix
@@ -1,0 +1,48 @@
+{
+  lib,
+  callPackage,
+  stdenvNoCC,
+  writeShellScript,
+}:
+let
+  mkEspansoPlugin =
+    attrs@{
+      pname,
+      version,
+      meta ? { },
+      ...
+    }:
+    stdenvNoCC.mkDerivation (
+      attrs
+      // {
+        installPhase = ''
+          runHook preInstall
+
+          cp -r packages/${pname}/${version} $out
+
+          runHook postInstall
+        '';
+        meta = meta // {
+          description = meta.description or "";
+          platforms = meta.platforms or lib.platforms.all;
+        };
+        passthru = (attrs.passthru or { }) // {
+          updateScript = {
+            command = writeShellScript "update-${pname}" ''
+              exec ${./update.py} ${pname}
+            '';
+            supportedFeatures = [ "commit" ];
+          };
+        };
+      }
+    );
+  call = name: callPackage (./. + "/${name}") { inherit mkEspansoPlugin; };
+in
+lib.pipe ./. [
+  builtins.readDir
+  (lib.filterAttrs (_: type: type == "directory"))
+  (builtins.mapAttrs (name: _: call name))
+]
+// {
+  inherit mkEspansoPlugin;
+}

--- a/pkgs/by-name/es/espanso/plugins/delays-characters/default.nix
+++ b/pkgs/by-name/es/espanso/plugins/delays-characters/default.nix
@@ -1,0 +1,29 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkEspansoPlugin,
+  python3,
+  python3Packages,
+}:
+mkEspansoPlugin {
+  pname = "delays-characters";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "espanso";
+    repo = "hub";
+    rev = "d62bde95fc6f6cf90d4c23ee243922037c053def";
+    hash = "sha256-1cPtknrIi+9uTQt0pMaOBnY3C1GAGXPAA4fIgBh5Wgs=";
+  };
+
+  buildInputs = [
+    python3
+    python3Packages.pynput
+  ];
+
+  meta = {
+    description = "A package to allow delays, and characters not supported by Espanso, to be injected using the Python pynput library.";
+    homepage = "https://github.com/smeech";
+    maintainers = with lib.maintainers; [ delafthi ];
+  };
+}

--- a/pkgs/by-name/es/espanso/plugins/discord-snippet/default.nix
+++ b/pkgs/by-name/es/espanso/plugins/discord-snippet/default.nix
@@ -1,0 +1,22 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkEspansoPlugin,
+}:
+mkEspansoPlugin {
+  pname = "discord-snippet";
+  version = "0.1.1";
+
+  src = fetchFromGitHub {
+    owner = "espanso";
+    repo = "hub";
+    rev = "d62bde95fc6f6cf90d4c23ee243922037c053def";
+    hash = "sha256-1cPtknrIi+9uTQt0pMaOBnY3C1GAGXPAA4fIgBh5Wgs=";
+  };
+
+  meta = {
+    description = "A Collection of snippets for Discord Markdown";
+    homepage = "https://github.com/NathanelM/discord-snippet/tree/main";
+    maintainers = with lib.maintainers; [ delafthi ];
+  };
+}

--- a/pkgs/by-name/es/espanso/plugins/divination-oracles/default.nix
+++ b/pkgs/by-name/es/espanso/plugins/divination-oracles/default.nix
@@ -1,0 +1,21 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkEspansoPlugin,
+}:
+mkEspansoPlugin {
+  pname = "divination-oracles";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "espanso";
+    repo = "hub";
+    rev = "d62bde95fc6f6cf90d4c23ee243922037c053def";
+    hash = "sha256-1cPtknrIi+9uTQt0pMaOBnY3C1GAGXPAA4fIgBh5Wgs=";
+  };
+
+  meta = {
+    description = "A package that simulates various divination oracles";
+    maintainers = with lib.maintainers; [ delafthi ];
+  };
+}

--- a/pkgs/by-name/es/espanso/plugins/docker-compose/default.nix
+++ b/pkgs/by-name/es/espanso/plugins/docker-compose/default.nix
@@ -1,0 +1,22 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkEspansoPlugin,
+}:
+mkEspansoPlugin {
+  pname = "docker-compose";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "espanso";
+    repo = "hub";
+    rev = "d62bde95fc6f6cf90d4c23ee243922037c053def";
+    hash = "sha256-1cPtknrIi+9uTQt0pMaOBnY3C1GAGXPAA4fIgBh5Wgs=";
+  };
+
+  meta = {
+    description = "Docker compose command";
+    homepage = "https://github.com/Jazys/espanso-docker-compose";
+    maintainers = with lib.maintainers; [ delafthi ];
+  };
+}

--- a/pkgs/by-name/es/espanso/plugins/double-stroke-letters/default.nix
+++ b/pkgs/by-name/es/espanso/plugins/double-stroke-letters/default.nix
@@ -1,0 +1,23 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkEspansoPlugin,
+}:
+mkEspansoPlugin {
+  pname = "double-stroke-letters";
+  version = "1.0.0";
+
+  src = fetchFromGitHub {
+    owner = "espanso";
+    repo = "hub";
+    rev = "d62bde95fc6f6cf90d4c23ee243922037c053def";
+    hash = "sha256-1cPtknrIi+9uTQt0pMaOBnY3C1GAGXPAA4fIgBh5Wgs=";
+  };
+
+  meta = {
+    description = "Easy write 𝕕𝕠𝕦𝕓𝕝𝕖 𝕤𝕥𝕣𝕠𝕜𝕖 𝕝𝕖𝕥𝕥𝕖𝕣𝕤";
+    homepage = "https://github.com/kopach/espanso-package-double-stroke-letters";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ delafthi ];
+  };
+}

--- a/pkgs/by-name/es/espanso/plugins/double-stroke-numbers/default.nix
+++ b/pkgs/by-name/es/espanso/plugins/double-stroke-numbers/default.nix
@@ -1,0 +1,23 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkEspansoPlugin,
+}:
+mkEspansoPlugin {
+  pname = "double-stroke-numbers";
+  version = "1.0.0";
+
+  src = fetchFromGitHub {
+    owner = "espanso";
+    repo = "hub";
+    rev = "d62bde95fc6f6cf90d4c23ee243922037c053def";
+    hash = "sha256-1cPtknrIi+9uTQt0pMaOBnY3C1GAGXPAA4fIgBh5Wgs=";
+  };
+
+  meta = {
+    description = "Easy write double stroke numbers: 𝟙𝟚𝟛";
+    homepage = "https://github.com/kopach/espanso-package-double-stroke-numbers";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ delafthi ];
+  };
+}

--- a/pkgs/by-name/es/espanso/plugins/drug-names/default.nix
+++ b/pkgs/by-name/es/espanso/plugins/drug-names/default.nix
@@ -1,0 +1,21 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkEspansoPlugin,
+}:
+mkEspansoPlugin {
+  pname = "drug-names";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "espanso";
+    repo = "hub";
+    rev = "d62bde95fc6f6cf90d4c23ee243922037c053def";
+    hash = "sha256-1cPtknrIi+9uTQt0pMaOBnY3C1GAGXPAA4fIgBh5Wgs=";
+  };
+
+  meta = {
+    description = "A quick autocompleteion which contains all US brand and generic drug names as of July 2022. Sourced from RxTerms202207";
+    maintainers = with lib.maintainers; [ delafthi ];
+  };
+}

--- a/pkgs/by-name/es/espanso/plugins/dummy-package/default.nix
+++ b/pkgs/by-name/es/espanso/plugins/dummy-package/default.nix
@@ -1,0 +1,22 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkEspansoPlugin,
+}:
+mkEspansoPlugin {
+  pname = "dummy-package";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "espanso";
+    repo = "hub";
+    rev = "d62bde95fc6f6cf90d4c23ee243922037c053def";
+    hash = "sha256-1cPtknrIi+9uTQt0pMaOBnY3C1GAGXPAA4fIgBh5Wgs=";
+  };
+
+  meta = {
+    description = "A dummy package for testing";
+    homepage = "https://espanso.org/docs/packages/creating-a-package/#publish-on-the-hub-public";
+    maintainers = with lib.maintainers; [ delafthi ];
+  };
+}

--- a/pkgs/by-name/es/espanso/plugins/encircled-letters/default.nix
+++ b/pkgs/by-name/es/espanso/plugins/encircled-letters/default.nix
@@ -1,0 +1,23 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkEspansoPlugin,
+}:
+mkEspansoPlugin {
+  pname = "encircled-letters";
+  version = "1.0.0";
+
+  src = fetchFromGitHub {
+    owner = "espanso";
+    repo = "hub";
+    rev = "d62bde95fc6f6cf90d4c23ee243922037c053def";
+    hash = "sha256-1cPtknrIi+9uTQt0pMaOBnY3C1GAGXPAA4fIgBh5Wgs=";
+  };
+
+  meta = {
+    description = "Easy write enclosed or Ⓔⓝⓒⓘⓡⓒⓛⓔⓓ ⓛⓔⓣⓣⓔⓡⓢ";
+    homepage = "https://github.com/kopach/espanso-package-encircled-letters";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ delafthi ];
+  };
+}

--- a/pkgs/by-name/es/espanso/plugins/encircled-numbers/default.nix
+++ b/pkgs/by-name/es/espanso/plugins/encircled-numbers/default.nix
@@ -1,0 +1,23 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkEspansoPlugin,
+}:
+mkEspansoPlugin {
+  pname = "encircled-numbers";
+  version = "1.0.0";
+
+  src = fetchFromGitHub {
+    owner = "espanso";
+    repo = "hub";
+    rev = "d62bde95fc6f6cf90d4c23ee243922037c053def";
+    hash = "sha256-1cPtknrIi+9uTQt0pMaOBnY3C1GAGXPAA4fIgBh5Wgs=";
+  };
+
+  meta = {
+    description = "Easy write encircled or enclosed numbers: ①❷③";
+    homepage = "https://github.com/kopach/espanso-package-encircled-numbers";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ delafthi ];
+  };
+}

--- a/pkgs/by-name/es/espanso/plugins/english-lorem/default.nix
+++ b/pkgs/by-name/es/espanso/plugins/english-lorem/default.nix
@@ -1,0 +1,21 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkEspansoPlugin,
+}:
+mkEspansoPlugin {
+  pname = "english-lorem";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "espanso";
+    repo = "hub";
+    rev = "d62bde95fc6f6cf90d4c23ee243922037c053def";
+    hash = "sha256-1cPtknrIi+9uTQt0pMaOBnY3C1GAGXPAA4fIgBh5Wgs=";
+  };
+
+  meta = {
+    description = "Lorem ipsum sentences and paragraphs generator but in English!";
+    maintainers = with lib.maintainers; [ delafthi ];
+  };
+}

--- a/pkgs/by-name/es/espanso/plugins/escape/default.nix
+++ b/pkgs/by-name/es/espanso/plugins/escape/default.nix
@@ -1,0 +1,23 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkEspansoPlugin,
+}:
+mkEspansoPlugin {
+  pname = "escape";
+  version = "1.0.0";
+
+  src = fetchFromGitHub {
+    owner = "espanso";
+    repo = "hub";
+    rev = "13eb7d6d7d242bbadfb43ed4284d6b46ba63ce11";
+    hash = "sha256-r0V24FeBiS8LRzbzMjLKJqitpoiOWnuynGMahmDYe3s=";
+  };
+
+  meta = {
+    description = "Common character escapes (backslashing, JSON, XML, URL-encoding, regex)";
+    homepage = "https://github.com/dicksonlaw583/espanso-escape";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ delafthi ];
+  };
+}

--- a/pkgs/by-name/es/espanso/plugins/espanso-dice/default.nix
+++ b/pkgs/by-name/es/espanso/plugins/espanso-dice/default.nix
@@ -1,0 +1,22 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkEspansoPlugin,
+}:
+mkEspansoPlugin {
+  pname = "espanso-dice";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "espanso";
+    repo = "hub";
+    rev = "d62bde95fc6f6cf90d4c23ee243922037c053def";
+    hash = "sha256-1cPtknrIi+9uTQt0pMaOBnY3C1GAGXPAA4fIgBh5Wgs=";
+  };
+
+  meta = {
+    description = "Dice emulator using the espanso random function.";
+    homepage = "https://github.com/Craftidore/espanso-dice";
+    maintainers = with lib.maintainers; [ delafthi ];
+  };
+}

--- a/pkgs/by-name/es/espanso/plugins/espanso-fractions/default.nix
+++ b/pkgs/by-name/es/espanso/plugins/espanso-fractions/default.nix
@@ -1,0 +1,22 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkEspansoPlugin,
+}:
+mkEspansoPlugin {
+  pname = "espanso-fractions";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "espanso";
+    repo = "hub";
+    rev = "d62bde95fc6f6cf90d4c23ee243922037c053def";
+    hash = "sha256-1cPtknrIi+9uTQt0pMaOBnY3C1GAGXPAA4fIgBh5Wgs=";
+  };
+
+  meta = {
+    description = "A package allowing you to use unicode fractions";
+    homepage = "https://github.com/apastuszak/espanso-package-fractions";
+    maintainers = with lib.maintainers; [ delafthi ];
+  };
+}

--- a/pkgs/by-name/es/espanso/plugins/espanso-latex/default.nix
+++ b/pkgs/by-name/es/espanso/plugins/espanso-latex/default.nix
@@ -1,0 +1,22 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkEspansoPlugin,
+}:
+mkEspansoPlugin {
+  pname = "espanso-latex";
+  version = "0.2.1";
+
+  src = fetchFromGitHub {
+    owner = "espanso";
+    repo = "hub";
+    rev = "d62bde95fc6f6cf90d4c23ee243922037c053def";
+    hash = "sha256-1cPtknrIi+9uTQt0pMaOBnY3C1GAGXPAA4fIgBh5Wgs=";
+  };
+
+  meta = {
+    description = "An espanso package to convert LaTeX symbol commands to Unicode symbols.";
+    homepage = "https://github.com/zoenglinghou/espanso-latex";
+    maintainers = with lib.maintainers; [ delafthi ];
+  };
+}

--- a/pkgs/by-name/es/espanso/plugins/espanso-pinyin-tones/default.nix
+++ b/pkgs/by-name/es/espanso/plugins/espanso-pinyin-tones/default.nix
@@ -1,0 +1,22 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkEspansoPlugin,
+}:
+mkEspansoPlugin {
+  pname = "espanso-pinyin-tones";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "espanso";
+    repo = "hub";
+    rev = "d62bde95fc6f6cf90d4c23ee243922037c053def";
+    hash = "sha256-1cPtknrIi+9uTQt0pMaOBnY3C1GAGXPAA4fIgBh5Wgs=";
+  };
+
+  meta = {
+    description = "A package for typing Chinese pinyin tones";
+    homepage = "https://github.com/IdiosApps/espanso-pinyin-tones";
+    maintainers = with lib.maintainers; [ delafthi ];
+  };
+}

--- a/pkgs/by-name/es/espanso/plugins/esperanto-accents/default.nix
+++ b/pkgs/by-name/es/espanso/plugins/esperanto-accents/default.nix
@@ -1,0 +1,22 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkEspansoPlugin,
+}:
+mkEspansoPlugin {
+  pname = "esperanto-accents";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "espanso";
+    repo = "hub";
+    rev = "d62bde95fc6f6cf90d4c23ee243922037c053def";
+    hash = "sha256-1cPtknrIi+9uTQt0pMaOBnY3C1GAGXPAA4fIgBh5Wgs=";
+  };
+
+  meta = {
+    description = "A package to type Esperanto accents. Type a non-accented letter followed by x e.g. cx, gx, hx, jx, sx, ux to get the corresponding letter with accent.";
+    homepage = "https://github.com/alexmiranda/espanso-package-esperanto";
+    maintainers = with lib.maintainers; [ delafthi ];
+  };
+}

--- a/pkgs/by-name/es/espanso/plugins/excel-package/default.nix
+++ b/pkgs/by-name/es/espanso/plugins/excel-package/default.nix
@@ -1,0 +1,22 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkEspansoPlugin,
+}:
+mkEspansoPlugin {
+  pname = "excel-package";
+  version = "1.0.0";
+
+  src = fetchFromGitHub {
+    owner = "espanso";
+    repo = "hub";
+    rev = "d62bde95fc6f6cf90d4c23ee243922037c053def";
+    hash = "sha256-1cPtknrIi+9uTQt0pMaOBnY3C1GAGXPAA4fIgBh5Wgs=";
+  };
+
+  meta = {
+    description = "Useful Excel formulas";
+    homepage = "https://github.com/karbassi/espanso-package-excel";
+    maintainers = with lib.maintainers; [ delafthi ];
+  };
+}

--- a/pkgs/by-name/es/espanso/plugins/expand-contractions-en/default.nix
+++ b/pkgs/by-name/es/espanso/plugins/expand-contractions-en/default.nix
@@ -1,0 +1,23 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkEspansoPlugin,
+}:
+mkEspansoPlugin {
+  pname = "expand-contractions-en";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "espanso";
+    repo = "hub";
+    rev = "d62bde95fc6f6cf90d4c23ee243922037c053def";
+    hash = "sha256-1cPtknrIi+9uTQt0pMaOBnY3C1GAGXPAA4fIgBh5Wgs=";
+  };
+
+  meta = {
+    description = "Expand English contractions";
+    homepage = "https://github.com/lewisblackburn/hub/tree/main/packages/expand-contractions-en";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ delafthi ];
+  };
+}

--- a/pkgs/by-name/es/espanso/plugins/flutter-snippets/default.nix
+++ b/pkgs/by-name/es/espanso/plugins/flutter-snippets/default.nix
@@ -1,0 +1,21 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkEspansoPlugin,
+}:
+mkEspansoPlugin {
+  pname = "flutter-snippets";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "espanso";
+    repo = "hub";
+    rev = "d62bde95fc6f6cf90d4c23ee243922037c053def";
+    hash = "sha256-1cPtknrIi+9uTQt0pMaOBnY3C1GAGXPAA4fIgBh5Wgs=";
+  };
+
+  meta = {
+    description = "A package for flutter code snippets";
+    maintainers = with lib.maintainers; [ delafthi ];
+  };
+}

--- a/pkgs/by-name/es/espanso/plugins/foreign-greetings/default.nix
+++ b/pkgs/by-name/es/espanso/plugins/foreign-greetings/default.nix
@@ -1,0 +1,23 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkEspansoPlugin,
+}:
+mkEspansoPlugin {
+  pname = "foreign-greetings";
+  version = "1.0.0";
+
+  src = fetchFromGitHub {
+    owner = "espanso";
+    repo = "hub";
+    rev = "d62bde95fc6f6cf90d4c23ee243922037c053def";
+    hash = "sha256-1cPtknrIi+9uTQt0pMaOBnY3C1GAGXPAA4fIgBh5Wgs=";
+  };
+
+  meta = {
+    description = "🌐 Espanso package to easy say Hi in different languages";
+    homepage = "https://github.com/kopach/espanso-package-foreign-greetings#readme";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ delafthi ];
+  };
+}

--- a/pkgs/by-name/es/espanso/plugins/foreign-thanks/default.nix
+++ b/pkgs/by-name/es/espanso/plugins/foreign-thanks/default.nix
@@ -1,0 +1,23 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkEspansoPlugin,
+}:
+mkEspansoPlugin {
+  pname = "foreign-thanks";
+  version = "1.1.0";
+
+  src = fetchFromGitHub {
+    owner = "espanso";
+    repo = "hub";
+    rev = "d62bde95fc6f6cf90d4c23ee243922037c053def";
+    hash = "sha256-1cPtknrIi+9uTQt0pMaOBnY3C1GAGXPAA4fIgBh5Wgs=";
+  };
+
+  meta = {
+    description = "🌐 Espanso package to easy say Thanks in different languages";
+    homepage = "https://github.com/kopach/espanso-package-foreign-thanks#readme";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ delafthi ];
+  };
+}

--- a/pkgs/by-name/es/espanso/plugins/form-list/default.nix
+++ b/pkgs/by-name/es/espanso/plugins/form-list/default.nix
@@ -1,0 +1,22 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkEspansoPlugin,
+}:
+mkEspansoPlugin {
+  pname = "form-list";
+  version = "0.2.1";
+
+  src = fetchFromGitHub {
+    owner = "espanso";
+    repo = "hub";
+    rev = "d62bde95fc6f6cf90d4c23ee243922037c053def";
+    hash = "sha256-1cPtknrIi+9uTQt0pMaOBnY3C1GAGXPAA4fIgBh5Wgs=";
+  };
+
+  meta = {
+    description = "Uses a CSV to present a list of links and then pastes the chosen URL.";
+    homepage = "https://github.com/smeech";
+    maintainers = with lib.maintainers; [ delafthi ];
+  };
+}

--- a/pkgs/by-name/es/espanso/plugins/french-accents/default.nix
+++ b/pkgs/by-name/es/espanso/plugins/french-accents/default.nix
@@ -1,0 +1,22 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkEspansoPlugin,
+}:
+mkEspansoPlugin {
+  pname = "french-accents";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "espanso";
+    repo = "hub";
+    rev = "d62bde95fc6f6cf90d4c23ee243922037c053def";
+    hash = "sha256-1cPtknrIi+9uTQt0pMaOBnY3C1GAGXPAA4fIgBh5Wgs=";
+  };
+
+  meta = {
+    description = "A package to type French with a non-French keyboard layout. It works by replacing keywords like e' with é.";
+    homepage = "https://github.com/ottopiramuthu/espanso-package-example";
+    maintainers = with lib.maintainers; [ delafthi ];
+  };
+}

--- a/pkgs/by-name/es/espanso/plugins/frontend-snippets/default.nix
+++ b/pkgs/by-name/es/espanso/plugins/frontend-snippets/default.nix
@@ -1,0 +1,22 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkEspansoPlugin,
+}:
+mkEspansoPlugin {
+  pname = "frontend-snippets";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "espanso";
+    repo = "hub";
+    rev = "d62bde95fc6f6cf90d4c23ee243922037c053def";
+    hash = "sha256-1cPtknrIi+9uTQt0pMaOBnY3C1GAGXPAA4fIgBh5Wgs=";
+  };
+
+  meta = {
+    description = "A simple package to make frontend development easier regardless of IDE.";
+    homepage = "https://github.com/irasanchez/frontend-snippets";
+    maintainers = with lib.maintainers; [ delafthi ];
+  };
+}

--- a/pkgs/by-name/es/espanso/plugins/gd-and-t/default.nix
+++ b/pkgs/by-name/es/espanso/plugins/gd-and-t/default.nix
@@ -1,0 +1,21 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkEspansoPlugin,
+}:
+mkEspansoPlugin {
+  pname = "gd-and-t";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "espanso";
+    repo = "hub";
+    rev = "d62bde95fc6f6cf90d4c23ee243922037c053def";
+    hash = "sha256-1cPtknrIi+9uTQt0pMaOBnY3C1GAGXPAA4fIgBh5Wgs=";
+  };
+
+  meta = {
+    description = "Common GD&T symbols";
+    maintainers = with lib.maintainers; [ delafthi ];
+  };
+}

--- a/pkgs/by-name/es/espanso/plugins/german-accents/default.nix
+++ b/pkgs/by-name/es/espanso/plugins/german-accents/default.nix
@@ -1,0 +1,22 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkEspansoPlugin,
+}:
+mkEspansoPlugin {
+  pname = "german-accents";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "espanso";
+    repo = "hub";
+    rev = "d62bde95fc6f6cf90d4c23ee243922037c053def";
+    hash = "sha256-1cPtknrIi+9uTQt0pMaOBnY3C1GAGXPAA4fIgBh5Wgs=";
+  };
+
+  meta = {
+    description = "Include German Accents substitutions to espanso";
+    homepage = "https://github.com/puven12/espanso-german-accents";
+    maintainers = with lib.maintainers; [ delafthi ];
+  };
+}

--- a/pkgs/by-name/es/espanso/plugins/german-plz/default.nix
+++ b/pkgs/by-name/es/espanso/plugins/german-plz/default.nix
@@ -1,0 +1,22 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkEspansoPlugin,
+}:
+mkEspansoPlugin {
+  pname = "german-plz";
+  version = "0.1.1";
+
+  src = fetchFromGitHub {
+    owner = "espanso";
+    repo = "hub";
+    rev = "d62bde95fc6f6cf90d4c23ee243922037c053def";
+    hash = "sha256-1cPtknrIi+9uTQt0pMaOBnY3C1GAGXPAA4fIgBh5Wgs=";
+  };
+
+  meta = {
+    description = "A package containing the german Postleitzahlen.";
+    homepage = "https://github.com/cyberfux/german-plz";
+    maintainers = with lib.maintainers; [ delafthi ];
+  };
+}

--- a/pkgs/by-name/es/espanso/plugins/german-words/default.nix
+++ b/pkgs/by-name/es/espanso/plugins/german-words/default.nix
@@ -1,0 +1,22 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkEspansoPlugin,
+}:
+mkEspansoPlugin {
+  pname = "german-words";
+  version = "0.0.4";
+
+  src = fetchFromGitHub {
+    owner = "espanso";
+    repo = "hub";
+    rev = "d62bde95fc6f6cf90d4c23ee243922037c053def";
+    hash = "sha256-1cPtknrIi+9uTQt0pMaOBnY3C1GAGXPAA4fIgBh5Wgs=";
+  };
+
+  meta = {
+    description = "A Package that includes basic German words.";
+    homepage = "https://github.com/Fatih5252/German-Words";
+    maintainers = with lib.maintainers; [ delafthi ];
+  };
+}

--- a/pkgs/by-name/es/espanso/plugins/get-ip/default.nix
+++ b/pkgs/by-name/es/espanso/plugins/get-ip/default.nix
@@ -1,0 +1,27 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkEspansoPlugin,
+  curl,
+}:
+mkEspansoPlugin {
+  pname = "get-ip";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "espanso";
+    repo = "hub";
+    rev = "d62bde95fc6f6cf90d4c23ee243922037c053def";
+    hash = "sha256-1cPtknrIi+9uTQt0pMaOBnY3C1GAGXPAA4fIgBh5Wgs=";
+  };
+
+  buildInputs = [
+    curl
+  ];
+
+  meta = {
+    description = "A espanso package to get IP address";
+    homepage = "https://github.com/yogeshbatra/espanso-get-ip-pack";
+    maintainers = with lib.maintainers; [ delafthi ];
+  };
+}

--- a/pkgs/by-name/es/espanso/plugins/git-conventional-commits/default.nix
+++ b/pkgs/by-name/es/espanso/plugins/git-conventional-commits/default.nix
@@ -1,0 +1,22 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkEspansoPlugin,
+}:
+mkEspansoPlugin {
+  pname = "git-conventional-commits";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "espanso";
+    repo = "hub";
+    rev = "d62bde95fc6f6cf90d4c23ee243922037c053def";
+    hash = "sha256-1cPtknrIi+9uTQt0pMaOBnY3C1GAGXPAA4fIgBh5Wgs=";
+  };
+
+  meta = {
+    description = "Snippets for creating conventional commits in git";
+    homepage = "https://github.com/devanlooches/espanso-git-conventional-commits";
+    maintainers = with lib.maintainers; [ delafthi ];
+  };
+}

--- a/pkgs/by-name/es/espanso/plugins/git/default.nix
+++ b/pkgs/by-name/es/espanso/plugins/git/default.nix
@@ -1,0 +1,22 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkEspansoPlugin,
+}:
+mkEspansoPlugin {
+  pname = "git";
+  version = "0.2.0";
+
+  src = fetchFromGitHub {
+    owner = "espanso";
+    repo = "hub";
+    rev = "d62bde95fc6f6cf90d4c23ee243922037c053def";
+    hash = "sha256-1cPtknrIi+9uTQt0pMaOBnY3C1GAGXPAA4fIgBh5Wgs=";
+  };
+
+  meta = {
+    description = "A package of the most common and important Git commands. Become faster with the Git CLI.";
+    homepage = "https://github.com/angelorpt/espanso-git";
+    maintainers = with lib.maintainers; [ delafthi ];
+  };
+}

--- a/pkgs/by-name/es/espanso/plugins/github-emojis-latest/default.nix
+++ b/pkgs/by-name/es/espanso/plugins/github-emojis-latest/default.nix
@@ -1,0 +1,21 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkEspansoPlugin,
+}:
+mkEspansoPlugin {
+  pname = "github-emojis-latest";
+  version = "1.0.0";
+
+  src = fetchFromGitHub {
+    owner = "espanso";
+    repo = "hub";
+    rev = "d62bde95fc6f6cf90d4c23ee243922037c053def";
+    hash = "sha256-1cPtknrIi+9uTQt0pMaOBnY3C1GAGXPAA4fIgBh5Wgs=";
+  };
+
+  meta = {
+    description = "A package that provides the latest emojis supported by GitHub";
+    maintainers = with lib.maintainers; [ delafthi ];
+  };
+}

--- a/pkgs/by-name/es/espanso/plugins/gitmojis/default.nix
+++ b/pkgs/by-name/es/espanso/plugins/gitmojis/default.nix
@@ -1,0 +1,22 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkEspansoPlugin,
+}:
+mkEspansoPlugin {
+  pname = "gitmojis";
+  version = "2.0.0";
+
+  src = fetchFromGitHub {
+    owner = "espanso";
+    repo = "hub";
+    rev = "d62bde95fc6f6cf90d4c23ee243922037c053def";
+    hash = "sha256-1cPtknrIi+9uTQt0pMaOBnY3C1GAGXPAA4fIgBh5Wgs=";
+  };
+
+  meta = {
+    description = "Translate gitmoji into emojis";
+    homepage = "https://github.com/Lyokolux/espanso-gitmojis";
+    maintainers = with lib.maintainers; [ delafthi ];
+  };
+}

--- a/pkgs/by-name/es/espanso/plugins/good-morning/default.nix
+++ b/pkgs/by-name/es/espanso/plugins/good-morning/default.nix
@@ -1,0 +1,22 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkEspansoPlugin,
+}:
+mkEspansoPlugin {
+  pname = "good-morning";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "espanso";
+    repo = "hub";
+    rev = "a5b6dbc16fa52e717f92a3667323cfd8646b47e0";
+    hash = "sha256-QoQqI1cKgX9Xkl6u5t0TggrjiNsn0N+nZsRVGh812Mg=";
+  };
+
+  meta = {
+    description = "Uses python to create personalized greetings that look like they were manually typed";
+    homepage = "https://github.com/josh-reeves/espanso-hub/tree/main/packages/good-morning/0.1.0";
+    maintainers = with lib.maintainers; [ delafthi ];
+  };
+}

--- a/pkgs/by-name/es/espanso/plugins/greek-letters-alt/default.nix
+++ b/pkgs/by-name/es/espanso/plugins/greek-letters-alt/default.nix
@@ -1,0 +1,22 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkEspansoPlugin,
+}:
+mkEspansoPlugin {
+  pname = "greek-letters-alt";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "espanso";
+    repo = "hub";
+    rev = "d62bde95fc6f6cf90d4c23ee243922037c053def";
+    hash = "sha256-1cPtknrIi+9uTQt0pMaOBnY3C1GAGXPAA4fIgBh5Wgs=";
+  };
+
+  meta = {
+    description = "Expand :[letter name] to the corresponding greek letter. The first character determines the letter case";
+    homepage = "https://github.com/Su-Well/espanso-package-greek-letters";
+    maintainers = with lib.maintainers; [ delafthi ];
+  };
+}

--- a/pkgs/by-name/es/espanso/plugins/greek-letters-improved/default.nix
+++ b/pkgs/by-name/es/espanso/plugins/greek-letters-improved/default.nix
@@ -1,0 +1,23 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkEspansoPlugin,
+}:
+mkEspansoPlugin {
+  pname = "greek-letters-improved";
+  version = "0.2.0";
+
+  src = fetchFromGitHub {
+    owner = "espanso";
+    repo = "hub";
+    rev = "d62bde95fc6f6cf90d4c23ee243922037c053def";
+    hash = "sha256-1cPtknrIi+9uTQt0pMaOBnY3C1GAGXPAA4fIgBh5Wgs=";
+  };
+
+  meta = {
+    description = "A package containing most of the Greek alphabet and some common variatons using Latex based naming scheme";
+    homepage = "https://github.com/jpmvferreira/espanso-mega-pack";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ delafthi ];
+  };
+}

--- a/pkgs/by-name/es/espanso/plugins/greek-letters/default.nix
+++ b/pkgs/by-name/es/espanso/plugins/greek-letters/default.nix
@@ -1,0 +1,22 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkEspansoPlugin,
+}:
+mkEspansoPlugin {
+  pname = "greek-letters";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "espanso";
+    repo = "hub";
+    rev = "d62bde95fc6f6cf90d4c23ee243922037c053def";
+    hash = "sha256-1cPtknrIi+9uTQt0pMaOBnY3C1GAGXPAA4fIgBh5Wgs=";
+  };
+
+  meta = {
+    description = "A simple way to type Greek upper and lowercase letters";
+    homepage = "https://github.com/exergonic/espanso-package-greek-letters";
+    maintainers = with lib.maintainers; [ delafthi ];
+  };
+}

--- a/pkgs/by-name/es/espanso/plugins/greetings-english/default.nix
+++ b/pkgs/by-name/es/espanso/plugins/greetings-english/default.nix
@@ -1,0 +1,22 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkEspansoPlugin,
+}:
+mkEspansoPlugin {
+  pname = "greetings-english";
+  version = "0.2.0";
+
+  src = fetchFromGitHub {
+    owner = "espanso";
+    repo = "hub";
+    rev = "d62bde95fc6f6cf90d4c23ee243922037c053def";
+    hash = "sha256-1cPtknrIi+9uTQt0pMaOBnY3C1GAGXPAA4fIgBh5Wgs=";
+  };
+
+  meta = {
+    description = "A few greeting snippets";
+    homepage = "https://github.com/espanso/hub/tree/main/packages/greetings-english/0.2.0";
+    maintainers = with lib.maintainers; [ delafthi ];
+  };
+}

--- a/pkgs/by-name/es/espanso/plugins/greetings-german/default.nix
+++ b/pkgs/by-name/es/espanso/plugins/greetings-german/default.nix
@@ -1,0 +1,22 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkEspansoPlugin,
+}:
+mkEspansoPlugin {
+  pname = "greetings-german";
+  version = "0.2.0";
+
+  src = fetchFromGitHub {
+    owner = "espanso";
+    repo = "hub";
+    rev = "d62bde95fc6f6cf90d4c23ee243922037c053def";
+    hash = "sha256-1cPtknrIi+9uTQt0pMaOBnY3C1GAGXPAA4fIgBh5Wgs=";
+  };
+
+  meta = {
+    description = "A few greeting snippets";
+    homepage = "https://github.com/espanso/hub/tree/main/packages/greetings-german/0.2.0";
+    maintainers = with lib.maintainers; [ delafthi ];
+  };
+}

--- a/pkgs/by-name/es/espanso/plugins/hax/default.nix
+++ b/pkgs/by-name/es/espanso/plugins/hax/default.nix
@@ -1,0 +1,21 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkEspansoPlugin,
+}:
+mkEspansoPlugin {
+  pname = "hax";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "espanso";
+    repo = "hub";
+    rev = "d62bde95fc6f6cf90d4c23ee243922037c053def";
+    hash = "sha256-1cPtknrIi+9uTQt0pMaOBnY3C1GAGXPAA4fIgBh5Wgs=";
+  };
+
+  meta = {
+    description = "Penetration testing utilities and replacements";
+    maintainers = with lib.maintainers; [ delafthi ];
+  };
+}

--- a/pkgs/by-name/es/espanso/plugins/html-colors/default.nix
+++ b/pkgs/by-name/es/espanso/plugins/html-colors/default.nix
@@ -1,0 +1,22 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkEspansoPlugin,
+}:
+mkEspansoPlugin {
+  pname = "html-colors";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "espanso";
+    repo = "hub";
+    rev = "d62bde95fc6f6cf90d4c23ee243922037c053def";
+    hash = "sha256-1cPtknrIi+9uTQt0pMaOBnY3C1GAGXPAA4fIgBh5Wgs=";
+  };
+
+  meta = {
+    description = "HTML color codes in hex and RGB formats.";
+    homepage = "https://github.com/danielvartan/html-colors";
+    maintainers = with lib.maintainers; [ delafthi ];
+  };
+}

--- a/pkgs/by-name/es/espanso/plugins/html-entities-unicode/default.nix
+++ b/pkgs/by-name/es/espanso/plugins/html-entities-unicode/default.nix
@@ -1,0 +1,22 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkEspansoPlugin,
+}:
+mkEspansoPlugin {
+  pname = "html-entities-unicode";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "espanso";
+    repo = "hub";
+    rev = "13eb7d6d7d242bbadfb43ed4284d6b46ba63ce11";
+    hash = "sha256-r0V24FeBiS8LRzbzMjLKJqitpoiOWnuynGMahmDYe3s=";
+  };
+
+  meta = {
+    description = "A character entity decoder, converting HTML/XML named character entities into their corresponding Unicode characters.";
+    homepage = "https://github.com/kijeEnki";
+    maintainers = with lib.maintainers; [ delafthi ];
+  };
+}

--- a/pkgs/by-name/es/espanso/plugins/html-utils-package/default.nix
+++ b/pkgs/by-name/es/espanso/plugins/html-utils-package/default.nix
@@ -1,0 +1,22 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkEspansoPlugin,
+}:
+mkEspansoPlugin {
+  pname = "html-utils-package";
+  version = "2.0.1";
+
+  src = fetchFromGitHub {
+    owner = "espanso";
+    repo = "hub";
+    rev = "d62bde95fc6f6cf90d4c23ee243922037c053def";
+    hash = "sha256-1cPtknrIi+9uTQt0pMaOBnY3C1GAGXPAA4fIgBh5Wgs=";
+  };
+
+  meta = {
+    description = "A simple package to make coding in HTML5 easier.";
+    homepage = "https://github.com/woodenbell/html-utils-package";
+    maintainers = with lib.maintainers; [ delafthi ];
+  };
+}

--- a/pkgs/by-name/es/espanso/plugins/hugo-shortcodes/default.nix
+++ b/pkgs/by-name/es/espanso/plugins/hugo-shortcodes/default.nix
@@ -1,0 +1,21 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkEspansoPlugin,
+}:
+mkEspansoPlugin {
+  pname = "hugo-shortcodes";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "espanso";
+    repo = "hub";
+    rev = "d62bde95fc6f6cf90d4c23ee243922037c053def";
+    hash = "sha256-1cPtknrIi+9uTQt0pMaOBnY3C1GAGXPAA4fIgBh5Wgs=";
+  };
+
+  meta = {
+    description = "A selection of shortcodes for the Hugo static site generator. platform.";
+    maintainers = with lib.maintainers; [ delafthi ];
+  };
+}

--- a/pkgs/by-name/es/espanso/plugins/icd10-codes-2025/default.nix
+++ b/pkgs/by-name/es/espanso/plugins/icd10-codes-2025/default.nix
@@ -1,0 +1,22 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkEspansoPlugin,
+}:
+mkEspansoPlugin {
+  pname = "icd10-codes-2025";
+  version = "1.0.0";
+
+  src = fetchFromGitHub {
+    owner = "espanso";
+    repo = "hub";
+    rev = "d62bde95fc6f6cf90d4c23ee243922037c053def";
+    hash = "sha256-1cPtknrIi+9uTQt0pMaOBnY3C1GAGXPAA4fIgBh5Wgs=";
+  };
+
+  meta = {
+    description = "Transforms ICD10 codes to their detailed descriptions.";
+    homepage = "https://github.com/spklk/hub/tree/main";
+    maintainers = with lib.maintainers; [ delafthi ];
+  };
+}

--- a/pkgs/by-name/es/espanso/plugins/ip/default.nix
+++ b/pkgs/by-name/es/espanso/plugins/ip/default.nix
@@ -1,0 +1,25 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkEspansoPlugin,
+  dig,
+}:
+mkEspansoPlugin {
+  pname = "ip";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "espanso";
+    repo = "hub";
+    rev = "d62bde95fc6f6cf90d4c23ee243922037c053def";
+    hash = "sha256-1cPtknrIi+9uTQt0pMaOBnY3C1GAGXPAA4fIgBh5Wgs=";
+  };
+
+  buildInputs = [ dig ];
+
+  meta = {
+    description = "Display your public IP with :ip ( Linux only )";
+    homepage = "https://github.com/profy12/espanso-package-ip";
+    maintainers = with lib.maintainers; [ delafthi ];
+  };
+}

--- a/pkgs/by-name/es/espanso/plugins/ip64/default.nix
+++ b/pkgs/by-name/es/espanso/plugins/ip64/default.nix
@@ -1,0 +1,25 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkEspansoPlugin,
+  curl,
+}:
+mkEspansoPlugin {
+  pname = "ip64";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "espanso";
+    repo = "hub";
+    rev = "d62bde95fc6f6cf90d4c23ee243922037c053def";
+    hash = "sha256-1cPtknrIi+9uTQt0pMaOBnY3C1GAGXPAA4fIgBh5Wgs=";
+  };
+
+  buildInputs = [ curl ];
+
+  meta = {
+    description = "Replace :ipv4 with your external IPv4 and :ip6 with your IPv6 (Linux and MacOS)";
+    homepage = "https://github.com/tweinreich/espanso-package-ip64";
+    maintainers = with lib.maintainers; [ delafthi ];
+  };
+}

--- a/pkgs/by-name/es/espanso/plugins/italian-accented-words/default.nix
+++ b/pkgs/by-name/es/espanso/plugins/italian-accented-words/default.nix
@@ -1,0 +1,22 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkEspansoPlugin,
+}:
+mkEspansoPlugin {
+  pname = "italian-accented-words";
+  version = "0.1.1";
+
+  src = fetchFromGitHub {
+    owner = "espanso";
+    repo = "hub";
+    rev = "d62bde95fc6f6cf90d4c23ee243922037c053def";
+    hash = "sha256-1cPtknrIi+9uTQt0pMaOBnY3C1GAGXPAA4fIgBh5Wgs=";
+  };
+
+  meta = {
+    description = "List of substitutions of Italian accented words";
+    homepage = "https://github.com/aecant/espanso-italian-accented-words";
+    maintainers = with lib.maintainers; [ delafthi ];
+  };
+}

--- a/pkgs/by-name/es/espanso/plugins/italian-accents/default.nix
+++ b/pkgs/by-name/es/espanso/plugins/italian-accents/default.nix
@@ -1,0 +1,21 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkEspansoPlugin,
+}:
+mkEspansoPlugin {
+  pname = "italian-accents";
+  version = "0.2.0";
+
+  src = fetchFromGitHub {
+    owner = "espanso";
+    repo = "hub";
+    rev = "d62bde95fc6f6cf90d4c23ee243922037c053def";
+    hash = "sha256-1cPtknrIi+9uTQt0pMaOBnY3C1GAGXPAA4fIgBh5Wgs=";
+  };
+
+  meta = {
+    description = "Include Italian accents substitutions to espanso.";
+    maintainers = with lib.maintainers; [ delafthi ];
+  };
+}

--- a/pkgs/by-name/es/espanso/plugins/jekyll-yaml/default.nix
+++ b/pkgs/by-name/es/espanso/plugins/jekyll-yaml/default.nix
@@ -1,0 +1,22 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkEspansoPlugin,
+}:
+mkEspansoPlugin {
+  pname = "jekyll-yaml";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "espanso";
+    repo = "hub";
+    rev = "d62bde95fc6f6cf90d4c23ee243922037c053def";
+    hash = "sha256-1cPtknrIi+9uTQt0pMaOBnY3C1GAGXPAA4fIgBh5Wgs=";
+  };
+
+  meta = {
+    description = "A simple package to add metadata to your jekyll posts before writing.";
+    homepage = "https://github.com/nullnein/espanso-hub/tree/main";
+    maintainers = with lib.maintainers; [ delafthi ];
+  };
+}

--- a/pkgs/by-name/es/espanso/plugins/jier/default.nix
+++ b/pkgs/by-name/es/espanso/plugins/jier/default.nix
@@ -1,0 +1,21 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkEspansoPlugin,
+}:
+mkEspansoPlugin {
+  pname = "jier";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "espanso";
+    repo = "hub";
+    rev = "d62bde95fc6f6cf90d4c23ee243922037c053def";
+    hash = "sha256-1cPtknrIi+9uTQt0pMaOBnY3C1GAGXPAA4fIgBh5Wgs=";
+  };
+
+  meta = {
+    description = "jier's tools";
+    maintainers = with lib.maintainers; [ delafthi ];
+  };
+}

--- a/pkgs/by-name/es/espanso/plugins/jojo-gifs/default.nix
+++ b/pkgs/by-name/es/espanso/plugins/jojo-gifs/default.nix
@@ -1,0 +1,22 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkEspansoPlugin,
+}:
+mkEspansoPlugin {
+  pname = "jojo-gifs";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "espanso";
+    repo = "hub";
+    rev = "d62bde95fc6f6cf90d4c23ee243922037c053def";
+    hash = "sha256-1cPtknrIi+9uTQt0pMaOBnY3C1GAGXPAA4fIgBh5Wgs=";
+  };
+
+  meta = {
+    description = "Macros for JoJo reaction GIFs imgur URLs";
+    homepage = "https://github.com/sin3point14/espanso-package-example";
+    maintainers = with lib.maintainers; [ delafthi ];
+  };
+}

--- a/pkgs/by-name/es/espanso/plugins/jops/default.nix
+++ b/pkgs/by-name/es/espanso/plugins/jops/default.nix
@@ -1,0 +1,21 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkEspansoPlugin,
+}:
+mkEspansoPlugin {
+  pname = "jops";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "espanso";
+    repo = "hub";
+    rev = "d62bde95fc6f6cf90d4c23ee243922037c053def";
+    hash = "sha256-1cPtknrIi+9uTQt0pMaOBnY3C1GAGXPAA4fIgBh5Wgs=";
+  };
+
+  meta = {
+    description = "Shortcuts for Joplin";
+    maintainers = with lib.maintainers; [ delafthi ];
+  };
+}

--- a/pkgs/by-name/es/espanso/plugins/julia-completions/default.nix
+++ b/pkgs/by-name/es/espanso/plugins/julia-completions/default.nix
@@ -1,0 +1,22 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkEspansoPlugin,
+}:
+mkEspansoPlugin {
+  pname = "julia-completions";
+  version = "1.7.0";
+
+  src = fetchFromGitHub {
+    owner = "espanso";
+    repo = "hub";
+    rev = "d62bde95fc6f6cf90d4c23ee243922037c053def";
+    hash = "sha256-1cPtknrIi+9uTQt0pMaOBnY3C1GAGXPAA4fIgBh5Wgs=";
+  };
+
+  meta = {
+    description = "Julia latex and emoji completions for espanso";
+    homepage = "https://github.com/lukeburns/espanso-julia-completions";
+    maintainers = with lib.maintainers; [ delafthi ];
+  };
+}

--- a/pkgs/by-name/es/espanso/plugins/k8s/default.nix
+++ b/pkgs/by-name/es/espanso/plugins/k8s/default.nix
@@ -1,0 +1,21 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkEspansoPlugin,
+}:
+mkEspansoPlugin {
+  pname = "k8s";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "espanso";
+    repo = "hub";
+    rev = "d62bde95fc6f6cf90d4c23ee243922037c053def";
+    hash = "sha256-1cPtknrIi+9uTQt0pMaOBnY3C1GAGXPAA4fIgBh5Wgs=";
+  };
+
+  meta = {
+    description = "k8s shortcodes";
+    maintainers = with lib.maintainers; [ delafthi ];
+  };
+}

--- a/pkgs/by-name/es/espanso/plugins/kaimoji/default.nix
+++ b/pkgs/by-name/es/espanso/plugins/kaimoji/default.nix
@@ -1,0 +1,22 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkEspansoPlugin,
+}:
+mkEspansoPlugin {
+  pname = "kaimoji";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "espanso";
+    repo = "hub";
+    rev = "d62bde95fc6f6cf90d4c23ee243922037c053def";
+    hash = "sha256-1cPtknrIi+9uTQt0pMaOBnY3C1GAGXPAA4fIgBh5Wgs=";
+  };
+
+  meta = {
+    description = "A package providing Kaimoji expansions";
+    homepage = "https://github.com/pard68/kaimoji";
+    maintainers = with lib.maintainers; [ delafthi ];
+  };
+}

--- a/pkgs/by-name/es/espanso/plugins/kaomoji/default.nix
+++ b/pkgs/by-name/es/espanso/plugins/kaomoji/default.nix
@@ -1,0 +1,23 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkEspansoPlugin,
+}:
+mkEspansoPlugin {
+  pname = "kaomoji";
+  version = "0.2.0";
+
+  src = fetchFromGitHub {
+    owner = "espanso";
+    repo = "hub";
+    rev = "d62bde95fc6f6cf90d4c23ee243922037c053def";
+    hash = "sha256-1cPtknrIi+9uTQt0pMaOBnY3C1GAGXPAA4fIgBh5Wgs=";
+  };
+
+  meta = {
+    description = "plenty of fun kaomoji";
+    homepage = "https://gitlab.com/citrusmunch/espanso-kaomoji";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ delafthi ];
+  };
+}

--- a/pkgs/by-name/es/espanso/plugins/kubernetes/default.nix
+++ b/pkgs/by-name/es/espanso/plugins/kubernetes/default.nix
@@ -1,0 +1,22 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkEspansoPlugin,
+}:
+mkEspansoPlugin {
+  pname = "kubernetes";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "espanso";
+    repo = "hub";
+    rev = "d62bde95fc6f6cf90d4c23ee243922037c053def";
+    hash = "sha256-1cPtknrIi+9uTQt0pMaOBnY3C1GAGXPAA4fIgBh5Wgs=";
+  };
+
+  meta = {
+    description = "Kubernetes manifests";
+    homepage = "https://github.com/QJoly/espanso-kubernetes";
+    maintainers = with lib.maintainers; [ delafthi ];
+  };
+}

--- a/pkgs/by-name/es/espanso/plugins/lean-symbols/default.nix
+++ b/pkgs/by-name/es/espanso/plugins/lean-symbols/default.nix
@@ -1,0 +1,23 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkEspansoPlugin,
+}:
+mkEspansoPlugin {
+  pname = "lean-symbols";
+  version = "1.0.0";
+
+  src = fetchFromGitHub {
+    owner = "espanso";
+    repo = "hub";
+    rev = "d62bde95fc6f6cf90d4c23ee243922037c053def";
+    hash = "sha256-1cPtknrIi+9uTQt0pMaOBnY3C1GAGXPAA4fIgBh5Wgs=";
+  };
+
+  meta = {
+    description = "Insert symbols like ∑ Π α → ↦  Γ etc, the same set of symbols as the VScode lean4  extension allows you to insert, using the same shortcuts. For example '\\a\\', '\\a ', '\\aTAB',  all insert α, i.e. the greek alpha. TAB denotes a single press of the tab key.
+";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ delafthi ];
+  };
+}

--- a/pkgs/by-name/es/espanso/plugins/lean/default.nix
+++ b/pkgs/by-name/es/espanso/plugins/lean/default.nix
@@ -1,0 +1,21 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkEspansoPlugin,
+}:
+mkEspansoPlugin {
+  pname = "lean";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "espanso";
+    repo = "hub";
+    rev = "d62bde95fc6f6cf90d4c23ee243922037c053def";
+    hash = "sha256-1cPtknrIi+9uTQt0pMaOBnY3C1GAGXPAA4fIgBh5Wgs=";
+  };
+
+  meta = {
+    description = "Input abbreviations for unicode symbols for the Lean theorem prover";
+    maintainers = with lib.maintainers; [ delafthi ];
+  };
+}

--- a/pkgs/by-name/es/espanso/plugins/linter-control-comments/default.nix
+++ b/pkgs/by-name/es/espanso/plugins/linter-control-comments/default.nix
@@ -1,0 +1,22 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkEspansoPlugin,
+}:
+mkEspansoPlugin {
+  pname = "linter-control-comments";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "espanso";
+    repo = "hub";
+    rev = "d62bde95fc6f6cf90d4c23ee243922037c053def";
+    hash = "sha256-1cPtknrIi+9uTQt0pMaOBnY3C1GAGXPAA4fIgBh5Wgs=";
+  };
+
+  meta = {
+    description = "A collection of linter control comments (currently: Golint, Rubocop, Clippy, and Shellcheck)";
+    homepage = "https://github.com/katrinleinweber/espanso-hub/tree/package-linter-control-comments";
+    maintainers = with lib.maintainers; [ delafthi ];
+  };
+}

--- a/pkgs/by-name/es/espanso/plugins/llm-ask-ai/default.nix
+++ b/pkgs/by-name/es/espanso/plugins/llm-ask-ai/default.nix
@@ -1,0 +1,31 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkEspansoPlugin,
+  python3,
+  python3Packages,
+}:
+mkEspansoPlugin {
+  pname = "llm-ask-ai";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "espanso";
+    repo = "hub";
+    rev = "a5b6dbc16fa52e717f92a3667323cfd8646b47e0";
+    hash = "sha256-QoQqI1cKgX9Xkl6u5t0TggrjiNsn0N+nZsRVGh812Mg=";
+  };
+
+  buildInputs = [
+    python3
+    python3Packages.openai
+    python3Packages.python-dotenv
+  ];
+
+  meta = {
+    description = "An Espanso package that enables users to quickly send prompts to a local (e.g. Ollama or LM Studio) or remote LLM API calls (OpenAI standard) and insert the AI-generated response directly into any text field.";
+    license = lib.licenses.mit;
+    homepage = "https://github.com/bgeneto/espanso-llm-ask-ai";
+    maintainers = with lib.maintainers; [ delafthi ];
+  };
+}

--- a/pkgs/by-name/es/espanso/plugins/llm-prompts/default.nix
+++ b/pkgs/by-name/es/espanso/plugins/llm-prompts/default.nix
@@ -1,0 +1,22 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkEspansoPlugin,
+}:
+mkEspansoPlugin {
+  pname = "llm-prompts";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "espanso";
+    repo = "hub";
+    rev = "d62bde95fc6f6cf90d4c23ee243922037c053def";
+    hash = "sha256-1cPtknrIi+9uTQt0pMaOBnY3C1GAGXPAA4fIgBh5Wgs=";
+  };
+
+  meta = {
+    description = "A package with helpful prompts for AI Chat and LLMs like ChatGPT, Gemini, Claude, ...";
+    homepage = "https://github.com/mmarschall/prompt-expander";
+    maintainers = with lib.maintainers; [ delafthi ];
+  };
+}

--- a/pkgs/by-name/es/espanso/plugins/logic-symbols/default.nix
+++ b/pkgs/by-name/es/espanso/plugins/logic-symbols/default.nix
@@ -1,0 +1,21 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkEspansoPlugin,
+}:
+mkEspansoPlugin {
+  pname = "logic-symbols";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "espanso";
+    repo = "hub";
+    rev = "d62bde95fc6f6cf90d4c23ee243922037c053def";
+    hash = "sha256-1cPtknrIi+9uTQt0pMaOBnY3C1GAGXPAA4fIgBh5Wgs=";
+  };
+
+  meta = {
+    description = "Commonly used symbols in predicate logic and boolean algebra.";
+    maintainers = with lib.maintainers; [ delafthi ];
+  };
+}

--- a/pkgs/by-name/es/espanso/plugins/lorem/default.nix
+++ b/pkgs/by-name/es/espanso/plugins/lorem/default.nix
@@ -1,0 +1,22 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkEspansoPlugin,
+}:
+mkEspansoPlugin {
+  pname = "lorem";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "espanso";
+    repo = "hub";
+    rev = "d62bde95fc6f6cf90d4c23ee243922037c053def";
+    hash = "sha256-1cPtknrIi+9uTQt0pMaOBnY3C1GAGXPAA4fIgBh5Wgs=";
+  };
+
+  meta = {
+    description = "Lorem ipsum sentences and paragraphs generator.";
+    homepage = "https://github.com/atika/espanso-lorem";
+    maintainers = with lib.maintainers; [ delafthi ];
+  };
+}

--- a/pkgs/by-name/es/espanso/plugins/lower-upper/default.nix
+++ b/pkgs/by-name/es/espanso/plugins/lower-upper/default.nix
@@ -1,0 +1,23 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkEspansoPlugin,
+}:
+mkEspansoPlugin {
+  pname = "lower-upper";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "espanso";
+    repo = "hub";
+    rev = "d62bde95fc6f6cf90d4c23ee243922037c053def";
+    hash = "sha256-1cPtknrIi+9uTQt0pMaOBnY3C1GAGXPAA4fIgBh5Wgs=";
+  };
+
+  meta = {
+    description = "A simple package to convert clipboard content to lower case or UPPER case. (UNIX only)";
+    homepage = "https://github.com/anthonygraignic/espanso-package-lower-upper";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ delafthi ];
+  };
+}

--- a/pkgs/by-name/es/espanso/plugins/mac-symbols/default.nix
+++ b/pkgs/by-name/es/espanso/plugins/mac-symbols/default.nix
@@ -1,0 +1,22 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkEspansoPlugin,
+}:
+mkEspansoPlugin {
+  pname = "mac-symbols";
+  version = "0.1.1";
+
+  src = fetchFromGitHub {
+    owner = "espanso";
+    repo = "hub";
+    rev = "d62bde95fc6f6cf90d4c23ee243922037c053def";
+    hash = "sha256-1cPtknrIi+9uTQt0pMaOBnY3C1GAGXPAA4fIgBh5Wgs=";
+  };
+
+  meta = {
+    description = "Display common Mac symbols like ⌘ and ⌥";
+    homepage = "https://github.com/lifesign/espanso-mac-symbols";
+    maintainers = with lib.maintainers; [ delafthi ];
+  };
+}

--- a/pkgs/by-name/es/espanso/plugins/markdown-shortcuts/default.nix
+++ b/pkgs/by-name/es/espanso/plugins/markdown-shortcuts/default.nix
@@ -1,0 +1,23 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkEspansoPlugin,
+}:
+mkEspansoPlugin {
+  pname = "markdown-shortcuts";
+  version = "0.2.0";
+
+  src = fetchFromGitHub {
+    owner = "espanso";
+    repo = "hub";
+    rev = "d62bde95fc6f6cf90d4c23ee243922037c053def";
+    hash = "sha256-1cPtknrIi+9uTQt0pMaOBnY3C1GAGXPAA4fIgBh5Wgs=";
+  };
+
+  meta = {
+    description = "A simple package to make writing Markdown easier";
+    homepage = "https://github.com/jpmvferreira/espanso-mega-pack";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ delafthi ];
+  };
+}

--- a/pkgs/by-name/es/espanso/plugins/math-symbols/default.nix
+++ b/pkgs/by-name/es/espanso/plugins/math-symbols/default.nix
@@ -1,0 +1,23 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkEspansoPlugin,
+}:
+mkEspansoPlugin {
+  pname = "math-symbols";
+  version = "0.2.0";
+
+  src = fetchFromGitHub {
+    owner = "espanso";
+    repo = "hub";
+    rev = "d62bde95fc6f6cf90d4c23ee243922037c053def";
+    hash = "sha256-1cPtknrIi+9uTQt0pMaOBnY3C1GAGXPAA4fIgBh5Wgs=";
+  };
+
+  meta = {
+    description = "Displays math symbols using Latex based naming scheme";
+    homepage = "https://github.com/jpmvferreira/espanso-mega-pack";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ delafthi ];
+  };
+}

--- a/pkgs/by-name/es/espanso/plugins/math/default.nix
+++ b/pkgs/by-name/es/espanso/plugins/math/default.nix
@@ -1,0 +1,22 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkEspansoPlugin,
+}:
+mkEspansoPlugin {
+  pname = "math";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "espanso";
+    repo = "hub";
+    rev = "d62bde95fc6f6cf90d4c23ee243922037c053def";
+    hash = "sha256-1cPtknrIi+9uTQt0pMaOBnY3C1GAGXPAA4fIgBh5Wgs=";
+  };
+
+  meta = {
+    description = "Mathematical symbols such as for Boolean and set operations";
+    homepage = "https://github.com/dmfay/espanso-math";
+    maintainers = with lib.maintainers; [ delafthi ];
+  };
+}

--- a/pkgs/by-name/es/espanso/plugins/med-expansions/default.nix
+++ b/pkgs/by-name/es/espanso/plugins/med-expansions/default.nix
@@ -1,0 +1,21 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkEspansoPlugin,
+}:
+mkEspansoPlugin {
+  pname = "med-expansions";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "espanso";
+    repo = "hub";
+    rev = "d62bde95fc6f6cf90d4c23ee243922037c053def";
+    hash = "sha256-1cPtknrIi+9uTQt0pMaOBnY3C1GAGXPAA4fIgBh5Wgs=";
+  };
+
+  meta = {
+    description = "Systematically formatted triggers for medical writing and notetaking";
+    maintainers = with lib.maintainers; [ delafthi ];
+  };
+}

--- a/pkgs/by-name/es/espanso/plugins/medical-docs/default.nix
+++ b/pkgs/by-name/es/espanso/plugins/medical-docs/default.nix
@@ -1,0 +1,23 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkEspansoPlugin,
+}:
+mkEspansoPlugin {
+  pname = "medical-docs";
+  version = "0.1.2";
+
+  src = fetchFromGitHub {
+    owner = "espanso";
+    repo = "hub";
+    rev = "d62bde95fc6f6cf90d4c23ee243922037c053def";
+    hash = "sha256-1cPtknrIi+9uTQt0pMaOBnY3C1GAGXPAA4fIgBh5Wgs=";
+  };
+
+  meta = {
+    description = "A package to assist in medical Documentation";
+    homepage = "https://github.com/wressl/medical-docs";
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [ delafthi ];
+  };
+}

--- a/pkgs/by-name/es/espanso/plugins/misspell-de/default.nix
+++ b/pkgs/by-name/es/espanso/plugins/misspell-de/default.nix
@@ -1,0 +1,22 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkEspansoPlugin,
+}:
+mkEspansoPlugin {
+  pname = "misspell-de";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "espanso";
+    repo = "hub";
+    rev = "a5b6dbc16fa52e717f92a3667323cfd8646b47e0";
+    hash = "sha256-QoQqI1cKgX9Xkl6u5t0TggrjiNsn0N+nZsRVGh812Mg=";
+  };
+
+  meta = {
+    description = "Replace commonly misspelled German words";
+    homepage = "https://github.com/Aki247/hub/tree/main";
+    maintainers = with lib.maintainers; [ delafthi ];
+  };
+}

--- a/pkgs/by-name/es/espanso/plugins/misspell-en-uk/default.nix
+++ b/pkgs/by-name/es/espanso/plugins/misspell-en-uk/default.nix
@@ -1,0 +1,23 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkEspansoPlugin,
+}:
+mkEspansoPlugin {
+  pname = "misspell-en-uk";
+  version = "0.1.2";
+
+  src = fetchFromGitHub {
+    owner = "espanso";
+    repo = "hub";
+    rev = "d62bde95fc6f6cf90d4c23ee243922037c053def";
+    hash = "sha256-1cPtknrIi+9uTQt0pMaOBnY3C1GAGXPAA4fIgBh5Wgs=";
+  };
+
+  meta = {
+    description = "Replace american english with british english.";
+    homepage = "https://github.com/timorunge/espanso-misspell-en";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ delafthi ];
+  };
+}

--- a/pkgs/by-name/es/espanso/plugins/misspell-en-us/default.nix
+++ b/pkgs/by-name/es/espanso/plugins/misspell-en-us/default.nix
@@ -1,0 +1,23 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkEspansoPlugin,
+}:
+mkEspansoPlugin {
+  pname = "misspell-en-us";
+  version = "0.1.2";
+
+  src = fetchFromGitHub {
+    owner = "espanso";
+    repo = "hub";
+    rev = "d62bde95fc6f6cf90d4c23ee243922037c053def";
+    hash = "sha256-1cPtknrIi+9uTQt0pMaOBnY3C1GAGXPAA4fIgBh5Wgs=";
+  };
+
+  meta = {
+    description = "Replace british english with american english.";
+    homepage = "https://github.com/timorunge/espanso-misspell-en";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ delafthi ];
+  };
+}

--- a/pkgs/by-name/es/espanso/plugins/misspell-en/default.nix
+++ b/pkgs/by-name/es/espanso/plugins/misspell-en/default.nix
@@ -1,0 +1,23 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkEspansoPlugin,
+}:
+mkEspansoPlugin {
+  pname = "misspell-en";
+  version = "0.1.2";
+
+  src = fetchFromGitHub {
+    owner = "espanso";
+    repo = "hub";
+    rev = "d62bde95fc6f6cf90d4c23ee243922037c053def";
+    hash = "sha256-1cPtknrIi+9uTQt0pMaOBnY3C1GAGXPAA4fIgBh5Wgs=";
+  };
+
+  meta = {
+    description = "Replace commonly misspelled english words.";
+    homepage = "https://github.com/timorunge/espanso-misspell-en";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ delafthi ];
+  };
+}

--- a/pkgs/by-name/es/espanso/plugins/named-html-entities/default.nix
+++ b/pkgs/by-name/es/espanso/plugins/named-html-entities/default.nix
@@ -1,0 +1,22 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkEspansoPlugin,
+}:
+mkEspansoPlugin {
+  pname = "named-html-entities";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "espanso";
+    repo = "hub";
+    rev = "a5b6dbc16fa52e717f92a3667323cfd8646b47e0";
+    hash = "sha256-QoQqI1cKgX9Xkl6u5t0TggrjiNsn0N+nZsRVGh812Mg=";
+  };
+
+  meta = {
+    description = "Replace HTML named entity references with their corresponding characters";
+    homepage = "https://github.com/mrled/espanso-named-html-entities";
+    maintainers = with lib.maintainers; [ delafthi ];
+  };
+}

--- a/pkgs/by-name/es/espanso/plugins/norwegian-us-keyboard/default.nix
+++ b/pkgs/by-name/es/espanso/plugins/norwegian-us-keyboard/default.nix
@@ -1,0 +1,21 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkEspansoPlugin,
+}:
+mkEspansoPlugin {
+  pname = "norwegian-us-keyboard";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "espanso";
+    repo = "hub";
+    rev = "d62bde95fc6f6cf90d4c23ee243922037c053def";
+    hash = "sha256-1cPtknrIi+9uTQt0pMaOBnY3C1GAGXPAA4fIgBh5Wgs=";
+  };
+
+  meta = {
+    description = "A simpler way to enter Norwegian characters (æøå, àéò and «») on US keyboards.";
+    maintainers = with lib.maintainers; [ delafthi ];
+  };
+}

--- a/pkgs/by-name/es/espanso/plugins/numeronyms/default.nix
+++ b/pkgs/by-name/es/espanso/plugins/numeronyms/default.nix
@@ -1,0 +1,23 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkEspansoPlugin,
+}:
+mkEspansoPlugin {
+  pname = "numeronyms";
+  version = "1.0.0";
+
+  src = fetchFromGitHub {
+    owner = "espanso";
+    repo = "hub";
+    rev = "d62bde95fc6f6cf90d4c23ee243922037c053def";
+    hash = "sha256-1cPtknrIi+9uTQt0pMaOBnY3C1GAGXPAA4fIgBh5Wgs=";
+  };
+
+  meta = {
+    description = "Commonly used numeronyms";
+    homepage = "https://github.com/omrilotan/espanso-package-numeronyms";
+    license = lib.licenses.unlicense;
+    maintainers = with lib.maintainers; [ delafthi ];
+  };
+}

--- a/pkgs/by-name/es/espanso/plugins/oasis-is-framework/default.nix
+++ b/pkgs/by-name/es/espanso/plugins/oasis-is-framework/default.nix
@@ -1,0 +1,22 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkEspansoPlugin,
+}:
+mkEspansoPlugin {
+  pname = "oasis-is-framework";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "espanso";
+    repo = "hub";
+    rev = "d62bde95fc6f6cf90d4c23ee243922037c053def";
+    hash = "sha256-1cPtknrIi+9uTQt0pMaOBnY3C1GAGXPAA4fIgBh5Wgs=";
+  };
+
+  meta = {
+    description = "OASIS-IS Generative AI mega-prompt framework for \"conversations\" with Generative AI.  This is a starter prompt that gets the information you need to added to your initial prompt.";
+    homepage = "https://github.com/Ryfter/oasis-is-framework/";
+    maintainers = with lib.maintainers; [ delafthi ];
+  };
+}

--- a/pkgs/by-name/es/espanso/plugins/pan-snippets/default.nix
+++ b/pkgs/by-name/es/espanso/plugins/pan-snippets/default.nix
@@ -1,0 +1,23 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkEspansoPlugin,
+}:
+mkEspansoPlugin {
+  pname = "pan-snippets";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "espanso";
+    repo = "hub";
+    rev = "a5b6dbc16fa52e717f92a3667323cfd8646b47e0";
+    hash = "sha256-QoQqI1cKgX9Xkl6u5t0TggrjiNsn0N+nZsRVGh812Mg=";
+  };
+
+  meta = {
+    description = "Snippets for Palo Alto Networks Firewalls and Panorama";
+    license = lib.licenses.mit;
+    homepage = "https://github.com/itsamemarkus/espanso-pan";
+    maintainers = with lib.maintainers; [ delafthi ];
+  };
+}

--- a/pkgs/by-name/es/espanso/plugins/pinyin/default.nix
+++ b/pkgs/by-name/es/espanso/plugins/pinyin/default.nix
@@ -1,0 +1,22 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkEspansoPlugin,
+}:
+mkEspansoPlugin {
+  pname = "pinyin";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "espanso";
+    repo = "hub";
+    rev = "d62bde95fc6f6cf90d4c23ee243922037c053def";
+    hash = "sha256-1cPtknrIi+9uTQt0pMaOBnY3C1GAGXPAA4fIgBh5Wgs=";
+  };
+
+  meta = {
+    description = "Pinyin vowels";
+    homepage = "https://github.com/j6k4m8/espanso-pinyin";
+    maintainers = with lib.maintainers; [ delafthi ];
+  };
+}

--- a/pkgs/by-name/es/espanso/plugins/portuguese-accents/default.nix
+++ b/pkgs/by-name/es/espanso/plugins/portuguese-accents/default.nix
@@ -1,0 +1,22 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkEspansoPlugin,
+}:
+mkEspansoPlugin {
+  pname = "portuguese-accents";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "espanso";
+    repo = "hub";
+    rev = "d62bde95fc6f6cf90d4c23ee243922037c053def";
+    hash = "sha256-1cPtknrIi+9uTQt0pMaOBnY3C1GAGXPAA4fIgBh5Wgs=";
+  };
+
+  meta = {
+    description = "A package to type Portuguese with a non-Portuguese keyboard layout.";
+    homepage = "https://github.com/tashima42/Portuguese-Accents";
+    maintainers = with lib.maintainers; [ delafthi ];
+  };
+}

--- a/pkgs/by-name/es/espanso/plugins/python-utils/default.nix
+++ b/pkgs/by-name/es/espanso/plugins/python-utils/default.nix
@@ -1,0 +1,22 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkEspansoPlugin,
+}:
+mkEspansoPlugin {
+  pname = "python-utils";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "espanso";
+    repo = "hub";
+    rev = "d62bde95fc6f6cf90d4c23ee243922037c053def";
+    hash = "sha256-1cPtknrIi+9uTQt0pMaOBnY3C1GAGXPAA4fIgBh5Wgs=";
+  };
+
+  meta = {
+    description = "A python code snippet package for Espanso to reduce boilerplate code";
+    homepage = "https://github.com/kchenTTP/espanso-python-utils";
+    maintainers = with lib.maintainers; [ delafthi ];
+  };
+}

--- a/pkgs/by-name/es/espanso/plugins/qazaq-typer/default.nix
+++ b/pkgs/by-name/es/espanso/plugins/qazaq-typer/default.nix
@@ -1,0 +1,22 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkEspansoPlugin,
+}:
+mkEspansoPlugin {
+  pname = "qazaq-typer";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "espanso";
+    repo = "hub";
+    rev = "d62bde95fc6f6cf90d4c23ee243922037c053def";
+    hash = "sha256-1cPtknrIi+9uTQt0pMaOBnY3C1GAGXPAA4fIgBh5Wgs=";
+  };
+
+  meta = {
+    description = "Faster method to type Qazaq on latin and Cirilic. AA -> Ә ";
+    homepage = "https://github.com/soulllink/Qazaq-Typer";
+    maintainers = with lib.maintainers; [ delafthi ];
+  };
+}

--- a/pkgs/by-name/es/espanso/plugins/quantum/default.nix
+++ b/pkgs/by-name/es/espanso/plugins/quantum/default.nix
@@ -1,0 +1,22 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkEspansoPlugin,
+}:
+mkEspansoPlugin {
+  pname = "quantum";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "espanso";
+    repo = "hub";
+    rev = "d62bde95fc6f6cf90d4c23ee243922037c053def";
+    hash = "sha256-1cPtknrIi+9uTQt0pMaOBnY3C1GAGXPAA4fIgBh5Wgs=";
+  };
+
+  meta = {
+    description = "Frequently-used unicode for quantum notation";
+    homepage = "https://github.com/j6k4m8/espanso-quantum";
+    maintainers = with lib.maintainers; [ delafthi ];
+  };
+}

--- a/pkgs/by-name/es/espanso/plugins/quick-translate/default.nix
+++ b/pkgs/by-name/es/espanso/plugins/quick-translate/default.nix
@@ -1,0 +1,25 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkEspansoPlugin,
+  translate-shell,
+}:
+mkEspansoPlugin {
+  pname = "quick-translate";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "espanso";
+    repo = "hub";
+    rev = "d62bde95fc6f6cf90d4c23ee243922037c053def";
+    hash = "sha256-1cPtknrIi+9uTQt0pMaOBnY3C1GAGXPAA4fIgBh5Wgs=";
+  };
+
+  buildInputs = [ translate-shell ];
+
+  meta = {
+    description = "A Package to quickly translate text of various languages";
+    homepage = "https://github.com/p0ly60n/quick-translate";
+    maintainers = with lib.maintainers; [ delafthi ];
+  };
+}

--- a/pkgs/by-name/es/espanso/plugins/quotes/default.nix
+++ b/pkgs/by-name/es/espanso/plugins/quotes/default.nix
@@ -1,0 +1,23 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkEspansoPlugin,
+}:
+mkEspansoPlugin {
+  pname = "quotes";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "espanso";
+    repo = "hub";
+    rev = "d62bde95fc6f6cf90d4c23ee243922037c053def";
+    hash = "sha256-1cPtknrIi+9uTQt0pMaOBnY3C1GAGXPAA4fIgBh5Wgs=";
+  };
+
+  meta = {
+    description = "Include different quotations and quotation-related characters to espanso.";
+    homepage = "https://github.com/WhistlingZephyr/espanso-package-quotes";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ delafthi ];
+  };
+}

--- a/pkgs/by-name/es/espanso/plugins/quotes/default.nix
+++ b/pkgs/by-name/es/espanso/plugins/quotes/default.nix
@@ -5,13 +5,13 @@
 }:
 mkEspansoPlugin {
   pname = "quotes";
-  version = "0.1.0";
+  version = "0.1.1";
 
   src = fetchFromGitHub {
     owner = "espanso";
     repo = "hub";
-    rev = "d62bde95fc6f6cf90d4c23ee243922037c053def";
-    hash = "sha256-1cPtknrIi+9uTQt0pMaOBnY3C1GAGXPAA4fIgBh5Wgs=";
+    rev = "13eb7d6d7d242bbadfb43ed4284d6b46ba63ce11";
+    hash = "sha256-r0V24FeBiS8LRzbzMjLKJqitpoiOWnuynGMahmDYe3s=";
   };
 
   meta = {

--- a/pkgs/by-name/es/espanso/plugins/rand-tools/default.nix
+++ b/pkgs/by-name/es/espanso/plugins/rand-tools/default.nix
@@ -1,0 +1,25 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkEspansoPlugin,
+  openssl,
+}:
+mkEspansoPlugin {
+  pname = "rand-tools";
+  version = "0.0.2";
+
+  src = fetchFromGitHub {
+    owner = "espanso";
+    repo = "hub";
+    rev = "d62bde95fc6f6cf90d4c23ee243922037c053def";
+    hash = "sha256-1cPtknrIi+9uTQt0pMaOBnY3C1GAGXPAA4fIgBh5Wgs=";
+  };
+
+  buildInputs = [ openssl ];
+
+  meta = {
+    description = "A tool for generating random strings with espanso";
+    homepage = "https://github.com/JettChenT/espanso-randtools";
+    maintainers = with lib.maintainers; [ delafthi ];
+  };
+}

--- a/pkgs/by-name/es/espanso/plugins/repeat/default.nix
+++ b/pkgs/by-name/es/espanso/plugins/repeat/default.nix
@@ -1,0 +1,23 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkEspansoPlugin,
+}:
+mkEspansoPlugin {
+  pname = "repeat";
+  version = "1.0.0";
+
+  src = fetchFromGitHub {
+    owner = "espanso";
+    repo = "hub";
+    rev = "13eb7d6d7d242bbadfb43ed4284d6b46ba63ce11";
+    hash = "sha256-r0V24FeBiS8LRzbzMjLKJqitpoiOWnuynGMahmDYe3s=";
+  };
+
+  meta = {
+    description = "Utility for typing text on repeat.";
+    homepage = "https://github.com/dicksonlaw583/espanso-repeat";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ delafthi ];
+  };
+}

--- a/pkgs/by-name/es/espanso/plugins/romanian-accent/default.nix
+++ b/pkgs/by-name/es/espanso/plugins/romanian-accent/default.nix
@@ -1,0 +1,22 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkEspansoPlugin,
+}:
+mkEspansoPlugin {
+  pname = "romanian-accent";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "espanso";
+    repo = "hub";
+    rev = "d62bde95fc6f6cf90d4c23ee243922037c053def";
+    hash = "sha256-1cPtknrIi+9uTQt0pMaOBnY3C1GAGXPAA4fIgBh5Wgs=";
+  };
+
+  meta = {
+    description = "A package to type Romanian with almost every keyboard.";
+    homepage = "https://github.com/CorentinDy/espanso-package-romanian-accent";
+    maintainers = with lib.maintainers; [ delafthi ];
+  };
+}

--- a/pkgs/by-name/es/espanso/plugins/script-letters/default.nix
+++ b/pkgs/by-name/es/espanso/plugins/script-letters/default.nix
@@ -1,0 +1,23 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkEspansoPlugin,
+}:
+mkEspansoPlugin {
+  pname = "script-letters";
+  version = "1.0.0";
+
+  src = fetchFromGitHub {
+    owner = "espanso";
+    repo = "hub";
+    rev = "d62bde95fc6f6cf90d4c23ee243922037c053def";
+    hash = "sha256-1cPtknrIi+9uTQt0pMaOBnY3C1GAGXPAA4fIgBh5Wgs=";
+  };
+
+  meta = {
+    description = "Easy write 𝒮𝒸𝓇𝒾𝓅𝓉 𝓁ℯ𝓉𝓉ℯ𝓇𝓈";
+    homepage = "https://github.com/kopach/espanso-package-script-letters";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ delafthi ];
+  };
+}

--- a/pkgs/by-name/es/espanso/plugins/serbian-accents/default.nix
+++ b/pkgs/by-name/es/espanso/plugins/serbian-accents/default.nix
@@ -1,0 +1,23 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkEspansoPlugin,
+}:
+mkEspansoPlugin {
+  pname = "serbian-accents";
+  version = "1.0.0";
+
+  src = fetchFromGitHub {
+    owner = "espanso";
+    repo = "hub";
+    rev = "d62bde95fc6f6cf90d4c23ee243922037c053def";
+    hash = "sha256-1cPtknrIi+9uTQt0pMaOBnY3C1GAGXPAA4fIgBh5Wgs=";
+  };
+
+  meta = {
+    description = "A way to type Serbian accented letters";
+    homepage = "https://github.com/cvladan/espanso-serbian-accents-package";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ delafthi ];
+  };
+}

--- a/pkgs/by-name/es/espanso/plugins/sf-symbols/default.nix
+++ b/pkgs/by-name/es/espanso/plugins/sf-symbols/default.nix
@@ -1,0 +1,22 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkEspansoPlugin,
+}:
+mkEspansoPlugin {
+  pname = "sf-symbols";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "espanso";
+    repo = "hub";
+    rev = "d62bde95fc6f6cf90d4c23ee243922037c053def";
+    hash = "sha256-1cPtknrIi+9uTQt0pMaOBnY3C1GAGXPAA4fIgBh5Wgs=";
+  };
+
+  meta = {
+    description = "Symbols/Icons from Apple’s San Francisco (SF Pro) system font";
+    maintainers = with lib.maintainers; [ delafthi ];
+    platforms = lib.platforms.darwin;
+  };
+}

--- a/pkgs/by-name/es/espanso/plugins/sharewifi/default.nix
+++ b/pkgs/by-name/es/espanso/plugins/sharewifi/default.nix
@@ -1,0 +1,24 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkEspansoPlugin,
+}:
+mkEspansoPlugin {
+  pname = "sharewifi";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "espanso";
+    repo = "hub";
+    rev = "d62bde95fc6f6cf90d4c23ee243922037c053def";
+    hash = "sha256-1cPtknrIi+9uTQt0pMaOBnY3C1GAGXPAA4fIgBh5Wgs=";
+  };
+
+  meta = {
+    description = "An espanso package for quickly sharing Wi-Fi passwords and connection details on macOS.";
+    homepage = "https://github.com/bradyjoslin/espanso-package-sharewifi";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ delafthi ];
+    platforms = lib.platforms.darwin;
+  };
+}

--- a/pkgs/by-name/es/espanso/plugins/shruggie/default.nix
+++ b/pkgs/by-name/es/espanso/plugins/shruggie/default.nix
@@ -1,0 +1,22 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkEspansoPlugin,
+}:
+mkEspansoPlugin {
+  pname = "shruggie";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "espanso";
+    repo = "hub";
+    rev = "d62bde95fc6f6cf90d4c23ee243922037c053def";
+    hash = "sha256-1cPtknrIi+9uTQt0pMaOBnY3C1GAGXPAA4fIgBh5Wgs=";
+  };
+
+  meta = {
+    description = "Display the text emoticon ¯\\_(ツ)_/¯ AKA the Shruggie";
+    homepage = "https://github.com/spikex/shruggie";
+    maintainers = with lib.maintainers; [ delafthi ];
+  };
+}

--- a/pkgs/by-name/es/espanso/plugins/single-steno/default.nix
+++ b/pkgs/by-name/es/espanso/plugins/single-steno/default.nix
@@ -1,0 +1,21 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkEspansoPlugin,
+}:
+mkEspansoPlugin {
+  pname = "single-steno";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "espanso";
+    repo = "hub";
+    rev = "d62bde95fc6f6cf90d4c23ee243922037c053def";
+    hash = "sha256-1cPtknrIi+9uTQt0pMaOBnY3C1GAGXPAA4fIgBh5Wgs=";
+  };
+
+  meta = {
+    description = "Convert single characters into the most common English words";
+    maintainers = with lib.maintainers; [ delafthi ];
+  };
+}

--- a/pkgs/by-name/es/espanso/plugins/sitelen-pona/default.nix
+++ b/pkgs/by-name/es/espanso/plugins/sitelen-pona/default.nix
@@ -1,0 +1,22 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkEspansoPlugin,
+}:
+mkEspansoPlugin {
+  pname = "sitelen-pona";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "espanso";
+    repo = "hub";
+    rev = "d62bde95fc6f6cf90d4c23ee243922037c053def";
+    hash = "sha256-1cPtknrIi+9uTQt0pMaOBnY3C1GAGXPAA4fIgBh5Wgs=";
+  };
+
+  meta = {
+    description = "A package for writing UCSUR sitelen pona with Espanso!";
+    homepage = "https://github.com/neroist/sitelen-pona-ucsur-guide";
+    maintainers = with lib.maintainers; [ delafthi ];
+  };
+}

--- a/pkgs/by-name/es/espanso/plugins/snipbank/default.nix
+++ b/pkgs/by-name/es/espanso/plugins/snipbank/default.nix
@@ -1,0 +1,23 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkEspansoPlugin,
+}:
+mkEspansoPlugin {
+  pname = "snipbank";
+  version = "1.0.0";
+
+  src = fetchFromGitHub {
+    owner = "espanso";
+    repo = "hub";
+    rev = "13eb7d6d7d242bbadfb43ed4284d6b46ba63ce11";
+    hash = "sha256-r0V24FeBiS8LRzbzMjLKJqitpoiOWnuynGMahmDYe3s=";
+  };
+
+  meta = {
+    description = "Easily configure custom snippets without manually editing the Espanso configs directory.";
+    homepage = "https://github.com/dicksonlaw583/espanso-snipbank";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ delafthi ];
+  };
+}

--- a/pkgs/by-name/es/espanso/plugins/spain-postal-codes/default.nix
+++ b/pkgs/by-name/es/espanso/plugins/spain-postal-codes/default.nix
@@ -1,0 +1,21 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkEspansoPlugin,
+}:
+mkEspansoPlugin {
+  pname = "spain-postal-codes";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "espanso";
+    repo = "hub";
+    rev = "d62bde95fc6f6cf90d4c23ee243922037c053def";
+    hash = "sha256-1cPtknrIi+9uTQt0pMaOBnY3C1GAGXPAA4fIgBh5Wgs=";
+  };
+
+  meta = {
+    description = "A package containing all postal codes of Spain.";
+    maintainers = with lib.maintainers; [ delafthi ];
+  };
+}

--- a/pkgs/by-name/es/espanso/plugins/spanish-accent/default.nix
+++ b/pkgs/by-name/es/espanso/plugins/spanish-accent/default.nix
@@ -1,0 +1,22 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkEspansoPlugin,
+}:
+mkEspansoPlugin {
+  pname = "spanish-accent";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "espanso";
+    repo = "hub";
+    rev = "d62bde95fc6f6cf90d4c23ee243922037c053def";
+    hash = "sha256-1cPtknrIi+9uTQt0pMaOBnY3C1GAGXPAA4fIgBh5Wgs=";
+  };
+
+  meta = {
+    description = "A package to type Spanish accents.";
+    homepage = "https://github.com/jacostag/espanso-package-spanish";
+    maintainers = with lib.maintainers; [ delafthi ];
+  };
+}

--- a/pkgs/by-name/es/espanso/plugins/sql-commands/default.nix
+++ b/pkgs/by-name/es/espanso/plugins/sql-commands/default.nix
@@ -1,0 +1,21 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkEspansoPlugin,
+}:
+mkEspansoPlugin {
+  pname = "sql-commands";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "espanso";
+    repo = "hub";
+    rev = "d62bde95fc6f6cf90d4c23ee243922037c053def";
+    hash = "sha256-1cPtknrIi+9uTQt0pMaOBnY3C1GAGXPAA4fIgBh5Wgs=";
+  };
+
+  meta = {
+    description = "A package that provides the most used SQL commands.";
+    maintainers = with lib.maintainers; [ delafthi ];
+  };
+}

--- a/pkgs/by-name/es/espanso/plugins/sql/default.nix
+++ b/pkgs/by-name/es/espanso/plugins/sql/default.nix
@@ -1,0 +1,22 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkEspansoPlugin,
+}:
+mkEspansoPlugin {
+  pname = "sql";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "espanso";
+    repo = "hub";
+    rev = "d62bde95fc6f6cf90d4c23ee243922037c053def";
+    hash = "sha256-1cPtknrIi+9uTQt0pMaOBnY3C1GAGXPAA4fIgBh5Wgs=";
+  };
+
+  meta = {
+    description = "An package to get sql command code snippets";
+    homepage = "https://github.com/zhangymPerson/espanso-package-sql";
+    maintainers = with lib.maintainers; [ delafthi ];
+  };
+}

--- a/pkgs/by-name/es/espanso/plugins/star-rating/default.nix
+++ b/pkgs/by-name/es/espanso/plugins/star-rating/default.nix
@@ -1,0 +1,23 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkEspansoPlugin,
+}:
+mkEspansoPlugin {
+  pname = "star-rating";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "espanso";
+    repo = "hub";
+    rev = "d62bde95fc6f6cf90d4c23ee243922037c053def";
+    hash = "sha256-1cPtknrIi+9uTQt0pMaOBnY3C1GAGXPAA4fIgBh5Wgs=";
+  };
+
+  meta = {
+    description = "Display a star rating. However you want, wherever you want. You decide";
+    homepage = "https://github.com/jacobfresco/star-rating/";
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [ delafthi ];
+  };
+}

--- a/pkgs/by-name/es/espanso/plugins/star-rating/default.nix
+++ b/pkgs/by-name/es/espanso/plugins/star-rating/default.nix
@@ -5,13 +5,13 @@
 }:
 mkEspansoPlugin {
   pname = "star-rating";
-  version = "0.1.0";
+  version = "0.1.1";
 
   src = fetchFromGitHub {
     owner = "espanso";
     repo = "hub";
-    rev = "d62bde95fc6f6cf90d4c23ee243922037c053def";
-    hash = "sha256-1cPtknrIi+9uTQt0pMaOBnY3C1GAGXPAA4fIgBh5Wgs=";
+    rev = "a5b6dbc16fa52e717f92a3667323cfd8646b47e0";
+    hash = "sha256-QoQqI1cKgX9Xkl6u5t0TggrjiNsn0N+nZsRVGh812Mg=";
   };
 
   meta = {

--- a/pkgs/by-name/es/espanso/plugins/super-sub-scripts/default.nix
+++ b/pkgs/by-name/es/espanso/plugins/super-sub-scripts/default.nix
@@ -1,0 +1,23 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkEspansoPlugin,
+}:
+mkEspansoPlugin {
+  pname = "super-sub-scripts";
+  version = "0.2.0";
+
+  src = fetchFromGitHub {
+    owner = "espanso";
+    repo = "hub";
+    rev = "d62bde95fc6f6cf90d4c23ee243922037c053def";
+    hash = "sha256-1cPtknrIi+9uTQt0pMaOBnY3C1GAGXPAA4fIgBh5Wgs=";
+  };
+
+  meta = {
+    description = "A collection of subscripts and superscripts with Latex based naming scheme";
+    homepage = "https://github.com/jpmvferreira/espanso-mega-pack";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ delafthi ];
+  };
+}

--- a/pkgs/by-name/es/espanso/plugins/supersubscript/default.nix
+++ b/pkgs/by-name/es/espanso/plugins/supersubscript/default.nix
@@ -1,0 +1,22 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkEspansoPlugin,
+}:
+mkEspansoPlugin {
+  pname = "supersubscript";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "espanso";
+    repo = "hub";
+    rev = "d62bde95fc6f6cf90d4c23ee243922037c053def";
+    hash = "sha256-1cPtknrIi+9uTQt0pMaOBnY3C1GAGXPAA4fIgBh5Wgs=";
+  };
+
+  meta = {
+    description = "An espanso package for superscripts and subscripts.";
+    homepage = "https://github.com/meggynw/espanso-package-supersubscript";
+    maintainers = with lib.maintainers; [ delafthi ];
+  };
+}

--- a/pkgs/by-name/es/espanso/plugins/table-topics/default.nix
+++ b/pkgs/by-name/es/espanso/plugins/table-topics/default.nix
@@ -1,0 +1,21 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkEspansoPlugin,
+}:
+mkEspansoPlugin {
+  pname = "table-topics";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "espanso";
+    repo = "hub";
+    rev = "d62bde95fc6f6cf90d4c23ee243922037c053def";
+    hash = "sha256-1cPtknrIi+9uTQt0pMaOBnY3C1GAGXPAA4fIgBh5Wgs=";
+  };
+
+  meta = {
+    description = "A package for generating Table Topics questions";
+    maintainers = with lib.maintainers; [ delafthi ];
+  };
+}

--- a/pkgs/by-name/es/espanso/plugins/tableflip-package/default.nix
+++ b/pkgs/by-name/es/espanso/plugins/tableflip-package/default.nix
@@ -1,0 +1,22 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkEspansoPlugin,
+}:
+mkEspansoPlugin {
+  pname = "tableflip-package";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "espanso";
+    repo = "hub";
+    rev = "d62bde95fc6f6cf90d4c23ee243922037c053def";
+    hash = "sha256-1cPtknrIi+9uTQt0pMaOBnY3C1GAGXPAA4fIgBh5Wgs=";
+  };
+
+  meta = {
+    description = "A simple espanso package for flipping tables.";
+    homepage = "https://github.com/timvoet/espanso-package-tableflip";
+    maintainers = with lib.maintainers; [ delafthi ];
+  };
+}

--- a/pkgs/by-name/es/espanso/plugins/tailwindcss-colors/default.nix
+++ b/pkgs/by-name/es/espanso/plugins/tailwindcss-colors/default.nix
@@ -1,0 +1,22 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkEspansoPlugin,
+}:
+mkEspansoPlugin {
+  pname = "tailwindcss-colors";
+  version = "0.1.1";
+
+  src = fetchFromGitHub {
+    owner = "espanso";
+    repo = "hub";
+    rev = "d62bde95fc6f6cf90d4c23ee243922037c053def";
+    hash = "sha256-1cPtknrIi+9uTQt0pMaOBnY3C1GAGXPAA4fIgBh5Wgs=";
+  };
+
+  meta = {
+    description = "A package that provides TailwindCSS's default color palette as hex color codes for quick access.";
+    homepage = "https://github.com/paulinek13/espanso-hub/blob/main/packages/tailwindcss-colors/0.1.1/README.md";
+    maintainers = with lib.maintainers; [ delafthi ];
+  };
+}

--- a/pkgs/by-name/es/espanso/plugins/tholzschuh-maths/default.nix
+++ b/pkgs/by-name/es/espanso/plugins/tholzschuh-maths/default.nix
@@ -1,0 +1,22 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkEspansoPlugin,
+}:
+mkEspansoPlugin {
+  pname = "tholzschuh-maths";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "espanso";
+    repo = "hub";
+    rev = "d62bde95fc6f6cf90d4c23ee243922037c053def";
+    hash = "sha256-1cPtknrIi+9uTQt0pMaOBnY3C1GAGXPAA4fIgBh5Wgs=";
+  };
+
+  meta = {
+    description = "A collection of unicode symbols often used by working mathematicians.";
+    homepage = "tholzschuh.github.io";
+    maintainers = with lib.maintainers; [ delafthi ];
+  };
+}

--- a/pkgs/by-name/es/espanso/plugins/timezone-date/default.nix
+++ b/pkgs/by-name/es/espanso/plugins/timezone-date/default.nix
@@ -1,0 +1,25 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkEspansoPlugin,
+  python3,
+}:
+mkEspansoPlugin {
+  pname = "timezone-date";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "espanso";
+    repo = "hub";
+    rev = "d62bde95fc6f6cf90d4c23ee243922037c053def";
+    hash = "sha256-1cPtknrIi+9uTQt0pMaOBnY3C1GAGXPAA4fIgBh5Wgs=";
+  };
+
+  buildInputs = [ python3 ];
+
+  meta = {
+    description = "A package that uses Python scripts to offer a choice from the full set of worldwide timezones, returning the current date and time there.";
+    homepage = "https://github.com/smeech";
+    maintainers = with lib.maintainers; [ delafthi ];
+  };
+}

--- a/pkgs/by-name/es/espanso/plugins/translate-en-zh/default.nix
+++ b/pkgs/by-name/es/espanso/plugins/translate-en-zh/default.nix
@@ -1,0 +1,22 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkEspansoPlugin,
+}:
+mkEspansoPlugin {
+  pname = "translate-en-zh";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "espanso";
+    repo = "hub";
+    rev = "d62bde95fc6f6cf90d4c23ee243922037c053def";
+    hash = "sha256-1cPtknrIi+9uTQt0pMaOBnY3C1GAGXPAA4fIgBh5Wgs=";
+  };
+
+  meta = {
+    description = "A proof-of-concept package for English-Chinese translation.";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ delafthi ];
+  };
+}

--- a/pkgs/by-name/es/espanso/plugins/translate-es-en/default.nix
+++ b/pkgs/by-name/es/espanso/plugins/translate-es-en/default.nix
@@ -1,0 +1,25 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkEspansoPlugin,
+}:
+mkEspansoPlugin {
+  pname = "translate-es-en";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "espanso";
+    repo = "hub";
+    rev = "d62bde95fc6f6cf90d4c23ee243922037c053def";
+    hash = "sha256-1cPtknrIi+9uTQt0pMaOBnY3C1GAGXPAA4fIgBh5Wgs=";
+  };
+
+  meta = {
+    description = "A proof-of-concept package for bidirectional Spanish-English translation";
+    license = with lib.licenses; [
+      cc-by-sa-30
+      fdl11Plus
+    ];
+    maintainers = with lib.maintainers; [ delafthi ];
+  };
+}

--- a/pkgs/by-name/es/espanso/plugins/translate-fr-en/default.nix
+++ b/pkgs/by-name/es/espanso/plugins/translate-fr-en/default.nix
@@ -1,0 +1,22 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkEspansoPlugin,
+}:
+mkEspansoPlugin {
+  pname = "translate-fr-en";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "espanso";
+    repo = "hub";
+    rev = "d62bde95fc6f6cf90d4c23ee243922037c053def";
+    hash = "sha256-1cPtknrIi+9uTQt0pMaOBnY3C1GAGXPAA4fIgBh5Wgs=";
+  };
+
+  meta = {
+    description = "A proof-of-concept package for bidirectional French-English translation";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ delafthi ];
+  };
+}

--- a/pkgs/by-name/es/espanso/plugins/turkish-accent/default.nix
+++ b/pkgs/by-name/es/espanso/plugins/turkish-accent/default.nix
@@ -1,0 +1,22 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkEspansoPlugin,
+}:
+mkEspansoPlugin {
+  pname = "turkish-accent";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "espanso";
+    repo = "hub";
+    rev = "d62bde95fc6f6cf90d4c23ee243922037c053def";
+    hash = "sha256-1cPtknrIi+9uTQt0pMaOBnY3C1GAGXPAA4fIgBh5Wgs=";
+  };
+
+  meta = {
+    description = "A simple package to convert English characters to Turkish.";
+    homepage = "https://github.com/enderahmetyurt/espanso-package-example";
+    maintainers = with lib.maintainers; [ delafthi ];
+  };
+}

--- a/pkgs/by-name/es/espanso/plugins/turkish/default.nix
+++ b/pkgs/by-name/es/espanso/plugins/turkish/default.nix
@@ -1,0 +1,21 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkEspansoPlugin,
+}:
+mkEspansoPlugin {
+  pname = "turkish";
+  version = "1.0.0";
+
+  src = fetchFromGitHub {
+    owner = "espanso";
+    repo = "hub";
+    rev = "d62bde95fc6f6cf90d4c23ee243922037c053def";
+    hash = "sha256-1cPtknrIi+9uTQt0pMaOBnY3C1GAGXPAA4fIgBh5Wgs=";
+  };
+
+  meta = {
+    description = "A package for typing Turkish characters with any keybord layout.";
+    maintainers = with lib.maintainers; [ delafthi ];
+  };
+}

--- a/pkgs/by-name/es/espanso/plugins/typofixer-en/default.nix
+++ b/pkgs/by-name/es/espanso/plugins/typofixer-en/default.nix
@@ -1,0 +1,21 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkEspansoPlugin,
+}:
+mkEspansoPlugin {
+  pname = "typofixer-en";
+  version = "1.0.4";
+
+  src = fetchFromGitHub {
+    owner = "espanso";
+    repo = "hub";
+    rev = "d62bde95fc6f6cf90d4c23ee243922037c053def";
+    hash = "sha256-1cPtknrIi+9uTQt0pMaOBnY3C1GAGXPAA4fIgBh5Wgs=";
+  };
+
+  meta = {
+    description = "Collection of typos fixed for English language";
+    maintainers = with lib.maintainers; [ delafthi ];
+  };
+}

--- a/pkgs/by-name/es/espanso/plugins/typofixer-en/default.nix
+++ b/pkgs/by-name/es/espanso/plugins/typofixer-en/default.nix
@@ -5,13 +5,13 @@
 }:
 mkEspansoPlugin {
   pname = "typofixer-en";
-  version = "1.0.4";
+  version = "1.0.5";
 
   src = fetchFromGitHub {
     owner = "espanso";
     repo = "hub";
-    rev = "d62bde95fc6f6cf90d4c23ee243922037c053def";
-    hash = "sha256-1cPtknrIi+9uTQt0pMaOBnY3C1GAGXPAA4fIgBh5Wgs=";
+    rev = "a5b6dbc16fa52e717f92a3667323cfd8646b47e0";
+    hash = "sha256-QoQqI1cKgX9Xkl6u5t0TggrjiNsn0N+nZsRVGh812Mg=";
   };
 
   meta = {

--- a/pkgs/by-name/es/espanso/plugins/typofixer-es/default.nix
+++ b/pkgs/by-name/es/espanso/plugins/typofixer-es/default.nix
@@ -1,0 +1,21 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkEspansoPlugin,
+}:
+mkEspansoPlugin {
+  pname = "typofixer-es";
+  version = "1.0.1";
+
+  src = fetchFromGitHub {
+    owner = "espanso";
+    repo = "hub";
+    rev = "d62bde95fc6f6cf90d4c23ee243922037c053def";
+    hash = "sha256-1cPtknrIi+9uTQt0pMaOBnY3C1GAGXPAA4fIgBh5Wgs=";
+  };
+
+  meta = {
+    description = "Collection of typos fixed for Spanish language";
+    maintainers = with lib.maintainers; [ delafthi ];
+  };
+}

--- a/pkgs/by-name/es/espanso/plugins/typofixer-fr/default.nix
+++ b/pkgs/by-name/es/espanso/plugins/typofixer-fr/default.nix
@@ -1,0 +1,21 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkEspansoPlugin,
+}:
+mkEspansoPlugin {
+  pname = "typofixer-fr";
+  version = "1.0.1";
+
+  src = fetchFromGitHub {
+    owner = "espanso";
+    repo = "hub";
+    rev = "d62bde95fc6f6cf90d4c23ee243922037c053def";
+    hash = "sha256-1cPtknrIi+9uTQt0pMaOBnY3C1GAGXPAA4fIgBh5Wgs=";
+  };
+
+  meta = {
+    description = "Collection of typos fixed for French language";
+    maintainers = with lib.maintainers; [ delafthi ];
+  };
+}

--- a/pkgs/by-name/es/espanso/plugins/typofixer-it/default.nix
+++ b/pkgs/by-name/es/espanso/plugins/typofixer-it/default.nix
@@ -1,0 +1,21 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkEspansoPlugin,
+}:
+mkEspansoPlugin {
+  pname = "typofixer-it";
+  version = "1.0.4";
+
+  src = fetchFromGitHub {
+    owner = "espanso";
+    repo = "hub";
+    rev = "d62bde95fc6f6cf90d4c23ee243922037c053def";
+    hash = "sha256-1cPtknrIi+9uTQt0pMaOBnY3C1GAGXPAA4fIgBh5Wgs=";
+  };
+
+  meta = {
+    description = "Collection of typos fixed for Italian language";
+    maintainers = with lib.maintainers; [ delafthi ];
+  };
+}

--- a/pkgs/by-name/es/espanso/plugins/typofixer-it/default.nix
+++ b/pkgs/by-name/es/espanso/plugins/typofixer-it/default.nix
@@ -5,13 +5,13 @@
 }:
 mkEspansoPlugin {
   pname = "typofixer-it";
-  version = "1.0.4";
+  version = "1.0.5";
 
   src = fetchFromGitHub {
     owner = "espanso";
     repo = "hub";
-    rev = "d62bde95fc6f6cf90d4c23ee243922037c053def";
-    hash = "sha256-1cPtknrIi+9uTQt0pMaOBnY3C1GAGXPAA4fIgBh5Wgs=";
+    rev = "a5b6dbc16fa52e717f92a3667323cfd8646b47e0";
+    hash = "sha256-QoQqI1cKgX9Xkl6u5t0TggrjiNsn0N+nZsRVGh812Mg=";
   };
 
   meta = {

--- a/pkgs/by-name/es/espanso/plugins/typofixer-pt-br/default.nix
+++ b/pkgs/by-name/es/espanso/plugins/typofixer-pt-br/default.nix
@@ -1,0 +1,23 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkEspansoPlugin,
+}:
+mkEspansoPlugin {
+  pname = "typofixer-pt-br";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "espanso";
+    repo = "hub";
+    rev = "13eb7d6d7d242bbadfb43ed4284d6b46ba63ce11";
+    hash = "sha256-r0V24FeBiS8LRzbzMjLKJqitpoiOWnuynGMahmDYe3s=";
+  };
+
+  meta = {
+    description = "A package for correcting common mistakes when writing some Brazilian Portuguese words.";
+    homepage = "https://github.com/rapha-au/typofixer-pt-br";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ delafthi ];
+  };
+}

--- a/pkgs/by-name/es/espanso/plugins/typst-math-symbols/default.nix
+++ b/pkgs/by-name/es/espanso/plugins/typst-math-symbols/default.nix
@@ -1,0 +1,22 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkEspansoPlugin,
+}:
+mkEspansoPlugin {
+  pname = "typst-math-symbols";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "espanso";
+    repo = "hub";
+    rev = "13eb7d6d7d242bbadfb43ed4284d6b46ba63ce11";
+    hash = "sha256-r0V24FeBiS8LRzbzMjLKJqitpoiOWnuynGMahmDYe3s=";
+  };
+
+  meta = {
+    description = "All Typst math symbols to Unicode";
+    homepage = "https://typst.app/docs/reference/symbols/sym/";
+    maintainers = with lib.maintainers; [ delafthi ];
+  };
+}

--- a/pkgs/by-name/es/espanso/plugins/update.py
+++ b/pkgs/by-name/es/espanso/plugins/update.py
@@ -1,0 +1,401 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i python3 -p python3 python3Packages.packaging python3Packages.pyyaml python3Packages.requests nix
+#
+# format:
+# $ nix run nixpkgs#python3Packages.ruff -- format update.py
+
+import os
+import re
+import argparse
+import sys
+import subprocess
+import pathlib
+
+import requests
+import json
+import base64
+import yaml
+from packaging import version
+
+from typing import Optional, Any
+
+ESPANSO_HUB_API_URL = "https://api.github.com/repos/espanso/hub"
+ESPANSO_HUB_URL = "https://github.com/espanso/hub"
+
+
+def get_github_headers() -> dict[str, str]:
+    """Create headers for GitHub API requests"""
+    headers = {"Accept": "application/vnd.github.v3+json"}
+    github_token = os.environ.get("GITHUB_TOKEN")
+    if github_token:
+        headers["Authorization"] = f"Bearer {github_token}"
+    headers["X-GitHub-Api-Version"] = "2022-11-28"
+
+    return headers
+
+
+def fetch_hub_packages(headers: dict[str, str]) -> list[str]:
+    """Fetch all packages on the hub."""
+    packages_dir_url = f"{ESPANSO_HUB_API_URL}/contents/packages"
+
+    try:
+        response = requests.get(packages_dir_url, headers=headers)
+        response.raise_for_status()
+    except requests.RequestException as e:
+        print(f"Error fetching packages: {e}")
+        return []
+    else:
+        package_dirs_json = json.loads(response.text)
+        return [str(package["name"]) for package in package_dirs_json]
+
+
+def fetch_license_file(package: str, version: str, headers: dict[str, str]) -> str:
+    """Fetch the `LICENSE` file."""
+    packages_dir_url = (
+        f"{ESPANSO_HUB_API_URL}/contents/packages/{package}/{version}/LICENSE"
+    )
+
+    try:
+        response = requests.get(packages_dir_url, headers=headers)
+        response.raise_for_status()
+    except requests.RequestException:
+        raise FileNotFoundError
+    else:
+        license_json = json.loads(response.text)
+        return str(base64.b64decode(license_json["content"]))
+
+
+def fetch_package_version_from_dir(
+    package: str, headers: dict[str, str]
+) -> Optional[str]:
+    """Fetch the package version from within the package directory."""
+    package_dir_url = f"{ESPANSO_HUB_API_URL}/contents/packages/{package}"
+
+    response = requests.get(package_dir_url, headers=headers)
+    response.raise_for_status()
+    version_dirs_json = json.loads(response.text)
+    if re.match(r"^\d+\.\d+\.\d+$", str(version_dirs_json[-1]["name"])):
+        return str(version_dirs_json[-1]["name"])
+    else:
+        return None
+
+
+def fetch_new_revision(branch: str, headers: dict[str, str]) -> str:
+    package_manifest_url = f"{ESPANSO_HUB_API_URL}/branches/{branch}"
+
+    response = requests.get(package_manifest_url, headers=headers)
+    response.raise_for_status()
+    branch_json = json.loads(response.text)
+    return str(branch_json["commit"]["sha"])
+
+
+def fetch_package_manifest(package: str, version: str, headers: dict[str, str]) -> Any:
+    """Fetch the package manifest from espanso/hub."""
+    package_manifest_url = (
+        f"{ESPANSO_HUB_API_URL}/contents/packages/{package}/{version}/_manifest.yml"
+    )
+
+    response = requests.get(package_manifest_url, headers=headers)
+    response.raise_for_status()
+    package_manifest_json = json.loads(response.text)
+    package_manifest_content = base64.b64decode(package_manifest_json["content"])
+    return yaml.safe_load(package_manifest_content)
+
+
+def get_package_nix_path(package: str) -> str:
+    """Get the path to the packages nix file."""
+    return f"{os.getcwd()}/pkgs/by-name/es/espanso/plugins/{package}/default.nix"
+
+
+def exec(cmd: str, capture_output: bool = True) -> str:
+    """Execute a shell command and return its output"""
+    result = subprocess.run(
+        cmd, shell=True, text=True, capture_output=capture_output, check=True
+    )
+    return result.stdout.strip() if capture_output else ""
+
+
+def get_current_package_version(package: str) -> version.Version:
+    """Get the current version of the espanso package packaged in nixpkgs."""
+    return version.Version(
+        exec(f'nix eval --raw -f {os.getcwd()} espansoPlugins."{package}".version')
+    )
+
+
+def read_nix_file(file_path: str) -> str:
+    """Read the content of a Nix file"""
+    with open(file_path, "r") as f:
+        return f.read()
+
+
+def write_nix_file(file_path: str, content: str) -> None:
+    """Write content to a Nix file"""
+    os.makedirs(os.path.dirname(file_path), exist_ok=True)
+    with open(file_path, "w") as f:
+        _ = f.write(content)
+
+
+def calculate_sri_hash(url: str, rev: str) -> str:
+    """Calculate the SRI hash of the source"""
+    prefetch_url = f"{url}/archive/{rev}.tar.gz"
+
+    new_hash = exec(
+        f"nix-prefetch-url --unpack --type sha256 {prefetch_url} 2>/dev/null"
+    )
+
+    # If the hash is not in SRI format, convert it
+    if not new_hash.startswith("sha256-"):
+        # Try to convert the hash to SRI format
+        new_hash = exec(f"nix hash to-sri --type sha256 {new_hash} 2>/dev/null")
+
+        # If that fails, try another approach
+        if not new_hash.startswith("sha256-"):
+            print(
+                "Warning: Failed to get SRI hash directly, trying alternative method..."
+            )
+            raw_hash = exec(
+                f"nix-prefetch-url --type sha256 {prefetch_url} 2>/dev/null"
+            )
+            new_hash = exec(f"nix hash to-sri --type sha256 {raw_hash} 2>/dev/null")
+
+    # Verify we got a valid SRI hash
+    if not new_hash.startswith("sha256-"):
+        print(f"Error: Failed to generate valid SRI hash. Output was: {new_hash}")
+        sys.exit(1)
+
+    return new_hash
+
+
+def update_version(content: str, version: str) -> str:
+    """Update the version within a Nix file."""
+    if "version = " in content:
+        return re.sub(r'version = "[^"]*"', f'version = "{version}"', content)
+    else:
+        return re.sub(r'(pname = "[^"]*";)', f'\\1\n  version = "{version}";', content)
+
+
+def update_rev(content: str, rev: str) -> str:
+    """Update the revision within a Nix file."""
+    return re.sub(r'rev = "[^"]*"', f'rev = "{rev}"', content)
+
+
+def update_hash(content: str, hash: str) -> str:
+    """Update the hash within a Nix file."""
+    if 'hash = "' in content:
+        return re.sub(r'hash = "[^"]*"', f'hash = "{hash}"', content)
+    elif "fetchFromGitHub" in content:
+        return re.sub(r'sha256 = "[^"]*"', f'sha256 = "{hash}"', content)
+    else:
+        print("Error: Could not find hash attribute")
+        sys.exit(1)
+
+
+def escape(input: str) -> str:
+    """Escape characters and character sequences that would break a string in Nix."""
+    output = input
+    output = output.replace("\\", "\\\\")
+    output = output.replace('"', '\\"')
+    output = output.replace("${", "''${")
+    return output
+
+
+def update_metadata(content: str, package_manifest: Any) -> str:
+    """Update the metadata within a Nix file."""
+    new_content = content
+    if 'description = "' in content:
+        new_content = re.sub(
+            r'description = "[^"]*"',
+            f'description = "{escape(package_manifest["description"])}"',
+            new_content,
+        )
+    if 'homepage = "' in content and "homepage" in package_manifest.keys():
+        new_content = re.sub(
+            r'homepage = "[^"]*"',
+            f'homepage = "{escape(package_manifest["homepage"])}"',
+            new_content,
+        )
+    return new_content
+
+
+def update_nix_file(
+    package: str,
+    rev: str,
+    hash: str,
+    package_manifest: Any,
+    commit_changes: Optional[str] = None,
+) -> None:
+    """Update the nix file of the package."""
+    package_nix_file = get_package_nix_path(package)
+    current_version = get_current_package_version(package)
+    new_version = version.Version(package_manifest["version"])
+
+    if current_version < new_version:
+        print(f"Updating {package}: {current_version} -> {new_version} ({rev})")
+
+        if commit_changes == "jj":
+            _ = exec("jj new", capture_output=False)
+            _ = exec(f"jj file track {package_nix_file}", capture_output=False)
+
+        content = read_nix_file(package_nix_file)
+        content = update_version(content, new_version)
+        content = update_rev(content, rev)
+        content = update_hash(content, hash)
+        content = update_metadata(content, package_manifest)
+
+        write_nix_file(package_nix_file, content)
+
+        if commit_changes is not None:
+            commit_package(
+                package,
+                f"espansoPlugins.{package}: {current_version} -> {new_version}",
+                commit_changes,
+            )
+
+
+def create_nix_file(
+    package: str,
+    rev: str,
+    hash: str,
+    package_manifest: Any,
+    maintainers: list[str],
+    commit_changes: Optional[str] = None,
+) -> None:
+    """Create a new nix file for the package."""
+    package_nix_file = get_package_nix_path(package)
+
+    print(
+        f"Creating {package} {package_manifest['version']} ({rev}) - Please add the `meta.license` attribute manually"
+    )
+
+    if commit_changes == "jj":
+        _ = exec("jj new", capture_output=False)
+
+    content = [
+        "{",
+        "  lib,",
+        "  fetchFromGitHub,",
+        "  mkEspansoPlugin,",
+        "}:",
+        "mkEspansoPlugin {",
+        f'  pname = "{package}";',
+        f'  version = "{package_manifest["version"]}";',
+        "",
+        "  src = fetchFromGitHub {",
+        '    owner = "espanso";',
+        '    repo = "hub";',
+        f'    rev = "{rev}";',
+        f'    hash = "{hash}";',
+        "  };",
+        "",
+        "  meta = {",
+        f'    description = "{escape(package_manifest["description"])}";',
+        *(
+            [f'    homepage = "{escape(package_manifest["homepage"])}";']
+            if "homepage" in package_manifest.keys()
+            else []
+        ),
+        f"    maintainers = with lib.maintainers; [ {str.join(' ', maintainers)} ];",
+        "  };",
+        "}",
+    ]
+
+    write_nix_file(package_nix_file, str.join("\n", content))
+
+    if commit_changes == "jj":
+        _ = exec(f"jj file track {package_nix_file}", capture_output=False)
+
+    if commit_changes is not None:
+        commit_package(
+            package,
+            f"espansoPlugins.{package}: init at {package_manifest['version']}",
+            commit_changes,
+        )
+
+
+def commit_package(package: str, message: str, tool: str = "git") -> None:
+    """Commit the package file with given commit message."""
+    package_nix_file = get_package_nix_path(package)
+    if tool == "git":
+        _ = exec(f"git add {package_nix_file}", capture_output=False)
+        _ = exec(f"nix fmt {package_nix_file}", capture_output=False)
+        _ = exec(f'git commit -m "{escape(message)}"', capture_output=False)
+    elif tool == "jj":
+        _ = exec(f"nix fmt {package_nix_file}", capture_output=False)
+        _ = exec(f'jj describe -m "{escape(message)}"', capture_output=False)
+
+
+def main(
+    packages: Optional[list[str]],
+    maintainers: list[str],
+    commit_changes: Optional[str],
+) -> None:
+    """Main function to update an Espanso package"""
+    gh_headers = get_github_headers()
+
+    packages = packages or fetch_hub_packages(gh_headers)
+    rev = fetch_new_revision("main", gh_headers)
+    hash = calculate_sri_hash(ESPANSO_HUB_URL, rev)
+
+    for package in packages:
+        version = fetch_package_version_from_dir(package, gh_headers)
+        if version is None:
+            print(f"Skipping '{package}' because it contains no version directory")
+        else:
+            package_manifest = fetch_package_manifest(package, version, gh_headers)
+
+            package_nix_file = get_package_nix_path(package)
+            if pathlib.Path(package_nix_file).exists():
+                try:
+                    update_nix_file(
+                        package, rev, hash, package_manifest, commit_changes
+                    )
+                except Exception as e:
+                    print(f"Failed to update '{package}': {e}")
+                    break
+
+            else:
+                try:
+                    create_nix_file(
+                        package,
+                        rev,
+                        hash,
+                        package_manifest,
+                        maintainers,
+                        commit_changes,
+                    )
+                except Exception as e:
+                    print(f"Failed to create '{package}': {e}")
+                    break
+
+
+parser = argparse.ArgumentParser(description="Update Espanso packages")
+_ = parser.add_argument(
+    "--commit-changes",
+    nargs="?",
+    const="git",
+    choices=["git", "jj"],
+    default=None,
+    help="Automatically commit changes with the according commit message. Defaults to git.",
+)
+_ = parser.add_argument(
+    "--maintainers",
+    type=str,
+    help="A comma separated list of maintainers which will be added to newly created packages.",
+)
+_ = parser.add_argument(
+    "packages",
+    nargs="*",
+    help="A list of package names to update. If no package names are specified, all packages from `github:espanso/hub/packages/ <https://github.com/espanso/hub/packages>`_ will be updated.",
+)
+
+if __name__ == "__main__":
+    args = parser.parse_args()
+    maintainers = []
+    if args.maintainers is not None:
+        maintainers = [s.strip() for s in args.maintainers.split(",")]
+
+    try:
+        main(args.packages, maintainers, args.commit_changes)
+    except KeyboardInterrupt as e:
+        # Let’s cancel outside of the main loop too.
+        sys.exit(130)

--- a/pkgs/by-name/es/espanso/plugins/us-time-zones/default.nix
+++ b/pkgs/by-name/es/espanso/plugins/us-time-zones/default.nix
@@ -1,0 +1,21 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkEspansoPlugin,
+}:
+mkEspansoPlugin {
+  pname = "us-time-zones";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "espanso";
+    repo = "hub";
+    rev = "d62bde95fc6f6cf90d4c23ee243922037c053def";
+    hash = "sha256-1cPtknrIi+9uTQt0pMaOBnY3C1GAGXPAA4fIgBh5Wgs=";
+  };
+
+  meta = {
+    description = "A simple package for printing converted time.";
+    maintainers = with lib.maintainers; [ delafthi ];
+  };
+}

--- a/pkgs/by-name/es/espanso/plugins/uuid/default.nix
+++ b/pkgs/by-name/es/espanso/plugins/uuid/default.nix
@@ -1,0 +1,23 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkEspansoPlugin,
+}:
+mkEspansoPlugin {
+  pname = "uuid";
+  version = "1.0.0";
+
+  src = fetchFromGitHub {
+    owner = "espanso";
+    repo = "hub";
+    rev = "13eb7d6d7d242bbadfb43ed4284d6b46ba63ce11";
+    hash = "sha256-r0V24FeBiS8LRzbzMjLKJqitpoiOWnuynGMahmDYe3s=";
+  };
+
+  meta = {
+    description = "Inserts a newly-generated UUIDv4, lowercase, uppercase, even non-dash.";
+    homepage = "https://github.com/Arylen/espanso-uuid";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ delafthi ];
+  };
+}

--- a/pkgs/by-name/es/espanso/plugins/verbose-form-template/default.nix
+++ b/pkgs/by-name/es/espanso/plugins/verbose-form-template/default.nix
@@ -1,0 +1,22 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkEspansoPlugin,
+}:
+mkEspansoPlugin {
+  pname = "verbose-form-template";
+  version = "1.0.1";
+
+  src = fetchFromGitHub {
+    owner = "espanso";
+    repo = "hub";
+    rev = "d62bde95fc6f6cf90d4c23ee243922037c053def";
+    hash = "sha256-1cPtknrIi+9uTQt0pMaOBnY3C1GAGXPAA4fIgBh5Wgs=";
+  };
+
+  meta = {
+    description = "Espanso shortcode to create espanso forms with the list extension";
+    homepage = "https://github.com/menawi/hub/tree/main/packages";
+    maintainers = with lib.maintainers; [ delafthi ];
+  };
+}

--- a/pkgs/by-name/es/espanso/plugins/vim-digraphs/default.nix
+++ b/pkgs/by-name/es/espanso/plugins/vim-digraphs/default.nix
@@ -1,0 +1,22 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkEspansoPlugin,
+}:
+mkEspansoPlugin {
+  pname = "vim-digraphs";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "espanso";
+    repo = "hub";
+    rev = "d62bde95fc6f6cf90d4c23ee243922037c053def";
+    hash = "sha256-1cPtknrIi+9uTQt0pMaOBnY3C1GAGXPAA4fIgBh5Wgs=";
+  };
+
+  meta = {
+    description = "A package implementing the digraphs of vim.";
+    homepage = "https://github.com/femtocept/espanso-package-example";
+    maintainers = with lib.maintainers; [ delafthi ];
+  };
+}

--- a/pkgs/by-name/es/espanso/plugins/wtc/default.nix
+++ b/pkgs/by-name/es/espanso/plugins/wtc/default.nix
@@ -1,0 +1,26 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkEspansoPlugin,
+  curl,
+}:
+mkEspansoPlugin {
+  pname = "wtc";
+  version = "1.0.1";
+
+  src = fetchFromGitHub {
+    owner = "espanso";
+    repo = "hub";
+    rev = "d62bde95fc6f6cf90d4c23ee243922037c053def";
+    hash = "sha256-1cPtknrIi+9uTQt0pMaOBnY3C1GAGXPAA4fIgBh5Wgs=";
+  };
+
+  buildInputs = [ curl ];
+
+  meta = {
+    description = "Get a hilarious random commit message";
+    homepage = "https://github.com/omrilotan/espanso-package-wtc";
+    license = lib.licenses.unlicense;
+    maintainers = with lib.maintainers; [ delafthi ];
+  };
+}

--- a/pkgs/by-name/es/espanso/plugins/wttr/default.nix
+++ b/pkgs/by-name/es/espanso/plugins/wttr/default.nix
@@ -1,0 +1,26 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkEspansoPlugin,
+  curl,
+}:
+mkEspansoPlugin {
+  pname = "wttr";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "espanso";
+    repo = "hub";
+    rev = "d62bde95fc6f6cf90d4c23ee243922037c053def";
+    hash = "sha256-1cPtknrIi+9uTQt0pMaOBnY3C1GAGXPAA4fIgBh5Wgs=";
+  };
+
+  buildInputs = [ curl ];
+
+  meta = {
+    description = "A package to get the weather from wttr.in.";
+    homepage = "https://github.com/bradyjoslin/espanso-package-wttr";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ delafthi ];
+  };
+}

--- a/pkgs/by-name/es/espanso/plugins/zipcodes-german/default.nix
+++ b/pkgs/by-name/es/espanso/plugins/zipcodes-german/default.nix
@@ -1,0 +1,22 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkEspansoPlugin,
+}:
+mkEspansoPlugin {
+  pname = "zipcodes-german";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "espanso";
+    repo = "hub";
+    rev = "d62bde95fc6f6cf90d4c23ee243922037c053def";
+    hash = "sha256-1cPtknrIi+9uTQt0pMaOBnY3C1GAGXPAA4fIgBh5Wgs=";
+  };
+
+  meta = {
+    description = "German Zip Codes";
+    homepage = "https://github.com/MegaTraveller/espanso-hub/tree/main/packages";
+    maintainers = with lib.maintainers; [ delafthi ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2031,6 +2031,8 @@ with pkgs;
     conf = config.element-web.conf or { };
   };
 
+  espansoPlugins = recurseIntoAttrs (callPackage ../by-name/es/espanso/plugins { });
+
   espanso-wayland = espanso.override {
     x11Support = false;
     waylandSupport = !stdenv.hostPlatform.isDarwin;


### PR DESCRIPTION
Add Espanso packages from [github:espanso/hub](https://github.com/espanso/hub) as plugins under
`espansoPlugins.<name>`. Accordingly, we also introduce a `plugins` option to the Espanso Home-Manager service to allow users to easily add these plugins.

- I tested the update script, which also supports generating Nix files for new packages. Note that license information (`meta.license`) must be added manually, so I reviewed each package and added the appropriate license metadata accordingly.  
- I built several of the packages, though not all, since they are auto-generated. The build process is straightforward — primarily copying files from `packages/<package-name>/<most-recent-version>/` to the output directory.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
