### PR TITLE
zcash: don't use custom vendoring logic

### DIFF
--- a/pkgs/applications/blockchains/zcash/default.nix
+++ b/pkgs/applications/blockchains/zcash/default.nix
@@ -13,6 +13,7 @@
   libevent,
   libsodium,
   makeWrapper,
+  rustc,
   rustPlatform,
   pkg-config,
   Security,
@@ -25,7 +26,7 @@
   zeromq,
 }:
 
-rustPlatform.buildRustPackage.override { inherit stdenv; } rec {
+stdenv.mkDerivation rec {
   pname = "zcash";
   version = "5.4.2";
 
@@ -36,14 +37,16 @@ rustPlatform.buildRustPackage.override { inherit stdenv; } rec {
     hash = "sha256-XGq/cYUo43FcpmRDO2YiNLCuEQLsTFLBFC4M1wM29l8=";
   };
 
-  prePatch = lib.optionalString stdenv.hostPlatform.isAarch64 ''
-    substituteInPlace .cargo/config.offline \
-      --replace "[target.aarch64-unknown-linux-gnu]" "" \
-      --replace "linker = \"aarch64-linux-gnu-gcc\"" ""
-  '';
+  patches = [
+    # upstream has a custom way of specifying a cargo vendor-directory
+    # we'll remove that logic, since cargoSetupHook from nixpkgs works better
+    ./dont-use-custom-vendoring-logic.patch
+  ];
 
-  useFetchCargoVendor = true;
-  cargoHash = "sha256-VBqasLpxqI4kr73Mr7OVuwb2OIhUwnY9CTyZZOyEElU=";
+  cargoDeps = rustPlatform.fetchCargoVendor {
+    inherit pname version src;
+    hash = "sha256-VBqasLpxqI4kr73Mr7OVuwb2OIhUwnY9CTyZZOyEElU=";
+  };
 
   nativeBuildInputs = [
     autoreconfHook
@@ -53,6 +56,8 @@ rustPlatform.buildRustPackage.override { inherit stdenv; } rec {
     hexdump
     makeWrapper
     pkg-config
+    rustc
+    rustPlatform.cargoSetupHook
   ];
 
   buildInputs =
@@ -68,19 +73,6 @@ rustPlatform.buildRustPackage.override { inherit stdenv; } rec {
     ++ lib.optionals stdenv.hostPlatform.isDarwin [
       Security
     ];
-
-  # Use the stdenv default phases (./configure; make) instead of the
-  # ones from buildRustPackage.
-  configurePhase = "configurePhase";
-  dontCargoBuild = true;
-  dontCargoCheck = true;
-  dontCargoInstall = true;
-
-  postPatch = ''
-    # Have to do this here instead of in preConfigure because
-    # cargoDepsCopy gets unset after postPatch.
-    configureFlagsArray+=("RUST_VENDORED_SOURCES=$cargoDepsCopy")
-  '';
 
   CXXFLAGS = [
     "-I${lib.getDev utf8cpp}/include/utf8cpp"

--- a/pkgs/applications/blockchains/zcash/dont-use-custom-vendoring-logic.patch
+++ b/pkgs/applications/blockchains/zcash/dont-use-custom-vendoring-logic.patch
@@ -1,0 +1,16 @@
+diff --git a/src/Makefile.am b/src/Makefile.am
+index 8b14284..e614755 100644
+--- a/src/Makefile.am
++++ b/src/Makefile.am
+@@ -121,10 +121,7 @@ else
+ RUST_BUILD_OPTS += --locked --offline
+ 
+ CARGO_CONFIGURED = $(top_srcdir)/.cargo/.configured-for-offline
+-$(CARGO_CONFIGURED): $(top_srcdir)/.cargo/config.offline
+-	$(AM_V_at)rm -f $(top_srcdir)/.cargo/.configured-for-online
+-	$(AM_V_at)cp $< $(top_srcdir)/.cargo/config
+-	$(AM_V_at)echo "directory = \"$(RUST_VENDORED_SOURCES)\"" >>$(top_srcdir)/.cargo/config
++$(CARGO_CONFIGURED):
+ 	$(AM_V_at)touch $@
+ endif
+ if ENABLE_SHANI


### PR DESCRIPTION
Originally part of https://github.com/NixOS/nixpkgs/pull/387337

This PR facilitates an easier migration to a non-standard cargo vendor director layout (see the PR above)

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
