### PR TITLE
marker: fix incompatible pointer type

### DIFF
--- a/pkgs/by-name/ma/marker/fix_incompatible_pointer_in_marker_window_init.patch
+++ b/pkgs/by-name/ma/marker/fix_incompatible_pointer_in_marker_window_init.patch
@@ -1,0 +1,25 @@
+From 92a679e02f08eef8e2f8c91371b7a3a1f95b4bbc Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Tomi=20L=C3=A4hteenm=C3=A4ki?= <lihis@lihis.net>
+Date: Fri, 25 Apr 2025 22:04:10 +0300
+Subject: [PATCH] Fix incompatible pointer in marker_window_init()
+
+The `g_action_group_activate_action()` takes `GActionGroup` as first parameter.
+
+This fixes compilation with `-Wincompatible-pointer-types`.
+---
+ src/marker-window.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/marker-window.c b/src/marker-window.c
+index 0ffd0ce3..98b2fdc5 100644
+--- a/src/marker-window.c
++++ b/src/marker-window.c
+@@ -866,7 +866,7 @@ marker_window_init (MarkerWindow *window)
+   if (marker_prefs_get_show_sidebar())
+   {
+     // show sidebar and set the "Sidebar" button as activated
+-    g_action_group_activate_action(G_ACTION_MAP (window), "sidebar", NULL);
++    g_action_group_activate_action(G_ACTION_GROUP (window), "sidebar", NULL);
+   }
+   g_signal_connect(window, "delete-event", G_CALLBACK(window_deleted_event_cb), window);
+ 

--- a/pkgs/by-name/ma/marker/package.nix
+++ b/pkgs/by-name/ma/marker/package.nix
@@ -26,6 +26,11 @@ stdenv.mkDerivation rec {
     hash = "sha256-HhDhigQ6Aqo8R57Yrf1i69sM0feABB9El5R5OpzOyB0=";
   };
 
+  patches = [
+    # https://github.com/fabiocolacio/Marker/pull/427
+    ./fix_incompatible_pointer_in_marker_window_init.patch
+  ];
+
   nativeBuildInputs = [
     itstool
     meson


### PR DESCRIPTION
ZHF: https://github.com/NixOS/nixpkgs/issues/403336

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
