### PR TITLE
orbbec: init at 2.3.5

### DIFF
--- a/pkgs/by-name/or/orbbec-sdk/package.nix
+++ b/pkgs/by-name/or/orbbec-sdk/package.nix
@@ -1,0 +1,131 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  pkg-config,
+  gcc-unwrapped,
+  libusb1,
+  libuvc,
+  opencv4,
+  eigen,
+  pcl,
+  boost,
+  openssl,
+  zlib,
+  libpng,
+  libjpeg,
+  abseil-cpp,
+  tbb,
+  jansson,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "orbbec-sdk";
+  version = "2.3.5";
+
+  src = fetchFromGitHub {
+    owner = "orbbec";
+    repo = "OrbbecSDK_v2";
+    rev = "v${finalAttrs.version}";
+    sha256 = "sha256-HfdOzh/QdzpET2YTEA9PfrqdmVEMqY+P3oCSpfR1kqA=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
+
+  buildInputs = [
+    gcc-unwrapped
+    libusb1
+    libuvc
+    opencv4
+    eigen
+    pcl
+    boost
+    openssl
+    zlib
+    libpng
+    libjpeg
+    abseil-cpp
+    tbb
+    jansson
+  ];
+
+  cmakeFlags = [
+    (lib.cmakeBool "OB_ENABLE_EXAMPLE" true)
+    (lib.cmakeBool "OB_BUILD_TOOLS" true)
+    (lib.cmakeBool "OB_BUILD_TEST" false)
+  ];
+
+  # Make sure USB rules are installed
+  postInstall = ''
+    # Install udev rules
+    mkdir -p $out/lib/udev/rules.d
+    if [ -f $src/CMake/99-orbbec.rules ]; then
+      cp $src/CMake/99-orbbec.rules $out/lib/udev/rules.d/
+    elif [ -f $src/scripts/99-orbbec.rules ]; then
+      cp $src/scripts/99-orbbec.rules $out/lib/udev/rules.d/
+    fi
+
+    # Copy all examples to a share directory
+    mkdir -p $out/share/${finalAttrs.pname}/examples
+    if [ -d $buildDir/examples ]; then
+      find $buildDir/examples -type f -executable -not -path "*/\.*" | while read exec_file; do
+        cp "$exec_file" $out/share/${finalAttrs.pname}/examples/
+      done
+    fi
+  '';
+
+  # Fix library paths for the executables
+  postFixup = ''
+    # Find all shared libraries and make sure they're included in the runtime path
+    mkdir -p $out/lib/${finalAttrs.pname}
+
+    # Copy any shared libraries from the build directory
+    find $buildDir -name "*.so*" -type f -not -name "*.a" -not -path "*/\.*" | while read lib_file; do
+      lib_basename=$(basename "$lib_file")
+      if [ ! -e "$out/lib/${finalAttrs.pname}/$lib_basename" ]; then
+        cp -P "$lib_file" $out/lib/${finalAttrs.pname}/
+      fi
+    done
+
+    # Create symlinks in the main lib directory if they don't exist
+    for lib_file in $out/lib/${finalAttrs.pname}/*.so*; do
+      if [ -f "$lib_file" ]; then
+        lib_basename=$(basename "$lib_file")
+        if [ ! -e "$out/lib/$lib_basename" ]; then
+          ln -sf "$lib_file" $out/lib/
+        fi
+      fi
+    done
+
+    # Fix rpath for all executables in bin and share/examples
+    for bin_dir in "$out/bin" "$out/share/${finalAttrs.pname}/examples"; do
+      if [ -d "$bin_dir" ]; then
+        for f in $bin_dir/*; do
+          if [ -f "$f" ] && [ -x "$f" ]; then
+            echo "Patching $f"
+            patchelf --set-rpath "${lib.makeLibraryPath finalAttrs.buildInputs}:$out/lib:$out/lib/${finalAttrs.pname}" "$f" || true
+          fi
+        done
+      fi
+    done
+
+    # Create summary files
+    ls -la $out/bin > $out/share/${finalAttrs.pname}/binary_list.txt || true
+    ls -la $out/lib/${finalAttrs.pname} > $out/share/${finalAttrs.pname}/library_list.txt || true
+    if [ -d "$out/share/${finalAttrs.pname}/examples" ]; then
+      ls -la $out/share/${finalAttrs.pname}/examples > $out/share/${finalAttrs.pname}/examples_list.txt || true
+    fi
+  '';
+
+  meta = {
+    description = "Orbbec SDK v2 for 3D cameras and depth sensors";
+    homepage = "https://github.com/orbbec/OrbbecSDK_v2";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ phodina ];
+  };
+})


### PR DESCRIPTION
Add Orbbec SDK for interfacing their cameras.

WIP: wipe the `thirdparty` directory and use nixpkgs instead

https://github.com/orbbec/OrbbecSDK_v2/tree/main/3rdparty

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
