### PR TITLE
liborbispkg-pkgtool: init at 0.3-unstable-2024-10-12

### DIFF
--- a/pkgs/by-name/li/liborbispkg-pkgtool/package.nix
+++ b/pkgs/by-name/li/liborbispkg-pkgtool/package.nix
@@ -1,0 +1,30 @@
+{
+  lib,
+  buildDotnetModule,
+  fetchFromGitHub,
+}:
+buildDotnetModule {
+  pname = "liborbispkg-pkgtool";
+  version = "0.3-unstable-2024-10-12";
+
+  src = fetchFromGitHub {
+    owner = "OpenOrbis";
+    repo = "LibOrbisPkg";
+    rev = "75616a28de0f49f05eeff872211e806fb6de3818";
+    hash = "sha256-ySlMzUfJ0IXi/NWbj53jqCRDNm9Xh4TuffyKhNh4wuM=";
+  };
+
+  projectFile = "PkgTool.Core/PkgTool.Core.csproj";
+
+  postFixup = ''
+    mv $out/bin/PkgTool.Core $out/bin/pkgtool
+  '';
+
+  meta = {
+    description = "Library, GUI, CLI for creating, inspecting, and modifying PS4 PKG, SFO, PFS, and related filetypes";
+    homepage = "https://github.com/OpenOrbis/LibOrbisPkg";
+    license = lib.licenses.lgpl3Plus;
+    maintainers = [ lib.maintainers.ryand56 ];
+    mainProgram = "pkgtool";
+  };
+}


### PR DESCRIPTION
Adds [LibOrbisPkg](https://github.com/OpenOrbis/LibOrbisPkg)'s PkgTool, useful for inspection of **homebrew** packages on the PS4. I don't condone piracy, use at your own risk.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
