### PR TITLE
gnunet-messenger-cli: init at 0.3.1

### DIFF
--- a/pkgs/by-name/gn/gnunet-messenger-cli/package.nix
+++ b/pkgs/by-name/gn/gnunet-messenger-cli/package.nix
@@ -1,0 +1,55 @@
+{
+  lib,
+  stdenv,
+  fetchgit,
+  meson,
+  ninja,
+  pkg-config,
+  gnunet,
+  libsodium,
+  libgcrypt,
+  libgnunetchat,
+  ncurses,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "gnunet-messenger-cli";
+  version = "0.3.1";
+
+  src = fetchgit {
+    url = "https://git.gnunet.org/messenger-cli.git";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-8Iby3IZXEZJ1dqVV62xDzXx/qq7JKhVtn6ZLb697ZSw=";
+  };
+
+  env.INSTALL_DIR = (placeholder "out") + "/";
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+  ];
+
+  buildInputs = [
+    gnunet
+    libgcrypt
+    libgnunetchat
+    libsodium
+    ncurses
+  ];
+
+  # No update script for now as the Nix-update-script didn't work for this
+
+  preInstall = "mkdir -p $out/bin";
+
+  preFixup = "mv $out/bin/messenger-cli $out/bin/gnunet-messenger-cli";
+
+  meta = {
+    description = "decentralized, privacy-preserving networking framework for secure peer-to-peer communication";
+    homepage = "https://git.gnunet.org/messenger-cli.git";
+    license = lib.licenses.gpl3Plus;
+    platforms = lib.platforms.all;
+    teams = with lib.teams; [ ngi ];
+    maintainers = [ lib.maintainers.oluchitheanalyst ];
+  };
+})

--- a/pkgs/by-name/li/libgnunetchat/package.nix
+++ b/pkgs/by-name/li/libgnunetchat/package.nix
@@ -1,0 +1,59 @@
+{
+  lib,
+  stdenv,
+  fetchgit,
+  meson,
+  ninja,
+  pkg-config,
+  validatePkgConfig,
+  testers,
+  check,
+  gnunet,
+  libsodium,
+  libgcrypt,
+  libextractor,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  name = "libgnunetchat";
+  version = "0.5.3";
+
+  src = fetchgit {
+    url = "https://git.gnunet.org/libgnunetchat.git";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-DhXPYa8ya9cEbwa4btQTrpjfoTGhzBInWXXH4gmDAQw=";
+  };
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+    validatePkgConfig
+  ];
+
+  buildInputs = [
+    check
+    gnunet
+    libextractor
+    libgcrypt
+    libsodium
+  ];
+
+  env.INSTALL_DIR = (placeholder "out") + "/";
+
+  # No update script for now as the Nix-update-script didn't work for this
+
+  prePatch = "mkdir -p $out/lib";
+
+  passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+
+  meta = {
+    pkgConfigModules = [ "gnunetchat" ];
+    description = "Library for secure, decentralized chat using GNUnet network services";
+    homepage = "https://git.gnunet.org/libgnunetchat.git";
+    license = lib.licenses.gpl3Plus;
+    platforms = lib.platforms.all;
+    teams = with lib.teams; [ ngi ];
+    maintainers = [ lib.maintainers.oluchitheanalyst ];
+  };
+})


### PR DESCRIPTION
- Added and tested the Nix update script to make sure it works
- Added Myself to maintainers
- Added The Nix@NGI team
- Built both packages with nix-build -A "package-name"
**Package description**
decentralized, privacy-preserving networking framework for secure peer-to-peer communication
**Homepage**: https://git.gnunet.org/messenger-cli.git
**License**: gpl3Plus
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
