### PR TITLE
goto: init at 2.1.0-unstable-2020-11-15

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3354,6 +3354,12 @@
     github = "bmilanov";
     githubId = 30090366;
   };
+  bmrips = {
+    name = "Benedikt M. Rips";
+    email = "benedikt.rips@gmail.com";
+    github = "bmrips";
+    githubId = 20407973;
+  };
   bmwalters = {
     name = "Bradley Walters";
     email = "oss@walters.app";

--- a/pkgs/by-name/go/goto/package.nix
+++ b/pkgs/by-name/go/goto/package.nix
@@ -1,0 +1,62 @@
+{
+  fetchFromGitHub,
+  gawk,
+  lib,
+  nix-update-script,
+  runCommand,
+  stdenvNoCC,
+  writableTmpDirAsHomeHook,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "goto";
+  version = "2.1.0-unstable-2020-11-15";
+
+  src = fetchFromGitHub {
+    owner = "iridakos";
+    repo = "goto";
+    # no tags
+    rev = "b7fda54e0817b9cb47e22a78bd00b4571011cf58";
+    hash = "sha256-dUxim8LLb+J9cI7HySkmC2DIWbWAKSsH/cTVXmt8zRo=";
+  };
+
+  strictDeps = true;
+
+  buildInputs = [ gawk ];
+
+  postInstall = ''
+    install -Dm644 goto.sh -t $out/share/
+  '';
+
+  passthru.tests.basic-usage =
+    runCommand "goto-basic-usage"
+      {
+        nativeBuildInputs = [ writableTmpDirAsHomeHook ];
+      }
+      ''
+        # Mock `complete` since the builder `pkgs.bash` is not interactive.
+        complete() { return; }
+
+        source ${finalAttrs.finalPackage}/share/goto.sh
+
+        goto --register pwd .
+        cd /
+        goto pwd
+        goto --unregister pwd
+        goto --list
+
+        touch $out
+      '';
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [ "--version=branch" ];
+  };
+
+  meta = {
+    description = "Alias and navigate to directories with tab completion";
+    homepage = "https://github.com/iridakos/goto";
+    changelog = "https://github.com/iridakos/goto/blob/${finalAttrs.src.rev}/CHANGELOG.md";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.bmrips ];
+  };
+})


### PR DESCRIPTION
Add a derivation for [goto](https://github.com/iridakos/goto#installation), a tool to alias and navigate to directories with tab completion.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

Besides the internal package tests, I tested it on my own systems.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
