### PR TITLE
workflows/backport: only trigger on backport labels

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -14,7 +14,7 @@ permissions: {}
 jobs:
   backport:
     name: Backport Pull Request
-    if: github.repository_owner == 'NixOS' && github.event.pull_request.merged == true && (github.event_name != 'labeled' || startsWith('backport', github.event.label.name))
+    if: github.repository_owner == 'NixOS' && github.event.pull_request.merged == true && (github.pull_request.action != 'labeled' || startsWith(github.event.label.name, 'backport'))
     runs-on: ubuntu-24.04
     steps:
       # Use a GitHub App to create the PR so that CI gets triggered


### PR DESCRIPTION
The backport job was previously triggered on any label activity, i.e. when the backport label was already set and a new label added, the backport would have been triggered again. (Example: #402332, where I tested that)

That's because `github.event_name` is actually "pull_request_target" in this case, not "closed" or "labeled" (the event's types). Thus, this part of the condition was always true.

This also means that the second part, the startsWith, was never evaluated. It had its arguments flipped and would have always been false.

This was introduced in #126825, but has never really worked as intended. @zowoq already mentioned this in https://github.com/NixOS/nixpkgs/pull/126825#issuecomment-1193917599

Resolves #199556

Relevant docs:
- https://docs.github.com/en/webhooks/webhook-events-and-payloads?actionType=labeled#pull_request
- https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/evaluate-expressions-in-workflows-and-actions#startswith

## Things done

- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
