### PR TITLE
nixos/mealie: add 'database.createLocally'

### DIFF
--- a/nixos/modules/services/web-apps/mealie.nix
+++ b/nixos/modules/services/web-apps/mealie.nix
@@ -50,13 +50,24 @@ in
         Expects the format of an `EnvironmentFile=`, as described by {manpage}`systemd.exec(5)`.
       '';
     };
+
+    database = {
+      createLocally = lib.mkOption {
+        type = lib.types.bool;
+        default = false;
+        description = ''
+          Configure local PostgreSQL database server for Mealie.
+        '';
+      };
+    };
   };
 
   config = lib.mkIf cfg.enable {
     systemd.services.mealie = {
       description = "Mealie, a self hosted recipe manager and meal planner";
 
-      after = [ "network-online.target" ];
+      after = [ "network-online.target" ] ++ lib.optional cfg.database.createLocally "postgresql.service";
+      requires = lib.optional cfg.database.createLocally "postgresql.service";
       wants = [ "network-online.target" ];
       wantedBy = [ "multi-user.target" ];
 
@@ -77,6 +88,22 @@ in
         StateDirectory = "mealie";
         StandardOutput = "journal";
       };
+    };
+
+    services.mealie.settings = lib.mkIf cfg.database.createLocally {
+      DB_ENGINE = "postgres";
+      POSTGRES_URL_OVERRIDE = "postgresql://mealie:@/mealie?host=/run/postgresql";
+    };
+
+    services.postgresql = lib.mkIf cfg.database.createLocally {
+      enable = true;
+      ensureDatabases = [ "mealie" ];
+      ensureUsers = [
+        {
+          name = "mealie";
+          ensureDBOwnership = true;
+        }
+      ];
     };
   };
 }

--- a/nixos/tests/mealie.nix
+++ b/nixos/tests/mealie.nix
@@ -10,20 +10,35 @@ import ./make-test-python.nix (
       ];
     };
 
-    nodes = {
-      server = {
-        services.mealie = {
-          enable = true;
-          port = 9001;
+    nodes =
+      let
+        sqlite = {
+          services.mealie = {
+            enable = true;
+            port = 9001;
+          };
         };
+        postgres = {
+          imports = [ sqlite ];
+          services.mealie.database.createLocally = true;
+        };
+      in
+      {
+        inherit sqlite postgres;
       };
-    };
 
     testScript = ''
       start_all()
-      server.wait_for_unit("mealie.service")
-      server.wait_for_open_port(9001)
-      server.succeed("curl --fail http://localhost:9001")
+
+      def test_mealie(node):
+        node.wait_for_unit("mealie.service")
+        node.wait_for_open_port(9001)
+        node.succeed("curl --fail http://localhost:9001")
+
+      test_mealie(sqlite)
+      simple.send_monitor_command("quit")
+      simple.wait_for_shutdown()
+      test_mealie(postgres)
     '';
   }
 )


### PR DESCRIPTION
## Things done

Unfortunately the package is currently broken so that makes testing annoying...

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
