### PR TITLE
fzf-tab-completion: init at 0-unstable-2026-01-31

### DIFF
--- a/pkgs/by-name/fz/fzf-tab-completion/package.nix
+++ b/pkgs/by-name/fz/fzf-tab-completion/package.nix
@@ -1,0 +1,59 @@
+{
+  fetchFromGitHub,
+  lib,
+  nix-update-script,
+  rustPlatform,
+  stdenvNoCC,
+  withReadlineSupport ? !stdenvNoCC.hostPlatform.isAarch,
+}:
+
+let
+  drvArgs = {
+    pname = "fzf-tab-completion";
+    version = "0-unstable-2025-01-20";
+
+    src = fetchFromGitHub {
+      owner = "lincheney";
+      repo = "fzf-tab-completion";
+      rev = "4850357beac6f8e37b66bd78ccf90008ea3de40b";
+      hash = "sha256-pgcrRRbZaLoChVPeOvw4jjdDCokUK1ew0Wfy42bXfQo=";
+    };
+
+    strictDeps = true;
+
+    postInstall = ''
+      install -Dt $out/share/fzf-tab-completion \
+        bash/fzf-bash-completion.sh \
+        node/fzf-node-completion.js \
+        python/fzf_python_completion.py \
+        zsh/fzf-zsh-completion.sh
+    '';
+
+    passthru.updateScript = nix-update-script {
+      extraArgs = [ "--version=branch" ];
+    };
+
+    meta = {
+      description = "Tab completion using fzf";
+      homepage = "https://github.com/lincheney/fzf-tab-completion";
+      license = lib.licenses.gpl3Only;
+      maintainers = [ lib.maintainers.bmrips ];
+      platforms = lib.platforms.all;
+    };
+  };
+in
+
+if !withReadlineSupport then
+  stdenvNoCC.mkDerivation drvArgs
+else
+  rustPlatform.buildRustPackage (
+    drvArgs
+    // {
+      sourceRoot = "source/readline/";
+      cargoHash = "sha256-Y9zQej5tW3DkptwnqdxxJTFgh1RL/r8xZultCoz0nYg=";
+      postInstall = ''
+        env -C .. install -Dt $out/bin/ readline/bin/rl_custom_complete
+        env -C .. ${drvArgs.postInstall}
+      '';
+    }
+  )

--- a/pkgs/by-name/fz/fzf-tab-completion/package.nix
+++ b/pkgs/by-name/fz/fzf-tab-completion/package.nix
@@ -1,0 +1,60 @@
+{
+  fetchFromGitHub,
+  lib,
+  nix-update-script,
+  rustPlatform,
+  stdenvNoCC,
+  withReadlineSupport ? !stdenvNoCC.hostPlatform.isAarch,
+}:
+
+let
+  drvArgs = {
+    pname = "fzf-tab-completion";
+    version = "0-unstable-2026-01-31";
+
+    src = fetchFromGitHub {
+      owner = "lincheney";
+      repo = "fzf-tab-completion";
+      rev = "7014e0a7cd68fe3530e2f58c45740d17e98f05b8";
+      hash = "sha256-qxHvd91QOv4LATikWGaL4AqEM52volP8TCYXhpZKtsA=";
+    };
+
+    __structuredAttrs = true;
+    strictDeps = true;
+
+    postInstall = ''
+      install -Dt $out/share/fzf-tab-completion \
+        bash/fzf-bash-completion.sh \
+        node/fzf-node-completion.js \
+        python/fzf_python_completion.py \
+        zsh/fzf-zsh-completion.sh
+    '';
+
+    passthru.updateScript = nix-update-script {
+      extraArgs = [ "--version=branch" ];
+    };
+
+    meta = {
+      description = "Tab completion using fzf";
+      homepage = "https://github.com/lincheney/fzf-tab-completion";
+      license = lib.licenses.gpl3Only;
+      maintainers = [ lib.maintainers.bmrips ];
+      platforms = lib.platforms.all;
+    };
+  };
+in
+
+if !withReadlineSupport then
+  stdenvNoCC.mkDerivation drvArgs
+else
+  rustPlatform.buildRustPackage (
+    drvArgs
+    // {
+      sourceRoot = "source/readline/";
+      cargoHash = "sha256-Y9zQej5tW3DkptwnqdxxJTFgh1RL/r8xZultCoz0nYg=";
+      postInstall = ''
+        env -C .. install -Dt $out/bin/ readline/bin/rl_custom_complete
+        env -C .. ${drvArgs.postInstall}
+      '';
+    }
+  )

