### PR TITLE
pkgs/buffybox: 3.2.0-unstable-2025-03-16 -> 3.3.0

### DIFF
--- a/nixos/modules/system/boot/unl0kr.nix
+++ b/nixos/modules/system/boot/unl0kr.nix
@@ -75,6 +75,7 @@ in
 
         "usbtouchscreen"
         "evdev"
+        "psmouse"
       ]
       ++ lib.optionals cfg.allowVendorDrivers [
         "intel_lpss_pci"

--- a/pkgs/by-name/bu/buffybox/package.nix
+++ b/pkgs/by-name/bu/buffybox/package.nix
@@ -11,27 +11,32 @@
   pkg-config,
   scdoc,
   stdenv,
-  unstableGitUpdater,
+  gitUpdater,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "buffybox";
-  version = "3.2.0-unstable-2025-03-16";
+  version = "3.3.0";
 
   src = fetchFromGitLab {
     domain = "gitlab.postmarketos.org";
     owner = "postmarketOS";
     repo = "buffybox";
     fetchSubmodules = true; # to use its vendored lvgl
-    rev = "56a9867e90ece88596e330774da64cf277069b59";
-    hash = "sha256-4lSgswcvvV6W1KN6QhsjeHY8MMXXC4fRYBmPE/hb0vA=";
+    rev = "dce41a6f07a2b63c3136409b7bcd0078299fadf9";
+    hash = "sha256-n5RQg7kGS+lg7sRe5Defl3nDEha0vhc/FbwywD5wBsg=";
   };
 
   patches = [
     (fetchpatch2 {
-      # https://gitlab.postmarketos.org/postmarketOS/buffybox/-/merge_requests/42
-      url = "https://gitlab.postmarketos.org/postmarketOS/buffybox/-/commit/1f0c30e88dc61b8b508696cd890393c3b7911b58.patch?full_index=1";
-      hash = "sha256-hQ6Hjfyj059j2cRfrFz9Se6xRowIGW1HVHULLYtHcS8=";
+      # This fixes a bug that might annoy you if you use something like PKCS#11
+      url = "https://gitlab.postmarketos.org/postmarketOS/buffybox/-/commit/d8214b522a3cc72cd4639a1dd114103a02e9218c.patch";
+      hash = "sha256-WxKuioJ1Fo5ARRYF/R4yULDVB4pq11phljzVGdWTV6s=";
+    })
+    (fetchpatch2 {
+      # Fixes up UB
+      url = "https://gitlab.postmarketos.org/postmarketOS/buffybox/-/commit/4e13c312241420cbb3e5cc7d4f0dd3e5d17449be.patch";
+      hash = "sha256-7yX6gGsptwijx+ZedSJWJKhwaoBVpxIbGK+ZiMLsIhc=";
     })
   ];
 
@@ -57,7 +62,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   strictDeps = true;
 
-  passthru.updateScript = unstableGitUpdater { };
+  passthru.updateScript = gitUpdater { };
 
   meta = with lib; {
     description = "A suite of graphical applications for the terminal";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Update to latest stable release. Somewhat "uneventful" since the latest rev.

Supposedly you can rotate the display but we have no way of doing it with the bespoke upstream agent. I guess we'll have to bump it again by the time we get there. Or patch it in manually.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
