### PR TITLE
sourcehut.*: update

### DIFF
--- a/nixos/tests/sourcehut/builds.nix
+++ b/nixos/tests/sourcehut/builds.nix
@@ -49,15 +49,15 @@ import ../make-test-python.nix (
       machine.wait_for_unit("multi-user.target")
 
       with subtest("Check whether meta comes up"):
-           machine.wait_for_unit("metasrht-api.service")
-           machine.wait_for_unit("metasrht.service")
-           machine.wait_for_unit("metasrht-webhooks.service")
+           machine.wait_for_unit("meta.sr.ht-api.service")
+           machine.wait_for_unit("meta.sr.ht.service")
+           machine.wait_for_unit("meta.sr.ht-webhooks.service")
            machine.wait_for_open_port(5000)
            machine.succeed("curl -sL http://localhost:5000 | grep meta.${domain}")
            machine.succeed("curl -sL http://meta.${domain} | grep meta.${domain}")
 
       with subtest("Check whether builds comes up"):
-           machine.wait_for_unit("buildsrht.service")
+           machine.wait_for_unit("builds.sr.ht.service")
            machine.wait_for_open_port(5002)
            machine.succeed("curl -sL http://localhost:5002 | grep builds.${domain}")
            #machine.wait_for_unit("buildsrht-worker.service")

--- a/nixos/tests/sourcehut/git.nix
+++ b/nixos/tests/sourcehut/git.nix
@@ -63,25 +63,26 @@ import ../make-test-python.nix (
         machine.wait_for_unit("sshd.service")
 
         with subtest("Check whether meta comes up"):
-             machine.wait_for_unit("metasrht-api.service")
-             machine.wait_for_unit("metasrht.service")
-             machine.wait_for_unit("metasrht-webhooks.service")
+             machine.wait_for_unit("meta.sr.ht-api.service")
+             machine.wait_for_unit("meta.sr.ht.service")
+             machine.wait_for_unit("meta.sr.ht-webhooks.service")
              machine.wait_for_open_port(5000)
              machine.succeed("curl -sL http://localhost:5000 | grep meta.${domain}")
              machine.succeed("curl -sL http://meta.${domain} | grep meta.${domain}")
 
         with subtest("Create a new user account and OAuth access key"):
-             machine.succeed("echo ${userPass} | metasrht-manageuser -ps -e ${userName}@${domain}\
-                              -t active_paying ${userName}");
+             machine.succeed("echo ${userPass} | meta.sr.ht-manageuser -ps -e ${userName}@${domain}\
+                              -t USER ${userName}");
+             cmd = "srht-gen-oauth-tok -i ${domain} -q ${userName} ${userPass}"
              (_, token) = machine.execute("srht-gen-oauth-tok -i ${domain} -q ${userName} ${userPass}")
              token = token.strip().replace("/", r"\\/") # Escape slashes in token before passing it to sed
              machine.execute("mkdir -p ~/.config/hut/")
              machine.execute("sed s/OAUTH-TOKEN/" + token + "/ ${hutConfig} > ~/.config/hut/config")
 
         with subtest("Check whether git comes up"):
-             machine.wait_for_unit("gitsrht-api.service")
-             machine.wait_for_unit("gitsrht.service")
-             machine.wait_for_unit("gitsrht-webhooks.service")
+             machine.wait_for_unit("git.sr.ht-api.service")
+             machine.wait_for_unit("git.sr.ht.service")
+             machine.wait_for_unit("git.sr.ht-webhooks.service")
              machine.succeed("curl -sL http://git.${domain} | grep git.${domain}")
 
         with subtest("Add an SSH key for Git access"):
@@ -95,7 +96,7 @@ import ../make-test-python.nix (
              machine.execute("cd test && git add .")
              machine.execute("cd test && git commit -m \"Initial commit\"")
              machine.execute("cd test && git tag v0.1")
-             machine.succeed("cd test && git remote add origin gitsrht@git.${domain}:~${userName}/test")
+             machine.succeed("cd test && git remote add origin git.sr.ht@git.${domain}:~${userName}/test")
              machine.execute("( echo -n 'git.${domain} '; cat /etc/ssh/ssh_host_ed25519_key.pub ) > ~/.ssh/known_hosts")
              machine.succeed("hut git create test")
              machine.succeed("cd test && git push --tags --set-upstream origin master")

--- a/pkgs/applications/version-management/sourcehut/core.nix
+++ b/pkgs/applications/version-management/sourcehut/core.nix
@@ -24,12 +24,12 @@
   sassc,
   pythonOlder,
   minify,
-  setuptools,
+  setuptools-scm,
 }:
 
 buildPythonPackage rec {
   pname = "srht";
-  version = "0.71.8";
+  version = "0.76.1";
   pyproject = true;
 
   disabled = pythonOlder "3.7";
@@ -38,7 +38,7 @@ buildPythonPackage rec {
     owner = "~sircmpwn";
     repo = "core.sr.ht";
     rev = version;
-    hash = "sha256-rDpm2HJOWScvIxOmHcat6y4CWdBE9T2gE/jZskYAFB0=";
+    hash = "sha256-lAN1JZXQuN2zxi/BdBtbNj52LPj9iYn0WB2OpyQcyuU=";
     fetchSubmodules = true;
   };
 
@@ -48,7 +48,7 @@ buildPythonPackage rec {
   ];
 
   nativeBuildInputs = [
-    setuptools
+    setuptools-scm
   ];
 
   propagatedNativeBuildInputs = [
@@ -81,12 +81,19 @@ buildPythonPackage rec {
     importlib-metadata
   ];
 
-  PKGVER = version;
+  env = {
+    PREFIX = placeholder "out";
+    PKGVER = version;
+  };
+
+  postInstall = ''
+    make install
+  '';
 
   pythonImportsCheck = [ "srht" ];
 
   meta = with lib; {
-    homepage = "https://git.sr.ht/~sircmpwn/srht";
+    homepage = "https://git.sr.ht/~sircmpwn/core.sr.ht";
     description = "Core modules for sr.ht";
     license = licenses.bsd3;
     maintainers = with maintainers; [

--- a/pkgs/applications/version-management/sourcehut/default.nix
+++ b/pkgs/applications/version-management/sourcehut/default.nix
@@ -5,8 +5,6 @@
   recurseIntoAttrs,
   nixosTests,
   config,
-  fetchPypi,
-  fetchpatch,
 }:
 
 # To expose the *srht modules, they have to be a python module so we use `buildPythonModule`
@@ -29,75 +27,6 @@ let
       todosrht = self.callPackage ./todo.nix { };
 
       scmsrht = self.callPackage ./scm.nix { };
-
-      # sourcehut is not (yet) compatible with SQLAlchemy 2.x
-      sqlalchemy = super.sqlalchemy_1_4;
-
-      # sourcehut is not (yet) compatible with flask-sqlalchemy 3.x
-      flask-sqlalchemy = super.flask-sqlalchemy.overridePythonAttrs (oldAttrs: rec {
-        version = "2.5.1";
-        format = "setuptools";
-        src = fetchPypi {
-          pname = "Flask-SQLAlchemy";
-          inherit version;
-          hash = "sha256-K9pEtD58rLFdTgX/PMH4vJeTbMRkYjQkECv8LDXpWRI=";
-        };
-        propagatedBuildInputs = with self; [
-          flask
-          sqlalchemy
-        ];
-        disabledTests = [ "test_persist_selectable" ];
-      });
-
-      # flask-sqlalchemy 2.x requires flask 2.x
-      flask = super.flask.overridePythonAttrs (oldAttrs: rec {
-        version = "2.3.3";
-        src = fetchPypi {
-          inherit (oldAttrs) pname;
-          inherit version;
-          hash = "sha256-CcNHqSqn/0qOfzIGeV8w2CZlS684uHPQdEzVccpgnvw=";
-        };
-      });
-
-      # flask 2.x requires werkzeug 2.x
-      werkzeug = super.werkzeug.overridePythonAttrs (oldAttrs: rec {
-        version = "2.3.8";
-        src = fetchPypi {
-          inherit (oldAttrs) pname;
-          inherit version;
-          hash = "sha256-VUslfHS763oNJUFgpPj/4YUkP1KlIDUGC3Ycpi2XfwM=";
-        };
-        # Fixes a test failure with Pytest 8
-        patches = (oldAttrs.patches or [ ]) ++ [
-          (fetchpatch {
-            url = "https://github.com/pallets/werkzeug/commit/4e5bdca7f8227d10cae828f8064fb98190ace4aa.patch";
-            hash = "sha256-83doVvfdpymlAB0EbfrHmuoKE5B2LJbFq+AY2xGpnl4=";
-          })
-        ];
-        nativeCheckInputs = oldAttrs.nativeCheckInputs or [ ] ++ [ self.pytest-xprocess ];
-      });
-
-      # sourcehut is not (yet) compatible with factory-boy 3.x
-      factory-boy = super.factory-boy.overridePythonAttrs (oldAttrs: rec {
-        version = "2.12.0";
-        src = fetchPypi {
-          pname = "factory_boy";
-          inherit version;
-          hash = "sha256-+vSNYIoXNfDQo8nL9TbWT5EytUfa57pFLE2Zp56Eo3A=";
-        };
-        nativeCheckInputs =
-          (with super; [
-            django
-            mongoengine
-            pytestCheckHook
-          ])
-          ++ (with self; [
-            sqlalchemy
-            flask
-            flask-sqlalchemy
-          ]);
-        postPatch = "";
-      });
     };
   };
 in

--- a/pkgs/applications/version-management/sourcehut/hg.nix
+++ b/pkgs/applications/version-management/sourcehut/hg.nix
@@ -1,6 +1,7 @@
 {
   lib,
   fetchFromSourcehut,
+  fetchpatch,
   buildGoModule,
   buildPythonPackage,
   srht,
@@ -11,65 +12,71 @@
   unzip,
   pip,
   pythonOlder,
-  setuptools,
+  setuptools-scm,
 }:
 
 let
-  version = "0.33.0";
+  version = "0.36.1";
   gqlgen = import ./fix-gqlgen-trimpath.nix {
     inherit unzip;
-    gqlgenVersion = "0.17.45";
+    gqlgenVersion = "0.17.64";
   };
 
-  pyproject = true;
-
-  disabled = pythonOlder "3.7";
+  patches = [
+    (fetchpatch {
+      name = "update-core-go-and-gqlgen.patch";
+      url = "https://hg.sr.ht/~sircmpwn/hg.sr.ht/rev/2765f086c3a67e00219cabe9a1dd01b2012c5c12.patch";
+      hash = "sha256-MLZG07tD7vrfvx2GDRUvFd/7VxxZLrAa/C3bB/IvQpI=";
+    })
+    ./patches/core-go-update/hg/patch-deps.patch
+  ];
 
   src = fetchFromSourcehut {
     owner = "~sircmpwn";
     repo = "hg.sr.ht";
     rev = version;
-    hash = "sha256-+BYeE+8dXY/MLLYyBBLD+eKqmrPiKyyCGIZLkCPzNYM=";
+    hash = "sha256-EeWRUb/BZ+KJXNqmzCFYHkvWUaPvF/F7ZaOYM0IEYwk=";
     vc = "hg";
   };
 
   hgsrht-api = buildGoModule (
     {
-      inherit src version;
+      inherit src version patches;
       pname = "hgsrht-api";
       modRoot = "api";
-      vendorHash = "sha256-K+KMhcvkG/qeQTnlHS4xhLCcvBQNNp2DcScJPm8Dbic=";
+      vendorHash = "sha256-elaVmyaO5IbzsnBYRjJvmoOFR8gx1xCfzd3z01KNXVA=";
     }
     // gqlgen
   );
 
   hgsrht-keys = buildGoModule {
-    inherit src version;
+    inherit src version patches;
     pname = "hgsrht-keys";
-    modRoot = "hgsrht-keys";
-    vendorHash = "sha256-7ti8xCjSrxsslF7/1X/GY4FDl+69hPL4UwCDfjxmJLU=";
+    modRoot = "keys";
+    vendorHash = "sha256-U5NtgyUgVqI25XBg51U7glNRpR5MZBCcsuuR6f+gZc8=";
 
     postPatch = ''
-      substituteInPlace hgsrht-keys/main.go \
-        --replace /var/log/hgsrht-keys /var/log/sourcehut/hgsrht-keys
+      substituteInPlace keys/main.go \
+        --replace-fail /var/log/hg.sr.ht-keys /var/log/sourcehut/hg.sr.ht-keys
     '';
   };
 in
 buildPythonPackage rec {
-  inherit src version;
+  inherit src version patches;
   pname = "hgsrht";
 
-  postPatch = ''
-    substituteInPlace Makefile \
-      --replace "all: api hgsrht-keys" ""
+  pyproject = true;
 
-    substituteInPlace hgsrht-shell \
-      --replace /var/log/hgsrht-shell /var/log/sourcehut/hgsrht-shell
+  disabled = pythonOlder "3.7";
+
+  postPatch = ''
+    substituteInPlace hg.sr.ht-shell \
+      --replace-fail /var/log/hg.sr.ht-shell /var/log/sourcehut/hg.sr.ht-shell
   '';
 
   nativeBuildInputs = [
     pip
-    setuptools
+    setuptools-scm
   ];
 
   propagatedBuildInputs = [
@@ -79,20 +86,27 @@ buildPythonPackage rec {
     unidiff
   ];
 
-  preBuild = ''
-    export PKGVER=${version}
-    export SRHT_PATH=${srht}/${python.sitePackages}/srht
+  env = {
+    PKGVER = version;
+    SRHT_PATH = "${srht}/${python.sitePackages}/srht";
+    PREFIX = placeholder "out";
+  };
+
+  postBuild = ''
+    make SASSC_INCLUDE=-I${srht}/share/sourcehut/scss/ all-share
   '';
 
   postInstall = ''
-    ln -s ${hgsrht-api}/bin/api $out/bin/hgsrht-api
-    ln -s ${hgsrht-keys}/bin/hgsrht-keys $out/bin/hgsrht-keys
+    ln -s ${hgsrht-api}/bin/api $out/bin/hg.sr.ht-api
+    ln -s ${hgsrht-keys}/bin/hgsrht-keys $out/bin/hg.sr.ht-keys
+    install -Dm644 schema.sql $out/share/sourcehut/hg.sr.ht-schema.sql
+    make install-share
   '';
 
   pythonImportsCheck = [ "hgsrht" ];
 
   meta = with lib; {
-    homepage = "https://git.sr.ht/~sircmpwn/hg.sr.ht";
+    homepage = "https://hg.sr.ht/~sircmpwn/hg.sr.ht";
     description = "Mercurial repository hosting service for the sr.ht network";
     license = licenses.agpl3Only;
     maintainers = with maintainers; [

--- a/pkgs/applications/version-management/sourcehut/lists.nix
+++ b/pkgs/applications/version-management/sourcehut/lists.nix
@@ -12,48 +12,45 @@
   unzip,
   pip,
   pythonOlder,
-  setuptools,
+  setuptools-scm,
 }:
 
 let
-  version = "0.57.18";
+  version = "0.62.3";
   gqlgen = import ./fix-gqlgen-trimpath.nix {
     inherit unzip;
-    gqlgenVersion = "0.17.45";
+    gqlgenVersion = "0.17.64";
   };
+
+  patches = [ ./patches/core-go-update/lists/patch-deps.patch ];
 
   src = fetchFromSourcehut {
     owner = "~sircmpwn";
     repo = "lists.sr.ht";
     rev = version;
-    hash = "sha256-l+QPocnwHTjrU+M0wnm4tBrbz8KmSb6DovC+skuAnLc=";
+    hash = "sha256-HU3hnKdIoseCo1/lt3GIOQ5d3joykN11/Bzvk4xvH4Y=";
   };
 
   listssrht-api = buildGoModule (
     {
-      inherit src version;
+      inherit src version patches;
       pname = "listssrht-api";
       modRoot = "api";
-      vendorHash = "sha256-UeVs/+uZNtv296bzXIBio2wcg3Uzu3fBM4APzF9O0hY=";
+      vendorHash = "sha256-XKDEr8ESs9oBh7DKu2jgPEMDY99nN25inkNwU/rrza8=";
     }
     // gqlgen
   );
 in
 buildPythonPackage rec {
-  inherit src version;
+  inherit src version patches;
   pname = "listssrht";
   pyproject = true;
 
   disabled = pythonOlder "3.7";
 
-  postPatch = ''
-    substituteInPlace Makefile \
-      --replace "all: api" ""
-  '';
-
   nativeBuildInputs = [
     pip
-    setuptools
+    setuptools-scm
   ];
 
   propagatedBuildInputs = [
@@ -65,13 +62,20 @@ buildPythonPackage rec {
     emailthreads
   ];
 
-  preBuild = ''
-    export PKGVER=${version}
-    export SRHT_PATH=${srht}/${python.sitePackages}/srht
+  env = {
+    PKGVER = version;
+    SRHT_PATH = "${srht}/${python.sitePackages}/srht";
+    PREFIX = placeholder "out";
+  };
+
+  postBuild = ''
+    make SASSC_INCLUDE=-I${srht}/share/sourcehut/scss/ all-share
   '';
 
   postInstall = ''
-    ln -s ${listssrht-api}/bin/api $out/bin/listssrht-api
+    ln -s ${listssrht-api}/bin/api $out/bin/lists.sr.ht-api
+    install -Dm644 schema.sql $out/share/sourcehut/lists.sr.ht-schema.sql
+    make install-share
   '';
 
   pythonImportsCheck = [ "listssrht" ];

--- a/pkgs/applications/version-management/sourcehut/meta.nix
+++ b/pkgs/applications/version-management/sourcehut/meta.nix
@@ -16,47 +16,44 @@
   unzip,
   pip,
   pythonOlder,
-  setuptools,
+  setuptools-scm,
 }:
 let
-  version = "0.69.8";
+  version = "0.72.11";
   gqlgen = import ./fix-gqlgen-trimpath.nix {
     inherit unzip;
-    gqlgenVersion = "0.17.43";
+    gqlgenVersion = "0.17.64";
   };
+
+  patches = [ ./patches/core-go-update/meta/patch-deps.patch ];
 
   src = fetchFromSourcehut {
     owner = "~sircmpwn";
     repo = "meta.sr.ht";
     rev = version;
-    hash = "sha256-K7p6cytkPYgUuYr7BVfU/+sVbSr2YEmreIDnTatUMyk=";
+    hash = "sha256-dh+9wSQLL69xZ2Elmkyb9vEwpE7U7szz62VVS/0IM7Q=";
   };
 
   metasrht-api = buildGoModule (
     {
-      inherit src version;
+      inherit src version patches;
       pname = "metasrht-api";
       modRoot = "api";
-      vendorHash = "sha256-vIkUK1pigVU8vZL5xpHLeinOga5eXXHTuDkHxwUz6uM=";
+      vendorHash = "sha256-z4gRqI05t3m7ANyDJHmBcOCW476IG/eTfLetPRPbqtg=";
     }
     // gqlgen
   );
 in
 buildPythonPackage rec {
   pname = "metasrht";
-  inherit version src;
+  inherit version src patches;
   pyproject = true;
 
   disabled = pythonOlder "3.7";
 
-  postPatch = ''
-    substituteInPlace Makefile \
-      --replace "all: api" ""
-  '';
-
   nativeBuildInputs = [
     pip
-    setuptools
+    setuptools-scm
   ];
 
   propagatedBuildInputs = [
@@ -71,14 +68,21 @@ buildPythonPackage rec {
     zxcvbn
   ];
 
-  preBuild = ''
-    export PKGVER=${version}
-    export SRHT_PATH=${srht}/${python.sitePackages}/srht
+  env = {
+    PKGVER = version;
+    SRHT_PATH = "${srht}/${python.sitePackages}/srht";
+    PREFIX = placeholder "out";
+  };
+
+  postBuild = ''
+    make SASSC_INCLUDE=-I${srht}/share/sourcehut/scss/ all-share
   '';
 
   postInstall = ''
     mkdir -p $out/bin
-    ln -s ${metasrht-api}/bin/api $out/bin/metasrht-api
+    ln -s ${metasrht-api}/bin/api $out/bin/meta.sr.ht-api
+    install -Dm644 schema.sql $out/share/sourcehut/meta.sr.ht-schema.sql
+    make install-share
   '';
 
   pythonImportsCheck = [ "metasrht" ];

--- a/pkgs/applications/version-management/sourcehut/pages.nix
+++ b/pkgs/applications/version-management/sourcehut/pages.nix
@@ -8,25 +8,23 @@
 buildGoModule (
   rec {
     pname = "pagessrht";
-    version = "0.15.7";
+    version = "0.16.0";
 
     src = fetchFromSourcehut {
       owner = "~sircmpwn";
       repo = "pages.sr.ht";
       rev = version;
-      hash = "sha256-Lobuf12ybSO7Y4ztOLMFW0dmPFaBSEPCy4Nmh89tylI=";
+      hash = "sha256-XnKNXYzg9wuL4U2twkAspaQJZy2HWLQQQl9AITtipVU=";
     };
+
+    patches = ./patches/core-go-update/pages/patch-deps.patch;
 
     postPatch = ''
       substituteInPlace Makefile \
-        --replace "all: server" ""
-
-      # fix build failure due to unused import
-      substituteInPlace server.go \
-        --replace-warn '	"fmt"' ""
+        --replace-fail "all: server daily" ""
     '';
 
-    vendorHash = "sha256-9hpOkP6AYSZe7MW1mrwFEKq7TvVt6OcF6eHWY4jARuU=";
+    vendorHash = "sha256-klDROxNvR7lk79ptckulImVVwsAfcnKtJJAaevlZSWU=";
 
     postInstall = ''
       mkdir -p $out/share/sql/
@@ -48,6 +46,6 @@ buildGoModule (
   }
   // import ./fix-gqlgen-trimpath.nix {
     inherit unzip;
-    gqlgenVersion = "0.17.42";
+    gqlgenVersion = "0.17.64";
   }
 )

--- a/pkgs/applications/version-management/sourcehut/patches/core-go-update/builds/patch-deps.patch
+++ b/pkgs/applications/version-management/sourcehut/patches/core-go-update/builds/patch-deps.patch
@@ -1,0 +1,25 @@
+diff --git a/go.mod b/go.mod
+index 07f7c64..972b258 100644
+--- a/go.mod
++++ b/go.mod
+@@ -5,7 +5,7 @@ go 1.22.5
+ toolchain go1.24.0
+ 
+ require (
+-	git.sr.ht/~sircmpwn/core-go v0.0.0-20250304085405-cbf919e45b5b
++	git.sr.ht/~sircmpwn/core-go v0.0.0-20250311210855-6ba248d8be1b
+ 	git.sr.ht/~sircmpwn/dowork v0.0.0-20241216125407-2b00aa42322c
+ 	github.com/99designs/gqlgen v0.17.64
+ 	github.com/Masterminds/squirrel v1.5.4
+diff --git a/go.sum b/go.sum
+index aaccf89..73bfe7c 100644
+--- a/go.sum
++++ b/go.sum
+@@ -1,5 +1,7 @@
+ git.sr.ht/~sircmpwn/core-go v0.0.0-20250304085405-cbf919e45b5b h1:d76irAQODAtl5G1zmKfwf60544fyGz74YT9k+7yYVxc=
+ git.sr.ht/~sircmpwn/core-go v0.0.0-20250304085405-cbf919e45b5b/go.mod h1:UHi3kXwgfZ/DIbMu5LeqZb3KrY/jsdUDefc8+3YWC3c=
++git.sr.ht/~sircmpwn/core-go v0.0.0-20250311210855-6ba248d8be1b h1:UuQxEJrh/NNdmaVcK34opEz7ypXnPyxeRcT7Aigz+7E=
++git.sr.ht/~sircmpwn/core-go v0.0.0-20250311210855-6ba248d8be1b/go.mod h1:UHi3kXwgfZ/DIbMu5LeqZb3KrY/jsdUDefc8+3YWC3c=
+ git.sr.ht/~sircmpwn/dowork v0.0.0-20241216125407-2b00aa42322c h1:v2opuaN0C5ZpuCifRNR9ZQ8V9IG+Ja80otK1MFj5RnI=
+ git.sr.ht/~sircmpwn/dowork v0.0.0-20241216125407-2b00aa42322c/go.mod h1:8neHEO3503w/rNtttnR0JFpQgM/GFhaafVwvkPsFIDw=
+ git.sr.ht/~sircmpwn/getopt v0.0.0-20191230200459-23622cc906b3/go.mod h1:wMEGFFFNuPos7vHmWXfszqImLppbc0wEhh6JBfJIUgw=

--- a/pkgs/applications/version-management/sourcehut/patches/core-go-update/git/patch-deps.patch
+++ b/pkgs/applications/version-management/sourcehut/patches/core-go-update/git/patch-deps.patch
@@ -1,0 +1,26 @@
+diff --git a/go.mod b/go.mod
+index b1e0834..8299f9b 100644
+--- a/go.mod
++++ b/go.mod
+@@ -5,7 +5,7 @@ go 1.22.5
+ toolchain go1.24.0
+ 
+ require (
+-	git.sr.ht/~sircmpwn/core-go v0.0.0-20250304085405-cbf919e45b5b
++	git.sr.ht/~sircmpwn/core-go v0.0.0-20250311210855-6ba248d8be1b
+ 	git.sr.ht/~sircmpwn/dowork v0.0.0-20241216125407-2b00aa42322c
+ 	git.sr.ht/~sircmpwn/scm.sr.ht/srht-keys v0.0.0-20241202093706-8da5ec7e6b94
+ 	git.sr.ht/~turminal/go-fnmatch v0.0.0-20211021204744-1a55764af6de
+diff --git a/go.sum b/go.sum
+index 193cce9..9b0bda4 100644
+--- a/go.sum
++++ b/go.sum
+@@ -35,6 +35,8 @@ dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7
+ git.sr.ht/~sircmpwn/core-go v0.0.0-20240124105042-864816cfbc0c/go.mod h1:OovCpg5LsbYJjmDTpk5wUgHM4tUor736Pmxekm9BUcQ=
+ git.sr.ht/~sircmpwn/core-go v0.0.0-20250304085405-cbf919e45b5b h1:d76irAQODAtl5G1zmKfwf60544fyGz74YT9k+7yYVxc=
+ git.sr.ht/~sircmpwn/core-go v0.0.0-20250304085405-cbf919e45b5b/go.mod h1:UHi3kXwgfZ/DIbMu5LeqZb3KrY/jsdUDefc8+3YWC3c=
++git.sr.ht/~sircmpwn/core-go v0.0.0-20250311210855-6ba248d8be1b h1:UuQxEJrh/NNdmaVcK34opEz7ypXnPyxeRcT7Aigz+7E=
++git.sr.ht/~sircmpwn/core-go v0.0.0-20250311210855-6ba248d8be1b/go.mod h1:UHi3kXwgfZ/DIbMu5LeqZb3KrY/jsdUDefc8+3YWC3c=
+ git.sr.ht/~sircmpwn/dowork v0.0.0-20221010085743-46c4299d76a1/go.mod h1:8neHEO3503w/rNtttnR0JFpQgM/GFhaafVwvkPsFIDw=
+ git.sr.ht/~sircmpwn/dowork v0.0.0-20241216125407-2b00aa42322c h1:v2opuaN0C5ZpuCifRNR9ZQ8V9IG+Ja80otK1MFj5RnI=
+ git.sr.ht/~sircmpwn/dowork v0.0.0-20241216125407-2b00aa42322c/go.mod h1:8neHEO3503w/rNtttnR0JFpQgM/GFhaafVwvkPsFIDw=

--- a/pkgs/applications/version-management/sourcehut/patches/core-go-update/hg/patch-deps.patch
+++ b/pkgs/applications/version-management/sourcehut/patches/core-go-update/hg/patch-deps.patch
@@ -1,0 +1,25 @@
+diff --git a/go.mod b/go.mod
+index ba49458..3a31083 100644
+--- a/go.mod
++++ b/go.mod
+@@ -5,7 +5,7 @@ go 1.22.5
+ toolchain go1.24.0
+ 
+ require (
+-	git.sr.ht/~sircmpwn/core-go v0.0.0-20250304085405-cbf919e45b5b
++	git.sr.ht/~sircmpwn/core-go v0.0.0-20250311210855-6ba248d8be1b
+ 	git.sr.ht/~sircmpwn/dowork v0.0.0-20241216125407-2b00aa42322c
+ 	github.com/99designs/gqlgen v0.17.64
+ 	github.com/Masterminds/squirrel v1.5.4
+diff --git a/go.sum b/go.sum
+index 61766aa..e01c045 100644
+--- a/go.sum
++++ b/go.sum
+@@ -1,5 +1,7 @@
+ git.sr.ht/~sircmpwn/core-go v0.0.0-20250304085405-cbf919e45b5b h1:d76irAQODAtl5G1zmKfwf60544fyGz74YT9k+7yYVxc=
+ git.sr.ht/~sircmpwn/core-go v0.0.0-20250304085405-cbf919e45b5b/go.mod h1:UHi3kXwgfZ/DIbMu5LeqZb3KrY/jsdUDefc8+3YWC3c=
++git.sr.ht/~sircmpwn/core-go v0.0.0-20250311210855-6ba248d8be1b h1:UuQxEJrh/NNdmaVcK34opEz7ypXnPyxeRcT7Aigz+7E=
++git.sr.ht/~sircmpwn/core-go v0.0.0-20250311210855-6ba248d8be1b/go.mod h1:UHi3kXwgfZ/DIbMu5LeqZb3KrY/jsdUDefc8+3YWC3c=
+ git.sr.ht/~sircmpwn/dowork v0.0.0-20241216125407-2b00aa42322c h1:v2opuaN0C5ZpuCifRNR9ZQ8V9IG+Ja80otK1MFj5RnI=
+ git.sr.ht/~sircmpwn/dowork v0.0.0-20241216125407-2b00aa42322c/go.mod h1:8neHEO3503w/rNtttnR0JFpQgM/GFhaafVwvkPsFIDw=
+ git.sr.ht/~sircmpwn/getopt v0.0.0-20191230200459-23622cc906b3/go.mod h1:wMEGFFFNuPos7vHmWXfszqImLppbc0wEhh6JBfJIUgw=

--- a/pkgs/applications/version-management/sourcehut/patches/core-go-update/hub/patch-deps.patch
+++ b/pkgs/applications/version-management/sourcehut/patches/core-go-update/hub/patch-deps.patch
@@ -1,0 +1,25 @@
+diff --git a/go.mod b/go.mod
+index ea624d5..3674152 100644
+--- a/go.mod
++++ b/go.mod
+@@ -5,7 +5,7 @@ go 1.22.5
+ toolchain go1.24.0
+ 
+ require (
+-	git.sr.ht/~sircmpwn/core-go v0.0.0-20250304085405-cbf919e45b5b
++	git.sr.ht/~sircmpwn/core-go v0.0.0-20250311210855-6ba248d8be1b
+ 	git.sr.ht/~sircmpwn/dowork v0.0.0-20241216125407-2b00aa42322c
+ 	github.com/99designs/gqlgen v0.17.64
+ 	github.com/vektah/gqlparser/v2 v2.5.23
+diff --git a/go.sum b/go.sum
+index f67a555..a366a60 100644
+--- a/go.sum
++++ b/go.sum
+@@ -1,5 +1,7 @@
+ git.sr.ht/~sircmpwn/core-go v0.0.0-20250304085405-cbf919e45b5b h1:d76irAQODAtl5G1zmKfwf60544fyGz74YT9k+7yYVxc=
+ git.sr.ht/~sircmpwn/core-go v0.0.0-20250304085405-cbf919e45b5b/go.mod h1:UHi3kXwgfZ/DIbMu5LeqZb3KrY/jsdUDefc8+3YWC3c=
++git.sr.ht/~sircmpwn/core-go v0.0.0-20250311210855-6ba248d8be1b h1:UuQxEJrh/NNdmaVcK34opEz7ypXnPyxeRcT7Aigz+7E=
++git.sr.ht/~sircmpwn/core-go v0.0.0-20250311210855-6ba248d8be1b/go.mod h1:UHi3kXwgfZ/DIbMu5LeqZb3KrY/jsdUDefc8+3YWC3c=
+ git.sr.ht/~sircmpwn/dowork v0.0.0-20241216125407-2b00aa42322c h1:v2opuaN0C5ZpuCifRNR9ZQ8V9IG+Ja80otK1MFj5RnI=
+ git.sr.ht/~sircmpwn/dowork v0.0.0-20241216125407-2b00aa42322c/go.mod h1:8neHEO3503w/rNtttnR0JFpQgM/GFhaafVwvkPsFIDw=
+ git.sr.ht/~sircmpwn/getopt v0.0.0-20191230200459-23622cc906b3/go.mod h1:wMEGFFFNuPos7vHmWXfszqImLppbc0wEhh6JBfJIUgw=

--- a/pkgs/applications/version-management/sourcehut/patches/core-go-update/lists/patch-deps.patch
+++ b/pkgs/applications/version-management/sourcehut/patches/core-go-update/lists/patch-deps.patch
@@ -1,0 +1,26 @@
+diff --git a/go.mod b/go.mod
+index da34484..24757a0 100644
+--- a/go.mod
++++ b/go.mod
+@@ -6,7 +6,7 @@ toolchain go1.24.0
+ 
+ require (
+ 	git.sr.ht/~emersion/go-emailthreads v0.0.0-20230220165133-75c43015b6c2
+-	git.sr.ht/~sircmpwn/core-go v0.0.0-20250304085405-cbf919e45b5b
++	git.sr.ht/~sircmpwn/core-go v0.0.0-20250311210855-6ba248d8be1b
+ 	git.sr.ht/~sircmpwn/dowork v0.0.0-20241216125407-2b00aa42322c
+ 	github.com/99designs/gqlgen v0.17.64
+ 	github.com/Masterminds/squirrel v1.5.4
+diff --git a/go.sum b/go.sum
+index 4590dd5..0c49985 100644
+--- a/go.sum
++++ b/go.sum
+@@ -2,6 +2,8 @@ git.sr.ht/~emersion/go-emailthreads v0.0.0-20230220165133-75c43015b6c2 h1:5CkkRD
+ git.sr.ht/~emersion/go-emailthreads v0.0.0-20230220165133-75c43015b6c2/go.mod h1:CQUF7XpyupxjwxlNX3PHRCYL+N2COXTRRRS4MgM49R4=
+ git.sr.ht/~sircmpwn/core-go v0.0.0-20250304085405-cbf919e45b5b h1:d76irAQODAtl5G1zmKfwf60544fyGz74YT9k+7yYVxc=
+ git.sr.ht/~sircmpwn/core-go v0.0.0-20250304085405-cbf919e45b5b/go.mod h1:UHi3kXwgfZ/DIbMu5LeqZb3KrY/jsdUDefc8+3YWC3c=
++git.sr.ht/~sircmpwn/core-go v0.0.0-20250311210855-6ba248d8be1b h1:UuQxEJrh/NNdmaVcK34opEz7ypXnPyxeRcT7Aigz+7E=
++git.sr.ht/~sircmpwn/core-go v0.0.0-20250311210855-6ba248d8be1b/go.mod h1:UHi3kXwgfZ/DIbMu5LeqZb3KrY/jsdUDefc8+3YWC3c=
+ git.sr.ht/~sircmpwn/dowork v0.0.0-20241216125407-2b00aa42322c h1:v2opuaN0C5ZpuCifRNR9ZQ8V9IG+Ja80otK1MFj5RnI=
+ git.sr.ht/~sircmpwn/dowork v0.0.0-20241216125407-2b00aa42322c/go.mod h1:8neHEO3503w/rNtttnR0JFpQgM/GFhaafVwvkPsFIDw=
+ git.sr.ht/~sircmpwn/getopt v0.0.0-20191230200459-23622cc906b3/go.mod h1:wMEGFFFNuPos7vHmWXfszqImLppbc0wEhh6JBfJIUgw=

--- a/pkgs/applications/version-management/sourcehut/patches/core-go-update/man/patch-deps.patch
+++ b/pkgs/applications/version-management/sourcehut/patches/core-go-update/man/patch-deps.patch
@@ -1,0 +1,25 @@
+diff --git a/go.mod b/go.mod
+index 21c7713..8f158a2 100644
+--- a/go.mod
++++ b/go.mod
+@@ -5,7 +5,7 @@ go 1.22.5
+ toolchain go1.24.0
+ 
+ require (
+-	git.sr.ht/~sircmpwn/core-go v0.0.0-20250304085405-cbf919e45b5b
++	git.sr.ht/~sircmpwn/core-go v0.0.0-20250311210855-6ba248d8be1b
+ 	git.sr.ht/~sircmpwn/dowork v0.0.0-20241216125407-2b00aa42322c
+ 	github.com/99designs/gqlgen v0.17.64
+ 	github.com/vektah/gqlparser/v2 v2.5.23
+diff --git a/go.sum b/go.sum
+index f67a555..a366a60 100644
+--- a/go.sum
++++ b/go.sum
+@@ -1,5 +1,7 @@
+ git.sr.ht/~sircmpwn/core-go v0.0.0-20250304085405-cbf919e45b5b h1:d76irAQODAtl5G1zmKfwf60544fyGz74YT9k+7yYVxc=
+ git.sr.ht/~sircmpwn/core-go v0.0.0-20250304085405-cbf919e45b5b/go.mod h1:UHi3kXwgfZ/DIbMu5LeqZb3KrY/jsdUDefc8+3YWC3c=
++git.sr.ht/~sircmpwn/core-go v0.0.0-20250311210855-6ba248d8be1b h1:UuQxEJrh/NNdmaVcK34opEz7ypXnPyxeRcT7Aigz+7E=
++git.sr.ht/~sircmpwn/core-go v0.0.0-20250311210855-6ba248d8be1b/go.mod h1:UHi3kXwgfZ/DIbMu5LeqZb3KrY/jsdUDefc8+3YWC3c=
+ git.sr.ht/~sircmpwn/dowork v0.0.0-20241216125407-2b00aa42322c h1:v2opuaN0C5ZpuCifRNR9ZQ8V9IG+Ja80otK1MFj5RnI=
+ git.sr.ht/~sircmpwn/dowork v0.0.0-20241216125407-2b00aa42322c/go.mod h1:8neHEO3503w/rNtttnR0JFpQgM/GFhaafVwvkPsFIDw=
+ git.sr.ht/~sircmpwn/getopt v0.0.0-20191230200459-23622cc906b3/go.mod h1:wMEGFFFNuPos7vHmWXfszqImLppbc0wEhh6JBfJIUgw=

--- a/pkgs/applications/version-management/sourcehut/patches/core-go-update/meta/patch-deps.patch
+++ b/pkgs/applications/version-management/sourcehut/patches/core-go-update/meta/patch-deps.patch
@@ -1,0 +1,26 @@
+diff --git a/go.mod b/go.mod
+index 463f022..a7dc400 100644
+--- a/go.mod
++++ b/go.mod
+@@ -8,7 +8,7 @@ require (
+ 	git.sr.ht/~emersion/go-oauth2 v0.0.0-20240217160856-2e0d6e20b088
+ 	git.sr.ht/~emersion/gqlclient v0.0.0-20230820050442-8873fe0204b9
+ 	git.sr.ht/~sircmpwn/abused v0.0.0-20240216134550-21e8606c6f89
+-	git.sr.ht/~sircmpwn/core-go v0.0.0-20250311090327-1e3cd785af1e
++	git.sr.ht/~sircmpwn/core-go v0.0.0-20250311210855-6ba248d8be1b
+ 	git.sr.ht/~sircmpwn/dowork v0.0.0-20241216125407-2b00aa42322c
+ 	github.com/99designs/gqlgen v0.17.64
+ 	github.com/Masterminds/squirrel v1.5.4
+diff --git a/go.sum b/go.sum
+index 9c08b1a..abf1a58 100644
+--- a/go.sum
++++ b/go.sum
+@@ -6,6 +6,8 @@ git.sr.ht/~sircmpwn/abused v0.0.0-20240216134550-21e8606c6f89 h1:usW1i77LjfTfNzX
+ git.sr.ht/~sircmpwn/abused v0.0.0-20240216134550-21e8606c6f89/go.mod h1:A+FTCDOSRA0naGMcM9OenO7kMhBxj+Kbd+4nBpg6NO4=
+ git.sr.ht/~sircmpwn/core-go v0.0.0-20250311090327-1e3cd785af1e h1:epi/OdTKtazVbHHn1Qunx+nSHt96+xBBiNgs+SgRGwo=
+ git.sr.ht/~sircmpwn/core-go v0.0.0-20250311090327-1e3cd785af1e/go.mod h1:UHi3kXwgfZ/DIbMu5LeqZb3KrY/jsdUDefc8+3YWC3c=
++git.sr.ht/~sircmpwn/core-go v0.0.0-20250311210855-6ba248d8be1b h1:UuQxEJrh/NNdmaVcK34opEz7ypXnPyxeRcT7Aigz+7E=
++git.sr.ht/~sircmpwn/core-go v0.0.0-20250311210855-6ba248d8be1b/go.mod h1:UHi3kXwgfZ/DIbMu5LeqZb3KrY/jsdUDefc8+3YWC3c=
+ git.sr.ht/~sircmpwn/dowork v0.0.0-20241216125407-2b00aa42322c h1:v2opuaN0C5ZpuCifRNR9ZQ8V9IG+Ja80otK1MFj5RnI=
+ git.sr.ht/~sircmpwn/dowork v0.0.0-20241216125407-2b00aa42322c/go.mod h1:8neHEO3503w/rNtttnR0JFpQgM/GFhaafVwvkPsFIDw=
+ git.sr.ht/~sircmpwn/getopt v0.0.0-20191230200459-23622cc906b3/go.mod h1:wMEGFFFNuPos7vHmWXfszqImLppbc0wEhh6JBfJIUgw=

--- a/pkgs/applications/version-management/sourcehut/patches/core-go-update/pages/patch-deps.patch
+++ b/pkgs/applications/version-management/sourcehut/patches/core-go-update/pages/patch-deps.patch
@@ -1,0 +1,25 @@
+diff --git a/go.mod b/go.mod
+index 67aa15c..baffe8e 100644
+--- a/go.mod
++++ b/go.mod
+@@ -6,7 +6,7 @@ toolchain go1.24.0
+ 
+ require (
+ 	git.sr.ht/~adnano/go-gemini v0.2.3
+-	git.sr.ht/~sircmpwn/core-go v0.0.0-20250326085317-29a3ebfee9d0
++	git.sr.ht/~sircmpwn/core-go v0.0.0-20250311210855-6ba248d8be1b
+ 	git.sr.ht/~sircmpwn/dowork v0.0.0-20241216125407-2b00aa42322c
+ 	github.com/99designs/gqlgen v0.17.64
+ 	github.com/CAFxX/httpcompression v0.0.9
+diff --git a/go.sum b/go.sum
+index ccd1f94..0945505 100644
+--- a/go.sum
++++ b/go.sum
+@@ -1,5 +1,7 @@
+ git.sr.ht/~adnano/go-gemini v0.2.3 h1:oJ+Y0/mheZ4Vg0ABjtf5dlmvq1yoONStiaQvmWWkofc=
+ git.sr.ht/~adnano/go-gemini v0.2.3/go.mod h1:hQ75Y0i5jSFL+FQ7AzWVAYr5LQsaFC7v3ZviNyj46dY=
++git.sr.ht/~sircmpwn/core-go v0.0.0-20250311210855-6ba248d8be1b h1:UuQxEJrh/NNdmaVcK34opEz7ypXnPyxeRcT7Aigz+7E=
++git.sr.ht/~sircmpwn/core-go v0.0.0-20250311210855-6ba248d8be1b/go.mod h1:UHi3kXwgfZ/DIbMu5LeqZb3KrY/jsdUDefc8+3YWC3c=
+ git.sr.ht/~sircmpwn/core-go v0.0.0-20250326085317-29a3ebfee9d0 h1:jFSTrW57GbcDoW850vw95zg0pLS1pe+cD5JtAQJ54ho=
+ git.sr.ht/~sircmpwn/core-go v0.0.0-20250326085317-29a3ebfee9d0/go.mod h1:UHi3kXwgfZ/DIbMu5LeqZb3KrY/jsdUDefc8+3YWC3c=
+ git.sr.ht/~sircmpwn/dowork v0.0.0-20241216125407-2b00aa42322c h1:v2opuaN0C5ZpuCifRNR9ZQ8V9IG+Ja80otK1MFj5RnI=

--- a/pkgs/applications/version-management/sourcehut/patches/core-go-update/paste/patch-deps.patch
+++ b/pkgs/applications/version-management/sourcehut/patches/core-go-update/paste/patch-deps.patch
@@ -1,0 +1,25 @@
+diff --git a/go.mod b/go.mod
+index bc39fc4..bd01e53 100644
+--- a/go.mod
++++ b/go.mod
+@@ -5,7 +5,7 @@ go 1.22.5
+ toolchain go1.24.0
+ 
+ require (
+-	git.sr.ht/~sircmpwn/core-go v0.0.0-20250304085405-cbf919e45b5b
++	git.sr.ht/~sircmpwn/core-go v0.0.0-20250311210855-6ba248d8be1b
+ 	git.sr.ht/~sircmpwn/dowork v0.0.0-20241216125407-2b00aa42322c
+ 	github.com/99designs/gqlgen v0.17.64
+ 	github.com/Masterminds/squirrel v1.5.4
+diff --git a/go.sum b/go.sum
+index 61766aa..e01c045 100644
+--- a/go.sum
++++ b/go.sum
+@@ -1,5 +1,7 @@
+ git.sr.ht/~sircmpwn/core-go v0.0.0-20250304085405-cbf919e45b5b h1:d76irAQODAtl5G1zmKfwf60544fyGz74YT9k+7yYVxc=
+ git.sr.ht/~sircmpwn/core-go v0.0.0-20250304085405-cbf919e45b5b/go.mod h1:UHi3kXwgfZ/DIbMu5LeqZb3KrY/jsdUDefc8+3YWC3c=
++git.sr.ht/~sircmpwn/core-go v0.0.0-20250311210855-6ba248d8be1b h1:UuQxEJrh/NNdmaVcK34opEz7ypXnPyxeRcT7Aigz+7E=
++git.sr.ht/~sircmpwn/core-go v0.0.0-20250311210855-6ba248d8be1b/go.mod h1:UHi3kXwgfZ/DIbMu5LeqZb3KrY/jsdUDefc8+3YWC3c=
+ git.sr.ht/~sircmpwn/dowork v0.0.0-20241216125407-2b00aa42322c h1:v2opuaN0C5ZpuCifRNR9ZQ8V9IG+Ja80otK1MFj5RnI=
+ git.sr.ht/~sircmpwn/dowork v0.0.0-20241216125407-2b00aa42322c/go.mod h1:8neHEO3503w/rNtttnR0JFpQgM/GFhaafVwvkPsFIDw=
+ git.sr.ht/~sircmpwn/getopt v0.0.0-20191230200459-23622cc906b3/go.mod h1:wMEGFFFNuPos7vHmWXfszqImLppbc0wEhh6JBfJIUgw=

--- a/pkgs/applications/version-management/sourcehut/patches/core-go-update/todo/patch-deps.patch
+++ b/pkgs/applications/version-management/sourcehut/patches/core-go-update/todo/patch-deps.patch
@@ -1,0 +1,25 @@
+diff --git a/go.mod b/go.mod
+index a352cfd..ab4beae 100644
+--- a/go.mod
++++ b/go.mod
+@@ -5,7 +5,7 @@ go 1.22.5
+ toolchain go1.24.0
+ 
+ require (
+-	git.sr.ht/~sircmpwn/core-go v0.0.0-20250306104433-8e729e7539f4
++	git.sr.ht/~sircmpwn/core-go v0.0.0-20250311210855-6ba248d8be1b
+ 	git.sr.ht/~sircmpwn/dowork v0.0.0-20241216125407-2b00aa42322c
+ 	github.com/99designs/gqlgen v0.17.64
+ 	github.com/Masterminds/squirrel v1.5.4
+diff --git a/go.sum b/go.sum
+index 5342a85..50c87f1 100644
+--- a/go.sum
++++ b/go.sum
+@@ -1,5 +1,7 @@
+ git.sr.ht/~sircmpwn/core-go v0.0.0-20250306104433-8e729e7539f4 h1:LvEcAyN0YDwqsa7QkFXne0bQEWAod6jAI2VIc+kk5sk=
+ git.sr.ht/~sircmpwn/core-go v0.0.0-20250306104433-8e729e7539f4/go.mod h1:UHi3kXwgfZ/DIbMu5LeqZb3KrY/jsdUDefc8+3YWC3c=
++git.sr.ht/~sircmpwn/core-go v0.0.0-20250311210855-6ba248d8be1b h1:UuQxEJrh/NNdmaVcK34opEz7ypXnPyxeRcT7Aigz+7E=
++git.sr.ht/~sircmpwn/core-go v0.0.0-20250311210855-6ba248d8be1b/go.mod h1:UHi3kXwgfZ/DIbMu5LeqZb3KrY/jsdUDefc8+3YWC3c=
+ git.sr.ht/~sircmpwn/dowork v0.0.0-20241216125407-2b00aa42322c h1:v2opuaN0C5ZpuCifRNR9ZQ8V9IG+Ja80otK1MFj5RnI=
+ git.sr.ht/~sircmpwn/dowork v0.0.0-20241216125407-2b00aa42322c/go.mod h1:8neHEO3503w/rNtttnR0JFpQgM/GFhaafVwvkPsFIDw=
+ git.sr.ht/~sircmpwn/getopt v0.0.0-20191230200459-23622cc906b3/go.mod h1:wMEGFFFNuPos7vHmWXfszqImLppbc0wEhh6JBfJIUgw=

--- a/pkgs/applications/version-management/sourcehut/patches/redis-socket/core/0001-Fix-Unix-socket-support-in-RedisQueueCollector.patch
+++ b/pkgs/applications/version-management/sourcehut/patches/redis-socket/core/0001-Fix-Unix-socket-support-in-RedisQueueCollector.patch
@@ -23,16 +23,17 @@ diff --git a/srht/metrics.py b/srht/metrics.py
 index 68caf8e..2df5777 100644
 --- a/srht/metrics.py
 +++ b/srht/metrics.py
-@@ -1,11 +1,12 @@
+@@ -1,12 +1,12 @@
  import time
 +from celery import Celery
  from prometheus_client.metrics_core import GaugeMetricFamily
- from redis import Redis, ResponseError
+ from redis import ResponseError
+-from srht.redis import from_url
  
  
  class RedisQueueCollector:
      def __init__(self, broker, name, documentation, queue_name="celery"):
--        self.redis = Redis.from_url(broker)
+-        self.redis = from_url(broker)
 +        self.redis = Celery("collector", broker=broker).connection_for_read().channel().client
          self.queue_name = queue_name
          self.name = name

--- a/pkgs/applications/version-management/sourcehut/scm.nix
+++ b/pkgs/applications/version-management/sourcehut/scm.nix
@@ -6,12 +6,12 @@
   pyyaml,
   buildsrht,
   pythonOlder,
-  setuptools,
+  setuptools-scm,
 }:
 
 buildPythonPackage rec {
   pname = "scmsrht";
-  version = "0.22.24";
+  version = "0.22.28";
   pyproject = true;
 
   disabled = pythonOlder "3.7";
@@ -20,11 +20,11 @@ buildPythonPackage rec {
     owner = "~sircmpwn";
     repo = "scm.sr.ht";
     rev = version;
-    hash = "sha256-9IgMmYzInfrten7z8bznlSFJlUjHf3k3z76lkP6tP50=";
+    hash = "sha256-+zxqiz5yPpgTwAw7w8GqJFb3OCcJEH/UhS5u2Xs7pzo=";
   };
 
   nativeBuildInputs = [
-    setuptools
+    setuptools-scm
   ];
 
   propagatedBuildInputs = [
@@ -33,9 +33,7 @@ buildPythonPackage rec {
     buildsrht
   ];
 
-  preBuild = ''
-    export PKGVER=${version}
-  '';
+  env.PKGVER = version;
 
   pythonImportsCheck = [ "scmsrht" ];
 

--- a/pkgs/by-name/sr/srht-gen-oauth-tok/fix-html-parsing.patch
+++ b/pkgs/by-name/sr/srht-gen-oauth-tok/fix-html-parsing.patch
@@ -1,0 +1,16 @@
+diff --git a/srht-gen-oauth-tok b/srht-gen-oauth-tok
+index a05e209..f2949b5 100755
+--- a/srht-gen-oauth-tok
++++ b/srht-gen-oauth-tok
+@@ -78,7 +78,10 @@ $mech->submit_form( with_fields => { comment => $tok_comment } );
+ 
+ # Parse the response as XML and find the access token via an XPath expression
+ my $xpc = XML::LibXML::XPathContext->new(
+-    XML::LibXML->load_xml(string => $mech->content())
++    XML::LibXML->load_html(
++        string => $mech->content(),
++        recover => 1,
++    )
+ );
+ # The token is set as the description (<dd>) of a 'Personal Access Token' term (<dt>)
+ my $token = $xpc->find("//dt[text() = 'Personal Access Token']/following-sibling::dd/*/node()");

--- a/pkgs/by-name/sr/srht-gen-oauth-tok/package.nix
+++ b/pkgs/by-name/sr/srht-gen-oauth-tok/package.nix
@@ -25,6 +25,8 @@ stdenv.mkDerivation rec {
     hash = "sha256-GcqP3XbVw2sR5n4+aLUmA4fthNkuVAGnhV1h7suJYdI=";
   };
 
+  patches = [ ./fix-html-parsing.patch ];
+
   buildInputs = [ perl ];
   nativeBuildInputs = [ perl ];
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Update all sourcehut packages to the latest version. This unbreaks them due to the previous versions being incompatible with go 1.24. Due to the breaking changes, the module had to also be adapted. Further changes are probably needed but this is enough for both tests to pass.

ZHF: #403336

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
