### PR TITLE
lipo-go: use finalAttrs style

### DIFF
--- a/pkgs/by-name/li/lipo-go/package.nix
+++ b/pkgs/by-name/li/lipo-go/package.nix
@@ -2,37 +2,26 @@
   lib,
   buildGoModule,
   fetchFromGitHub,
-  ast-grep,
   versionCheckHook,
   nix-update-script,
   lipo-go,
 }:
-buildGoModule rec {
+buildGoModule (finalAttrs: {
   pname = "lipo-go";
   version = "0.10.0";
 
   src = fetchFromGitHub {
     owner = "konoui";
     repo = "lipo";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-V1KlgCNKvxnY/B8cmiWFdXzHH6k6VmhNMIta3nckXtA=";
   };
   vendorHash = "sha256-7M6CRxJd4fgYQLJDkNa3ds3f7jOp3dyloOZtwMtCBQk=";
 
-  nativeBuildInputs = [ ast-grep ];
-
-  postPatch =
-    # Remove the test case that is not compatible with nix-build
-    ''
-      ast-grep run \
-        --pattern 'func TestLipo_ArchsToLocalFiles($$$) { $$$ }' \
-        --rewrite "" \
-        pkg/lipo/archs_test.go
-    '';
   buildPhase = ''
     runHook preBuild
 
-    make build VERSION=${version} REVISION="" BINARY=$out/bin/lipo
+    make build VERSION=${finalAttrs.version} REVISION="" BINARY=$out/bin/lipo
 
     runHook postBuild
   '';
@@ -44,16 +33,14 @@ buildGoModule rec {
   versionCheckProgramArg = "-version";
   doInstallCheck = true;
 
-  passthru = {
-    updateScript = nix-update-script { };
-  };
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "Designed to be compatible with macOS lipo, written in golang";
     homepage = "https://github.com/konoui/lipo";
-    changelog = "https://github.com/konoui/lipo/releases/tag/v${version}";
+    changelog = "https://github.com/konoui/lipo/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ xiaoxiangmoe ];
     mainProgram = "lipo";
   };
-}
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
