### PR TITLE
python312Packages.gpu-rir: init at 0-unstable-2025-01-20

### DIFF
--- a/pkgs/development/python-modules/gpu-rir/default.nix
+++ b/pkgs/development/python-modules/gpu-rir/default.nix
@@ -1,0 +1,83 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  # build-system
+  cmake,
+  setuptools,
+
+  # nativeBuildInputs
+  autoAddDriverRunpath,
+  cudaPackages,
+
+  # dependencies
+  numpy,
+  scipy,
+}:
+
+buildPythonPackage {
+  pname = "gpu-rir";
+  version = "0-unstable-2025-01-20";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "DavidDiazGuerra";
+    repo = "gpuRIR";
+    rev = "fd8af43a4a113d3c2c05f0085a0119ecb1f1a484";
+    hash = "sha256-nYi91iaNb9gswYzXW7aNpD3yYIgMvTen9r02G4d6joo=";
+  };
+
+  # Inject cmakeFlags in the cmake call
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace-fail \
+        "cmake_args = [" \
+        "cmake_args = os.environ.get('cmakeFlags', \"\").split() + ["
+  '';
+
+  build-system = [
+    cmake
+    setuptools
+  ];
+  dontUseCmakeConfigure = true;
+
+  nativeBuildInputs = [
+    autoAddDriverRunpath
+    cudaPackages.cuda_nvcc
+  ];
+
+  # TODO: Investigate why (deprecated) FindCUDA fails to set these variables
+  cmakeFlags = [
+    (lib.cmakeFeature "CUDA_CUFFT_LIBARIES" "${lib.getLib cudaPackages.libcufft}/lib/libcufft.so")
+    (lib.cmakeFeature "CUDA_curand_LIBRARY" "${lib.getLib cudaPackages.libcurand}/lib/libcurand.so")
+  ];
+
+  buildInputs = with cudaPackages; [
+    cuda_cccl # <nv/target>
+    cuda_cudart # cuda_runtime.h
+    libcufft
+    libcurand
+  ];
+
+  dependencies = [
+    numpy
+    scipy
+  ];
+
+  pythonImportsCheck = [ "gpuRIR" ];
+  # Fails at import because there is no GPU access in the sandbox:
+  # Check whether the following modules can be imported: gpuRIR
+  # GPUassert: CUDA driver version is insufficient for CUDA runtime version /build/source/src/gpuRIR_cuda.cu 1037
+  dontUsePythonImportsCheck = true;
+
+  # No tests
+  doCheck = false;
+
+  meta = {
+    description = "Python library for Room Impulse Response (RIR) simulation with GPU acceleration";
+    homepage = "https://github.com/DavidDiazGuerra/gpuRIR";
+    license = lib.licenses.agpl3Only;
+    maintainers = with lib.maintainers; [ GaetanLepage ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5914,6 +5914,8 @@ self: super: with self; {
 
   gptcache = callPackage ../development/python-modules/gptcache { };
 
+  gpu-rir = callPackage ../development/python-modules/gpu-rir { };
+
   gpuctypes = callPackage ../development/python-modules/gpuctypes { };
 
   gpustat = callPackage ../development/python-modules/gpustat { };


### PR DESCRIPTION
## Things done

Add [gpuRIR](https://github.com/DavidDiazGuerra/gpuRIR/tree/master), a python library for Room Impulse Response (RIR) simulation with GPU acceleration.

cc @SomeoneSerge

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
