### PR TITLE
python313Packages.asyncpraw: init at 7.8.1

### DIFF
--- a/pkgs/development/python-modules/asyncpraw/default.nix
+++ b/pkgs/development/python-modules/asyncpraw/default.nix
@@ -1,0 +1,77 @@
+{
+  lib,
+  aiofiles,
+  aiohttp,
+  aiosqlite,
+  asyncprawcore,
+  buildPythonPackage,
+  fetchFromGitHub,
+  flit-core,
+  mock,
+  pytestCheckHook,
+  pytest-asyncio,
+  pytest-vcr,
+  pythonOlder,
+  requests-toolbelt,
+  update-checker,
+  vcrpy,
+}:
+
+buildPythonPackage rec {
+  pname = "asyncpraw";
+  version = "7.8.1";
+  pyproject = true;
+
+  disabled = pythonOlder "3.8";
+
+  src = fetchFromGitHub {
+    owner = "praw-dev";
+    repo = "asyncpraw";
+    tag = "v${version}";
+    hash = "sha256-glWAQoUjMFbjU3C4+MGuRGSGJS9mun15+6udMPCf9nU=";
+  };
+
+  pythonRelaxDeps = [ "aiosqlite" ];
+
+  # 'aiosqlite' is also checked when building the wheel
+  pypaBuildFlags = [ "--skip-dependency-check" ];
+
+  build-system = [ flit-core ];
+
+  dependencies = [
+    aiofiles
+    aiohttp
+    aiosqlite
+    asyncprawcore
+    mock
+    update-checker
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    pytest-asyncio
+    pytest-vcr
+    vcrpy
+    requests-toolbelt
+  ];
+
+  disabledTestPaths = [
+    # Ignored due to error with request cannot pickle 'BufferedReader' instances
+    # Upstream issue: https://github.com/kevin1024/vcrpy/issues/737
+    "tests/integration/models/reddit/test_emoji.py"
+    "tests/integration/models/reddit/test_submission.py"
+    "tests/integration/models/reddit/test_subreddit.py"
+    "tests/integration/models/reddit/test_widgets.py"
+    "tests/integration/models/reddit/test_wikipage.py"
+  ];
+
+  pythonImportsCheck = [ "asyncpraw" ];
+
+  meta = {
+    description = "Asynchronous Python Reddit API Wrapper";
+    homepage = "https://asyncpraw.readthedocs.io/";
+    changelog = "https://github.com/praw-dev/asyncpraw/blob/v${version}/CHANGES.rst";
+    license = lib.licenses.bsd2;
+    maintainers = [ lib.maintainers.amadejkastelic ];
+  };
+}

--- a/pkgs/development/python-modules/asyncprawcore/default.nix
+++ b/pkgs/development/python-modules/asyncprawcore/default.nix
@@ -1,0 +1,66 @@
+{
+  lib,
+  aiohttp,
+  buildPythonPackage,
+  fetchFromGitHub,
+  flit-core,
+  mock,
+  pytestCheckHook,
+  pytest-asyncio,
+  pytest-vcr,
+  pythonOlder,
+  requests,
+  requests-toolbelt,
+  testfixtures,
+  vcrpy,
+  yarl,
+}:
+
+buildPythonPackage rec {
+  pname = "asyncprawcore";
+  version = "2.4.0";
+  pyproject = true;
+
+  disabled = pythonOlder "3.8";
+
+  src = fetchFromGitHub {
+    owner = "praw-dev";
+    repo = "asyncprawcore";
+    tag = "v${version}";
+    hash = "sha256-FDQdtnNjsbiEp9BUYdQFMC/hkyJDhCh2WHhQWSQwrFY=";
+  };
+
+  nativeBuildInputs = [ flit-core ];
+
+  propagatedBuildInputs = [
+    requests
+    aiohttp
+    yarl
+  ];
+
+  nativeCheckInputs = [
+    testfixtures
+    mock
+    requests-toolbelt
+    pytestCheckHook
+    pytest-asyncio
+    pytest-vcr
+    vcrpy
+  ];
+
+  disabledTestPaths = [
+    # Ignored due to error with request cannot pickle 'BufferedReader' instances
+    # Upstream issue: https://github.com/kevin1024/vcrpy/issues/737
+    "tests/integration/test_sessions.py"
+  ];
+
+  pythonImportsCheck = [ "asyncprawcore" ];
+
+  meta = {
+    description = "Low-level asynchronous communication layer for Async PRAW";
+    homepage = "https://asyncpraw.readthedocs.io/";
+    changelog = "https://github.com/praw-dev/asyncprawcore/blob/v${version}/CHANGES.rst";
+    license = lib.licenses.bsd2;
+    maintainers = [ lib.maintainers.amadejkastelic ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1020,6 +1020,8 @@ self: super: with self; {
 
   asyncpg = callPackage ../development/python-modules/asyncpg { };
 
+  asyncprawcore = callPackage ../development/python-modules/asyncprawcore { };
+
   asyncserial = callPackage ../development/python-modules/asyncserial { };
 
   asyncsleepiq = callPackage ../development/python-modules/asyncsleepiq { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1020,6 +1020,8 @@ self: super: with self; {
 
   asyncpg = callPackage ../development/python-modules/asyncpg { };
 
+  asyncpraw = callPackage ../development/python-modules/asyncpraw { };
+
   asyncprawcore = callPackage ../development/python-modules/asyncprawcore { };
 
   asyncserial = callPackage ../development/python-modules/asyncserial { };


### PR DESCRIPTION
Add asyncpraw and it's dependency asyncprawcore.

Also manually tested with a simple script

<details><summary>Show</summary>

```python
import asyncio

import asyncpraw


async def main():
    client = asyncpraw.Reddit(
        client_id="/",
        client_secret="/",
        user_agent="/",
    )

    submission = await client.submission(url='https://old.reddit.com/r/NixOS/comments/1fjtv4j/my_spaghetti_looks_like_nixos/')

    print(f'''Title: {submission.title}
Author: {submission.author.name}
Score: {submission.score}
Comments: {submission.num_comments}
Spoiler: {submission.spoiler}
Created at: {submission.created_utc}
URL: {submission.url}
    ''')

    await client.close()


if __name__ == "__main__":
    asyncio.run(main())
```

```bash
nix-repl> let      
          venv = pkgs.mkShell {
          buildInputs = [(pkgs.python313.withPackages(ps: [ps.asyncpraw]))];
          };
          in
          venv
«derivation /nix/store/831s0bnig9kr7gm0c21q8gvmz8w96g2w-nix-shell.drv»

› nix-shell /nix/store/831s0bnig9kr7gm0c21q8gvmz8w96g2w-nix-shell.drv
[nix-shell:~/Documents/nixpkgs]$ python test.py 
Title: My Spaghetti looks like NixOS
Author: gnuzius
Score: 888
Comments: 46
Spoiler: False
Created at: 1726668893.0
URL: https://i.redd.it/u3hrv0nxskpd1.jpeg
```
</details>

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
