### PR TITLE
workflows/backport: avoid broken korthout/backport-action output

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -46,7 +46,7 @@ jobs:
               * Even as a non-commiter, if you find that it is not acceptable, leave a comment.
 
       - name: "Add 'has: port to stable' label"
-        if: steps.backport.outputs.was_successful
+        if: steps.backport.outputs.created_pull_numbers != ''
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           REPOSITORY: ${{ github.repository }}


### PR DESCRIPTION
Somehow, the was_successful output didn't work correctly. It's hard to imagine that the created_pull_numbers output fails the same way, because... when the backport action fails there **are no pull request numbers**.


## Things done

- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
