### PR TITLE
workflows/backport: add "has: port to stable" label on success

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -33,6 +33,7 @@ jobs:
           token: ${{ steps.app-token.outputs.token }}
 
       - name: Create backport PRs
+        id: backport
         uses: korthout/backport-action@436145e922f9561fc5ea157ff406f21af2d6b363 # v3.2.0
         with:
           # Config README: https://github.com/korthout/backport-action#backport-action
@@ -43,3 +44,15 @@ jobs:
 
             * [ ] Before merging, ensure that this backport is [acceptable for the release](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#changes-acceptable-for-releases).
               * Even as a non-commiter, if you find that it is not acceptable, leave a comment.
+
+      - name: "Add 'has: port to stable' label"
+        if: steps.backport.outputs.was_successful
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          REPOSITORY: ${{ github.repository }}
+          NUMBER: ${{ github.event.number }}
+        run: |
+          gh api \
+            --method POST \
+            /repos/"$REPOSITORY"/issues/"$NUMBER"/labels \
+            -f "labels[]=8.has: port to stable"


### PR DESCRIPTION
This allows filtering for PRs with a backport label, but without the "has: port to stable" label to find those which need to be manually acted on.

Resolves #325359

Note: I wondered whether we need to somehow label already existing PRs retroactively to make use of this - but that's not the case once we flip the page to 25.05. With the new 25.05 backport labels, we won't filter for older PRs anyway, so this should work as is.

## Things done

- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
