### PR TITLE
git: fix checks by limiting build cores

### DIFF
--- a/pkgs/applications/version-management/git/default.nix
+++ b/pkgs/applications/version-management/git/default.nix
@@ -456,6 +456,12 @@ stdenv.mkDerivation (finalAttrs: {
 
   preInstallCheck =
     ''
+      # Some tests break with high concurrency
+      # https://github.com/NixOS/nixpkgs/pull/403237
+      if ((NIX_BUILD_CORES > 32)); then
+        NIX_BUILD_CORES=32
+      fi
+
       installCheckFlagsArray+=(
         GIT_PROVE_OPTS="--jobs $NIX_BUILD_CORES --failures --state=failed,save"
         GIT_TEST_INSTALLED=$out/bin


### PR DESCRIPTION
building git on a 96 core machine fails during installCheckPhase

Even when limiting to 48 cores, it still fails.
32 cores seem to work.

Error on too many cores:
```
git> Test Summary Report
git> -------------------
git> t7002-mv-sparse-checkout.sh                      (Wstat: 256 (exited 1) Tests: 22 Failed: 1)
git>   Failed test:  7
git>   Non-zero exit status: 1
git> t5319-multi-pack-index.sh                        (Wstat: 256 (exited 1) Tests: 93 Failed: 1)
git>   Failed test:  11
git>   Non-zero exit status: 1
git> t5515-fetch-merge-logic.sh                       (Wstat: 256 (exited 1) Tests: 65 Failed: 1)
git>   Failed test:  31
git>   Non-zero exit status: 1
git> t7513-interpret-trailers.sh                      (Wstat: 256 (exited 1) Tests: 99 Failed: 1)
git>   Failed test:  66
git>   Non-zero exit status: 1
git> Files=1016, Tests=30358, 87 wallclock secs ( 6.47 usr  3.63 sys + 219.99 cusr 2407.64 csys = 2637.73 CPU)
git> Result: FAIL
git> make[1]: *** [Makefile:73: prove] Error 1
git> make[1]: Leaving directory '/build/git-2.49.0/t'
git> make: *** [Makefile:3274: test] Error 2
```


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
