### PR TITLE
opencv: fix `!= "x86_64-darwin"` check; also use `lib.systems.equals`

### DIFF
--- a/pkgs/development/libraries/opencv/4.x.nix
+++ b/pkgs/development/libraries/opencv/4.x.nix
@@ -157,7 +157,7 @@ let
       else if effectiveStdenv.hostPlatform.system == "x86_64-darwin" then
         { ${name "mac_intel64"} = ""; }
       else
-        throw "ICV is not available for this platform (or not yet supported by this package)";
+        throw "ICV is not available for ${effectiveStdenv.hostPlatform.system} (or not yet supported by this package)";
     dst = ".cache/ippicv";
   };
 

--- a/pkgs/development/libraries/opencv/4.x.nix
+++ b/pkgs/development/libraries/opencv/4.x.nix
@@ -103,7 +103,6 @@ let
     optionalString
     ;
   inherit (lib.trivial) flip;
-  sysEquals = lib.systems.equals;
 
   version = "4.11.0";
 
@@ -345,7 +344,7 @@ effectiveStdenv.mkDerivation {
       pythonPackages.python
     ]
     # FIXME: Do we actually want `equals`, or should we use `canExec`?
-    ++ optionals (sysEquals effectiveStdenv.buildPlatform effectiveStdenv.hostPlatform) [
+    ++ optionals (lib.systems.equals effectiveStdenv.buildPlatform effectiveStdenv.hostPlatform) [
       hdf5
     ]
     ++ optionals enableGtk2 [
@@ -456,8 +455,7 @@ effectiveStdenv.mkDerivation {
         pythonPackages.wheel
         pythonPackages.setuptools
       ]
-      # FIXME: Do we actually want `equals`, or should we use `canExec`?
-      ++ optionals (sysEquals effectiveStdenv.hostPlatform effectiveStdenv.buildPlatform) [
+      ++ optionals (effectiveStdenv.buildPlatform.canExec effectiveStdenv.hostPlatform) [
         pythonPackages.pythonImportsCheckHook
       ]
     )

--- a/pkgs/development/libraries/opencv/4.x.nix
+++ b/pkgs/development/libraries/opencv/4.x.nix
@@ -103,6 +103,7 @@ let
     optionalString
     ;
   inherit (lib.trivial) flip;
+  sysEquals = lib.systems.equals;
 
   version = "4.11.0";
 
@@ -343,7 +344,8 @@ effectiveStdenv.mkDerivation {
     ++ optionals enablePython [
       pythonPackages.python
     ]
-    ++ optionals (effectiveStdenv.buildPlatform == effectiveStdenv.hostPlatform) [
+    # FIXME: Do we actually want `equals`, or should we use `canExec`?
+    ++ optionals (sysEquals effectiveStdenv.buildPlatform effectiveStdenv.hostPlatform) [
       hdf5
     ]
     ++ optionals enableGtk2 [
@@ -454,7 +456,8 @@ effectiveStdenv.mkDerivation {
         pythonPackages.wheel
         pythonPackages.setuptools
       ]
-      ++ optionals (effectiveStdenv.hostPlatform == effectiveStdenv.buildPlatform) [
+      # FIXME: Do we actually want `equals`, or should we use `canExec`?
+      ++ optionals (sysEquals effectiveStdenv.hostPlatform effectiveStdenv.buildPlatform) [
         pythonPackages.pythonImportsCheckHook
       ]
     )

--- a/pkgs/development/libraries/opencv/4.x.nix
+++ b/pkgs/development/libraries/opencv/4.x.nix
@@ -631,7 +631,8 @@ effectiveStdenv.mkDerivation {
         withIpp = opencv4.override { enableIpp = true; };
       }
       // optionalAttrs (!enablePython) { pythonEnabled = pythonPackages.opencv4; }
-      // optionalAttrs (effectiveStdenv.buildPlatform != "x86_64-darwin") {
+      # FIXME: is !(isx86_64 && isDarwin) correct, or should it be more general, like !isDarwin ?
+      // optionalAttrs (with effectiveStdenv.buildPlatform; !(isx86_64 && isDarwin)) {
         opencv4-tests = callPackage ./tests.nix {
           inherit
             enableGStreamer

--- a/pkgs/development/libraries/opencv/4.x.nix
+++ b/pkgs/development/libraries/opencv/4.x.nix
@@ -449,19 +449,20 @@ effectiveStdenv.mkDerivation {
       pkg-config
       unzip
     ]
-    ++ optionals enablePython (
-      [
-        pythonPackages.pip
-        pythonPackages.wheel
-        pythonPackages.setuptools
-      ]
-      ++ optionals (effectiveStdenv.buildPlatform.canExec effectiveStdenv.hostPlatform) [
-        pythonPackages.pythonImportsCheckHook
-      ]
-    )
+    ++ optionals enablePython [
+      pythonPackages.pip
+      pythonPackages.wheel
+      pythonPackages.setuptools
+    ]
     ++ optionals enableCuda [
       cudaPackages.cuda_nvcc
     ];
+
+  nativeCheckInputs =
+    optionals (enablePython && effectiveStdenv.buildPlatform.canExec effectiveStdenv.hostPlatform)
+      [
+        pythonPackages.pythonImportsCheckHook
+      ];
 
   # Configure can't find the library without this.
   OpenBLAS_HOME = optionalString withOpenblas openblas_.dev;


### PR DESCRIPTION
- **opencv: replace `==` with `lib.systems.equals`**
- **ovencv: fix platform != "x86_64-darwin" check**
- **opencv: show unsupported platform in ICV error**


Found this while working on #380005, the existing `effectiveStdenv.buildPlatform != "x86_64-darwin"` condition will never be false, because `buildPlatform` is never a string.

I've replaced this with `!(isx86_64 && isDarwin)`, however I suspect it may not need to be quite this specific?

Additionally I've replaced the usage of `==` to compare platforms with the more correct `lib.systems.equals`. However, it may be more accurate to use `buildPlatform.canExecute hostPlatform`.

I've included some FIXME comments in the diff; if maintainers/reviewers can clarify intent, I'd like to resolve them in this PR. Otherwise they can be addressed in future work.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
