### PR TITLE
mythtv: update src hash to fix build

### DIFF
--- a/pkgs/applications/video/mythtv/default.nix
+++ b/pkgs/applications/video/mythtv/default.nix
@@ -48,7 +48,7 @@ mkDerivation rec {
   src = fetchFromGitHub {
     owner = "MythTV";
     repo = "mythtv";
-    rev = "v${version}";
+    tag = "v${version}";
     hash = "sha256-ZhVlDX5I6SJEntVg30Iy/XxgsorDjFycAt2uksJMJps=";
   };
 

--- a/pkgs/applications/video/mythtv/default.nix
+++ b/pkgs/applications/video/mythtv/default.nix
@@ -49,7 +49,7 @@ mkDerivation rec {
     owner = "MythTV";
     repo = "mythtv";
     tag = "v${version}";
-    hash = "sha256-ZhVlDX5I6SJEntVg30Iy/XxgsorDjFycAt2uksJMJps=";
+    hash = "sha256-4mWtPJi2CBoek8LWEfdFxe1ybomAOCTWBTKExMm7nLU=";
   };
 
   patches = [


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

To fix failing build

https://hydra.nixos.org/build/295015255/nixlog/2
ZHF: #403336

I’m not sure why this happened, but it seems the `v35.0` tag was moved to a different commit after the [initial release](https://github.com/NixOS/nixpkgs/pull/385015).

According to their [release notes](https://www.mythtv.org/wiki/Release_Notes_-_35):

>The 35 release encompasses development revisions from [1f5dfbce31] though [665b315a3b].

However, the current commit pointed to by the `v35.0` tag is now https://github.com/MythTV/mythtv/commit/2cee6aa218f72004fb42688d7b93f77a9da41c75.

This might have been a silent correction or re-tagging, but I couldn't find an official explanation in their issues or changelog.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

cc: @wolfgangwalther

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
