### PR TITLE
openrazer-daemon: Add missing dependency

### DIFF
--- a/pkgs/development/python-modules/openrazer/daemon.nix
+++ b/pkgs/development/python-modules/openrazer/daemon.nix
@@ -13,6 +13,7 @@
   wrapGAppsNoGuiHook,
   notify2,
   glib,
+  libnotify,
 }:
 
 let
@@ -56,6 +57,7 @@ buildPythonPackage (
       pyudev
       setproctitle
       notify2
+      libnotify
     ];
 
     postInstall = ''


### PR DESCRIPTION
Daemon was not able to notify user because of a missing `notify-send` executable.

```
> 2025-05-03 01:47:46 | razer                          | INFO     | Serving DBus
> Exception in thread Thread-1:
> Traceback (most recent call last):
>   File "/nix/store/fqm9bqqlmaqqr02qbalm1bazp810qfiw-python3-3.12.9/lib/python3.12/threading.py", line 1075, in _bootstrap_inner
>     self.run()
>   File "/nix/store/4422hksm0livy0n12kab6s5fgc6r4y6q-python3.12-openrazer-daemon-3.10.1/lib/python3.12/site-packages/openrazer_daemon/misc/battery_notifier.py", line 107, in run
>     self.notify_battery()
>   File "/nix/store/4422hksm0livy0n12kab6s5fgc6r4y6q-python3.12-openrazer-daemon-3.10.1/lib/python3.12/site-packages/openrazer_daemon/misc/battery_notifier.py", line 98, in notify_battery
>     self.show_notification(summary=title, message=message, icon=icon)
>   File "/nix/store/4422hksm0livy0n12kab6s5fgc6r4y6q-python3.12-openrazer-daemon-3.10.1/lib/python3.12/site-packages/openrazer_daemon/misc/battery_notifier.py", line 53, in show_notification
>     subprocess.run(["notify-send", "-a", "OpenRazer", "-i", icon, "-t", "4000", summary, message],
>   File "/nix/store/fqm9bqqlmaqqr02qbalm1bazp810qfiw-python3-3.12.9/lib/python3.12/subprocess.py", line 550, in run
>     with Popen(*popenargs, **kwargs) as process:
>          ^^^^^^^^^^^^^^^^^^^^^^^^^^^
>   File "/nix/store/fqm9bqqlmaqqr02qbalm1bazp810qfiw-python3-3.12.9/lib/python3.12/subprocess.py", line 1028, in __init__
>     self._execute_child(args, executable, preexec_fn, close_fds,
>   File "/nix/store/fqm9bqqlmaqqr02qbalm1bazp810qfiw-python3-3.12.9/lib/python3.12/subprocess.py", line 1963, in _execute_child
>     raise child_exception_type(errno_num, err_msg, err_filename)
> FileNotFoundError: [Errno 2] No such file or directory: 'notify-send'
```

After adding the library which contains the said executable, execution works as expected (without errors).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
