### PR TITLE
nixos/device-tree: support out-of-tree device

### DIFF
--- a/nixos/modules/system/boot/loader/grub/grub.nix
+++ b/nixos/modules/system/boot/loader/grub/grub.nix
@@ -769,6 +769,16 @@ in
         '';
       };
 
+      loadDeviceTree = mkOption {
+        default = with config.hardware.deviceTree; enable && name != null;
+        type = types.bool;
+        defaultText = ''with config.hardware.deviceTree; enable && name != null'';
+        description = ''
+          Load the devicetree blob specified by `config.hardware.deviceTree.name`
+          and instruct grub to pass this DTB to linux.
+        '';
+      };
+
     };
 
   };
@@ -797,6 +807,10 @@ in
       ];
 
       boot.loader.supportsInitrdSecrets = true;
+
+      boot.bootspec.extensions."org.nixos.grub" = lib.mkIf cfg.loadDeviceTree {
+        devicetree = "${config.hardware.deviceTree.package}/${config.hardware.deviceTree.name}";
+      };
 
       system.systemBuilderArgs.configurationName = cfg.configurationName;
       system.systemBuilderCommands = ''
@@ -891,6 +905,11 @@ in
           {
             assertion = if args.efiSysMountPoint == null then true else hasPrefix "/" args.efiSysMountPoint;
             message = "EFI paths must be absolute, not ${args.efiSysMountPoint}";
+          }
+          {
+            assertion =
+              cfg.loadDeviceTree -> config.hardware.deviceTree.enable -> config.hardware.deviceTree.name != null;
+            message = "Cannot load devicetree without 'config.hardware.deviceTree.enable' enabled and 'config.hardware.deviceTree.name' set";
           }
         ]
         ++ forEach args.devices (device: {

--- a/nixos/modules/system/boot/loader/grub/install-grub.pl
+++ b/nixos/modules/system/boot/loader/grub/install-grub.pl
@@ -337,7 +337,9 @@ $conf .= "
     # Setup the graphics stack for bios and efi systems
     if [ \"\${grub_platform}\" = \"efi\" ]; then
       insmod efi_gop
-      insmod efi_uga
+      if [ \"\${grub_cpu}\" = \"i386\" -o \"\${grub_cpu}\" = \"x86_64\"]; then
+        insmod efi_uga
+      fi
     else
       insmod vbe
     fi

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -416,6 +416,7 @@ in
   deluge = runTest ./deluge.nix;
   dendrite = runTest ./matrix/dendrite.nix;
   dependency-track = runTest ./dependency-track.nix;
+  device-tree = import ./device-tree.nix { inherit pkgs runTestOn; };
   devpi-server = runTest ./devpi-server.nix;
   dex-oidc = runTest ./dex-oidc.nix;
   dhparams = runTest ./dhparams.nix;

--- a/nixos/tests/device-tree.nix
+++ b/nixos/tests/device-tree.nix
@@ -1,0 +1,118 @@
+{
+  pkgs,
+  runTestOn,
+}:
+
+let
+  inherit (pkgs) lib;
+  common = {
+    virtualisation.useBootLoader = true;
+    virtualisation.useEFIBoot = true;
+
+    hardware.deviceTree = {
+      dtbFile = lib.mkOverride 1490 (
+        pkgs.runCommand "qemu-aarch64-virt.dtb" { } ''
+          ${pkgs.qemu}/bin/qemu-system-aarch64 -cpu max -machine virt,gic-version=max,accel=kvm:tcg,dumpdtb=$out
+        ''
+      );
+
+      overlays = [
+        {
+          name = "model";
+          dtsText = ''
+            /dts-v1/;
+            /plugin/;
+
+            / {
+                compatible = "linux,dummy-virt";
+
+                fragment@0 {
+                    target-path = "/";
+                    __overlay__ {
+                        model = "test model";
+                    };
+                };
+            };
+          '';
+        }
+      ];
+    };
+
+    specialisation.something.configuration = {
+      hardware.deviceTree.platform = "rockchip";
+      hardware.deviceTree.dtsText = ''
+        /dts-v1/;
+
+        #include "rk3588.dtsi"
+
+        / {
+          model = "Test Model";
+          compatible = "rockchip,rk3588";
+        };
+
+        &sdhci {
+          status = "okay";
+        };
+      '';
+    };
+  };
+in
+
+{
+  systemd-boot = runTestOn [ "aarch64-linux" ] {
+    name = "systemd-boot-devicetree";
+    meta.maintainers = with lib.maintainers; [
+      qbisi
+    ];
+
+    nodes.machine =
+      { pkgs, lib, ... }:
+      {
+        imports = [ common ];
+
+        boot.loader.systemd-boot.enable = true;
+      };
+
+    testScript =
+      { nodes, ... }:
+      ''
+        machine.start()
+        machine.wait_for_unit("multi-user.target")
+
+        machine.succeed("grep 'test model' /sys/firmware/devicetree/base/model")
+
+        machine.succeed(r"grep 'devicetree /EFI/nixos/[a-z0-9]\{32\}.*fromtext' /boot/loader/entries/nixos-generation-1-specialisation-something.conf")
+      '';
+  };
+
+  grub = runTestOn [ "aarch64-linux" ] {
+    name = "grub-devicetree";
+    meta.maintainers = with lib.maintainers; [
+      qbisi
+    ];
+
+    nodes.machine =
+      { pkgs, lib, ... }:
+      {
+        imports = [ common ];
+
+        boot.loader.grub = {
+          enable = true;
+          device = "nodev";
+          efiSupport = true;
+          efiInstallAsRemovable = true;
+        };
+      };
+
+    testScript =
+      { nodes, ... }:
+      ''
+        machine.start()
+        machine.wait_for_unit("multi-user.target")
+
+        machine.succeed("grep 'test model' /sys/firmware/devicetree/base/model")
+
+        machine.succeed(r"grep 'devicetree .*fromtext.dtb' /boot/grub/grub.cfg")
+      '';
+  };
+}

--- a/pkgs/os-specific/linux/kernel/manual-config.nix
+++ b/pkgs/os-specific/linux/kernel/manual-config.nix
@@ -488,6 +488,9 @@ lib.makeOverridable (
           # Keep linker scripts (they are required for out-of-tree modules on aarch64)
           find .  -type f -name '*.lds' -print0 | xargs -0 -r chmod u-w
 
+          # Keep devicetree related files (they are required for out-of-tree dts compile)
+          find -L scripts/dtc/include-prefixes -type f -name '*.dtsi' -print0 | xargs -0 -r chmod u-w
+
           # Keep root and arch-specific Makefiles
           chmod u-w Makefile arch/"$arch"/Makefile*
 


### PR DESCRIPTION
This pr add support for thouse out-of-tree boards based on [expose compileDts](https://github.com/NixOS/nixpkgs/commit/8da771560c5d664f4de452fb901a1eb2c7507382).

With some modification of kernel^dev, we can compile the deviceTree of a custom board without patching kernel source.
A test nixosTest.device-tree.{systemd-boot,grub} is added to valid this pr.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
