### PR TITLE
python3Packages.pytestCheckHook: fix Bash heredoc EOF outside subshell

### DIFF
--- a/pkgs/development/interpreters/python/hooks/pytest-check-hook.sh
+++ b/pkgs/development/interpreters/python/hooks/pytest-check-hook.sh
@@ -38,7 +38,7 @@ function pytestCheckPhase() {
         else
             # The `|| kill "$$"` trick propagates the errors from the process substitutiton subshell,
             # which is suggested by a StackOverflow answer: https://unix.stackexchange.com/a/217643
-            readarray -t -O"${#flagsArray[@]}" flagsArray < <(@pythonCheckInterpreter@ - "$path" <<EOF || kill "$$")
+            readarray -t -O"${#flagsArray[@]}" flagsArray < <(@pythonCheckInterpreter@ - "$path" <<EOF || kill "$$"
 import glob
 import sys
 path_glob=sys.argv[1]
@@ -50,6 +50,7 @@ if not len(path_expanded):
 for path in path_expanded:
     print(path)
 EOF
+            )
         fi
     done
 

--- a/pkgs/development/interpreters/python/hooks/pytest-check-hook.sh
+++ b/pkgs/development/interpreters/python/hooks/pytest-check-hook.sh
@@ -38,7 +38,8 @@ function pytestCheckPhase() {
         else
             # The `|| kill "$$"` trick propagates the errors from the process substitutiton subshell,
             # which is suggested by a StackOverflow answer: https://unix.stackexchange.com/a/217643
-            readarray -t -O"${#flagsArray[@]}" flagsArray < <(@pythonCheckInterpreter@ - "$path" <<EOF || kill "$$"
+            readarray -t -O"${#flagsArray[@]}" flagsArray < <(
+                @pythonCheckInterpreter@ - "$path" <<EOF || kill "$$"
 import glob
 import sys
 path_glob=sys.argv[1]


### PR DESCRIPTION
This PR fixes the unterminated here document of the `pytest-check-hook.sh` error mesage by moving the EOF of the here document between the parenthesis of the process substitution.

Context: https://github.com/NixOS/nixpkgs/pull/386513#pullrequestreview-2810559572

The error it fixes is passed silently due to [Bash's tolerance to errors inside prcess substitution subshell](https://unix.stackexchange.com/questions/128560/how-do-i-capture-the-exit-code-handle-errors-correctly-when-using-process-subs), but the error message is printed out to the build log.

Here's the partial build logs of `python3Packages.tests.basic` before and after this fix:

Before:

```
python3.12-test-pytestCheckHook-basic-objprint> Sourcing pytest-check-hook
python3.12-test-pytestCheckHook-basic-objprint> /nix/store/lbw329diypjdljmc229l9h6zd51drp2v-pytest-check-hook/nix-support/setup-hook: line 41: warning: command substitution: 1 unterminated here-document
python3.12-test-pytestCheckHook-basic-objprint> Using pytestCheckPhase
```

After:

```
python3.12-test-pytestCheckHook-basic-objprint> Sourcing pytest-check-hook
python3.12-test-pytestCheckHook-basic-objprint> Using pytestCheckPhase
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
