### PR TITLE
nerd-fonts: add with warning alias mplus for m+

### DIFF
--- a/pkgs/data/fonts/nerd-fonts/aliases.nix
+++ b/pkgs/data/fonts/nerd-fonts/aliases.nix
@@ -1,0 +1,9 @@
+{
+  nerd-fonts,
+  lib,
+}:
+{
+  mplus =
+    lib.warnOnInstantiate "nerd-fonts.mplus has been renamed to nerd-fonts.\"m+\""
+      nerd-fonts."m+";
+}

--- a/pkgs/data/fonts/nerd-fonts/default.nix
+++ b/pkgs/data/fonts/nerd-fonts/default.nix
@@ -94,10 +94,15 @@ let
       };
     };
 
-  nerdFonts = lib.trivial.pipe fontsInfo [
-    (map (font: lib.nameValuePair (convertAttrName font.caskName) (makeNerdFont font)))
-    builtins.listToAttrs
-  ];
+  nerdFonts =
+    lib.trivial.pipe fontsInfo [
+      (map (font: lib.nameValuePair (convertAttrName font.caskName) (makeNerdFont font)))
+      builtins.listToAttrs
+    ]
+    // import ./aliases.nix {
+      inherit lib;
+      nerd-fonts = nerdFonts;
+    };
 in
 
 nerdFonts


### PR DESCRIPTION
The upstream renamed the cask name of M+ from `mplus` to `m+` (https://github.com/ryanoasis/nerd-fonts/commit/ab68756409576b38ee9c9cb983f720f870a0c56a) by version 3.4.0. This has induced confusion (#402922) in some Nixpkgs users because the character `+` is very unusual among attribute names although it is totally allowed.

Thus I add an alias `mplus` that redirects to `m+` after popping up a warning message. It seems that it can't be placed in the global `aliases.nix` because the attribute `nerd-fonts` has already occurred in `all-packages.nix`, so I placed it in a "more local" file.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

@doronbehar @Th1nkK1D