### PR TITLE
action-validator: 0.6.0 -> 0.6.0-unstable-2025-02-16 to fix build

### DIFF
--- a/pkgs/by-name/ac/action-validator/package.nix
+++ b/pkgs/by-name/ac/action-validator/package.nix
@@ -2,22 +2,28 @@
   lib,
   rustPlatform,
   fetchFromGitHub,
+  unstableGitUpdater,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage {
   pname = "action-validator";
-  version = "0.6.0";
+  version = "0.6.0-unstable-2025-02-16";
 
   src = fetchFromGitHub {
     owner = "mpalmer";
     repo = "action-validator";
-    rev = "v${version}";
-    hash = "sha256-lJHGx/GFddIwVVXRj75Z/l5CH/yuw/uIhr02Qkjruww=";
+    rev = "2f8be1d2066eb3687496a156d00b4f1b3ea7b028";
+    hash = "sha256-QDnikgAfkrvn7/vnmgTQ5J8Ro2HZ6SVkp9cPUYgejqM=";
     fetchSubmodules = true;
   };
 
   useFetchCargoVendor = true;
-  cargoHash = "sha256-dy66ZkU9lIYGe9T3oR8m5cGcBQO5MF1KsLjfaHTtvlY=";
+  cargoHash = "sha256-FuJ5NzeZhfN312wK5Q1DgIXUAN6hqxu/1BhGqasbdS8=";
+
+  passthru.updateScript = unstableGitUpdater {
+    tagPrefix = "v";
+    branch = "main";
+  };
 
   meta = with lib; {
     description = "Tool to validate GitHub Action and Workflow YAML files";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Diff: https://github.com/mpalmer/action-validator/compare/v0.6.0...2f8be1d2066eb3687496a156d00b4f1b3ea7b028

Required including https://github.com/mpalmer/action-validator/commit/6573ff1273557fe2b0d5b3aed1854b3374ab3e20 to fix following build error.

https://hydra.nixos.org/build/294955749
ZHF: #403336

```
error: older versions of the `wasm-bindgen` crate are incompatible with current versions of Rust; please update to `wasm-bindgen` v0.2.88
```

Updated to the latest revision to address the issue. Since updates are released infrequently, I chose to use the unstable updater rather than rely only on tags.

```console
> gh release list
TITLE                                                                     TYPE    TAG NAME  PUBLISHED
Support+test negative globs                                               Latest  v0.6.0    about 1 year ago
Loosen the requirements on runs-on                                                v0.5.4    about 1 year ago
Updated schemas                                                                   v0.5.3    about 1 year ago
Binary releases for the correct architecture!                                     v0.5.2    about 1 year ago
Executable executables are good                                                   v0.5.1    about 2 years ago
Remove wee_alloc from WASM builds                                                 v0.5.0    about 2 years ago
wasm builds, multiple filenames, and binaries that support older distros          v0.4.0    about 2 years ago
The features, keep rolling, along                                                 v0.3.0    about 2 years ago
Picky software is picky!                                                          v0.2.1    about 2 years ago
The "New Years Resolution" release                                                v0.2.0    about 2 years ago
Correct version number in the built binary                                        v0.1.2    about 3 years ago
Make cargo happy                                                                  v0.1.4    about 2 years ago
Tweak command-line help                                                           v0.1.1    about 3 years ago
Initial Release                                                                   v0.1.0    about 3 years ago
```

I also tried applying the following patch without changing the version, but it didn’t update the `cargoHash`. => Using `cargoPatches` might resolve it

```diff
+  patches = [
+    (fetchpatch {
+      # Workaround for "error: older versions of the `wasm-bindgen` crate are incompatible with current versions of Rust"
+      # Should be removed next 0.6.X action-validator update or possibly 0.7.X.
+      url = "https://github.com/mpalmer/action-validator/commit/6573ff1273557fe2b0d5b3aed1854b3374ab3e20.patch";
+      hash = "sha256-HH427S/MFebBolWXD32K+cM9eJ8OhOLhoJyKQ98GyZk=";
+    })
+  ];
```


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [x] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

cc: @thiagokokada

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
