### PR TITLE
nixos-rebuild-ng: kill underlying remote process

### DIFF
--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/__init__.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/__init__.py
@@ -5,7 +5,7 @@ import os
 import sys
 from pathlib import Path
 from subprocess import CalledProcessError, run
-from typing import assert_never
+from typing import Final, assert_never
 
 from . import nix, tmpdir
 from .constants import EXECUTABLE, WITH_NIX_2_18, WITH_REEXEC, WITH_SHELL_FILES
@@ -13,7 +13,7 @@ from .models import Action, BuildAttr, Flake, ImageVariants, NRError, Profile
 from .process import Remote, cleanup_ssh
 from .utils import Args, LogFormatter, tabulate
 
-logger = logging.getLogger()
+logger: Final = logging.getLogger()
 logger.setLevel(logging.INFO)
 
 

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/constants.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/constants.py
@@ -1,9 +1,11 @@
+from typing import Final
+
 # Build-time flags
 # Use strings to avoid breaking standalone (e.g.: `python -m nixos_rebuild`)
 # usage
-EXECUTABLE = "@executable@"
+EXECUTABLE: Final[str] = "@executable@"
 # Use either `== "true"` if the default (e.g.: `python -m nixos_rebuild`) is
 # `False` or `!= "false"` if the default is `True`
-WITH_NIX_2_18 = "@withNix218@" != "false"  # type: ignore
-WITH_REEXEC = "@withReexec@" == "true"  # type: ignore
-WITH_SHELL_FILES = "@withShellFiles@" == "true"  # type: ignore
+WITH_NIX_2_18: Final[bool] = "@withNix218@" != "false"
+WITH_REEXEC: Final[bool] = "@withReexec@" == "true"
+WITH_SHELL_FILES: Final[bool] = "@withShellFiles@" == "true"

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/nix.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/nix.py
@@ -45,7 +45,7 @@ SWITCH_TO_CONFIGURATION_CMD_PREFIX: Final = [
     "--service-type=exec",
     "--unit=nixos-rebuild-switch-to-configuration",
 ]
-logger = logging.getLogger(__name__)
+logger: Final = logging.getLogger(__name__)
 
 
 def build(

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/process.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/process.py
@@ -11,7 +11,7 @@ from typing import Final, Self, TypedDict, Unpack
 
 from . import tmpdir
 
-logger = logging.getLogger(__name__)
+logger: Final = logging.getLogger(__name__)
 
 SSH_DEFAULT_OPTS: Final = [
     "-o",

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/process.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/process.py
@@ -1,6 +1,7 @@
 import atexit
 import logging
 import os
+import re
 import shlex
 import subprocess
 from collections.abc import Sequence
@@ -20,6 +21,8 @@ SSH_DEFAULT_OPTS: Final = [
     "-o",
     "ControlPersist=60",
 ]
+
+type Args = Sequence[str | bytes | os.PathLike[str] | os.PathLike[bytes]]
 
 
 @dataclass(frozen=True)
@@ -82,7 +85,7 @@ atexit.register(cleanup_ssh)
 
 
 def run_wrapper(
-    args: Sequence[str | bytes | os.PathLike[str] | os.PathLike[bytes]],
+    args: Args,
     *,
     check: bool = True,
     extra_env: dict[str, str] | None = None,
@@ -93,6 +96,8 @@ def run_wrapper(
     "Wrapper around `subprocess.run` that supports extra functionality."
     env = None
     process_input = None
+    run_args = args
+
     if remote:
         if extra_env:
             extra_env_args = [f"{env}={value}" for env, value in extra_env.items()]
@@ -103,7 +108,7 @@ def run_wrapper(
                 process_input = remote.sudo_password + "\n"
             else:
                 args = ["sudo", *args]
-        args = [
+        run_args = [
             "ssh",
             *remote.opts,
             *SSH_DEFAULT_OPTS,
@@ -119,32 +124,39 @@ def run_wrapper(
         if extra_env:
             env = os.environ | extra_env
         if sudo:
-            args = ["sudo", *args]
+            run_args = ["sudo", *run_args]
 
     logger.debug(
         "calling run with args=%r, kwargs=%r, extra_env=%r",
-        args,
+        run_args,
         kwargs,
         extra_env,
     )
 
     try:
         r = subprocess.run(
-            args,
+            run_args,
             check=check,
             env=env,
             input=process_input,
-            # Hope nobody is using NixOS with non-UTF8 encodings, but "surrogateescape"
-            # should still work in those systems.
+            # Hope nobody is using NixOS with non-UTF8 encodings, but
+            # "surrogateescape" should still work in those systems.
             text=True,
             errors="surrogateescape",
             **kwargs,
         )
 
         if kwargs.get("capture_output") or kwargs.get("stderr") or kwargs.get("stdout"):
-            logger.debug("captured output stdout=%r, stderr=%r", r.stdout, r.stderr)
+            logger.debug(
+                "captured output with stdout=%r, stderr=%r", r.stdout, r.stderr
+            )
 
         return r
+    except KeyboardInterrupt:
+        # sudo commands are activation only and unlikely to be long running
+        if remote and not sudo:
+            _kill_long_running_ssh_process(args, remote)
+        raise
     except subprocess.CalledProcessError:
         if sudo and remote and remote.sudo_password is None:
             logger.error(
@@ -152,3 +164,42 @@ def run_wrapper(
                 + "--ask-sudo-password?"
             )
         raise
+
+
+# SSH does not send the signals to the process when running without usage of
+# pseudo-TTY (that causes a whole other can of worms), so if the process is
+# long running (e.g.: a build) this will result in the underlying process
+# staying alive.
+# See: https://stackoverflow.com/a/44354466
+# Issue: https://github.com/NixOS/nixpkgs/issues/403269
+def _kill_long_running_ssh_process(args: Args, remote: Remote) -> None:
+    logger.info("cleaning-up remote process, please wait...")
+
+    # We need to escape both the shell and regex here (since pkill interprets
+    # its arguments as regex)
+    quoted_args = re.escape(shlex.join(str(a) for a in args))
+    logger.debug("killing remote process using pkill with args=%r", quoted_args)
+    r = subprocess.run(
+        [
+            "ssh",
+            *remote.opts,
+            *SSH_DEFAULT_OPTS,
+            remote.host,
+            "--",
+            "pkill",
+            "--signal",
+            "SIGINT",
+            "--full",
+            "--",
+            quoted_args,
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    logger.debug(
+        "remote pkill captured output with stdout=%r, stderr=%r, returncode=%s",
+        r.stdout,
+        r.stderr,
+        r.returncode,
+    )


### PR DESCRIPTION
`nixos-rebuild-ng` explicitly don't allocate a pseudo-TTY for SSH because this causes lots of issues depending on the use case (for example, multiplexing multiple SSH sessions).

Sadly not using a pseudo-TTY also cause other issues, like the fact that using Ctrl+C (SIGINT) doesn't kill the underlying process because SSH doesn't support it.

We can't really start using pseudo-TTY unless we want to overcomplicate the code for parsing results (pseudo-TTY mangles the stdout/stderr together), so we need to handle killing the underlying remote process manually.

This is what this commit does, when we receive a `KeyboardInterrupt` exception while calling `run_wrapper`, we will check if it is a remote process and send a `pkill --full` with the arguments (this should ensure that we don't kill other process, but we can't guarantee it). This assumes the user has `procps` installed, but I think it is a safe assumption since this seems to be a core package.

Sadly nothing we can do if the user doesn't have `procps` installed, the good thing is that the worst that can happen is that we will silent fail and the process will stay in background until it finishes.

Fix #403269.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
