### PR TITLE
lunatic: 0.13.2 -> 0.13.2-unstable-2025-03-29 to fix build

### DIFF
--- a/pkgs/by-name/lu/lunatic/package.nix
+++ b/pkgs/by-name/lu/lunatic/package.nix
@@ -6,21 +6,22 @@
   openssl,
   stdenv,
   darwin,
+  unstableGitUpdater,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage {
   pname = "lunatic";
-  version = "0.13.2";
+  version = "0.13.2-unstable-2025-03-29";
 
   src = fetchFromGitHub {
     owner = "lunatic-solutions";
     repo = "lunatic";
-    rev = "v${version}";
-    hash = "sha256-uMMssZaPDZn3bOtQIho+GvUCPmzRllv7eJ+SJuKaYtg=";
+    rev = "28a2f387ebf6a64ce4b87e2638812e2c032d5049";
+    hash = "sha256-FnUYnSWarQf68jBfSlIKVZbQHJt5U93MvA6rbNJE23U=";
   };
 
   useFetchCargoVendor = true;
-  cargoHash = "sha256-SzfM4hQW9vTTRqCAEn/EPv9mK9WlXYRFUW8pA/Gfw04=";
+  cargoHash = "sha256-+2koGrhM9VMLh8uO1YcaugcfmZaCP4S2twKem+y2oks=";
 
   nativeBuildInputs = [
     pkg-config
@@ -39,10 +40,15 @@ rustPlatform.buildRustPackage rec {
     "--skip=state::tests::import_filter_signature_matches"
   ];
 
+  passthru.updateScript = unstableGitUpdater {
+    tagPrefix = "v";
+    branch = "main";
+  };
+
   meta = with lib; {
     description = "Erlang inspired runtime for WebAssembly";
     homepage = "https://lunatic.solutions";
-    changelog = "https://github.com/lunatic-solutions/lunatic/blob/v${version}/CHANGELOG.md";
+    changelog = "https://github.com/lunatic-solutions/lunatic/blob/main/CHANGELOG.md";
     license = with licenses; [
       mit # or
       asl20


### PR DESCRIPTION
Diff: https://github.com/lunatic-solutions/lunatic/compare/v0.13.2...28a2f387ebf6a64ce4b87e2638812e2c032d5049

Required including https://github.com/lunatic-solutions/lunatic/commit/38c85471341cf6a317366a90e0eaf207095e788c to fix build

https://hydra.nixos.org/build/295012347/nixlog/3
ZHF: #403336

```
   Compiling time v0.3.20
error[E0282]: type annotations needed for `Box<_>`
  --> /build/lunatic-0.13.2-vendor/time-0.3.20/src/format_description/parse/mod.rs:83:9
   |
83 |     let items = format_items
   |         ^^^^^
...
86 |     Ok(items.into())
   |              ---- type must be known at this point
   |
   = note: this is an inference error on crate `time` caused by an API change in Rust 1.80.0; update `time` to version `>=0.3.35` by calling `cargo update`

For more information about this error, try `rustc --explain E0282`.
error: could not compile `time` (lib) due to 1 previous error
warning: build failed, waiting for other jobs to finish...
```

```console
> hydra-check lunatic
Build Status for nixpkgs.lunatic.x86_64-linux on jobset nixos/trunk-combined
https://hydra.nixos.org/job/nixos/trunk-combined/nixpkgs.lunatic.x86_64-linux
✖ (Failed)  lunatic-0.13.2  2025-04-24  https://hydra.nixos.org/build/295012347
✖ (Failed)  lunatic-0.13.2  2025-03-22  https://hydra.nixos.org/build/293037178
✖ (Failed)  lunatic-0.13.2  2025-03-13  https://hydra.nixos.org/build/292333901
✖ (Failed)  lunatic-0.13.2  2025-02-22  https://hydra.nixos.org/build/290650792
✖ (Failed)  lunatic-0.13.2  2025-02-07  https://hydra.nixos.org/build/287767377
✖ (Failed)  lunatic-0.13.2  2025-01-20  https://hydra.nixos.org/build/286034891
✖ (Failed)  lunatic-0.13.2  2025-01-14  https://hydra.nixos.org/build/282582142
✖ (Failed)  lunatic-0.13.2  2024-12-03  https://hydra.nixos.org/build/280794010
✖ (Failed)  lunatic-0.13.2  2024-11-15  https://hydra.nixos.org/build/278331218
✖ (Failed)  lunatic-0.13.2  2024-11-05  https://hydra.nixos.org/build/276567397
```

ref: https://github.com/NixOS/nixpkgs/pull/353827#issuecomment-2659113149, https://github.com/NixOS/nixpkgs/pull/394134

I don't have confidence how to deprecate this package, so just fixed the failing build with following guide

https://github.com/NixOS/nixpkgs/blob/a3394a0783f3c50caf4874df8a10a6edc4c4dafa/pkgs/README.md?plain=1#L560-L564

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [x] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

cc: @figsoda @itepastra @ghpzin @donovanglover

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
