### PR TITLE
optinix: fix build

### DIFF
--- a/pkgs/by-name/op/optinix/package.nix
+++ b/pkgs/by-name/op/optinix/package.nix
@@ -20,11 +20,6 @@ buildGoModule rec {
 
   nativeBuildInputs = [ installShellFiles ];
 
-  preBuild = ''
-    substituteInPlace vendor/modernc.org/libc/honnef.co/go/netdb/netdb.go \
-      --replace-fail '!os.IsNotExist(err)' '!os.IsNotExist(err) && !os.IsPermission(err)'
-  '';
-
   postInstall = ''
     installShellCompletion --cmd optinix \
       --bash <($out/bin/optinix completion bash) \


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

To fix failing build https://hydra.nixos.org/build/295018317/nixlog/10
ZHF: #403336

```
Running phase: buildPhase
substitute(): ERROR: file 'vendor/modernc.org/libc/honnef.co/go/netdb/netdb.go' does not exist
```

```console
> hydra-check optinix
Build Status for nixpkgs.optinix.x86_64-linux on jobset nixos/trunk-combined
https://hydra.nixos.org/job/nixos/trunk-combined/nixpkgs.optinix.x86_64-linux
✖ (Dependency failed)  optinix-0.1.4  2025-04-24  https://hydra.nixos.org/build/295018317
✖ (Dependency failed)  optinix-0.1.4  2025-03-23  https://hydra.nixos.org/build/293043100
✖ (Dependency failed)  optinix-0.1.4  2025-03-12  https://hydra.nixos.org/build/292339727
✖ (Dependency failed)  optinix-0.1.4  2025-02-23  https://hydra.nixos.org/build/290656583
✖ (Dependency failed)  optinix-0.1.4  2025-02-16  https://hydra.nixos.org/build/290036203
✔                      optinix-0.1.3  2025-02-07  https://hydra.nixos.org/build/287736653
```

The code appears to be available at https://github.com/NixOS/nixpkgs/pull/381645#issuecomment-2656211797. I'm not sure why it's failing after merging to master.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [x] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

cc: @brianmcgillion @hmajid2301

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
