### PR TITLE
brogue: fix build, update upstream url

### DIFF
--- a/pkgs/by-name/br/brogue/fix-compilation.diff
+++ b/pkgs/by-name/br/brogue/fix-compilation.diff
@@ -1,0 +1,38 @@
+diff --git a/src/brogue/Architect.c b/src/brogue/Architect.c
+index abe5acf..b38291d 100755
+--- a/src/brogue/Architect.c
++++ b/src/brogue/Architect.c
+@@ -1676,7 +1676,7 @@ void addMachines() {
+     // Add the amulet holder if it's depth 26:
+     if (rogue.depthLevel == AMULET_LEVEL) {
+         for (failsafe = 50; failsafe; failsafe--) {
+-            if (buildAMachine(MT_AMULET_AREA, -1, -1, NULL, NULL, NULL, NULL)) {
++            if (buildAMachine(MT_AMULET_AREA, -1, -1, 0L, NULL, NULL, NULL)) {
+                 break;
+             }
+         }
+diff --git a/src/brogue/RogueMain.c b/src/brogue/RogueMain.c
+index 49b08b9..3666963 100755
+--- a/src/brogue/RogueMain.c
++++ b/src/brogue/RogueMain.c
+@@ -880,7 +880,7 @@ void startLevel(short oldLevelNumber, short stairDirection) {
+             getQualifyingPathLocNear(&loc[0], &loc[1],
+                                      player.xLoc, player.yLoc,
+                                      true,
+-                                     T_DIVIDES_LEVEL, NULL,
++                                     T_DIVIDES_LEVEL, 0L,
+                                      T_PATHING_BLOCKER, (HAS_MONSTER | HAS_ITEM | HAS_STAIRS | IS_IN_MACHINE),
+                                      false);
+         }
+diff --git a/src/platform/platformdependent.c b/src/platform/platformdependent.c
+index 635a738..e725513 100644
+--- a/src/platform/platformdependent.c
++++ b/src/platform/platformdependent.c
+@@ -21,6 +21,7 @@
+  *  along with Brogue.  If not, see <http://www.gnu.org/licenses/>.
+  */
+ 
++#include <ctype.h>
+ #include <stdio.h>
+ #include <string.h>
+ #include <time.h>

--- a/pkgs/by-name/br/brogue/package.nix
+++ b/pkgs/by-name/br/brogue/package.nix
@@ -14,9 +14,11 @@ stdenv.mkDerivation (finalAttrs: {
   version = "1.7.5";
 
   src = fetchurl {
-    url = "https://sites.google.com/site/broguegame/brogue-${finalAttrs.version}-linux-amd64.tbz2";
-    sha256 = "0i042zb3axjf0cpgpdh8hvfn66dbfizidyvw0iymjk2n760z2kx7";
+    url = "https://drive.google.com/uc?export=download&id=1ED_2nPubP-P0e_PHKYVzZF42M1Y9pUb4";
+    hash = "sha256-p0/xgTlWTFl9BHz7Fn90qxlj3YYItvsuA052NdYXBEQ=";
+    name = "brogue.tbz2";
   };
+
   patches = [
     # Pull upstream fix for -fno-common toolchains:
     #  https://github.com/tmewett/BrogueCE/pull/63
@@ -25,6 +27,8 @@ stdenv.mkDerivation (finalAttrs: {
       url = "https://github.com/tmewett/BrogueCE/commit/2c7ed0c48d9efd06bf0a2589ba967c0a22a8fa87.patch";
       sha256 = "19lr2fa25dh79klm4f4kqyyqq7w5xmw9z0fvylkcckqvcv7dwhp3";
     })
+    # error: passing argument 4 of 'buildAMachine' makes integer from pointer without a cast []
+    ./fix-compilation.diff
   ];
 
   prePatch = ''


### PR DESCRIPTION
Fix build failure from `brogue`. I could not find the tarball from the `sites.google.com` domain, so I changed upstream to GitHub repository. Had to apply a few patches to make it work properly. I also had to use `pkg-config` to resolve `SDL` config.

- part of #388196
- Hydra failure: https://hydra.nixos.org/build/294960937

depends on:
- #403376

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
