### PR TITLE
ctpv: fix img previews and correct dependency

### DIFF
--- a/pkgs/by-name/ct/ctpv/package.nix
+++ b/pkgs/by-name/ct/ctpv/package.nix
@@ -15,6 +15,7 @@
   glow,
   imagemagick,
   jq,
+  poppler-utils,
   ueberzug,
 }:
 
@@ -52,10 +53,14 @@ stdenv.mkDerivation rec {
           glow # for markdown files
           imagemagick
           jq # for json files
+          poppler-utils # for pdf files
           ueberzug # for image files on X11
         ]
       }";
   '';
+
+  # Until https://github.com/NikitaIvanovV/ctpv/pull/90 is merged
+  patches = [ ./use-polite-flag.patch ];
 
   meta = with lib; {
     description = "File previewer for a terminal";

--- a/pkgs/by-name/ct/ctpv/use-polite-flag.patch
+++ b/pkgs/by-name/ct/ctpv/use-polite-flag.patch
@@ -1,0 +1,13 @@
+diff --git a/sh/helpers.sh b/sh/helpers.sh
+index fef8691..229d38f 100644
+--- a/sh/helpers.sh
++++ b/sh/helpers.sh
+@@ -73,7 +73,7 @@ is_anim_image() {
+ chafa_run() {
+ 	format='-f symbols'
+ 	autochafa && format=
+-	chafasixel && format='-f sixels'
++	chafasixel && format='-f sixels --polite on'
+ 	chafa -s "${w}x${h}" $format "$1" | sed 's/#/\n#/g'
+ }
+ 


### PR DESCRIPTION
Add missing pdf preview dependency. `ctpv` uses `pdftoppm` [1] to preview pdf files. Required dependency was not included on the last PR targeting `ctpv`, although it added the tools for other ftypes [2].

Fix chafa image privews by passing the missing flag via a patch. This comes from a year long bug fix PR open at upstream, for details refer there [3].

[1]: https://github.com/NikitaIvanovV/ctpv/blob/4efa0f976eaf8cb814e0aba4f4f1a1d12ee9262e/README.md#L58
[2]: github:NixOS/nixpkgs#223487
[3]: github:NikitaIvanovV/ctpv#90


## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
