### PR TITLE
lib.systems: raise minimum loongarch64 feature support

### DIFF
--- a/doc/release-notes/rl-2511.section.md
+++ b/doc/release-notes/rl-2511.section.md
@@ -5,6 +5,12 @@
 
 - Added `allowVariants` to gate availability of package sets like `pkgsLLVM`, `pkgsMusl`, `pkgsZig`, etc.
 
+- The initial work to support native compilation on LoongArch64 has completed, with further changes currently
+  in preparation. In accordance with the [Software Development and Build Convention for LoongArch Architectures](https://github.com/loongson/la-softdev-convention),
+  this release sets the default march level to `la64v1.0`, covering the desktop and server processors of 3X5000
+  and newer series. However, embedded chips without LSX (Loongson SIMD eXtension), such as 2K0300 SoC, are not
+  supported. `pkgsCross.loongarch64-linux-embedded` can be used to build software and systems for these platforms.
+
 ## Backward Incompatibilities {#sec-nixpkgs-release-25.11-incompatibilities}
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->

--- a/lib/systems/architectures.nix
+++ b/lib/systems/architectures.nix
@@ -329,6 +329,39 @@ rec {
       "avx512"
       "fma"
     ];
+    # LoongArch64
+    # https://github.com/loongson/la-toolchain-conventions
+    loongarch64 = [
+      "fpu64"
+    ];
+    la464 = [
+      "fpu64"
+      "lsx"
+      "lasx"
+    ];
+    la664 = [
+      "fpu64"
+      "lsx"
+      "lasx"
+      "div32"
+      "frecipe"
+      "lam-bh"
+      "lamcas"
+      "ld-seq-sa"
+    ];
+    "la64v1.0" = [
+      "fpu64"
+      "lsx"
+    ];
+    "la64v1.1" = [
+      "fpu64"
+      "lsx"
+      "div32"
+      "frecipe"
+      "lam-bh"
+      "lamcas"
+      "ld-seq-sa"
+    ];
     # other
     armv5te = [ ];
     armv6 = [ ];
@@ -486,6 +519,16 @@ rec {
       ampere1a = [ "ampere1" ] ++ inferiors.ampere1;
       ampere1b = [ "ampere1a" ] ++ inferiors.ampere1a;
 
+      # LoongArch64
+      loongarch64 = [ ];
+      "la64v1.0" = [ "loongarch64" ];
+      la464 = [ "la64v1.0" ] ++ inferiors."la64v1.0";
+      "la64v1.1" = [ "la64v1.0" ] ++ inferiors."la64v1.0";
+      la664 = withInferiors [
+        "la464"
+        "la64v1.1"
+      ];
+
       # other
       armv5te = [ ];
       armv6 = [ ];
@@ -510,5 +553,7 @@ rec {
       aesSupport = featureSupport "aes";
       fmaSupport = featureSupport "fma";
       fma4Support = featureSupport "fma4";
+      lsxSupport = featureSupport "lsx";
+      lasxSupport = featureSupport "lasx";
     };
 }

--- a/lib/systems/examples.nix
+++ b/lib/systems/examples.nix
@@ -170,8 +170,16 @@ rec {
     libc = "newlib";
   };
 
-  loongarch64-linux = {
+  # https://github.com/loongson/la-softdev-convention/blob/master/la-softdev-convention.adoc#10-operating-system-package-build-requirements
+  loongarch64-linux = lib.recursiveUpdate platforms.loongarch64-multiplatform {
     config = "loongarch64-unknown-linux-gnu";
+  };
+  loongarch64-linux-embedded = lib.recursiveUpdate platforms.loongarch64-multiplatform {
+    config = "loongarch64-unknown-linux-gnu";
+    gcc = {
+      arch = "loongarch64";
+      strict-align = true;
+    };
   };
 
   mmix = {

--- a/lib/systems/platforms.nix
+++ b/lib/systems/platforms.nix
@@ -572,6 +572,19 @@ rec {
     };
   };
 
+  loongarch64-multiplatform = {
+    gcc = {
+      # https://github.com/loongson/la-softdev-convention/blob/master/la-softdev-convention.adoc#10-operating-system-package-build-requirements
+      arch = "la64v1.0";
+      strict-align = false;
+      # Avoid text sections of large apps exceeding default code model
+      # Will be default behavior in LLVM 21 and hopefully GCC16
+      # https://github.com/loongson-community/discussions/issues/43
+      # https://github.com/llvm/llvm-project/pull/132173
+      cmodel = "medium";
+    };
+  };
+
   # This function takes a minimally-valid "platform" and returns an
   # attrset containing zero or more additional attrs which should be
   # included in the platform in order to further elaborate it.
@@ -607,6 +620,8 @@ rec {
     else if platform.parsed.cpu == lib.systems.parse.cpuTypes.powerpc64le then
       powernv
 
+    else if platform.isLoongArch64 then
+      loongarch64-multiplatform
     else
       { };
 }

--- a/pkgs/build-support/cc-wrapper/default.nix
+++ b/pkgs/build-support/cc-wrapper/default.nix
@@ -199,6 +199,14 @@ let
         znver3 = versionAtLeast ccVersion "11.0";
         znver4 = versionAtLeast ccVersion "13.0";
         znver5 = versionAtLeast ccVersion "14.0";
+
+        # LoongArch64
+        # https://gcc.gnu.org/gcc-12/changes.html#loongarch
+        # la464 was added together with loongarch64 support
+        # https://gcc.gnu.org/gcc-14/changes.html#loongarch
+        "la64v1.0" = versionAtLeast ccVersion "14.0";
+        "la64v1.1" = versionAtLeast ccVersion "14.0";
+        la664 = versionAtLeast ccVersion "14.0";
       }
       .${arch} or true
     else if isClang then
@@ -223,6 +231,14 @@ let
         znver3 = versionAtLeast ccVersion "12.0";
         znver4 = versionAtLeast ccVersion "16.0";
         znver5 = versionAtLeast ccVersion "19.1";
+
+        # LoongArch64
+        # https://releases.llvm.org/16.0.0/tools/clang/docs/ReleaseNotes.html#loongarch-support
+        # la464 was added together with loongarch64 support
+        # https://releases.llvm.org/19.1.0/tools/clang/docs/ReleaseNotes.html#loongarch-support
+        "la64v1.0" = versionAtLeast ccVersion "19.1";
+        "la64v1.1" = versionAtLeast ccVersion "19.1";
+        la664 = versionAtLeast ccVersion "19.1";
       }
       .${arch} or true
     else

