### PR TITLE
vimPlugins.peek-nvim: build JS

### DIFF
--- a/pkgs/applications/editors/vim/plugins/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/overrides.nix
@@ -2748,9 +2748,15 @@ in
     ];
   };
 
-  peek-nvim = super.peek-nvim.overrideAttrs {
-    runtimeDeps = [ deno ];
-  };
+  peek-nvim = super.peek-nvim.overrideAttrs (old: {
+    patches = [
+      # Patch peek-nvim to run using nixpkgs deno
+      # This means end-users have to build peek-nvim the first time they use it...
+      (replaceVars ./patches/peek-nvim/cmd.patch {
+        deno = lib.getExe deno;
+      })
+    ];
+  });
 
   persisted-nvim = super.persisted-nvim.overrideAttrs {
     nvimSkipModules = [

--- a/pkgs/applications/editors/vim/plugins/patches/peek-nvim/cmd.patch
+++ b/pkgs/applications/editors/vim/plugins/patches/peek-nvim/cmd.patch
@@ -1,0 +1,37 @@
+diff --git a/app/src/main.ts b/app/src/main.ts
+index c82d914..e8542f3 100644
+--- a/app/src/main.ts
++++ b/app/src/main.ts
+@@ -73,7 +73,7 @@ async function init(socket: WebSocket) {
+     const onListen: Deno.ServeOptions['onListen'] = ({ hostname, port }) => {
+       const serverUrl = `${hostname.replace('0.0.0.0', 'localhost')}:${port}`;
+       logger.info(`listening on ${serverUrl}`);
+-      const webview = new Deno.Command('deno', {
++      const webview = new Deno.Command('@deno@', {
+         cwd: dirname(fromFileUrl(Deno.mainModule)),
+         args: [
+           'run',
+diff --git a/lua/peek/app.lua b/lua/peek/app.lua
+index af5148e..5e67563 100644
+--- a/lua/peek/app.lua
++++ b/lua/peek/app.lua
+@@ -38,10 +38,17 @@ function module.setup()
+   end
+
+   cmd = vim.list_extend({
+-    'deno',
+-    'task',
+-    '--quiet',
++    '@deno@',
+     'run',
++    '--allow-read',
++    '--allow-write',
++    '--allow-net',
++    '--allow-env',
++    '--allow-run',
++    '--no-check',
++    '--allow-import',
++    '--no-lock',
++    '../../app/src/main.ts',
+   }, args)
+ end


### PR DESCRIPTION
## Things done

Currently, using `peek.nvim` fails with:
```
Peek error: error: Module not found "file:///nix/store/a0xhznlqbcjw587yj88s73bpjs0sw048-vimplugin-peek.nvim-2024-04-0
9/public/main.bundle.js".
Press ENTER or type command to continue
```
We should be building the JS in the `buildPhase`.
Upstream explains that it should be:
```
deno task --quiet build:fase
```
but this requires internet access.
So instead, we should fetch the dependencies before hand.
I am not sure about how to do that though.

cc @MattSturgeon @Lurgrif

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
