### PR TITLE
xrootd: 5.8.0 -> 5.8.1

### DIFF
--- a/pkgs/by-name/xr/xrootd/package.nix
+++ b/pkgs/by-name/xr/xrootd/package.nix
@@ -30,14 +30,14 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "xrootd";
-  version = "5.8.0";
+  version = "5.8.1";
 
   src = fetchFromGitHub {
     owner = "xrootd";
     repo = "xrootd";
     tag = "v${finalAttrs.version}";
     fetchSubmodules = true;
-    hash = "sha256-i0gVKk2nFQQGxvUI2zqPWL82SFJdNglAuZ5gNdNhg2M=";
+    hash = "sha256-zeyg/VdzcWbMXuCE1RELiyGg9mytfpNfIa911BwqqIA=";
   };
 
   postPatch =
@@ -45,17 +45,6 @@ stdenv.mkDerivation (finalAttrs: {
       patchShebangs genversion.sh
       substituteInPlace cmake/XRootDConfig.cmake.in \
         --replace-fail "@PACKAGE_CMAKE_INSTALL_" "@CMAKE_INSTALL_FULL_"
-    ''
-    # Upstream started using an absolute path in an install's DESTINATION directive.
-    # This causes our build to fail in `fixupPhase` with:
-    #   Moving /nix/store/jbh4667k5zm74h9wv8y1j11x89cv6pnd-xrootd-5.8.0/include to /nix/store/6vnmipw8p1hc6cmkrsq9v1ay7j6iycq2-xrootd-5.8.0-dev/include
-    #   mv: cannot overwrite '/nix/store/6vnmipw8p1hc6cmkrsq9v1ay7j6iycq2-xrootd-5.8.0-dev/include/xrootd': Directory not empty
-    # Patch submitted upstream: https://github.com/xrootd/xrootd/pull/2478
-    + ''
-      substituteInPlace src/XrdPfc.cmake \
-        --replace-fail \
-        'DESTINATION ''${CMAKE_INSTALL_PREFIX}/include/xrootd/XrdPfc' \
-        'DESTINATION ''${CMAKE_INSTALL_INCLUDEDIR}/xrootd/XrdPfc'
     ''
     + lib.optionalString stdenv.hostPlatform.isDarwin ''
       sed -i cmake/XRootDOSDefs.cmake -e '/set( MacOSX TRUE )/ainclude( GNUInstallDirs )'


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Diff: https://github.com/xrootd/xrootd/compare/refs/tags/v5.8.0...refs/tags/v5.8.1
Changelog: https://github.com/xrootd/xrootd/releases/tag/v5.8.1

cc @ShamrockLee

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
