### PR TITLE
otfcc: mark as broken

### DIFF
--- a/pkgs/by-name/ot/otfcc/package.nix
+++ b/pkgs/by-name/ot/otfcc/package.nix
@@ -9,6 +9,7 @@ stdenv.mkDerivation rec {
   pname = "otfcc";
   version = "0.10.4";
 
+  # archived by the owner on Jun 3, 2022. No viable forks.
   src = fetchFromGitHub {
     owner = "caryll";
     repo = "otfcc";
@@ -38,6 +39,11 @@ stdenv.mkDerivation rec {
     license = licenses.asl20;
     platforms = platforms.unix;
     maintainers = with maintainers; [ ttuegel ];
+    # Build fails on all platforms with
+    #        > configure flags: gmake
+    #   > ** Warning: action 'xcode4' sets 'os' field, which is deprecated, use 'targetos' instead.
+    #   > Error: invalid value 'StaticRuntime' for flags
+    broken = true;
   };
 
 }


### PR DESCRIPTION
Hydra: https://hydra.nixos.org/build/295018511

`otfcc` compilation fails on linux with:
``` sh
        > configure flags: gmake
   > ** Warning: action 'xcode4' sets 'os' field, which is deprecated, use 'targetos' instead.
   > Error: invalid value 'StaticRuntime' for flags
```
After updating `premake5` to latest (5.0.0-beta6), the same error also happens on darwin. #403805

The source repo was archived in 2022. The repo lost its active maintainer in 2023 (#268708) and has only received treewide changes since. It appears to be an ex-parrot.

Fixes:
1. Add comments documenting the situation.
2. Mark as broken. 

ZHF: #403336 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s) -- before marking as broken
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
