### PR TITLE
python3Packages.craft-application: 4.10.0 -> 5.3.0

### DIFF
--- a/pkgs/by-name/sn/snapcraft/package.nix
+++ b/pkgs/by-name/sn/snapcraft/package.nix
@@ -14,7 +14,7 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "snapcraft";
-  version = "8.8.1";
+  version = "8.9.2";
 
   pyproject = true;
 
@@ -22,7 +22,7 @@ python3Packages.buildPythonApplication rec {
     owner = "canonical";
     repo = "snapcraft";
     tag = version;
-    hash = "sha256-gn2roiwNLUFJsuen2qGPvl4DyE6gPUQibS1Cn7cj2L8=";
+    hash = "sha256-4Dv2q/aKWnQkQ6ANYev/5fT1fFKh1MytYJtHK0iAzhk=";
   };
 
   patches = [

--- a/pkgs/development/python-modules/craft-application/default.nix
+++ b/pkgs/development/python-modules/craft-application/default.nix
@@ -10,7 +10,7 @@
   craft-providers,
   jinja2,
   fetchFromGitHub,
-  git,
+  gitMinimal,
   hypothesis,
   license-expression,
   nix-update-script,
@@ -20,29 +20,33 @@
   pytest-mock,
   pytest-subprocess,
   pytestCheckHook,
-  pythonOlder,
   pyyaml,
   responses,
   setuptools-scm,
   snap-helpers,
   freezegun,
+  cacert,
+  writableTmpDirAsHomeHook,
 }:
 
 buildPythonPackage rec {
   pname = "craft-application";
-  version = "4.10.0";
+  version = "5.3.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "canonical";
     repo = "craft-application";
     tag = version;
-    hash = "sha256-9M49/XQuWwKuQqseleTeZYcrwd/S16lNCljvlVsoXbs=";
+    hash = "sha256-6iD35ql3/vUzILh5VMWiFwBKPoGPfCUgEKD4g7s55Y0=";
   };
 
   postPatch = ''
     substituteInPlace pyproject.toml \
       --replace-fail "setuptools==75.8.0" "setuptools"
+
+      substituteInPlace craft_application/git/_utils.py \
+        --replace-fail "/snap/core22/current/etc/ssl/certs" "${cacert}/etc/ssl/certs"
   '';
 
   build-system = [ setuptools-scm ];
