### PR TITLE
olm: fix darwin build

### DIFF
--- a/pkgs/by-name/ol/olm/package.nix
+++ b/pkgs/by-name/ol/olm/package.nix
@@ -1,11 +1,16 @@
 {
   lib,
   stdenv,
+  llvmPackages_18,
   fetchFromGitLab,
   cmake,
 }:
-
-stdenv.mkDerivation rec {
+let
+  # Specifically Clang 19.1.0 or later doesn't like `include/olm/list.hh`.
+  broken = stdenv.cc.isClang && lib.versionAtLeast stdenv.cc.version "19.1.0";
+  chosenStdenv = if broken then llvmPackages_18.stdenv else stdenv;
+in
+chosenStdenv.mkDerivation rec {
   pname = "olm";
   version = "3.2.16";
 


### PR DESCRIPTION
Fixes build for any platform that uses Clang 19.1.0 or higher by default (in practice, darwin), by swapping out `stdenv` for `llvmPackages_18.stdenv`. For some reason, starting from Clang 19, the file `include/olm/list.hh` doesn't compile. On linux, this PR does nothing, because `stdenv.cc.isGNU == true`.

I have no idea wether or not this is the right way to do this, but it works.

ZHF: https://github.com/NixOS/nixpkgs/issues/403336

Hydra build: https://hydra.nixos.org/build/294810877

Compiler explorer for relevant code: https://godbolt.org/z/1nnWW4fde

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
