### PR TITLE
gnome48Extensions: init

### DIFF
--- a/pkgs/desktops/gnome/extensions/README.md
+++ b/pkgs/desktops/gnome/extensions/README.md
@@ -1,6 +1,6 @@
 # GNOME Shell extensions
 
-All extensions are packaged automatically. They can be found in the `pkgs.gnomeXYExtensions` for XY being a GNOME version. The package names are the extension’s UUID, which can be a bit unwieldy to use. `pkgs.gnomeExtensions` is a set of manually curated extensions that match the current `gnome.gnome-shell` versions. Their name is human-friendly, compared to the other extensions sets. Some of its extensions are manually packaged.
+All extensions are packaged automatically. They can be found in the `pkgs.gnomeXYExtensions` for XY being a GNOME version. The package names are the extension’s UUID, which can be a bit unwieldy to use. `pkgs.gnomeExtensions` is a set of manually curated extensions that match the current `pkgs.gnome-shell` versions. Their name is human-friendly, compared to the other extensions sets. Some of its extensions are manually packaged.
 
 ## Automatically packaged extensions
 
@@ -8,19 +8,24 @@ The actual packages are created by `buildGnomeExtension.nix`, provided the corre
 
 ### Extensions updates
 
-For everyday updates,
+#### For everyday updates,
 
 1. Run `update-extensions.py`.
 2. Update `extensionRenames.nix` according to the comment at the top.
 
-For GNOME updates,
+#### To package the extensions for new GNOME version,
 