--- a/pkgs/by-name/rl/rl_custom_function/package.nix
+++ b/pkgs/by-name/rl/rl_custom_function/package.nix
@@ -1,0 +1,33 @@
+{
+  lib,
+  fetchFromGitHub,
+  nix-update-script,
+  rustPlatform,
+}:
+
+rustPlatform.buildRustPackage {
+  pname = "rl_custom_function";
+  version = "0-unstable-2023-03-02";
+
+  src = fetchFromGitHub {
+    owner = "lincheney";
+    repo = "rl_custom_function";
+    rev = "398f757aa3a098a7e2a1e0bf8a8746c16bdf2f2d";
+    hash = "sha256-A8k3ciFyYqHwVo2AjfGfxpqvL+ej39Yqfw2Fizby5BM=";
+  };
+
+  cargoHash = "sha256-TFOlsWX9PJkOnsqU7JcLhzXX5tNgJUp5z8GKOT/kulU=";
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [ "--version=branch" ];
+  };
+
+  meta = {
+    description = "Inject custom functions into readline";
+    homepage = "https://github.com/lincheney/rl_custom_function";
+    license = lib.licenses.gpl3Only;
+    maintainers = [ lib.maintainers.bmrips ];
+    platforms = lib.platforms.all;
+    badPlatforms = [ lib.systems.inspect.patterns.isAarch ];
+  };
+}

--- a/pkgs/by-name/rl/rl_custom_function/package.nix
+++ b/pkgs/by-name/rl/rl_custom_function/package.nix
@@ -1,0 +1,35 @@
+{
+  lib,
+  fetchFromGitHub,
+  nix-update-script,
+  rustPlatform,
+}:
+
+rustPlatform.buildRustPackage {
+  pname = "rl_custom_function";
+  version = "0-unstable-2023-03-02";
+
+  src = fetchFromGitHub {
+    owner = "lincheney";
+    repo = "rl_custom_function";
+    rev = "398f757aa3a098a7e2a1e0bf8a8746c16bdf2f2d";
+    hash = "sha256-A8k3ciFyYqHwVo2AjfGfxpqvL+ej39Yqfw2Fizby5BM=";
+  };
+
+  __structuredAttrs = true;
+
+  cargoHash = "sha256-TFOlsWX9PJkOnsqU7JcLhzXX5tNgJUp5z8GKOT/kulU=";
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [ "--version=branch" ];
+  };
+
+  meta = {
+    description = "Inject custom functions into readline";
+    homepage = "https://github.com/lincheney/rl_custom_function";
+    license = lib.licenses.gpl3Only;
+    maintainers = [ lib.maintainers.bmrips ];
+    platforms = lib.platforms.all;
+    badPlatforms = [ lib.systems.inspect.patterns.isAarch ];
+  };
+}


### PR DESCRIPTION
I added derivations for [fzf-tab-completion](https://github.com/lincheney/fzf-tab-completion) and [rl_custom_function](https://github.com/lincheney/rl_custom_function). The former enables completion with fzf in Bash, Zsh, readline, the Python3 REPL, and the Node REPL. The latter is a runtime dependency of fzf-tab-completion.

Note that I did not list rl_custom_function in fzf-tab-completion's `buildInputs` since it is only required to enable fzf-tab-completion in `/etc/environment`, `~/.bash_profile`, etc. See [here](https://github.com/lincheney/fzf-tab-completion#readline) for more information.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

Since the tool is meant to be integrated, I did not create standalone tests but tested it on my own machine through [this home-manager module](https://github.com/bmrips/dotfiles/blob/main/home-manager/modules/programs/fzf-tab-completion.nix).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
