### PR TITLE
python3Packages.pytest-postgresql-darwin: disable checkPhase on darwin

### DIFF
--- a/pkgs/development/python-modules/pytest-postgresql/default.nix
+++ b/pkgs/development/python-modules/pytest-postgresql/default.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildPythonPackage,
   fetchFromGitHub,
   pytestCheckHook,
@@ -62,7 +63,9 @@ buildPythonPackage rec {
     "pytest_postgresql.executor"
   ];
 
-  __darwinAllowLocalNetworking = true;
+  # Can't reliably run checkPhase on darwin because of nix bug, see:
+  #  https://github.com/NixOS/nixpkgs/issues/371242
+  doCheck = !stdenv.buildPlatform.isDarwin;
 
   meta = {
     homepage = "https://pypi.python.org/pypi/pytest-postgresql";


### PR DESCRIPTION
This is because the checkPhase can't be run consistently on darwin due to a nix bug described in #371242.

ZHF: #403336

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
