### PR TITLE
nixos/livekit, nixos/lk-jwt-service: Fix docs issues

### DIFF
--- a/nixos/modules/services/matrix/lk-jwt-service.nix
+++ b/nixos/modules/services/matrix/lk-jwt-service.nix
@@ -10,7 +10,7 @@ in
 {
   meta.maintainers = [ lib.maintainers.quadradical ];
   options.services.lk-jwt-service = {
-    enable = lib.mkEnableOption "Enable lk-jwt-service";
+    enable = lib.mkEnableOption "lk-jwt-service";
     package = lib.mkPackageOption pkgs "lk-jwt-service" { };
 
     livekitUrl = lib.mkOption {
@@ -28,9 +28,7 @@ in
         Path to a file containing the credential mapping (`<keyname>: <secret>`) to access LiveKit.
 
         Example:
-        ```
-          lk-jwt-service: f6lQGaHtM5HfgZjIcec3cOCRfiDqIine4CpZZnqdT5cE
-        ```
+        `lk-jwt-service: f6lQGaHtM5HfgZjIcec3cOCRfiDqIine4CpZZnqdT5cE`
 
         For more information, see <https://github.com/element-hq/lk-jwt-service#configuration>.
       '';

--- a/nixos/modules/services/networking/livekit.nix
+++ b/nixos/modules/services/networking/livekit.nix
@@ -12,7 +12,7 @@ in
 {
   meta.maintainers = with lib.maintainers; [ quadradical ];
   options.services.livekit = {
-    enable = lib.mkEnableOption "Enable the livekit server";
+    enable = lib.mkEnableOption "the livekit server";
     package = lib.mkPackageOption pkgs "livekit" { };
 
     keyFile = lib.mkOption {
@@ -20,10 +20,9 @@ in
       description = ''
         LiveKit key file holding one or multiple application secrets. Use `livekit-server generate-keys` to generate a random key name and secret.
 
-        The file should have the format `<keyname>: <secret>`. Example:
-        ```
-          lk-jwt-service: f6lQGaHtM5HfgZjIcec3cOCRfiDqIine4CpZZnqdT5cE
-        ```
+        The file should have the format `<keyname>: <secret>`.
+        Example:
+        `lk-jwt-service: f6lQGaHtM5HfgZjIcec3cOCRfiDqIine4CpZZnqdT5cE`
 
         Individual key/secret pairs need to be passed to clients to connect to this instance.
       '';


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
Fixed enable text and formatting for the nixos search for the newly merged livekit modules. This is really simple, can I just get a merge @mweinelt!
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->
---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
