### PR TITLE
python3Packages.sjcl: fix build

### DIFF
--- a/pkgs/development/python-modules/sjcl/default.nix
+++ b/pkgs/development/python-modules/sjcl/default.nix
@@ -2,32 +2,34 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+  setuptools,
   pycryptodome,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage {
   pname = "sjcl";
   version = "0.2.1";
-
-  format = "setuptools";
+  pyproject = true;
 
   # PyPi release is missing tests
   src = fetchFromGitHub {
     owner = "berlincode";
-    repo = pname;
+    repo = "sjcl";
     # commit from: 2018-08-16, because there aren't any tags on git
     rev = "e8bdad312fa99c89c74f8651a1240afba8a9f3bd";
-    sha256 = "1v8rc55v28v8cl7nxcavj34am005wi63zcvwnbc6pyfbv4ss30ab";
+    hash = "sha256-S4GhNdnL+WvYsnyzP0zkBYCqyJBbsW4PZWgjsUthGe0=";
   };
 
-  propagatedBuildInputs = [ pycryptodome ];
+  build-system = [ setuptools ];
+
+  dependencies = [ pycryptodome ];
 
   pythonImportsCheck = [ "sjcl" ];
 
-  meta = with lib; {
-    description = "Decrypt and encrypt messages compatible to the \"Stanford Javascript Crypto Library (SJCL)\" message format. This is a wrapper around pycrypto";
+  meta = {
+    description = "Decrypt and encrypt messages compatible to the \"Stanford Javascript Crypto Library (SJCL)\" message format";
     homepage = "https://github.com/berlincode/sjcl";
-    license = licenses.bsd3;
-    maintainers = with maintainers; [ binsky ];
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ binsky ];
   };
 }

--- a/pkgs/development/python-modules/sjcl/default.nix
+++ b/pkgs/development/python-modules/sjcl/default.nix
@@ -3,7 +3,6 @@
   buildPythonPackage,
   fetchFromGitHub,
   pycryptodome,
-  unittestCheckHook,
 }:
 
 buildPythonPackage rec {
@@ -22,8 +21,6 @@ buildPythonPackage rec {
   };
 
   propagatedBuildInputs = [ pycryptodome ];
-
-  nativeCheckInputs = [ unittestCheckHook ];
 
   pythonImportsCheck = [ "sjcl" ];
 


### PR DESCRIPTION
sjcl was never running any unit tests in nixpkgs anyways[1], and python
3.12 seems to have introduced an error when no unit test is being run.

[1]: https://hydra.nixos.org/build/176216230/log/tail

ZHF: #403336
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
