### PR TITLE
[24.11]: workflows/labels: skip for staging-next / haskell-updates / python-updates

### DIFF
--- a/.github/labeler-development-branches.yml
+++ b/.github/labeler-development-branches.yml
@@ -1,5 +1,5 @@
 # This file is used by .github/workflows/labels.yml
-# This version is only run for Pull Requests from protected branches like staging-next, haskell-updates or python-updates.
+# This version is only run for Pull Requests from development branches like staging-next, haskell-updates or python-updates.
 
 "4.workflow: package set update":
   - any:

--- a/.github/labeler-no-sync.yml
+++ b/.github/labeler-no-sync.yml
@@ -1,0 +1,21 @@
+# This file is used by .github/workflows/labels.yml
+# This version uses `sync-labels: false`, meaning that a non-match will NOT remove the label
+
+"6.topic: policy discussion":
+  - any:
+    - changed-files:
+      - any-glob-to-any-file:
+        - .github/**/*
+        - CONTRIBUTING.md
+        - pkgs/README.md
+        - nixos/README.md
+        - maintainers/README.md
+        - lib/README.md
+        - doc/README.md
+
+"8.has: documentation":
+  - any:
+    - changed-files:
+      - any-glob-to-any-file:
+        - doc/**/*
+        - nixos/doc/**/*

--- a/.github/labeler-protected-branches.yml
+++ b/.github/labeler-protected-branches.yml
@@ -1,0 +1,12 @@
+# This file is used by .github/workflows/labels.yml
+# This version is only run for Pull Requests from protected branches like staging-next, haskell-updates or python-updates.
+
+"6.topic: haskell":
+  - any:
+    - head-branch:
+      - '^haskell-updates$'
+
+"6.topic: python":
+  - any:
+    - head-branch:
+      - '^python-updates$'

--- a/.github/labeler-protected-branches.yml
+++ b/.github/labeler-protected-branches.yml
@@ -1,6 +1,17 @@
 # This file is used by .github/workflows/labels.yml
 # This version is only run for Pull Requests from protected branches like staging-next, haskell-updates or python-updates.
 
+"4.workflow: package set update":
+  - any:
+    - head-branch:
+      - '-updates$'
+
+"4.workflow: staging":
+  - any:
+    - head-branch:
+      - '^staging-next$'
+      - '^staging-next-'
+
 "6.topic: haskell":
   - any:
     - head-branch:

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,6 +1,12 @@
 # This file is used by .github/workflows/labels.yml
 # This version uses `sync-labels: true`, meaning that a non-match will remove the label
 
+"4.workflow: backport":
+  - any:
+    - base-branch:
+      - '^release-'
+      - '^staging-'
+
 # NOTE: bsd, darwin and cross-compilation labels are handled by ofborg
 "6.topic: agda":
   - any:

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,3 +1,6 @@
+# This file is used by .github/workflows/labels.yml
+# This version uses `sync-labels: true`, meaning that a non-match will remove the label
+
 # NOTE: bsd, darwin and cross-compilation labels are handled by ofborg
 "6.topic: agda":
   - any:
@@ -365,18 +368,6 @@
         - pkgs/test/php/default.nix
         - pkgs/top-level/php-packages.nix
 
-"6.topic: policy discussion":
-  - any:
-    - changed-files:
-      - any-glob-to-any-file:
-        - .github/**/*
-        - CONTRIBUTING.md
-        - pkgs/README.md
-        - nixos/README.md
-        - maintainers/README.md
-        - lib/README.md
-        - doc/README.md
-
 "6.topic: printing":
   - any:
     - changed-files:
@@ -548,13 +539,6 @@
     - changed-files:
       - any-glob-to-any-file:
         - nixos/doc/manual/release-notes/**/*
-
-"8.has: documentation":
-  - any:
-    - changed-files:
-      - any-glob-to-any-file:
-        - doc/**/*
-        - nixos/doc/**/*
 
 "8.has: module (update)":
   - any:

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -14,7 +14,7 @@ permissions: {}
 jobs:
   backport:
     name: Backport Pull Request
