### PR TITLE
gst_all_1.gst-plugins-bad: fix eval for riscv64

### DIFF
--- a/pkgs/development/libraries/gstreamer/bad/default.nix
+++ b/pkgs/development/libraries/gstreamer/bad/default.nix
@@ -20,6 +20,7 @@
   opencvSupport ? false,
   opencv4,
   faad2,
+  lcevcdecSupport ? lib.meta.availableOn stdenv.hostPlatform lcevcdec,
   lcevcdec,
   ldacbt,
   liblc3,
@@ -174,7 +175,6 @@ stdenv.mkDerivation (finalAttrs: {
       curl.dev
       fdk_aac
       gsm
-      lcevcdec
       libaom
       libdc1394
       libde265
@@ -265,6 +265,9 @@ stdenv.mkDerivation (finalAttrs: {
     ++ lib.optionals guiSupport [
       gtk3
     ]
+    ++ lib.optionals lcevcdecSupport [
+      lcevcdec
+    ]
     ++ lib.optionals stdenv.hostPlatform.isDarwin [
       apple-sdk_gstreamer
     ];
@@ -321,6 +324,7 @@ stdenv.mkDerivation (finalAttrs: {
       (lib.mesonEnable "openh264" openh264Support)
       (lib.mesonEnable "doc" enableDocumentation)
       (lib.mesonEnable "directfb" false)
+      (lib.mesonEnable "lcevcdecoder" lcevcdecSupport)
     ]
     ++ lib.optionals (!stdenv.hostPlatform.isLinux) [
       "-Ddoc=disabled" # needs gstcuda to be enabled which is Linux-only


### PR DESCRIPTION
lcevcdec doesn't support riscv64

Tested by building:
- [x] pkgs.gst_all_1.gst-plugins-bad
- [x] pkgsCross.riscv64.gst_all_1.gst-plugins-bad

The cross build depends on https://github.com/NixOS/nixpkgs/pull/403830

Related: https://github.com/NixOS/nixpkgs/pull/402541

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