--- a/pkgs/build-support/cc-wrapper/default.nix
+++ b/pkgs/build-support/cc-wrapper/default.nix
@@ -332,7 +332,17 @@ let
     ++ optional (targetPlatform ? gcc.fpu) "-mfpu=${targetPlatform.gcc.fpu}"
     ++ optional (targetPlatform ? gcc.mode) "-mmode=${targetPlatform.gcc.mode}"
     ++ optional (targetPlatform ? gcc.thumb) "-m${thumb}"
-    ++ optional (tune != null) "-mtune=${tune}";
+    ++ optional (tune != null) "-mtune=${tune}"
+    ++
+      optional (targetPlatform ? gcc.strict-align)
+        "-m${optionalString (!targetPlatform.gcc.strict-align) "no-"}strict-align"
+    ++ optional (
+      targetPlatform ? gcc.cmodel
+      &&
+        # TODO: clang on powerpcspe also needs a condition: https://github.com/llvm/llvm-project/issues/71356
+        # https://releases.llvm.org/18.1.6/tools/clang/docs/ReleaseNotes.html#loongarch-support
+        ((targetPlatform.isLoongArch64 && isClang) -> versionAtLeast ccVersion "18.1")
+    ) "-mcmodel=${targetPlatform.gcc.cmodel}";
 
   defaultHardeningFlags = bintools.defaultHardeningFlags or [ ];
 


### PR DESCRIPTION
(folks, please don't cherry-pick this)

```
nix-repl> pkgsCross.loongarch64-linux.stdenv.hostPlatform.gcc  
{
  arch = "la64v1.0";
  strict-align = false;
}

nix-repl> pkgsCross.loongarch64_nosimd-linux.stdenv.hostPlatform.gcc
{
  arch = "loongarch64";
  strict-align = true;
}

nix-repl> (lib.systems.elaborate "loongarch64-linux").gcc
{
  arch = "la64v1.0";
  strict-align = false;
}
```

The situation is all loongarch64 desktop and server CPUs support la64v1.0, mainly lsx 128-bit vector instruction set; however, there are still cheap SBCs with 2K0300 on the market, and they don't support lsx. Given their cost-effectiveness and widespread adoption in various college competitions, they may not be out of the market for the time being. Considering that the performance of 2K0300 is approximately equivalent to 0.6 times of one cortex A53, most of these SBCs are only equipped with 512MB of memory, and are mainly used as embedded comtrollers, they are less likely to benefit from native compilation,

The current plan is that our native bootstrap tarball and cache (in preparation!) are only for users of la64v1.0, and users of loongarch64 baseline (if any) should use `pkgsCross.loongarch64_nosimd-linux` to build the software and systems.

Loongson community has not obtained a formal name for this special kind of CPU yet, so we follow the "loongarch64-nosimd" name coming from AOSC OS.

See https://github.com/loongson/la-softdev-convention/blob/master/la-softdev-convention.adoc#10-operating-system-package-build-requirements

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
