### PR TITLE
_7-segment-font: init at 3.0-unstable-2025-06-03

### DIFF
--- a/pkgs/by-name/_7/_7-segment-font/package.nix
+++ b/pkgs/by-name/_7/_7-segment-font/package.nix
@@ -1,0 +1,38 @@
+{
+  stdenvNoCC,
+  fetchurl,
+  lib,
+}:
+stdenvNoCC.mkDerivation {
+  pname = "7-segment-font";
+  version = "3.0-unstable-2025-06-03";
+
+  src = fetchurl {
+    url = "https://torinak.com/font/7segment.ttf";
+    hash = "sha256-zIjaEGDLR9ad192GH9pIU6/A3ZGAuR0oF3ZB3Ew3Xbs=";
+  };
+
+  dontUnpack = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm444 "$src" "$out/share/fonts/truetype/7segment.ttf"
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Font that imitates classic seven-segment LCD and LED displays";
+    longDescription = ''
+      A font that imitates classic seven-segment LCD and LED displays.
+      Beside digits, it contains Latin letters and some symbols constructed from segments,
+      with separate dot and colon as used in calculators and digital clocks.
+    '';
+    homepage = "https://torinak.com/font/7-segment";
+    downloadPage = "https://torinak.com/font/7-segment";
+    license = lib.licenses.ofl;
+    maintainers = with lib.maintainers; [ elfenermarcell ];
+    platforms = lib.platforms.all;
+  };
+}


### PR DESCRIPTION
Font that imitates classic seven-segment LCD and LED displays. (I use it in KDE Plasma for the clock on my panel.)

It is just hosted on some website with no version information (but it does at least say it is OFL-licensed), so this package uses the latest archive.org snapshot to download from (which, as I am writing this is the same file as on the website).
## Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
