### PR TITLE
python3Packages.parfive: disable failing test

### DIFF
--- a/pkgs/development/python-modules/parfive/default.nix
+++ b/pkgs/development/python-modules/parfive/default.nix
@@ -58,6 +58,9 @@ buildPythonPackage rec {
     "test_ftp"
     "test_ftp_pasv_command"
     "test_ftp_http"
+
+    # flaky comparison between runtime types
+    "test_http_callback_fail"
   ];
 
   # Tests require local network access


### PR DESCRIPTION
Hydra: https://hydra.nixos.org/build/296088641

Despite working on every box I have, another test failed (incorrectly) in Hydra:
```
>       assert isinstance(cb_status, (SocketConnectBlockedError, ClientConnectorError))
E       assert False
E        +  where False = isinstance(RuntimeError('Multiple exceptions: A test tried to use socket.socket.connect() with host "34.224.149.186" (allowed: "127.0.0.1,::1")., A test tried to use socket.socket.connect() with host "3.18.255.247" (allowed: "127.0.0.1,::1").'), (<class 'pytest_socket.SocketConnectBlockedError'>, <class 'aiohttp.client_exceptions.ClientConnectorError'>))

parfive/tests/test_downloader.py:535: AssertionError
```

It's comparing runtime types and getting it wrong. (https://github.com/Cadair/parfive/issues/171) This may be a moot issue: the offending code was removed some time ago and a new release is being tested now (two rc releases in as many days). Upgrading in a few days may solve the broken test issues. 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [x] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
