### PR TITLE
stestrCheckHook: init

### DIFF
--- a/doc/languages-frameworks/python.section.md
+++ b/doc/languages-frameworks/python.section.md
@@ -568,6 +568,7 @@ are used in [`buildPythonPackage`](#buildpythonpackage-function).
 - `pythonRemoveBinBytecode` to remove bytecode from the `/bin` folder.
 - `setuptoolsBuildHook` to build a wheel using `setuptools`.
 - `sphinxHook` to build documentation and manpages using Sphinx.
+- `stestrCheckHook` to run tests with `stestr`.
 - `venvShellHook` to source a Python 3 `venv` at the `venvDir` location. A
   `venv` is created if it does not yet exist. `postVenvCreation` can be used to
   to run commands only after venv is first created.

--- a/pkgs/development/interpreters/python/hooks/default.nix
+++ b/pkgs/development/interpreters/python/hooks/default.nix
@@ -438,6 +438,19 @@ in
     } ./setuptools-rust-hook.sh
   ) { };
 
+  stestrCheckHook = callPackage (
+    { makePythonHook }:
+    makePythonHook {
+      name = "stestr-check-hook";
+      propagatedBuildInputs = [
+        stestr
+      ];
+      substitutions = {
+        inherit pythonCheckInterpreter;
+      };
+    } ./stestr-check-hook.sh
+  ) { };
+
   unittestCheckHook = callPackage (
     { makePythonHook }:
     makePythonHook {

--- a/pkgs/development/interpreters/python/hooks/stestr-check-hook.sh
+++ b/pkgs/development/interpreters/python/hooks/stestr-check-hook.sh
@@ -1,0 +1,19 @@
+# Setup hook for stestr.
+# shellcheck shell=bash
+
+echo "Sourcing stestr-check-hook"
+
+stestrCheckPhase() {
+    echo "Executing stestrCheckPhase"
+    runHook preCheck
+
+    @pythonCheckInterpreter@ -m stestr run
+
+    runHook postCheck
+    echo "Finished executing stestrCheckPhase"
+}
+
+if [[ -z "${dontUseStestrCheck-}" ]] && [[ -z "${installCheckPhase-}" ]]; then
+    echo "Using stestrCheckPhase"
+    appendToVar preDistPhases stestrCheckPhase
+fi

--- a/pkgs/development/python-modules/osc-placement/default.nix
+++ b/pkgs/development/python-modules/osc-placement/default.nix
@@ -12,7 +12,7 @@
   pythonOlder,
   setuptools,
   sphinxHook,
-  stestr,
+  stestrCheckHook,
 }:
 
 buildPythonPackage rec {
@@ -53,14 +53,8 @@ buildPythonPackage rec {
   nativeCheckInputs = [
     oslo-serialization
     oslotest
-    stestr
+    stestrCheckHook
   ];
-
-  checkPhase = ''
-    runHook preCheck
-    stestr run
-    runHook postCheck
-  '';
 
   pythonImportsCheck = [ "osc_placement" ];
 


### PR DESCRIPTION
This adds a useful hook to be used for projects that use stestr,
it is primiative at the moment but covers most scenarios for using
it.

This PR also changes a Python module to start using it, once it
lands, follow up PRs can update all of them to use it tree-wide.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
