### PR TITLE
workflows/labeler: fix double quotes

### DIFF
--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -22,10 +22,10 @@ jobs:
       - uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # v5.0.0
         if: |
           github.event.pull_request.head.repo.owner.login != 'NixOS' || !(
-            github.head_ref == "haskell-updates" ||
-            github.head_ref == "python-updates" ||
-            github.head_ref == "staging-next" ||
-            startsWith(github.head_ref, "staging-next-")
+            github.head_ref == 'haskell-updates' ||
+            github.head_ref == 'python-updates' ||
+            github.head_ref == 'staging-next' ||
+            startsWith(github.head_ref, 'staging-next-')
           )
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
@@ -34,10 +34,10 @@ jobs:
       - uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # v5.0.0
         if: |
           github.event.pull_request.head.repo.owner.login != 'NixOS' || !(
-            github.head_ref == "haskell-updates" ||
-            github.head_ref == "python-updates" ||
-            github.head_ref == "staging-next" ||
-            startsWith(github.head_ref, "staging-next-")
+            github.head_ref == 'haskell-updates' ||
+            github.head_ref == 'python-updates' ||
+            github.head_ref == 'staging-next' ||
+            startsWith(github.head_ref, 'staging-next-')
           )
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
@@ -49,10 +49,10 @@ jobs:
         # the backport labels.
         if: |
           github.event.pull_request.head.repo.owner.login == 'NixOS' && (
-            github.head_ref == "haskell-updates" ||
-            github.head_ref == "python-updates" ||
-            github.head_ref == "staging-next" ||
-            startsWith(github.head_ref, "staging-next-")
+            github.head_ref == 'haskell-updates' ||
+            github.head_ref == 'python-updates' ||
+            github.head_ref == 'staging-next' ||
+            startsWith(github.head_ref, 'staging-next-')
           )
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Because GitHub Actions doesn't like double quotes.

## Things done

- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
