### PR TITLE
workflows/labels: fix wrong yaml file

### DIFF
--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -56,5 +56,5 @@ jobs:
           )
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          configuration-path: .github/labeler-protected-branches.yml
+          configuration-path: .github/labeler-development-branches.yml
           sync-labels: true


### PR DESCRIPTION
Renamed the yaml file in #404152, but forgot to adjust it in the workflow file.

Results in https://github.com/NixOS/nixpkgs/actions/runs/14823773241/job/41614216567?pr=401526 on staging-next.

## Things done

- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
