### PR TITLE
workflows/labeler: fix conditionals

### DIFF
--- a/.github/labeler-development-branches.yml
+++ b/.github/labeler-development-branches.yml
@@ -1,5 +1,5 @@
 # This file is used by .github/workflows/labels.yml
-# This version is only run for Pull Requests from protected branches like staging-next, haskell-updates or python-updates.
+# This version is only run for Pull Requests from development branches like staging-next, haskell-updates or python-updates.
 
 "4.workflow: package set update":
   - any:

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -20,22 +20,40 @@ jobs:
     if: "github.repository_owner == 'NixOS' && !contains(github.event.pull_request.title, '[skip treewide]')"
     steps:
       - uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # v5.0.0
-        if: "!(github.pull_request.head.repo == 'NixOS' && github.ref_protected)"
+        if: |
+          github.event.pull_request.head.repo.owner.login != 'NixOS' || !(
+            github.head_ref == "haskell-updates" ||
+            github.head_ref == "python-updates" ||
+            github.head_ref == "staging-next" ||
+            startsWith(github.head_ref, "staging-next-")
+          )
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           configuration-path: .github/labeler.yml # default
           sync-labels: true
       - uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # v5.0.0
-        if: "!(github.pull_request.head.repo == 'NixOS' && github.ref_protected)"
+        if: |
+          github.event.pull_request.head.repo.owner.login != 'NixOS' || !(
+            github.head_ref == "haskell-updates" ||
+            github.head_ref == "python-updates" ||
+            github.head_ref == "staging-next" ||
+            startsWith(github.head_ref, "staging-next-")
+          )
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           configuration-path: .github/labeler-no-sync.yml
           sync-labels: false
       - uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # v5.0.0
-        # Protected branches like staging-next, haskell-updates and python-updates get special labels.
+        # Development branches like staging-next, haskell-updates and python-updates get special labels.
         # This is to avoid the mass of labels there, which is mostly useless - and really annoying for
         # the backport labels.
-        if: "github.pull_request.head.repo == 'NixOS' && github.ref_protected"
+        if: |
+          github.event.pull_request.head.repo.owner.login == 'NixOS' && (
+            github.head_ref == "haskell-updates" ||
+            github.head_ref == "python-updates" ||
+            github.head_ref == "staging-next" ||
+            startsWith(github.head_ref, "staging-next-")
+          )
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           configuration-path: .github/labeler-protected-branches.yml


### PR DESCRIPTION
Introduced in #402332, but broken on all ends\*:

- pull_request needs to be event.pull_request
- pull_request.head is an object, not a string
- github.ref_protected is about the target branch, because this runs as a pull_request_target event

Thus, we need to list the branches manually.

\* but broken in a way that it would default to the previous behavior in all cases, so not critical.

## Things done

- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
