### PR TITLE
oakctl: init at 0.2.12

### DIFF
--- a/pkgs/by-name/oa/oakctl/package.nix
+++ b/pkgs/by-name/oa/oakctl/package.nix
@@ -1,0 +1,80 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  libgcc,
+  autoPatchelfHook,
+  testers,
+  oakctl,
+}:
+
+let
+  version = "0.2.12";
+
+  # Note: Extracted from install script
+  # https://oakctl-releases.luxonis.com/oakctl-installer.sh
+  sources = {
+    x86_64-linux = fetchurl {
+      url = "https://oakctl-releases.luxonis.com/data/${version}/linux_x86_64/oakctl";
+      hash = "sha256-HCnFD0LD6sQp9k3SP2g4svjA5/kLvfrnN+IwiuMWGCY=";
+    };
+    aarch64-linux = fetchurl {
+      url = "https://oakctl-releases.luxonis.com/data/${version}/linux_aarch64/oakctl";
+      hash = "sha256-1oJQs57/tW3rsMM+LAuKiBUf1aKOKFoPQAMcVUfXqlE=";
+    };
+    aarch64-darwin = fetchurl {
+      url = "https://oakctl-releases.luxonis.com/data/${version}/darwin_arm64/oakctl";
+      hash = "sha256-arS2qfd/Z/ZCNWAKD9bc2PMwkhVtO5WViTibMST7zd8=";
+    };
+    x86_64-darwin = fetchurl {
+      url = "https://oakctl-releases.luxonis.com/data/${version}/darwin_x86_64/oakctl";
+      hash = "sha256-yyvDQbFEtlB8xmdbxquy22wAIUcCSVchP/AuSpi4TAU=";
+    };
+  };
+
+  src =
+    sources.${stdenv.hostPlatform.system}
+      or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "oakctl";
+  inherit version src;
+
+  dontUnpack = true;
+  dontConfigure = true;
+  dontBuild = true;
+
+  passthru.tests.version = testers.testVersion {
+    command = "HOME=$TMPDIR oakctl version";
+    package = oakctl;
+  };
+
+  nativeBuildInputs = lib.optionals stdenv.hostPlatform.isLinux [ autoPatchelfHook ];
+
+  buildInputs = lib.optionals stdenv.hostPlatform.isLinux [ libgcc ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+    install -D -m 0755 $src $out/bin/${finalAttrs.pname}
+
+    runHook postInstall
+  '';
+
+  # Note: The command 'oakctl self-update' won't work as the binary is located in the nix/store
+  meta = {
+    description = "Tool to interact with Luxonis OAK4 cameras";
+    homepage = "https://rvc4.docs.luxonis.com/software/tools/oakctl";
+    license = lib.licenses.unfree;
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+      "x86_64-darwin"
+      "aarch64-darwin"
+    ];
+    mainProgram = "oakctl";
+    maintainers = with lib.maintainers; [ phodina ];
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+  };
+})


### PR DESCRIPTION
This adds tool to work with Luxonis OAK4 cameras, list them, push app in container to the camera, etc.

It's distributed only as a shell script :-/

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
