### PR TITLE
temurin-{,jre-}bin-23: drop, open{jdk,jfx}23: drop

### DIFF
--- a/doc/languages-frameworks/gradle.section.md
+++ b/doc/languages-frameworks/gradle.section.md
@@ -129,7 +129,7 @@ The update script does the following:
 `fetchDeps` takes the following arguments:
 
 - `attrPath` - the path to the package in nixpkgs (for example,
-  `"javaPackages.openjfx22"`). Used for update script metadata.
+  `"javaPackages.openjfx25"`). Used for update script metadata.
 - `pname` - an alias for `attrPath` for convenience. This is what you
   will generally use instead of `pkg` or `attrPath`.
 - `pkg` - the package to be used for fetching the dependencies. Defaults

--- a/doc/languages-frameworks/index.md
+++ b/doc/languages-frameworks/index.md
@@ -20,7 +20,7 @@ Each supported language or software ecosystem has its own package set named `<la
   $ nix repl '<nixpkgs>' -I nixpkgs=channel:nixpkgs-unstable
   nix-repl> javaPackages.<tab>
   javaPackages.compiler               javaPackages.openjfx15              javaPackages.openjfx21              javaPackages.recurseForDerivations
-  javaPackages.jogl_2_4_0             javaPackages.openjfx17              javaPackages.openjfx22
+  javaPackages.jogl_2_4_0             javaPackages.openjfx17              javaPackages.openjfx25
   javaPackages.mavenfod               javaPackages.openjfx19              javaPackages.override
   javaPackages.openjfx11              javaPackages.openjfx20              javaPackages.overrideDerivation
   ```

