### PR TITLE
klipperscreen: 0.4.4 -> 0.4.5, fix Network panel

### DIFF
--- a/pkgs/by-name/kl/klipperscreen/package.nix
+++ b/pkgs/by-name/kl/klipperscreen/package.nix
@@ -8,14 +8,14 @@
 }:
 python3.pkgs.buildPythonApplication rec {
   pname = "KlipperScreen";
-  version = "0.4.4";
+  version = "0.4.5";
   format = "other";
 
   src = fetchFromGitHub {
     owner = "KlipperScreen";
     repo = "KlipperScreen";
     rev = "v${version}";
-    hash = "sha256-MxuUmkuEnfFC0iPwNUc0Wh8bIEl1J1FMgGEYMjHePZ8=";
+    hash = "sha256-lKGMz5N4lKSqA614wjJiUfP5fUY+WqFDPxeX/Iyp2TQ=";
   };
 
   nativeBuildInputs = [
@@ -33,6 +33,7 @@ python3.pkgs.buildPythonApplication rec {
     mpv
     six
     dbus-python
+    sdbus-networkmanager
   ];
 
   dontWrapGApps = true;

--- a/pkgs/development/python-modules/sdbus-networkmanager/default.nix
+++ b/pkgs/development/python-modules/sdbus-networkmanager/default.nix
@@ -1,0 +1,20 @@
+{
+  buildPythonPackage,
+  fetchPypi,
+  sdbus,
+}:
+
+let
+  pname = "sdbus-networkmanager";
+  version = "2.0.0";
+in
+buildPythonPackage {
+  inherit pname version;
+
+  propagatedBuildInputs = [ sdbus ];
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-NXKsOoGJxoPsBBassUh2F3Oo8Iga09eLbW9oZO/5xQs=";
+  };
+}

--- a/pkgs/development/python-modules/sdbus/default.nix
+++ b/pkgs/development/python-modules/sdbus/default.nix
@@ -1,0 +1,22 @@
+{
+  pkgs,
+  buildPythonPackage,
+  fetchPypi,
+  pkg-config,
+}:
+
+let
+  pname = "sdbus";
+  version = "0.14.0";
+in
+buildPythonPackage {
+  inherit pname version;
+
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [ pkgs.systemd ];
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-QdYbdswFqepB0Q1woR6fmobtlfQPcTYwxeGDQODkx28=";
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -15568,6 +15568,10 @@ self: super: with self; {
 
   scspell = callPackage ../development/python-modules/scspell { };
 
+  sdbus = callPackage ../development/python-modules/sdbus { };
+
+  sdbus-networkmanager = callPackage ../development/python-modules/sdbus-networkmanager { };
+
   sdds = callPackage ../development/python-modules/sdds { };
 
   sdjson = callPackage ../development/python-modules/sdjson { };


### PR DESCRIPTION
Add sdbus and sdbus-network-manager Python libraries, required for enabling the Network panel of KlipperScreen.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [X] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
