### PR TITLE
nixos/postgresql: move postStart into separate unit

### DIFF
--- a/doc/languages-frameworks/beam.section.md
+++ b/doc/languages-frameworks/beam.section.md
@@ -259,13 +259,13 @@ in
     wantedBy = [ "multi-user.target" ];
     after = [
       "network.target"
-      "postgresql.service"
+      "postgresql.target"
     ];
     # note that if you are connecting to a postgres instance on a different host
-    # postgresql.service should not be included in the requires.
+    # postgresql.target should not be included in the requires.
     requires = [
       "network-online.target"
-      "postgresql.service"
+      "postgresql.target"
     ];
     description = "my app";
     environment = {

--- a/nixos/doc/manual/redirects.json
+++ b/nixos/doc/manual/redirects.json
@@ -1316,22 +1316,14 @@
   "module-services-postgres-initializing-extra-permissions": [
     "index.html#module-services-postgres-initializing-extra-permissions"
   ],
-  "module-services-postgres-initializing-extra-permissions-superuser": [
-    "index.html#module-services-postgres-initializing-extra-permissions-superuser"
-  ],
   "module-services-postgres-initializing-extra-permissions-superuser-post-start": [
-    "index.html#module-services-postgres-initializing-extra-permissions-superuser-post-start"
-  ],
-  "module-services-postgres-initializing-extra-permissions-superuser-oneshot": [
-    "index.html#module-services-postgres-initializing-extra-permissions-superuser-oneshot"
-  ],
-  "module-services-postgres-initializing-extra-permissions-service-user": [
+    "index.html#module-services-postgres-initializing-extra-permissions-superuser-post-start",
+    "index.html#module-services-postgres-initializing-extra-permissions-superuser",
+    "index.html#module-services-postgres-initializing-extra-permissions-service-user-pre-start",
     "index.html#module-services-postgres-initializing-extra-permissions-service-user"
   ],
-  "module-services-postgres-initializing-extra-permissions-service-user-pre-start": [
-    "index.html#module-services-postgres-initializing-extra-permissions-service-user-pre-start"
-  ],
-  "module-services-postgres-initializing-extra-permissions-service-user-oneshot": [
+  "module-services-postgres-initializing-extra-permissions-superuser-oneshot": [
+    "index.html#module-services-postgres-initializing-extra-permissions-superuser-oneshot",
     "index.html#module-services-postgres-initializing-extra-permissions-service-user-oneshot"
   ],
   "module-services-postgres-authentication": [

--- a/nixos/doc/manual/release-notes/rl-2511.section.md
+++ b/nixos/doc/manual/release-notes/rl-2511.section.md
@@ -64,6 +64,8 @@
 
 - The `yeahwm` package and `services.xserver.windowManager.yeahwm` module were removed due to the package being broken and unmaintained upstream.
 
+- The `services.postgresql` module now sets up a systemd unit `postgresql.target`. Depending on `postgresql.target` guarantees that initial/ensure scripts were executed.
+
 - The `services.siproxd` module has been removed as `siproxd` is unmaintained and broken with libosip 5.x.
 
 - `services.dwm-status.extraConfig` was replaced by [RFC0042](https://github.com/NixOS/rfcs/blob/master/rfcs/0042-config-option.md)-compliant [](#opt-services.dwm-status.settings), which is used to generate the config file. `services.dwm-status.order` is now moved to [](#opt-services.dwm-status.settings.order), as it's a part of the config file.

--- a/nixos/doc/manual/release-notes/rl-2511.section.md
+++ b/nixos/doc/manual/release-notes/rl-2511.section.md
@@ -64,7 +64,7 @@
 
 - The `yeahwm` package and `services.xserver.windowManager.yeahwm` module were removed due to the package being broken and unmaintained upstream.
 
-- The `services.postgresql` module now sets up a systemd unit `postgresql.target`. Depending on `postgresql.target` guarantees that initial/ensure scripts were executed.
+- The `services.postgresql` module now sets up a systemd unit `postgresql.target`. Depending on `postgresql.target` guarantees that postgres is in read-write mode and initial/ensure scripts were executed. Depending on `postgresql.service` only guarantees a read-only connection.
 
 - The `services.siproxd` module has been removed as `siproxd` is unmaintained and broken with libosip 5.x.
 

--- a/nixos/modules/services/admin/pgadmin.nix
+++ b/nixos/modules/services/admin/pgadmin.nix
@@ -182,7 +182,7 @@ in
       requires = [ "network.target" ];
       # we're adding this optionally so just in case there's any race it'll be caught
       # in case postgres doesn't start, pgadmin will just start normally
-      wants = [ "postgresql.service" ];
+      wants = [ "postgresql.target" ];
 
       path = [
         config.services.postgresql.package

--- a/nixos/modules/services/backup/bacula.nix
+++ b/nixos/modules/services/backup/bacula.nix
@@ -720,7 +720,7 @@ in
     systemd.services.bacula-dir = mkIf dir_cfg.enable {
       after = [
         "network.target"
-        "postgresql.service"
+        "postgresql.target"
       ];
       description = "Bacula Director Daemon";
       wantedBy = [ "multi-user.target" ];

--- a/nixos/modules/services/backup/postgresql-backup.nix
+++ b/nixos/modules/services/backup/postgresql-backup.nix
@@ -35,7 +35,7 @@ let
 
       description = "Backup of ${db} database(s)";
 
-      requires = [ "postgresql.service" ];
+      requires = [ "postgresql.target" ];
 
       path = [
         pkgs.coreutils

--- a/nixos/modules/services/continuous-integration/hydra/default.nix
+++ b/nixos/modules/services/continuous-integration/hydra/default.nix
@@ -334,8 +334,8 @@ in
 
     systemd.services.hydra-init = {
       wantedBy = [ "multi-user.target" ];
-      requires = lib.optional haveLocalDB "postgresql.service";
-      after = lib.optional haveLocalDB "postgresql.service";
+      requires = lib.optional haveLocalDB "postgresql.target";
+      after = lib.optional haveLocalDB "postgresql.target";
       environment = env // {
         HYDRA_DBI = "${env.HYDRA_DBI};application_name=hydra-init";
       };

--- a/nixos/modules/services/databases/pgmanage.nix
+++ b/nixos/modules/services/databases/pgmanage.nix
@@ -185,8 +185,8 @@ in
   config = lib.mkIf cfg.enable {
     systemd.services.pgmanage = {
       description = "pgmanage - PostgreSQL Administration for the web";
-      wants = [ "postgresql.service" ];
-      after = [ "postgresql.service" ];
+      wants = [ "postgresql.target" ];
+      after = [ "postgresql.target" ];
       wantedBy = [ "multi-user.target" ];
       serviceConfig = {
         User = pgmanage;

--- a/nixos/modules/services/databases/postgres-websockets.nix
+++ b/nixos/modules/services/databases/postgres-websockets.nix
@@ -156,7 +156,7 @@ in
       wants = [ "network-online.target" ];
       after = [
         "network-online.target"
-        "postgresql.service"
+        "postgresql.target"
       ];
 
       environment =

--- a/nixos/modules/services/databases/postgresql.md
+++ b/nixos/modules/services/databases/postgresql.md
@@ -89,29 +89,21 @@ database migrations.
 
 **NOTE:** please make sure that any added migrations are idempotent (re-runnable).
 
-#### as superuser {#module-services-postgres-initializing-extra-permissions-superuser}
+#### in database's setup `postStart` {#module-services-postgres-initializing-extra-permissions-superuser-post-start}
 
-**Advantage:** compatible with postgres < 15, because it's run
-as the database superuser `postgres`.
-
-##### in database `postStart` {#module-services-postgres-initializing-extra-permissions-superuser-post-start}
-
-**Disadvantage:** need to take care of ordering yourself. In this
-example, `mkAfter` ensures that permissions are assigned after any
-databases from `ensureDatabases` and `extraUser1` from `ensureUsers`
-are already created.
+`ensureUsers` is run in `postgresql-setup`, so this is where `postStart` must be added to:
 
 ```nix
   {
-    systemd.services.postgresql.postStart = lib.mkAfter ''
-      $PSQL service1 -c 'GRANT SELECT ON ALL TABLES IN SCHEMA public TO "extraUser1"'
-      $PSQL service1 -c 'GRANT SELECT ON ALL SEQUENCES IN SCHEMA public TO "extraUser1"'
+    systemd.services.postgresql-setup.postStart = ''
+      psql service1 -c 'GRANT SELECT ON ALL TABLES IN SCHEMA public TO "extraUser1"'
+      psql service1 -c 'GRANT SELECT ON ALL SEQUENCES IN SCHEMA public TO "extraUser1"'
       # ....
     '';
   }
 ```
 
-##### in intermediate oneshot service {#module-services-postgres-initializing-extra-permissions-superuser-oneshot}
+#### in intermediate oneshot service {#module-services-postgres-initializing-extra-permissions-superuser-oneshot}
 
 ```nix
   {
@@ -119,54 +111,13 @@ are already created.
       serviceConfig.Type = "oneshot";
       requiredBy = "service1.service";
       before = "service1.service";
-      after = "postgresql.service";
+      after = "postgresql.target";
       serviceConfig.User = "postgres";
-      environment.PSQL = "psql --port=${toString services.postgresql.settings.port}";
+      environment.PGPORT = toString services.postgresql.settings.port;
       path = [ postgresql ];
       script = ''
-        $PSQL service1 -c 'GRANT SELECT ON ALL TABLES IN SCHEMA public TO "extraUser1"'
-        $PSQL service1 -c 'GRANT SELECT ON ALL SEQUENCES IN SCHEMA public TO "extraUser1"'
-        # ....
-      '';
-    };
-  }
-```
-
-#### as service user {#module-services-postgres-initializing-extra-permissions-service-user}
-
-**Advantage:** re-uses systemd's dependency ordering;
-
-**Disadvantage:** relies on service user having grant permission. To be combined with `ensureDBOwnership`.
-
-##### in service `preStart` {#module-services-postgres-initializing-extra-permissions-service-user-pre-start}
-
-```nix
-  {
-    environment.PSQL = "psql --port=${toString services.postgresql.settings.port}";
-    path = [ postgresql ];
-    systemd.services."service1".preStart = ''
-      $PSQL -c 'GRANT SELECT ON ALL TABLES IN SCHEMA public TO "extraUser1"'
-      $PSQL -c 'GRANT SELECT ON ALL SEQUENCES IN SCHEMA public TO "extraUser1"'
-      # ....
-    '';
-  }
-```
-
-##### in intermediate oneshot service {#module-services-postgres-initializing-extra-permissions-service-user-oneshot}
-
-```nix
-  {
-    systemd.services."migrate-service1-db1" = {
-      serviceConfig.Type = "oneshot";
-      requiredBy = "service1.service";
-      before = "service1.service";
-      after = "postgresql.service";
-      serviceConfig.User = "service1";
-      environment.PSQL = "psql --port=${toString services.postgresql.settings.port}";
-      path = [ postgresql ];
-      script = ''
-        $PSQL -c 'GRANT SELECT ON ALL TABLES IN SCHEMA public TO "extraUser1"'
-        $PSQL -c 'GRANT SELECT ON ALL SEQUENCES IN SCHEMA public TO "extraUser1"'
+        psql service1 -c 'GRANT SELECT ON ALL TABLES IN SCHEMA public TO "extraUser1"'
+        psql service1 -c 'GRANT SELECT ON ALL SEQUENCES IN SCHEMA public TO "extraUser1"'
         # ....
       '';
     };

--- a/nixos/modules/services/databases/postgresql.md
+++ b/nixos/modules/services/databases/postgresql.md
@@ -105,6 +105,14 @@ database migrations.
 
 #### in intermediate oneshot service {#module-services-postgres-initializing-extra-permissions-superuser-oneshot}
 
+Make sure to run this service after `postgresql.target`, not `postgresql.service`.
+
+They differ in two aspects:
+- `postgresql.target` includes `postgresql-setup`, so users managed via `ensureUsers` are already created.
+- `postgresql.target` will wait until PostgreSQL is in read-write mode after restoring from backup, while `postgresql.service` will already be ready when PostgreSQL is still recovering in read-only mode.
+
+Both can lead to unexpected errors either during initial database creation or restore, when using `postgresql.service`.
+
 ```nix
   {
     systemd.services."migrate-service1-db1" = {

--- a/nixos/modules/services/databases/postgresql.nix
+++ b/nixos/modules/services/databases/postgresql.nix
@@ -751,11 +751,22 @@ in
       cfg.checkConfig && pkgs.stdenv.hostPlatform == pkgs.stdenv.buildPlatform
     ) configFileCheck;
 
+    systemd.targets.postgresql = {
+      description = "PostgreSQL";
+      wantedBy = [ "multi-user.target" ];
+      bindsTo = [
+        "postgresql.service"
+        "postgresql-setup.service"
+      ];
+    };
+
     systemd.services.postgresql = {
       description = "PostgreSQL Server";
 
-      wantedBy = [ "multi-user.target" ];
       after = [ "network.target" ];
+
+      # To trigger the .target also on "systemctl start postgresql".
+      bindsTo = [ "postgresql.target" ];
 
       environment.PGDATA = cfg.dataDir;
 
@@ -775,49 +786,6 @@ in
 
         ln -sfn "${configFile}/postgresql.conf" "${cfg.dataDir}/postgresql.conf"
       '';
-
-      # Wait for PostgreSQL to be ready to accept connections.
-      postStart =
-        ''
-          PSQL="psql --port=${builtins.toString cfg.settings.port}"
-
-          while ! $PSQL -d postgres -c "" 2> /dev/null; do
-              if ! kill -0 "$MAINPID"; then exit 1; fi
-              sleep 0.1
-          done
-
-          if test -e "${cfg.dataDir}/.first_startup"; then
-            ${optionalString (cfg.initialScript != null) ''
-              $PSQL -f "${cfg.initialScript}" -d postgres
-            ''}
-            rm -f "${cfg.dataDir}/.first_startup"
-          fi
-        ''
-        + optionalString (cfg.ensureDatabases != [ ]) ''
-          ${concatMapStrings (database: ''
-            $PSQL -tAc "SELECT 1 FROM pg_database WHERE datname = '${database}'" | grep -q 1 || $PSQL -tAc 'CREATE DATABASE "${database}"'
-          '') cfg.ensureDatabases}
-        ''
-        + ''
-          ${concatMapStrings (
-            user:
-            let
-              dbOwnershipStmt = optionalString user.ensureDBOwnership ''$PSQL -tAc 'ALTER DATABASE "${user.name}" OWNER TO "${user.name}";' '';
-
-              filteredClauses = filterAttrs (name: value: value != null) user.ensureClauses;
-
-              clauseSqlStatements = attrValues (mapAttrs (n: v: if v then n else "no${n}") filteredClauses);
-
-              userClauses = ''$PSQL -tAc 'ALTER ROLE "${user.name}" ${concatStringsSep " " clauseSqlStatements}' '';
-            in
-            ''
-              $PSQL -tAc "SELECT 1 FROM pg_roles WHERE rolname='${user.name}'" | grep -q 1 || $PSQL -tAc 'CREATE USER "${user.name}"'
-              ${userClauses}
-
-              ${dbOwnershipStmt}
-            ''
-          ) cfg.ensureUsers}
-        '';
 
       serviceConfig = mkMerge [
         {
@@ -890,6 +858,64 @@ in
       ];
 
       unitConfig.RequiresMountsFor = "${cfg.dataDir}";
+    };
+
+    systemd.services.postgresql-setup = {
+      description = "PostgreSQL Setup Scripts";
+
+      requires = [ "postgresql.service" ];
+      after = [ "postgresql.service" ];
+
+      serviceConfig = {
+        User = "postgres";
+        Group = "postgres";
+        Type = "oneshot";
+        RemainAfterExit = true;
+      };
+
+      path = [ cfg.finalPackage ];
+      environment.PGPORT = builtins.toString cfg.settings.port;
+
+      # Wait for PostgreSQL to be ready to accept connections.
+      script =
+        ''
+          while ! psql -d postgres -c "" 2> /dev/null; do
+              if ! systemctl is-active --quiet postgresql.service; then exit 1; fi
+              sleep 0.1
+          done
+
+          if test -e "${cfg.dataDir}/.first_startup"; then
+            ${optionalString (cfg.initialScript != null) ''
+              psql -f "${cfg.initialScript}" -d postgres
+            ''}
+            rm -f "${cfg.dataDir}/.first_startup"
+          fi
+        ''
+        + optionalString (cfg.ensureDatabases != [ ]) ''
+          ${concatMapStrings (database: ''
+            psql -tAc "SELECT 1 FROM pg_database WHERE datname = '${database}'" | grep -q 1 || psql -tAc 'CREATE DATABASE "${database}"'
+          '') cfg.ensureDatabases}
+        ''
+        + ''
+          ${concatMapStrings (
+            user:
+            let
+              dbOwnershipStmt = optionalString user.ensureDBOwnership ''psql -tAc 'ALTER DATABASE "${user.name}" OWNER TO "${user.name}";' '';
+
+              filteredClauses = filterAttrs (name: value: value != null) user.ensureClauses;
+
+              clauseSqlStatements = attrValues (mapAttrs (n: v: if v then n else "no${n}") filteredClauses);
+
+              userClauses = ''psql -tAc 'ALTER ROLE "${user.name}" ${concatStringsSep " " clauseSqlStatements}' '';
+            in
+            ''
+              psql -tAc "SELECT 1 FROM pg_roles WHERE rolname='${user.name}'" | grep -q 1 || psql -tAc 'CREATE USER "${user.name}"'
+              ${userClauses}
+
+              ${dbOwnershipStmt}
+            ''
+          ) cfg.ensureUsers}
+        '';
     };
   };
 

--- a/nixos/modules/services/databases/postgresql.nix
+++ b/nixos/modules/services/databases/postgresql.nix
@@ -894,8 +894,5 @@ in
   };
 
   meta.doc = ./postgresql.md;
-  meta.maintainers = with lib.maintainers; [
-    thoughtpolice
-    danbst
-  ];
+  meta.maintainers = pkgs.postgresql.meta.maintainers;
 }

--- a/nixos/modules/services/databases/postgrest.nix
+++ b/nixos/modules/services/databases/postgrest.nix
@@ -256,7 +256,7 @@ in
       wants = [ "network-online.target" ];
       after = [
         "network-online.target"
-        "postgresql.service"
+        "postgresql.target"
       ];
 
       serviceConfig = {

--- a/nixos/modules/services/development/zammad.nix
+++ b/nixos/modules/services/development/zammad.nix
@@ -275,13 +275,13 @@ in
           "systemd-tmpfiles-setup.service"
         ]
         ++ lib.optionals (cfg.database.createLocally) [
-          "postgresql.service"
+          "postgresql.target"
         ]
         ++ lib.optionals cfg.redis.createLocally [
           "redis-${cfg.redis.name}.service"
         ];
       requires = lib.optionals (cfg.database.createLocally) [
-        "postgresql.service"
+        "postgresql.target"
       ];
       description = "Zammad web";
       wantedBy = [ "multi-user.target" ];

--- a/nixos/modules/services/finance/libeufin/common.nix
+++ b/nixos/modules/services/finance/libeufin/common.nix
@@ -123,8 +123,8 @@ libeufinComponent:
                   echo "Bank initialisation complete"
                 fi
               '';
-            requires = lib.optionals cfg.createLocalDatabase [ "postgresql.service" ];
-            after = [ "network.target" ] ++ lib.optionals cfg.createLocalDatabase [ "postgresql.service" ];
+            requires = lib.optionals cfg.createLocalDatabase [ "postgresql.target" ];
+            after = [ "network.target" ] ++ lib.optionals cfg.createLocalDatabase [ "postgresql.target" ];
           };
       };
 

--- a/nixos/modules/services/finance/odoo.nix
+++ b/nixos/modules/services/finance/odoo.nix
@@ -119,13 +119,13 @@ in
         wantedBy = [ "multi-user.target" ];
         after = [
           "network.target"
-          "postgresql.service"
+          "postgresql.target"
         ];
 
         # pg_dump
         path = [ config.services.postgresql.package ];
 
-        requires = [ "postgresql.service" ];
+        requires = [ "postgresql.target" ];
 
         serviceConfig = {
           ExecStart = "${cfg.package}/bin/odoo";

--- a/nixos/modules/services/finance/taler/common.nix
+++ b/nixos/modules/services/finance/taler/common.nix
@@ -89,8 +89,8 @@ in
             Restart = "on-failure";
             RestartSec = "5s";
           };
-          requires = [ "postgresql.service" ];
-          after = [ "postgresql.service" ];
+          requires = [ "postgresql.target" ];
+          after = [ "postgresql.target" ];
         };
       }
     ];

--- a/nixos/modules/services/home-automation/home-assistant.nix
+++ b/nixos/modules/services/home-automation/home-assistant.nix
@@ -623,7 +623,7 @@ in
 
         # prevent races with database creation
         "mysql.service"
-        "postgresql.service"
+        "postgresql.target"
       ];
       reloadTriggers =
         optionals (cfg.config != null) [ configFile ]

--- a/nixos/modules/services/mail/dspam.nix
+++ b/nixos/modules/services/mail/dspam.nix
@@ -107,7 +107,7 @@ in
         systemd.services.dspam = {
           description = "dspam spam filtering daemon";
           wantedBy = [ "multi-user.target" ];
-          after = [ "postgresql.service" ];
+          after = [ "postgresql.target" ];
           restartTriggers = [ cfgfile ];
 
           serviceConfig = {

--- a/nixos/modules/services/mail/listmonk.nix
+++ b/nixos/modules/services/mail/listmonk.nix
@@ -193,7 +193,7 @@ in
 
     systemd.services.listmonk = {
       description = "Listmonk - newsletter and mailing list manager";
-      after = [ "network.target" ] ++ lib.optional cfg.database.createLocally "postgresql.service";
+      after = [ "network.target" ] ++ lib.optional cfg.database.createLocally "postgresql.target";
       wantedBy = [ "multi-user.target" ];
       serviceConfig = {
         Type = "exec";

--- a/nixos/modules/services/mail/mailman.nix
+++ b/nixos/modules/services/mail/mailman.nix
@@ -575,9 +575,9 @@ in
           after =
             [ "network.target" ]
             ++ lib.optional cfg.enablePostfix "postfix-setup.service"
-            ++ lib.optional withPostgresql "postgresql.service";
+            ++ lib.optional withPostgresql "postgresql.target";
           restartTriggers = [ mailmanCfgFile ];
-          requires = lib.optional withPostgresql "postgresql.service";
+          requires = lib.optional withPostgresql "postgresql.target";
           wantedBy = [ "multi-user.target" ];
           serviceConfig = {
             ExecStart = "${mailmanEnv}/bin/mailman start";
@@ -609,8 +609,8 @@ in
             "hyperkitty.service"
           ];
           path = with pkgs; [ jq ];
-          after = lib.optional withPostgresql "postgresql.service";
-          requires = lib.optional withPostgresql "postgresql.service";
+          after = lib.optional withPostgresql "postgresql.target";
+          requires = lib.optional withPostgresql "postgresql.target";
           serviceConfig.RemainAfterExit = true;
           serviceConfig.Type = "oneshot";
           script = ''
@@ -709,11 +709,11 @@ in
           in
           {
             wantedBy = [ "multi-user.target" ];
-            after = lib.optional withPostgresql "postgresql.service";
+            after = lib.optional withPostgresql "postgresql.target";
             requires = [
               "mailman-uwsgi.socket"
               "mailman-web-setup.service"
-            ] ++ lib.optional withPostgresql "postgresql.service";
+            ] ++ lib.optional withPostgresql "postgresql.target";
             restartTriggers = [ config.environment.etc."mailman3/settings.py".source ];
             serviceConfig = {
               # Since the mailman-web settings.py obstinately creates a logs

--- a/nixos/modules/services/mail/postfixadmin.nix
+++ b/nixos/modules/services/mail/postfixadmin.nix
@@ -148,8 +148,8 @@ in
     # objects owners and extensions; for now we tack on what's needed
     # here.
     systemd.services.postfixadmin-postgres = lib.mkIf localDB {
-      after = [ "postgresql.service" ];
-      bindsTo = [ "postgresql.service" ];
+      after = [ "postgresql.target" ];
+      bindsTo = [ "postgresql.target" ];
       wantedBy = [ "multi-user.target" ];
       path = [
         pgsql.package

--- a/nixos/modules/services/mail/roundcube.nix
+++ b/nixos/modules/services/mail/roundcube.nix
@@ -273,8 +273,8 @@ in
 
     systemd.services.roundcube-setup = lib.mkMerge [
       (lib.mkIf localDB {
-        requires = [ "postgresql.service" ];
-        after = [ "postgresql.service" ];
+        requires = [ "postgresql.target" ];
+        after = [ "postgresql.target" ];
       })
       {
         wants = [ "network-online.target" ];

--- a/nixos/modules/services/matrix/appservice-irc.nix
+++ b/nixos/modules/services/matrix/appservice-irc.nix
@@ -196,7 +196,7 @@ in
       description = "Matrix-IRC bridge";
       before = [ "matrix-synapse.service" ]; # So the registration can be used by Synapse
       after = lib.optionals (cfg.settings.database.engine == "postgres") [
-        "postgresql.service"
+        "postgresql.target"
       ];
       wantedBy = [ "multi-user.target" ];
 

--- a/nixos/modules/services/matrix/maubot.nix
+++ b/nixos/modules/services/matrix/maubot.nix
@@ -440,7 +440,7 @@ in
 
     systemd.services.maubot = rec {
       description = "maubot - a plugin-based Matrix bot system written in Python";
-      after = [ "network.target" ] ++ wants ++ lib.optional hasLocalPostgresDB "postgresql.service";
+      after = [ "network.target" ] ++ wants ++ lib.optional hasLocalPostgresDB "postgresql.target";
       # all plugins get automatically disabled if maubot starts before synapse
       wants = lib.optional config.services.matrix-synapse.enable config.services.matrix-synapse.serviceUnit;
       wantedBy = [ "multi-user.target" ];

--- a/nixos/modules/services/matrix/synapse-auto-compressor.nix
+++ b/nixos/modules/services/matrix/synapse-auto-compressor.nix
@@ -119,7 +119,7 @@ in
     systemd.services.synapse-auto-compressor = {
       description = "synapse-auto-compressor";
       requires = lib.optionals synapseUsesLocalPostgresql [
-        "postgresql.service"
+        "postgresql.target"
       ];
       inherit (cfg) startAt;
       serviceConfig = {

--- a/nixos/modules/services/matrix/synapse.nix
+++ b/nixos/modules/services/matrix/synapse.nix
@@ -1439,7 +1439,7 @@ in
     systemd.targets.matrix-synapse = lib.mkIf hasWorkers {
       description = "Synapse Matrix parent target";
       wants = [ "network-online.target" ];
-      after = [ "network-online.target" ] ++ optional hasLocalPostgresDB "postgresql.service";
+      after = [ "network-online.target" ] ++ optional hasLocalPostgresDB "postgresql.target";
       wantedBy = [ "multi-user.target" ];
     };
 
@@ -1451,13 +1451,13 @@ in
               partOf = [ "matrix-synapse.target" ];
               wantedBy = [ "matrix-synapse.target" ];
               unitConfig.ReloadPropagatedFrom = "matrix-synapse.target";
-              requires = optional hasLocalPostgresDB "postgresql.service";
+              requires = optional hasLocalPostgresDB "postgresql.target";
             }
           else
             {
               wants = [ "network-online.target" ];
-              after = [ "network-online.target" ] ++ optional hasLocalPostgresDB "postgresql.service";
-              requires = optional hasLocalPostgresDB "postgresql.service";
+              after = [ "network-online.target" ] ++ optional hasLocalPostgresDB "postgresql.target";
+              requires = optional hasLocalPostgresDB "postgresql.target";
               wantedBy = [ "multi-user.target" ];
             };
         baseServiceConfig = {

--- a/nixos/modules/services/misc/atuin.nix
+++ b/nixos/modules/services/misc/atuin.nix
@@ -92,13 +92,13 @@ in
 
     systemd.services.atuin = {
       description = "atuin server";
-      requires = lib.optionals cfg.database.createLocally [ "postgresql.service" ];
+      requires = lib.optionals cfg.database.createLocally [ "postgresql.target" ];
       after = [
         "network-online.target"
-      ] ++ lib.optionals cfg.database.createLocally [ "postgresql.service" ];
+      ] ++ lib.optionals cfg.database.createLocally [ "postgresql.target" ];
       wants = [
         "network-online.target"
-      ] ++ lib.optionals cfg.database.createLocally [ "postgresql.service" ];
+      ] ++ lib.optionals cfg.database.createLocally [ "postgresql.target" ];
       wantedBy = [ "multi-user.target" ];
 
       serviceConfig = {

--- a/nixos/modules/services/misc/disnix.nix
+++ b/nixos/modules/services/misc/disnix.nix
@@ -77,7 +77,7 @@ in
           [ "dbus.service" ]
           ++ lib.optional config.services.httpd.enable "httpd.service"
           ++ lib.optional config.services.mysql.enable "mysql.service"
-          ++ lib.optional config.services.postgresql.enable "postgresql.service"
+          ++ lib.optional config.services.postgresql.enable "postgresql.target"
           ++ lib.optional config.services.tomcat.enable "tomcat.service"
           ++ lib.optional config.services.svnserve.enable "svnserve.service"
           ++ lib.optional config.services.mongodb.enable "mongodb.service"

--- a/nixos/modules/services/misc/forgejo.nix
+++ b/nixos/modules/services/misc/forgejo.nix
@@ -663,7 +663,7 @@ in
           "network.target"
         ]
         ++ optionals usePostgresql [
-          "postgresql.service"
+          "postgresql.target"
         ]
         ++ optionals useMysql [
           "mysql.service"
@@ -673,7 +673,7 @@ in
         ];
       requires =
         optionals (cfg.database.createDatabase && usePostgresql) [
-          "postgresql.service"
+          "postgresql.target"
         ]
         ++ optionals (cfg.database.createDatabase && useMysql) [
           "mysql.service"

--- a/nixos/modules/services/misc/gammu-smsd.nix
+++ b/nixos/modules/services/misc/gammu-smsd.nix
@@ -238,7 +238,7 @@ in
 
       wants =
         with cfg.backend;
-        [ ] ++ lib.optionals (service == "sql" && sql.driver == "native_pgsql") [ "postgresql.service" ];
+        [ ] ++ lib.optionals (service == "sql" && sql.driver == "native_pgsql") [ "postgresql.target" ];
 
       preStart =
         with cfg.backend;

--- a/nixos/modules/services/misc/gitea.nix
+++ b/nixos/modules/services/misc/gitea.nix
@@ -758,10 +758,10 @@ in
       description = "gitea";
       after =
         [ "network.target" ]
-        ++ optional usePostgresql "postgresql.service"
+        ++ optional usePostgresql "postgresql.target"
         ++ optional useMysql "mysql.service";
       requires =
-        optional (cfg.database.createDatabase && usePostgresql) "postgresql.service"
+        optional (cfg.database.createDatabase && usePostgresql) "postgresql.target"
         ++ optional (cfg.database.createDatabase && useMysql) "mysql.service";
       wantedBy = [ "multi-user.target" ];
       path = [

--- a/nixos/modules/services/misc/gitlab.nix
+++ b/nixos/modules/services/misc/gitlab.nix
@@ -1295,8 +1295,8 @@ in
         pgsql = config.services.postgresql;
       in
       mkIf databaseActuallyCreateLocally {
-        after = [ "postgresql.service" ];
-        bindsTo = [ "postgresql.service" ];
+        after = [ "postgresql.target" ];
+        bindsTo = [ "postgresql.target" ];
         wantedBy = [ "gitlab.target" ];
         partOf = [ "gitlab.target" ];
         path = [
@@ -1561,12 +1561,12 @@ in
     systemd.services.gitlab-db-config = {
       after = [
         "gitlab-config.service"
-        "gitlab-postgresql.service"
-        "postgresql.service"
+        "gitlab-postgresql.target"
+        "postgresql.target"
       ];
       wants =
-        optional (cfg.databaseHost == "") "postgresql.service"
-        ++ optional databaseActuallyCreateLocally "gitlab-postgresql.service";
+        optional (cfg.databaseHost == "") "postgresql.target"
+        ++ optional databaseActuallyCreateLocally "gitlab-postgresql.target";
       bindsTo = [ "gitlab-config.service" ];
       wantedBy = [ "gitlab.target" ];
       partOf = [ "gitlab.target" ];
@@ -1596,7 +1596,7 @@ in
       after = [
         "network.target"
         "redis-gitlab.service"
-        "postgresql.service"
+        "postgresql.target"
         "gitlab-config.service"
         "gitlab-db-config.service"
       ];
@@ -1604,7 +1604,7 @@ in
         "gitlab-config.service"
         "gitlab-db-config.service"
       ];
-      wants = [ "redis-gitlab.service" ] ++ optional (cfg.databaseHost == "") "postgresql.service";
+      wants = [ "redis-gitlab.service" ] ++ optional (cfg.databaseHost == "") "postgresql.target";
       wantedBy = [ "gitlab.target" ];
       partOf = [ "gitlab.target" ];
       environment =
@@ -1847,7 +1847,7 @@ in
         "gitlab-config.service"
         "gitlab-db-config.service"
       ];
-      wants = [ "redis-gitlab.service" ] ++ optional (cfg.databaseHost == "") "postgresql.service";
+      wants = [ "redis-gitlab.service" ] ++ optional (cfg.databaseHost == "") "postgresql.target";
       requiredBy = [ "gitlab.target" ];
       partOf = [ "gitlab.target" ];
       environment = gitlabEnv;

--- a/nixos/modules/services/misc/paperless.nix
+++ b/nixos/modules/services/misc/paperless.nix
@@ -491,18 +491,18 @@ in
               fi
             fi
           '';
-          requires = lib.optional cfg.database.createLocally "postgresql.service";
+          requires = lib.optional cfg.database.createLocally "postgresql.target";
           after =
             lib.optional enableRedis "redis-paperless.service"
-            ++ lib.optional cfg.database.createLocally "postgresql.service";
+            ++ lib.optional cfg.database.createLocally "postgresql.target";
         };
 
         systemd.services.paperless-task-queue = {
           description = "Paperless Celery Workers";
-          requires = lib.optional cfg.database.createLocally "postgresql.service";
+          requires = lib.optional cfg.database.createLocally "postgresql.target";
           after = [
             "paperless-scheduler.service"
-          ] ++ lib.optional cfg.database.createLocally "postgresql.service";
+          ] ++ lib.optional cfg.database.createLocally "postgresql.target";
           serviceConfig = defaultServiceConfig // {
             User = cfg.user;
             ExecStart = "${cfg.package}/bin/celery --app paperless worker --loglevel INFO";
@@ -520,10 +520,10 @@ in
           # Bind to `paperless-scheduler` so that the consumer never runs
           # during migrations
           bindsTo = [ "paperless-scheduler.service" ];
-          requires = lib.optional cfg.database.createLocally "postgresql.service";
+          requires = lib.optional cfg.database.createLocally "postgresql.target";
           after = [
             "paperless-scheduler.service"
-          ] ++ lib.optional cfg.database.createLocally "postgresql.service";
+          ] ++ lib.optional cfg.database.createLocally "postgresql.target";
           serviceConfig = defaultServiceConfig // {
             User = cfg.user;
             ExecStart = "${cfg.package}/bin/paperless-ngx document_consumer";
@@ -541,10 +541,10 @@ in
           # Bind to `paperless-scheduler` so that the web server never runs
           # during migrations
           bindsTo = [ "paperless-scheduler.service" ];
-          requires = lib.optional cfg.database.createLocally "postgresql.service";
+          requires = lib.optional cfg.database.createLocally "postgresql.target";
           after = [
             "paperless-scheduler.service"
-          ] ++ lib.optional cfg.database.createLocally "postgresql.service";
+          ] ++ lib.optional cfg.database.createLocally "postgresql.target";
           # Setup PAPERLESS_SECRET_KEY.
           # If this environment variable is left unset, paperless-ngx defaults
           # to a well-known value, which is insecure.

--- a/nixos/modules/services/misc/redmine.nix
+++ b/nixos/modules/services/misc/redmine.nix
@@ -374,7 +374,7 @@ in
       after =
         [ "network.target" ]
         ++ lib.optional mysqlLocal "mysql.service"
-        ++ lib.optional pgsqlLocal "postgresql.service";
+        ++ lib.optional pgsqlLocal "postgresql.target";
       wantedBy = [ "multi-user.target" ];
       environment.RAILS_ENV = "production";
       environment.RAILS_CACHE = "${cfg.stateDir}/cache";

--- a/nixos/modules/services/misc/sourcehut/service.nix
+++ b/nixos/modules/services/misc/sourcehut/service.nix
@@ -52,10 +52,10 @@ let
       {
         after =
           [ "network.target" ]
-          ++ optional cfg.postgresql.enable "postgresql.service"
+          ++ optional cfg.postgresql.enable "postgresql.target"
           ++ optional cfg.redis.enable "redis-sourcehut-${srvsrht}.service";
         requires =
-          optional cfg.postgresql.enable "postgresql.service"
+          optional cfg.postgresql.enable "postgresql.target"
           ++ optional cfg.redis.enable "redis-sourcehut-${srvsrht}.service";
         path = [ pkgs.gawk ];
         environment.HOME = runDir;
@@ -482,11 +482,9 @@ in
             && lib.strings.versionAtLeast config.services.postgresql.package.version "15.0"
           )
           {
-            postgresql.postStart = (
-              lib.mkAfter ''
-                $PSQL -tAc 'ALTER DATABASE "${srvCfg.postgresql.database}" OWNER TO "${srvCfg.user}";'
-              ''
-            );
+            postgresql-setup.postStart = ''
+              psql -tAc 'ALTER DATABASE "${srvCfg.postgresql.database}" OWNER TO "${srvCfg.user}";'
+            '';
           }
         )
       ];

--- a/nixos/modules/services/monitoring/grafana.nix
+++ b/nixos/modules/services/monitoring/grafana.nix
@@ -2020,7 +2020,7 @@ in
       wantedBy = [ "multi-user.target" ];
       after =
         [ "networking.target" ]
-        ++ lib.optional usePostgresql "postgresql.service"
+        ++ lib.optional usePostgresql "postgresql.target"
         ++ lib.optional useMysql "mysql.service";
       script = ''
         set -o errexit -o pipefail -o nounset -o errtrace

--- a/nixos/modules/services/monitoring/zabbix-proxy.nix
+++ b/nixos/modules/services/monitoring/zabbix-proxy.nix
@@ -337,7 +337,7 @@ in
       description = "Zabbix Proxy";
 
       wantedBy = [ "multi-user.target" ];
-      after = optional mysqlLocal "mysql.service" ++ optional pgsqlLocal "postgresql.service";
+      after = optional mysqlLocal "mysql.service" ++ optional pgsqlLocal "postgresql.target";
 
       path = [ "/run/wrappers" ] ++ cfg.extraPackages;
       preStart =

--- a/nixos/modules/services/monitoring/zabbix-server.nix
+++ b/nixos/modules/services/monitoring/zabbix-server.nix
@@ -328,7 +328,7 @@ in
       description = "Zabbix Server";
 
       wantedBy = [ "multi-user.target" ];
-      after = optional mysqlLocal "mysql.service" ++ optional pgsqlLocal "postgresql.service";
+      after = optional mysqlLocal "mysql.service" ++ optional pgsqlLocal "postgresql.target";
 
       path = [ "/run/wrappers" ] ++ cfg.extraPackages;
       preStart =
@@ -374,7 +374,7 @@ in
 
     systemd.services.httpd.after =
       optional (config.services.zabbixWeb.enable && mysqlLocal) "mysql.service"
-      ++ optional (config.services.zabbixWeb.enable && pgsqlLocal) "postgresql.service";
+      ++ optional (config.services.zabbixWeb.enable && pgsqlLocal) "postgresql.target";
 
   };
 

--- a/nixos/modules/services/networking/atticd.nix
+++ b/nixos/modules/services/networking/atticd.nix
@@ -169,8 +169,8 @@ in
 
     systemd.services.atticd = {
       wantedBy = [ "multi-user.target" ];
-      after = [ "network-online.target" ] ++ lib.optionals hasLocalPostgresDB [ "postgresql.service" ];
-      requires = lib.optionals hasLocalPostgresDB [ "postgresql.service" ];
+      after = [ "network-online.target" ] ++ lib.optionals hasLocalPostgresDB [ "postgresql.target" ];
+      requires = lib.optionals hasLocalPostgresDB [ "postgresql.target" ];
       wants = [ "network-online.target" ];
 
       serviceConfig = {

--- a/nixos/modules/services/networking/firezone/server.nix
+++ b/nixos/modules/services/networking/firezone/server.nix
@@ -1105,8 +1105,8 @@ in
       systemd.services.firezone-initialize = {
         description = "Backend initialization service for the Firezone zero-trust access platform";
 
-        after = mkIf cfg.enableLocalDB [ "postgresql.service" ];
-        requires = mkIf cfg.enableLocalDB [ "postgresql.service" ];
+        after = mkIf cfg.enableLocalDB [ "postgresql.target" ];
+        requires = mkIf cfg.enableLocalDB [ "postgresql.target" ];
         wantedBy = [ "firezone.target" ];
         partOf = [ "firezone.target" ];
 

--- a/nixos/modules/services/networking/pleroma.nix
+++ b/nixos/modules/services/networking/pleroma.nix
@@ -122,7 +122,7 @@ in
           wants = [ "network-online.target" ];
           after = [
             "network-online.target"
-            "postgresql.service"
+            "postgresql.target"
           ];
           wantedBy = [ "pleroma.service" ];
           environment.RELEASE_COOKIE = "/var/lib/pleroma/.cookie";

--- a/nixos/modules/services/networking/powerdns.nix
+++ b/nixos/modules/services/networking/powerdns.nix
@@ -53,7 +53,7 @@ in
       after = [
         "network.target"
         "mysql.service"
-        "postgresql.service"
+        "postgresql.target"
         "openldap.service"
       ];
 

--- a/nixos/modules/services/networking/quassel.nix
+++ b/nixos/modules/services/networking/quassel.nix
@@ -120,7 +120,7 @@ in
       wantedBy = [ "multi-user.target" ];
       after =
         [ "network.target" ]
-        ++ optional config.services.postgresql.enable "postgresql.service"
+        ++ optional config.services.postgresql.enable "postgresql.target"
         ++ optional config.services.mysql.enable "mysql.service";
 
       serviceConfig = {

--- a/nixos/modules/services/security/canaille.nix
+++ b/nixos/modules/services/security/canaille.nix
@@ -283,7 +283,7 @@ in
     systemd.services.canaille-install = {
       # We want this on boot, not on socket activation
       wantedBy = [ "multi-user.target" ];
-      after = optional createLocalPostgresqlDb "postgresql.service";
+      after = optional createLocalPostgresqlDb "postgresql.target";
       serviceConfig = commonServiceConfig // {
         Type = "oneshot";
         ExecStart = "${getExe finalPackage} install";
@@ -296,7 +296,7 @@ in
       after = [
         "network.target"
         "canaille-install.service"
-      ] ++ optional createLocalPostgresqlDb "postgresql.service";
+      ] ++ optional createLocalPostgresqlDb "postgresql.target";
       requires = [
         "canaille-install.service"
         "canaille.socket"

--- a/nixos/modules/services/torrent/bitmagnet.nix
+++ b/nixos/modules/services/torrent/bitmagnet.nix
@@ -127,8 +127,8 @@ in
       wantedBy = [ "multi-user.target" ];
       after = [
         "network.target"
-      ] ++ optional cfg.useLocalPostgresDB "postgresql.service";
-      requires = optional cfg.useLocalPostgresDB "postgresql.service";
+      ] ++ optional cfg.useLocalPostgresDB "postgresql.target";
+      requires = optional cfg.useLocalPostgresDB "postgresql.target";
       serviceConfig = {
         Type = "simple";
         DynamicUser = true;

--- a/nixos/modules/services/web-apps/akkoma.nix
+++ b/nixos/modules/services/web-apps/akkoma.nix
@@ -1231,7 +1231,7 @@ in
       requiredBy = [ "akkoma.service" ];
       after = [
         "akkoma-config.service"
-        "postgresql.service"
+        "postgresql.target"
       ];
       before = [ "akkoma.service" ];
 
@@ -1269,7 +1269,7 @@ in
           "akkoma-config.target"
           "network.target"
           "network-online.target"
-          "postgresql.service"
+          "postgresql.target"
         ];
 
         confinement.packages = mkIf isConfined runtimeInputs;

--- a/nixos/modules/services/web-apps/crabfit.nix
+++ b/nixos/modules/services/web-apps/crabfit.nix
@@ -109,7 +109,7 @@ in
         description = "The API for Crab Fit.";
 
         wantedBy = [ "multi-user.target" ];
-        after = [ "postgresql.service" ];
+        after = [ "postgresql.target" ];
 
         serviceConfig = {
           # TODO: harden

--- a/nixos/modules/services/web-apps/davis.nix
+++ b/nixos/modules/services/web-apps/davis.nix
@@ -444,11 +444,11 @@ in
         before = [ "phpfpm-davis.service" ];
         after =
           lib.optional mysqlLocal "mysql.service"
-          ++ lib.optional pgsqlLocal "postgresql.service"
+          ++ lib.optional pgsqlLocal "postgresql.target"
           ++ [ "davis-env-setup.service" ];
         requires =
           lib.optional mysqlLocal "mysql.service"
-          ++ lib.optional pgsqlLocal "postgresql.service"
+          ++ lib.optional pgsqlLocal "postgresql.target"
           ++ [ "davis-env-setup.service" ];
         wantedBy = [ "multi-user.target" ];
         serviceConfig = defaultServiceConfig // {
@@ -483,7 +483,7 @@ in
           "davis-db-migrate.service"
         ]
         ++ lib.optional mysqlLocal "mysql.service"
-        ++ lib.optional pgsqlLocal "postgresql.service";
+        ++ lib.optional pgsqlLocal "postgresql.target";
       systemd.services.phpfpm-davis.serviceConfig.ReadWritePaths = [ cfg.dataDir ];
 
       services.nginx = lib.mkIf (cfg.nginx != null) {

--- a/nixos/modules/services/web-apps/dependency-track.nix
+++ b/nixos/modules/services/web-apps/dependency-track.nix
@@ -535,9 +535,9 @@ in
     };
 
     systemd.services.dependency-track-postgresql-init = lib.mkIf cfg.database.createLocally {
-      after = [ "postgresql.service" ];
+      after = [ "postgresql.target" ];
       before = [ "dependency-track.service" ];
-      bindsTo = [ "postgresql.service" ];
+      bindsTo = [ "postgresql.target" ];
       path = [ config.services.postgresql.package ];
       serviceConfig = {
         Type = "oneshot";
@@ -572,7 +572,7 @@ in
           if cfg.database.createLocally then
             [
               "dependency-track-postgresql-init.service"
-              "postgresql.service"
+              "postgresql.target"
             ]
           else
             [ ];

--- a/nixos/modules/services/web-apps/dex.nix
+++ b/nixos/modules/services/web-apps/dex.nix
@@ -100,7 +100,7 @@ in
       wantedBy = [ "multi-user.target" ];
       after = [
         "networking.target"
-      ] ++ (optional (cfg.settings.storage.type == "postgres") "postgresql.service");
+      ] ++ (optional (cfg.settings.storage.type == "postgres") "postgresql.target");
       path = with pkgs; [ replace-secret ];
       restartTriggers = restartTriggers;
       serviceConfig =

--- a/nixos/modules/services/web-apps/discourse.nix
+++ b/nixos/modules/services/web-apps/discourse.nix
@@ -705,8 +705,8 @@ in
         pgsql = config.services.postgresql;
       in
       lib.mkIf databaseActuallyCreateLocally {
-        after = [ "postgresql.service" ];
-        bindsTo = [ "postgresql.service" ];
+        after = [ "postgresql.target" ];
+        bindsTo = [ "postgresql.target" ];
         wantedBy = [ "discourse.service" ];
         partOf = [ "discourse.service" ];
         path = [
@@ -732,16 +732,16 @@ in
       wantedBy = [ "multi-user.target" ];
       after = [
         "redis-discourse.service"
-        "postgresql.service"
-        "discourse-postgresql.service"
+        "postgresql.target"
+        "discourse-postgresql.target"
       ];
       bindsTo =
         [
           "redis-discourse.service"
         ]
         ++ lib.optionals (cfg.database.host == null) [
-          "postgresql.service"
-          "discourse-postgresql.service"
+          "postgresql.target"
+          "discourse-postgresql.target"
         ];
       path = cfg.package.runtimeDeps ++ [
         postgresqlPackage

--- a/nixos/modules/services/web-apps/fider.nix
+++ b/nixos/modules/services/web-apps/fider.nix
@@ -87,8 +87,8 @@ in
       wantedBy = [ "multi-user.target" ];
       after = [
         "network.target"
-      ] ++ lib.optionals (cfg.database.url == "local") [ "postgresql.service" ];
-      requires = lib.optionals (cfg.database.url == "local") [ "postgresql.service" ];
+      ] ++ lib.optionals (cfg.database.url == "local") [ "postgresql.target" ];
+      requires = lib.optionals (cfg.database.url == "local") [ "postgresql.target" ];
       environment =
         let
           localPostgresqlUrl = "postgres:///fider?host=/run/postgresql";

--- a/nixos/modules/services/web-apps/filesender.nix
+++ b/nixos/modules/services/web-apps/filesender.nix
@@ -227,7 +227,7 @@ in
         "multi-user.target"
         "phpfpm-filesender.service"
       ];
-      after = [ "postgresql.service" ];
+      after = [ "postgresql.target" ];
 
       restartIfChanged = true;
 

--- a/nixos/modules/services/web-apps/firefly-iii.nix
+++ b/nixos/modules/services/web-apps/firefly-iii.nix
@@ -308,7 +308,7 @@ in
 
     systemd.services.firefly-iii-setup = {
       after = [
-        "postgresql.service"
+        "postgresql.target"
         "mysql.service"
       ];
       requiredBy = [ "phpfpm-firefly-iii.service" ];
@@ -325,7 +325,7 @@ in
     systemd.services.firefly-iii-cron = {
       after = [
         "firefly-iii-setup.service"
-        "postgresql.service"
+        "postgresql.target"
         "mysql.service"
       ];
       wants = [ "firefly-iii-setup.service" ];

--- a/nixos/modules/services/web-apps/froide-govplan.nix
+++ b/nixos/modules/services/web-apps/froide-govplan.nix
@@ -163,9 +163,9 @@ in
     systemd = {
       services = {
 
-        postgresql.serviceConfig.ExecStartPost =
+        postgresql-setup.serviceConfig.ExecStartPost =
           let
-            sqlFile = pkgs.writeText "immich-pgvectors-setup.sql" ''
+            sqlFile = pkgs.writeText "froide-govplan-postgis-setup.sql" ''
               CREATE EXTENSION IF NOT EXISTS postgis;
             '';
           in
@@ -184,7 +184,7 @@ in
             Group = "govplan";
           };
           after = [
-            "postgresql.service"
+            "postgresql.target"
             "network.target"
             "systemd-tmpfiles-setup.service"
           ];

--- a/nixos/modules/services/web-apps/gancio.nix
+++ b/nixos/modules/services/web-apps/gancio.nix
@@ -211,7 +211,7 @@ in
         wantedBy = [ "multi-user.target" ];
         after = [
           "network.target"
-        ] ++ optional (cfg.settings.db.dialect == "postgres") "postgresql.service";
+        ] ++ optional (cfg.settings.db.dialect == "postgres") "postgresql.target";
 
         environment = {
           NODE_ENV = "production";

--- a/nixos/modules/services/web-apps/glitchtip.nix
+++ b/nixos/modules/services/web-apps/glitchtip.nix
@@ -171,11 +171,11 @@ in
 
           wants = [ "network-online.target" ];
           requires =
-            lib.optional cfg.database.createLocally "postgresql.service"
+            lib.optional cfg.database.createLocally "postgresql.target"
             ++ lib.optional cfg.redis.createLocally "redis-glitchtip.service";
           after =
             [ "network-online.target" ]
-            ++ lib.optional cfg.database.createLocally "postgresql.service"
+            ++ lib.optional cfg.database.createLocally "postgresql.target"
             ++ lib.optional cfg.redis.createLocally "redis-glitchtip.service";
 
           inherit environment;

--- a/nixos/modules/services/web-apps/gotosocial.nix
+++ b/nixos/modules/services/web-apps/gotosocial.nix
@@ -144,8 +144,8 @@ in
     systemd.services.gotosocial = {
       description = "ActivityPub social network server";
       wantedBy = [ "multi-user.target" ];
-      after = [ "network.target" ] ++ lib.optional cfg.setupPostgresqlDB "postgresql.service";
-      requires = lib.optional cfg.setupPostgresqlDB "postgresql.service";
+      after = [ "network.target" ] ++ lib.optional cfg.setupPostgresqlDB "postgresql.target";
+      requires = lib.optional cfg.setupPostgresqlDB "postgresql.target";
       restartTriggers = [ configFile ];
 
       serviceConfig = {

--- a/nixos/modules/services/web-apps/homebox.nix
+++ b/nixos/modules/services/web-apps/homebox.nix
@@ -81,8 +81,8 @@ in
       ];
     };
     systemd.services.homebox = {
-      requires = lib.optional cfg.database.createLocally "postgresql.service";
-      after = lib.optional cfg.database.createLocally "postgresql.service";
+      requires = lib.optional cfg.database.createLocally "postgresql.target";
+      after = lib.optional cfg.database.createLocally "postgresql.target";
       environment = cfg.settings;
       serviceConfig = {
         User = "homebox";

--- a/nixos/modules/services/web-apps/immich.nix
+++ b/nixos/modules/services/web-apps/immich.nix
@@ -254,7 +254,7 @@ in
         search_path = "\"$user\", public, vectors";
       };
     };
-    systemd.services.postgresql.serviceConfig.ExecStartPost =
+    systemd.services.postgresql-setup.serviceConfig.ExecStartPost =
       let
         sqlFile = pkgs.writeText "immich-pgvectors-setup.sql" ''
           CREATE EXTENSION IF NOT EXISTS unaccent;

--- a/nixos/modules/services/web-apps/invidious.nix
+++ b/nixos/modules/services/web-apps/invidious.nix
@@ -19,8 +19,8 @@ let
   commonInvidousServiceConfig = {
     description = "Invidious (An alternative YouTube front-end)";
     wants = [ "network-online.target" ];
-    after = [ "network-online.target" ] ++ lib.optional cfg.database.createLocally "postgresql.service";
-    requires = lib.optional cfg.database.createLocally "postgresql.service";
+    after = [ "network-online.target" ] ++ lib.optional cfg.database.createLocally "postgresql.target";
+    requires = lib.optional cfg.database.createLocally "postgresql.target";
     wantedBy = [ "multi-user.target" ];
 
     serviceConfig = {

--- a/nixos/modules/services/web-apps/keycloak.nix
+++ b/nixos/modules/services/web-apps/keycloak.nix
@@ -602,9 +602,9 @@ in
         ];
 
       systemd.services.keycloakPostgreSQLInit = mkIf createLocalPostgreSQL {
-        after = [ "postgresql.service" ];
+        after = [ "postgresql.target" ];
         before = [ "keycloak.service" ];
-        bindsTo = [ "postgresql.service" ];
+        bindsTo = [ "postgresql.target" ];
         path = [ config.services.postgresql.package ];
         serviceConfig = {
           Type = "oneshot";
@@ -690,7 +690,7 @@ in
             if createLocalPostgreSQL then
               [
                 "keycloakPostgreSQLInit.service"
-                "postgresql.service"
+                "postgresql.target"
               ]
             else if createLocalMySQL then
               [

--- a/nixos/modules/services/web-apps/lasuite-docs.nix
+++ b/nixos/modules/services/web-apps/lasuite-docs.nix
@@ -350,10 +350,10 @@ in
       description = "Docs from SuiteNumérique";
       after =
         [ "network.target" ]
-        ++ (optional cfg.postgresql.createLocally "postgresql.service")
+        ++ (optional cfg.postgresql.createLocally "postgresql.target")
         ++ (optional cfg.redis.createLocally "redis-lasuite-docs.service");
       wants =
-        (optional cfg.postgresql.createLocally "postgresql.service")
+        (optional cfg.postgresql.createLocally "postgresql.target")
         ++ (optional cfg.redis.createLocally "redis-lasuite-docs.service");
       wantedBy = [ "multi-user.target" ];
 
@@ -398,10 +398,10 @@ in
       description = "Docs Celery broker from SuiteNumérique";
       after =
         [ "network.target" ]
-        ++ (optional cfg.postgresql.createLocally "postgresql.service")
+        ++ (optional cfg.postgresql.createLocally "postgresql.target")
         ++ (optional cfg.redis.createLocally "redis-lasuite-docs.service");
       wants =
-        (optional cfg.postgresql.createLocally "postgresql.service")
+        (optional cfg.postgresql.createLocally "postgresql.target")
         ++ (optional cfg.redis.createLocally "redis-lasuite-docs.service");
       wantedBy = [ "multi-user.target" ];
 

--- a/nixos/modules/services/web-apps/lemmy.nix
+++ b/nixos/modules/services/web-apps/lemmy.nix
@@ -325,9 +325,9 @@ in
 
           wantedBy = [ "multi-user.target" ];
 
-          after = [ "pict-rs.service" ] ++ lib.optionals cfg.database.createLocally [ "postgresql.service" ];
+          after = [ "pict-rs.service" ] ++ lib.optionals cfg.database.createLocally [ "postgresql.target" ];
 
-          requires = lib.optionals cfg.database.createLocally [ "postgresql.service" ];
+          requires = lib.optionals cfg.database.createLocally [ "postgresql.target" ];
 
           # substitute secrets and prevent others from reading the result
           # if somehow $CREDENTIALS_DIRECTORY is not set we fail

--- a/nixos/modules/services/web-apps/limesurvey.nix
+++ b/nixos/modules/services/web-apps/limesurvey.nix
@@ -413,7 +413,7 @@ in
     systemd.services.limesurvey-init = {
       wantedBy = [ "multi-user.target" ];
       before = [ "phpfpm-limesurvey.service" ];
-      after = optional mysqlLocal "mysql.service" ++ optional pgsqlLocal "postgresql.service";
+      after = optional mysqlLocal "mysql.service" ++ optional pgsqlLocal "postgresql.target";
       environment.DBENGINE = "${cfg.database.dbEngine}";
       environment.LIMESURVEY_CONFIG = limesurveyConfig;
       script = ''
@@ -444,7 +444,7 @@ in
 
     systemd.services.httpd.after =
       optional mysqlLocal "mysql.service"
-      ++ optional pgsqlLocal "postgresql.service";
+      ++ optional pgsqlLocal "postgresql.target";
 
     users.users.${user} = {
       group = group;

--- a/nixos/modules/services/web-apps/mastodon.nix
+++ b/nixos/modules/services/web-apps/mastodon.nix
@@ -126,10 +126,10 @@ let
     SystemCallArchitectures = "native";
   };
 
-  # Services that all Mastodon units After= and Requires= on
-  commonServices =
+  # Units that all Mastodon units After= and Requires= on
+  commonUnits =
     lib.optional redisActuallyCreateLocally "redis-mastodon.service"
-    ++ lib.optional databaseActuallyCreateLocally "postgresql.service"
+    ++ lib.optional databaseActuallyCreateLocally "postgresql.target"
     ++ lib.optional cfg.automaticMigrations "mastodon-init-db.service";
 
   envFile = pkgs.writeText "mastodon.env" (
@@ -170,8 +170,8 @@ let
         after = [
           "network.target"
           "mastodon-init-dirs.service"
-        ] ++ commonServices;
-        requires = [ "mastodon-init-dirs.service" ] ++ commonServices;
+        ] ++ commonUnits;
+        requires = [ "mastodon-init-dirs.service" ] ++ commonUnits;
         description = "Mastodon sidekiq${jobClassLabel}";
         wantedBy = [ "mastodon.target" ];
         environment = env // {
@@ -209,8 +209,8 @@ let
         after = [
           "network.target"
           "mastodon-init-dirs.service"
-        ] ++ commonServices;
-        requires = [ "mastodon-init-dirs.service" ] ++ commonServices;
+        ] ++ commonUnits;
+        requires = [ "mastodon-init-dirs.service" ] ++ commonUnits;
         wantedBy = [
           "mastodon.target"
           "mastodon-streaming.target"
@@ -998,18 +998,18 @@ in
           after = [
             "network.target"
             "mastodon-init-dirs.service"
-          ] ++ lib.optional databaseActuallyCreateLocally "postgresql.service";
+          ] ++ lib.optional databaseActuallyCreateLocally "postgresql.target";
           requires = [
             "mastodon-init-dirs.service"
-          ] ++ lib.optional databaseActuallyCreateLocally "postgresql.service";
+          ] ++ lib.optional databaseActuallyCreateLocally "postgresql.target";
         };
 
         systemd.services.mastodon-web = {
           after = [
             "network.target"
             "mastodon-init-dirs.service"
-          ] ++ commonServices;
-          requires = [ "mastodon-init-dirs.service" ] ++ commonServices;
+          ] ++ commonUnits;
+          requires = [ "mastodon-init-dirs.service" ] ++ commonUnits;
           wantedBy = [ "mastodon.target" ];
           description = "Mastodon web";
           environment =

--- a/nixos/modules/services/web-apps/mattermost.nix
+++ b/nixos/modules/services/web-apps/mattermost.nix
@@ -840,7 +840,7 @@ in
         wantedBy = [ "multi-user.target" ];
         after = mkMerge [
           [ "network.target" ]
-          (mkIf (cfg.database.driver == "postgres" && cfg.database.create) [ "postgresql.service" ])
+          (mkIf (cfg.database.driver == "postgres" && cfg.database.create) [ "postgresql.target" ])
           (mkIf (cfg.database.driver == "mysql" && cfg.database.create) [ "mysql.service" ])
         ];
         requires = after;
@@ -946,7 +946,7 @@ in
         ];
 
         unitConfig.JoinsNamespaceOf = mkMerge [
-          (mkIf (cfg.database.driver == "postgres" && cfg.database.create) [ "postgresql.service" ])
+          (mkIf (cfg.database.driver == "postgres" && cfg.database.create) [ "postgresql.target" ])
           (mkIf (cfg.database.driver == "mysql" && cfg.database.create) [ "mysql.service" ])
         ];
       };

--- a/nixos/modules/services/web-apps/mealie.nix
+++ b/nixos/modules/services/web-apps/mealie.nix
@@ -66,8 +66,8 @@ in
     systemd.services.mealie = {
       description = "Mealie, a self hosted recipe manager and meal planner";
 
-      after = [ "network-online.target" ] ++ lib.optional cfg.database.createLocally "postgresql.service";
-      requires = lib.optional cfg.database.createLocally "postgresql.service";
+      after = [ "network-online.target" ] ++ lib.optional cfg.database.createLocally "postgresql.target";
+      requires = lib.optional cfg.database.createLocally "postgresql.target";
       wants = [ "network-online.target" ];
       wantedBy = [ "multi-user.target" ];
 

--- a/nixos/modules/services/web-apps/mediagoblin.nix
+++ b/nixos/modules/services/web-apps/mediagoblin.nix
@@ -339,11 +339,11 @@ in
         mediagoblin-paster = lib.recursiveUpdate serviceDefaults {
           after = [
             "mediagoblin-celeryd.service"
-            "postgresql.service"
+            "postgresql.target"
           ];
           requires = [
             "mediagoblin-celeryd.service"
-            "postgresql.service"
+            "postgresql.target"
           ];
           preStart = ''
             cp --remove-destination ${pasteConfig} /var/lib/mediagoblin/paste.ini

--- a/nixos/modules/services/web-apps/mediawiki.nix
+++ b/nixos/modules/services/web-apps/mediawiki.nix
@@ -707,7 +707,7 @@ in
       before = [ "phpfpm-mediawiki.service" ];
       after =
         optional (cfg.database.type == "mysql" && cfg.database.createLocally) "mysql.service"
-        ++ optional (cfg.database.type == "postgres" && cfg.database.createLocally) "postgresql.service";
+        ++ optional (cfg.database.type == "postgres" && cfg.database.createLocally) "postgresql.target";
       script = ''
         if ! test -e "${stateDir}/secret.key"; then
           tr -dc A-Za-z0-9 </dev/urandom 2>/dev/null | head -c 64 > ${stateDir}/secret.key
@@ -754,7 +754,7 @@ in
       ) "mysql.service"
       ++ optional (
         cfg.webserver == "apache" && cfg.database.createLocally && cfg.database.type == "postgres"
-      ) "postgresql.service";
+      ) "postgresql.target";
 
     users.users.${user} = {
       inherit group;

--- a/nixos/modules/services/web-apps/miniflux.nix
+++ b/nixos/modules/services/web-apps/miniflux.nix
@@ -107,10 +107,10 @@ in
 
     systemd.services.miniflux-dbsetup = lib.mkIf cfg.createDatabaseLocally {
       description = "Miniflux database setup";
-      requires = [ "postgresql.service" ];
+      requires = [ "postgresql.target" ];
       after = [
         "network.target"
-        "postgresql.service"
+        "postgresql.target"
       ];
       serviceConfig = {
         Type = "oneshot";
@@ -126,7 +126,7 @@ in
       after =
         [ "network.target" ]
         ++ lib.optionals cfg.createDatabaseLocally [
-          "postgresql.service"
+          "postgresql.target"
           "miniflux-dbsetup.service"
         ];
 

--- a/nixos/modules/services/web-apps/misskey.nix
+++ b/nixos/modules/services/web-apps/misskey.nix
@@ -319,7 +319,7 @@ in
     systemd.services.misskey = {
       after = [
         "network-online.target"
-        "postgresql.service"
+        "postgresql.target"
       ];
       wants = [ "network-online.target" ];
       wantedBy = [ "multi-user.target" ];

--- a/nixos/modules/services/web-apps/mobilizon.nix
+++ b/nixos/modules/services/web-apps/mobilizon.nix
@@ -366,7 +366,7 @@ in
     systemd.services.mobilizon-postgresql = mkIf isLocalPostgres {
       description = "Mobilizon PostgreSQL setup";
 
-      after = [ "postgresql.service" ];
+      after = [ "postgresql.target" ];
       before = [
         "mobilizon.service"
         "mobilizon-setup-secrets.service"

--- a/nixos/modules/services/web-apps/moodle.nix
+++ b/nixos/modules/services/web-apps/moodle.nix
@@ -351,7 +351,7 @@ in
     systemd.services.moodle-init = {
       wantedBy = [ "multi-user.target" ];
       before = [ "phpfpm-moodle.service" ];
-      after = optional mysqlLocal "mysql.service" ++ optional pgsqlLocal "postgresql.service";
+      after = optional mysqlLocal "mysql.service" ++ optional pgsqlLocal "postgresql.target";
       environment.MOODLE_CONFIG = moodleConfig;
       script = ''
         ${phpExt}/bin/php ${cfg.package}/share/moodle/admin/cli/check_database_schema.php && rc=$? || rc=$?
@@ -394,7 +394,7 @@ in
 
     systemd.services.httpd.after =
       optional mysqlLocal "mysql.service"
-      ++ optional pgsqlLocal "postgresql.service";
+      ++ optional pgsqlLocal "postgresql.target";
 
     users.users.${user} = {
       group = group;

--- a/nixos/modules/services/web-apps/movim.nix
+++ b/nixos/modules/services/web-apps/movim.nix
@@ -165,9 +165,9 @@ let
   fpm = config.services.phpfpm.pools.${pool};
   phpExecutionUnit = "phpfpm-${pool}";
 
-  dbService =
+  dbUnit =
     {
-      "postgresql" = "postgresql.service";
+      "postgresql" = "postgresql.target";
       "mariadb" = "mysql.service";
     }
     .${cfg.database.type};
@@ -843,8 +843,8 @@ in
         requiredBy = [ "${phpExecutionUnit}.service" ];
         before = [ "${phpExecutionUnit}.service" ];
         wants = [ "local-fs.target" ];
-        requires = lib.optional cfg.database.createLocally dbService;
-        after = lib.optional cfg.database.createLocally dbService;
+        requires = lib.optional cfg.database.createLocally dbUnit;
+        after = lib.optional cfg.database.createLocally dbUnit;
 
         serviceConfig =
           {
@@ -899,8 +899,8 @@ in
         requiredBy = [ "movim.service" ];
         before = [ "movim.service" ] ++ lib.optional (webServerService != null) webServerService;
         wants = [ "network.target" ];
-        requires = [ "movim-data-setup.service" ] ++ lib.optional cfg.database.createLocally dbService;
-        after = [ "movim-data-setup.service" ] ++ lib.optional cfg.database.createLocally dbService;
+        requires = [ "movim-data-setup.service" ] ++ lib.optional cfg.database.createLocally dbUnit;
+        after = [ "movim-data-setup.service" ] ++ lib.optional cfg.database.createLocally dbUnit;
       };
 
       services.movim = {
@@ -915,14 +915,14 @@ in
             "movim-data-setup.service"
             "${phpExecutionUnit}.service"
           ]
-          ++ lib.optional cfg.database.createLocally dbService
+          ++ lib.optional cfg.database.createLocally dbUnit
           ++ lib.optional (webServerService != null) webServerService;
         after =
           [
             "movim-data-setup.service"
             "${phpExecutionUnit}.service"
           ]
-          ++ lib.optional cfg.database.createLocally dbService
+          ++ lib.optional cfg.database.createLocally dbUnit
           ++ lib.optional (webServerService != null) webServerService;
         environment = {
           PUBLIC_URL = "//${cfg.domain}";

--- a/nixos/modules/services/web-apps/nextcloud.nix
+++ b/nixos/modules/services/web-apps/nextcloud.nix
@@ -1167,8 +1167,8 @@ in
             wantedBy = [ "multi-user.target" ];
             wants = [ "nextcloud-update-db.service" ];
             before = [ "phpfpm-nextcloud.service" ];
-            after = optional mysqlLocal "mysql.service" ++ optional pgsqlLocal "postgresql.service";
-            requires = optional mysqlLocal "mysql.service" ++ optional pgsqlLocal "postgresql.service";
+            after = optional mysqlLocal "mysql.service" ++ optional pgsqlLocal "postgresql.target";
+            requires = optional mysqlLocal "mysql.service" ++ optional pgsqlLocal "postgresql.target";
             path = [ occ ];
             restartTriggers = [ overrideConfig ];
             script = ''

--- a/nixos/modules/services/web-apps/nipap.nix
+++ b/nixos/modules/services/web-apps/nipap.nix
@@ -234,8 +234,8 @@ in
             after = [
               "network.target"
               "systemd-tmpfiles-setup.service"
-            ] ++ lib.optional (cfg.settings.nipapd.db_host == "") "postgresql.service";
-            requires = lib.optional (cfg.settings.nipapd.db_host == "") "postgresql.service";
+            ] ++ lib.optional (cfg.settings.nipapd.db_host == "") "postgresql.target";
+            requires = lib.optional (cfg.settings.nipapd.db_host == "") "postgresql.target";
             wantedBy = [ "multi-user.target" ];
             preStart = lib.optionalString (cfg.settings.auth.default_backend == defaultAuthBackend) ''
               # Create/upgrade local auth database

--- a/nixos/modules/services/web-apps/onlyoffice.nix
+++ b/nixos/modules/services/web-apps/onlyoffice.nix
@@ -235,12 +235,12 @@ in
         after = [
           "network.target"
           "onlyoffice-docservice.service"
-          "postgresql.service"
+          "postgresql.target"
         ];
         requires = [
           "network.target"
           "onlyoffice-docservice.service"
-          "postgresql.service"
+          "postgresql.target"
         ];
         wantedBy = [ "multi-user.target" ];
         serviceConfig = {
@@ -314,9 +314,9 @@ in
           description = "onlyoffice documentserver";
           after = [
             "network.target"
-            "postgresql.service"
+            "postgresql.target"
           ];
-          requires = [ "postgresql.service" ];
+          requires = [ "postgresql.target" ];
           wantedBy = [ "multi-user.target" ];
           serviceConfig = {
             ExecStart = "${cfg.package.fhs}/bin/onlyoffice-wrapper DocService/docservice /run/onlyoffice/config";

--- a/nixos/modules/services/web-apps/outline.nix
+++ b/nixos/modules/services/web-apps/outline.nix
@@ -634,10 +634,10 @@ in
         wantedBy = [ "multi-user.target" ];
         after =
           [ "networking.target" ]
-          ++ lib.optional (cfg.databaseUrl == "local") "postgresql.service"
+          ++ lib.optional (cfg.databaseUrl == "local") "postgresql.target"
           ++ lib.optional (cfg.redisUrl == "local") "redis-outline.service";
         requires =
-          lib.optional (cfg.databaseUrl == "local") "postgresql.service"
+          lib.optional (cfg.databaseUrl == "local") "postgresql.target"
           ++ lib.optional (cfg.redisUrl == "local") "redis-outline.service";
         path = [
           pkgs.openssl # Required by the preStart script

--- a/nixos/modules/services/web-apps/part-db.nix
+++ b/nixos/modules/services/web-apps/part-db.nix
@@ -195,8 +195,8 @@ in
       services = {
         part-db-migrate = {
           before = [ "phpfpm-part-db.service" ];
-          after = [ "postgresql.service" ];
-          requires = [ "postgresql.service" ];
+          after = [ "postgresql.target" ];
+          requires = [ "postgresql.target" ];
           wantedBy = [ "multi-user.target" ];
           serviceConfig = {
             Type = "oneshot";
@@ -216,7 +216,7 @@ in
           after = [ "part-db-migrate.service" ];
           requires = [
             "part-db-migrate.service"
-            "postgresql.service"
+            "postgresql.target"
           ];
           # ensure nginx can access the php-fpm socket
           postStart = ''

--- a/nixos/modules/services/web-apps/peertube.nix
+++ b/nixos/modules/services/web-apps/peertube.nix
@@ -439,9 +439,9 @@ in
       description = "Initialization database for PeerTube daemon";
       after = [
         "network.target"
-        "postgresql.service"
+        "postgresql.target"
       ];
-      requires = [ "postgresql.service" ];
+      requires = [ "postgresql.target" ];
 
       script =
         let
@@ -475,13 +475,13 @@ in
         [ "network.target" ]
         ++ lib.optional cfg.redis.createLocally "redis-peertube.service"
         ++ lib.optionals cfg.database.createLocally [
-          "postgresql.service"
+          "postgresql.target"
           "peertube-init-db.service"
         ];
       requires =
         lib.optional cfg.redis.createLocally "redis-peertube.service"
         ++ lib.optionals cfg.database.createLocally [
-          "postgresql.service"
+          "postgresql.target"
           "peertube-init-db.service"
         ];
       wantedBy = [ "multi-user.target" ];

--- a/nixos/modules/services/web-apps/pixelfed.nix
+++ b/nixos/modules/services/web-apps/pixelfed.nix
@@ -53,9 +53,9 @@ let
       "mysql" = "/run/mysqld/mysqld.sock";
     }
     .${cfg.database.type};
-  dbService =
+  dbUnit =
     {
-      "pgsql" = "postgresql.service";
+      "pgsql" = "postgresql.target";
       "mysql" = "mysql.service";
     }
     .${cfg.database.type};
@@ -355,7 +355,7 @@ in
         "pixelfed-horizon.service"
         "pixelfed-data-setup.service"
       ]
-      ++ lib.optional cfg.database.createLocally dbService
+      ++ lib.optional cfg.database.createLocally dbUnit
       ++ lib.optional cfg.redis.createLocally redisService;
     # Ensure image optimizations programs are available.
     systemd.services.phpfpm-pixelfed.path = extraPrograms;
@@ -368,7 +368,7 @@ in
       ];
       requires =
         [ "pixelfed-data-setup.service" ]
-        ++ (lib.optional cfg.database.createLocally dbService)
+        ++ (lib.optional cfg.database.createLocally dbUnit)
         ++ (lib.optional cfg.redis.createLocally redisService);
       wantedBy = [ "multi-user.target" ];
       # Ensure image optimizations programs are available.
@@ -412,8 +412,8 @@ in
     systemd.services.pixelfed-data-setup = {
       description = "Pixelfed setup: migrations, environment file update, cache reload, data changes";
       wantedBy = [ "multi-user.target" ];
-      after = lib.optional cfg.database.createLocally dbService;
-      requires = lib.optional cfg.database.createLocally dbService;
+      after = lib.optional cfg.database.createLocally dbUnit;
+      requires = lib.optional cfg.database.createLocally dbUnit;
       path =
         with pkgs;
         [

--- a/nixos/modules/services/web-apps/plausible.nix
+++ b/nixos/modules/services/web-apps/plausible.nix
@@ -196,13 +196,13 @@ in
           after =
             optional cfg.database.clickhouse.setup "clickhouse.service"
             ++ optionals cfg.database.postgres.setup [
-              "postgresql.service"
+              "postgresql.target"
               "plausible-postgres.service"
             ];
           requires =
             optional cfg.database.clickhouse.setup "clickhouse.service"
             ++ optionals cfg.database.postgres.setup [
-              "postgresql.service"
+              "postgresql.target"
               "plausible-postgres.service"
             ];
 
@@ -309,7 +309,7 @@ in
       (mkIf cfg.database.postgres.setup {
         # `plausible' requires the `citext'-extension.
         plausible-postgres = {
-          after = [ "postgresql.service" ];
+          after = [ "postgresql.target" ];
           partOf = [ "plausible.service" ];
           serviceConfig = {
             Type = "oneshot";

--- a/nixos/modules/services/web-apps/pretalx.nix
+++ b/nixos/modules/services/web-apps/pretalx.nix
@@ -434,7 +434,7 @@ in
               "redis-pretalx.service"
             ]
             ++ lib.optionals (cfg.settings.database.backend == "postgresql") [
-              "postgresql.service"
+              "postgresql.target"
             ]
             ++ lib.optionals (cfg.settings.database.backend == "mysql") [
               "mysql.service"
@@ -484,7 +484,7 @@ in
                 "redis-pretalx.service"
               ]
               ++ lib.optionals (cfg.settings.database.backend == "postgresql") [
-                "postgresql.service"
+                "postgresql.target"
               ]
               ++ lib.optionals (cfg.settings.database.backend == "mysql") [
                 "mysql.service"

--- a/nixos/modules/services/web-apps/pretix.nix
+++ b/nixos/modules/services/web-apps/pretix.nix
@@ -533,7 +533,7 @@ in
           after = [
             "network.target"
             "redis-pretix.service"
-            "postgresql.service"
+            "postgresql.target"
           ];
           wantedBy = [ "multi-user.target" ];
           preStart = ''
@@ -574,7 +574,7 @@ in
           after = [
             "network.target"
             "redis-pretix.service"
-            "postgresql.service"
+            "postgresql.target"
           ];
           wantedBy = [ "multi-user.target" ];
           serviceConfig = {

--- a/nixos/modules/services/web-apps/reposilite.nix
+++ b/nixos/modules/services/web-apps/reposilite.nix
@@ -398,7 +398,7 @@ in
       after =
         [ "network.target" ]
         ++ (lib.optional useMySQL "mysql.service")
-        ++ (lib.optional usePostgres "postgresql.service");
+        ++ (lib.optional usePostgres "postgresql.target");
 
       script =
         lib.optionalString (cfg.keyPasswordFile != null && cfg.settings.keyPassword == null) ''

--- a/nixos/modules/services/web-apps/shiori.nix
+++ b/nixos/modules/services/web-apps/shiori.nix
@@ -62,7 +62,7 @@ in
       description = "Shiori simple bookmarks manager";
       wantedBy = [ "multi-user.target" ];
       after = [
-        "postgresql.service"
+        "postgresql.target"
         "mysql.service"
       ];
       environment =

--- a/nixos/modules/services/web-apps/sogo.nix
+++ b/nixos/modules/services/web-apps/sogo.nix
@@ -104,7 +104,7 @@ in
     systemd.services.sogo = {
       description = "SOGo groupware";
       after = [
-        "postgresql.service"
+        "postgresql.target"
         "mysql.service"
         "memcached.service"
         "openldap.service"
@@ -191,7 +191,7 @@ in
       description = "SOGo email alarms";
 
       after = [
-        "postgresql.service"
+        "postgresql.target"
         "mysqld.service"
         "memcached.service"
         "openldap.service"

--- a/nixos/modules/services/web-apps/tt-rss.nix
+++ b/nixos/modules/services/web-apps/tt-rss.nix
@@ -667,11 +667,11 @@ in
         };
 
         wantedBy = [ "multi-user.target" ];
-        requires = optional mysqlLocal "mysql.service" ++ optional pgsqlLocal "postgresql.service";
+        requires = optional mysqlLocal "mysql.service" ++ optional pgsqlLocal "postgresql.target";
         after =
           [ "network.target" ]
           ++ optional mysqlLocal "mysql.service"
-          ++ optional pgsqlLocal "postgresql.service";
+          ++ optional pgsqlLocal "postgresql.target";
       };
     };
 

--- a/nixos/modules/services/web-apps/vikunja.nix
+++ b/nixos/modules/services/web-apps/vikunja.nix
@@ -117,7 +117,7 @@ in
       description = "vikunja";
       after =
         [ "network.target" ]
-        ++ lib.optional usePostgresql "postgresql.service"
+        ++ lib.optional usePostgresql "postgresql.target"
         ++ lib.optional useMysql "mysql.service";
       wantedBy = [ "multi-user.target" ];
       path = [ cfg.package ];

--- a/nixos/modules/services/web-apps/wakapi.nix
+++ b/nixos/modules/services/web-apps/wakapi.nix
@@ -135,10 +135,10 @@ in
       description = "Wakapi (self-hosted WakaTime-compatible backend)";
       wants = [
         "network-online.target"
-      ] ++ optional (cfg.database.dialect == "postgres") "postgresql.service";
+      ] ++ optional (cfg.database.dialect == "postgres") "postgresql.target";
       after = [
         "network-online.target"
-      ] ++ optional (cfg.database.dialect == "postgres") "postgresql.service";
+      ] ++ optional (cfg.database.dialect == "postgres") "postgresql.target";
       wantedBy = [ "multi-user.target" ];
 
       script = ''

--- a/nixos/modules/services/web-apps/weblate.nix
+++ b/nixos/modules/services/web-apps/weblate.nix
@@ -251,7 +251,7 @@ in
 
     systemd.services.weblate-postgresql-setup = {
       description = "Weblate PostgreSQL setup";
-      after = [ "postgresql.service" ];
+      after = [ "postgresql.target" ];
       serviceConfig = {
         Type = "oneshot";
         User = "postgres";
@@ -290,7 +290,7 @@ in
       after = [
         "network.target"
         "redis-weblate.service"
-        "postgresql.service"
+        "postgresql.target"
       ];
       # We want this to be active on boot, not just on socket activation
       wantedBy = [ "multi-user.target" ];

--- a/nixos/modules/services/web-apps/windmill.nix
+++ b/nixos/modules/services/web-apps/windmill.nix
@@ -134,39 +134,37 @@ in
         # coming from https://github.com/windmill-labs/windmill/blob/main/init-db-as-superuser.sql
         # modified to not grant privileges on all tables
         # create role windmill_user and windmill_admin only if they don't exist
-        postgresql.postStart = lib.mkIf cfg.database.createLocally (
-          lib.mkAfter ''
-                  $PSQL -tA <<"EOF"
-            DO $$
-            BEGIN
-                IF NOT EXISTS (
-                    SELECT FROM pg_catalog.pg_roles
-                    WHERE rolname = 'windmill_user'
-                ) THEN
-                    CREATE ROLE windmill_user;
-                    GRANT ALL PRIVILEGES ON DATABASE ${cfg.database.name} TO windmill_user;
-                ELSE
-                  RAISE NOTICE 'Role "windmill_user" already exists. Skipping.';
-                END IF;
-                IF NOT EXISTS (
-                    SELECT FROM pg_catalog.pg_roles
-                    WHERE rolname = 'windmill_admin'
-                ) THEN
-                  CREATE ROLE windmill_admin WITH BYPASSRLS;
-                  GRANT windmill_user TO windmill_admin;
-                ELSE
-                  RAISE NOTICE 'Role "windmill_admin" already exists. Skipping.';
-                END IF;
-                GRANT windmill_admin TO windmill;
-            END
-            $$;
-            EOF
-          ''
-        );
+        postgresql.postStart = lib.mkIf cfg.database.createLocally ''
+          psql -tA <<"EOF"
+          DO $$
+          BEGIN
+              IF NOT EXISTS (
+                  SELECT FROM pg_catalog.pg_roles
+                  WHERE rolname = 'windmill_user'
+              ) THEN
+                  CREATE ROLE windmill_user;
+                  GRANT ALL PRIVILEGES ON DATABASE ${cfg.database.name} TO windmill_user;
+              ELSE
+                RAISE NOTICE 'Role "windmill_user" already exists. Skipping.';
+              END IF;
+              IF NOT EXISTS (
+                  SELECT FROM pg_catalog.pg_roles
+                  WHERE rolname = 'windmill_admin'
+              ) THEN
+                CREATE ROLE windmill_admin WITH BYPASSRLS;
+                GRANT windmill_user TO windmill_admin;
+              ELSE
+                RAISE NOTICE 'Role "windmill_admin" already exists. Skipping.';
+              END IF;
+              GRANT windmill_admin TO windmill;
+          END
+          $$;
+          EOF
+        '';
 
         windmill-server = {
           description = "Windmill server";
-          after = [ "network.target" ] ++ lib.optional cfg.database.createLocally "postgresql.service";
+          after = [ "network.target" ] ++ lib.optional cfg.database.createLocally "postgresql.target";
           wantedBy = [ "multi-user.target" ];
 
           serviceConfig = serviceConfig // {
@@ -183,7 +181,7 @@ in
 
         windmill-worker = {
           description = "Windmill worker";
-          after = [ "network.target" ] ++ lib.optional cfg.database.createLocally "postgresql.service";
+          after = [ "network.target" ] ++ lib.optional cfg.database.createLocally "postgresql.target";
           wantedBy = [ "multi-user.target" ];
 
           serviceConfig = serviceConfig // {
@@ -201,7 +199,7 @@ in
 
         windmill-worker-native = {
           description = "Windmill worker native";
-          after = [ "network.target" ] ++ lib.optional cfg.database.createLocally "postgresql.service";
+          after = [ "network.target" ] ++ lib.optional cfg.database.createLocally "postgresql.target";
           wantedBy = [ "multi-user.target" ];
 
           serviceConfig = serviceConfig // {

--- a/nixos/modules/services/web-apps/zipline.nix
+++ b/nixos/modules/services/web-apps/zipline.nix
@@ -93,8 +93,8 @@ in
       wantedBy = [ "multi-user.target" ];
 
       wants = [ "network-online.target" ];
-      after = [ "network-online.target" ] ++ lib.optional cfg.database.createLocally "postgresql.service";
-      requires = lib.optional cfg.database.createLocally "postgresql.service";
+      after = [ "network-online.target" ] ++ lib.optional cfg.database.createLocally "postgresql.target";
+      requires = lib.optional cfg.database.createLocally "postgresql.target";
 
       environment = lib.mapAttrs (_: value: toString value) cfg.settings;
 

--- a/nixos/modules/services/web-servers/keter/default.nix
+++ b/nixos/modules/services/web-servers/keter/default.nix
@@ -182,7 +182,7 @@ in
         after = [
           "network.target"
           "local-fs.target"
-          "postgresql.service"
+          "postgresql.target"
         ];
       };
 

--- a/nixos/tests/coder.nix
+++ b/nixos/tests/coder.nix
@@ -14,7 +14,7 @@
 
   testScript = ''
     machine.start()
-    machine.wait_for_unit("postgresql.service")
+    machine.wait_for_unit("postgresql.target")
     machine.wait_for_unit("coder.service")
     machine.wait_for_open_port(3000)
 

--- a/nixos/tests/davis.nix
+++ b/nixos/tests/davis.nix
@@ -55,7 +55,7 @@
   testScript = ''
     start_all()
 
-    machine1.wait_for_unit("postgresql.service")
+    machine1.wait_for_unit("postgresql.target")
     machine1.wait_for_unit("davis-env-setup.service")
     machine1.wait_for_unit("davis-db-migrate.service")
     machine1.wait_for_unit("phpfpm-davis.service")

--- a/nixos/tests/documize.nix
+++ b/nixos/tests/documize.nix
@@ -18,8 +18,8 @@
       };
 
       systemd.services.documize-server = {
-        after = [ "postgresql.service" ];
-        requires = [ "postgresql.service" ];
+        after = [ "postgresql.target" ];
+        requires = [ "postgresql.target" ];
       };
 
       services.postgresql = {

--- a/nixos/tests/ferretdb.nix
+++ b/nixos/tests/ferretdb.nix
@@ -29,8 +29,8 @@ with import ../lib/testing-python.nix { inherit system; };
         };
 
         systemd.services.ferretdb.serviceConfig = {
-          Requires = "postgresql.service";
-          After = "postgresql.service";
+          Requires = "postgresql.target";
+          After = "postgresql.target";
         };
 
         services.postgresql = {

--- a/nixos/tests/firefly-iii.nix
+++ b/nixos/tests/firefly-iii.nix
@@ -105,7 +105,7 @@ in
     fireflySqlite.succeed("systemctl start firefly-iii-cron.service")
     fireflyPostgresql.wait_for_unit("phpfpm-firefly-iii.service")
     fireflyPostgresql.wait_for_unit("nginx.service")
-    fireflyPostgresql.wait_for_unit("postgresql.service")
+    fireflyPostgresql.wait_for_unit("postgresql.target")
     fireflyPostgresql.succeed("curl -fvvv -Ls http://localhost/ | grep 'Firefly III'")
     fireflyPostgresql.succeed("systemctl start firefly-iii-cron.service")
     fireflyMysql.wait_for_unit("phpfpm-firefly-iii.service")

--- a/nixos/tests/freshrss/pgsql.nix
+++ b/nixos/tests/freshrss/pgsql.nix
@@ -38,8 +38,8 @@ import ../make-test-python.nix (
         };
 
         systemd.services."freshrss-config" = {
-          requires = [ "postgresql.service" ];
-          after = [ "postgresql.service" ];
+          requires = [ "postgresql.target" ];
+          after = [ "postgresql.target" ];
         };
       };
 

--- a/nixos/tests/gancio.nix
+++ b/nixos/tests/gancio.nix
@@ -67,7 +67,7 @@ in
   testScript = ''
     start_all()
 
-    server.wait_for_unit("postgresql")
+    server.wait_for_unit("postgresql.target")
     server.wait_for_unit("gancio")
     server.wait_for_unit("nginx")
     server.wait_for_file("/run/gancio/socket")

--- a/nixos/tests/gitlab.nix
+++ b/nixos/tests/gitlab.nix
@@ -488,7 +488,7 @@ in
       gitlab.systemctl("start gitlab-backup.service")
       gitlab.wait_for_unit("gitlab-backup.service")
       gitlab.wait_for_file("${nodes.gitlab.services.gitlab.statePath}/backup/dump_gitlab_backup.tar")
-      gitlab.systemctl("stop postgresql.service gitlab-config.service gitlab.target")
+      gitlab.systemctl("stop postgresql gitlab-config.service gitlab.target")
       gitlab.succeed(
           "find ${nodes.gitlab.services.gitlab.statePath} -mindepth 1 -maxdepth 1 -not -name backup -execdir rm -r {} +"
       )

--- a/nixos/tests/grafana/basic.nix
+++ b/nixos/tests/grafana/basic.nix
@@ -63,7 +63,7 @@ import ../make-test-python.nix (
             }
           ];
         };
-        systemd.services.grafana.after = [ "postgresql.service" ];
+        systemd.services.grafana.after = [ "postgresql.target" ];
       };
 
       mysql = {
@@ -133,7 +133,7 @@ import ../make-test-python.nix (
 
       with subtest("Successful API query as admin user with postgresql db"):
           postgresql.wait_for_unit("grafana.service")
-          postgresql.wait_for_unit("postgresql.service")
+          postgresql.wait_for_unit("postgresql.target")
           postgresql.wait_for_open_port(3000)
           postgresql.wait_for_open_port(5432)
           postgresql.succeed(

--- a/nixos/tests/hedgedoc.nix
+++ b/nixos/tests/hedgedoc.nix
@@ -13,7 +13,7 @@
     hedgedocPostgresWithTCPSocket =
       { ... }:
       {
-        systemd.services.hedgedoc.after = [ "postgresql.service" ];
+        systemd.services.hedgedoc.after = [ "postgresql.target" ];
         services = {
           hedgedoc = {
             enable = true;
@@ -47,7 +47,7 @@
     hedgedocPostgresWithUNIXSocket =
       { ... }:
       {
-        systemd.services.hedgedoc.after = [ "postgresql.service" ];
+        systemd.services.hedgedoc.after = [ "postgresql.target" ];
         services = {
           hedgedoc = {
             enable = true;
@@ -83,14 +83,14 @@
         hedgedocSqlite.wait_until_succeeds("curl -sSf http://localhost:3000/new")
 
     with subtest("HedgeDoc postgres with TCP socket"):
-        hedgedocPostgresWithTCPSocket.wait_for_unit("postgresql.service")
+        hedgedocPostgresWithTCPSocket.wait_for_unit("postgresql.target")
         hedgedocPostgresWithTCPSocket.wait_for_unit("hedgedoc.service")
         hedgedocPostgresWithTCPSocket.wait_for_open_port(5432)
         hedgedocPostgresWithTCPSocket.wait_for_open_port(3000)
         hedgedocPostgresWithTCPSocket.wait_until_succeeds("curl -sSf http://localhost:3000/new")
 
     with subtest("HedgeDoc postgres with UNIX socket"):
-        hedgedocPostgresWithUNIXSocket.wait_for_unit("postgresql.service")
+        hedgedocPostgresWithUNIXSocket.wait_for_unit("postgresql.target")
         hedgedocPostgresWithUNIXSocket.wait_for_unit("hedgedoc.service")
         hedgedocPostgresWithUNIXSocket.wait_for_open_port(5432)
         hedgedocPostgresWithUNIXSocket.wait_for_open_port(3000)

--- a/nixos/tests/hydra/default.nix
+++ b/nixos/tests/hydra/default.nix
@@ -18,7 +18,7 @@ in
     # let the system boot up
     machine.wait_for_unit("multi-user.target")
     # test whether the database is running
-    machine.wait_for_unit("postgresql.service")
+    machine.wait_for_unit("postgresql.target")
     # test whether the actual hydra daemons are running
     machine.wait_for_unit("hydra-init.service")
     machine.require_unit_state("hydra-queue-runner.service")

--- a/nixos/tests/invidious.nix
+++ b/nixos/tests/invidious.nix
@@ -144,7 +144,7 @@
       curl_assert_status_code("http://invidious.example.com/search", 200)
       machine.succeed("journalctl -eu invidious.service | grep -o \"SigHelper: Using helper at 'tcp://127.0.0.1:2999'\"")
 
-      postgres_tcp.wait_for_unit("postgresql.service")
+      postgres_tcp.wait_for_unit("postgresql.target")
       activate_specialisation("postgres-tcp")
       machine.wait_for_open_port(port)
       curl_assert_status_code(f"{url}/search", 200)

--- a/nixos/tests/listmonk.nix
+++ b/nixos/tests/listmonk.nix
@@ -41,7 +41,7 @@ import ./make-test-python.nix (
          return f'curl -u "{basic_auth}" -X {type} "http://localhost:9000/api/{url}" -H "Content-Type: application/json; charset=utf-8" --data-raw \'{json_data}\'''
 
       machine.wait_for_unit("mailhog.service")
-      machine.wait_for_unit("postgresql.service")
+      machine.wait_for_unit("postgresql.target")
       machine.wait_for_unit("listmonk.service")
       machine.wait_for_open_port(1025)
       machine.wait_for_open_port(8025)

--- a/nixos/tests/matrix/synapse.nix
+++ b/nixos/tests/matrix/synapse.nix
@@ -233,7 +233,7 @@ in
     serverpostgres.wait_until_succeeds(
         "journalctl -u matrix-synapse.service | grep -q 'Connected to redis'"
     )
-    serverpostgres.require_unit_state("postgresql.service")
+    serverpostgres.require_unit_state("postgresql.target")
     serverpostgres.succeed("REQUESTS_CA_BUNDLE=${ca_pem} register_new_matrix_user -u ${testUser} -p ${testPassword} -a -k ${registrationSharedSecret} https://localhost:8448/")
     serverpostgres.succeed("obtain-token-and-register-email")
     serversqlite.wait_for_unit("matrix-synapse.service")

--- a/nixos/tests/miniflux.nix
+++ b/nixos/tests/miniflux.nix
@@ -80,7 +80,7 @@ in
             host sameuser miniflux samenet scram-sha-256
           '';
         };
-        systemd.services.postgresql.postStart = lib.mkAfter ''
+        systemd.services.postgresql-setup.postStart = lib.mkAfter ''
           $PSQL -tAd miniflux -c 'CREATE EXTENSION hstore;'
         '';
         networking.firewall.allowedTCPPorts = [ config.services.postgresql.settings.port ];
@@ -123,7 +123,7 @@ in
     runTest(withoutSudo, ${toString defaultPort}, "${defaultUsername}:${defaultPassword}")
     runTest(customized, ${toString port}, "${username}:${password}")
 
-    postgresTcp.wait_for_unit("postgresql.service")
+    postgresTcp.wait_for_unit("postgresql.target")
     externalDb.start()
     runTest(externalDb, ${toString defaultPort}, "${defaultUsername}:${defaultPassword}")
   '';

--- a/nixos/tests/nextcloud/with-declarative-redis-and-secrets.nix
+++ b/nixos/tests/nextcloud/with-declarative-redis-and-secrets.nix
@@ -65,14 +65,14 @@ runTest (
           };
 
           systemd.services.nextcloud-setup = {
-            requires = [ "postgresql.service" ];
-            after = [ "postgresql.service" ];
+            requires = [ "postgresql.target" ];
+            after = [ "postgresql.target" ];
           };
 
           services.postgresql = {
             enable = true;
           };
-          systemd.services.postgresql.postStart = lib.mkAfter ''
+          systemd.services.postgresql-setup.postStart = ''
             password=$(cat ${config.services.nextcloud.config.dbpassFile})
             ${config.services.postgresql.package}/bin/psql <<EOF
               CREATE ROLE ${adminuser} WITH LOGIN PASSWORD '$password' CREATEDB;

--- a/nixos/tests/pgadmin4.nix
+++ b/nixos/tests/pgadmin4.nix
@@ -55,7 +55,7 @@
 
   testScript = ''
     with subtest("Check pgadmin module"):
-      machine.wait_for_unit("postgresql")
+      machine.wait_for_unit("postgresql.target")
       machine.wait_for_unit("pgadmin")
       machine.wait_until_succeeds("curl -sS localhost:5051")
       machine.wait_until_succeeds("curl -sS localhost:5051/login | grep \"<title>pgAdmin 4</title>\" > /dev/null")
@@ -80,7 +80,7 @@
       machine.succeed("wget -nv --level=1 --spider --recursive localhost:5050/browser")
 
     with subtest("Check pgadmin minimum password length"):
-      machine2.wait_for_unit("postgresql")
+      machine2.wait_for_unit("postgresql.target")
       machine2.wait_for_console_text("Password must be at least 12 characters long")
   '';
 }

--- a/nixos/tests/pgbackrest/posix.nix
+++ b/nixos/tests/pgbackrest/posix.nix
@@ -27,6 +27,13 @@ in
           CREATE TABLE t(c text);
           INSERT INTO t VALUES ('hello world');
         '';
+        # To make sure we're waiting for read-write after recovery.
+        ensureUsers = [
+          {
+            name = "app-user";
+            ensureClauses.login = true;
+          }
+        ];
       };
 
       services.pgbackrest = {
@@ -141,7 +148,7 @@ in
         primary.succeed("sudo -u postgres pgbackrest --stanza=default restore --delta")
 
         primary.systemctl("start postgresql")
-        primary.wait_for_unit("postgresql.service")
+        primary.wait_for_unit("postgresql.target")
         assert "hello world" in primary.succeed("sudo -u postgres psql -c 'TABLE t;'")
     '';
 }

--- a/nixos/tests/pgbackrest/sftp.nix
+++ b/nixos/tests/pgbackrest/sftp.nix
@@ -89,7 +89,7 @@ in
         primary.succeed("sudo -u postgres pgbackrest --stanza=default restore --delta")
 
         primary.systemctl("start postgresql")
-        primary.wait_for_unit("postgresql.service")
+        primary.wait_for_unit("postgresql.target")
         assert "hello world" in primary.succeed("sudo -u postgres psql -c 'TABLE t;'")
     '';
 }

--- a/nixos/tests/pgbouncer.nix
+++ b/nixos/tests/pgbouncer.nix
@@ -10,7 +10,7 @@
     one =
       { pkgs, ... }:
       {
-        systemd.services.postgresql = {
+        systemd.services.postgresql-setup = {
           postStart = ''
             ${pkgs.postgresql}/bin/psql -U postgres -c "ALTER ROLE testuser WITH LOGIN PASSWORD 'testpass'";
             ${pkgs.postgresql}/bin/psql -U postgres -c "ALTER DATABASE testdb OWNER TO testuser;";

--- a/nixos/tests/pghero.nix
+++ b/nixos/tests/pghero.nix
@@ -53,7 +53,7 @@ in
         assert http_code.split("\n")[-1].strip() == code, \
           f"expected HTTP status code {code} but got {http_code}"
 
-    machine.wait_for_unit("postgresql.service")
+    machine.wait_for_unit("postgresql.target")
     machine.wait_for_unit("pghero.service")
 
     with subtest("requires HTTP Basic Auth credentials"):

--- a/nixos/tests/pgweb.nix
+++ b/nixos/tests/pgweb.nix
@@ -19,7 +19,7 @@
           ExecStart = "${pkgs.pgweb}/bin/pgweb --url postgresql://postgres@localhost:5432/postgres";
         };
         path = [ pkgs.getent ];
-        after = [ "postgresql.service" ];
+        after = [ "postgresql.target" ];
         wantedBy = [ "multi-user.target" ];
       };
     };

--- a/nixos/tests/pleroma.nix
+++ b/nixos/tests/pleroma.nix
@@ -266,7 +266,7 @@ import ./make-test-python.nix (
     testScript =
       { nodes, ... }:
       ''
-        pleroma.wait_for_unit("postgresql.service")
+        pleroma.wait_for_unit("postgresql.target")
         pleroma.wait_until_succeeds("ls /var/lib/pleroma")
         pleroma.succeed("provision-db")
         pleroma.wait_for_file("/var/lib/pleroma")

--- a/nixos/tests/postfixadmin.nix
+++ b/nixos/tests/postfixadmin.nix
@@ -23,7 +23,7 @@
 
   testScript = ''
     postfixadmin.start
-    postfixadmin.wait_for_unit("postgresql.service")
+    postfixadmin.wait_for_unit("postgresql.target")
     postfixadmin.wait_for_unit("phpfpm-postfixadmin.service")
     postfixadmin.wait_for_unit("nginx.service")
     postfixadmin.succeed(

--- a/nixos/tests/postgres-websockets.nix
+++ b/nixos/tests/postgres-websockets.nix
@@ -58,7 +58,7 @@
       token = jwt.encode({ "mode": "rw" }, "reallyreallyreallyreallyverysafe")
 
       def test():
-          machine.wait_for_unit("postgresql.service")
+          machine.wait_for_unit("postgresql.target")
           machine.wait_for_unit("postgres-websockets.service")
 
           machine.succeed(f"echo 'hi there' | websocat --no-close 'ws://localhost:3000/test/{token}' > output &")

--- a/nixos/tests/postgresql/anonymizer.nix
+++ b/nixos/tests/postgresql/anonymizer.nix
@@ -28,7 +28,7 @@ let
       testScript = ''
         start_all()
         machine.wait_for_unit("multi-user.target")
-        machine.wait_for_unit("postgresql.service")
+        machine.wait_for_unit("postgresql.target")
 
         with subtest("Setup"):
             machine.succeed("sudo -u postgres psql --command 'create database demo'")

--- a/nixos/tests/postgresql/pgjwt.nix
+++ b/nixos/tests/postgresql/pgjwt.nix
@@ -40,7 +40,7 @@ let
         in
         ''
           start_all()
-          master.wait_for_unit("postgresql")
+          master.wait_for_unit("postgresql.target")
           master.succeed(
               "${pkgs.sudo}/bin/sudo -u ${sqlSU} ${pgProve}/bin/pg_prove -d postgres -v -f ${pgjwt.src}/test.sql"
           )

--- a/nixos/tests/postgresql/postgresql-jit.nix
+++ b/nixos/tests/postgresql/postgresql-jit.nix
@@ -29,7 +29,7 @@ let
 
       testScript = ''
         machine.start()
-        machine.wait_for_unit("postgresql.service")
+        machine.wait_for_unit("postgresql.target")
 
         with subtest("JIT is enabled"):
             machine.succeed("sudo -u postgres psql <<<'show jit;' | grep 'on'")

--- a/nixos/tests/postgresql/postgresql-wal-receiver.nix
+++ b/nixos/tests/postgresql/postgresql-wal-receiver.nix
@@ -62,7 +62,7 @@ let
 
       testScript = ''
         # make an initial base backup
-        machine.wait_for_unit("postgresql")
+        machine.wait_for_unit("postgresql.target")
         machine.wait_for_unit("postgresql-wal-receiver-main")
         # WAL receiver healthchecks PG every 5 seconds, so let's be sure they have connected each other
         # required only for 9.4
@@ -99,7 +99,7 @@ let
         machine.systemctl("start postgresql")
         machine.wait_for_file("${postgresqlDataDir}/recovery.done")
         machine.systemctl("restart postgresql")
-        machine.wait_for_unit("postgresql")
+        machine.wait_for_unit("postgresql.target")
 
         # check that our records have been restored
         machine.succeed(

--- a/nixos/tests/postgresql/postgresql.nix
+++ b/nixos/tests/postgresql/postgresql.nix
@@ -82,7 +82,7 @@ let
 
 
           machine.start()
-          machine.wait_for_unit("postgresql")
+          machine.wait_for_unit("postgresql.target")
 
           with subtest("Postgresql is available just after unit start"):
               machine.succeed(
@@ -94,7 +94,7 @@ let
               import time
               time.sleep(2)
               machine.start()
-              machine.wait_for_unit("postgresql")
+              machine.wait_for_unit("postgresql.target")
 
           machine.fail(check_count("SELECT * FROM sth;", 3))
           machine.succeed(check_count("SELECT * FROM sth;", 5))
@@ -219,7 +219,7 @@ let
         ''
           import json
           machine.start()
-          machine.wait_for_unit("postgresql")
+          machine.wait_for_unit("postgresql.target")
 
           with subtest("All user permissions are set according to the ensureClauses attr"):
               clauses = json.loads(

--- a/nixos/tests/postgresql/wal2json.nix
+++ b/nixos/tests/postgresql/wal2json.nix
@@ -27,7 +27,7 @@ let
       };
 
       testScript = ''
-        machine.wait_for_unit("postgresql")
+        machine.wait_for_unit("postgresql.target")
         machine.succeed(
             "sudo -u postgres psql -qAt -f ${./wal2json/example2.sql} postgres > /tmp/example2.out"
         )

--- a/nixos/tests/postgrest.nix
+++ b/nixos/tests/postgrest.nix
@@ -57,7 +57,7 @@
     ''
       import jwt
 
-      machine.wait_for_unit("postgresql.service")
+      machine.wait_for_unit("postgresql.target")
 
       def wait_for_postgrest():
           machine.wait_for_unit("postgrest.service")

--- a/nixos/tests/powerdns-admin.nix
+++ b/nixos/tests/powerdns-admin.nix
@@ -92,7 +92,7 @@ let
           '';
         };
         systemd.services.powerdns-admin = {
-          after = [ "postgresql.service" ];
+          after = [ "postgresql.target" ];
           serviceConfig.BindPaths = "/run/postgresql";
         };
 

--- a/nixos/tests/prometheus-exporters.nix
+++ b/nixos/tests/prometheus-exporters.nix
@@ -1121,7 +1121,7 @@ let
         };
       };
       exporterTest = ''
-        wait_for_unit("postgresql.service")
+        wait_for_unit("postgresql.target")
         wait_for_unit("pgbouncer.service")
         wait_for_unit("prometheus-pgbouncer-exporter.service")
         wait_for_open_port(9127)
@@ -1254,18 +1254,18 @@ let
       exporterTest = ''
         wait_for_unit("prometheus-postgres-exporter.service")
         wait_for_open_port(9187)
-        wait_for_unit("postgresql.service")
+        wait_for_unit("postgresql.target")
         succeed(
             "curl -sSf http://localhost:9187/metrics | grep 'pg_exporter_last_scrape_error 0'"
         )
         succeed("curl -sSf http://localhost:9187/metrics | grep 'pg_up 1'")
-        systemctl("stop postgresql.service")
+        systemctl("stop postgresql")
         succeed(
             "curl -sSf http://localhost:9187/metrics | grep -v 'pg_exporter_last_scrape_error 0'"
         )
         succeed("curl -sSf http://localhost:9187/metrics | grep 'pg_up 0'")
-        systemctl("start postgresql.service")
-        wait_for_unit("postgresql.service")
+        systemctl("start postgresql")
+        wait_for_unit("postgresql.target")
         succeed(
             "curl -sSf http://localhost:9187/metrics | grep 'pg_exporter_last_scrape_error 0'"
         )
@@ -1609,7 +1609,7 @@ let
             GRANT SELECT ON points TO "prometheus-sql-exporter";
           '';
         };
-        systemd.services.prometheus-sql-exporter.after = [ "postgresql.service" ];
+        systemd.services.prometheus-sql-exporter.after = [ "postgresql.target" ];
       };
       exporterTest = ''
         wait_for_unit("prometheus-sql-exporter.service")

--- a/nixos/tests/roundcube.nix
+++ b/nixos/tests/roundcube.nix
@@ -30,7 +30,7 @@
 
   testScript = ''
     roundcube.start
-    roundcube.wait_for_unit("postgresql.service")
+    roundcube.wait_for_unit("postgresql.target")
     roundcube.wait_for_unit("phpfpm-roundcube.service")
     roundcube.wait_for_unit("nginx.service")
     roundcube.succeed("curl -sSfL http://roundcube/ | grep 'Keep me logged in'")

--- a/nixos/tests/sftpgo.nix
+++ b/nixos/tests/sftpgo.nix
@@ -216,7 +216,7 @@ in
         };
 
         systemd.services.sftpgo = {
-          after = [ "postgresql.service" ];
+          after = [ "postgresql.target" ];
           environment = {
             # Update existing users
             SFTPGO_LOADDATA_MODE = "0";

--- a/nixos/tests/tandoor-recipes.nix
+++ b/nixos/tests/tandoor-recipes.nix
@@ -29,7 +29,7 @@
 
       systemd.services = {
         tandoor-recipes = {
-          after = [ "postgresql.service" ];
+          after = [ "postgresql.target" ];
         };
       };
     };

--- a/nixos/tests/vault-postgresql.nix
+++ b/nixos/tests/vault-postgresql.nix
@@ -25,7 +25,7 @@
 
       systemd.services.vault = {
         after = [
-          "postgresql.service"
+          "postgresql.target"
         ];
         # Try for about 10 minutes rather than the default of 5 attempts.
         serviceConfig.RestartSec = 1;

--- a/nixos/tests/vaultwarden.nix
+++ b/nixos/tests/vaultwarden.nix
@@ -138,7 +138,7 @@ let
 
                     services.vaultwarden.config.databaseUrl = "postgresql:///vaultwarden?host=/run/postgresql";
 
-                    systemd.services.vaultwarden.after = [ "postgresql.service" ];
+                    systemd.services.vaultwarden.after = [ "postgresql.target" ];
                   };
 
                   sqlite = {

--- a/nixos/tests/web-apps/gotosocial.nix
+++ b/nixos/tests/web-apps/gotosocial.nix
@@ -20,7 +20,7 @@
 
   testScript = ''
     machine.wait_for_unit("gotosocial.service")
-    machine.wait_for_unit("postgresql.service")
+    machine.wait_for_unit("postgresql.target")
     machine.wait_for_open_port(8081)
     # Database migrations are running, wait until gotosocial no longer serves 503
     machine.wait_until_succeeds("curl -sS -f http://localhost:8081/readyz", timeout=300)

--- a/nixos/tests/web-apps/mastodon/remote-databases.nix
+++ b/nixos/tests/web-apps/mastodon/remote-databases.nix
@@ -207,7 +207,7 @@ import ../../make-test-python.nix (
         nginx.wait_for_unit("nginx.service")
         nginx.wait_for_open_port(443)
         databases.wait_for_unit("redis-mastodon.service")
-        databases.wait_for_unit("postgresql.service")
+        databases.wait_for_unit("postgresql.target")
         databases.wait_for_open_port(31637)
         databases.wait_for_open_port(5432)
       '';

--- a/nixos/tests/web-apps/mastodon/standard.nix
+++ b/nixos/tests/web-apps/mastodon/standard.nix
@@ -101,7 +101,7 @@ import ../../make-test-python.nix (
         server.wait_for_unit("nginx.service")
         server.wait_for_open_port(443)
         server.wait_for_unit("redis-mastodon.service")
-        server.wait_for_unit("postgresql.service")
+        server.wait_for_unit("postgresql.target")
         server.wait_for_open_port(5432)
       '';
     };

--- a/nixos/tests/web-apps/peertube.nix
+++ b/nixos/tests/web-apps/peertube.nix
@@ -142,7 +142,7 @@ import ../make-test-python.nix (
     testScript = ''
       start_all()
 
-      database.wait_for_unit("postgresql.service")
+      database.wait_for_unit("postgresql.target")
       database.wait_for_unit("redis-peertube.service")
 
       database.wait_for_open_port(5432)

--- a/nixos/tests/wiki-js.nix
+++ b/nixos/tests/wiki-js.nix
@@ -27,8 +27,8 @@
         ];
       };
       systemd.services.wiki-js = {
-        requires = [ "postgresql.service" ];
-        after = [ "postgresql.service" ];
+        requires = [ "postgresql.target" ];
+        after = [ "postgresql.target" ];
       };
       environment.systemPackages = with pkgs; [ jq ];
     };

--- a/nixos/tests/zammad.nix
+++ b/nixos/tests/zammad.nix
@@ -21,7 +21,7 @@
 
   testScript = ''
     start_all()
-    machine.wait_for_unit("postgresql.service")
+    machine.wait_for_unit("postgresql.target")
     machine.wait_for_unit("redis-zammad.service")
     machine.wait_for_unit("zammad-web.service")
     machine.wait_for_unit("zammad-websocket.service")


### PR DESCRIPTION
This avoids restarting the postgresql server, when only `ensureDatabases` or `ensureUsers` have been changed. Later, it will also allow to properly wait for recovery to finish (https://github.com/NixOS/nixpkgs/issues/346886#issuecomment-2839062089).

To wait for "postgresql is ready" in other services, we now provide a `postgresql.target`.

Supersedes #400018

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [x] (Module updates) Added a release notes entry if the change is significant
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
