### PR TITLE
korrect: init at 0.1.3

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6791,6 +6791,12 @@
     githubId = 7389000;
     name = "Dominic Wrege";
   };
+  dwt = {
+    email = "spamfaenger@gmx.de";
+    github = "dwt";
+    githubId = 57199;
+    name = "Martin Häcker";
+  };
   dxf = {
     email = "dingxiangfei2009@gmail.com";
     github = "dingxiangfei2009";

--- a/pkgs/by-name/ko/korrect/package.nix
+++ b/pkgs/by-name/ko/korrect/package.nix
@@ -1,0 +1,38 @@
+{
+  lib,
+  stdenv,
+  fetchCrate,
+  rustPlatform,
+  installShellFiles,
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "korrect";
+  version = "0.1.3";
+
+  src = fetchCrate {
+    inherit (finalAttrs) pname version;
+    hash = "sha256-U363YI1CQg7KAUtzN2GPm4fNnD3TgJy+6hT/3JZ8e2s=";
+  };
+  cargoHash = "sha256-WP03Gv+Nai834xurVzdzV4uLA8fT/lbdu4zGWUgDKJo=";
+
+  passthru.updateScript = nix-update-script { };
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+    installShellCompletion --cmd ${finalAttrs.meta.mainProgram} \
+      --bash <($out/bin/${finalAttrs.meta.mainProgram} completions bash) \
+      --fish <($out/bin/${finalAttrs.meta.mainProgram} completions fish) \
+      --zsh <($out/bin/${finalAttrs.meta.mainProgram} completions zsh)
+  '';
+
+  meta = {
+    description = "Kubectl version managing shim that invokes the correct kubectl version";
+    homepage = "https://gitlab.com/cromulentbanana/korrect";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.dwt ];
+    mainProgram = "korrect";
+  };
+})


### PR DESCRIPTION
## Things done

Added the tool korrect which helps with always using the correct version of kubectl (and downloading that version when necessary) when talking to kubernetes clusters. This is necessary, because there can be at most a 3 version split between between the version of kubectl (on your system) and the version of the kubernetes cluster.

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
