### PR TITLE
python312Packages.biothings-client: fix build

### DIFF
--- a/pkgs/development/python-modules/biothings-client/default.nix
+++ b/pkgs/development/python-modules/biothings-client/default.nix
@@ -3,8 +3,9 @@
   buildPythonPackage,
   fetchFromGitHub,
   setuptools,
+  httpx,
   pytestCheckHook,
-  requests,
+  pytest-asyncio,
 }:
 buildPythonPackage rec {
   pname = "biothings-client";
@@ -19,15 +20,24 @@ buildPythonPackage rec {
   };
 
   build-system = [ setuptools ];
-  dependencies = [ requests ];
+  dependencies = [ httpx ];
   pythonImportsCheck = [ "biothings_client" ];
-  nativeCheckInputs = [ pytestCheckHook ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    pytest-asyncio
+  ];
 
   pytestFlagsArray = [
     # All other tests make network requests to exercise the API
-    "tests/gene.py::TestGeneClient::test_http"
-    "tests/test.py::TestBiothingsClient::test_generate_settings_from_url"
-    "tests/variant.py::TestVariantClient::test_format_hgvs"
+    "tests/test_async.py::test_generate_async_settings"
+    "tests/test_async.py::test_url_protocol"
+    "tests/test_async.py::test_async_client_proxy_discovery"
+    "tests/test_async_variant.py::test_format_hgvs"
+    "tests/test_sync.py::test_generate_settings"
+    "tests/test_sync.py::test_url_protocol"
+    "tests/test_sync.py::test_client_proxy_discovery"
+    "tests/test_variant.py::test_format_hgvs"
   ];
 
   meta = {


### PR DESCRIPTION
Hydra: https://hydra.nixos.org/build/294877815/nixlog/2

- Tests changed, `requests` was replaced with `httpx`.

ZHF: https://github.com/NixOS/nixpkgs/issues/403336

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
