### PR TITLE
ory: 0.3.4 -> v1.1.0

### DIFF
--- a/pkgs/by-name/or/ory/package.nix
+++ b/pkgs/by-name/or/ory/package.nix
@@ -3,32 +3,38 @@
   buildGoModule,
   fetchFromGitHub,
   installShellFiles,
+  nix-update-script,
+  versionCheckHook,
 }:
 
-buildGoModule rec {
+buildGoModule (finalAttrs: {
   pname = "ory";
-  version = "0.3.4";
+  version = "v1.1.0";
 
   src = fetchFromGitHub {
     owner = "ory";
     repo = "cli";
-    tag = "v${version}";
-    hash = "sha256-q7+Fpttgx62GbKxCCiEDlX//e/pNO24e7KhhBeGRDH0=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-+Su2FIuCb2vpPW/OCOTzqQOZPpY9gGRbwylSepLh2hk=";
   };
 
   nativeBuildInputs = [
     installShellFiles
   ];
 
-  subPackages = [ "." ];
-
   env.CGO_ENABLED = 1;
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X github.com/ory/cli/buildinfo.Version=${finalAttrs.version}"
+  ];
 
   tags = [
     "sqlite"
   ];
 
-  vendorHash = "sha256-B0y1JVjJmC5eitn7yIcDpl+9+xaBDJBMdvm+7N/ZxTk=";
+  vendorHash = "sha256-VXaMc4VnHPljVugJyuGn8EQvNUBkEhbvepg2p7vw2EY=";
 
   postInstall = ''
     mv $out/bin/cli $out/bin/ory
@@ -38,14 +44,21 @@ buildGoModule rec {
       --zsh <($out/bin/ory completion zsh)
   '';
 
-  meta = with lib; {
+  doCheck = false;
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgramArg = "version";
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
     mainProgram = "ory";
     description = "Ory CLI";
     homepage = "https://www.ory.sh/cli";
-    license = licenses.asl20;
-    maintainers = with maintainers; [
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [
       luleyleo
       nicolas-goudry
     ];
   };
-}
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Changes introduced

- update ory to v1.1.0
- use `finalAttrs` instead of `rec`
- remove useless `subPackages`
- add `ldflags`
- disable Go tests and use `versionCheckHook` to check successful build(see below notes)
- add `updateScript`
- avoid scoping `with lib`

## Notes for reviewers

1. `version` is now using a leading `v` char because, without it, the `checkPhase` fails with the following error:

```
       > Running phase: checkPhase
       >
       > The configuration contains values or keys which are invalid:
       > version: 1.1.0
       >          ^-- does not match pattern "^v(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$"
       >
       > time=2025-05-02T22:59:27Z level=fatal msg=Unable to load config. audience=application error=map[message:I[#/version] S[#/properties/version/pattern] does not match pattern "^v(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$"] service_name= service_version
=
       > FAIL    github.com/ory/cli/cmd  0.058s
       > FAIL
```

I didn’t find another way than setting the derivation `version` field to `v1.1.0`. This might not be needed after all (see item 2 below).

2. Go tests are entirely disabled because I wasn’t able to make them work with `checkFlags`. For some reason unknown to me, even if I provide the `-skip` flag, tests are still run. Here is the `checkFlags` content and the build output (with `NIX_DEBUG=1`):

```nix
checkFlags = [
  "-skip=TestMain"
];
```

```
$WORK/b001/accountexperience.test -test.paniconexit0 -test.timeout=10m0s -test.skip=TestMain
rm -rf $WORK/b001/

        Error Trace:    /build/source/cmd/cloudx/testhelpers/testhelpers.go:210
                                                /build/source/cmd/cloudx/testhelpers/testmain.go:44
                                                /build/source/cmd/cloudx/accountexperience/accountexperience_test.go:29
        Error:          Received unexpected error:
                        Get "https://project.console.staging.ory.dev/self-service/registration/api": dial tcp: lookup project.console.staging.ory.dev on [::1]:53: read udp [::1]:34005->[::1]:53: read: connection refused
        Test:           TestMain

goroutine 1 [running]:
runtime/debug.Stack()
        /nix/store/rv9g1p18w52vip6652svdgy138wgx7dj-go-1.24.2/share/go/src/runtime/debug/stack.go:26 +0x5e
runtime/debug.PrintStack()
        /nix/store/rv9g1p18w52vip6652svdgy138wgx7dj-go-1.24.2/share/go/src/runtime/debug/stack.go:18 +0x13
github.com/ory/cli/cmd/cloudx/testhelpers.MockTestingTForMain.Errorf({{0xc0019879c8?, 0x2?}}, {0x1ed8446?, 0x480a05?}, {0xc001a920f0?, 0x1af9a20?, 0x101?})
        /build/source/cmd/cloudx/testhelpers/testmain.go:87 +0x4c
github.com/stretchr/testify/assert.Fail({0x7fffa8fc1020, 0xc000f64b90}, {0xc00052e2a0, 0xde}, {0x0, 0x0, 0x0})
        /build/source/vendor/github.com/stretchr/testify/assert/assertions.go:363 +0x370
github.com/stretchr/testify/assert.NoError({0x7fffa8fc1020, 0xc000f64b90}, {0x24ee3e0, 0xc001a94330}, {0x0, 0x0, 0x0})
        /build/source/vendor/github.com/stretchr/testify/assert/assertions.go:1545 +0x125
github.com/stretchr/testify/require.NoError({0x24f7360, 0xc000f64b90}, {0x24ee3e0, 0xc001a94330}, {0x0, 0x0, 0x0})
        /build/source/vendor/github.com/stretchr/testify/require/require.go:1354 +0xb0
github.com/ory/cli/cmd/cloudx/testhelpers.RegisterAccount({0x2504e38, 0x3ac53c0}, {0x251b060, 0xc000f64b90})
        /build/source/cmd/cloudx/testhelpers/testhelpers.go:210 +0x1a5
github.com/ory/cli/cmd/cloudx/testhelpers.CreateDefaultAssetsBrowser()
        /build/source/cmd/cloudx/testhelpers/testmain.go:44 +0x112
github.com/ory/cli/cmd/cloudx/accountexperience_test.TestMain(0xc000f26dc0)
        /build/source/cmd/cloudx/accountexperience/accountexperience_test.go:29 +0x1c
main.main()
        _testmain.go:49 +0xa8
FAIL    github.com/ory/cli/cmd/cloudx/accountexperience 0.053s
FAIL

```

The `versionCheckHook` tester is used instead, to ensure the built binary is working.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
