### PR TITLE
lib.systems.elaborate.canExecute: handle different gcc.arch

### DIFF
--- a/lib/systems/architectures.nix
+++ b/lib/systems/architectures.nix
@@ -494,6 +494,70 @@ rec {
       loongson2f = [ ];
     };
 
+  /**
+    Check whether one GCC architecture has the the other inferior architecture.
+
+    # Inputs
+
+    `arch1`
+    : GCC architecture in string
+
+    `arch2`
+    : GCC architecture in string
+
+    # Type
+
+    ```
+    hasInferior :: string -> string -> bool
+    ```
+
+    # Examples
+    ::: {.example}
+    ## `lib.systems.architectures.hasInferior` usage example
+
+    ```nix
+    hasInferior "x86-64-v3" "x86-64"
+    => true
+    hasInferior "x86-64" "x86-64-v3"
+    => false
+    hasInferior "x86-64" "x86-64"
+    => false
+    ```
+  */
+  hasInferior = arch1: arch2: inferiors ? ${arch1} && lib.elem arch2 inferiors.${arch1};
+
+  /**
+    Check whether one GCC architecture can execute the other.
+
+    # Inputs
+
+    `arch1`
+    : GCC architecture in string
+
+    `arch2`
+    : GCC architecture in string
+
+    # Type
+
+    ```
+    canExecute :: string -> string -> bool
+    ```
+
+    # Examples
+    ::: {.example}
+    ## `lib.systems.architectures.canExecute` usage example
+
+    ```nix
+    canExecute "x86-64" "x86-64-v3"
+    => false
+    canExecute "x86-64-v3" "x86-64"
+    => true
+    canExecute "x86-64" "x86-64"
+    => true
+    ```
+  */
+  canExecute = arch1: arch2: arch1 == arch2 || hasInferior arch1 arch2;
+
   predicates =
     let
       featureSupport = feature: x: builtins.elem feature features.${x} or [ ];

--- a/lib/systems/default.nix
+++ b/lib/systems/default.nix
@@ -97,7 +97,21 @@ let
             platform:
             final.isAndroid == platform.isAndroid
             && parse.isCompatible final.parsed.cpu platform.parsed.cpu
-            && final.parsed.kernel == platform.parsed.kernel;
+            && final.parsed.kernel == platform.parsed.kernel
+            && (
+              # Only perform this check when cpus have the same type;
+              # assume compatible cpu have all the instructions included
+              final.parsed.cpu == platform.parsed.cpu
+              ->
+                # if both have gcc.arch defined, check whether final can execute the given platform
+                (
+                  (final ? gcc.arch && platform ? gcc.arch)
+                  -> architectures.canExecute final.gcc.arch platform.gcc.arch
+                )
+                # if platform has gcc.arch defined but final doesn't, don't assume it can be executed
+                || (platform ? gcc.arch -> !(final ? gcc.arch))
+            );
+
           isCompatible =
             _:
             throw "2022-05-23: isCompatible has been removed in favor of canExecute, refer to the 22.11 changelog for details";


### PR DESCRIPTION
As the comment https://github.com/NixOS/nixpkgs/blob/master/lib/systems/architectures.nix#L341 suggests, `canExecute` will get `gcc.arch` into consideration now.

This is helpful for e.g. https://github.com/NixOS/nixpkgs/pull/403201, where if `stdenv.buildPlatform` is `loongarch64`, and `stdenv.hostPlatform` is `loongarch64_nosimd`, `stdenv.buildPlatform.canExecute stdenv.hostPlatform` should be `true`, but not vice-versa. By incorporating this PR into the above PR and testing eval, we can get results that are consistent with expectations said. This will also help us in the later work of raising x86_64 feature level.

Please check carefully whether the logic here matches our expectations.

I'm not sure if this is a breaking change or not.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
