### PR TITLE
unclutter: fix build

### DIFF
--- a/pkgs/by-name/un/unclutter/package.nix
+++ b/pkgs/by-name/un/unclutter/package.nix
@@ -15,7 +15,10 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ libX11 ];
 
-  buildFlags = [ "CC=${stdenv.cc.targetPrefix}cc" ];
+  buildFlags = [
+    "CC=${stdenv.cc.targetPrefix}cc"
+    "CFLAGS=-std=c89"
+  ];
 
   installPhase = ''
     mkdir -pv "$out/bin"

--- a/pkgs/by-name/un/unclutter/package.nix
+++ b/pkgs/by-name/un/unclutter/package.nix
@@ -20,11 +20,19 @@ stdenv.mkDerivation rec {
     "CFLAGS=-std=c89"
   ];
 
-  installPhase = ''
-    mkdir -pv "$out/bin"
-    mkdir -pv "$out/share/man/man1"
-    make DESTDIR="$out" BINDIR="$out/bin" PREFIX="" install
-    make DESTDIR="$out" MANPATH="$out/share/man" PREFIX="" install.man
+  installFlags = [
+    "DESTDIR=${placeholder "out"}"
+    "BINDIR=${placeholder "out"}/bin"
+    "MANPATH=${placeholder "out"}/share/man"
+  ];
+
+  installTargets = [
+    "install"
+    "install.man"
+  ];
+
+  preInstall = ''
+    mkdir -pv "$out"/{bin,share/man/man1}
   '';
 
   meta = with lib; {


### PR DESCRIPTION
Apparently C89 not longer builds by default.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
