### PR TITLE
terraform-providers: special case for aws to use go123

### DIFF
--- a/pkgs/applications/networking/cluster/terraform-providers/default.nix
+++ b/pkgs/applications/networking/cluster/terraform-providers/default.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   buildGoModule,
+  buildGo123Module,
   fetchFromGitHub,
   fetchFromGitLab,
   callPackage,
@@ -96,6 +97,7 @@ let
 
   # These are the providers that don't fall in line with the default model
   special-providers = {
+    aws = automated-providers.aws.override { mkProviderGoModule = buildGo123Module; };
     # github api seems to be broken, doesn't just fail to recognize the license, it's ignored entirely.
     checkly = automated-providers.checkly.override { spdx = "MIT"; };
     gitlab = automated-providers.gitlab.override {


### PR DESCRIPTION
terraform-providers updates have been broken for aws. Context is here: https://github.com/NixOS/nixpkgs/pull/397429#issuecomment-2845822808 and fix is proposed by @zowoq 

## Things done
- Added exception for the aws provider.
- Tested that the update-provider script succeeds to allow automatic updates again.
- Tested that the resulting terraform-provider-aws-5.97.0 can be built.

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin