### PR TITLE
python313Packages.devtools: fix build

### DIFF
--- a/pkgs/development/python-modules/devtools/default.nix
+++ b/pkgs/development/python-modules/devtools/default.nix
@@ -25,6 +25,11 @@ buildPythonPackage rec {
     hash = "sha256-1HFbNswdKa/9cQX0Gf6lLW1V5Kt/N4X6/5kQDdzp1Wo=";
   };
 
+  patches = [
+    # https://github.com/samuelcolvin/python-devtools/pull/166
+    ./fix-test-ast-expr.patch
+  ];
+
   postPatch = ''
     substituteInPlace pyproject.toml \
       --replace-fail 'asttokens>=2.0.0,<3.0.0' 'asttokens>=2.0.0' \

--- a/pkgs/development/python-modules/devtools/default.nix
+++ b/pkgs/development/python-modules/devtools/default.nix
@@ -8,15 +8,12 @@
   pygments,
   pytest-mock,
   pytestCheckHook,
-  pythonOlder,
 }:
 
 buildPythonPackage rec {
   pname = "devtools";
   version = "0.12.2";
-  format = "pyproject";
-
-  disabled = pythonOlder "3.7";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "samuelcolvin";
@@ -35,9 +32,9 @@ buildPythonPackage rec {
       --replace-fail 'asttokens>=2.0.0,<3.0.0' 'asttokens>=2.0.0' \
   '';
 
-  nativeBuildInputs = [ hatchling ];
+  build-system = [ hatchling ];
 
-  propagatedBuildInputs = [
+  dependencies = [
     asttokens
     executing
     pygments
@@ -68,7 +65,7 @@ buildPythonPackage rec {
   meta = with lib; {
     description = "Python's missing debug print command and other development tools";
     homepage = "https://python-devtools.helpmanual.io/";
-    changelog = "https://github.com/samuelcolvin/python-devtools/releases/tag/v${version}";
+    changelog = "https://github.com/samuelcolvin/python-devtools/releases/tag/${src.tag}";
     license = licenses.mit;
     maintainers = with maintainers; [ jdahm ];
   };

--- a/pkgs/development/python-modules/devtools/fix-test-ast-expr.patch
+++ b/pkgs/development/python-modules/devtools/fix-test-ast-expr.patch
@@ -1,0 +1,44 @@
+From 7a95b33f8fe9b2d426c2680291ccbae2e973faa0 Mon Sep 17 00:00:00 2001
+From: Tom Hunze <dev@thunze.de>
+Date: Sun, 4 May 2025 00:49:57 +0200
+Subject: [PATCH] Fix `test_ast_expr` for Python 3.13
+
+---
+ tests/test_prettier.py | 17 +++++++++++++++++
+ 1 file changed, 17 insertions(+)
+
+diff --git a/tests/test_prettier.py b/tests/test_prettier.py
+index 298dc58..0f24756 100644
+--- a/tests/test_prettier.py
++++ b/tests/test_prettier.py
+@@ -486,6 +486,7 @@ class User(SQLAlchemyBase):
+ 
+ 
+ @pytest.mark.skipif(sys.version_info < (3, 9), reason='no indent on older versions')
++@pytest.mark.skipif(sys.version_info >= (3, 13), reason='show_empty=False on newer versions')
+ def test_ast_expr():
+     assert pformat(ast.parse('print(1, 2, round(3))', mode='eval')) == (
+         "Expression("
+@@ -503,6 +504,22 @@ def test_ast_expr():
+     )
+ 
+ 
++@pytest.mark.skipif(sys.version_info < (3, 13), reason='no show_empty on older versions')
++def test_ast_expr_show_empty():
++    assert pformat(ast.parse('print(1, 2, round(3))', mode='eval')) == (
++        "Expression("
++        "\n    body=Call("
++        "\n        func=Name(id='print', ctx=Load()),"
++        "\n        args=["
++        "\n            Constant(value=1),"
++        "\n            Constant(value=2),"
++        "\n            Call("
++        "\n                func=Name(id='round', ctx=Load()),"
++        "\n                args=["
++        "\n                    Constant(value=3)])]))"
++    )
++
++
+ @pytest.mark.skipif(sys.version_info < (3, 9), reason='no indent on older versions')
+ def test_ast_module():
+     assert pformat(ast.parse('print(1, 2, round(3))')).startswith('Module(\n    body=[')


### PR DESCRIPTION
Hydra: https://hydra.nixos.org/build/294880588/nixlog/2

- A test currently fails on Python 3.13 due to a change in the default behavior of `ast.dump`.
- Submitted a patch upstream.
- Added the patch to the Nix package for now to fix the build.

Upstream patch: https://github.com/samuelcolvin/python-devtools/pull/166

ZHF: #403336

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
