### PR TITLE
gates_of_skeldal: init at 0-unstable-2025-05-02

### DIFF
--- a/pkgs/by-name/ga/gates_of_skeldal/package.nix
+++ b/pkgs/by-name/ga/gates_of_skeldal/package.nix
@@ -1,0 +1,72 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  fetchpatch,
+  cmake,
+  pkg-config,
+  SDL2,
+  zlib,
+  nix-update-script,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "gates-of-skeldal";
+  version = "0-unstable-2025-05-02";
+
+  src = fetchFromGitHub {
+    owner = "ondra-novak";
+    repo = "gates_of_skeldal";
+    rev = "9013f1038a13d7d2c2bf707d6e860de258fb9d2e";
+    hash = "sha256-a6yH5kq9IBZAAYvM30mUddE6JC+Yzg+6WtgEqcnVje4=";
+  };
+
+  strictDeps = true;
+
+  patches = [
+    # Fix build on darwin
+    (fetchpatch {
+       url = "https://github.com/phodina/gates_of_skeldal/commit/ba500bec5f63acd9cad38a88760f42e9a51dc41f.patch";
+       sha256 = "sha256-awHBgy10tLvh3A0obaOdubX7uR1H/DsNkRzo2btqFCQ=";
+     })
+    # Remove the mylib target on darwin
+    (fetchpatch {
+       url = "https://github.com/phodina/gates_of_skeldal/commit/8d5c5c419a21361ad4a2196dfcadaa8a9f1f1c38.patch";
+       sha256 = "sha256-IrqnFFHbR5+9RNPljdhmp+jFjGARoaFFB8mEsBCedEM=";
+     })
+  ];
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
+
+  buildInputs = [
+    SDL2
+    zlib
+  ];
+
+  preConfigure = ''
+    # Remove -Werror from CMake configuration
+    find . -type f -name 'CMakeLists.txt' -exec sed -i 's/-Werror//g' {} +
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir $out
+    cp --recursive bin $out
+
+    runHook postInstall
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Open source release of the game 'Brány Skeldalu' (Gates of Skeldal)";
+    homepage = "https://github.com/ondra-novak/gates_of_skeldal";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ phodina ];
+  };
+})


### PR DESCRIPTION
Packaged old school rewritten game Gates of Skeldal, requires original files to play.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
