### PR TITLE
nixos/amule: fix and improve

### DIFF
--- a/nixos/doc/manual/redirects.json
+++ b/nixos/doc/manual/redirects.json
@@ -71,6 +71,9 @@
   "modular-services": [
     "index.html#modular-services"
   ],
+  "module-services-amule": [
+    "index.html#module-services-amule"
+  ],
   "module-services-anubis": [
     "index.html#module-services-anubis"
   ],

--- a/nixos/modules/services/networking/amuled.md
+++ b/nixos/modules/services/networking/amuled.md
@@ -1,0 +1,30 @@
+# aMule {#module-services-amule}
+
+[aMule](https://www.amule.org/) is a free and open-source peer-to-peer file sharing client that supports the eD2k and Kad networks.
+It allows users to search for, download, and share files with others on these networks.
+The `amuled` daemon is the command-line version of aMule, designed to run as a background service without a graphical user interface, making it suitable for servers or headless systems.
+It handles finding sources, managing download and upload queues, and interacting with the eD2k servers and Kad network.
+
+Here an example which also enables the web server and sets custom paths for the downloads:
+
+```nix
+{
+  services.amule = {
+    enable = true;
+    openPeerPorts = true;
+    openWebServerPort = true;
+    ExternalConnectPasswordFile = "/run/secrets/amule-password";
+    WebServerPasswordFile = "/run/secrets/amule-web/password";
+    settings = {
+      eMule = {
+        IncomingDir = "/mnt/hd/amule";
+        TempDir = "/mnt/hd/amule/Temp";
+      };
+      WebServer.Enabled = 1;
+    };
+  };
+}
+```
+
+You can connect using `amulegui` and choosing the host, port (`4712` by default) and password, the username is always `amule`.
+Otherwise, if you enabled the web server, connect using the browser (port `4711` by default).

--- a/nixos/modules/services/networking/amuled.nix
+++ b/nixos/modules/services/networking/amuled.nix
@@ -1,89 +1,323 @@
 {
   config,
   lib,
-  options,
+  utils,
   pkgs,
   ...
 }:
 let
   cfg = config.services.amule;
-  opt = options.services.amule;
-  user = if cfg.user != null then cfg.user else "amule";
-in
 
-{
+  settingsFormat = pkgs.formats.ini { };
 
-  ###### interface
+  inherit (lib)
+    mkOption
+    mkEnableOption
+    mkPackageOption
+    types
+    optionalAttrs
+    mkIf
+    mkMerge
+    literalExpression
+    optionalString
+    optionals
+    getExe
+    ;
 
-  options = {
-
-    services.amule = {
-
-      enable = lib.mkOption {
-        type = lib.types.bool;
-        default = false;
+  settingsOptions = {
+    eMule = {
+      Port = mkOption {
+        type = types.port;
+        default = 4662;
         description = ''
-          Whether to run the AMule daemon. You need to manually run "amuled --ec-config" to configure the service for the first time.
+          TCP port for eD2k connections.
+          Required for connecting to servers and achieving a High ID.
         '';
       };
-
-      dataDir = lib.mkOption {
-        type = lib.types.str;
-        default = "/home/${user}/";
-        defaultText = lib.literalExpression ''
-          "/home/''${config.${opt.user}}/"
-        '';
+      UDPPort = mkOption {
+        type = types.port;
+        default = 4672;
         description = ''
-          The directory holding configuration, incoming and temporary files.
+          UDP port for eD2k traffic (searches, source exchange) and all Kad network communication.
+          Essential for a High ID on both networks and proper Kad functioning.
         '';
       };
-
-      user = lib.mkOption {
-        type = lib.types.nullOr lib.types.str;
-        default = null;
+      TempDir = mkOption {
+        type = types.path;
+        default = "${cfg.dataDir}/Temp";
+        defaultText = literalExpression "\${config.services.amule.dataDir}/Temp";
         description = ''
-          The user the AMule daemon should run as.
+          Directory where aMule stores incomplete downloads (.part/.part.met files).
         '';
       };
-
+      IncomingDir = mkOption {
+        type = types.path;
+        default = "${cfg.dataDir}/Incoming";
+        defaultText = literalExpression "\${config.services.amule.dataDir}/Incoming";
+        description = ''
+          Directory where aMule moves completed downloads.
+          Files in this directory are automatically shared.
+          Ensure the aMule service has write permissions
+        '';
+      };
+      OSDirectory = mkOption {
+        type = types.path;
+        default = cfg.dataDir;
+        defaultText = literalExpression "\${config.services.amule.dataDir}";
+        description = "On-disk state directory, probably you don't want to change this";
+        internal = true;
+      };
     };
-
+    ExternalConnect = {
+      AcceptExternalConnections = mkOption {
+        type = types.enum [
+          0
+          1
+        ];
+        default = 1;
+        description = "Whether to accept external connections, if disabled amuled refuses to start";
+        internal = true;
+      };
+      ECPort = mkOption {
+        type = types.port;
+        default = 4712;
+        description = "TCP port for external connections, like remote control via amule-gui";
+      };
+      ECPassword = mkOption {
+        type = types.str;
+        default = "";
+        description = ''
+          MD5 hash of the password, obtainaible with `echo "<password>" | md5sum | cut -d ' ' -f 1`
+        '';
+      };
+    };
+    WebServer = {
+      Enabled = lib.mkOption {
+        type = types.enum [
+          0
+          1
+        ];
+        default = 0;
+        description = "Set to 1 to enable the web server";
+      };
+      Password = mkOption {
+        type = types.str;
+        default = "";
+        description = ''
+          MD5 hash of the password, obtainaible with `echo "<password>" | md5sum | cut -d ' ' -f 1`
+        '';
+      };
+      Port = mkOption {
+        type = types.port;
+        default = 4711;
+        description = "Web server port";
+      };
+    };
   };
 
-  ###### implementation
+  webServerEnabled = cfg.settings.WebServer.Enabled == 1;
+in
+{
+  options.services.amule = {
+    enable = mkEnableOption "aMule daemon";
 
-  config = lib.mkIf cfg.enable {
+    package = mkPackageOption pkgs "amule-daemon" { };
 
-    users.users = lib.mkIf (cfg.user == null) [
+    amuleWebPackage = mkPackageOption pkgs "amule-web" { };
+
+    extraArgs = mkOption {
+      type = types.listOf types.str;
+      default = [ ];
+      description = "Additional passed arguments";
+    };
+
+    dataDir = mkOption {
+      type = types.path;
+      default = "/var/lib/amuled";
+      description = "Directory holding configuration and by default also incoming and temporary files";
+    };
+
+    user = mkOption {
+      type = types.str;
+      default = "amule";
+      description = "The user the aMule daemon should run as";
+    };
+
+    group = mkOption {
+      type = types.str;
+      default = "amule";
+      description = "Group under which amule runs";
+    };
+
+    openPeerPorts = mkEnableOption "open the peer port(s) in the firewall";
+
+    openExternalConnectPort = mkEnableOption "open the external connect port";
+
+    openWebServerPort = mkEnableOption "open the web server port";
+
+    ExternalConnectPasswordFile = mkOption {
+      type = types.nullOr types.path;
+      default = null;
+      description = ''
+        File containing the password for connecting with amule-gui,
+        set this only if you didn't set `settings.ExternalConnect.ECPassword`
+      '';
+    };
+
+    WebServerPasswordFile = mkOption {
+      type = types.nullOr types.path;
+      default = null;
+      description = ''
+        File containing the password for connecting to the web server,
+        set this only if you didn't set `settings.ExternalConnect.ECPassword`
+      '';
+    };
+
+    settings = mkOption {
+      type = types.submodule {
+        freeformType = settingsFormat.type;
+        options = settingsOptions;
+      };
+      description = ''
+        Free form attribute set for aMule settings.
+        The final configuration file is generated merging the default settings with these options.
+      '';
+      example = literalExpression ''
+        {
+          eMule = {
+            IncomingDir = "/mnt/hd/amule/Incoming";
+            TempDir = "/mnt/hd/amule/Temp";
+          };
+          WebServer.Enabled = 1;
+        }
+      '';
+      default = { };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    assertions = [
       {
-        name = "amule";
-        description = "AMule daemon";
-        group = "amule";
+        assertion = isNull cfg.ExternalConnectPasswordFile -> cfg.settings.ExternalConnect.ECPassword != "";
+        message = "Set only one between `ExternalConnectPasswordFile` and `settings.ExternalConnect.ECPassword`";
+      }
+    ]
+    ++ optionals webServerEnabled [
+      {
+        assertion = isNull cfg.WebServerPasswordFile -> cfg.settings.WebServer.Password != "";
+        message = "Set only one between `ExternalWebServerFile` `settings.WebServer.Password`";
+      }
+    ];
+
+    users.users = optionalAttrs (cfg.user == "amule") {
+      amule = {
+        group = cfg.group;
+        description = "aMule user";
+        isSystemUser = true;
         uid = config.ids.uids.amule;
-      }
-    ];
+      };
+    };
 
-    users.groups = lib.mkIf (cfg.user == null) [
-      {
-        name = "amule";
-        gid = config.ids.gids.amule;
-      }
-    ];
+    users.groups = optionalAttrs (cfg.group == "amule") {
+      amule.gid = config.ids.gids.amule;
+    };
+
+    systemd.tmpfiles.settings."10-amuled".${cfg.dataDir}.d = {
+      inherit (cfg) user group;
+      mode = "0755";
+    };
+
+    services.amule.settings = {
+      eMule.AppVersion = lib.getVersion cfg.package;
+    };
 
     systemd.services.amuled = {
       description = "AMule daemon";
-      wantedBy = [ "multi-user.target" ];
       after = [ "network.target" ];
+      wantedBy = [ "multi-user.target" ];
+      path = [ pkgs.crudini ];
 
       preStart = ''
-        mkdir -p ${cfg.dataDir}
-        chown ${user} ${cfg.dataDir}
+        AMULE_CONF="${cfg.dataDir}/amule.conf"
+
+        if [ ! -f "$AMULE_CONF" ]; then
+          echo "First run detected: starting aMule to generate default configuration..."
+          echo "aMule will fail with an error - this is expected and normal"
+          rm -f ${cfg.dataDir}/lastversion
+          set +e
+          ${getExe cfg.package} --config-dir ${cfg.dataDir}
+          set -e
+        fi
+      ''
+      + (lib.concatMapAttrsStringSep "" (
+        section:
+        lib.concatMapAttrsStringSep "" (
+          param: value: ''
+            crudini --inplace --set "$AMULE_CONF" "${section}" "${param}" "${builtins.toString value}"
+          ''
+        )
+      ) cfg.settings)
+      + optionalString (!isNull cfg.ExternalConnectPasswordFile) ''
+        EC_PASSWORD=$(cat ${cfg.ExternalConnectPasswordFile} | md5sum | cut -d ' ' -f 1)
+        crudini --inplace --set "$AMULE_CONF" "ExternalConnect" "ECPassword" "$EC_PASSWORD"
+      ''
+      + optionalString (!isNull cfg.WebServerPasswordFile) ''
+        WEB_PASSWORD=$(cat ${cfg.WebServerPasswordFile} | md5sum | cut -d ' ' -f 1)
+        crudini --inplace --set "$AMULE_CONF" "WebServer" "Password" "$WEB_PASSWORD"
       '';
 
-      script = ''
-        ${pkgs.su}/bin/su -s ${pkgs.runtimeShell} ${user} \
-            -c 'HOME="${cfg.dataDir}" ${pkgs.amule-daemon}/bin/amuled'
-      '';
+      serviceConfig = {
+        User = cfg.user;
+        Group = cfg.group;
+
+        ExecStart = utils.escapeSystemdExecArgs (
+          [
+            (getExe cfg.package)
+            "--config-dir"
+            cfg.dataDir
+          ]
+          ++ optionals webServerEnabled [ "--use-amuleweb=${getExe cfg.amuleWebPackage}" ]
+          ++ cfg.extraArgs
+        );
+
+        Restart = "on-failure";
+        RestartSec = "5s";
+
+        # Hardening
+        NoNewPrivileges = true;
+        PrivateTmp = true;
+        PrivateDevices = true;
+        DevicePolicy = "closed";
+        ProtectSystem = "strict";
+        ProtectControlGroups = true;
+        ProtectKernelModules = true;
+        ProtectKernelTunables = true;
+        ReadWritePaths = [
+          cfg.dataDir
+          cfg.settings.eMule.TempDir
+          cfg.settings.eMule.IncomingDir
+        ];
+        RestrictAddressFamilies = "AF_INET";
+        RestrictNamespaces = true;
+        RestrictRealtime = true;
+        RestrictSUIDSGID = true;
+        LockPersonality = true;
+      };
     };
+
+    networking.firewall = mkMerge [
+      (mkIf cfg.openPeerPorts {
+        allowedTCPPorts = [ cfg.settings.eMule.Port ];
+        allowedUDPPorts = [ cfg.settings.eMule.UDPPort ];
+      })
+      (mkIf cfg.openWebServerPort {
+        allowedTCPPorts = [ cfg.settings.WebServer.Port ];
+      })
+    ];
+  };
+
+  meta = {
+    maintainers = with lib.maintainers; [ aciceri ];
+    doc = ./amuled.md;
   };
 }

--- a/pkgs/by-name/am/amule/package.nix
+++ b/pkgs/by-name/am/amule/package.nix
@@ -3,6 +3,7 @@
   enableDaemon ? false, # build amule daemon
   httpServer ? false, # build web interface for the daemon
   client ? false, # build amule remote gui
+  mainProgram ? "amule",
   fetchFromGitHub,
   fetchpatch,
   stdenv,
@@ -103,10 +104,10 @@ stdenv.mkDerivation rec {
       no adware or spyware as is often found in proprietary P2P
       applications.
     '';
-
     homepage = "https://github.com/amule-project/amule";
     license = lib.licenses.gpl2Plus;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ aciceri ];
+    inherit mainProgram;
     platforms = lib.platforms.unix;
     # Undefined symbols for architecture arm64: "_FSFindFolder"
     broken = stdenv.hostPlatform.isDarwin;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1531,16 +1531,19 @@ with pkgs;
   amule-daemon = amule.override {
     monolithic = false;
     enableDaemon = true;
+    mainProgram = "amuled";
   };
 
   amule-gui = amule.override {
     monolithic = false;
     client = true;
+    mainProgram = "amulegui";
   };
 
   amule-web = amule.override {
     monolithic = false;
     httpServer = true;
+    mainProgram = "amuleweb";
   };
 
   inherit (callPackages ../tools/security/bitwarden-directory-connector { })


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->
- Done
  - [x] doesn't require performing manual operations the first time it was started
  - [x] free form `settings` option
  - [x] (partially) included hardening options from #354517
  - [x] complete refactor and improved ergonomics
  - [x] use file options for passwords
  - [x] section in NixOS manual
  - [x] add myself as maintainer for both packages (`amule`, `amule-gui`, `amule-web` and `amule-daemon`) and the NixOS module
  - [x] add `mainProgram` to all the packages above 

This PR should supersede both #226502 and #354517

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
