### PR TITLE
nixos/networking: Add enable option

### DIFF
--- a/nixos/modules/services/networking/firewall.nix
+++ b/nixos/modules/services/networking/firewall.nix
@@ -293,7 +293,7 @@ in
 
   };
 
-  config = lib.mkIf cfg.enable {
+  config = lib.mkIf (config.networking.enable && cfg.enable) {
 
     assertions = [
       {

--- a/nixos/modules/tasks/network-interfaces-scripted.nix
+++ b/nixos/modules/tasks/network-interfaces-scripted.nix
@@ -748,12 +748,12 @@ let
 in
 
 {
-  config = mkMerge [
+  config = lib.mkIf cfg.enable (mkMerge [
     bondWarnings
     (mkIf (!cfg.useNetworkd) normalConfig)
     {
       # Ensure slave interfaces are brought up
       networking.interfaces = genAttrs slaves (i: { });
     }
-  ];
+  ]);
 }

--- a/nixos/modules/tasks/network-interfaces-systemd.nix
+++ b/nixos/modules/tasks/network-interfaces-systemd.nix
@@ -210,7 +210,7 @@ let
 in
 
 {
-  config = mkMerge [
+  config = lib.mkIf cfg.enable (mkMerge [
 
     (mkIf config.boot.initrd.network.enable {
       # Note this is if initrd.network.enable, not if
@@ -567,5 +567,5 @@ in
         };
     })
 
-  ];
+  ]);
 }

--- a/nixos/modules/tasks/network-interfaces.nix
+++ b/nixos/modules/tasks/network-interfaces.nix
@@ -548,6 +548,10 @@ in
   ###### interface
 
   options = {
+    networking.enable = lib.mkEnableOption "networking" // {
+      default = true;
+      example = false;
+    };
 
     networking.hostName = mkOption {
       default = config.system.nixos.distroId;
@@ -1535,7 +1539,7 @@ in
 
   ###### implementation
 
-  config = {
+  config = lib.mkIf cfg.enable {
 
     warnings =
       (concatMap (i: i.warnings) interfaces)

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -949,6 +949,7 @@ in
   node-red = runTest ./node-red.nix;
   nomad = runTest ./nomad.nix;
   non-default-filesystems = handleTest ./non-default-filesystems.nix { };
+  no-networking = handleTest ./no-networking.nix { };
   non-switchable-system = runTest ./non-switchable-system.nix;
   noto-fonts = runTest ./noto-fonts.nix;
   noto-fonts-cjk-qt-default-weight = handleTest ./noto-fonts-cjk-qt-default-weight.nix { };

--- a/nixos/tests/no-networking.nix
+++ b/nixos/tests/no-networking.nix
@@ -1,0 +1,24 @@
+import ./make-test-python.nix (
+  { pkgs, ... }:
+  {
+    name = "no-networking";
+    meta = {
+      maintainers = [ ];
+    };
+
+    nodes.machine =
+      { ... }:
+      {
+        networking.enable = false;
+      };
+
+    testScript = ''
+      start_all()
+
+      # Assert that the system does not have iproute2
+      machine.fail(
+          'test -e /run/current-system/sw/bin/ip'
+      )
+    '';
+  }
+)


### PR DESCRIPTION
## Things done

This option is useful for building minimal embedded NixOS images.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
