### PR TITLE
nixos/config: correct hashedPasswordFile doc

### DIFF
--- a/nixos/modules/config/users-groups.nix
+++ b/nixos/modules/config/users-groups.nix
@@ -382,8 +382,8 @@ let
           description = ''
             The full path to a file that contains the hash of the user's
             password. The password file is read on each system activation. The
-            file should contain exactly one line, which should be the password in
-            an encrypted form that is suitable for the `chpasswd -e` command.
+            file should contain exactly one line, the salted password hash
+            produced by `mkpasswd`.
 
             ${passwordDescription}
           '';


### PR DESCRIPTION
`chpasswd -e` accepts entries in the form of:

    <user>:<hashed-password-etc>

However, using a value in the above format fails to set the password hash. Using ONLY the <hashed-password> generated by `mkpasswd` works as expected.

I do not know if the other colon delimited fields of `SHADOW(5)` would be accepted if provided.