### PR TITLE
gn: 2168 -> 2233 (2024-05-03 -> 2025-04-28)

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/default.nix
+++ b/pkgs/applications/networking/browsers/chromium/default.nix
@@ -85,16 +85,6 @@ let
           url = "https://gn.googlesource.com/gn";
           inherit (upstream-info.deps.gn) rev hash;
         };
-
-        # Relax hardening as otherwise gn unstable 2024-06-06 and later fail with:
-        # cc1plus: error: '-Wformat-security' ignored without '-Wformat' [-Werror=format-security]
-        hardeningDisable = [ "format" ];
-
-        # At the time of writing, gn is at v2024-05-13 and has a backported patch.
-        # This patch appears to be already present in v2024-09-09 (from M130), which
-        # results in the patch not applying and thus failing the build.
-        # As a work around until gn is updated again, we filter specifically that patch out.
-        patches = lib.filter (e: lib.getName e != "LFS64.patch") oldAttrs.patches;
       });
     });
 

--- a/pkgs/by-name/gn/gn/generic.nix
+++ b/pkgs/by-name/gn/gn/generic.nix
@@ -41,15 +41,6 @@ stdenv.mkDerivation {
     inherit rev sha256;
   };
 
-  patches = [
-    (fetchpatch {
-      name = "LFS64.patch";
-      url = "https://gn.googlesource.com/gn/+/b5ff50936a726ff3c8d4dfe2a0ae120e6ce1350d%5E%21/?format=TEXT";
-      decode = "base64 -d";
-      hash = "sha256-/kh8t/Ip1EG2OIhydS//st/C80KJ4P31vGx7j8QpFh0=";
-    })
-  ];
-
   nativeBuildInputs = [
     ninja
     python3
@@ -69,6 +60,9 @@ stdenv.mkDerivation {
   );
 
   env.NIX_CFLAGS_COMPILE = "-Wno-error";
+  # Relax hardening as otherwise gn unstable 2024-06-06 and later fail with:
+  # cc1plus: error: '-Wformat-security' ignored without '-Wformat' [-Werror=format-security]
+  hardeningDisable = [ "format" ];
 
   buildPhase = ''
     python build/gen.py --no-last-commit-position

--- a/pkgs/by-name/gn/gn/package.nix
+++ b/pkgs/by-name/gn/gn/package.nix
@@ -1,10 +1,10 @@
 { callPackage, ... }@args:
 
 callPackage ./generic.nix args {
-  # Note: Please use the recommended version for Chromium stabe, i.e. from
-  # <nixpkgs>/pkgs/applications/networking/browsers/chromium/upstream-info.nix
-  rev = "df98b86690c83b81aedc909ded18857296406159";
-  revNum = "2168"; # git describe $rev --match initial-commit | cut -d- -f3
-  version = "2024-05-13";
-  sha256 = "sha256-mNoQeHSSM+rhR0UHrpbyzLJC9vFqfxK1SD0X8GiRsqw=";
+  # Note: Please use the recommended version for Chromium stable, i.e. from
+  # <nixpkgs>/pkgs/applications/networking/browsers/chromium/info.json
+  rev = "85cc21e94af590a267c1c7a47020d9b420f8a033";
+  revNum = "2233"; # git describe $rev --match initial-commit | cut -d- -f3
+  version = "2025-04-28";
+  sha256 = "sha256-+nKP2hBUKIqdNfDz1vGggXSdCuttOt0GwyGUQ3Z1ZHI=";
 }


### PR DESCRIPTION
* Matches commit to chromium info.json https://github.com/NixOS/nixpkgs/blob/a5df9ceb5f057fdbe6f7e7a2a0350c878e34da25/pkgs/applications/networking/browsers/chromium/info.json#L807
* Drops now unneeded patch.
* Use -Wno-format-security.

Tested x86_64-linux, aarch64-linux, pkgsStatic.gn,
pkgsCross.aarch64-multiplatform.gn.

Signed-off-by: Peter Waller <p@pwaller.net>


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
