### PR TITLE
python313Packages.hieroglyph: fix build failure

### DIFF
--- a/pkgs/development/python-modules/hieroglyph/default.nix
+++ b/pkgs/development/python-modules/hieroglyph/default.nix
@@ -1,23 +1,58 @@
 {
   lib,
-  fetchPypi,
   buildPythonPackage,
-  isPy27,
+  fetchFromGitHub,
+  fetchpatch,
+
+  # build-system
+  setuptools,
+
+  # dependencies
   sphinx,
 }:
 
 buildPythonPackage rec {
   pname = "hieroglyph";
   version = "2.1.0";
-  format = "setuptools";
-  disabled = isPy27; # python2 compatible sphinx is too low
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "b4b5db13a9d387438e610c2ca1d81386ccd206944d9a9dd273f21874486cddaf";
+  src = fetchFromGitHub {
+    owner = "nyergler";
+    repo = "hieroglyph";
+    tag = "hieroglyph-${version}";
+    hash = "sha256-nr5cHF0Lg2mjQvnOoM5HCmMUiGh1QOeTD0nc8BvCBOE=";
   };
 
-  propagatedBuildInputs = [ sphinx ];
+  pyproject = true;
+
+  build-system = [ setuptools ];
+
+  patches = [
+    # https://github.com/nyergler/hieroglyph/pull/177hieroglyph-quickstart
+    (fetchpatch {
+      name = "hieroglyph-upgrade-versioneer";
+      url = "https://github.com/nyergler/hieroglyph/commit/9cebee269ac10964b2436c0204156b7bd620a3d4.patch";
+      hash = "sha256-ZvU7uASU727/NUAW8I7k9idzMpEdnuwRshdHm2/GQ3w=";
+    })
+    # https://github.com/nyergler/hieroglyph/pull/174
+    (fetchpatch {
+      name = "hieroglyph-slide-builder-type-error";
+      url = "https://github.com/nyergler/hieroglyph/pull/174/commits/d75c550f797e3635d33db11f50968755288962a7.patch";
+      hash = "sha256-qNQVgWL9jy0cwtxKUbWi3Qc77RU2H3raN0BzBjDk9C8=";
+    })
+  ];
+
+  # load_additional_themes has been deprecated, need to use its deprecated name
+  postPatch = ''
+    substituteInPlace src/hieroglyph/builder.py \
+      --replace-fail "theme_factory.load_additional_themes" "theme_factory._load_additional_themes"
+  '';
+
+  dependencies = [
+    setuptools
+    sphinx
+  ];
+
+  pythonImportsCheck = [ "hieroglyph" ];
 
   # all tests fail; don't know why:
   # test_absolute_paths_made_relative (hieroglyph.tests.test_path_fixing.PostProcessImageTests) ... ERROR


### PR DESCRIPTION
Hydra was failing on an ancient dependency https://hydra.nixos.org/build/294850021
```
Traceback (most recent call last):
  File "/private/tmp/nix-build-python3.12-hieroglyph-2.1.0.drv-0/hieroglyph-2.1.0/nix_run_setup", line 8, in <module>
    exec(compile(getattr(tokenize, 'open', open)(__file__).read().replace('\\r\\n', '\\n'), __file__, 'exec'))
  File "setup.py", line 19, in <module>
    version=versioneer.get_version(),
            ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/private/tmp/nix-build-python3.12-hieroglyph-2.1.0.drv-0/hieroglyph-2.1.0/versioneer.py", line 1480, in get_version
    return get_versions()["version"]
           ^^^^^^^^^^^^^^
  File "/private/tmp/nix-build-python3.12-hieroglyph-2.1.0.drv-0/hieroglyph-2.1.0/versioneer.py", line 1412, in get_versions
    cfg = get_config_from_root(root)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/private/tmp/nix-build-python3.12-hieroglyph-2.1.0.drv-0/hieroglyph-2.1.0/versioneer.py", line 342, in get_config_from_root
    parser = configparser.SafeConfigParser()
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: module 'configparser' has no attribute 'SafeConfigParser'. Did you mean: 'RawConfigParser'?
```

Fixes:
1. Pulled in a patch to fix this
2. Switched from PyPi to building from source
3. Added imports check
4. Removed python2 references
5. Pulled in an additional patch found when running `make slides`

Also brought up the imports and python building up to current practice.

ZHF: #403336

P.S. Experimented with getting the tests working, but discovered it would require substantial upstream work.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [x] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
