### PR TITLE
qt6.qttranslations: bootstrap directly

### DIFF
--- a/pkgs/development/libraries/qt-6/default.nix
+++ b/pkgs/development/libraries/qt-6/default.nix
@@ -159,7 +159,12 @@ let
       qtsvg = callPackage ./modules/qtsvg.nix { };
       qtscxml = callPackage ./modules/qtscxml.nix { };
       qttools = callPackage ./modules/qttools { };
-      qttranslations = callPackage ./modules/qttranslations.nix { };
+      qttranslations = callPackage ./modules/qttranslations.nix {
+        qttools = self.qttools.override {
+          qtbase = self.qtbase.override { qttranslations = null; };
+          qtdeclarative = null;
+        };
+      };
       qtvirtualkeyboard = callPackage ./modules/qtvirtualkeyboard.nix { };
       qtwayland = callPackage ./modules/qtwayland.nix { };
       qtwebchannel = callPackage ./modules/qtwebchannel.nix { };
@@ -215,18 +220,5 @@ let
     otherSplices = generateSplicesForMkScope "qt6";
     f = addPackages;
   };
-
-  bootstrapScope = baseScope.overrideScope (
-    final: prev: {
-      qtbase = prev.qtbase.override { qttranslations = null; };
-      qtdeclarative = null;
-    }
-  );
-
-  finalScope = baseScope.overrideScope (
-    final: prev: {
-      qttranslations = bootstrapScope.qttranslations;
-    }
-  );
 in
-finalScope
+baseScope


### PR DESCRIPTION
This fixes `pkgsCross.aarch64-multiplatform.pkgsBuildHost.qt6.qttranslations`, which is needed for cross-compiling packages like zenity.

Here how it looks like without this change:
```
% nix-build . -A pkgsCross.aarch64-multiplatform.pkgsBuildHost.qt6.qttranslations
<...................>
[275/282] Generating ../../nix/store/2qvpnrk3vhqz2scri09f6kq6hig83wng-qttranslations-6.9.0/translations/qtwebsockets_ja.qm
[276/282] Generating ../../nix/store/2qvpnrk3vhqz2scri09f6kq6hig83wng-qttranslations-6.9.0/translations/qtwebsockets_en.qm
[277/282] Generating ../../nix/store/2qvpnrk3vhqz2scri09f6kq6hig83wng-qttranslations-6.9.0/translations/qtwebsockets_de.qm
[278/282] Generating ../../nix/store/2qvpnrk3vhqz2scri09f6kq6hig83wng-qttranslations-6.9.0/translations/qtwebsockets_ko.qm
[279/282] Generating ../../nix/store/2qvpnrk3vhqz2scri09f6kq6hig83wng-qttranslations-6.9.0/translations/qtwebsockets_zh_CN.qm
[280/282] Generating ../../nix/store/2qvpnrk3vhqz2scri09f6kq6hig83wng-qttranslations-6.9.0/translations/qtwebsockets_uk.qm
[281/282] Generating ../../nix/store/2qvpnrk3vhqz2scri09f6kq6hig83wng-qttranslations-6.9.0/translations/qtwebsockets_pl.qm
[282/282] Generating ../../nix/store/2qvpnrk3vhqz2scri09f6kq6hig83wng-qttranslations-6.9.0/translations/qtwebsockets_ru.qm
Running phase: glibPreInstallPhase
Running phase: installPhase
install flags: -j16 install
[0/1] Install the project...
-- Install configuration: "Release"
-- Installing: /nix/store/2qvpnrk3vhqz2scri09f6kq6hig83wng-qttranslations-6.9.0/translations/assistant_ar.qm
CMake Error at src/translations/cmake_install.cmake:54 (file):
  file INSTALL cannot copy file
  "/build/qttranslations-everywhere-src-6.9.0/build//nix/store/2qvpnrk3vhqz2scri09f6kq6hig83wng-qttranslations-6.9.0/translations/assistant_ar.qm"
  to
  "/nix/store/2qvpnrk3vhqz2scri09f6kq6hig83wng-qttranslations-6.9.0/translations/assistant_ar.qm":
  Permission denied.
Call Stack (most recent call first):
  src/cmake_install.cmake:47 (include)
  cmake_install.cmake:47 (include)


FAILED: CMakeFiles/install.util
cd /build/qttranslations-everywhere-src-6.9.0/build && /nix/store/mp0vxkdnx5279fr2y6w1vhndzx92jh9k-cmake-3.31.6/bin/cmake -P cmake_install.cmake
ninja: build stopped: subcommand failed.
```

Tested by building
- [x] pkgsCross.aarch64-multiplatform.zenity (depends on https://github.com/NixOS/nixpkgs/pull/403830)

Related: https://github.com/NixOS/nixpkgs/commit/0597d865ef4f763f3fed54702b29ce328d28e2b4

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