-    if: github.repository_owner == 'NixOS' && github.event.pull_request.merged == true && (github.event_name != 'labeled' || startsWith('backport', github.event.label.name))
+    if: github.repository_owner == 'NixOS' && github.event.pull_request.merged == true && (github.pull_request.action != 'labeled' || startsWith(github.event.label.name, 'backport'))
     runs-on: ubuntu-24.04
     steps:
       # Use a GitHub App to create the PR so that CI gets triggered

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -46,7 +46,7 @@ jobs:
               * Even as a non-commiter, if you find that it is not acceptable, leave a comment.
 
       - name: "Add 'has: port to stable' label"
-        if: steps.backport.outputs.was_successful
+        if: steps.backport.outputs.created_pull_numbers != ''
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           REPOSITORY: ${{ github.repository }}

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -33,6 +33,7 @@ jobs:
           token: ${{ steps.app-token.outputs.token }}
 
       - name: Create backport PRs
+        id: backport
         uses: korthout/backport-action@436145e922f9561fc5ea157ff406f21af2d6b363 # v3.2.0
         with:
           # Config README: https://github.com/korthout/backport-action#backport-action
@@ -43,3 +44,15 @@ jobs:
 
             * [ ] Before merging, ensure that this backport is [acceptable for the release](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#changes-acceptable-for-releases).
               * Even as a non-commiter, if you find that it is not acceptable, leave a comment.
+
+      - name: "Add 'has: port to stable' label"
+        if: steps.backport.outputs.was_successful
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          REPOSITORY: ${{ github.repository }}
+          NUMBER: ${{ github.event.number }}
+        run: |
+          gh api \
+            --method POST \
+            /repos/"$REPOSITORY"/issues/"$NUMBER"/labels \
+            -f "labels[]=8.has: port to stable"

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -14,7 +14,7 @@ permissions: {}
 jobs:
   backport:
     name: Backport Pull Request
-    if: github.repository_owner == 'NixOS' && github.event.pull_request.merged == true && (github.pull_request.action != 'labeled' || startsWith(github.event.label.name, 'backport'))
+    if: github.repository_owner == 'NixOS' && github.event.pull_request.merged == true && (github.event.action != 'labeled' || startsWith(github.event.label.name, 'backport'))
     runs-on: ubuntu-24.04
     steps:
       # Use a GitHub App to create the PR so that CI gets triggered

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -22,4 +22,10 @@ jobs:
       - uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # v5.0.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+          configuration-path: .github/labeler.yml # default
           sync-labels: true
+      - uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # v5.0.0
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          configuration-path: .github/labeler-no-sync.yml
+          sync-labels: false

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -20,12 +20,23 @@ jobs:
     if: "github.repository_owner == 'NixOS' && !contains(github.event.pull_request.title, '[skip treewide]')"
     steps:
       - uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # v5.0.0
+        if: "!(github.pull_request.head.repo == 'NixOS' && github.ref_protected)"
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           configuration-path: .github/labeler.yml # default
           sync-labels: true
       - uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # v5.0.0
+        if: "!(github.pull_request.head.repo == 'NixOS' && github.ref_protected)"
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           configuration-path: .github/labeler-no-sync.yml
           sync-labels: false
+      - uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # v5.0.0
+        # Protected branches like staging-next, haskell-updates and python-updates get special labels.
+        # This is to avoid the mass of labels there, which is mostly useless - and really annoying for
+        # the backport labels.
+        if: "github.pull_request.head.repo == 'NixOS' && github.ref_protected"
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          configuration-path: .github/labeler-protected-branches.yml
+          sync-labels: true

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -20,22 +20,40 @@ jobs:
     if: "github.repository_owner == 'NixOS' && !contains(github.event.pull_request.title, '[skip treewide]')"
     steps:
       - uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # v5.0.0
-        if: "!(github.pull_request.head.repo == 'NixOS' && github.ref_protected)"
+        if: |
+          github.event.pull_request.head.repo.owner.login != 'NixOS' || !(
+            github.head_ref == "haskell-updates" ||
+            github.head_ref == "python-updates" ||
+            github.head_ref == "staging-next" ||
+            startsWith(github.head_ref, "staging-next-")
+          )
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           configuration-path: .github/labeler.yml # default
           sync-labels: true
       - uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # v5.0.0
-        if: "!(github.pull_request.head.repo == 'NixOS' && github.ref_protected)"
+        if: |
+          github.event.pull_request.head.repo.owner.login != 'NixOS' || !(
+            github.head_ref == "haskell-updates" ||
+            github.head_ref == "python-updates" ||
+            github.head_ref == "staging-next" ||
+            startsWith(github.head_ref, "staging-next-")
+          )
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           configuration-path: .github/labeler-no-sync.yml
           sync-labels: false
       - uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # v5.0.0
-        # Protected branches like staging-next, haskell-updates and python-updates get special labels.
+        # Development branches like staging-next, haskell-updates and python-updates get special labels.
         # This is to avoid the mass of labels there, which is mostly useless - and really annoying for
         # the backport labels.
-        if: "github.pull_request.head.repo == 'NixOS' && github.ref_protected"
+        if: |
+          github.event.pull_request.head.repo.owner.login == 'NixOS' && (
+            github.head_ref == "haskell-updates" ||
+            github.head_ref == "python-updates" ||
+            github.head_ref == "staging-next" ||
+            startsWith(github.head_ref, "staging-next-")
+          )
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           configuration-path: .github/labeler-protected-branches.yml

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -22,10 +22,10 @@ jobs:
       - uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # v5.0.0
         if: |
           github.event.pull_request.head.repo.owner.login != 'NixOS' || !(
-            github.head_ref == "haskell-updates" ||
-            github.head_ref == "python-updates" ||
-            github.head_ref == "staging-next" ||
-            startsWith(github.head_ref, "staging-next-")
+            github.head_ref == 'haskell-updates' ||
+            github.head_ref == 'python-updates' ||
+            github.head_ref == 'staging-next' ||
+            startsWith(github.head_ref, 'staging-next-')
           )
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
@@ -34,10 +34,10 @@ jobs:
       - uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # v5.0.0
         if: |
           github.event.pull_request.head.repo.owner.login != 'NixOS' || !(
-            github.head_ref == "haskell-updates" ||
-            github.head_ref == "python-updates" ||
-            github.head_ref == "staging-next" ||
-            startsWith(github.head_ref, "staging-next-")
+            github.head_ref == 'haskell-updates' ||
+            github.head_ref == 'python-updates' ||
+            github.head_ref == 'staging-next' ||
+            startsWith(github.head_ref, 'staging-next-')
           )
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
@@ -49,10 +49,10 @@ jobs:
         # the backport labels.
         if: |
           github.event.pull_request.head.repo.owner.login == 'NixOS' && (
-            github.head_ref == "haskell-updates" ||
-            github.head_ref == "python-updates" ||
-            github.head_ref == "staging-next" ||
-            startsWith(github.head_ref, "staging-next-")
+            github.head_ref == 'haskell-updates' ||
+            github.head_ref == 'python-updates' ||
+            github.head_ref == 'staging-next' ||
+            startsWith(github.head_ref, 'staging-next-')
           )
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -56,5 +56,5 @@ jobs:
           )
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          configuration-path: .github/labeler-protected-branches.yml
+          configuration-path: .github/labeler-development-branches.yml
           sync-labels: true


### PR DESCRIPTION
Manual backport of #402332 and parts of #374921.

I did not backport the configuration of backport labels for CI PRs from #374921... because otherwise we'd end up with backport labels on the backport PRs as well. On the same vein, we'll need to remove those labels from release-25.05 after branch-off.

## Things done

- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
