### PR TITLE
laurel: 0.7.0 -> 0.7.2

### DIFF
--- a/pkgs/servers/monitoring/laurel/default.nix
+++ b/pkgs/servers/monitoring/laurel/default.nix
@@ -7,17 +7,17 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "laurel";
-  version = "0.7.1";
+  version = "0.7.2";
 
   src = fetchFromGitHub {
     owner = "threathunters-io";
     repo = "laurel";
     tag = "v${version}";
-    hash = "sha256-SXCQxIzprBt0qnUpniHp3AOu9yxgQTtf+1b/p9X+7xc=";
+    hash = "sha256-rOf7UtkMoYpReZr/2135QcpMEfYD80IY4zF0TwAWr4I=";
   };
 
   useFetchCargoVendor = true;
-  cargoHash = "sha256-qXsbq6lgQMNQAbrU2ntw0yGeNcR1h/g8jKg2ZoU0XfA=";
+  cargoHash = "sha256-Pfs4Bg6VZIiiXQu0ZKcDi9zeEYl08kOnWi3R2iaQG24=";
 
   postPatch = ''
     # Upstream started to redirect aarch64-unknown-linux-gnu to aarch64-linux-gnu-gcc

--- a/pkgs/servers/monitoring/laurel/default.nix
+++ b/pkgs/servers/monitoring/laurel/default.nix
@@ -7,17 +7,17 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "laurel";
-  version = "0.7.0";
+  version = "0.7.1";
 
   src = fetchFromGitHub {
     owner = "threathunters-io";
     repo = "laurel";
     tag = "v${version}";
-    hash = "sha256-fToxRAcZOZvuuzaaWSjweqEwdUu3K2EKXY0K2Qixqpo=";
+    hash = "sha256-SXCQxIzprBt0qnUpniHp3AOu9yxgQTtf+1b/p9X+7xc=";
   };
 
   useFetchCargoVendor = true;
-  cargoHash = "sha256-i5wsS7y65sIvICfgViVIAbQU9f1E0EmspX+YVKDSKOU=";
+  cargoHash = "sha256-qXsbq6lgQMNQAbrU2ntw0yGeNcR1h/g8jKg2ZoU0XfA=";
 
   postPatch = ''
     # Upstream started to redirect aarch64-unknown-linux-gnu to aarch64-linux-gnu-gcc
@@ -28,6 +28,14 @@ rustPlatform.buildRustPackage rec {
 
   nativeBuildInputs = [ rustPlatform.bindgenHook ];
   buildInputs = [ acl ];
+
+  checkFlags = [
+    # Nix' build sandbox does not allow setting ACLs:
+    # https://github.com/NixOS/nix/blob/2.28.3/src/libstore/unix/build/local-derivation-goal.cc#L1760-L1769
+    # Skip the tests that are failing with "Operation not supported (os error 95)" because of this:
+    "--skip=rotate::test::existing"
+    "--skip=rotate::test::fresh_file"
+  ];
 
   meta = with lib; {
     description = "Transform Linux Audit logs for SIEM usage";


### PR DESCRIPTION
https://github.com/threathunters-io/laurel/releases/tag/v0.7.1
https://github.com/threathunters-io/laurel/releases/tag/v0.7.2

diff: https://github.com/threathunters-io/laurel/compare/v0.7.0...v0.7.1
diff: https://github.com/threathunters-io/laurel/compare/v0.7.1...v0.7.2

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