-1. Add a new `gnomeXYExtensions` set
-2. Remove old ones for GNOME versions we don’t want to support any more
-3. Update `supported_versions` in `./update-extensions.py` and re-run it
-4. Change `gnomeExtensions` to the new version
-5. Update `./extensionsRenames.nix` accordingly
-6. Update `all-packages.nix` accordingly (grep for `gnomeExtensions`)
+1. Add a new `gnomeXYExtensions` set in `default.nix`.
+2. Update `all-packages.nix` accordingly. (grep for `gnomeExtensions`)
+3. Update `supported_versions` in `update-extensions.py`.
+4. Follow the [For everyday updates](#for-everyday-updates) section.
+
+#### For GNOME updates,
+
+1. Follow the [To package the extensions for new GNOME version](#to-package-the-extensions-for-new-gnome-version) section if required.
+2. Update `versions_to_merge` variable in `./update-extensions.py`.
+3. Run `update-extensions.py --skip-fetch`, and update `extensionRenames.nix` according to the comment at the top.
+4. Update `gnomeExtensions` in `default.nix` to the new versions.
 
 ## Manually packaged extensions
 

--- a/pkgs/desktops/gnome/extensions/collisions.json
+++ b/pkgs/desktops/gnome/extensions/collisions.json
@@ -4,25 +4,26 @@
     "apps-menu@gnome-shell-extensions.gcampax.github.com"
   ],
   "persian-calendar": [
-    "persian-calendar@iamrezamousavi.gmail.com",
-    "PersianCalendar@oxygenws.com"
+    "PersianCalendar@oxygenws.com",
+    "persian-calendar@iamrezamousavi.gmail.com"
   ],
   "system-monitor": [
-    "system-monitor@gnome-shell-extensions.gcampax.github.com",
-    "System_Monitor@bghome.gmail.com"
+    "System_Monitor@bghome.gmail.com",
+    "system-monitor@gnome-shell-extensions.gcampax.github.com"
   ],
   "fuzzy-clock": [
-    "fuzzy-clock@keepawayfromfire.co.uk",
+    "FuzzyClock@fire-man-x",
     "FuzzyClock@johngoetz",
-    "FuzzyClock@fire-man-x"
+    "fuzzy-clock@keepawayfromfire.co.uk"
   ],
   "battery-time": [
-    "batterytime@typeof.pw",
-    "batime@martin.zurowietz.de"
+    "batime@martin.zurowietz.de",
+    "battery-time@eetumos.github.com",
+    "batterytime@typeof.pw"
   ],
   "nepali-calendar": [
-    "nepali-date@biplab",
-    "nepali-calendar-gs-extension@subashghimire.info.np"
+    "nepali-calendar-gs-extension@subashghimire.info.np",
+    "nepali-date@biplab"
   ],
   "mouse-follows-focus": [
     "mouse-follows-focus@crisidev.org",
@@ -33,8 +34,8 @@
     "power-profile@fthx"
   ],
   "fullscreen-to-empty-workspace": [
-    "fullscreen-to-empty-workspace@aiono.dev",
-    "fullscreen-to-empty-workspace2@corgijan.dev"
+    "fullscreen-to-empty-workspace2@corgijan.dev",
+    "fullscreen-to-empty-workspace@aiono.dev"
   ],
   "eur-usd": [
     "eur-usd-gshell@vezza.github.com",

--- a/pkgs/desktops/gnome/extensions/default.nix
+++ b/pkgs/desktops/gnome/extensions/default.nix
@@ -76,6 +76,7 @@ rec {
   gnome45Extensions = mapUuidNames (produceExtensionsList "45");
   gnome46Extensions = mapUuidNames (produceExtensionsList "46");
   gnome47Extensions = mapUuidNames (produceExtensionsList "47");
+  gnome48Extensions = mapUuidNames (produceExtensionsList "48");
 
   # Keep the last three versions in here
   gnomeExtensions = lib.trivial.pipe (gnome45Extensions // gnome46Extensions // gnome47Extensions) [

--- a/pkgs/desktops/gnome/extensions/extensionOverrides.nix
+++ b/pkgs/desktops/gnome/extensions/extensionOverrides.nix
@@ -27,6 +27,9 @@
   vte,
   wrapGAppsHook3,
   xdg-utils,
+  gtk4,
+  desktop-file-utils,
+  xdg-user-dirs,
 }:
 let
   # Helper method to reduce redundancy
@@ -128,7 +131,10 @@ lib.trivial.pipe super [
         inherit gjs;
         util_linux = util-linux;
         xdg_utils = xdg-utils;
-        nautilus_gsettings_path = "${glib.getSchemaPath nautilus}";
+        gtk_update_icon_cache = "${gtk4.out}/bin/gtk4-update-icon-cache";
+        update_desktop_database = "${desktop-file-utils.out}/bin/update-desktop-database";
+        xdg_user_dirs = lib.getExe xdg-user-dirs;
+        nautilus_gsettings_path = glib.getSchemaPath nautilus;
       })
     ];
   }))

--- a/pkgs/desktops/gnome/extensions/extensionOverridesPatches/gtk4-ding_at_smedius.gitlab.com.patch
+++ b/pkgs/desktops/gnome/extensions/extensionOverridesPatches/gtk4-ding_at_smedius.gitlab.com.patch
@@ -1,19 +1,59 @@
-diff --git a/app/ding.js b/app/ding.js
-index 1062bc7..c312d48 100755
+diff --git a/app/adw-ding.js b/app/adw-ding.js
+index 42cb878c..929ddce2 100755
 --- a/app/adw-ding.js
 +++ b/app/adw-ding.js
 @@ -1,4 +1,4 @@
 -#!/usr/bin/env -S gjs -m
 +#!@gjs@/bin/gjs -m
  
