### PR TITLE
smtp4dev: 3.6.1 -> 3.8.6

### DIFF
--- a/pkgs/by-name/sm/smtp4dev/deps.json
+++ b/pkgs/by-name/sm/smtp4dev/deps.json
@@ -1,8 +1,8 @@
 [
   {
     "pname": "Ardalis.GuardClauses",
-    "version": "4.5.0",
-    "hash": "sha256-YqVmWM9f57Lof1e1dUWoIig7D2M9G/c2slUNicCX6Hg="
+    "version": "5.0.0",
+    "hash": "sha256-jQOXJzEIRzPVEFTcbdCNj450hbpSTrIbYSi5m2Q5MEo="
   },
   {
     "pname": "AspNetCore.Authentication.Basic",
@@ -11,8 +11,8 @@
   },
   {
     "pname": "BouncyCastle.Cryptography",
-    "version": "2.3.0",
-    "hash": "sha256-TIBOegJAEfFRyvtwuPakvKsQbqoPHj1RSTmK7SKYsf0="
+    "version": "2.5.1",
+    "hash": "sha256-ISDd8fS6/cIJIXBFDd7F3FQ0wzWkAo4r8dvycb8iT6c="
   },
   {
     "pname": "CommandLiners",
@@ -26,13 +26,13 @@
   },
   {
     "pname": "DeepEqual",
-    "version": "5.0.0",
-    "hash": "sha256-tkmNXgjD+wS65uIqTqDQgRupq9EwW1JZwpobChwTjYM="
+    "version": "5.1.0",
+    "hash": "sha256-AGPZXr7FJdEEVYtQ9I2BOHG/x8cU7s0euy+XvovOHpA="
   },
   {
     "pname": "dotnet-ef",
-    "version": "8.0.4",
-    "hash": "sha256-9mxOR/6SU5sqBiWYNNMM8aah81XnfahEAg24/5Skn4A="
+    "version": "8.0.15",
+    "hash": "sha256-a/Wb9PIfyBLs0d8VOUQdEvxk73i8nlvd1kCCqOpEHs8="
   },
   {
     "pname": "DotNet.Glob",
@@ -41,8 +41,8 @@
   },
   {
     "pname": "EntityFramework",
-    "version": "6.3.0",
-    "hash": "sha256-rh9cBlFA5NlFoppMMULpM0SSRQtKeDr10Caa/+GGTSY="
+    "version": "6.5.0",
+    "hash": "sha256-WZ4AI6XjyMMIDw6y3ggz5lym4ihmFTndInt35ij9E0k="
   },
   {
     "pname": "Esprima",
@@ -50,9 +50,14 @@
     "hash": "sha256-KyZHjy7QTh3WRdY/fUrqrcaoZOa0RnUAUFLTzSOBVYA="
   },
   {
+    "pname": "FSharp.Core",
+    "version": "8.0.200",
+    "hash": "sha256-wjYiedFiqOTKaM4mF6uT9kc/yKDJ78mqfw9qLoBFHOw="
+  },
+  {
     "pname": "HtmlAgilityPack",
-    "version": "1.11.61",
-    "hash": "sha256-exRJTP7mHNt31CKaejKSSkKPm74ratfnpGl50AqZwlY="
+    "version": "1.12.1",
+    "hash": "sha256-qravAvCdB/KjWujRk2GL/kGre/B9XVAP+jewICxiKKo="
   },
   {
     "pname": "Humanizer.Core",
@@ -65,24 +70,29 @@
     "hash": "sha256-oOq7ze1QFYHK/9zNDF7ClbWZaW4A/478M4yQ/LQnUJ8="
   },
   {
+    "pname": "Linq.Expression.Optimizer",
+    "version": "1.0.29",
+    "hash": "sha256-F0ZvZ6hbdnjkuNuSoFzSjYUgG/hEHuG7o8wExDS1LLo="
+  },
+  {
     "pname": "LinqKit",
-    "version": "1.2.5",
-    "hash": "sha256-rF1/FIR41PrwZX4N6bkhXNG2BQsXbjZmx8/qfVdKiAI="
+    "version": "1.3.8",
+    "hash": "sha256-kX82JIKz2mNK11na8M84ChWgrdBhhB0Zd+JhL4FmR1U="
   },
   {
     "pname": "LinqKit.Core",
-    "version": "1.2.5",
-    "hash": "sha256-0z4RpAt+WvydeCN0GJu4vsMfCxzxmoi+LTE6fQ51NZY="
+    "version": "1.2.8",
+    "hash": "sha256-7PTxzw8n3vpmNKJlumOwL5eWGM7nmdC4oomPTKlm7LE="
   },
   {
     "pname": "MailKit",
-    "version": "4.5.0",
-    "hash": "sha256-quU88XNBF+tzb1yr7+lSfx90kmvZpbX43+YJtdYgPzk="
+    "version": "4.11.0",
+    "hash": "sha256-T41OHePMaYkd7rRP2ytMfEjaD+bpJ65yWBJJuvs7y18="
   },
   {
     "pname": "Microsoft.AspNetCore.Hosting.WindowsServices",
-    "version": "8.0.4",
-    "hash": "sha256-sK7ZOyoQv/bwmaJLK0Dk7kGDJAFlIwUxVhru8kwvea0="
+    "version": "8.0.15",
+    "hash": "sha256-HqNCXJfBZxbtCf94EirLczAl8bsHhmIAzFIFsEjBspE="
   },
   {
     "pname": "Microsoft.AspNetCore.SpaServices.Extensions",
@@ -93,11 +103,6 @@
     "pname": "Microsoft.Bcl.AsyncInterfaces",
     "version": "6.0.0",
     "hash": "sha256-49+H/iFwp+AfCICvWcqo9us4CzxApPKC37Q5Eqrw+JU="
-  },
-  {
-    "pname": "Microsoft.Bcl.AsyncInterfaces",
-    "version": "8.0.0",
-    "hash": "sha256-9aWmiwMJKrKr9ohD1KSuol37y+jdDxPGJct3m2/Bknw="
   },
   {
     "pname": "Microsoft.Build",
@@ -126,18 +131,18 @@
   },
   {
     "pname": "Microsoft.CodeAnalysis.Analyzers",
-    "version": "3.3.4",
-    "hash": "sha256-qDzTfZBSCvAUu9gzq2k+LOvh6/eRvJ9++VCNck/ZpnE="
+    "version": "3.3.3",
+    "hash": "sha256-pkZiggwLw8k+CVSXKTzsVGsT+K49LxXUS3VH5PNlpCY="
   },
   {
     "pname": "Microsoft.CodeAnalysis.Common",
-    "version": "4.9.2",
-    "hash": "sha256-QU/nyiJWpdPQGHBdaOEVc+AghnGHcKBFBX0oyhRZ9CQ="
+    "version": "4.5.0",
+    "hash": "sha256-qo1oVNTB9JIMEPoiIZ+02qvF/O8PshQ/5gTjsY9iX0I="
   },
   {
     "pname": "Microsoft.CodeAnalysis.CSharp",
-    "version": "4.9.2",
-    "hash": "sha256-j06Q4A9E65075SBXdXVCMRgeLxA63Rv1vxarydmmVAA="
+    "version": "4.5.0",
+    "hash": "sha256-5dZTS9PYtY83vyVa5bdNG3XKV5EjcnmddfUqWmIE29A="
   },
   {
     "pname": "Microsoft.CodeAnalysis.CSharp.Workspaces",
@@ -156,53 +161,53 @@
   },
   {
     "pname": "Microsoft.CSharp",
-    "version": "4.6.0",
-    "hash": "sha256-16OdEKbPLxh+jLYS4cOiGRX/oU6nv3KMF4h5WnZAsHs="
+    "version": "4.7.0",
+    "hash": "sha256-Enknv2RsFF68lEPdrf5M+BpV1kHoLTVRApKUwuk/pj0="
   },
   {
     "pname": "Microsoft.Data.Sqlite.Core",
-    "version": "8.0.4",
-    "hash": "sha256-bbKpSaEHKYezjxSZECmDQr0gv9zYTN042dpuYQtZKQ4="
+    "version": "8.0.15",
+    "hash": "sha256-JWnPERvxWL+5n0dQh+s9zhkWL1gnGexq8LpBszAIaco="
   },
   {
     "pname": "Microsoft.EntityFrameworkCore",
-    "version": "8.0.4",
-    "hash": "sha256-nkrtoqGn43RdVjSlwa/jzLaixnZ1CNDDTvvSubUmR5E="
+    "version": "8.0.15",
+    "hash": "sha256-C5TRzSpdH11L+slXG3Gxmhtjl76DGlaKl3G9k9G6giQ="
   },
   {
     "pname": "Microsoft.EntityFrameworkCore.Abstractions",
-    "version": "8.0.4",
-    "hash": "sha256-ywVWOje6duVcJ8gSSC5HER2UO0mAzfg6VMtqloRmQfc="
+    "version": "8.0.15",
+    "hash": "sha256-QM0bhIyoBR8j9epa8eoFhtf/fA7u2dW3vU1tfneNsr0="
   },
   {
     "pname": "Microsoft.EntityFrameworkCore.Analyzers",
-    "version": "8.0.4",
-    "hash": "sha256-Kqv9ZFl1nMJ1hRmT3kQbN5vSvMrRSZ5XOF9wzw5sS8A="
+    "version": "8.0.15",
+    "hash": "sha256-SVQd3sX0TjNz1kXN4PVWdThyyWpzE8JC0ch5vKVSDKE="
   },
   {
     "pname": "Microsoft.EntityFrameworkCore.Design",
-    "version": "8.0.4",
-    "hash": "sha256-TjDkQOUSFIM5OOFcm4+yNiXmAiKgs8Q3XpJl9eTEJdo="
+    "version": "8.0.15",
+    "hash": "sha256-G+A43Fv8cqdbg3SKewEKs2NTItBCjELdhVQCtYwEu3U="
   },
   {
     "pname": "Microsoft.EntityFrameworkCore.InMemory",
-    "version": "8.0.4",
-    "hash": "sha256-m0zvYVaD72UVHnOc7Ea0/FwoVw/FhqKVladnacHkQlc="
+    "version": "8.0.15",
+    "hash": "sha256-iQwlHSclsftdgYnlYODBbeP1I9mWiVM8f3whPtWYrtk="
   },
   {
     "pname": "Microsoft.EntityFrameworkCore.Relational",
-    "version": "8.0.4",
-    "hash": "sha256-TRP/Ior708EQjD03GGxKom2eLOxcUYN1MoFqzk3lYp8="
+    "version": "8.0.15",
+    "hash": "sha256-U+pLbWgYmi+2JhGUkYa/ZdU89IutJewGRNA3TrP4vjk="
   },
   {
     "pname": "Microsoft.EntityFrameworkCore.Sqlite",
-    "version": "8.0.4",
-    "hash": "sha256-/IOzElVUh6k2eiTiMHhsdTSsBx4j3whX1lWSMgFYMUE="
+    "version": "8.0.15",
+    "hash": "sha256-Pc7/YnigKXfAZQE1Rb2awo1YHYz48knv7WMeaKP9QjY="
   },
   {
     "pname": "Microsoft.EntityFrameworkCore.Sqlite.Core",
-    "version": "8.0.4",
-    "hash": "sha256-gC8yod0XV1/xZAk1PDqTf+QlzJAOjj6kT8mJZ9LvQF0="
+    "version": "8.0.15",
+    "hash": "sha256-MwbVFf22PLUZvMxAm5+ooAoYP7UsPvnX6mYkU4C9RLU="
   },
   {
     "pname": "Microsoft.Extensions.ApiDescription.Server",
@@ -216,8 +221,8 @@
   },
   {
     "pname": "Microsoft.Extensions.Caching.Memory",
-    "version": "8.0.0",
-    "hash": "sha256-RUQe2VgOATM9JkZ/wGm9mreKoCmOS4pPyvyJWBqMaC8="
+    "version": "8.0.1",
+    "hash": "sha256-5Q0vzHo3ZvGs4nPBc/XlBF4wAwYO8pxq6EGdYjjXZps="
   },
   {
     "pname": "Microsoft.Extensions.Configuration",
@@ -240,9 +245,19 @@
     "hash": "sha256-4eBpDkf7MJozTZnOwQvwcfgRKQGcNXe0K/kF+h5Rl8o="
   },
   {
+    "pname": "Microsoft.Extensions.Configuration.Abstractions",
+    "version": "9.0.0",
+    "hash": "sha256-xtG2USC9Qm0f2Nn6jkcklpyEDT3hcEZOxOwTc0ep7uc="
+  },
+  {
     "pname": "Microsoft.Extensions.Configuration.Binder",
-    "version": "8.0.0",
-    "hash": "sha256-GanfInGzzoN2bKeNwON8/Hnamr6l7RTpYLA49CNXD9Q="
+    "version": "8.0.2",
+    "hash": "sha256-aGB0VuoC34YadAEqrwoaXLc5qla55pswDV2xLSmR7SE="
+  },
+  {
+    "pname": "Microsoft.Extensions.Configuration.Binder",
+    "version": "9.0.0",
+    "hash": "sha256-6ajYWcNOQX2WqftgnoUmVtyvC1kkPOtTCif4AiKEffU="
   },
   {
     "pname": "Microsoft.Extensions.Configuration.CommandLine",
@@ -256,18 +271,18 @@
   },
   {
     "pname": "Microsoft.Extensions.Configuration.FileExtensions",
-    "version": "8.0.0",
-    "hash": "sha256-BCxcjVP+kvrDDB0nzsFCJfU74UK4VBvct2JA4r+jNcs="
+    "version": "8.0.1",
+    "hash": "sha256-iRA8L7BX/fe5LHCVOhzBSk30GfshP7V2Qj2nxpEvStA="
   },
   {
     "pname": "Microsoft.Extensions.Configuration.Json",
-    "version": "8.0.0",
-    "hash": "sha256-Fi/ijcG5l0BOu7i96xHu96aN5/g7zO6SWQbTsI3Qetg="
+    "version": "8.0.1",
+    "hash": "sha256-J8EK/yhsfTpeSUY8F81ZTBV9APHiPUliN7d+n2OX9Ig="
   },
   {
     "pname": "Microsoft.Extensions.Configuration.UserSecrets",
-    "version": "8.0.0",
-    "hash": "sha256-/yj5QaEzeRStvOFoBpPRPXlEehGtr2E6/rJb+OEPIK8="
+    "version": "8.0.1",
+    "hash": "sha256-yGvWfwBhyFudcIv96pKWaQ1MIMOiv5LHSCn+9J7Doz0="
   },
   {
     "pname": "Microsoft.Extensions.DependencyInjection",
@@ -278,6 +293,11 @@
     "pname": "Microsoft.Extensions.DependencyInjection",
     "version": "8.0.0",
     "hash": "sha256-+qIDR8hRzreCHNEDtUcPfVHQdurzWPo/mqviCH78+EQ="
+  },
+  {
+    "pname": "Microsoft.Extensions.DependencyInjection",
+    "version": "8.0.1",
+    "hash": "sha256-O9g0jWS+jfGoT3yqKwZYJGL+jGSIeSbwmvomKDC3hTU="
   },
   {
     "pname": "Microsoft.Extensions.DependencyInjection.Abstractions",
@@ -291,23 +311,33 @@
   },
   {
     "pname": "Microsoft.Extensions.DependencyInjection.Abstractions",
-    "version": "8.0.1",
-    "hash": "sha256-lzTYLpRDAi3wW9uRrkTNJtMmaYdtGJJHdBLbUKu60PM="
+    "version": "8.0.2",
+    "hash": "sha256-UfLfEQAkXxDaVPC7foE/J3FVEXd31Pu6uQIhTic3JgY="
   },
   {
     "pname": "Microsoft.Extensions.DependencyModel",
-    "version": "8.0.0",
-    "hash": "sha256-qkCdwemqdZY/yIW5Xmh7Exv74XuE39T8aHGHCofoVgo="
+    "version": "8.0.2",
+    "hash": "sha256-PyuO/MyCR9JtYqpA1l/nXGh+WLKCq34QuAXN9qNza9Q="
+  },
+  {
+    "pname": "Microsoft.Extensions.DependencyModel",
+    "version": "9.0.0",
+    "hash": "sha256-xirwlMWM0hBqgTneQOGkZ8l45mHT08XuSSRIbprgq94="
   },
   {
     "pname": "Microsoft.Extensions.Diagnostics",
-    "version": "8.0.0",
-    "hash": "sha256-fBLlb9xAfTgZb1cpBxFs/9eA+BlBvF8Xg0DMkBqdHD4="
+    "version": "8.0.1",
+    "hash": "sha256-CraHNCaVlMiYx6ff9afT6U7RC/MoOCXM3pn2KrXkiLc="
   },
   {
     "pname": "Microsoft.Extensions.Diagnostics.Abstractions",
     "version": "8.0.0",
     "hash": "sha256-USD5uZOaahMqi6u7owNWx/LR4EDrOwqPrAAim7iRpJY="
+  },
+  {
+    "pname": "Microsoft.Extensions.Diagnostics.Abstractions",
+    "version": "8.0.1",
+    "hash": "sha256-d5DVXhA8qJFY9YbhZjsTqs5w5kDuxF5v+GD/WZR1QL0="
   },
   {
     "pname": "Microsoft.Extensions.FileProviders.Abstractions",
@@ -361,8 +391,8 @@
   },
   {
     "pname": "Microsoft.Extensions.Hosting",
-    "version": "8.0.0",
-    "hash": "sha256-sKHa+w4/pMeQb5RRFqLtMTUJy5H6hSIGWchbH2pxSrg="
+    "version": "8.0.1",
+    "hash": "sha256-FFLo6em0N2vaWg6//vaQhxoOgT9LLH5Y2KWkCeX5xQ4="
   },
   {
     "pname": "Microsoft.Extensions.Hosting.Abstractions",
@@ -370,9 +400,14 @@
     "hash": "sha256-0JBx+wwt5p1SPfO4m49KxNOXPAzAU0A+8tEc/itvpQE="
   },
   {
+    "pname": "Microsoft.Extensions.Hosting.Abstractions",
+    "version": "8.0.1",
+    "hash": "sha256-/bIVL9uvBQhV/KQmjA1ZjR74sMfaAlBb15sVXsGDEVA="
+  },
+  {
     "pname": "Microsoft.Extensions.Hosting.WindowsServices",
-    "version": "8.0.0",
-    "hash": "sha256-+uYKf6LT/wN7UrHSgJ3diIqVKCi214yJQgh5oXqYi/c="
+    "version": "8.0.1",
+    "hash": "sha256-JBrZuv1RxpJf5wR81g91bE1/JQgBeOtnJDvA98rlYKE="
   },
   {
     "pname": "Microsoft.Extensions.Logging",
@@ -383,6 +418,11 @@
     "pname": "Microsoft.Extensions.Logging",
     "version": "8.0.0",
     "hash": "sha256-Meh0Z0X7KyOEG4l0RWBcuHHihcABcvCyfUXgasmQ91o="
+  },
+  {
+    "pname": "Microsoft.Extensions.Logging",
+    "version": "8.0.1",
+    "hash": "sha256-vkfVw4tQEg86Xg18v6QO0Qb4Ysz0Njx57d1XcNuj6IU="
   },
   {
     "pname": "Microsoft.Extensions.Logging.Abstractions",
@@ -396,33 +436,38 @@
   },
   {
     "pname": "Microsoft.Extensions.Logging.Abstractions",
-    "version": "8.0.1",
-    "hash": "sha256-TYce3qvMr92JbAZ62ATBsocaH0joJzw0px0tYGZ9N0U="
+    "version": "8.0.2",
+    "hash": "sha256-cHpe8X2BgYa5DzulZfq24rg8O2K5Lmq2OiLhoyAVgJc="
+  },
+  {
+    "pname": "Microsoft.Extensions.Logging.Abstractions",
+    "version": "8.0.3",
+    "hash": "sha256-5MSY1aEwUbRXehSPHYw0cBZyFcUH4jkgabddxhMiu3Q="
   },
   {
     "pname": "Microsoft.Extensions.Logging.Configuration",
-    "version": "8.0.0",
-    "hash": "sha256-mzmstNsVjKT0EtQcdAukGRifD30T82BMGYlSu8k4K7U="
+    "version": "8.0.1",
+    "hash": "sha256-E2JbJG2EXlv2HUWLi17kIkAL6RC9rC2E18C3gAyOuaE="
   },
   {
     "pname": "Microsoft.Extensions.Logging.Console",
-    "version": "8.0.0",
-    "hash": "sha256-bdb9YWWVn//AeySp7se87/tCN2E7e8Gx2GPMw28cd9c="
+    "version": "8.0.1",
+    "hash": "sha256-2thhF1JbDNj3Bx2fcH7O26uHGNeMd9MYah6N60lIpIU="
   },
   {
     "pname": "Microsoft.Extensions.Logging.Debug",
-    "version": "8.0.0",
-    "hash": "sha256-AJunzYBZM2wCg86hnPnMrBuWIIyW/4PnIVoDSU969cA="
+    "version": "8.0.1",
+    "hash": "sha256-gKFqBg5lbjy5VBEcAuoQ/SsXAxvrYdBYOu9dV60eJKg="
   },
   {
     "pname": "Microsoft.Extensions.Logging.EventLog",
-    "version": "8.0.0",
-    "hash": "sha256-vXBm4yhWGP4uow0CqstuqOkxO8yeZEM15JTTenjPbhc="
+    "version": "8.0.1",
+    "hash": "sha256-1UkEOwl3Op2b3jTvpI10hHxIe9FqeVVy+VB1tZp6Lc8="
   },
   {
     "pname": "Microsoft.Extensions.Logging.EventSource",
-    "version": "8.0.0",
-    "hash": "sha256-kaR7YOlq5s8W9nZDtH/lKtnfGbrgOuQY4DUPcA2lcj0="
+    "version": "8.0.1",
+    "hash": "sha256-EINT/PgfB4Dvf+1JBzL1plPT35ezT7kyS8y/XMMgYxA="
   },
   {
     "pname": "Microsoft.Extensions.Options",
@@ -433,6 +478,11 @@
     "pname": "Microsoft.Extensions.Options",
     "version": "8.0.0",
     "hash": "sha256-n2m4JSegQKUTlOsKLZUUHHKMq926eJ0w9N9G+I3FoFw="
+  },
+  {
+    "pname": "Microsoft.Extensions.Options",
+    "version": "8.0.2",
+    "hash": "sha256-AjcldddddtN/9aH9pg7ClEZycWtFHLi9IPe1GGhNQys="
   },
   {
     "pname": "Microsoft.Extensions.Options.ConfigurationExtensions",
@@ -458,6 +508,11 @@
     "pname": "Microsoft.Extensions.Primitives",
     "version": "8.0.0",
     "hash": "sha256-FU8qj3DR8bDdc1c+WeGZx/PCZeqqndweZM9epcpXjSo="
+  },
+  {
+    "pname": "Microsoft.Extensions.Primitives",
+    "version": "9.0.0",
+    "hash": "sha256-ZNLusK1CRuq5BZYZMDqaz04PIKScE2Z7sS2tehU7EJs="
   },
   {
     "pname": "Microsoft.NETCore.App",
@@ -496,8 +551,8 @@
   },
   {
     "pname": "Microsoft.NETCore.Platforms",
-    "version": "3.0.0",
-    "hash": "sha256-ocB+U+mMvi/xVwII7bGsIfAqSXiKVSnEMLHCODLJaK4="
+    "version": "3.1.0",
+    "hash": "sha256-cnygditsEaU86bnYtIthNMymAHqaT/sf9Gjykhzqgb0="
   },
   {
     "pname": "Microsoft.NETCore.Targets",
@@ -510,9 +565,24 @@
     "hash": "sha256-0AqQ2gMS8iNlYkrD+BxtIg7cXMnr9xZHtKAuN4bjfaQ="
   },
   {
+    "pname": "Microsoft.NETFramework.ReferenceAssemblies",
+    "version": "1.0.3",
+    "hash": "sha256-FBoJP5DHZF0QHM0xLm9yd4HJZVQOuSpSKA+VQRpphEE="
+  },
+  {
+    "pname": "Microsoft.NETFramework.ReferenceAssemblies.net45",
+    "version": "1.0.3",
+    "hash": "sha256-I6n5TqPiy4jNg0GvdbgRxvtcuCUW/Glule1GICeRKOM="
+  },
+  {
+    "pname": "Microsoft.NETFramework.ReferenceAssemblies.net46",
+    "version": "1.0.3",
+    "hash": "sha256-3Lt5uzho2/u2TGQxFvqmPYiO6ezLoMTpZemZLtfE410="
+  },
+  {
     "pname": "Microsoft.TypeScript.MSBuild",
-    "version": "5.4.4",
-    "hash": "sha256-bE1F3XgGxF0g+zX8TLx0glAVK57k8ITRe/NI4Tf8mxw="
+    "version": "5.8.1",
+    "hash": "sha256-5x81TEhXaEEYnBeosK8zmBwPLKPifMf4JUFrGsk/IxA="
   },
   {
     "pname": "Microsoft.VisualStudio.Web.CodeGeneration.Contracts",
@@ -541,23 +611,18 @@
   },
   {
     "pname": "Microsoft.Win32.Registry",
-    "version": "4.5.0",
-    "hash": "sha256-WMBXsIb0DgPFPaFkNVxY9b9vcMxPqtgFgijKYMJfV/0="
-  },
-  {
-    "pname": "Microsoft.Win32.Registry",
-    "version": "4.6.0",
-    "hash": "sha256-Wrj0Sc9srH5+ma0lCbgRYYP6gKgnlXcL6h7j7AU6nkQ="
+    "version": "4.7.0",
+    "hash": "sha256-+jWCwRqU/J/jLdQKDFm93WfIDrDMXMJ984UevaQMoi8="
   },
   {
     "pname": "Microsoft.Win32.SystemEvents",
-    "version": "4.6.0",
-    "hash": "sha256-7BRoIg1Hm/OVHZBPGD+eugyyMTZHhmv0yLTV3HWOFd4="
+    "version": "6.0.0",
+    "hash": "sha256-N9EVZbl5w1VnMywGXyaVWzT9lh84iaJ3aD48hIBk1zA="
   },
   {
     "pname": "MimeKit",
-    "version": "4.5.0",
-    "hash": "sha256-Nsk3Br9yLOC5wDLtRQyw04Kq205y5QCISpyiB13mwLU="
+    "version": "4.11.0",
+    "hash": "sha256-UTP+pfP3q4X65/KNGBTkHo4KZjeHZ10dQbr58Qf42iQ="
   },
   {
     "pname": "Mono.Options",
@@ -571,8 +636,8 @@
   },
   {
     "pname": "Namotion.Reflection",
-    "version": "3.1.1",
-    "hash": "sha256-WXHT/prJSLS7yRoepu5pls5xe58pCbR6S8VjuR5uJR0="
+    "version": "3.3.0",
+    "hash": "sha256-YBYWLYmnCZrKfiJWQo7tofiz2A7ROpxFfAYdYLa5cgI="
   },
   {
     "pname": "NETStandard.Library",
@@ -586,8 +651,8 @@
   },
   {
     "pname": "NETStandard.Library",
-    "version": "2.0.1",
-    "hash": "sha256-s4UiH848a+p2yWwMH+8PaYGnQL2qnY0GmixoeLvkhDQ="
+    "version": "2.0.3",
+    "hash": "sha256-Prh2RPebz/s8AzHb2sPHg3Jl8s31inv9k+Qxd293ybo="
   },
   {
     "pname": "Newtonsoft.Json",
@@ -601,63 +666,58 @@
   },
   {
     "pname": "NJsonSchema",
-    "version": "11.0.0",
-    "hash": "sha256-MK/i30Y6lXotOKNDBZA7koeOVlcI5V9AQ5ZzxjHWxwo="
+    "version": "11.2.0",
+    "hash": "sha256-Y1FggfzRf54+ioMKvyyzMW30psrHF7hmAwnYom/Ud8s="
   },
   {
     "pname": "NJsonSchema.Annotations",
-    "version": "11.0.0",
-    "hash": "sha256-AVOWOj94Zw9DzpT07YebJa79/fCvRWa7E7zYG5e+/6w="
+    "version": "11.2.0",
+    "hash": "sha256-uQYU/NuAbz+HlImemuv1Yi4ODKoaQ38BSrWONOR9jFs="
   },
   {
     "pname": "NJsonSchema.NewtonsoftJson",
-    "version": "11.0.0",
-    "hash": "sha256-ddnWplAPnLE9rDMm10f7FceY8bE/T8MpbOuiVPo3wsU="
+    "version": "11.2.0",
+    "hash": "sha256-NyXB3rcdPpjaZq0CAZy5xMmvLqqzPGyddeTVtowqaBU="
   },
   {
     "pname": "NJsonSchema.Yaml",
-    "version": "11.0.0",
-    "hash": "sha256-MkUdfh/erCTFO0mgkKj1kWEKgie6rJtiwV1emsvYJzc="
+    "version": "11.2.0",
+    "hash": "sha256-NtlUldW5D0VSj10XqfMvxDMVULdw99owTS1zGYg4aKg="
   },
   {
     "pname": "NSwag.Annotations",
-    "version": "14.0.7",
-    "hash": "sha256-fQIIREC86xdjGvjPyV/vvHnZmcgtmFSG9SilgSO78ek="
+    "version": "14.3.0",
+    "hash": "sha256-kz+fEwUlEjsPsOiFCTcXYHAAYCJa2cepDRIY4mkye4U="
   },
   {
     "pname": "NSwag.AspNetCore",
-    "version": "14.0.7",
-    "hash": "sha256-EOJrEUq1kgx0JvmTmcR6oRWk3Ci68kYhByVrZlBLtwA="
+    "version": "14.3.0",
+    "hash": "sha256-lGeH27yzj5fXPpBMqtoFOTRiu+gve8oSgugW2u4tMAk="
   },
   {
     "pname": "NSwag.Core",
-    "version": "14.0.7",
-    "hash": "sha256-t42U+Zl2QcfsvEWJGg6A3f+OWbenu/itjrnS8loszH4="
+    "version": "14.3.0",
+    "hash": "sha256-FjWms/V5+j4ut1TShKWDsTr1LuBsHxRQIFs1fwD0jGw="
   },
   {
     "pname": "NSwag.Core.Yaml",
-    "version": "14.0.7",
-    "hash": "sha256-hGCff58hTcv9y4b8Dx3P7GhC5r8A5SyJaxACtS4yTK0="
+    "version": "14.3.0",
+    "hash": "sha256-CcGXuyNUvF/e3f9K3wZY+h0RIbzoLOLLguUcj+VVFXI="
   },
   {
     "pname": "NSwag.Generation",
-    "version": "14.0.7",
-    "hash": "sha256-nmYwfjwvkkozItdoNqIuNS/9BI2i6dPpVCxu16m0T8w="
+    "version": "14.3.0",
+    "hash": "sha256-M487C7OsnZnURcAN90DGIhZTnxlToaIskkztCKkXzQc="
   },
   {
     "pname": "NSwag.Generation.AspNetCore",
-    "version": "14.0.7",
-    "hash": "sha256-Jsa5MT9LjY7GVMIi/QTyP2de7BW+tu809dm1RPA2mdA="
+    "version": "14.3.0",
+    "hash": "sha256-DvjSjbM2ug0AvjAE8CwVUej2hZbLWopmZMbOx4Oy2IU="
   },
   {
     "pname": "NuGet.Frameworks",
     "version": "4.7.0-preview1-4986",
     "hash": "sha256-B8Fax4r73AjdTbcV3mF9dPGAV4P++UMUh2cbItNk0JE="
-  },
-  {
-    "pname": "Rnwood.LumiSoft.Net",
-    "version": "1.0.2",
-    "hash": "sha256-Ud4K6lN2QMQXUUZn157HaPd2MtHTrKNmGBZn8N2hwxo="
   },
   {
     "pname": "runtime.any.System.Collections",
@@ -688,11 +748,6 @@
     "pname": "runtime.any.System.Reflection",
     "version": "4.3.0",
     "hash": "sha256-ns6f++lSA+bi1xXgmW1JkWFb2NaMD+w+YNTfMvyAiQk="
-  },
-  {
-    "pname": "runtime.any.System.Reflection.Extensions",
-    "version": "4.3.0",
-    "hash": "sha256-Y2AnhOcJwJVYv7Rp6Jz6ma0fpITFqJW+8rsw106K2X8="
   },
   {
     "pname": "runtime.any.System.Reflection.Primitives",
@@ -776,8 +831,8 @@
   },
   {
     "pname": "runtime.native.System.Data.SqlClient.sni",
-    "version": "4.6.0",
-    "hash": "sha256-TenFWtugim8xFtilE3Z9br0FPnLCosdLQ5DV1uW3448="
+    "version": "4.7.0",
+    "hash": "sha256-cj0+BpmoibwOWj2wNXwONJeTGosmFwhD349zPjNaBK0="
   },
   {
     "pname": "runtime.native.System.IO.Compression",
@@ -941,13 +996,13 @@
   },
   {
     "pname": "Serilog",
-    "version": "3.1.1",
-    "hash": "sha256-L263y8jkn7dNFD2jAUK6mgvyRTqFe39i1tRhVZsNZTI="
+    "version": "4.2.0",
+    "hash": "sha256-7f3EpCsEbDxXgsuhE430KVI14p7oDUuCtwRpOCqtnbs="
   },
   {
     "pname": "Serilog.AspNetCore",
-    "version": "8.0.1",
-    "hash": "sha256-a07P+0co6QuLuUw09PvvpLf9gix88Nw3dACsnSRcuW4="
+    "version": "8.0.3",
+    "hash": "sha256-ZyBlauyG/7CLTqrbhRalmayFd99d7bimNTMw4hXDR2I="
   },
   {
     "pname": "Serilog.Extensions.Hosting",
@@ -966,13 +1021,13 @@
   },
   {
     "pname": "Serilog.Settings.Configuration",
-    "version": "8.0.0",
-    "hash": "sha256-JQ39fvhOFSUHE6r9DXJvLaZI+Lk7AYzuskQu3ux+hQg="
+    "version": "9.0.0",
+    "hash": "sha256-Q/q5UiSrcxoy5a/orod20E2RfiRtHDhxjjGMe1dW35I="
   },
   {
     "pname": "Serilog.Sinks.Console",
-    "version": "5.0.1",
-    "hash": "sha256-aveoZM25ykc2haBHCXWD09jxZ2t2tYIGmaNTaO2V0jI="
+    "version": "6.0.0",
+    "hash": "sha256-QH8ykDkLssJ99Fgl+ZBFBr+RQRl0wRTkeccQuuGLyro="
   },
   {
     "pname": "Serilog.Sinks.Debug",
@@ -981,8 +1036,8 @@
   },
   {
     "pname": "Serilog.Sinks.EventLog",
-    "version": "3.1.0",
-    "hash": "sha256-oAzpAdcF9Hdf99JjpbWvgYa5BkN+Ec4gc7SPHFVH7As="
+    "version": "4.0.0",
+    "hash": "sha256-ccSnzL/I4gZoL2xH5Y9Q9zoP7iV8+n95wNQ/JOP3vOg="
   },
   {
     "pname": "Serilog.Sinks.File",
@@ -1010,6 +1065,11 @@
     "hash": "sha256-zHc/YZsd72eXlI8ba1tv58HZWUIiyjJaxq2CCP1hQe8="
   },
   {
+    "pname": "StreamLib",
+    "version": "0.12.0",
+    "hash": "sha256-oAsRU/n575cgAms0AngignhSYPWfVvWvnThYLFz+cNU="
+  },
+  {
     "pname": "System.AppContext",
     "version": "4.1.0",
     "hash": "sha256-v6YfyfrKmhww+EYHUq6cwYUMj00MQ6SOfJtcGVRlYzs="
@@ -1025,19 +1085,14 @@
     "hash": "sha256-XqZWb4Kd04960h4U9seivjKseGA/YEIpdplfHYHQ9jk="
   },
   {
-    "pname": "System.Buffers",
-    "version": "4.5.1",
-    "hash": "sha256-wws90sfi9M7kuCPWkv1CEYMJtCqx9QB/kj0ymlsNaxI="
-  },
-  {
     "pname": "System.CodeDom",
     "version": "4.4.0",
     "hash": "sha256-L1xyspJ8pDJNVPYKl+FMGf4Zwm0tlqtAyQCNW6pT6/0="
   },
   {
     "pname": "System.CodeDom",
-    "version": "4.6.0",
-    "hash": "sha256-nKJQMD3qFkNX+J+aXOjsSVloB1CbZ3QNLb96Xiz7wK0="
+    "version": "6.0.0",
+    "hash": "sha256-uPetUFZyHfxjScu5x4agjk9pIhbCkt5rG4Axj25npcQ="
   },
   {
     "pname": "System.Collections",
@@ -1066,8 +1121,8 @@
   },
   {
     "pname": "System.Collections.Immutable",
-    "version": "8.0.0",
-    "hash": "sha256-F7OVjKNwpqbUh8lTidbqJWYi476nsq9n+6k0+QVRo3w="
+    "version": "6.0.0",
+    "hash": "sha256-DKEbpFqXCIEfqp9p3ezqadn5b/S1YTk32/EQK+tEScs="
   },
   {
     "pname": "System.Collections.NonGeneric",
@@ -1088,11 +1143,6 @@
     "pname": "System.ComponentModel",
     "version": "4.3.0",
     "hash": "sha256-i00uujMO4JEDIEPKLmdLY3QJ6vdSpw6Gh9oOzkFYBiU="
-  },
-  {
-    "pname": "System.ComponentModel.Annotations",
-    "version": "4.6.0",
-    "hash": "sha256-dn91soWaR30tghqyv3oIjc0UgMAnuErwG0oXRKFdl0w="
   },
   {
     "pname": "System.ComponentModel.Annotations",
@@ -1141,8 +1191,8 @@
   },
   {
     "pname": "System.Configuration.ConfigurationManager",
-    "version": "4.6.0",
-    "hash": "sha256-x54SBQYZLkU5AcCMOqx5VR6jM/43E2JFL894UtPAxE4="
+    "version": "6.0.1",
+    "hash": "sha256-U/0HyekAZK5ya2VNfGA1HeuQyJChoaqcoIv57xLpzLQ="
   },
   {
     "pname": "System.Console",
@@ -1151,8 +1201,8 @@
   },
   {
     "pname": "System.Data.SqlClient",
-    "version": "4.7.0",
-    "hash": "sha256-fckcu7RCKtndbfbIvBKnOb2xgr8bZKZ5B2mx0pBRwZw="
+    "version": "4.8.6",
+    "hash": "sha256-Qc/yco3e0+6jP8UiMA0ERlfSEKdINv0BmHixh9Z8fJQ="
   },
   {
     "pname": "System.Diagnostics.Contracts",
@@ -1186,13 +1236,13 @@
   },
   {
     "pname": "System.Diagnostics.EventLog",
-    "version": "4.5.0",
-    "hash": "sha256-tKBKgUhEM6D7XJlzmHc/F8ekqJx8rHO4QYUMjzbIs9I="
+    "version": "8.0.0",
+    "hash": "sha256-rt8xc3kddpQY4HEdghlBeOK4gdw5yIj4mcZhAVtk2/Y="
   },
   {
     "pname": "System.Diagnostics.EventLog",
-    "version": "8.0.0",
-    "hash": "sha256-rt8xc3kddpQY4HEdghlBeOK4gdw5yIj4mcZhAVtk2/Y="
+    "version": "8.0.1",
+    "hash": "sha256-zvqd72pwgcGoa1nH3ZT1C0mP9k53vFLJ69r5MCQ1saA="
   },
   {
     "pname": "System.Diagnostics.FileVersionInfo",
@@ -1231,8 +1281,8 @@
   },
   {
     "pname": "System.Drawing.Common",
-    "version": "4.6.0",
-    "hash": "sha256-D6PMDq8M2aSrnDeBYfFftaX7hFLcxrOYFLrtxbERMAM="
+    "version": "6.0.0",
+    "hash": "sha256-/9EaAbEeOjELRSMZaImS1O8FmUe8j4WuFUw1VOrPyAo="
   },
   {
     "pname": "System.Dynamic.Runtime",
@@ -1246,8 +1296,8 @@
   },
   {
     "pname": "System.Formats.Asn1",
-    "version": "8.0.0",
-    "hash": "sha256-AVMl6N3SG2AqAcQHFruf2QDQeQIC3CICxID+Sh0vBxI="
+    "version": "8.0.1",
+    "hash": "sha256-may/Wg+esmm1N14kQTG4ESMBi+GQKPp0ZrrBo/o6OXM="
   },
   {
     "pname": "System.Globalization",
@@ -1325,6 +1375,11 @@
     "hash": "sha256-v+FOmjRRKlDtDW6+TfmyMiiki010YGVTa0EwXu9X7ck="
   },
   {
+    "pname": "System.IO.Pipelines",
+    "version": "9.0.0",
+    "hash": "sha256-vb0NrPjfEao3kfZ0tavp2J/29XnsQTJgXv3/qaAwwz0="
+  },
+  {
     "pname": "System.IO.Pipes",
     "version": "4.0.0",
     "hash": "sha256-6qMAD6DCZ5c1wswLWi1msqwu8GwI8un1RzjpUhzbrjs="
@@ -1341,8 +1396,8 @@
   },
   {
     "pname": "System.Linq.Dynamic.Core",
-    "version": "1.3.14",
-    "hash": "sha256-tT9V1Y9vKfrzEmmBTYmGmzLPBfCHCXMZ8Jvluf3mliA="
+    "version": "1.6.0.2",
+    "hash": "sha256-5qzEVm+33ATR+SQljwe/LcP5o0MNjv49nHfXIVG27dw="
   },
   {
     "pname": "System.Linq.Expressions",
@@ -1363,11 +1418,6 @@
     "pname": "System.Memory",
     "version": "4.5.3",
     "hash": "sha256-Cvl7RbRbRu9qKzeRBWjavUkseT2jhZBUWV1SPipUWFk="
-  },
-  {
-    "pname": "System.Memory",
-    "version": "4.5.5",
-    "hash": "sha256-EPQ9o1Kin7KzGI5O3U3PUQAZTItSbk9h/i4rViN3WiI="
   },
   {
     "pname": "System.Net.Http",
@@ -1395,11 +1445,6 @@
     "hash": "sha256-muK7oXIX7ykqhXskuUt0KX6Hzg5VogJhUS0JiOB2BY0="
   },
   {
-    "pname": "System.Numerics.Vectors",
-    "version": "4.4.0",
-    "hash": "sha256-auXQK2flL/JpnB/rEcAcUm4vYMCYMEMiWOCAlIaqu2U="
-  },
-  {
     "pname": "System.ObjectModel",
     "version": "4.0.12",
     "hash": "sha256-MudZ/KYcvYsn2cST3EE049mLikrNkmE7QoUoYKKby+s="
@@ -1421,8 +1466,8 @@
   },
   {
     "pname": "System.Reactive",
-    "version": "6.0.0",
-    "hash": "sha256-hXB18OsiUHSCmRF3unAfdUEcbXVbG6/nZxcyz13oe9Y="
+    "version": "6.0.1",
+    "hash": "sha256-Lo5UMqp8DsbVSUxa2UpClR1GoYzqQQcSxkfyFqB/d4Q="
   },
   {
     "pname": "System.Reflection",
@@ -1481,8 +1526,8 @@
   },
   {
     "pname": "System.Reflection.Metadata",
-    "version": "8.0.0",
-    "hash": "sha256-dQGC30JauIDWNWXMrSNOJncVa1umR1sijazYwUDdSIE="
+    "version": "6.0.1",
+    "hash": "sha256-id27sU4qIEIpgKenO5b4IHt6L1XuNsVe4TR9TKaLWDo="
   },
   {
     "pname": "System.Reflection.Primitives",
@@ -1538,11 +1583,6 @@
     "pname": "System.Runtime.CompilerServices.Unsafe",
     "version": "4.5.0-preview1-26216-02",
     "hash": "sha256-xE1bUh7w/hZrknJ2kn1ZKIQO/vW2js9SJxaGXkGq3TI="
-  },
-  {
-    "pname": "System.Runtime.CompilerServices.Unsafe",
-    "version": "4.5.3",
-    "hash": "sha256-lnZMUqRO4RYRUeSO8HSJ9yBHqFHLVbmenwHWkIU20ak="
   },
   {
     "pname": "System.Runtime.CompilerServices.Unsafe",
@@ -1621,13 +1661,13 @@
   },
   {
     "pname": "System.Security.AccessControl",
-    "version": "4.5.0",
-    "hash": "sha256-AFsKPb/nTk2/mqH/PYpaoI8PLsiKKimaXf+7Mb5VfPM="
+    "version": "4.7.0",
+    "hash": "sha256-/9ZCPIHLdhzq7OW4UKqTsR0O93jjHd6BRG1SRwgHE1g="
   },
   {
     "pname": "System.Security.AccessControl",
-    "version": "4.6.0",
-    "hash": "sha256-rspJ63MbjNVDve0owXby0Pu2vHjQvR2uuhCDCJ9vgfI="
+    "version": "6.0.0",
+    "hash": "sha256-qOyWEBbNr3EjyS+etFG8/zMbuPjA+O+di717JP9Cxyg="
   },
   {
     "pname": "System.Security.Claims",
@@ -1686,8 +1726,8 @@
   },
   {
     "pname": "System.Security.Cryptography.Pkcs",
-    "version": "8.0.0",
-    "hash": "sha256-yqfIIeZchsII2KdcxJyApZNzxM/VKknjs25gDWlweBI="
+    "version": "8.0.1",
+    "hash": "sha256-KMNIkJ3yQ/5O6WIhPjyAIarsvIMhkp26A6aby5KkneU="
   },
   {
     "pname": "System.Security.Cryptography.Primitives",
@@ -1701,8 +1741,8 @@
   },
   {
     "pname": "System.Security.Cryptography.ProtectedData",
-    "version": "4.6.0",
-    "hash": "sha256-vmZTCnDlFMzMpsJX5SE4fVJTZh6jKN7AbHjKMftYg7s="
+    "version": "6.0.0",
+    "hash": "sha256-Wi9I9NbZlpQDXgS7Kl06RIFxY/9674S7hKiYw5EabRY="
   },
   {
     "pname": "System.Security.Cryptography.X509Certificates",
@@ -1716,13 +1756,8 @@
   },
   {
     "pname": "System.Security.Permissions",
-    "version": "4.5.0",
-    "hash": "sha256-Fa6dX6Gyse1A/RBoin8cVaHQePbfBvp6jjWxUXPhXKQ="
-  },
-  {
-    "pname": "System.Security.Permissions",
-    "version": "4.6.0",
-    "hash": "sha256-AByObHSxKL0vJvhTWuv4QPN01WnXDKKbnxfzG2tWrCA="
+    "version": "6.0.0",
+    "hash": "sha256-/MMvtFWGN/vOQfjXdOhet1gsnMgh6lh5DCHimVsnVEs="
   },
   {
     "pname": "System.Security.Principal",
@@ -1736,18 +1771,13 @@
   },
   {
     "pname": "System.Security.Principal.Windows",
-    "version": "4.5.0",
-    "hash": "sha256-BkUYNguz0e4NJp1kkW7aJBn3dyH9STwB5N8XqnlCsmY="
-  },
-  {
-    "pname": "System.Security.Principal.Windows",
-    "version": "4.6.0",
-    "hash": "sha256-lZeXm45RboVgqnPQVJ65y8b5b+9FSVr0MBciG777rso="
+    "version": "4.7.0",
+    "hash": "sha256-rWBM2U8Kq3rEdaa1MPZSYOOkbtMGgWyB8iPrpIqmpqg="
   },
   {
     "pname": "System.ServiceProcess.ServiceController",
-    "version": "8.0.0",
-    "hash": "sha256-mq/Qm8JeMUvitHf32/F8uvw1YJGx4prGnEI/VzdaFAI="
+    "version": "8.0.1",
+    "hash": "sha256-2cXTzNOyXqJinFPzdVJ9Gu6qrFtycfivu7RHDzBJic8="
   },
   {
     "pname": "System.Text.Encoding",
@@ -1766,8 +1796,8 @@
   },
   {
     "pname": "System.Text.Encoding.CodePages",
-    "version": "8.0.0",
-    "hash": "sha256-fjCLQc1PRW0Ix5IZldg0XKv+J1DqPSfu9pjMyNBp7dE="
+    "version": "6.0.0",
+    "hash": "sha256-nGc2A6XYnwqGcq8rfgTRjGr+voISxNe/76k2K36coj4="
   },
   {
     "pname": "System.Text.Encoding.Extensions",
@@ -1781,13 +1811,13 @@
   },
   {
     "pname": "System.Text.Encodings.Web",
-    "version": "8.0.0",
-    "hash": "sha256-IUQkQkV9po1LC0QsqrilqwNzPvnc+4eVvq+hCvq8fvE="
+    "version": "9.0.0",
+    "hash": "sha256-WGaUklQEJywoGR2jtCEs5bxdvYu5SHaQchd6s4RE5x0="
   },
   {
     "pname": "System.Text.Json",
-    "version": "8.0.0",
-    "hash": "sha256-XFcCHMW1u2/WujlWNHaIWkbW1wn8W4kI0QdrwPtWmow="
+    "version": "9.0.0",
+    "hash": "sha256-aM5Dh4okLnDv940zmoFAzRmqZre83uQBtGOImJpoIqk="
   },
   {
     "pname": "System.Text.RegularExpressions",
@@ -1808,11 +1838,6 @@
     "pname": "System.Threading",
     "version": "4.3.0",
     "hash": "sha256-ZDQ3dR4pzVwmaqBg4hacZaVenQ/3yAF/uV7BXZXjiWc="
-  },
-  {
-    "pname": "System.Threading.AccessControl",
-    "version": "4.5.0",
-    "hash": "sha256-x3Na5DscrtkFGnZycNeZd3vc8zDsIWKnINL/1JGzcOI="
   },
   {
     "pname": "System.Threading.Channels",
@@ -1850,11 +1875,6 @@
     "hash": "sha256-X2hQ5j+fxcmnm88Le/kSavjiGOmkcumBGTZKBLvorPc="
   },
   {
-    "pname": "System.Threading.Tasks.Extensions",
-    "version": "4.5.4",
-    "hash": "sha256-owSpY8wHlsUXn5xrfYAiu847L6fAKethlvYx97Ri1ng="
-  },
-  {
     "pname": "System.Threading.Tasks.Parallel",
     "version": "4.0.1",
     "hash": "sha256-5VyRZ97Fug4reK/cQ6wsCrJ5jH53aGu1a4ZkKMZrnIQ="
@@ -1881,8 +1901,8 @@
   },
   {
     "pname": "System.Windows.Extensions",
-    "version": "4.6.0",
-    "hash": "sha256-08W7PEiGAJJIMIKXieRgesIvtj4+/bUnBaFGypdXRcU="
+    "version": "6.0.0",
+    "hash": "sha256-N+qg1E6FDJ9A9L50wmVt3xPQV8ZxlG1xeXgFuxO+yfM="
   },
   {
     "pname": "System.Xml.ReaderWriter",
@@ -1936,7 +1956,7 @@
   },
   {
     "pname": "YamlDotNet",
-    "version": "13.7.1",
-    "hash": "sha256-v8w1hh8FCxJQMEPq+YUh9Oi4LE/ndi+vE2igLJazVNQ="
+    "version": "16.3.0",
+    "hash": "sha256-4Gi8wSQ8Rsi/3+LyegJr//A83nxn2fN8LN1wvSSp39Q="
   }
 ]