@@ -68,7 +72,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [
     freezegun
-    git
+    gitMinimal
     hypothesis
     pyfakefs
     pytest-check
@@ -76,11 +80,10 @@ buildPythonPackage rec {
     pytest-subprocess
     pytestCheckHook
     responses
+    writableTmpDirAsHomeHook
   ];
 
   preCheck = ''
-    export HOME=$(mktemp -d)
-
     # Tests require access to /etc/os-release, which isn't accessible in
     # the test environment, so create a fake file, and modify the code
     # to look for it.
@@ -90,6 +93,11 @@ buildPythonPackage rec {
 
     substituteInPlace craft_application/util/platforms.py \
       --replace-fail "os_utils.OsRelease()" "os_utils.OsRelease(os_release_file='$HOME/os-release')"
+
+    # Not using `--replace-fail` here only because it simplifies overriding this package in the charmcraft
+    # derivation. Once charmcraft has moved to craft-application >= 5, `--replace-fail` can be added.
+    substituteInPlace tests/conftest.py \
+      --replace "include_lsb=False, include_uname=False, include_oslevel=False" "include_lsb=False, include_uname=False, include_oslevel=False, os_release_file='$HOME/os-release'"
   '';
 
   pythonImportsCheck = [ "craft_application" ];
@@ -109,6 +117,10 @@ buildPythonPackage rec {
       # slightly in a later revision of craft-platforms. No functional error.
       "test_platform_invalid_arch"
       "test_platform_invalid_build_arch"
+      # Asserts against string output which fails when not on Ubuntu.
+      "test_run_error_with_docs_url"
+      # Asserts a fallback path for SSL certs that we override in a patch.
+      "test_import_fallback_wrong_metadata"
     ]
     ++ lib.optionals stdenv.hostPlatform.isAarch64 [
       # These tests have hardcoded "amd64" strings which fail on aarch64
@@ -116,6 +128,11 @@ buildPythonPackage rec {
       "test_process_grammar_platform"
       "test_process_grammar_default"
     ];
+
+  disabledTestPaths = [
+    # These tests assert outputs of commands that assume Ubuntu-related output.
+    "tests/unit/services/test_lifecycle.py"
+  ];
 
   passthru.updateScript = nix-update-script { };
 

--- a/pkgs/development/python-modules/craft-parts/default.nix
+++ b/pkgs/development/python-modules/craft-parts/default.nix
@@ -25,11 +25,12 @@
   ant,
   maven,
   jdk,
+  writableTmpDirAsHomeHook,
 }:
 
 buildPythonPackage rec {
   pname = "craft-parts";
-  version = "2.8.0";
+  version = "2.10.0";
 
   pyproject = true;
 
@@ -37,7 +38,7 @@ buildPythonPackage rec {
     owner = "canonical";
     repo = "craft-parts";
     tag = version;
-    hash = "sha256-1SnT/yB6vJm82yhszBRjeph13B91KYap8/KR4L9VcjM=";
+    hash = "sha256-nGOLzQ+mlLHmqkknWklCIEN7HOgQznuYO1rbqUvL1N4=";
   };
 
   patches = [ ./bash-path.patch ];
@@ -76,13 +77,10 @@ buildPythonPackage rec {
     requests-mock
     socat
     squashfsTools
+    writableTmpDirAsHomeHook
   ];
 
   pytestFlagsArray = [ "tests/unit" ];
-
-  preCheck = ''
-    export HOME=$(mktemp -d)
-  '';
 
   disabledTests = [
     # Relies upon paths not present in Nix (like /bin/bash)

--- a/pkgs/development/python-modules/craft-platforms/default.nix
+++ b/pkgs/development/python-modules/craft-platforms/default.nix
@@ -14,7 +14,7 @@
 
 buildPythonPackage rec {
   pname = "craft-platforms";
-  version = "0.8.0";
+  version = "0.9.0";
   pyproject = true;
 
   disabled = pythonOlder "3.10";
@@ -23,7 +23,7 @@ buildPythonPackage rec {
     owner = "canonical";
     repo = "craft-platforms";
     tag = version;
-    hash = "sha256-U57hmQ3UPuwoue8kAxAXiH8ecViryFqIxmpnaAdQnZo=";
+    hash = "sha256-Ec4zncigqampXND0YvDnExrrB9ls3Sf0KfYVbwLGbqY=";
   };
 
   postPatch = ''

--- a/pkgs/development/python-modules/craft-providers/default.nix
+++ b/pkgs/development/python-modules/craft-providers/default.nix
@@ -16,11 +16,12 @@
   freezegun,
   pytest-subprocess,
   logassert,
+  writableTmpDirAsHomeHook,
 }:
 
 buildPythonPackage rec {
   pname = "craft-providers";
-  version = "2.2.0";
+  version = "2.3.0";
 
   pyproject = true;
 
@@ -28,7 +29,7 @@ buildPythonPackage rec {
     owner = "canonical";
     repo = "craft-providers";
     tag = version;
-    hash = "sha256-HCt6xdUu8+6CtkLeUrY2KYnULLwLLobDDm4O1DAiZrc=";
+    hash = "sha256-EJoFuESgjEKoI1BKO02jd4iI/DFBphLujR/vGST/JGk=";
   };
 
   patches = [
@@ -75,12 +76,8 @@ buildPythonPackage rec {
     pytest-subprocess
     pytestCheckHook
     responses
+    writableTmpDirAsHomeHook
   ];
-
-  preCheck = ''
-    mkdir -p check-phase
-    export HOME="$(pwd)/check-phase"
-  '';
 
   pytestFlagsArray = [ "tests/unit" ];
 

--- a/pkgs/development/python-modules/logassert/default.nix
+++ b/pkgs/development/python-modules/logassert/default.nix
@@ -10,7 +10,7 @@
 
 buildPythonPackage rec {
   pname = "logassert";
-  version = "8.2";
+  version = "8.4";
 
   pyproject = true;
 
@@ -18,7 +18,7 @@ buildPythonPackage rec {
     owner = "facundobatista";
     repo = "logassert";
     tag = version;
-    hash = "sha256-wtSX1jAHanHCF58cSNluChWY3lrrsgludnnW+xVJuOo=";
+    hash = "sha256-GKGNvOZde8Q6X5h+QC5936qTDWpcXYHuLXpsGuxw1Mw=";
   };
 
   build-system = [ setuptools ];

--- a/pkgs/development/python-modules/pydantic-yaml/default.nix
+++ b/pkgs/development/python-modules/pydantic-yaml/default.nix
@@ -13,7 +13,7 @@
 
 buildPythonPackage rec {
   pname = "pydantic-yaml";
-  version = "1.4.0";
+  version = "1.5.1";
 
   pyproject = true;
 
@@ -21,7 +21,7 @@ buildPythonPackage rec {
     owner = "NowanIlfideme";
     repo = "pydantic-yaml";
     tag = "v${version}";
-    hash = "sha256-xlFSczMCEkSDhtzSl8qzZwwZd0IelPmjTEV+Jk9G0fI=";
+    hash = "sha256-UOehghNjPymuZtGp1yM5T15M6/XmK1rgTN9uVCVOst4=";
   };
 
   postPatch = ''
@@ -48,7 +48,7 @@ buildPythonPackage rec {
   meta = {
     description = "Small helper library that adds some YAML capabilities to pydantic";
     homepage = "https://github.com/NowanIlfideme/pydantic-yaml";
-    changelog = "https://github.com/NowanIlfideme/pydantic-yaml/releases/tag/v${version}";
+    changelog = "https://github.com/NowanIlfideme/pydantic-yaml/releases/tag/${src.tag}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ jnsgruk ];
   };


### PR DESCRIPTION
## Things done

Migrates to craft-application version 5, which requires updates to all of the *crafts.

The most complicated is `charmcraft`, which has not yet moved, so I have overriden Python to provide the last 4.x version to that specific application.

Changelog for craft-application 5 is pretty huge: https://github.com/canonical/craft-application/compare/4.10.0...5.2.0


- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
