### PR TITLE
python312Packages.blosc2: 3.0.0 -> 3.3.2

### DIFF
--- a/pkgs/development/python-modules/blosc2/default.nix
+++ b/pkgs/development/python-modules/blosc2/default.nix
@@ -15,12 +15,13 @@
   c-blosc2,
 
   # dependencies
-  httpx,
   msgpack,
   ndindex,
   numexpr,
   numpy,
+  platformdirs,
   py-cpuinfo,
+  requests,
 
   # tests
   psutil,
@@ -31,17 +32,15 @@
 
 buildPythonPackage rec {
   pname = "blosc2";
-  version = "3.0.0";
+  version = "3.3.2";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "Blosc";
     repo = "python-blosc2";
     tag = "v${version}";
-    hash = "sha256-em03vwTPURkyZfGdlgpoy8QUzbib9SlcR73vYznlsYA=";
+    hash = "sha256-0DSHXUuIqFP/k0oIibgMKxDsXyOSvGZllql9MfrkisM=";
   };
-
-  pythonRelaxDeps = [ "numpy" ];
 
   nativeBuildInputs = [
     cmake
@@ -54,32 +53,26 @@ buildPythonPackage rec {
 
   build-system = [
     cython
+    numpy
     scikit-build-core
   ];
 
   buildInputs = [ c-blosc2 ];
 
   dependencies = [
-    httpx
     msgpack
     ndindex
     numexpr
     numpy
+    platformdirs
     py-cpuinfo
+    requests
   ];
 
   nativeCheckInputs = [
     psutil
     pytestCheckHook
   ] ++ lib.optionals runTorchTests [ torch ];
-
-  disabledTests = [
-    # RuntimeError: Error while getting the slice
-    "test_lazyexpr"
-    "test_eval_item"
-    # RuntimeError: Error while creating the NDArray
-    "test_lossy"
-  ];
 
   passthru.c-blosc2 = c-blosc2;
 


### PR DESCRIPTION
We held back on bumping this for a while because of its new dependency on numpy 2.0, but that's not a problem anymore.

Also able to remove some of the hacks.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux (+ `pkgsCross.aarch64-multiplatform`)
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