--- a/pkgs/by-name/sm/smtp4dev/package.nix
+++ b/pkgs/by-name/sm/smtp4dev/package.nix
@@ -7,19 +7,26 @@
   npmHooks,
   fetchNpmDeps,
   dotnetCorePackages,
+  nix-update-script,
 }:
 let
-  version = "3.6.1";
+  version = "3.8.6";
   src = fetchFromGitHub {
     owner = "rnwood";
     repo = "smtp4dev";
     tag = version;
-    hash = "sha256-T6ci7+xbzpOrNr8hpDCwk5qe01L2Ho5V1oM7Hhd8bgg=";
+    hash = "sha256-k4nerh4cVVcFQF7a4Wvcfhefa3SstEOASk+0soN0n9k=";
   };
   npmRoot = "Rnwood.Smtp4dev/ClientApp";
+  patches = [ ./smtp4dev-npm-packages.patch ];
 in
 buildDotnetModule {
-  inherit version src npmRoot;
+  inherit
+    version
+    src
+    npmRoot
+    patches
+    ;
   pname = "smtp4dev";
 
   nativeBuildInputs = [
@@ -30,8 +37,9 @@ buildDotnetModule {
   ];
 
   npmDeps = fetchNpmDeps {
-    src = "${src}/${npmRoot}";
-    hash = "sha256-/Z6sBxA2ReHlEbz0zJjlpn6IwzHDQiXN5ixEV1/iCJI=";
+    inherit src patches;
+    hash = "sha256-Uj0EnnsA+QHq5KHF2B93OG8rwxYrV6sEgMTbd43ttCA=";
+    postPatch = "cd ${npmRoot}";
   };
 
   dotnet-sdk = dotnetCorePackages.sdk_8_0;
@@ -43,6 +51,10 @@ buildDotnetModule {
   postFixup = ''
     mv $out/bin/Rnwood.Smtp4dev $out/bin/smtp4dev
   '';
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [ "--version-regex=^(\\d+\\.\\d+\\.\\d+)$" ];
+  };
 
   meta = {
     description = "Fake smtp email server for development and testing";

--- a/pkgs/by-name/sm/smtp4dev/smtp4dev-npm-packages.patch
+++ b/pkgs/by-name/sm/smtp4dev/smtp4dev-npm-packages.patch
@@ -1,0 +1,699 @@
+diff --git a/Rnwood.Smtp4dev/ClientApp/package-lock.json b/Rnwood.Smtp4dev/ClientApp/package-lock.json
+index be143b7..6e8b0b4 100644
+--- a/Rnwood.Smtp4dev/ClientApp/package-lock.json
++++ b/Rnwood.Smtp4dev/ClientApp/package-lock.json
+@@ -20,7 +20,8 @@
+         "@microsoft/signalr": "^8.0.0",
+         "@types/jest": "^29.5.12",
+         "@types/sanitize-html": "^2.11.0",
+-        "@typescript-eslint/parser": "^8.0.0",
++        "@typescript-eslint/eslint-plugin": "^8.31.1",
++        "@typescript-eslint/parser": "^8.31.1",
+         "@vitejs/plugin-vue": "^5.0.4",
+         "@vue/eslint-config-typescript": "^13.0.0",
+         "@vue/vue3-jest": "^29.2.6",
+@@ -2937,7 +2938,8 @@
+       "version": "7.0.15",
+       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+-      "dev": true
++      "dev": true,
++      "peer": true
+     },
+     "node_modules/@types/lodash": {
+       "version": "4.17.0",
+@@ -2993,12 +2995,6 @@
+         "entities": "^4.4.0"
+       }
+     },
+-    "node_modules/@types/semver": {
+-      "version": "7.5.8",
+-      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.8.tgz",
+-      "integrity": "sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ==",
+-      "dev": true
+-    },
+     "node_modules/@types/stack-utils": {
+       "version": "2.0.3",
+       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
+@@ -3039,84 +3035,59 @@
+       "dev": true
+     },
+     "node_modules/@typescript-eslint/eslint-plugin": {
+-      "version": "7.6.0",
+-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-7.6.0.tgz",
+-      "integrity": "sha512-gKmTNwZnblUdnTIJu3e9kmeRRzV2j1a/LUO27KNNAnIC5zjy1aSvXSRp4rVNlmAoHlQ7HzX42NbKpcSr4jF80A==",
++      "version": "8.31.1",
++      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.31.1.tgz",
++      "integrity": "sha512-oUlH4h1ABavI4F0Xnl8/fOtML/eu8nI2A1nYd+f+55XI0BLu+RIqKoCiZKNo6DtqZBEQm5aNKA20G3Z5w3R6GQ==",
+       "dev": true,
++      "license": "MIT",
+       "dependencies": {
+         "@eslint-community/regexpp": "^4.10.0",
+-        "@typescript-eslint/scope-manager": "7.6.0",
+-        "@typescript-eslint/type-utils": "7.6.0",
+-        "@typescript-eslint/utils": "7.6.0",
+-        "@typescript-eslint/visitor-keys": "7.6.0",
+-        "debug": "^4.3.4",
++        "@typescript-eslint/scope-manager": "8.31.1",
++        "@typescript-eslint/type-utils": "8.31.1",
++        "@typescript-eslint/utils": "8.31.1",
++        "@typescript-eslint/visitor-keys": "8.31.1",
+         "graphemer": "^1.4.0",
+         "ignore": "^5.3.1",
+         "natural-compare": "^1.4.0",
+-        "semver": "^7.6.0",
+-        "ts-api-utils": "^1.3.0"
++        "ts-api-utils": "^2.0.1"
+       },
+       "engines": {
+-        "node": "^18.18.0 || >=20.0.0"
++        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+       },
+       "funding": {
+         "type": "opencollective",
+         "url": "https://opencollective.com/typescript-eslint"
+       },
+       "peerDependencies": {
+-        "@typescript-eslint/parser": "^7.0.0",
+-        "eslint": "^8.56.0"
+-      },
+-      "peerDependenciesMeta": {
+-        "typescript": {
+-          "optional": true
+-        }
++        "@typescript-eslint/parser": "^8.0.0 || ^8.0.0-alpha.0",
++        "eslint": "^8.57.0 || ^9.0.0",
++        "typescript": ">=4.8.4 <5.9.0"
+       }
+     },
+-    "node_modules/@typescript-eslint/eslint-plugin/node_modules/lru-cache": {
+-      "version": "6.0.0",
+-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
++    "node_modules/@typescript-eslint/eslint-plugin/node_modules/ts-api-utils": {
++      "version": "2.1.0",
++      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.1.0.tgz",
++      "integrity": "sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==",
+       "dev": true,
+-      "dependencies": {
+-        "yallist": "^4.0.0"
+-      },
++      "license": "MIT",
+       "engines": {
+-        "node": ">=10"
+-      }
+-    },
+-    "node_modules/@typescript-eslint/eslint-plugin/node_modules/semver": {
+-      "version": "7.6.0",
+-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+-      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
+-      "dev": true,
+-      "dependencies": {
+-        "lru-cache": "^6.0.0"
+-      },
+-      "bin": {
+-        "semver": "bin/semver.js"
++        "node": ">=18.12"
+       },
+-      "engines": {
+-        "node": ">=10"
++      "peerDependencies": {
++        "typescript": ">=4.8.4"
+       }
+     },
+-    "node_modules/@typescript-eslint/eslint-plugin/node_modules/yallist": {
+-      "version": "4.0.0",
+-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+-      "dev": true
+-    },
+     "node_modules/@typescript-eslint/parser": {
+-      "version": "8.31.0",
+-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.31.0.tgz",
+-      "integrity": "sha512-67kYYShjBR0jNI5vsf/c3WG4u+zDnCTHTPqVMQguffaWWFs7artgwKmfwdifl+r6XyM5LYLas/dInj2T0SgJyw==",
++      "version": "8.31.1",
++      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.31.1.tgz",
++      "integrity": "sha512-oU/OtYVydhXnumd0BobL9rkJg7wFJ9bFFPmSmB/bf/XWN85hlViji59ko6bSKBXyseT9V8l+CN1nwmlbiN0G7Q==",
+       "dev": true,
+       "license": "MIT",
+       "dependencies": {
+-        "@typescript-eslint/scope-manager": "8.31.0",
+-        "@typescript-eslint/types": "8.31.0",
+-        "@typescript-eslint/typescript-estree": "8.31.0",
+-        "@typescript-eslint/visitor-keys": "8.31.0",
++        "@typescript-eslint/scope-manager": "8.31.1",
++        "@typescript-eslint/types": "8.31.1",
++        "@typescript-eslint/typescript-estree": "8.31.1",
++        "@typescript-eslint/visitor-keys": "8.31.1",
+         "debug": "^4.3.4"
+       },
+       "engines": {
+@@ -3131,15 +3102,15 @@
+         "typescript": ">=4.8.4 <5.9.0"
+       }
+     },
+-    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/scope-manager": {
+-      "version": "8.31.0",
+-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.31.0.tgz",
+-      "integrity": "sha512-knO8UyF78Nt8O/B64i7TlGXod69ko7z6vJD9uhSlm0qkAbGeRUSudcm0+K/4CrRjrpiHfBCjMWlc08Vav1xwcw==",
++    "node_modules/@typescript-eslint/scope-manager": {
++      "version": "8.31.1",
++      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.31.1.tgz",
++      "integrity": "sha512-BMNLOElPxrtNQMIsFHE+3P0Yf1z0dJqV9zLdDxN/xLlWMlXK/ApEsVEKzpizg9oal8bAT5Sc7+ocal7AC1HCVw==",
+       "dev": true,
+       "license": "MIT",
+       "dependencies": {
+-        "@typescript-eslint/types": "8.31.0",
+-        "@typescript-eslint/visitor-keys": "8.31.0"
++        "@typescript-eslint/types": "8.31.1",
++        "@typescript-eslint/visitor-keys": "8.31.1"
+       },
+       "engines": {
+         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+@@ -3149,34 +3120,16 @@
+         "url": "https://opencollective.com/typescript-eslint"
+       }
+     },
+-    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/types": {
+-      "version": "8.31.0",
+-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.31.0.tgz",
+-      "integrity": "sha512-Ch8oSjVyYyJxPQk8pMiP2FFGYatqXQfQIaMp+TpuuLlDachRWpUAeEu1u9B/v/8LToehUIWyiKcA/w5hUFRKuQ==",
+-      "dev": true,
+-      "license": "MIT",
+-      "engines": {
+-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+-      },
+-      "funding": {
+-        "type": "opencollective",
+-        "url": "https://opencollective.com/typescript-eslint"
+-      }
+-    },
+-    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/typescript-estree": {
+-      "version": "8.31.0",
+-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.31.0.tgz",
+-      "integrity": "sha512-xLmgn4Yl46xi6aDSZ9KkyfhhtnYI15/CvHbpOy/eR5NWhK/BK8wc709KKwhAR0m4ZKRP7h07bm4BWUYOCuRpQQ==",
++    "node_modules/@typescript-eslint/type-utils": {
++      "version": "8.31.1",
++      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.31.1.tgz",
++      "integrity": "sha512-fNaT/m9n0+dpSp8G/iOQ05GoHYXbxw81x+yvr7TArTuZuCA6VVKbqWYVZrV5dVagpDTtj/O8k5HBEE/p/HM5LA==",
+       "dev": true,
+       "license": "MIT",
+       "dependencies": {
+-        "@typescript-eslint/types": "8.31.0",
+-        "@typescript-eslint/visitor-keys": "8.31.0",
++        "@typescript-eslint/typescript-estree": "8.31.1",
++        "@typescript-eslint/utils": "8.31.1",
+         "debug": "^4.3.4",
+-        "fast-glob": "^3.3.2",
+-        "is-glob": "^4.0.3",
+-        "minimatch": "^9.0.4",
+-        "semver": "^7.6.0",
+         "ts-api-utils": "^2.0.1"
+       },
+       "engines": {
+@@ -3187,80 +3140,11 @@
+         "url": "https://opencollective.com/typescript-eslint"
+       },
+       "peerDependencies": {
++        "eslint": "^8.57.0 || ^9.0.0",
+         "typescript": ">=4.8.4 <5.9.0"
+       }
+     },
+-    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/visitor-keys": {
+-      "version": "8.31.0",
+-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.31.0.tgz",
+-      "integrity": "sha512-QcGHmlRHWOl93o64ZUMNewCdwKGU6WItOU52H0djgNmn1EOrhVudrDzXz4OycCRSCPwFCDrE2iIt5vmuUdHxuQ==",
+-      "dev": true,
+-      "license": "MIT",
+-      "dependencies": {
+-        "@typescript-eslint/types": "8.31.0",
+-        "eslint-visitor-keys": "^4.2.0"
+-      },
+-      "engines": {
+-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+-      },
+-      "funding": {
+-        "type": "opencollective",
+-        "url": "https://opencollective.com/typescript-eslint"
+-      }
+-    },
+-    "node_modules/@typescript-eslint/parser/node_modules/brace-expansion": {
+-      "version": "2.0.1",
+-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+-      "dev": true,
+-      "license": "MIT",
+-      "dependencies": {
+-        "balanced-match": "^1.0.0"
+-      }
+-    },
+-    "node_modules/@typescript-eslint/parser/node_modules/eslint-visitor-keys": {
+-      "version": "4.2.0",
+-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.0.tgz",
+-      "integrity": "sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==",
+-      "dev": true,
+-      "license": "Apache-2.0",
+-      "engines": {
+-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+-      },
+-      "funding": {
+-        "url": "https://opencollective.com/eslint"
+-      }
+-    },
+-    "node_modules/@typescript-eslint/parser/node_modules/minimatch": {
+-      "version": "9.0.5",
+-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+-      "dev": true,
+-      "license": "ISC",
+-      "dependencies": {
+-        "brace-expansion": "^2.0.1"
+-      },
+-      "engines": {
+-        "node": ">=16 || 14 >=14.17"
+-      },
+-      "funding": {
+-        "url": "https://github.com/sponsors/isaacs"
+-      }
+-    },
+-    "node_modules/@typescript-eslint/parser/node_modules/semver": {
+-      "version": "7.7.1",
+-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+-      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+-      "dev": true,
+-      "license": "ISC",
+-      "bin": {
+-        "semver": "bin/semver.js"
+-      },
+-      "engines": {
+-        "node": ">=10"
+-      }
+-    },
+-    "node_modules/@typescript-eslint/parser/node_modules/ts-api-utils": {
++    "node_modules/@typescript-eslint/type-utils/node_modules/ts-api-utils": {
+       "version": "2.1.0",
+       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.1.0.tgz",
+       "integrity": "sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==",
+@@ -3273,57 +3157,14 @@
+         "typescript": ">=4.8.4"
+       }
+     },
+-    "node_modules/@typescript-eslint/scope-manager": {
+-      "version": "7.6.0",
+-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-7.6.0.tgz",
+-      "integrity": "sha512-ngttyfExA5PsHSx0rdFgnADMYQi+Zkeiv4/ZxGYUWd0nLs63Ha0ksmp8VMxAIC0wtCFxMos7Lt3PszJssG/E6w==",
+-      "dev": true,
+-      "dependencies": {
+-        "@typescript-eslint/types": "7.6.0",
+-        "@typescript-eslint/visitor-keys": "7.6.0"
+-      },
+-      "engines": {
+-        "node": "^18.18.0 || >=20.0.0"
+-      },
+-      "funding": {
+-        "type": "opencollective",
+-        "url": "https://opencollective.com/typescript-eslint"
+-      }
+-    },
+-    "node_modules/@typescript-eslint/type-utils": {
+-      "version": "7.6.0",
+-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-7.6.0.tgz",
+-      "integrity": "sha512-NxAfqAPNLG6LTmy7uZgpK8KcuiS2NZD/HlThPXQRGwz6u7MDBWRVliEEl1Gj6U7++kVJTpehkhZzCJLMK66Scw==",
+-      "dev": true,
+-      "dependencies": {
+-        "@typescript-eslint/typescript-estree": "7.6.0",
+-        "@typescript-eslint/utils": "7.6.0",
+-        "debug": "^4.3.4",
+-        "ts-api-utils": "^1.3.0"
+-      },
+-      "engines": {
+-        "node": "^18.18.0 || >=20.0.0"
+-      },
+-      "funding": {
+-        "type": "opencollective",
+-        "url": "https://opencollective.com/typescript-eslint"
+-      },
+-      "peerDependencies": {
+-        "eslint": "^8.56.0"
+-      },
+-      "peerDependenciesMeta": {
+-        "typescript": {
+-          "optional": true
+-        }
+-      }
+-    },
+     "node_modules/@typescript-eslint/types": {
+-      "version": "7.6.0",
+-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.6.0.tgz",
+-      "integrity": "sha512-h02rYQn8J+MureCvHVVzhl69/GAfQGPQZmOMjG1KfCl7o3HtMSlPaPUAPu6lLctXI5ySRGIYk94clD/AUMCUgQ==",
++      "version": "8.31.1",
++      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.31.1.tgz",
++      "integrity": "sha512-SfepaEFUDQYRoA70DD9GtytljBePSj17qPxFHA/h3eg6lPTqGJ5mWOtbXCk1YrVU1cTJRd14nhaXWFu0l2troQ==",
+       "dev": true,
++      "license": "MIT",
+       "engines": {
+-        "node": "^18.18.0 || >=20.0.0"
++        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+       },
+       "funding": {
+         "type": "opencollective",
+@@ -3331,31 +3172,30 @@
+       }
+     },
+     "node_modules/@typescript-eslint/typescript-estree": {
+-      "version": "7.6.0",
+-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.6.0.tgz",
+-      "integrity": "sha512-+7Y/GP9VuYibecrCQWSKgl3GvUM5cILRttpWtnAu8GNL9j11e4tbuGZmZjJ8ejnKYyBRb2ddGQ3rEFCq3QjMJw==",
++      "version": "8.31.1",
++      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.31.1.tgz",
++      "integrity": "sha512-kaA0ueLe2v7KunYOyWYtlf/QhhZb7+qh4Yw6Ni5kgukMIG+iP773tjgBiLWIXYumWCwEq3nLW+TUywEp8uEeag==",
+       "dev": true,
++      "license": "MIT",
+       "dependencies": {
+-        "@typescript-eslint/types": "7.6.0",
+-        "@typescript-eslint/visitor-keys": "7.6.0",
++        "@typescript-eslint/types": "8.31.1",
++        "@typescript-eslint/visitor-keys": "8.31.1",
+         "debug": "^4.3.4",
+-        "globby": "^11.1.0",
++        "fast-glob": "^3.3.2",
+         "is-glob": "^4.0.3",
+         "minimatch": "^9.0.4",
+         "semver": "^7.6.0",
+-        "ts-api-utils": "^1.3.0"
++        "ts-api-utils": "^2.0.1"
+       },
+       "engines": {
+-        "node": "^18.18.0 || >=20.0.0"
++        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+       },
+       "funding": {
+         "type": "opencollective",
+         "url": "https://opencollective.com/typescript-eslint"
+       },
+-      "peerDependenciesMeta": {
+-        "typescript": {
+-          "optional": true
+-        }
++      "peerDependencies": {
++        "typescript": ">=4.8.4 <5.9.0"
+       }
+     },
+     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
+@@ -3363,27 +3203,17 @@
+       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+       "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+       "dev": true,
++      "license": "MIT",
+       "dependencies": {
+         "balanced-match": "^1.0.0"
+       }
+     },
+-    "node_modules/@typescript-eslint/typescript-estree/node_modules/lru-cache": {
+-      "version": "6.0.0",
+-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+-      "dev": true,
+-      "dependencies": {
+-        "yallist": "^4.0.0"
+-      },
+-      "engines": {
+-        "node": ">=10"
+-      }
+-    },
+     "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
+-      "version": "9.0.4",
+-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.4.tgz",
+-      "integrity": "sha512-KqWh+VchfxcMNRAJjj2tnsSJdNbHsVgnkBhTNrW7AjVo6OvLtxw8zfT9oLw1JSohlFzJ8jCoTgaoXvJ+kHt6fw==",
++      "version": "9.0.5",
++      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
++      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+       "dev": true,
++      "license": "ISC",
+       "dependencies": {
+         "brace-expansion": "^2.0.1"
+       },
+@@ -3395,13 +3225,11 @@
+       }
+     },
+     "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
+-      "version": "7.6.0",
+-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+-      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
++      "version": "7.7.1",
++      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
++      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+       "dev": true,
+-      "dependencies": {
+-        "lru-cache": "^6.0.0"
+-      },
++      "license": "ISC",
+       "bin": {
+         "semver": "bin/semver.js"
+       },
+@@ -3409,85 +3237,72 @@
+         "node": ">=10"
+       }
+     },
+-    "node_modules/@typescript-eslint/typescript-estree/node_modules/yallist": {
+-      "version": "4.0.0",
+-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+-      "dev": true
++    "node_modules/@typescript-eslint/typescript-estree/node_modules/ts-api-utils": {
++      "version": "2.1.0",
++      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.1.0.tgz",
++      "integrity": "sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==",
++      "dev": true,
++      "license": "MIT",
++      "engines": {
++        "node": ">=18.12"
++      },
++      "peerDependencies": {
++        "typescript": ">=4.8.4"
++      }
+     },
+     "node_modules/@typescript-eslint/utils": {
+-      "version": "7.6.0",
+-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-7.6.0.tgz",
+-      "integrity": "sha512-x54gaSsRRI+Nwz59TXpCsr6harB98qjXYzsRxGqvA5Ue3kQH+FxS7FYU81g/omn22ML2pZJkisy6Q+ElK8pBCA==",
++      "version": "8.31.1",
++      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.31.1.tgz",
++      "integrity": "sha512-2DSI4SNfF5T4oRveQ4nUrSjUqjMND0nLq9rEkz0gfGr3tg0S5KB6DhwR+WZPCjzkZl3cH+4x2ce3EsL50FubjQ==",
+       "dev": true,
++      "license": "MIT",
+       "dependencies": {
+         "@eslint-community/eslint-utils": "^4.4.0",
+-        "@types/json-schema": "^7.0.15",
+-        "@types/semver": "^7.5.8",
+-        "@typescript-eslint/scope-manager": "7.6.0",
+-        "@typescript-eslint/types": "7.6.0",
+-        "@typescript-eslint/typescript-estree": "7.6.0",
+-        "semver": "^7.6.0"
++        "@typescript-eslint/scope-manager": "8.31.1",
++        "@typescript-eslint/types": "8.31.1",
++        "@typescript-eslint/typescript-estree": "8.31.1"
+       },
+       "engines": {
+-        "node": "^18.18.0 || >=20.0.0"
++        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+       },
+       "funding": {
+         "type": "opencollective",
+         "url": "https://opencollective.com/typescript-eslint"
+       },
+       "peerDependencies": {
+-        "eslint": "^8.56.0"
++        "eslint": "^8.57.0 || ^9.0.0",
++        "typescript": ">=4.8.4 <5.9.0"
+       }
+     },
+-    "node_modules/@typescript-eslint/utils/node_modules/lru-cache": {
+-      "version": "6.0.0",
+-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
++    "node_modules/@typescript-eslint/visitor-keys": {
++      "version": "8.31.1",
++      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.31.1.tgz",
++      "integrity": "sha512-I+/rgqOVBn6f0o7NDTmAPWWC6NuqhV174lfYvAm9fUaWeiefLdux9/YI3/nLugEn9L8fcSi0XmpKi/r5u0nmpw==",
+       "dev": true,
++      "license": "MIT",
+       "dependencies": {
+-        "yallist": "^4.0.0"
++        "@typescript-eslint/types": "8.31.1",
++        "eslint-visitor-keys": "^4.2.0"
+       },
+       "engines": {
+-        "node": ">=10"
+-      }
+-    },
+-    "node_modules/@typescript-eslint/utils/node_modules/semver": {
+-      "version": "7.6.0",
+-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+-      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
+-      "dev": true,
+-      "dependencies": {
+-        "lru-cache": "^6.0.0"
+-      },
+-      "bin": {
+-        "semver": "bin/semver.js"
++        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+       },
+-      "engines": {
+-        "node": ">=10"
++      "funding": {
++        "type": "opencollective",
++        "url": "https://opencollective.com/typescript-eslint"
+       }
+     },
+-    "node_modules/@typescript-eslint/utils/node_modules/yallist": {
+-      "version": "4.0.0",
+-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+-      "dev": true
+-    },
+-    "node_modules/@typescript-eslint/visitor-keys": {
+-      "version": "7.6.0",
+-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.6.0.tgz",
+-      "integrity": "sha512-4eLB7t+LlNUmXzfOu1VAIAdkjbu5xNSerURS9X/S5TUKWFRpXRQZbmtPqgKmYx8bj3J0irtQXSiWAOY82v+cgw==",
++    "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
++      "version": "4.2.0",
++      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.0.tgz",
++      "integrity": "sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==",
+       "dev": true,
+-      "dependencies": {
+-        "@typescript-eslint/types": "7.6.0",
+-        "eslint-visitor-keys": "^3.4.3"
+-      },
++      "license": "Apache-2.0",
+       "engines": {
+-        "node": "^18.18.0 || >=20.0.0"
++        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+       },
+       "funding": {
+-        "type": "opencollective",
+-        "url": "https://opencollective.com/typescript-eslint"
++        "url": "https://opencollective.com/eslint"
+       }
+     },
+     "node_modules/@ungap/structured-clone": {
+@@ -3591,6 +3406,40 @@
+         }
+       }
+     },
++    "node_modules/@vue/eslint-config-typescript/node_modules/@typescript-eslint/eslint-plugin": {
++      "version": "7.18.0",
++      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-7.18.0.tgz",
++      "integrity": "sha512-94EQTWZ40mzBc42ATNIBimBEDltSJ9RQHCC8vc/PDbxi4k8dVwUAv4o98dk50M1zB+JGFxp43FP7f8+FP8R6Sw==",
++      "dev": true,
++      "license": "MIT",
++      "dependencies": {
++        "@eslint-community/regexpp": "^4.10.0",
++        "@typescript-eslint/scope-manager": "7.18.0",
++        "@typescript-eslint/type-utils": "7.18.0",
++        "@typescript-eslint/utils": "7.18.0",
++        "@typescript-eslint/visitor-keys": "7.18.0",
++        "graphemer": "^1.4.0",
++        "ignore": "^5.3.1",
++        "natural-compare": "^1.4.0",
++        "ts-api-utils": "^1.3.0"
++      },
++      "engines": {
++        "node": "^18.18.0 || >=20.0.0"
++      },
++      "funding": {
++        "type": "opencollective",
++        "url": "https://opencollective.com/typescript-eslint"
++      },
++      "peerDependencies": {
++        "@typescript-eslint/parser": "^7.0.0",
++        "eslint": "^8.56.0"
++      },
++      "peerDependenciesMeta": {
++        "typescript": {
++          "optional": true
++        }
++      }
++    },
+     "node_modules/@vue/eslint-config-typescript/node_modules/@typescript-eslint/parser": {
+       "version": "7.18.0",
+       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-7.18.0.tgz",
+@@ -3638,6 +3487,34 @@
+         "url": "https://opencollective.com/typescript-eslint"
+       }
+     },
++    "node_modules/@vue/eslint-config-typescript/node_modules/@typescript-eslint/type-utils": {
++      "version": "7.18.0",
++      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-7.18.0.tgz",
++      "integrity": "sha512-XL0FJXuCLaDuX2sYqZUUSOJ2sG5/i1AAze+axqmLnSkNEVMVYLF+cbwlB2w8D1tinFuSikHmFta+P+HOofrLeA==",
++      "dev": true,
++      "license": "MIT",
++      "dependencies": {
++        "@typescript-eslint/typescript-estree": "7.18.0",
++        "@typescript-eslint/utils": "7.18.0",
++        "debug": "^4.3.4",
++        "ts-api-utils": "^1.3.0"
++      },
++      "engines": {
++        "node": "^18.18.0 || >=20.0.0"
++      },
++      "funding": {
++        "type": "opencollective",
++        "url": "https://opencollective.com/typescript-eslint"
++      },
++      "peerDependencies": {
++        "eslint": "^8.56.0"
++      },
++      "peerDependenciesMeta": {
++        "typescript": {
++          "optional": true
++        }
++      }
++    },
+     "node_modules/@vue/eslint-config-typescript/node_modules/@typescript-eslint/types": {
+       "version": "7.18.0",
+       "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.18.0.tgz",
+@@ -3681,6 +3558,29 @@
+         }
+       }
+     },
++    "node_modules/@vue/eslint-config-typescript/node_modules/@typescript-eslint/utils": {
++      "version": "7.18.0",
++      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-7.18.0.tgz",
++      "integrity": "sha512-kK0/rNa2j74XuHVcoCZxdFBMF+aq/vH83CXAOHieC+2Gis4mF8jJXT5eAfyD3K0sAxtPuwxaIOIOvhwzVDt/kw==",
++      "dev": true,
++      "license": "MIT",
++      "dependencies": {
++        "@eslint-community/eslint-utils": "^4.4.0",
++        "@typescript-eslint/scope-manager": "7.18.0",
++        "@typescript-eslint/types": "7.18.0",
++        "@typescript-eslint/typescript-estree": "7.18.0"
++      },
++      "engines": {
++        "node": "^18.18.0 || >=20.0.0"
++      },
++      "funding": {
++        "type": "opencollective",
++        "url": "https://opencollective.com/typescript-eslint"
++      },
++      "peerDependencies": {
++        "eslint": "^8.56.0"
++      }
++    },
+     "node_modules/@vue/eslint-config-typescript/node_modules/@typescript-eslint/visitor-keys": {
+       "version": "7.18.0",
+       "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.18.0.tgz",
+diff --git a/Rnwood.Smtp4dev/ClientApp/package.json b/Rnwood.Smtp4dev/ClientApp/package.json
+index a9e301a..619e55b 100644
+--- a/Rnwood.Smtp4dev/ClientApp/package.json
++++ b/Rnwood.Smtp4dev/ClientApp/package.json
+@@ -19,7 +19,8 @@
+     "@microsoft/signalr": "^8.0.0",
+     "@types/jest": "^29.5.12",
+     "@types/sanitize-html": "^2.11.0",
+-    "@typescript-eslint/parser": "^8.0.0",
++    "@typescript-eslint/eslint-plugin": "^8.31.1",
++    "@typescript-eslint/parser": "^8.31.1",
+     "@vitejs/plugin-vue": "^5.0.4",
+     "@vue/eslint-config-typescript": "^13.0.0",
+     "@vue/vue3-jest": "^29.2.6",


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Following request: https://github.com/NixOS/nixpkgs/issues/403182 I've updated this package.

Due to some problems with the package-lock upstream in the project, I had to perform:
`npm install --save-dev   @typescript-eslint/parser@^8.31.0   @typescript-eslint/eslint-plugin@^8.31.0`

and create a patch, if this was not applied, nixpkgs wasn't able to succesfully fetch the deps with fetchNpmDeps.

I'll open an issue regarding this topic in smtp4dev repository and I expect this to be fixed in the future, so the patch can be removed.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
