### PR TITLE
treewide: fix patsh cross patching

### DIFF
--- a/pkgs/by-name/cs/csvquote/package.nix
+++ b/pkgs/by-name/cs/csvquote/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  coreutils,
   patsh,
 }:
 
@@ -25,6 +26,9 @@ stdenv.mkDerivation rec {
     patsh
   ];
 
+  # needed for cross
+  buildInputs = [ coreutils ];
+
   makeFlags = [
     "BINDIR=$(out)/bin"
   ];
@@ -35,7 +39,7 @@ stdenv.mkDerivation rec {
 
   postInstall = ''
     substituteAllInPlace $out/bin/csvheader
-    patsh $out/bin/csvheader -fs ${builtins.storeDir}
+    patsh $out/bin/csvheader -fs ${builtins.storeDir} --path "$HOST_PATH"
   '';
 
   meta = with lib; {

--- a/pkgs/by-name/rm/rmate-sh/package.nix
+++ b/pkgs/by-name/rm/rmate-sh/package.nix
@@ -4,6 +4,7 @@
   fetchFromGitHub,
   patsh,
   hostname,
+  coreutils,
 }:
 
 stdenv.mkDerivation rec {
@@ -19,6 +20,9 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ patsh ];
 
+  # needed for cross
+  buildInputs = [ coreutils ];
+
   buildPhase = ''
     runHook preBuild
 
@@ -26,7 +30,7 @@ stdenv.mkDerivation rec {
       --replace-fail \
         'echo "hostname"' \
         'echo "${hostname}/bin/hostname"'
-    patsh -f rmate -s ${builtins.storeDir}
+    patsh -f rmate -s ${builtins.storeDir} --path "$HOST_PATH"
 
     runHook postBuild
   '';

--- a/pkgs/by-name/sc/script-directory/package.nix
+++ b/pkgs/by-name/sc/script-directory/package.nix
@@ -4,6 +4,7 @@
   fetchFromGitHub,
   installShellFiles,
   patsh,
+  coreutils,
 }:
 
 stdenvNoCC.mkDerivation rec {
@@ -22,10 +23,13 @@ stdenvNoCC.mkDerivation rec {
     patsh
   ];
 
+  # needed for cross
+  buildInputs = [ coreutils ];
+
   installPhase = ''
     runHook preInstall
 
-    patsh -f sd
+    patsh -f sd -s ${builtins.storeDir} --path "$HOST_PATH"
     install -Dt "$out/bin" sd
     installShellCompletion --zsh _sd
 

--- a/pkgs/by-name/sx/sx/package.nix
+++ b/pkgs/by-name/sx/sx/package.nix
@@ -4,6 +4,7 @@
   fetchFromGitHub,
   makeDesktopItem,
   patsh,
+  coreutils,
   xorg,
   nixosTests,
 }:
@@ -24,12 +25,13 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   nativeBuildInputs = [ patsh ];
 
   buildInputs = [
+    coreutils # needed for cross
     xorg.xauth
     xorg.xorgserver
   ];
 
   postInstall = ''
-    patsh -f $out/bin/sx -s ${builtins.storeDir}
+    patsh -f $out/bin/sx -s ${builtins.storeDir} --path "$HOST_PATH"
 
     install -Dm755 -t $out/share/xsessions ${
       makeDesktopItem {

--- a/pkgs/by-name/wi/wifi-qr/package.nix
+++ b/pkgs/by-name/wi/wifi-qr/package.nix
@@ -12,6 +12,10 @@
   stdenvNoCC,
   xdg-utils,
   zbar,
+  coreutils,
+  gnused,
+  gnugrep,
+  file,
 }:
 stdenvNoCC.mkDerivation (finalAttr: {
   pname = "wifi-qr";
@@ -37,6 +41,12 @@ stdenvNoCC.mkDerivation (finalAttr: {
     qrencode
     xdg-utils
     zbar
+    # needed for cross
+    # TODO: somehow splice the packages in stdenvNoCC.initialPath and use that
+    coreutils
+    gnugrep
+    gnused
+    file
   ];
 
   nativeBuildInputs = [
@@ -74,7 +84,7 @@ stdenvNoCC.mkDerivation (finalAttr: {
     runHook preFixup
 
     patchShebangs $out/bin/wifi-qr
-    patsh -f $out/bin/wifi-qr -s ${builtins.storeDir}
+    patsh -f $out/bin/wifi-qr -s ${builtins.storeDir} --path "$HOST_PATH"
 
     runHook postFixup
   '';


### PR DESCRIPTION
- **csvquote: fix cross patching**
- **rmate-sh: fix cross patching**
- **script-directory: fix cross patching**
- **sx: fix cross patching**
- **wifi-qr: fix cross patching**

should close https://github.com/nix-community/patsh/issues/137

@sorki please test

CC @figsoda


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
