### PR TITLE
lux-cli: init at 0.3.14, luaPackages.lux-lua: init at 0.1.0

### DIFF
--- a/pkgs/by-name/lu/lux-cli/package.nix
+++ b/pkgs/by-name/lu/lux-cli/package.nix
@@ -1,0 +1,111 @@
+{
+  fetchFromGitHub,
+  gnupg,
+  gpgme,
+  installShellFiles,
+  lib,
+  libgit2,
+  libgpg-error,
+  lua51Packages,
+  lua52Packages,
+  lua53Packages,
+  lua54Packages,
+  luajit,
+  makeWrapper,
+  nix,
+  openssl,
+  pkg-config,
+  rustPlatform,
+  symlinkJoin,
+  versionCheckHook,
+}:
+let
+  lux-lua-bundle = symlinkJoin {
+    name = "lux-lua-bundle";
+    paths = [
+      lua51Packages.lux-lua
+      lua52Packages.lux-lua
+      lua53Packages.lux-lua
+      lua54Packages.lux-lua
+    ];
+  };
+in
+rustPlatform.buildRustPackage rec {
+  pname = "lux-cli";
+
+  version = "0.3.14";
+
+  src = fetchFromGitHub {
+    owner = "nvim-neorocks";
+    repo = "lux";
+    tag = "v${version}";
+    hash = "sha256-gkUj3eeN0GnHM5sN4SKM/nHeBKe9ifrkg8TZRvA7FlM=";
+  };
+
+  buildAndTestSubdir = "lux-cli";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-2bFVF4X4OpWwbxAjTr0orCLQNHKSO/koyeTXtD6d76M=";
+
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+  versionCheckProgram = "${placeholder "out"}/bin/${meta.mainProgram}";
+  versionCheckProgramArg = "--version";
+  doInstallCheck = true;
+
+  nativeBuildInputs = [
+    installShellFiles
+    makeWrapper
+    pkg-config
+  ];
+
+  buildInputs = [
+    gnupg
+    gpgme
+    libgit2
+    libgpg-error
+    luajit
+    openssl
+  ];
+
+  env = {
+    LIBGIT2_NO_VENDOR = 1;
+    LIBSSH2_SYS_USE_PKG_CONFIG = 1;
+    LUX_SKIP_IMPURE_TESTS = 1; # Disable impure unit tests
+  };
+
+  cargoTestFlags = "--lib"; # Disable impure integration tests
+
+  nativeCheckInputs = [
+    luajit
+    nix
+  ];
+
+  postBuild = ''
+    cargo xtask dist-man
+    cargo xtask dist-completions
+  '';
+
+  postFixup = ''
+    # Instruct Lux to search for the lux-specific shared libraries in the lux-lua bundle
+    # (temporary solution, until https://github.com/nvim-neorocks/lux/issues/655 is implemented)
+    wrapProgram $out/bin/lx --set LUX_LIB_DIR "${lux-lua-bundle}"
+  '';
+
+  meta = {
+    description = "Luxurious package manager for Lua";
+    longDescription = ''
+      A modern package manager for Lua.
+      compatible with luarocks.org and the Rockspec specification,
+      with first-class support for Nix and Neovim.
+    '';
+    homepage = "https://nvim-neorocks.github.io/";
+    changelog = "https://github.com/nvim-neorocks/lux/blob/${src.tag}/CHANGELOG.md";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
+      mrcjkb
+    ];
+    platforms = lib.platforms.all;
+    mainProgram = "lx";
+  };
+}

