### PR TITLE
noi: init at 0.4.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5197,6 +5197,17 @@
     githubId = 176372446;
     name = "Katja Kwast";
   };
+  culxttes = {
+    email = "culottes@sagbot.com";
+    name = "Edouard Haddag";
+    github = "culxttes";
+    githubId = 59392138;
+    keys = [
+      {
+        fingerprint = "C15C C360 2178 F45D BCD5  D07D A2A7 3EE1 93D1 6B42";
+      }
+    ];
+  };
   curran = {
     email = "curran@mercury.com";
     github = "curranosaurus";

--- a/pkgs/by-name/no/noi/package.nix
+++ b/pkgs/by-name/no/noi/package.nix
@@ -1,0 +1,34 @@
+{
+  lib,
+  appimageTools,
+  fetchurl,
+}:
+
+appimageTools.wrapType2 rec {
+  pname = "noi";
+  version = "0.4.0";
+  src = fetchurl {
+    url = "https://github.com/lencx/Noi/releases/download/v${version}/Noi_linux_${version}.Appimage";
+    hash = "sha256-ZwI1MpEoQn48zaan/GB7St6b15jtPHjwoUfD6bPkA3A=";
+  };
+
+  extraInstallCommands =
+    let
+      contents = appimageTools.extract { inherit pname version src; };
+    in
+    ''
+      install -m 644 -D ${contents}/Noi.desktop -t $out/share/applications
+      echo "Icon=noi" >> $out/share/applications/Noi.desktop
+
+      install -m 644 -D ${contents}/usr/lib/noi/resources/icons/icon.png $out/share/icons/hicolor/512x512/apps/noi.png
+    '';
+
+  meta = {
+    description = "AI-enhanced, customizable browser designed to streamline your digital experience";
+    homepage = "https://noi.nofwl.com";
+    maintainers = with lib.maintainers; [ culxttes ];
+    license = lib.licenses.unfree;
+    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+    mainProgram = "noi";
+  };
+}


### PR DESCRIPTION
Correction of https://github.com/NixOS/nixpkgs/issues/366844

Closes https://github.com/NixOS/nixpkgs/issues/366844 adds Noi to nixpkgs

Noi, an AI-enhanced, customizable browser.
🚀 Power Your World with AI - Explore, Extend, Empower.
Homepage:[noi.nofwl.com](https://noi.nofwl.com/)

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
