### PR TITLE
sgx-psw: fix build

### DIFF
--- a/pkgs/os-specific/linux/sgx/psw/default.nix
+++ b/pkgs/os-specific/linux/sgx/psw/default.nix
@@ -3,6 +3,7 @@
   lib,
   fetchurl,
   fetchFromGitHub,
+  fetchpatch,
   cmake,
   coreutils,
   curl,
@@ -90,6 +91,10 @@ stdenv.mkDerivation rec {
     # binary. Without changes, the `aesm_service` will be different after every
     # build because the embedded zip file contents have different modified times.
     ./cppmicroservices-no-mtime.patch
+
+    # Fix build with GCC 14.
+    # https://github.com/intel/linux-sgx/pull/1063
+    ./gcc14-fix.patch
   ];
 
   postPatch =

--- a/pkgs/os-specific/linux/sgx/psw/gcc14-fix.patch
+++ b/pkgs/os-specific/linux/sgx/psw/gcc14-fix.patch
@@ -1,0 +1,53 @@
+From 72186018e974398dfadc1b0825ac22e45920ddf3 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Daniel=20P=2E=20Berrang=C3=A9?= <berrange@redhat.com>
+Date: Mon, 24 Jun 2024 17:36:13 +0100
+Subject: [PATCH] enclave_common: add missing <algorithm> header for GCC 14
+ compat
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+When building with GCC 14, various c++ stdlib functions are undefined:
+
+sgx_enclave_common.cpp: In function ‘void* get_enclave_base_address_from_address(void*)’:
+sgx_enclave_common.cpp:164:23: error: ‘upper_bound’ is not a member of ‘std’; did you mean ‘lower_bound’?
+  164 |     auto upper = std::upper_bound(s_enclave_base_address.begin(), s_enclave_base_address.end(), (uint64_t)target_address);
+      |                       ^~~~~~~~~~~
+      |                       lower_bound
+sgx_enclave_common.cpp: In function ‘void* enclave_create_ex(void*, size_t, size_t, uint32_t, const void*, size_t, uint32_t, const void**, uint32_t*)’:
+sgx_enclave_common.cpp:790:14: error: ‘sort’ is not a member of ‘std’; did you mean ‘qsort’?
+  790 |         std::sort(s_enclave_base_address.begin(), s_enclave_base_address.end());
+      |              ^~~~
+      |              qsort
+sgx_enclave_common.cpp: In function ‘bool enclave_delete(void*, uint32_t*)’:
+sgx_enclave_common.cpp:1255:43: error: ‘remove’ is not a member of ‘std’; did you mean ‘move’?
+ 1255 |         s_enclave_base_address.erase(std::remove(s_enclave_base_address.begin(), s_enclave_base_address.end(), (uint64_t)base_address),
+      |                                           ^~~~~~
+      |                                           move
+
+These stdlib functions are provided by bits/stl_algo.h, and prior
+to GCC 14, the <functional> header would pull in stl_algo.h.
+
+With GCC 14, the <functional> header was changed to only pull in
+stl_algobase.h.
+
+We must now use <algorithm> to get these definitions, which should
+work on all versions of GCC.
+
+Signed-off-by: Daniel P. Berrangé <berrange@redhat.com>
+---
+ psw/enclave_common/sgx_enclave_common.cpp | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/psw/enclave_common/sgx_enclave_common.cpp b/psw/enclave_common/sgx_enclave_common.cpp
+index 9867ecc86..46fcf8733 100644
+--- a/psw/enclave_common/sgx_enclave_common.cpp
++++ b/psw/enclave_common/sgx_enclave_common.cpp
+@@ -35,6 +35,7 @@
+ #include <dlfcn.h>
+ #include <map>
+ #include <functional>
++#include <algorithm>
+ #include "sgx_enclave_common.h"
+ #include "sgx_urts.h"
+ #include "arch.h"


### PR DESCRIPTION
- GCC 14 requires including `<algorithm>` for some stdlib definitions used by `sgx-psw`.
- Upstream patch: https://github.com/intel/linux-sgx/pull/1063

ZHF: #403336

GCC 14 tracking: #388196, #356812

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
