### PR TITLE
nixos/firewall: add optional filter for outgoing traffic

### DIFF
--- a/doc/release-notes/rl-2511.section.md
+++ b/doc/release-notes/rl-2511.section.md
@@ -384,6 +384,9 @@
 
 - `dragonflydb` has been updated from version 0.1.0 to version 1.34.2.
 
+- The nftables-based firewall has learned to filter outgoing traffic with the
+  new `networking.firewall.filterOutgoing` options.
+
 ## Nixpkgs Library {#sec-nixpkgs-release-25.11-lib}
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->

--- a/nixos/modules/services/networking/firewall-nftables.nix
+++ b/nixos/modules/services/networking/firewall-nftables.nix
@@ -8,7 +8,7 @@ let
 
   cfg = config.networking.firewall;
 
-  ifaceSet = lib.concatStringsSep ", " (map (x: ''"${x}"'') cfg.trustedInterfaces);
+  incomingTrustedInterfaces = lib.concatStringsSep ", " (map (x: ''"${x}"'') cfg.trustedInterfaces);
 
   portsToNftSet =
     ports: portRanges:
@@ -114,8 +114,8 @@ in
         type filter hook input priority filter; policy drop;
 
         ${lib.optionalString (
-          ifaceSet != ""
-        ) ''iifname { ${ifaceSet} } accept comment "trusted interfaces"''}
+          incomingTrustedInterfaces != ""
+        ) ''iifname { ${incomingTrustedInterfaces} } accept comment "trusted interfaces"''}
 
         # Some ICMPv6 types like NDP is untracked
         ct state vmap {

--- a/nixos/modules/services/networking/firewall.nix
+++ b/nixos/modules/services/networking/firewall.nix
@@ -10,7 +10,7 @@ let
 
   canonicalizePortList = ports: lib.unique (builtins.sort builtins.lessThan ports);
 
-  commonOptions = {
+  commonOptions = direction: {
     allowedTCPPorts = lib.mkOption {
       type = lib.types.listOf lib.types.port;
       default = [ ];
@@ -20,7 +20,7 @@ let
         80
       ];
       description = ''
-        List of TCP ports on which incoming connections are
+        List of TCP ports on which ${direction} connections are
         accepted.
       '';
     };
@@ -35,7 +35,7 @@ let
         }
       ];
       description = ''
-        A range of TCP ports on which incoming connections are
+        A range of TCP ports on which ${direction} connections are
         accepted.
       '';
     };
@@ -46,7 +46,8 @@ let
       apply = canonicalizePortList;
       example = [ 53 ];
       description = ''
-        List of open UDP ports.
+        List of UDP ports on which ${direction} packets are
+        accepted.
       '';
     };
 
@@ -60,11 +61,13 @@ let
         }
       ];
       description = ''
-        Range of open UDP ports.
+        A range of UDP ports on which ${direction} UDP packets are
+        accepted.
       '';
     };
   };
 
+  commonOptionsIncoming = commonOptions "incoming";
 in
 
 {
@@ -296,7 +299,7 @@ in
 
       interfaces = lib.mkOption {
         default = { };
-        type = with lib.types; attrsOf (submodule [ { options = commonOptions; } ]);
+        type = with lib.types; attrsOf (submodule [ { options = commonOptionsIncoming; } ]);
         description = ''
           Interface-specific open ports.
         '';
@@ -306,16 +309,16 @@ in
         internal = true;
         visible = false;
         default = {
-          default = lib.mapAttrs (name: value: cfg.${name}) commonOptions;
+          default = lib.mapAttrs (name: value: cfg.${name}) commonOptionsIncoming;
         }
         // cfg.interfaces;
-        type = with lib.types; attrsOf (submodule [ { options = commonOptions; } ]);
+        type = with lib.types; attrsOf (submodule [ { options = commonOptionsIncoming; } ]);
         description = ''
           All open ports.
         '';
       };
     }
-    // commonOptions;
+    // commonOptionsIncoming;
   };
 
   config = lib.mkIf cfg.enable {


### PR DESCRIPTION
While the firewall module is able to filter incoming traffic as well
as forwarding, one notable omission is that it cannot filter outgoing
traffic at all. There are some use cases for this though, for
example:

  - To ensure that machines that use a global VPN will only ever use
    the VPN to send data.

  - To ensure that servers won't be able to send data except for the
    specific services that they provide.

Introduce a new "networking.firewall.filterOutput" option that allows
administrators to configure an outgoing firewall. The options provided
by this module mirror the same options that we have for incoming
traffic:

  - "allowTCPPorts", "allowUDPPorts", "allowTCPPortRange" as well as
    "allowUDPPortRange" configure which outgoing TCP and UDP ports are
    accepted.

  - "interfaces" allows to configure which destination TCP and UDP ports
    are accepted on a specific interface.

  - "trustedInterfaces" allows to configure trusted interfaces on which
    outgoing data is always accepted. As with incoming traffic, "lo"
    is marked as trusted interface by default.

  - "extraRules" allows to configure specific rules that cannot be
    configured via any of the above options.

Most of the rules could in theory work with both iptables and nftables.
For now though, they are only implemented for nftables.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
