### PR TITLE
python313Packages.reflex: 0.7.8 -> 0.7.10

### DIFF
--- a/pkgs/development/python-modules/reflex-hosting-cli/default.nix
+++ b/pkgs/development/python-modules/reflex-hosting-cli/default.nix
@@ -18,14 +18,14 @@
 
 buildPythonPackage rec {
   pname = "reflex-hosting-cli";
-  version = "0.1.47";
+  version = "0.1.49";
   pyproject = true;
 
   # source is not published https://github.com/reflex-dev/reflex/issues/3762
   src = fetchPypi {
     pname = "reflex_hosting_cli";
     inherit version;
-    hash = "sha256-RPXdLcnuXBDXQGfgFo5EZ+MoBr7nnJmVD1xSRwkWFDY=";
+    hash = "sha256-cIU2/hTxXtAsxn5twV8xGwAOcRfqBjeqL4dklXt5fkQ=";
   };
 
   pythonRelaxDeps = [

--- a/pkgs/development/python-modules/reflex-hosting-cli/default.nix
+++ b/pkgs/development/python-modules/reflex-hosting-cli/default.nix
@@ -2,7 +2,7 @@
   lib,
   buildPythonPackage,
   fetchPypi,
-  poetry-core,
+  hatchling,
   charset-normalizer,
   httpx,
   pipdeptree,
@@ -18,14 +18,14 @@
 
 buildPythonPackage rec {
   pname = "reflex-hosting-cli";
-  version = "0.1.42";
+  version = "0.1.47";
   pyproject = true;
 
   # source is not published https://github.com/reflex-dev/reflex/issues/3762
   src = fetchPypi {
     pname = "reflex_hosting_cli";
     inherit version;
-    hash = "sha256-kp2S3xnclMktEi6aqMBahQVZQeLriSigq77mRu+7A9I=";
+    hash = "sha256-RPXdLcnuXBDXQGfgFo5EZ+MoBr7nnJmVD1xSRwkWFDY=";
   };
 
   pythonRelaxDeps = [
@@ -33,7 +33,7 @@ buildPythonPackage rec {
     "pipdeptree"
   ];
 
-  build-system = [ poetry-core ];
+  build-system = [ hatchling ];
 
   dependencies = [
     charset-normalizer

--- a/pkgs/development/python-modules/reflex/default.nix
+++ b/pkgs/development/python-modules/reflex/default.nix
@@ -5,17 +5,13 @@
   alembic,
   attrs,
   build,
-  charset-normalizer,
   ruff,
   dill,
-  distro,
   fastapi,
   granian,
-  gunicorn,
   hatchling,
   httpx,
   jinja2,
-  lazy-loader,
   numpy,
   packaging,
   pandas,
@@ -29,7 +25,6 @@
   pytest-mock,
   python-dotenv,
   pytestCheckHook,
-  python-engineio,
   python-multipart,
   python-socketio,
   redis,
@@ -37,28 +32,25 @@
   rich,
   sqlmodel,
   starlette-admin,
-  tomlkit,
-  twine,
   typer,
   typing-extensions,
   unzip,
   uvicorn,
   versionCheckHook,
-  wheel,
   wrapt,
   writableTmpDirAsHomeHook,
 }:
 
 buildPythonPackage rec {
   pname = "reflex";
-  version = "0.7.8";
+  version = "0.7.9";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "reflex-dev";
     repo = "reflex";
     tag = "v${version}";
-    hash = "sha256-/Kf1V1goGaoYarhJ9wlZ2lf6e3BUH/F7UJqoPEnMnk0=";
+    hash = "sha256-xY1A618BUciWbHtCPUVPZz/41PBVId4qI6WlCFOdoT8=";
   };
 
   # 'rich' is also somehow checked when building the wheel,
@@ -70,7 +62,6 @@ buildPythonPackage rec {
     "rich"
     # preventative
     "fastapi"
-    "gunicorn"
   ];
 
   build-system = [ hatchling ];
@@ -78,35 +69,24 @@ buildPythonPackage rec {
   dependencies = [
     alembic
     build # used in custom_components/custom_components.py
-    charset-normalizer
-    ruff
-    dill
-    distro
+    dill # used in state.py
     fastapi
     granian
     granian.optional-dependencies.reload
-    gunicorn
     httpx
     jinja2
-    lazy-loader
-    packaging
+    packaging # used in utils/prerequisites.py
     platformdirs
     psutil
     pydantic
-    python-engineio
     python-multipart
     python-socketio
     redis
     reflex-hosting-cli
     rich
     sqlmodel
-    starlette-admin
-    tomlkit
-    twine # used in custom_components/custom_components.py
-    typer
+    typer # optional dep
     typing-extensions
-    uvicorn
-    wheel
     wrapt
   ];
 
@@ -123,6 +103,8 @@ buildPythonPackage rec {
     pandas
     pillow
     unzip
+    uvicorn
+    starlette-admin
     writableTmpDirAsHomeHook
     versionCheckHook
   ];

--- a/pkgs/development/python-modules/reflex/default.nix
+++ b/pkgs/development/python-modules/reflex/default.nix
@@ -43,14 +43,14 @@
 
 buildPythonPackage rec {
   pname = "reflex";
-  version = "0.7.9";
+  version = "0.7.10";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "reflex-dev";
     repo = "reflex";
     tag = "v${version}";
-    hash = "sha256-xY1A618BUciWbHtCPUVPZz/41PBVId4qI6WlCFOdoT8=";
+    hash = "sha256-4A/pemu8inIoHjF1Q7INtaEQe4zOU48n4DpwQogtzb4=";
   };
 
   # 'rich' is also somehow checked when building the wheel,


### PR DESCRIPTION
- **python313Packages.reflex: 0.7.8 -> 0.7.10**
- **python313Packages.reflex-hosting-cli: 0.1.42 -> 0.1.49**


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
