### PR TITLE
python312Packages.meeko: fix build

### DIFF
--- a/pkgs/development/python-modules/meeko/default.nix
+++ b/pkgs/development/python-modules/meeko/default.nix
@@ -2,7 +2,7 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  fetchpatch,
+  gemmi,
   numpy,
   pytestCheckHook,
   pythonOlder,
@@ -24,22 +24,9 @@ buildPythonPackage rec {
     hash = "sha256-ViIBiczwxTwraYn8UnFAZFCFT28v3WEYm04W2YpU/4g=";
   };
 
-  patches = [
-    # https://github.com/forlilab/Meeko/issues/60
-    (fetchpatch {
-      name = "fix-unknown-sidechains.patch";
-      url = "https://github.com/forlilab/Meeko/commit/28c9fbfe3b778aa1bd5e8d7e4f3e6edf44633a0c.patch";
-      hash = "sha256-EJbLnbKTTOsTxKtLiU7Af07yjfY63ungGUHbGvrm0AU=";
-    })
-    (fetchpatch {
-      name = "add-test-data.patch";
-      url = "https://github.com/forlilab/Meeko/commit/57b52e3afffb82685cdd1ef1bf6820d55924b97a.patch";
-      hash = "sha256-nLnyIjT68iaY3lAEbH9EJ5jZflhxABBwDqw8kaRKf3k=";
-    })
-  ];
-
   propagatedBuildInputs = [
     # setup.py only requires numpy but others are needed at runtime
+    gemmi
     numpy
     rdkit
     scipy

--- a/pkgs/development/python-modules/rdkit/default.nix
+++ b/pkgs/development/python-modules/rdkit/default.nix
@@ -117,10 +117,10 @@ buildPythonPackage rec {
     (lib.cmakeBool "RDK_BUILD_INCHI_SUPPORT" true)
     (lib.cmakeBool "RDK_BUILD_MAEPARSER_SUPPORT" true)
     (lib.cmakeBool "RDK_BUILD_THREADSAFE_SSS" true)
+    (lib.cmakeBool "RDK_BUILD_XYZ2MOL_SUPPORT" true)
     (lib.cmakeBool "RDK_BUILD_YAEHMOP_SUPPORT" true)
     (lib.cmakeBool "RDK_INSTALL_INTREE" false)
     (lib.cmakeBool "RDK_INSTALL_STATIC_LIBS" false)
-    (lib.cmakeBool "RDK_TEST_MULTITHREADED" true)
     (lib.cmakeBool "RDK_TEST_MULTITHREADED" true)
     (lib.cmakeBool "RDK_USE_FLEXBISON" false)
     (lib.cmakeBool "RDK_USE_URF" false)
@@ -141,6 +141,7 @@ buildPythonPackage rec {
     "rdkit"
     "rdkit.Chem"
     "rdkit.Chem.AllChem"
+    "rdkit.Chem.rdDetermineBonds"
   ];
 
   meta = with lib; {


### PR DESCRIPTION
- Patches were applied that are already contained in the current version, so I removed them.
- The package imports `rdkit.Chem.rdDetermineBonds`, which requires `rdkit` to be built with xyz2mol support, so I enabled the corresponding flag.
- The package now depends on `gemmi`, so I added it as a dependency.

ZHF: #403336

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
