### PR TITLE
matchbox-keyboard: init at 5f6aa66

### DIFF
--- a/pkgs/by-name/ma/matchbox-keyboard/implicit-functions.patch
+++ b/pkgs/by-name/ma/matchbox-keyboard/implicit-functions.patch
@@ -1,0 +1,47 @@
+--- a/src/matchbox-keyboard-ui-xft-backend.h
++++ b/src/matchbox-keyboard-ui-xft-backend.h
+@@ -27,6 +27,9 @@
+ MBKeyboardUIBackend*
+ mb_kbd_ui_xft_init(MBKeyboardUI *ui);
+ 
++void
++mb_kbd_ui_xft_destroy (MBKeyboardUI *ui);
++
+ #define MB_KBD_UI_BACKEND_INIT_FUNC(ui)  mb_kbd_ui_xft_init((ui))
+ #define MB_KBD_UI_BACKEND_DESTROY_FUNC(ui)  mb_kbd_ui_xft_destroy((ui))
+ 
+--- a/src/matchbox-keyboard.h
++++ b/src/matchbox-keyboard.h
+@@ -332,6 +332,12 @@
+ void
+ mb_kbd_ui_handle_widget_xevent (MBKeyboardUI *ui, XEvent *xev);
+ 
++void
++mb_kbd_ui_handle_configure(MBKeyboardUI *ui, int width, int height);
++
++void
++mb_kbd_ui_update_display_size(MBKeyboardUI *ui);
++
+ #ifdef WANT_CAIRO
+ #define mb_kbd_image_width(x) cairo_image_surface_get_width (x)
+ #define mb_kbd_image_height(x) cairo_image_surface_get_height (x)
+@@ -379,6 +385,9 @@
+             int x, int y, int w, int h);
+ #endif
+ 
++void
++mb_kbd_destroy (MBKeyboard *kb);
++
+ int
+ mb_kbd_row_spacing(MBKeyboard *kb);
+ 
+@@ -647,6 +656,9 @@
+ void
+ mb_kbd_key_dump_key(MBKeyboardKey *key);
+ 
++MBKeyboardKeyActionType
++mb_kbd_key_get_action_type(MBKeyboardKey *key, MBKeyboardKeyStateType state);
++
+ #define mb_kdb_key_foreach_state(k,s)                     \
+        for((s)=0; (s) < N_MBKeyboardKeyStateTypes; (s)++) \
+             if (mb_kdb_key_has_state((k), (s)))

--- a/pkgs/by-name/ma/matchbox-keyboard/package.nix
+++ b/pkgs/by-name/ma/matchbox-keyboard/package.nix
@@ -1,0 +1,53 @@
+{
+  lib,
+  stdenv,
+  autoconf,
+  automake,
+  expat,
+  fetchFromGitHub,
+  libfakekey,
+  libtool,
+  libXft,
+  pkg-config,
+  xorg,
+}:
+
+stdenv.mkDerivation {
+  pname = "matchbox-keyboard";
+  version = "5f6aa66";
+
+  src = fetchFromGitHub {
+    owner = "mwilliams03";
+    repo = "matchbox-keyboard";
+    rev = "5f6aa668bfe8fa26af0524e45893832fb804541d";
+    hash = "sha256-XDs6EYYwCTgNTNQN4Q1mkH1j0DAMwZD9axsjV9qqXo4=";
+  };
+
+  patches = [
+    ./implicit-functions.patch
+  ];
+
+  nativeBuildInputs = [
+    autoconf
+    automake
+    expat
+    libfakekey
+    libtool
+    libXft
+    pkg-config
+    xorg.libXtst
+    xorg.libXi
+  ];
+
+  postUnpack = ''
+    autoreconf -v --install source
+  '';
+
+  meta = with lib; {
+    description = "Matchbox-keyboard is an on screen 'virtual' or 'software' keyboard";
+    homepage = "https://github.com/mwilliams03/matchbox-keyboard";
+    license = licenses.lgpl2;
+    maintainers = with maintainers; [ camelpunch ];
+    platforms = platforms.linux;
+  };
+}


### PR DESCRIPTION
Ultimately I want to add this so that KlipperScreen can make use of it (see https://github.com/NixOS/nixpkgs/pull/403654), but felt that it made sense to add matchbox-keyboard in its own PR.
    
I've copy+pasted a Debian packaging patch to make the build go through. There are two other patches added by Debian but didn't think they were relevant (xmonad support could be added later):
    
https://sources.debian.org/patches/matchbox-keyboard/0.2%2Bgit20160713-1.1/
    
matchbox-keyboard apparently doesn't have normal releases, and it looks like it's normally built from HEAD. As such I've set the version to a shortened git SHA. Totally open to inventing a version instead, which looks like what Debian does.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
