### PR TITLE
nixos/ntpd-rs: Handle configuring NTP pools

### DIFF
--- a/nixos/modules/services/networking/ntp/ntpd-rs.nix
+++ b/nixos/modules/services/networking/ntp/ntpd-rs.nix
@@ -63,7 +63,7 @@ in
       };
       source = lib.mkIf cfg.useNetworkingTimeServers (
         map (ts: {
-          mode = "server";
+          mode = if lib.strings.hasInfix "pool" ts then "pool" else "server";
           address = ts;
         }) config.networking.timeServers
       );

--- a/nixos/tests/ntpd-rs.nix
+++ b/nixos/tests/ntpd-rs.nix
@@ -11,7 +11,7 @@ import ./make-test-python.nix (
       client = {
         services.ntpd-rs = {
           enable = true;
-          metrics.enable = true;
+          metrics.enable = false;
           useNetworkingTimeServers = false;
           settings = {
             source = [
@@ -27,11 +27,22 @@ import ./make-test-python.nix (
         };
       };
       server = {
-        networking.firewall.allowedUDPPorts = [ 123 ];
+        networking.firewall = {
+          allowedTCPPorts = [
+            9975
+          ];
+          allowedUDPPorts = [
+            123
+          ];
+        };
+
         services.ntpd-rs = {
           enable = true;
           metrics.enable = true;
           settings = {
+            observability = {
+              metrics-exporter-listen = "[::]:9975";
+            };
             server = [
               { listen = "[::]:123"; }
             ];
@@ -48,8 +59,13 @@ import ./make-test-python.nix (
         for machine in (server, client):
           machine.wait_for_unit('multi-user.target')
           machine.succeed('systemctl is-active ntpd-rs.service')
-          machine.succeed('systemctl is-active ntpd-rs-metrics.service')
-          machine.succeed('curl http://localhost:9975/metrics | grep ntp_uptime_seconds')
+
+        client.fail('systemctl is-active ntpd-rs-metrics.service')
+        server.succeed('systemctl is-active ntpd-rs-metrics.service')
+
+        server.wait_for_open_port(9975)
+        client.succeed('curl http://server:9975/metrics | grep ntp_uptime_seconds')
+        server.fail('curl --fail --connect-timeout 2 http://client:9975/metrics | grep ntp_uptime_seconds')
 
         client.succeed("ntp-ctl status | grep server:123")
         server.succeed("ntp-ctl status | grep '\[::\]:123'")

--- a/nixos/tests/ntpd-rs.nix
+++ b/nixos/tests/ntpd-rs.nix
@@ -50,6 +50,9 @@ import ./make-test-python.nix (
           machine.succeed('systemctl is-active ntpd-rs.service')
           machine.succeed('systemctl is-active ntpd-rs-metrics.service')
           machine.succeed('curl http://localhost:9975/metrics | grep ntp_uptime_seconds')
+
+        client.succeed("ntp-ctl status | grep server:123")
+        server.succeed("ntp-ctl status | grep '\[::\]:123'")
       '';
   }
 )

--- a/nixos/tests/ntpd-rs.nix
+++ b/nixos/tests/ntpd-rs.nix
@@ -69,6 +69,9 @@ import ./make-test-python.nix (
 
         client.succeed("ntp-ctl status | grep server:123")
         server.succeed("ntp-ctl status | grep '\[::\]:123'")
+
+        client.succeed("grep '^mode = \"server\"' $(systemctl status ntpd-rs | grep -oE '/nix/store[^ ]*ntpd-rs.toml')")
+        server.succeed("grep '^mode = \"pool\"' $(systemctl status ntpd-rs | grep -oE '/nix/store[^ ]*ntpd-rs.toml')")
       '';
   }
 )


### PR DESCRIPTION
Automagically configures `ntpd-rs` to use NTP pools if 'pool' is in the timeserver FQDN.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
