### PR TITLE
libcdio: revert "use fetchFromGitHub", fixes cross

### DIFF
--- a/pkgs/by-name/li/libcdio/package.nix
+++ b/pkgs/by-name/li/libcdio/package.nix
@@ -1,11 +1,9 @@
 {
   lib,
   stdenv,
-  fetchFromGitHub,
   nix-update-script,
-  autoreconfHook,
   testers,
-  texinfo,
+  fetchurl,
   libcddb,
   pkg-config,
   ncurses,
@@ -17,11 +15,9 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "libcdio";
   version = "2.2.0";
 
-  src = fetchFromGitHub {
-    owner = "libcdio";
-    repo = "libcdio";
-    tag = finalAttrs.version;
-    hash = "sha256-izjZk2kz9PkLm9+INUdl1e7jMz3nUsQKdplKI9Io+CM=";
+  src = fetchurl {
+    url = "https://github.com/libcdio/libcdio/releases/download/${finalAttrs.version}/${finalAttrs.pname}-${finalAttrs.version}.tar.bz2";
+    hash = "sha256-b4+99NGJz2Pyp6FUnFFs1yDHsiLHqq28kkom50WkhTk=";
   };
 
   env = lib.optionalAttrs stdenv.is32bit {
@@ -30,23 +26,11 @@ stdenv.mkDerivation (finalAttrs: {
 
   postPatch = ''
     patchShebangs .
-    echo "
-    @set UPDATED 1 January 1970
-    @set UPDATED-MONTH January 1970
-    @set EDITION ${finalAttrs.version}
-    @set VERSION ${finalAttrs.version}
-    " > doc/version.texi
   '';
-
-  configureFlags = [
-    (lib.enableFeature true "maintainer-mode")
-  ];
 
   nativeBuildInputs = [
     pkg-config
     help2man
-    autoreconfHook
-    texinfo
   ];
 
   buildInputs = [


### PR DESCRIPTION
Fixes cross-compilation

Tested by building:
- [x] pkgs.libcdio
- [x] pkgsCross.aarch64-multiplatform.libcdio
- [x] pkgsCross.riscv64.libcdio

This reverts commit 937c706c27a925ca60c93896f36a10b488b84dcd.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
