### PR TITLE
python3Packages.dspy: init at 3.0.0b2

### DIFF
--- a/pkgs/development/python-modules/dspy/default.nix
+++ b/pkgs/development/python-modules/dspy/default.nix
@@ -1,0 +1,150 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  wheel,
+  anyio,
+  asyncer,
+  backoff,
+  cachetools,
+  cloudpickle,
+  diskcache,
+  joblib,
+  json-repair,
+  litellm,
+  magicattr,
+  numpy,
+  openai,
+  optuna,
+  pydantic,
+  regex,
+  requests,
+  rich,
+  tenacity,
+  tqdm,
+  ujson,
+  anthropic,
+  build,
+  datamodel-code-generator,
+  pillow,
+  pre-commit,
+  pytest,
+  pytest-asyncio,
+  pytest-mock,
+  ruff,
+  langchain-core,
+  mcp,
+  datasets,
+  pandas,
+  weaviate-client,
+  pytestCheckHook,
+}:
+
+buildPythonPackage rec {
+  pname = "dspy";
+  version = "3.0.0b2";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "stanfordnlp";
+    repo = "dspy";
+    tag = version;
+    hash = "sha256-iMEppyMf4yLLhoKr7AITs1GoSvZ3msjn3IH/Urws4Ds=";
+  };
+
+  build-system = [
+    setuptools
+    wheel
+  ];
+
+  dependencies = [
+    anyio
+    asyncer
+    backoff
+    cachetools
+    cloudpickle
+    diskcache
+    joblib
+    json-repair
+    litellm
+    magicattr
+    numpy
+    openai
+    optuna
+    pydantic
+    regex
+    requests
+    rich
+    tenacity
+    tqdm
+    ujson
+  ];
+
+  optional-dependencies = {
+    anthropic = [
+      anthropic
+    ];
+    dev = [
+      build
+      datamodel-code-generator
+      litellm
+      pillow
+      pre-commit
+      pytest
+      pytest-asyncio
+      pytest-mock
+      ruff
+    ];
+    langchain = [
+      langchain-core
+    ];
+    mcp = [
+      mcp
+    ];
+    test_extras = [
+      datasets
+      langchain-core
+      mcp
+      optuna
+      pandas
+    ];
+    weaviate = [
+      weaviate-client
+    ];
+  };
+
+  __darwinAllowLocalNetworking = true; # tests run local server
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    datamodel-code-generator
+    litellm
+    pillow
+  ] ++ litellm.optional-dependencies.proxy;
+
+  # Don't try to write to default cache dir (~/.dspy_cache) during import check
+  env.DSPY_CACHEDIR = "$(TMPDIR)/dummy";
+
+  pythonImportsCheck = [
+    "dspy"
+  ];
+
+  disabledTests = [
+    # Require internet access
+    "test_pdf_url_support"
+    "test_different_mime_types"
+    "test_mime_type_from_response_headers"
+    "test_pdf_from_file"
+    "test_image_input_formats"
+    "test_predictor_save_load"
+  ];
+
+  meta = {
+    description = "Framework for programming—not prompting—language models";
+    homepage = "https://github.com/stanfordnlp/dspy";
+    changelog = "https://github.com/stanfordnlp/dspy/releases/tag/${version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ mcwitt ];
+  };
+}

--- a/pkgs/development/python-modules/magicattr/default.nix
+++ b/pkgs/development/python-modules/magicattr/default.nix
@@ -37,7 +37,7 @@ buildPythonPackage rec {
   ];
 
   meta = {
-    description = "A getattr and setattr that works on nested objects, lists, dicts, and any combination thereof without resorting to eval";
+    description = "Getattr and setattr that works on nested objects, lists, dicts, and any combination thereof without resorting to eval";
     homepage = "https://github.com/frmdstryr/magicattr";
     changelog = "https://github.com/frmdstryr/magicattr/releases/tag/v${version}";
     license = lib.licenses.mit;

--- a/pkgs/development/python-modules/magicattr/default.nix
+++ b/pkgs/development/python-modules/magicattr/default.nix
@@ -1,0 +1,46 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  wheel,
+  pytestCheckHook,
+}:
+
+buildPythonPackage rec {
+  pname = "magicattr";
+  version = "0.1.6";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "frmdstryr";
+    repo = "magicattr";
+    tag = "v${version}";
+    hash = "sha256-hV425AnXoYL3oSYMhbXaF8VRe/B1s5f5noAZYz4MMwc=";
+  };
+
+  build-system = [
+    setuptools
+    wheel
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  enabledTestPaths = [
+    "tests.py"
+  ];
+
+  pythonImportsCheck = [
+    "magicattr"
+  ];
+
+  meta = {
+    description = "A getattr and setattr that works on nested objects, lists, dicts, and any combination thereof without resorting to eval";
+    homepage = "https://github.com/frmdstryr/magicattr";
+    changelog = "https://github.com/frmdstryr/magicattr/releases/tag/v${version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ mcwitt ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8728,6 +8728,8 @@ self: super: with self; {
     callPackage ../development/python-modules/magic-wormhole-transit-relay
       { };
 
+  magicattr = callPackage ../development/python-modules/magicattr { };
+
   magicgui = callPackage ../development/python-modules/magicgui { };
 
   magika = callPackage ../development/python-modules/magika { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4350,6 +4350,8 @@ self: super: with self; {
 
   dsnap = callPackage ../development/python-modules/dsnap { };
 
+  dspy = callPackage ../development/python-modules/dspy { };
+
   dtfabric = callPackage ../development/python-modules/dtfabric { };
 
   dtlssocket = callPackage ../development/python-modules/dtlssocket { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

* Adds [DSPy](https://github.com/stanfordnlp/dspy), a framework for programming language models
* Adds [magicattr](https://github.com/frmdstryr/magicattr), a dependency missing from nixpkgs

Closes #323924

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
