### PR TITLE
kanagawa-gtk-theme: 0-unstable-2023-07-03 -> 0-unstable-2025-04-24, kanagawa-icon-theme: 0-unstable-2023-07-03 -> 0-unstable-2025-04-24

### DIFF
--- a/pkgs/by-name/ka/kanagawa-icon-theme/package.nix
+++ b/pkgs/by-name/ka/kanagawa-icon-theme/package.nix
@@ -7,13 +7,13 @@
 }:
 stdenvNoCC.mkDerivation {
   pname = "kanagawa-icon-theme";
-  version = "0-unstable-2023-07-03";
+  version = "0-unstable-2025-04-24";
 
   src = fetchFromGitHub {
     owner = "Fausto-Korpsvart";
     repo = "Kanagawa-GKT-Theme";
-    rev = "35936a1e3bbd329339991b29725fc1f67f192c1e";
-    hash = "sha256-BZRmjVas8q6zsYbXFk4bCk5Ec/3liy9PQ8fqFGHAXe0=";
+    rev = "825ac8d90e16ce612b487f29ee6db60b5dc63012";
+    hash = "sha256-YOA3qBtMcz0to2yOStd33rF4NGhZWiLAJMo7MHx9nqM=";
   };
 
   nativeBuildInputs = [
@@ -43,6 +43,6 @@ stdenvNoCC.mkDerivation {
     homepage = "https://github.com/Fausto-Korpsvart/Kanagawa-GKT-Theme";
     license = licenses.gpl3Only;
     maintainers = with maintainers; [ iynaix ];
-    platforms = gtk3.meta.platforms;
+    platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
Updated for Gnome 48 support.

**BREAKING CHANGE**: upstream is now using an install script similar to the one used by colloid-gtk-theme. The default arguments generate the following themes:

```
Kanagawa-Dark
Kanagawa-Dark-hdpi
Kanagawa-Dark-xhdpi
Kanagawa-Light
Kanagawa-Light-hdpi
Kanagawa-Light-xhdpi
```

Diff: https://github.com/Fausto-Korpsvart/Kanagawa-GKT-Theme/compare/35936a1e3bbd329339991b29725fc1f67f192c1e...825ac8d90e16ce612b487f29ee6db60b5dc63012

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