--- a/pkgs/applications/misc/pdfsam-basic/default.nix
+++ b/pkgs/applications/misc/pdfsam-basic/default.nix
@@ -49,7 +49,7 @@ stdenv.mkDerivation (finalAttrs: {
          --set PDFSAM_JAVA_PATH ${temurin-jre-bin-21} \
          --prefix LD_LIBRARY_PATH : ${
            lib.makeLibraryPath [
-             javaPackages.openjfx23 # PDFSam Basic requires JDK 21 and JavaFX 23 https://github.com/torakiki/pdfsam/issues/785#issuecomment-3446564717
+             javaPackages.openjfx25 # PDFSam Basic requires JDK 21 and JavaFX 23 https://github.com/torakiki/pdfsam/issues/785#issuecomment-3446564717
              xorg.libXxf86vm
              xorg.libXtst
              gtk3

--- a/pkgs/by-name/cr/cratedb/package.nix
+++ b/pkgs/by-name/cr/cratedb/package.nix
@@ -4,13 +4,13 @@
   maven,
   fetchFromGitHub,
   replaceVars,
-  openjdk23,
+  openjdk25,
   libarchive,
   makeWrapper,
 }:
 let
   # Wants at least Java 22
-  jdk = openjdk23;
+  jdk = openjdk25;
   version = "5.9.6";
 in
 maven.buildMavenPackage {

--- a/pkgs/by-name/cr/cryptomator/package.nix
+++ b/pkgs/by-name/cr/cryptomator/package.nix
@@ -3,7 +3,7 @@
   fetchFromGitHub,
   fuse3,
   glib,
-  jdk23,
+  jdk25,
   lib,
   libayatana-appindicator,
   makeShellWrapper,
@@ -13,7 +13,7 @@
 }:
 
 let
-  jdk = jdk23.override { enableJavaFX = true; };
+  jdk = jdk25.override { enableJavaFX = true; };
 in
 maven.buildMavenPackage rec {
   pname = "cryptomator";

--- a/pkgs/by-name/ja/jabref/package.nix
+++ b/pkgs/by-name/ja/jabref/package.nix
@@ -9,14 +9,14 @@
   xdg-utils,
   gtk3,
   jdk21,
-  openjfx23,
+  openjfx25,
   gradle_8,
   python3,
 }:
 let
   jdk = jdk21.override {
     enableJavaFX = true;
-    openjfx_jdk = openjfx23;
+    openjfx_jdk = openjfx25;
   };
   # "Deprecated Gradle features were used in this build, making it incompatible with Gradle 9.0."
   gradle = gradle_8;

--- a/pkgs/by-name/je/jextract/package.nix
+++ b/pkgs/by-name/je/jextract/package.nix
@@ -4,7 +4,7 @@
   fetchFromGitHub,
   makeBinaryWrapper,
   gradle,
-  jdk23,
+  jdk25,
   llvmPackages,
 }:
 
@@ -26,7 +26,7 @@ stdenv.mkDerivation {
 
   gradleFlags = [
     "-Pllvm_home=${lib.getLib llvmPackages.libclang}"
-    "-Pjdk_home=${jdk23}"
+    "-Pjdk_home=${jdk25}"
   ];
 
   patches = [
@@ -51,7 +51,7 @@ stdenv.mkDerivation {
     description = "Tool which mechanically generates Java bindings from a native library headers";
     mainProgram = "jextract";
     homepage = "https://github.com/openjdk/jextract";
-    platforms = jdk23.meta.platforms;
+    platforms = jdk25.meta.platforms;
     license = licenses.gpl2Only;
     maintainers = with maintainers; [
       jlesquembre

--- a/pkgs/by-name/ko/komga/package.nix
+++ b/pkgs/by-name/ko/komga/package.nix
@@ -3,7 +3,7 @@
   stdenvNoCC,
   fetchurl,
   makeWrapper,
-  jdk23_headless,
+  jdk25_headless,
   libwebp, # Fixes https://github.com/gotson/komga/issues/1294
   nixosTests,
 }:
@@ -22,7 +22,7 @@ stdenvNoCC.mkDerivation rec {
   ];
 
   buildCommand = ''
-    makeWrapper ${jdk23_headless}/bin/java $out/bin/komga --add-flags "-jar $src" \
+    makeWrapper ${jdk25_headless}/bin/java $out/bin/komga --add-flags "-jar $src" \
       --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ libwebp ]}
   '';
 
@@ -34,7 +34,7 @@ stdenvNoCC.mkDerivation rec {
     description = "Free and open source comics/mangas server";
     homepage = "https://komga.org/";
     license = lib.licenses.mit;
-    platforms = jdk23_headless.meta.platforms;
+    platforms = jdk25_headless.meta.platforms;
     maintainers = with lib.maintainers; [
       tebriel
       govanify

--- a/pkgs/by-name/mo/moneydance/package.nix
+++ b/pkgs/by-name/mo/moneydance/package.nix
@@ -4,12 +4,12 @@
   buildPackages,
   fetchzip,
   makeWrapper,
-  openjdk23,
+  openjdk25,
   wrapGAppsHook3,
   jvmFlags ? [ ],
 }:
 let
-  jdk = openjdk23.override {
+  jdk = openjdk25.override {
     enableJavaFX = true;
   };
 in

--- a/pkgs/by-name/op/openjfx/package.nix
+++ b/pkgs/by-name/op/openjfx/package.nix
@@ -35,13 +35,11 @@
 
   jdk17_headless,
   jdk21_headless,
-  jdk23_headless,
   jdk25_headless,
   jdk-bootstrap ?
     {
       "17" = jdk17_headless;
       "21" = jdk21_headless;
-      "23" = jdk23_headless;
       "25" = jdk25_headless;
     }
     .${featureVersion},

--- a/pkgs/by-name/re/recaf-launcher/package.nix
+++ b/pkgs/by-name/re/recaf-launcher/package.nix
@@ -19,7 +19,7 @@ buildFHSEnv {
     p: with p; [
       jar
 
-      openjdk23
+      openjdk25
       xorg.libX11
       at-spi2-atk
       cairo

--- a/pkgs/development/compilers/openjdk/23/source.json
+++ b/pkgs/development/compilers/openjdk/23/source.json
@@ -1,6 +1,0 @@
-{
-  "hash": "sha256-zlL2DV6iOfV3hgq/Ci95gTwVrhcvz5MWsg4/+O2ntE8=",
-  "owner": "openjdk",
-  "repo": "jdk23u",
-  "rev": "refs/tags/jdk-23.0.2+7"
-}

--- a/pkgs/development/compilers/openjdk/generic.nix
+++ b/pkgs/development/compilers/openjdk/generic.nix
@@ -78,7 +78,6 @@
   temurin-bin-11,
   temurin-bin-17,
   temurin-bin-21,
-  temurin-bin-23,
   temurin-bin-25,
   jdk-bootstrap ?
     {
@@ -86,7 +85,6 @@
       "11" = temurin-bin-11.__spliced.buildBuild or temurin-bin-11;
       "17" = temurin-bin-17.__spliced.buildBuild or temurin-bin-17;
       "21" = temurin-bin-21.__spliced.buildBuild or temurin-bin-21;
-      "23" = temurin-bin-23.__spliced.buildBuild or temurin-bin-23;
       "25" = temurin-bin-25.__spliced.buildBuild or temurin-bin-25;
     }
     .${featureVersion},

--- a/pkgs/development/compilers/openjdk/generic.nix
+++ b/pkgs/development/compilers/openjdk/generic.nix
@@ -58,13 +58,11 @@
   enableJavaFX ? false,
   openjfx17,
   openjfx21,
-  openjfx23,
   openjfx25,
   openjfx_jdk ?
     {
       "17" = openjfx17;
       "21" = openjfx21;
-      "23" = openjfx23;
       "25" = openjfx25;
     }
     .${featureVersion} or (throw "JavaFX is not supported on OpenJDK ${featureVersion}"),

--- a/pkgs/development/compilers/temurin-bin/generate-sources.py
+++ b/pkgs/development/compilers/temurin-bin/generate-sources.py
@@ -6,7 +6,7 @@ import re
 import requests
 import sys
 
-feature_versions = (8, 11, 17, 21, 23, 25)
+feature_versions = (8, 11, 17, 21, 25)
 oses = ("mac", "linux", "alpine-linux")
 types = ("jre", "jdk")
 impls = ("hotspot",)

--- a/pkgs/development/compilers/temurin-bin/jdk-darwin.nix
+++ b/pkgs/development/compilers/temurin-bin/jdk-darwin.nix
@@ -19,9 +19,6 @@ in
   jdk-21 = common { sourcePerArch = sources.jdk.openjdk21; };
   jre-21 = common { sourcePerArch = sources.jre.openjdk21; };
 
-  jdk-23 = common { sourcePerArch = sources.jdk.openjdk23; };
-  jre-23 = common { sourcePerArch = sources.jre.openjdk23; };
-
   jdk-25 = common { sourcePerArch = sources.jdk.openjdk25; };
   jre-25 = common { sourcePerArch = sources.jre.openjdk25; };
 }

--- a/pkgs/development/compilers/temurin-bin/jdk-linux.nix
+++ b/pkgs/development/compilers/temurin-bin/jdk-linux.nix
@@ -24,9 +24,6 @@ in
   jdk-21 = common { sourcePerArch = sources.jdk.openjdk21; };
   jre-21 = common { sourcePerArch = sources.jre.openjdk21; };
 
-  jdk-23 = common { sourcePerArch = sources.jdk.openjdk23; };
-  jre-23 = common { sourcePerArch = sources.jre.openjdk23; };
-
   jdk-25 = common { sourcePerArch = sources.jdk.openjdk25; };
   jre-25 = common { sourcePerArch = sources.jre.openjdk25; };
 }

--- a/pkgs/development/compilers/temurin-bin/sources.json
+++ b/pkgs/development/compilers/temurin-bin/sources.json
@@ -38,22 +38,6 @@
             "version": "21.0.8"
           }
         },
-        "openjdk23": {
-          "aarch64": {
-            "build": "7",
-            "sha256": "b55c5c881a2fed17ec5a59feaa33d9263703b399d1bfae3a5eaed3f140aa4570",
-            "url": "https://github.com/adoptium/temurin23-binaries/releases/download/jdk-23.0.2%2B7/OpenJDK23U-jdk_aarch64_alpine-linux_hotspot_23.0.2_7.tar.gz",
-            "version": "23.0.2"
-          },
-          "packageType": "jdk",
-          "vmType": "hotspot",
-          "x86_64": {
-            "build": "7",
-            "sha256": "2c05c6dfea23a83fdbfaf5b03cc3cfd8d998c8069e930e0e585a39d4a99f3d99",
-            "url": "https://github.com/adoptium/temurin23-binaries/releases/download/jdk-23.0.2%2B7/OpenJDK23U-jdk_x64_alpine-linux_hotspot_23.0.2_7.tar.gz",
-            "version": "23.0.2"
-          }
-        },
         "openjdk25": {
           "aarch64": {
             "build": "36",
@@ -116,22 +100,6 @@
             "sha256": "f499e2d5c596fd531c8427b2fb207c9eeabed783adad32aeed64b03dd476a231",
             "url": "https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.8%2B9/OpenJDK21U-jre_x64_alpine-linux_hotspot_21.0.8_9.tar.gz",
             "version": "21.0.8"
-          }
-        },
-        "openjdk23": {
-          "aarch64": {
-            "build": "7",
-            "sha256": "248a2ffb3abcb0cee7841ce648af7af415c96ee88cba4f8bf676c0115d38de5e",
-            "url": "https://github.com/adoptium/temurin23-binaries/releases/download/jdk-23.0.2%2B7/OpenJDK23U-jre_aarch64_alpine-linux_hotspot_23.0.2_7.tar.gz",
-            "version": "23.0.2"
-          },
-          "packageType": "jre",
-          "vmType": "hotspot",
-          "x86_64": {
-            "build": "7",
-            "sha256": "4513750bd10cc6c38f0c19d335dac7dcc112bba64e52010f81ba29e7a71e2a76",
-            "url": "https://github.com/adoptium/temurin23-binaries/releases/download/jdk-23.0.2%2B7/OpenJDK23U-jre_x64_alpine-linux_hotspot_23.0.2_7.tar.gz",
-            "version": "23.0.2"
           }
         },
         "openjdk25": {
@@ -264,34 +232,6 @@
             "sha256": "f2dc5418092c43003db8f9005c4a286e1c0104fea96ccdd49e8ebd037cac9219",
             "url": "https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.8%2B9/OpenJDK21U-jdk_x64_linux_hotspot_21.0.8_9.tar.gz",
             "version": "21.0.8"
-          }
-        },
-        "openjdk23": {
-          "aarch64": {
-            "build": "7",
-            "sha256": "fb43ae1202402842559cb6223886ec1663b90ffbec48479abbcb92c92c9012eb",
-            "url": "https://github.com/adoptium/temurin23-binaries/releases/download/jdk-23.0.2%2B7/OpenJDK23U-jdk_aarch64_linux_hotspot_23.0.2_7.tar.gz",
-            "version": "23.0.2"
-          },
-          "packageType": "jdk",
-          "powerpc64le": {
-            "build": "7",
-            "sha256": "548fd82af4eb0802fe20b0b61a4664a69c7f03cd963540908f30dbf73636dafe",
-            "url": "https://github.com/adoptium/temurin23-binaries/releases/download/jdk-23.0.2%2B7/OpenJDK23U-jdk_ppc64le_linux_hotspot_23.0.2_7.tar.gz",
-            "version": "23.0.2"
-          },
-          "riscv64": {
-            "build": "7",
-            "sha256": "1e102e1e6653f8810ef6c275b0d38ea7036abd4a8709f0f916b339f65e76bb56",
-            "url": "https://github.com/adoptium/temurin23-binaries/releases/download/jdk-23.0.2%2B7/OpenJDK23U-jdk_riscv64_linux_hotspot_23.0.2_7.tar.gz",
-            "version": "23.0.2"
-          },
-          "vmType": "hotspot",
-          "x86_64": {
-            "build": "7",
-            "sha256": "870ac8c05c6fe563e7a3878a47d0234b83c050e83651d2c47e8b822ec74512dd",
-            "url": "https://github.com/adoptium/temurin23-binaries/releases/download/jdk-23.0.2%2B7/OpenJDK23U-jdk_x64_linux_hotspot_23.0.2_7.tar.gz",
-            "version": "23.0.2"
           }
         },
         "openjdk25": {
@@ -460,34 +400,6 @@
             "version": "21.0.8"
           }
         },
-        "openjdk23": {
-          "aarch64": {
-            "build": "7",
-            "sha256": "b2a8a287ebd2d2a1d5d32eb6b79768cf2b5e02f1b4d6d4791297feb8636b9e2f",
-            "url": "https://github.com/adoptium/temurin23-binaries/releases/download/jdk-23.0.2%2B7/OpenJDK23U-jre_aarch64_linux_hotspot_23.0.2_7.tar.gz",
-            "version": "23.0.2"
-          },
-          "packageType": "jre",
-          "powerpc64le": {
-            "build": "7",
-            "sha256": "a21355923fdcdcc49fcf6359f2763f49f001bd4caeb970f7313f18aeaa61b588",
-            "url": "https://github.com/adoptium/temurin23-binaries/releases/download/jdk-23.0.2%2B7/OpenJDK23U-jre_ppc64le_linux_hotspot_23.0.2_7.tar.gz",
-            "version": "23.0.2"
-          },
-          "riscv64": {
-            "build": "7",
-            "sha256": "c2c8f8add6af6518cfc565ec0a7410e031301b91f2d8bd594303d7f04680da4e",
-            "url": "https://github.com/adoptium/temurin23-binaries/releases/download/jdk-23.0.2%2B7/OpenJDK23U-jre_riscv64_linux_hotspot_23.0.2_7.tar.gz",
-            "version": "23.0.2"
-          },
-          "vmType": "hotspot",
-          "x86_64": {
-            "build": "7",
-            "sha256": "1a16c654e67a72dadfa632969a457404ad1cc30c6375857fdcb393e0592ce3ba",
-            "url": "https://github.com/adoptium/temurin23-binaries/releases/download/jdk-23.0.2%2B7/OpenJDK23U-jre_x64_linux_hotspot_23.0.2_7.tar.gz",
-            "version": "23.0.2"
-          }
-        },
         "openjdk25": {
           "aarch64": {
             "build": "36",
@@ -602,22 +514,6 @@
             "version": "21.0.8"
           }
         },
-        "openjdk23": {
-          "aarch64": {
-            "build": "7",
-            "sha256": "749993e751f085c7ae713140066a90800075e4aeedfac50a5ed0c5457131c5a0",
-            "url": "https://github.com/adoptium/temurin23-binaries/releases/download/jdk-23.0.2%2B7/OpenJDK23U-jdk_aarch64_mac_hotspot_23.0.2_7.tar.gz",
-            "version": "23.0.2"
-          },
-          "packageType": "jdk",
-          "vmType": "hotspot",
-          "x86_64": {
-            "build": "7",
-            "sha256": "97fca2e90668351f248f149d4e96e16875094eba6716a8dd1dcf163be9e19085",
-            "url": "https://github.com/adoptium/temurin23-binaries/releases/download/jdk-23.0.2%2B7/OpenJDK23U-jdk_x64_mac_hotspot_23.0.2_7.tar.gz",
-            "version": "23.0.2"
-          }
-        },
         "openjdk25": {
           "aarch64": {
             "build": "36",
@@ -692,22 +588,6 @@
             "sha256": "34464861ed170ea0e5acdf870011f9e92f836e712b620ba37c4b2d0e5aeb8675",
             "url": "https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.8%2B9/OpenJDK21U-jre_x64_mac_hotspot_21.0.8_9.tar.gz",
             "version": "21.0.8"
-          }
-        },
-        "openjdk23": {
-          "aarch64": {
-            "build": "7",
-            "sha256": "56b86d4f5745ba44894310c3417755e4b4aaa62d4a17a5cb4dab6200c14c56fe",
-            "url": "https://github.com/adoptium/temurin23-binaries/releases/download/jdk-23.0.2%2B7/OpenJDK23U-jre_aarch64_mac_hotspot_23.0.2_7.tar.gz",
-            "version": "23.0.2"
-          },
-          "packageType": "jre",
-          "vmType": "hotspot",
-          "x86_64": {
-            "build": "7",
-            "sha256": "2c5b81ce3234d6bef0ec352734aa2de19c0950020c55a1cbfc21ae5fda7690b8",
-            "url": "https://github.com/adoptium/temurin23-binaries/releases/download/jdk-23.0.2%2B7/OpenJDK23U-jre_x64_mac_hotspot_23.0.2_7.tar.gz",
-            "version": "23.0.2"
           }
         },
         "openjdk25": {

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -1149,6 +1149,7 @@ mapAliases {
   openjdk23_headless = throw "OpenJDK 23 was removed as it has reached its end of life"; # Added 2025-11-04
   openjdk24 = throw "OpenJDK 24 was removed as it has reached its end of life"; # Added 2025-10-04
   openjdk24_headless = throw "OpenJDK 24 was removed as it has reached its end of life"; # Added 2025-10-04
+  openjfx23 = throw "OpenJFX 23 was removed as it has reached its end of life"; # Added 2025-11-04
   openjfx24 = throw "OpenJFX 24 was removed as it has reached its end of life"; # Added 2025-10-04
   openmw-tes3mp = throw "'openmw-tes3mp' has been removed due to lack of maintenance upstream"; # Added 2025-08-30
   openssl_3_0 = throw "'openssl_3_0' has been renamed to/replaced by 'openssl_3'"; # Converted to throw 2025-10-27

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -723,6 +723,8 @@ mapAliases {
   jami-client = throw "'jami-client' has been renamed to/replaced by 'jami'"; # Converted to throw 2025-10-27
   jami-client-qt = throw "'jami-client-qt' has been renamed to/replaced by 'jami-client'"; # Converted to throw 2025-10-27
   jami-daemon = throw "'jami-daemon' has been renamed to/replaced by 'jami.daemon'"; # Converted to throw 2025-10-27
+  jdk23 = throw "OpenJDK 23 was removed as it has reached its end of life"; # Added 2025-11-04
+  jdk23_headless = throw "OpenJDK 23 was removed as it has reached its end of life"; # Added 2025-11-04
   jdk24 = throw "OpenJDK 24 was removed as it has reached its end of life"; # Added 2025-10-04
   jdk24_headless = throw "OpenJDK 24 was removed as it has reached its end of life"; # Added 2025-10-04
   jikespg = throw "'jikespg' has been removed due to lack of maintenance upstream."; # Added 2025-06-10
@@ -1143,6 +1145,8 @@ mapAliases {
   openconnect_gnutls = throw "'openconnect_gnutls' has been renamed to/replaced by 'openconnect'"; # Converted to throw 2025-10-27
   openexr_3 = throw "'openexr_3' has been renamed to/replaced by 'openexr'"; # Converted to throw 2025-10-27
   openimageio2 = throw "'openimageio2' has been renamed to/replaced by 'openimageio'"; # Converted to throw 2025-10-27
+  openjdk23 = throw "OpenJDK 23 was removed as it has reached its end of life"; # Added 2025-11-04
+  openjdk23_headless = throw "OpenJDK 23 was removed as it has reached its end of life"; # Added 2025-11-04
   openjdk24 = throw "OpenJDK 24 was removed as it has reached its end of life"; # Added 2025-10-04
   openjdk24_headless = throw "OpenJDK 24 was removed as it has reached its end of life"; # Added 2025-10-04
   openjfx24 = throw "OpenJFX 24 was removed as it has reached its end of life"; # Added 2025-10-04

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -1468,7 +1468,9 @@ mapAliases {
   teamspeak_client = throw "'teamspeak_client' has been renamed to/replaced by 'teamspeak3'"; # Converted to throw 2025-10-27
   tegaki-zinnia-japanese = throw "'tegaki-zinnia-japanese' has been removed due to lack of maintenance"; # Added 2025-09-10
   temporalite = throw "'temporalite' has been removed as it is obsolete and unmaintained, please use 'temporal-cli' instead (with `temporal server start-dev`)"; # Added 2025-06-26
+  temurin-bin-23 = throw "Temurin 23 has been removed as it has reached its end of life"; # Added 2025-11-04
   temurin-bin-24 = throw "Temurin 24 has been removed as it has reached its end of life"; # Added 2025-10-04
+  temurin-jre-bin-23 = throw "Temurin 23 has been removed as it has reached its end of life"; # Added 2025-11-04
   temurin-jre-bin-24 = throw "Temurin 24 has been removed as it has reached its end of life"; # Added 2025-10-04
   tepl = throw "'tepl' has been renamed to/replaced by 'libgedit-tepl'"; # Converted to throw 2025-10-27
   terminus-nerdfont = throw "'terminus-nerdfont' has been renamed to/replaced by 'nerd-fonts.terminess-ttf'"; # Converted to throw 2025-10-27

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4988,7 +4988,6 @@ with pkgs;
 
   openjfx17 = openjfx;
   openjfx21 = callPackage ../by-name/op/openjfx/package.nix { featureVersion = "21"; };
-  openjfx23 = callPackage ../by-name/op/openjfx/package.nix { featureVersion = "23"; };
   openjfx25 = callPackage ../by-name/op/openjfx/package.nix { featureVersion = "25"; };
 
   openjdk8-bootstrap = javaPackages.compiler.openjdk8-bootstrap;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5016,11 +5016,6 @@ with pkgs;
   jdk21 = openjdk21;
   jdk21_headless = openjdk21_headless;
 
-  openjdk23 = javaPackages.compiler.openjdk23;
-  openjdk23_headless = javaPackages.compiler.openjdk23.headless;
-  jdk23 = openjdk23;
-  jdk23_headless = openjdk23_headless;
-
   openjdk25 = javaPackages.compiler.openjdk25;
   openjdk25_headless = javaPackages.compiler.openjdk25.headless;
   jdk25 = openjdk25;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4322,9 +4322,6 @@ with pkgs;
   temurin-bin-25 = javaPackages.compiler.temurin-bin.jdk-25;
   temurin-jre-bin-25 = javaPackages.compiler.temurin-bin.jre-25;
 
-  temurin-bin-23 = javaPackages.compiler.temurin-bin.jdk-23;
-  temurin-jre-bin-23 = javaPackages.compiler.temurin-bin.jre-23;
-
   temurin-bin-21 = javaPackages.compiler.temurin-bin.jdk-21;
   temurin-jre-bin-21 = javaPackages.compiler.temurin-bin.jre-21;
 

--- a/pkgs/top-level/java-packages.nix
+++ b/pkgs/top-level/java-packages.nix
@@ -52,7 +52,6 @@ in
       openjdk11 = mkOpenjdk "11";
       openjdk17 = mkOpenjdk "17";
       openjdk21 = mkOpenjdk "21";
-      openjdk23 = mkOpenjdk "23";
       openjdk25 = mkOpenjdk "25";
 
       # Legacy aliases

--- a/pkgs/top-level/java-packages.nix
+++ b/pkgs/top-level/java-packages.nix
@@ -8,7 +8,7 @@ let
     ;
 in
 {
-  inherit (pkgs) openjfx17 openjfx21 openjfx23;
+  inherit (pkgs) openjfx17 openjfx21 openjfx25;
   compiler = lib.recurseIntoAttrs (
     let
       # merge meta.platforms of both packages so that dependent packages and hydra build them


### PR DESCRIPTION
With the release of Temurin 24, version 23 is no longer supported so users should not be using that any more since that is not an LTS (21 and 17 are). So, removing Temurin 23 to avoid confusion.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
