### PR TITLE
bagels: init at 0.3.8

### DIFF
--- a/pkgs/by-name/ba/bagels/package.nix
+++ b/pkgs/by-name/ba/bagels/package.nix
@@ -1,0 +1,100 @@
+{
+  lib,
+  python3Packages,
+  fetchFromGitHub,
+}:
+
+python3Packages.buildPythonApplication rec {
+  pname = "bagels";
+  version = "0.3.8";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "EnhancedJax";
+    repo = "bagels";
+    tag = version;
+    hash = "sha256-dmBu0HSRGs4LmJY2PHNlRf0RdodmN+ZM0brwuiNmPyU=";
+  };
+
+  build-system = with python3Packages; [
+    hatchling
+  ];
+
+  pythonRelaxDeps = [
+    "aiohappyeyeballs"
+    "aiohttp"
+    "aiosignal"
+    "attrs"
+    "blinker"
+    "click"
+    "multidict"
+    "platformdirs"
+    "propcache"
+    "pydantic-core"
+    "pydantic"
+    "pygments"
+    "requests"
+    "rich"
+    "sqlalchemy"
+    "textual"
+    "typing-extensions"
+    "werkzeug"
+    "yarl"
+  ];
+
+  dependencies = with python3Packages; [
+    aiohappyeyeballs
+    aiohttp-jinja2
+    aiohttp
+    aiosignal
+    annotated-types
+    attrs
+    blinker
+    click-default-group
+    click
+    frozenlist
+    idna
+    itsdangerous
+    linkify-it-py
+    markdown-it-py
+    markupsafe
+    mdit-py-plugins
+    mdurl
+    msgpack
+    multidict
+    numpy
+    packaging
+    platformdirs
+    plotext
+    propcache
+    pydantic-core
+    pydantic
+    pygments
+    python-dateutil
+    pyyaml
+    requests
+    rich
+    sqlalchemy
+    textual
+    tomli
+    typing-extensions
+    uc-micro-py
+    werkzeug
+    xdg-base-dirs
+    yarl
+  ];
+
+  meta = {
+    homepage = "https://github.com/EnhancedJax/Bagels";
+    description = "Powerful expense tracker that lives in your terminal.";
+    longDescription = ''
+      Bagels expense tracker is a TUI application where you can track and analyse your money flow, with convenience oriented features and a complete interface.
+    '';
+    changelog = "https://github.com/EnhancedJax/Bagels/releases/tag/${version}";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [
+      loc
+    ];
+    mainProgram = "bagels";
+  };
+}


### PR DESCRIPTION
## Things done

Added Bagels package. Resolves #403956.
https://github.com/EnhancedJax/Bagels

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
