### PR TITLE
generic-updater: Add rev-suffix support

### DIFF
--- a/pkgs/common-updater/directory-listing-updater.nix
+++ b/pkgs/common-updater/directory-listing-updater.nix
@@ -11,6 +11,7 @@
   allowedVersions ? "",
   ignoredVersions ? "",
   rev-prefix ? "",
+  rev-suffix ? "",
   odd-unstable ? false,
   patchlevel-unstable ? false,
   url ? null,
@@ -25,6 +26,7 @@ genericUpdater {
     allowedVersions
     ignoredVersions
     rev-prefix
+    rev-suffix
     odd-unstable
     patchlevel-unstable
     ;

--- a/pkgs/common-updater/generic-updater.nix
+++ b/pkgs/common-updater/generic-updater.nix
@@ -18,6 +18,7 @@
   allowedVersions ? "",
   ignoredVersions ? "",
   rev-prefix ? "",
+  rev-suffix ? "",
   odd-unstable ? false,
   patchlevel-unstable ? false,
 }:
@@ -43,8 +44,9 @@ let
     allowed_versions="$6"
     ignored_versions="$7"
     rev_prefix="$8"
-    odd_unstable="$9"
-    patchlevel_unstable="''${10}"
+    rev_suffix="$9"
+    odd_unstable="''${10}"
+    patchlevel_unstable="''${11}"
 
     [[ -n "$name" ]] || name="$UPDATE_NIX_NAME"
     [[ -n "$pname" ]] || pname="$UPDATE_NIX_PNAME"
@@ -88,6 +90,11 @@ let
     if [ -n "$rev_prefix" ]; then
       tags=$(echo "$tags" | ${grep} "^$rev_prefix")
       tags=$(echo "$tags" | ${sed} -e "s,^$rev_prefix,,")
+    fi
+    # cut any revision suffix not used in the NixOS package version
+    if [ -n "$rev_suffix" ]; then
+      tags=$(echo "$tags" | ${grep} -- "$rev_suffix$")
+      tags=$(echo "$tags" | ${sed} -e "s,$rev_suffix\$,,")
     fi
     tags=$(echo "$tags" | ${grep} "^[0-9]")
     if [ -n "$allowed_versions" ]; then
@@ -145,6 +152,7 @@ in
     allowedVersions
     ignoredVersions
     rev-prefix
+    rev-suffix
     odd-unstable
     patchlevel-unstable
   ];

--- a/pkgs/common-updater/git-updater.nix
+++ b/pkgs/common-updater/git-updater.nix
@@ -11,6 +11,7 @@
   allowedVersions ? "",
   ignoredVersions ? "",
   rev-prefix ? "",
+  rev-suffix ? "",
   odd-unstable ? false,
   patchlevel-unstable ? false,
   # an explicit url is needed when src.meta.homepage or src.url don't
@@ -26,6 +27,7 @@ genericUpdater {
     allowedVersions
     ignoredVersions
     rev-prefix
+    rev-suffix
     odd-unstable
     patchlevel-unstable
     ;

--- a/pkgs/common-updater/http-two-levels-updater.nix
+++ b/pkgs/common-updater/http-two-levels-updater.nix
@@ -11,6 +11,7 @@
   allowedVersions ? "",
   ignoredVersions ? "",
   rev-prefix ? "",
+  rev-suffix ? "",
   odd-unstable ? false,
   patchlevel-unstable ? false,
   url ? null,
@@ -24,6 +25,7 @@ genericUpdater {
     allowedVersions
     ignoredVersions
     rev-prefix
+    rev-suffix
     odd-unstable
     patchlevel-unstable
     ;


### PR DESCRIPTION
Needed for ashpd-demo, which has tags ending with `-demo`: https://github.com/bilelmoussaoui/ashpd/releases

See 84ad3afd1186f9a9e78fdae9eff2566d76c4fe8f

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
