### PR TITLE
sladeUnstable: 3.2.6-unstable-2024-11-26 -> 3.2.7-unstable-2025-04-22

### DIFF
--- a/pkgs/games/doom-ports/slade/git.nix
+++ b/pkgs/games/doom-ports/slade/git.nix
@@ -69,11 +69,11 @@ stdenv.mkDerivation {
     url = "https://github.com/sirjuddington/SLADE.git";
   };
 
-  meta = with lib; {
+  meta = {
     description = "Doom editor";
     homepage = "http://slade.mancubus.net/";
-    license = licenses.gpl2Only; # https://github.com/sirjuddington/SLADE/issues/1754
-    platforms = platforms.linux;
-    maintainers = with maintainers; [ ertes ];
+    license = lib.licenses.gpl2Only; # https://github.com/sirjuddington/SLADE/issues/1754
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ ertes ];
   };
 }

--- a/pkgs/games/doom-ports/slade/git.nix
+++ b/pkgs/games/doom-ports/slade/git.nix
@@ -8,27 +8,27 @@
   zip,
   wxGTK,
   gtk3,
-  sfml,
+  sfml_2,
   fluidsynth,
   curl,
-  freeimage,
   ftgl,
   glew,
   lua,
   mpg123,
   wrapGAppsHook3,
   unstableGitUpdater,
+  libwebp,
 }:
 
 stdenv.mkDerivation {
   pname = "slade";
-  version = "3.2.6-unstable-2024-11-26";
+  version = "3.2.7-unstable-2025-04-22";
 
   src = fetchFromGitHub {
     owner = "sirjuddington";
     repo = "SLADE";
-    rev = "f8ca52edf98e649c6455f6cc32f7aa361e41babe";
-    hash = "sha256-h43kYVLDxr1Z3vKJ+IZaDmvkerUdGJFLzJrPj0b2VUI=";
+    rev = "f8584231353845148c7623990dd90291fcb70f33";
+    hash = "sha256-tP84FfSjfOxFh8S7GuyHB0M13Svx6SLbloo8xt9oORU=";
   };
 
   nativeBuildInputs = [
@@ -42,14 +42,14 @@ stdenv.mkDerivation {
   buildInputs = [
     wxGTK
     gtk3
-    sfml
+    sfml_2
     fluidsynth
     curl
-    freeimage
     ftgl
     glew
     lua
     mpg123
+    libwebp
   ];
 
   cmakeFlags = [

--- a/pkgs/games/doom-ports/slade/git.nix
+++ b/pkgs/games/doom-ports/slade/git.nix
@@ -54,6 +54,7 @@ stdenv.mkDerivation {
 
   cmakeFlags = [
     "-DwxWidgets_LIBRARIES=${wxGTK}/lib"
+    (lib.cmakeFeature "CL_WX_CONFIG" (lib.getExe' (lib.getDev wxGTK) "wx-config"))
   ];
 
   env.NIX_CFLAGS_COMPILE = "-Wno-narrowing";


### PR DESCRIPTION
Bump `sladeUnstable`, which now doesn't rely on the insecure `freeimage`.

Also added the fix for crossbuild, which is already present on the stable version.
And I got rid of the `with lib` to make this package closer to the stable one.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
