### PR TITLE
python3Packages.twscrape: init at 0.17.0

### DIFF
--- a/pkgs/development/python-modules/twscrape/default.nix
+++ b/pkgs/development/python-modules/twscrape/default.nix
@@ -1,0 +1,58 @@
+{
+  lib,
+  aiosqlite,
+  beautifulsoup4,
+  buildPythonPackage,
+  fake-useragent,
+  fetchFromGitHub,
+  hatchling,
+  httpx,
+  loguru,
+  pyotp,
+  pytestCheckHook,
+  pytest-httpx,
+  pythonOlder,
+}:
+
+buildPythonPackage rec {
+  pname = "twscrape";
+  version = "0.17.0";
+  pyproject = true;
+
+  disabled = pythonOlder "3.10";
+
+  src = fetchFromGitHub {
+    owner = "vladkens";
+    repo = "twscrape";
+    tag = "v${version}";
+    hash = "sha256-0j6nE8V0CWTuIHMS+2p5Ncz7d+D6VagjtyfMbQuI8Eg=";
+  };
+
+  build-system = [ hatchling ];
+
+  pythonRelaxDeps = [ "beautifulsoup4" ];
+
+  dependencies = [
+    aiosqlite
+    beautifulsoup4
+    fake-useragent
+    httpx
+    loguru
+    pyotp
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    pytest-httpx
+  ];
+
+  pythonImportsCheck = [ "twscrape" ];
+
+  meta = {
+    description = "Twitter API scrapper with authorization support.";
+    homepage = "https://github.com/vladkens/twscrape";
+    changelog = "https://github.com/vladkens/twscrape/releases/tag/v${version}";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.amadejkastelic ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -17799,6 +17799,8 @@ self: super: with self; {
 
   twofish = callPackage ../development/python-modules/twofish { };
 
+  twscrape = callPackage ../development/python-modules/twscrape { };
+
   txaio = callPackage ../development/python-modules/txaio { };
 
   txamqp = callPackage ../development/python-modules/txamqp { };


### PR DESCRIPTION
https://github.com/vladkens/twscrape/releases/tag/v0.17.0

Also manually tested with a simple script

<details><summary>Show</summary>

```python
import asyncio

import twscrape


async def main():
    client = twscrape.API()
    await client.pool.add_account(
        username='Unknown',
        password='******',
        email='*****',
        email_password='******',
    )
    await client.pool.login_all()

    tweet = await client.tweet_details(twid=1918319917960462613)
    print(f'''URL: {tweet.url}
Date: {tweet.date}
User: {tweet.user.username}
Text: {tweet.rawContent}
    ''')

if __name__ == "__main__":
    asyncio.run(main())
```

```bash
nix-repl> let
          venv = pkgs.mkShell {
          buildInputs = [(pkgs.python313.withPackages(ps: [ps.twscrape]))];
          };
          in
          venv
«derivation /nix/store/3cdbscc9jgiqfahrzi5qlr45c3hc0x9s-nix-shell.drv»

› nix-shell /nix/store/3cdbscc9jgiqfahrzi5qlr45c3hc0x9s-nix-shell.drv                                                         
this derivation will be built:
  /nix/store/1wnv4c5vd9k5kfknlllxsi362bqdip7b-python3-3.13.2-env.drv
building '/nix/store/1wnv4c5vd9k5kfknlllxsi362bqdip7b-python3-3.13.2-env.drv'...
created 260 symlinks in user environment

[nix-shell:~/Documents/nixpkgs]$ python test.py 
2025-05-04 15:37:30.245 | INFO     | twscrape.db:migrate:96 - Running migration to v1
2025-05-04 15:37:30.263 | INFO     | twscrape.db:migrate:96 - Running migration to v2
2025-05-04 15:37:30.276 | INFO     | twscrape.db:migrate:96 - Running migration to v3
2025-05-04 15:37:30.285 | INFO     | twscrape.db:migrate:96 - Running migration to v4
2025-05-04 15:37:30.330 | INFO     | twscrape.accounts_pool:add_account:110 - Account Unknown added successfully (active=False)
2025-05-04 15:37:30.331 | INFO     | twscrape.accounts_pool:login_all:183 - [1/1] Logging in Unknown - *****
2025-05-04 15:37:32.091 | INFO     | twscrape.accounts_pool:login:158 - Logged in to Unknown successfully
URL: https://x.com/nixos_org/status/1918319917960462613
Date: 2025-05-02 15:01:23+00:00
User: nixos_org
Text: Only 10 days left to apply for Summer of Nix 2025!
Are you a student or early-career dev passionate about #OSS?
Join the program to work on real #FOSS projects, learn #Nix with experienced mentors, and connect with a global community.
Apply by May 12: https://t.co/hphJWobr97 https://t.co/O2IS1dpEc4
```
</details>

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
