### PR TITLE
python3Package.parfive: build from source

### DIFF
--- a/pkgs/development/python-modules/parfive/default.nix
+++ b/pkgs/development/python-modules/parfive/default.nix
@@ -1,38 +1,49 @@
 {
   lib,
-  aiofiles,
-  aioftp,
-  aiohttp,
   buildPythonPackage,
-  fetchPypi,
+  fetchFromGitHub,
+
+  # build-system
+  setuptools-scm,
+
+  # dependencies
+  aiofiles,
+  aiohttp,
+
+  # optional dependencies
+  aioftp,
+
+  # tests
   pytest-asyncio,
   pytest-localserver,
   pytest-socket,
   pytestCheckHook,
-  pythonOlder,
-  setuptools-scm,
   tqdm,
 }:
 
 buildPythonPackage rec {
   pname = "parfive";
   version = "2.1.0";
-  format = "setuptools";
 
-  disabled = pythonOlder "3.7";
-
-  src = fetchPypi {
-    inherit pname version;
-    hash = "sha256-zWy0GSQhMHMM9B1M9vKE6/UPGnHObJUI4EZ+yY8X3I4=";
+  src = fetchFromGitHub {
+    owner = "Cadair";
+    repo = "parfive";
+    tag = "v${version}";
+    hash = "sha256-fzyXKw+/aWlnE09CCHqak8MVIk/kcjXkFyV1EKw2cjA=";
   };
 
-  buildInputs = [ setuptools-scm ];
+  pyproject = true;
 
-  propagatedBuildInputs = [
-    aioftp
+  build-system = [ setuptools-scm ];
+
+  dependencies = [
     aiohttp
     tqdm
   ];
+
+  optional-dependencies = {
+    ftp = [ aioftp ];
+  };
 
   nativeCheckInputs = [
     aiofiles
@@ -49,13 +60,17 @@ buildPythonPackage rec {
     "test_ftp_http"
   ];
 
+  # Tests require local network access
+  __darwinAllowLocalNetworking = true;
+
   pythonImportsCheck = [ "parfive" ];
 
-  meta = with lib; {
+  meta = {
     description = "HTTP and FTP parallel file downloader";
     mainProgram = "parfive";
     homepage = "https://parfive.readthedocs.io/";
-    license = licenses.mit;
-    maintainers = [ ];
+    changelog = "https://github.com/Cadair/parfive/releases/tag/v${version}";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.sarahec ];
   };
 }


### PR DESCRIPTION
Hydra build failure on Darwin due to use of local networking.

Changes:
1. Enabled local networking on Darwin
2. Switched to building from source
3. Modernized the python build
4. Made `aioftp` optional
5. Fixed `meta` block
6. Adopted

ZHF: #403336

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [x] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