- /* DING: Desktop Icons New Generation for GNOME Shell
+ /* ADW-DING: Desktop Icons New Generation for GNOME Shell
   *
+@@ -535,7 +535,7 @@ const adWDingApp = GObject.registerClass(
+                 ]);
+ 
+                 const updated = await GLib.spawn_command_line_async(
+-                    'gtk-update-icon-cache ' +
++                    '@gtk_update_icon_cache@ ' +
+                     '-q -t -f ' +
+                     `${iconCachePath}`
+                 );
+@@ -566,7 +566,7 @@ const adWDingApp = GObject.registerClass(
+                 // and we need to do it manually for the app to be
+                 // available sooner
+                 const updated = await GLib.spawn_command_line_async(
+-                    'update-desktop-database -q ' +
++                    '@update_desktop_database@ -q ' +
+                     `${GLib.path_get_dirname(appDesktopFile)}`
+                 );
+ 
+diff --git a/app/adwPreferencesWindow.js b/app/adwPreferencesWindow.js
+index 93d53554..8f5bb8fe 100644
+--- a/app/adwPreferencesWindow.js
++++ b/app/adwPreferencesWindow.js
+@@ -540,7 +540,7 @@ const AdwPreferencesWindow = class {
+     }
+ 
+     setDesktopFolder(path) {
+-        const command = 'xdg-user-dirs-update --set DESKTOP';
++        const command = '@xdg_user_dirs@/bin/xdg-user-dirs-update --set DESKTOP';
+ 
+         try {
+             GLib.spawn_command_line_async(
+@@ -564,7 +564,7 @@ const AdwPreferencesWindow = class {
+     }
+ 
+     getCurrentDesktopFolder() {
+-        const command = 'xdg-user-dir DESKTOP';
++        const command = '@xdg_user_dirs@/bin/xdg-user-dir DESKTOP';
+         const decoder = new TextDecoder();
+         const [, out,, status] = GLib.spawn_command_line_sync(command);
+ 
 diff --git a/app/enums.js b/app/enums.js
-index 2b541f3..594d288 100644
+index 5434fa7a..e36d3670 100644
 --- a/app/enums.js
 +++ b/app/enums.js
-@@ -124,7 +124,8 @@ export const THUMBNAILS_DIR = '.cache/thumbnails';
- export const DND_HOVER_TIMEOUT = 500; // In milliseconds
+@@ -134,7 +134,8 @@ export const THUMBNAILS_DIR = '.cache/thumbnails';
+ export const DND_HOVER_TIMEOUT = 1500; // In milliseconds
  export const DND_SHELL_HOVER_POLL = 200; // In milliseconds
  export const TOOLTIP_HOVER_TIMEOUT = 1000; // In milliseconds
 -export const XDG_EMAIL_CMD = 'xdg-email';
@@ -23,40 +63,40 @@ index 2b541f3..594d288 100644
  export const ZIP_CMD = 'zip';
  export const ZIP_CMD_OPTIONS = '-r';
 diff --git a/app/preferences.js b/app/preferences.js
-index 6849a86..83a7247 100644
+index 95ffe60b..75370403 100644
 --- a/app/preferences.js
 +++ b/app/preferences.js
-@@ -29,6 +29,7 @@ const Preferences = class {
-         this._programVersion = Data.programversion;
+@@ -30,6 +30,7 @@ const Preferences = class {
+         this._mainApp = Data.mainApp;
          this._Enums = Data.Enums;
          let schemaSource = GioSSS.get_default();
 +        const schemaSourceNautilus = Gio.SettingsSchemaSource.new_from_directory('@nautilus_gsettings_path@', Gio.SettingsSchemaSource.get_default(), true);
          this._desktopManager = null;
  
-         // Gtk
-@@ -36,7 +37,7 @@ const Preferences = class {
-         this.gtkSettings = new Gio.Settings({settings_schema: schemaGtk});
+         // Adw Style Manager
+@@ -52,7 +53,7 @@ const Preferences = class {
  
          // Gnome Files
--        let schemaObj = schemaSource.lookup(this._Enums.SCHEMA_NAUTILUS, true);
-+        let schemaObj = schemaSourceNautilus.lookup(this._Enums.SCHEMA_NAUTILUS, true);
+         const schemaObj =
+-            schemaSource.lookup(this._Enums.SCHEMA_NAUTILUS, true);
++            schemaSourceNautilus.lookup(this._Enums.SCHEMA_NAUTILUS, true);
+ 
          if (!schemaObj) {
              this.nautilusSettings = null;
-             this.CLICK_POLICY_SINGLE = false;
-@@ -48,7 +49,7 @@ const Preferences = class {
- 
+@@ -69,7 +70,7 @@ const Preferences = class {
  
          // Compression
--        const compressionSchema = schemaSource.lookup(this._Enums.SCHEMA_NAUTILUS_COMPRESSION, true);
-+        const compressionSchema = schemaSourceNautilus.lookup(this._Enums.SCHEMA_NAUTILUS_COMPRESSION, true);
-         if (!compressionSchema)
+         const compressionSchema =
+-            schemaSource.lookup(this._Enums.SCHEMA_NAUTILUS_COMPRESSION, true);
++            schemaSourceNautilus.lookup(this._Enums.SCHEMA_NAUTILUS_COMPRESSION, true);
+ 
+         if (!compressionSchema) {
              this.nautilusCompression = null;
-         else
 diff --git a/dingManager.js b/dingManager.js
-index f1b497f..29f2156 100644
+index 7a0de9e3..bbc23704 100644
 --- a/dingManager.js
 +++ b/dingManager.js
-@@ -401,7 +401,7 @@ const DingManager = class {
+@@ -482,7 +482,7 @@ const DingManager = class {
      async _doKillAllOldDesktopProcesses() {
          const procFolder = Gio.File.new_for_path('/proc');
          const processes = await FileUtils.enumerateDir(procFolder);
@@ -64,21 +104,21 @@ index f1b497f..29f2156 100644
 +        const thisPath = `@gjs@/bin/gjs ${GLib.build_filenamev([
              this.path,
              'app',
-             'ding.js',
-@@ -425,7 +425,7 @@ const DingManager = class {
-                 }
+             'adw-ding.js',
+@@ -510,7 +510,7 @@ const DingManager = class {
  
                  if (contents.startsWith(thisPath)) {
--                    let proc = new Gio.Subprocess({argv: ['/bin/kill', filename]});
-+                    let proc = new Gio.Subprocess({argv: ['@util_linux@/bin/kill', filename]});
+                     let proc =
+-                        new Gio.Subprocess({argv: ['/bin/kill', filename]});
++                        new Gio.Subprocess({argv: ['@util_linux@/bin/kill', filename]});
+ 
                      proc.init(null);
                      console.log(`Killing old DING process ${filename}`);
-                     await proc.wait_async_promise(null);
 diff --git a/prefs.js b/prefs.js
-index 5ed03f6..5302836 100644
+index 50430fa5..82fca2e3 100644
 --- a/prefs.js
 +++ b/prefs.js
-@@ -30,7 +30,8 @@ export default class dingPreferences extends ExtensionPreferences {
+@@ -34,7 +34,8 @@ export default class dingPreferences extends ExtensionPreferences {
          const schemaSource = GioSSS.get_default();
          const schemaGtk = schemaSource.lookup(Enums.SCHEMA_GTK, true);
          const gtkSettings = new Gio.Settings({settings_schema: schemaGtk});
@@ -86,5 +126,5 @@ index 5ed03f6..5302836 100644
 +        const schemaSourceNautilus = Gio.SettingsSchemaSource.new_from_directory('@nautilus_gsettings_path@', Gio.SettingsSchemaSource.get_default(), true);
 +		const schemaNautilus = schemaSourceNautilus.lookup(Enums.SCHEMA_NAUTILUS, true);
          const version = this.metadata['version-name'];
+ 
          let nautilusSettings;
-         if (!schemaNautilus)

--- a/pkgs/desktops/gnome/extensions/extensionRenames.nix
+++ b/pkgs/desktops/gnome/extensions/extensionRenames.nix
@@ -17,6 +17,7 @@
   "fuzzy-clock@keepawayfromfire.co.uk" = "fuzzy-clock-2";
   "FuzzyClock@johngoetz" = "fuzzy-clock";
 
+  "battery-time@eetumos.github.com" = "battery-time-3";
   "batterytime@typeof.pw" = "battery-time-2";
   "batime@martin.zurowietz.de" = "battery-time";
 

--- a/pkgs/desktops/gnome/extensions/update-extensions.py
+++ b/pkgs/desktops/gnome/extensions/update-extensions.py
@@ -336,7 +336,7 @@ def find_collisions(
             if shell_version in extension["shell_version_map"]:
                 package_name_registry.setdefault(pname, set()).add(uuid)
     return {
-        pname: list(uuids)
+        pname: sorted(uuids)
         for pname, uuids in package_name_registry.items()
         if len(uuids) > 1
     }

--- a/pkgs/desktops/gnome/extensions/update-extensions.py
+++ b/pkgs/desktops/gnome/extensions/update-extensions.py
@@ -315,23 +315,23 @@ if __name__ == "__main__":
             else:
                 out.write(", ")
             # Dump each extension into a single-line string forst
-            extension = json.dumps(extension, ensure_ascii=False)
+            serialized_extension = json.dumps(extension, ensure_ascii=False)
             # Inject line breaks for each supported version
             for version in supported_versions:
                 # This one only matches the first entry
-                extension = extension.replace(
+                serialized_extension = serialized_extension.replace(
                     f'{{"{version}": {{',
                     f'{{\n    "{version}": {{',
                 )
                 # All other entries
-                extension = extension.replace(
+                serialized_extension = serialized_extension.replace(
                     f', "{version}": {{',
                     f',\n    "{version}": {{',
                 )
             # One last line break around the closing braces
-            extension = extension.replace("}}}", "}\n  }}")
+            serialized_extension = serialized_extension.replace("}}}", "}\n  }}")
 
-            out.write(extension)
+            out.write(serialized_extension)
             out.write("\n")
         out.write("]\n")
 

--- a/pkgs/desktops/gnome/extensions/update-extensions.py
+++ b/pkgs/desktops/gnome/extensions/update-extensions.py
@@ -31,6 +31,7 @@ supported_versions = {
     "45": "45",
     "46": "46",
     "47": "47",
+    "48": "48",
 }
 
 # shell versions that we want to put into the gnomeExtensions attr set

--- a/pkgs/desktops/gnome/extensions/update-extensions.py
+++ b/pkgs/desktops/gnome/extensions/update-extensions.py
@@ -345,21 +345,19 @@ def find_collisions(
     versions: list[str],
 ) -> dict[PackageName, list[Uuid]]:
     package_name_registry_for_versions = [
-        v for k, v in package_name_registry.items() if k in versions
+        package_name_registry
+        for version, package_name_registry in package_name_registry.items()
+        if version in versions
     ]
-    # Merge all package names into a single dictionary
-    package_name_registry_filtered: dict[PackageName, set[Uuid]] = {}
+    package_name_registry_merged: dict[PackageName, set[Uuid]] = {}
     for pkgs in package_name_registry_for_versions:
         for pname, uuids in pkgs.items():
-            if pname not in package_name_registry_filtered:
-                package_name_registry_filtered[pname] = set()
-            package_name_registry_filtered[pname].update(uuids)
-    # Filter out those that are not duplicates
-    package_name_registry_filtered = {
-        k: v for k, v in package_name_registry_filtered.items() if len(v) > 1
+            package_name_registry_merged.setdefault(pname, set()).update(uuids)
+    return {
+        pname: list(uuids)
+        for pname, uuids in package_name_registry_merged.items()
+        if len(uuids) > 1
     }
-    # Convert set to list
-    return {k: list(v) for k, v in package_name_registry_filtered.items()}
 
 
 def main() -> None:

--- a/pkgs/desktops/gnome/extensions/update-extensions.py
+++ b/pkgs/desktops/gnome/extensions/update-extensions.py
@@ -223,9 +223,15 @@ def process_extension(extension: dict[str, Any]) -> dict[str, Any] | None:
 
 @contextmanager
 def request(url: str, retries: int = 5, retry_codes: list[int] = [500, 502, 503, 504]):
+    req = urllib.request.Request(
+        url,
+        headers={
+            "User-Agent": "NixpkgsGnomeExtensionUpdate (+https://github.com/NixOS/nixpkgs)"
+        },
+    )
     for attempt in range(retries + 1):
         try:
-            with urllib.request.urlopen(url) as response:
+            with urllib.request.urlopen(req) as response:
                 yield response
                 break
         except urllib.error.HTTPError as e:

--- a/pkgs/desktops/gnome/extensions/update-extensions.py
+++ b/pkgs/desktops/gnome/extensions/update-extensions.py
@@ -26,6 +26,9 @@ supported_versions = {
     "47": "47",
 }
 
+# shell versions that we want to put into the gnomeExtensions attr set
+versions_to_merge = ["45", "46", "47"]
+
 # Some type alias to increase readability of complex compound types
 PackageName = str
 ShellVersion = str
@@ -338,15 +341,11 @@ def serialize_extensions(processed_extensions: list[dict[str, Any]]) -> None:
         out.write("]\n")
 
 
-def find_collisions() -> dict[PackageName, list[Uuid]]:
-    # Find the name collisions only for the last 3 shell versions
-    last_3_versions = sorted(
-        supported_versions.keys(),
-        key=lambda v: float(v),
-        reverse=True,
-    )[:3]
+def find_collisions(
+    versions: list[str],
+) -> dict[PackageName, list[Uuid]]:
     package_name_registry_for_versions = [
-        v for k, v in package_name_registry.items() if k in last_3_versions
+        v for k, v in package_name_registry.items() if k in versions
     ]
     # Merge all package names into a single dictionary
     package_name_registry_filtered: dict[PackageName, set[Uuid]] = {}
@@ -378,7 +377,7 @@ def main() -> None:
         # Check that the generated file actually is valid JSON, just to be sure
         json.load(out)
 
-    collisions = find_collisions()
+    collisions = find_collisions(versions_to_merge)
 
     with open(updater_dir_path / "collisions.json", "w") as out:
         json.dump(collisions, out, indent=2, ensure_ascii=False)

--- a/pkgs/desktops/gnome/extensions/update-extensions.py
+++ b/pkgs/desktops/gnome/extensions/update-extensions.py
@@ -4,6 +4,7 @@
 import base64
 import json
 import logging
+import argparse
 import subprocess
 import urllib.error
 import urllib.request
@@ -350,14 +351,22 @@ def find_collisions(
 
 def main() -> None:
     logging.basicConfig(level=logging.DEBUG)
-
-    processed_extensions = fetch_extensions()
-
-    serialize_extensions(processed_extensions)
-
-    logging.info(
-        f"Done. Writing results to extensions.json ({len(processed_extensions)} extensions in total)"
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--skip-fetch",
+        action="store_true",
+        help="Skip fetching extensions. When this option is set, the script does not fetch extensions from the internet, but checks for name collisions.",
     )
+    args = parser.parse_args()
+
+    if not args.skip_fetch:
+        processed_extensions = fetch_extensions()
+
+        serialize_extensions(processed_extensions)
+
+        logging.info(
+            f"Done. Writing results to extensions.json ({len(processed_extensions)} extensions in total)"
+        )
 
     with open(updater_dir_path / "extensions.json", "r") as out:
         extensions = json.load(out)

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17527,6 +17527,7 @@ with pkgs;
     gnome45Extensions
     gnome46Extensions
     gnome47Extensions
+    gnome48Extensions
     ;
 
   gnome-extensions-cli = python3Packages.callPackage ../desktops/gnome/misc/gnome-extensions-cli { };


### PR DESCRIPTION
- Introduce `--skip-fetch` option to update script. When this option is enabled, the script will not fetch extensions from EGO, but will still find name conflicts. 
- Set the user agent
- Fetch GNOME 48 extensions (but don't put them in `gnomeExtensions`)

With the `--skip-fetch` option, we can update `gnomeExtensions` for new GNOME version without having to download and update all extensions. 



## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