--- a/pkgs/by-name/lu/lux-cli/package.nix
+++ b/pkgs/by-name/lu/lux-cli/package.nix
@@ -1,5 +1,4 @@
 {
-  fetchFromGitHub,
   gnupg,
   gpgme,
   installShellFiles,
@@ -35,16 +34,11 @@ rustPlatform.buildRustPackage rec {
 
   version = "0.3.14";
 
-  src = fetchFromGitHub {
-    owner = "nvim-neorocks";
-    repo = "lux";
-    tag = "v${version}";
-    hash = "sha256-gkUj3eeN0GnHM5sN4SKM/nHeBKe9ifrkg8TZRvA7FlM=";
-  };
+  src = lua52Packages.lux-lua.src;
 
   buildAndTestSubdir = "lux-cli";
   useFetchCargoVendor = true;
-  cargoHash = "sha256-2bFVF4X4OpWwbxAjTr0orCLQNHKSO/koyeTXtD6d76M=";
+  cargoHash = lua52Packages.lux-lua.cargoHash;
 
   nativeInstallCheckInputs = [
     versionCheckHook

--- a/pkgs/development/lua-modules/lux-lua.nix
+++ b/pkgs/development/lua-modules/lux-lua.nix
@@ -1,0 +1,90 @@
+{
+  fetchFromGitHub,
+  gnupg,
+  gpgme,
+  isLuaJIT,
+  lib,
+  libgit2,
+  libgpg-error,
+  lua,
+  nix,
+  openssl,
+  pkg-config,
+  rustPlatform,
+  stdenv,
+}:
+let
+  luaMajorMinor = lib.take 2 (lib.splitVersion lua.version);
+  luaVersionDir = if isLuaJIT then "jit" else lib.concatStringsSep "." luaMajorMinor;
+  luaFeature = if isLuaJIT then "luajit" else "lua${lib.concatStringsSep "" luaMajorMinor}";
+in
+rustPlatform.buildRustPackage rec {
+  pname = "lux-lua";
+
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "nvim-neorocks";
+    repo = "lux";
+    # NOTE: Lux's tags represent the lux-cli version, which may differ from the lux-lua version
+    tag = "v0.3.14";
+    hash = "sha256-gkUj3eeN0GnHM5sN4SKM/nHeBKe9ifrkg8TZRvA7FlM=";
+  };
+
+  buildAndTestSubdir = "lux-lua";
+  buildNoDefaultFeatures = true;
+  buildFeatures = [ luaFeature ];
+
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-2bFVF4X4OpWwbxAjTr0orCLQNHKSO/koyeTXtD6d76M=";
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  buildInputs = [
+    gnupg
+    gpgme
+    libgit2
+    libgpg-error
+    lua
+    openssl
+  ];
+
+  # lux-lua checks are broken right now (https://github.com/nvim-neorocks/lux/pull/616)
+  doCheck = false;
+  useNextest = true;
+  nativeCheckInputs = [
+    lua
+    nix
+  ];
+
+  env = {
+    LIBGIT2_NO_VENDOR = 1;
+    LIBSSH2_SYS_USE_PKG_CONFIG = 1;
+    LUX_SKIP_IMPURE_TESTS = 1; # Disable impure unit tests
+  };
+
+  installPhase =
+    let
+      libExt = stdenv.hostPlatform.extensions.sharedLibrary;
+    in
+    ''
+      mkdir -p $out/${luaVersionDir}
+      ls target/release
+      install -T -v target/*/release/liblux_lua${libExt} $out/${luaVersionDir}/lux.so
+    '';
+
+  cargoTestFlags = "--lib"; # Disable impure integration tests
+
+  meta = {
+    description = "Lua API for the Lux package manager";
+    homepage = "https://nvim-neorocks.github.io/";
+    changelog = "https://github.com/nvim-neorocks/lux/blob/${src.tag}/CHANGELOG.md";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
+      mrcjkb
+    ];
+    platforms = lib.platforms.all;
+  };
+}

--- a/pkgs/development/lua-modules/overrides.nix
+++ b/pkgs/development/lua-modules/overrides.nix
@@ -711,6 +711,8 @@ in
     };
   });
 
+  lux-lua = final.callPackage ./lux-lua.nix { inherit lua; };
+
   lz-n = prev.lz-n.overrideAttrs (oa: {
     doCheck = lua.luaversion == "5.1";
     nativeCheckInputs = [


### PR DESCRIPTION
This PR adds the Lux package manager for Lua, along with its Lua API.

See:

- https://github.com/nvim-neorocks/lux
- https://nvim-neorocks.github.io/

cc @NixOS/neovim @NixOS/lua 

We might want to get a review by someone who is familiar with `rustPlatform`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
