### PR TITLE
lauti: rename from eintopf and update to 1.0.0

### DIFF
--- a/nixos/modules/services/web-apps/eintopf.nix
+++ b/nixos/modules/services/web-apps/eintopf.nix
@@ -15,14 +15,14 @@ in
 {
   options.services.eintopf = {
 
-    enable = mkEnableOption "Eintopf community event calendar web app";
+    enable = mkEnableOption "Lauti (Eintopf) community event calendar web app";
 
     settings = mkOption {
       type = types.attrsOf types.str;
       default = { };
       description = ''
         Settings to configure web service. See
-        <https://codeberg.org/Klasse-Methode/eintopf/src/branch/main/DEPLOYMENT.md>
+        <https://codeberg.org/Klasse-Methode/lauti/src/branch/main/DEPLOYMENT.md>
         for available options.
       '';
       example = literalExpression ''
@@ -54,7 +54,7 @@ in
       wants = [ "network-online.target" ];
       environment = cfg.settings;
       serviceConfig = {
-        ExecStart = "${pkgs.eintopf}/bin/eintopf";
+        ExecStart = lib.getExe pkgs.lauti;
         WorkingDirectory = "/var/lib/eintopf";
         StateDirectory = "eintopf";
         EnvironmentFile = [ cfg.secrets ];

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -421,7 +421,7 @@ in
   ecryptfs = handleTest ./ecryptfs.nix { };
   fscrypt = handleTest ./fscrypt.nix { };
   fastnetmon-advanced = runTest ./fastnetmon-advanced.nix;
-  eintopf = handleTest ./eintopf.nix { };
+  eintopf = runTest ./eintopf.nix;
   ejabberd = handleTest ./xmpp/ejabberd.nix { };
   elk = handleTestOn [ "x86_64-linux" ] ./elk.nix { };
   emacs-daemon = runTest ./emacs-daemon.nix;

--- a/nixos/tests/eintopf.nix
+++ b/nixos/tests/eintopf.nix
@@ -1,26 +1,24 @@
-import ./make-test-python.nix (
-  { pkgs, ... }:
-  {
-    name = "eintopf";
-    meta = with pkgs.lib.maintainers; {
-      maintainers = [ onny ];
-    };
+{
+  lib,
+  pkgs,
+  ...
+}:
 
-    nodes = {
-      eintopf =
-        { config, pkgs, ... }:
-        {
-          services.eintopf = {
-            enable = true;
-          };
-        };
-    };
+{
+  name = "eintopf";
+  meta.maintainers = with lib.maintainers; [ onny ];
 
-    testScript = ''
-      eintopf.start
-      eintopf.wait_for_unit("eintopf.service")
-      eintopf.wait_for_open_port(3333)
-      eintopf.succeed("curl -sSfL http://eintopf:3333 | grep 'Es sind keine Veranstaltungen eingetragen'")
-    '';
-  }
-)
+  nodes = {
+    eintopf = {
+      services.eintopf.enable = true;
+    };
+  };
+
+  testScript = ''
+    eintopf.start
+    eintopf.wait_for_unit("eintopf.service")
+    eintopf.wait_for_open_port(3333)
+    eintopf.succeed("curl -sSfL http://eintopf:3333 | grep 'No events available'")
+  '';
+
+}

--- a/pkgs/by-name/la/lauti/frontend.nix
+++ b/pkgs/by-name/la/lauti/frontend.nix
@@ -4,20 +4,20 @@
   src,
   version,
   nodejs,
-  eintopf,
+  lauti,
   yarnConfigHook,
   yarnBuildHook,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
-  pname = "eintopf";
+  pname = "lauti";
   inherit version src;
 
-  sourceRoot = "${finalAttrs.src.name}/backstage";
+  sourceRoot = "${finalAttrs.src.name}/";
 
   offlineCache = fetchYarnDeps {
-    yarnLock = "${finalAttrs.src}/backstage/yarn.lock";
-    hash = "sha256-3TPBrQxvTfmBfhAavHy8eDcZwRZMwu0dCovnE1fcuTE=";
+    yarnLock = "${finalAttrs.src}/yarn.lock";
+    hash = "sha256-uIDBE4ewdzrtJqOjFQTAei1TpAjQMRqls7CtG1h8KnA=";
   };
 
   nativeBuildInputs = [
@@ -26,6 +26,10 @@ stdenv.mkDerivation (finalAttrs: {
     # Needed for executing package.json scripts
     nodejs
   ];
+
+  preBuild = ''
+    cd backstage
+  '';
 
   installPhase = ''
     runHook preInstall
@@ -39,7 +43,7 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   meta = {
-    inherit (eintopf.meta)
+    inherit (lauti.meta)
       homepage
       description
       license

--- a/pkgs/by-name/la/lauti/frontend.nix
+++ b/pkgs/by-name/la/lauti/frontend.nix
@@ -13,8 +13,6 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "lauti";
   inherit version src;
 
-  sourceRoot = "${finalAttrs.src.name}/";
-
   offlineCache = fetchYarnDeps {
     yarnLock = "${finalAttrs.src}/yarn.lock";
     hash = "sha256-uIDBE4ewdzrtJqOjFQTAei1TpAjQMRqls7CtG1h8KnA=";

--- a/pkgs/by-name/la/lauti/package.nix
+++ b/pkgs/by-name/la/lauti/package.nix
@@ -7,22 +7,22 @@
 }:
 
 let
-  version = "0.14.3";
+  version = "1.0.0";
   src = fetchFromGitea {
     domain = "codeberg.org";
     owner = "Klasse-Methode";
-    repo = "eintopf";
-    rev = "v${version}";
-    hash = "sha256-cWHWRxZFoArBB5PiuY6EQubKJKm3/79fwNhnABOtBrM=";
+    repo = "lauti";
+    tag = "v${version}";
+    hash = "sha256-cO9rK7GAVRlv5x4WI/xbXNJ594QqB+KIPUteB3TifKM=";
   };
   frontend = callPackage ./frontend.nix { inherit src version; };
 in
 
 buildGoModule rec {
-  pname = "eintopf";
+  pname = "lauti";
   inherit version src;
 
-  vendorHash = "sha256-ysAgyaewREI8TaMnKH+kh33QT6AN1eLhog35lv7CbVU=";
+  vendorHash = "sha256-ushTvIpvRLZP3q6tLN6BA4tl2Xp/UImWugm2ZgTAm8k=";
 
   ldflags = [
     "-s"
@@ -37,19 +37,20 @@ buildGoModule rec {
 
   preCheck = ''
     # Disable test, requires running Docker daemon
-    rm cmd/eintopf/main_test.go
+    rm cmd/lauti/main_test.go
     rm service/email/email_test.go
   '';
 
   passthru.tests = {
-    inherit (nixosTests) eintopf;
+    inherit (nixosTests) lauti;
   };
 
   meta = {
-    description = "A calendar for Stuttgart, showing events, groups and places";
-    homepage = "https://codeberg.org/Klasse-Methode/eintopf";
+    description = "An open source calendar for events, groups and places";
+    homepage = "https://lauti.org";
     license = lib.licenses.agpl3Only;
     maintainers = with lib.maintainers; [ onny ];
     platforms = lib.platforms.unix;
+    mainProgram = "lauti";
   };
 }

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -550,6 +550,7 @@ mapAliases {
   ecryptfs-helper = throw "'ecryptfs-helper' has been removed, for filesystem-level encryption, use fscrypt"; # Added 2025-04-08
   edUnstable = throw "edUnstable was removed; use ed instead"; # Added 2024-07-01
   edgedb = throw "edgedb replaced to gel because of change of upstream"; # Added 2025-02-24
+  eintopf = lauti; # Project was renamed, added 2025-05-01
   elasticsearch7Plugins = elasticsearchPlugins;
   electronplayer = throw "'electronplayer' has been removed as it had been discontinued upstream since October 2024"; # Added 2024-12-17
 


### PR DESCRIPTION
The project got renamed from "eintopf" to "lauti" and updated from version 0.14.3 to 1.0.0

Changes: https://codeberg.org/Klasse-Methode/lauti/compare/v0.14.3...v1.0.0

Added an alias for the new package but leaving the service name as "eintopf" for now.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
