### PR TITLE
zoom-us: restore darwin support

### DIFF
--- a/pkgs/by-name/zo/zoom-us/package.nix
+++ b/pkgs/by-name/zo/zoom-us/package.nix
@@ -2,6 +2,9 @@
   stdenv,
   lib,
   fetchurl,
+  makeWrapper,
+  xar,
+  cpio,
   pulseaudioSupport ? true,
   xdgDesktopPortalSupport ? true,
   callPackage,
@@ -9,37 +12,88 @@
 }:
 
 let
-  unpacked = stdenv.mkDerivation (finalAttrs: {
-    pname = "zoom";
-    version = "6.4.6.1370";
+  inherit (stdenv.hostPlatform) system;
+  throwSystem = throw "Unsupported system: ${system}";
 
-    src = fetchurl {
-      url = "https://zoom.us/client/${finalAttrs.version}/zoom_x86_64.pkg.tar.xz";
+  # Zoom versions are released at different times for each platform
+  # and often with different versions. We write them on three lines
+  # like this (rather than using {}) so that the updater script can
+  # find where to edit them.
+  versions.aarch64-darwin = "6.4.6.53970";
+  versions.x86_64-darwin = "6.4.6.53970";
+  versions.x86_64-linux = "6.4.6.1370";
+
+  srcs = {
+    aarch64-darwin = fetchurl {
+      url = "https://zoom.us/client/${versions.aarch64-darwin}/zoomusInstallerFull.pkg?archType=arm64";
+      name = "zoomusInstallerFull.pkg";
+      hash = "sha256-yNsiFZNte4432d8DUyDhPUOVbLul7gUdvr+3qK/Y+tk=";
+    };
+    x86_64-darwin = fetchurl {
+      url = "https://zoom.us/client/${versions.x86_64-darwin}/zoomusInstallerFull.pkg";
+      hash = "sha256-Ut93qQFFN0d58wXD5r8u0B17HbihFg3FgY3a1L8nsIA=";
+    };
+    x86_64-linux = fetchurl {
+      url = "https://zoom.us/client/${versions.x86_64-linux}/zoom_x86_64.pkg.tar.xz";
       hash = "sha256-Y+8garSqDcKLCVv1cTiqGEfrGKpK3UoXIq8X4E8CF+8=";
     };
+  };
 
-    dontUnpack = true;
+  unpacked = stdenv.mkDerivation {
+    pname = "zoom";
+    version = versions.${system} or throwSystem;
 
-    # Note: In order to uncover missing libraries,
-    # add "pkgs" to this file's arguments
+    src = srcs.${system} or throwSystem;
+
+    dontUnpack = stdenv.hostPlatform.isLinux;
+    unpackPhase = lib.optionalString stdenv.hostPlatform.isDarwin ''
+      xar -xf $src
+      zcat < zoomus.pkg/Payload | cpio -i
+    '';
+
+    # Note: In order to uncover missing libraries
+    # on x86_64-linux, add "pkgs" to this file's arguments
     # (at the top of this file), then add these attributes here:
     # > buildInputs = linuxGetDependencies pkgs;
     # > dontAutoPatchelf = true;
     # > dontWrapQtApps = true;
-    # > nativeBuildInputs = [ pkgs.autoPatchelfHook ];
     # > preFixup = ''
     # >   addAutoPatchelfSearchPath $out/opt/zoom
     # >   autoPatchelf $out/opt/zoom/{cef,Qt,*.so*,aomhost,zoom,zopen,ZoomLauncher,ZoomWebviewHost}
     # > '';
+    # ...and finally "pkgs.autoPatchelfHook"
+    # to `nativeBuildInputs` right below.
     # Then build `zoom-us.unpacked`:
     # `autoPatchelfHook` will report missing library files.
+    nativeBuildInputs = lib.optionals stdenv.hostPlatform.isDarwin [
+      makeWrapper
+      xar
+      cpio
+    ];
 
     installPhase = ''
       runHook preInstall
-      mkdir $out
-      tar -C $out -xf $src
-      mv $out/usr/* $out/
+      ${
+        rec {
+          aarch64-darwin = ''
+            mkdir -p $out/Applications
+            cp -R zoom.us.app $out/Applications/
+          '';
+          # darwin steps same on both architectures
+          x86_64-darwin = aarch64-darwin;
+          x86_64-linux = ''
+            mkdir $out
+            tar -C $out -xf $src
+            mv $out/usr/* $out/
+          '';
+        }
+        .${system} or throwSystem
+      }
       runHook postInstall
+    '';
+
+    postFixup = lib.optionalString stdenv.hostPlatform.isDarwin ''
+      makeWrapper $out/Applications/zoom.us.app/Contents/MacOS/zoom.us $out/bin/zoom
     '';
 
     dontPatchELF = true;
@@ -53,13 +107,18 @@ let
       description = "zoom.us video conferencing application";
       sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
       license = lib.licenses.unfree;
-      platforms = [ "x86_64-linux" ];
+      platforms = builtins.attrNames srcs;
       maintainers = with lib.maintainers; [
         danbst
         tadfisher
       ];
+      mainProgram = "zoom";
     };
-  });
+  };
+  packages.aarch64-darwin = unpacked;
+  packages.x86_64-darwin = unpacked;
+
+  # linux definitions
 
   linuxGetDependencies =
     pkgs:
@@ -132,35 +191,35 @@ let
       pkgs.xdg-desktop-portal-xapp
     ];
 
+  # We add the `unpacked` zoom archive to the FHS env
+  # and also bind-mount its `/opt` directory.
+  # This should assist Zoom in finding all its
+  # files in the places where it expects them to be.
+  packages.x86_64-linux = buildFHSEnv {
+    pname = "zoom"; # Will also be the program's name!
+    version = versions.${system} or throwSystem;
+
+    targetPkgs = pkgs: (linuxGetDependencies pkgs) ++ [ unpacked ];
+    extraPreBwrapCmds = "unset QT_PLUGIN_PATH";
+    extraBwrapArgs = [ "--ro-bind ${unpacked}/opt /opt" ];
+    runScript = "/opt/zoom/ZoomLauncher";
+
+    extraInstallCommands = ''
+      cp -Rt $out/ ${unpacked}/share
+      substituteInPlace \
+          $out/share/applications/Zoom.desktop \
+          --replace-fail Exec={/usr/bin/,}zoom
+
+      # Backwards compatibility: we used to call it zoom-us
+      ln -s $out/bin/{zoom,zoom-us}
+    '';
+
+    passthru = unpacked.passthru // {
+      inherit unpacked;
+    };
+    inherit (unpacked) meta;
+  };
+
 in
 
-# We add the `unpacked` zoom archive to the FHS env
-# and also bind-mount its `/opt` directory.
-# This should assist Zoom in finding all its
-# files in the places where it expects them to be.
-buildFHSEnv rec {
-  pname = "zoom"; # Will also be the program's name!
-  inherit (unpacked) version;
-
-  targetPkgs = pkgs: (linuxGetDependencies pkgs) ++ [ unpacked ];
-  extraPreBwrapCmds = "unset QT_PLUGIN_PATH";
-  extraBwrapArgs = [ "--ro-bind ${unpacked}/opt /opt" ];
-  runScript = "/opt/zoom/ZoomLauncher";
-
-  extraInstallCommands = ''
-    cp -Rt $out/ ${unpacked}/share
-    substituteInPlace \
-        $out/share/applications/Zoom.desktop \
-        --replace-fail Exec={/usr/bin/,}zoom
-
-    # Backwards compatibility: we used to call it zoom-us
-    ln -s $out/bin/{zoom,zoom-us}
-  '';
-
-  passthru = unpacked.passthru // {
-    inherit unpacked;
-  };
-  meta = unpacked.meta // {
-    mainProgram = pname;
-  };
-}
+packages.${system} or throwSystem

--- a/pkgs/by-name/zo/zoom-us/update.sh
+++ b/pkgs/by-name/zo/zoom-us/update.sh
@@ -29,6 +29,6 @@ echo >&2 "=== Updating package.nix ..."
 # update-source-version expects to be at the root of nixpkgs
 (cd "$nixpkgs" && update-source-version zoom-us "$version_aarch64_darwin" $hash_aarch64_darwin --system=aarch64-darwin --version-key=versions.aarch64-darwin)
 (cd "$nixpkgs" && update-source-version zoom-us "$version_x86_64_darwin" $hash_x86_64_darwin --system=x86_64-darwin --version-key=versions.x86_64-darwin)
-(cd "$nixpkgs" && update-source-version zoom-us "$version_x86_64_linux" $hash_x86_64_linux --system=x86_64-linux --version-key=versions.x86_64-linux)
+(cd "$nixpkgs" && update-source-version zoom-us "$version_x86_64_linux" $hash_x86_64_linux --system=x86_64-linux --version-key=versions.x86_64-linux --source-key=unpacked.src)
 
 echo >&2 "=== Done!"

--- a/pkgs/by-name/zo/zoom-us/update.sh
+++ b/pkgs/by-name/zo/zoom-us/update.sh
@@ -3,4 +3,32 @@
 
 set -eu -o pipefail
 
-update-source-version zoom-us $(curl -Ls 'https://zoom.us/rest/download?os=linux' | jq -r .result.downloadVO.zoom.version) --source-key=unpacked.src
+scriptDir=$(cd "${BASH_SOURCE[0]%/*}" && pwd)
+nixpkgs=$(realpath "$scriptDir"/../../../..)
+
+echo >&2 "=== Obtaining version data from https://zoom.us/rest/download ..."
+linux_data=$(curl -Ls 'https://zoom.us/rest/download?os=linux' | jq .result.downloadVO)
+mac_data=$(curl -Ls 'https://zoom.us/rest/download?os=mac' | jq .result.downloadVO)
+
+version_aarch64_darwin=$(jq -r .zoomArm64.version <<<"$mac_data")
+version_x86_64_darwin=$(jq -r .zoom.version <<<"$mac_data")
+version_x86_64_linux=$(jq -r .zoom.version <<<"$linux_data")
+
+echo >&2 "=== Downloading packages and computing hashes..."
+# We precalculate the hashes before calling update-source-version
+# because it attempts to calculate each architecture's package's hash
+# by running `nix-build --system <architecture> -A zoom-us.src` which
+# causes cross compiling headaches; using nix-prefetch-url with
+# hard-coded URLs is simpler.  Keep these URLs in sync with the ones
+# in package.nix where `srcs` is defined.
+hash_aarch64_darwin=$(nix hash to-sri --type sha256 $(nix-prefetch-url --type sha256 "https://zoom.us/client/${version_aarch64_darwin}/zoomusInstallerFull.pkg?archType=arm64"))
+hash_x86_64_darwin=$(nix hash to-sri --type sha256 $(nix-prefetch-url --type sha256 "https://zoom.us/client/${version_x86_64_darwin}/zoomusInstallerFull.pkg"))
+hash_x86_64_linux=$(nix hash to-sri --type sha256 $(nix-prefetch-url --type sha256 "https://zoom.us/client/${version_x86_64_linux}/zoom_x86_64.pkg.tar.xz"))
+
+echo >&2 "=== Updating package.nix ..."
+# update-source-version expects to be at the root of nixpkgs
+(cd "$nixpkgs" && update-source-version zoom-us "$version_aarch64_darwin" $hash_aarch64_darwin --system=aarch64-darwin --version-key=versions.aarch64-darwin)
+(cd "$nixpkgs" && update-source-version zoom-us "$version_x86_64_darwin" $hash_x86_64_darwin --system=x86_64-darwin --version-key=versions.x86_64-darwin)
+(cd "$nixpkgs" && update-source-version zoom-us "$version_x86_64_linux" $hash_x86_64_linux --system=x86_64-linux --version-key=versions.x86_64-linux)
+
+echo >&2 "=== Done!"


### PR DESCRIPTION
It was dropped in #397036 ; but it worked fine, so this PR reverts the patch.

Signed-off-by: Ihar Hrachyshka <ihar.hrachyshka@gmail.com>


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
