### PR TITLE
python3Packages.langchain*:  automated bulk update

### DIFF
--- a/pkgs/development/python-modules/langchain-core/default.nix
+++ b/pkgs/development/python-modules/langchain-core/default.nix
@@ -33,14 +33,14 @@
 
 buildPythonPackage rec {
   pname = "langchain-core";
-  version = "0.3.56";
+  version = "0.3.58";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "langchain-ai";
     repo = "langchain";
     tag = "langchain-core==${version}";
-    hash = "sha256-gsjYr22Phb71oKN4iVGsi6r1iETDhFHCKKOiwp0SuLU=";
+    hash = "sha256-tyDlWYoqxx6/+uzauA9IZE2boyXJOm604EMKAutE4rU=";
   };
 
   sourceRoot = "${src.name}/libs/core";

--- a/pkgs/development/python-modules/langchain-ollama/default.nix
+++ b/pkgs/development/python-modules/langchain-ollama/default.nix
@@ -22,14 +22,14 @@
 
 buildPythonPackage rec {
   pname = "langchain-ollama";
-  version = "0.3.1";
+  version = "0.3.2";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "langchain-ai";
     repo = "langchain";
     tag = "langchain-ollama==${version}";
-    hash = "sha256-nKLz9eCGaonECmr3Uby3j4ul5jQZaqUH3PD20z/JKek=";
+    hash = "sha256-GRaWwUR26yZqjtO5f5p8abj/4KSrQE2uGAECGjeDxPY=";
   };
 
   sourceRoot = "${src.name}/libs/partners/ollama";
@@ -64,7 +64,7 @@ buildPythonPackage rec {
   passthru.updateScript = nix-update-script {
     extraArgs = [
       "--version-regex"
-      "langchain-ollama==(.*)"
+      "langchain-ollama==([0-9.]+)"
     ];
   };
 

--- a/pkgs/development/python-modules/langchain-openai/default.nix
+++ b/pkgs/development/python-modules/langchain-openai/default.nix
@@ -29,14 +29,14 @@
 
 buildPythonPackage rec {
   pname = "langchain-openai";
-  version = "0.3.12";
+  version = "0.3.16";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "langchain-ai";
     repo = "langchain";
     tag = "langchain-openai==${version}";
-    hash = "sha256-pIXdXGrYOoE8sF+cKpX82QfTaYna8kbzUv0n+yR7uHE=";
+    hash = "sha256-e8y5rL+OUFOAPfXTC+XHn/wVfsecPInsS8hBxm1USAw=";
   };
 
   sourceRoot = "${src.name}/libs/partners/openai";
@@ -88,6 +88,7 @@ buildPythonPackage rec {
     "test_azure_openai_uses_actual_secret_value_from_secretstr"
     "test_azure_serialized_secrets"
     "test_chat_openai_get_num_tokens"
+    "test_embed_documents_with_custom_chunk_size"
     "test_get_num_tokens_from_messages"
     "test_get_token_ids"
     "test_init_o1"
@@ -99,7 +100,7 @@ buildPythonPackage rec {
   passthru.updateScript = nix-update-script {
     extraArgs = [
       "--version-regex"
-      "^langchain-openai==([0-9.]+)$"
+      "langchain-openai==([0-9.]+)"
     ];
   };
 

--- a/pkgs/development/python-modules/langchain-tests/default.nix
+++ b/pkgs/development/python-modules/langchain-tests/default.nix
@@ -19,18 +19,21 @@
   pytest-asyncio,
   pytest-socket,
   pytestCheckHook,
+
+  # passthru
+  nix-update-script,
 }:
 
 buildPythonPackage rec {
   pname = "langchain-tests";
-  version = "0.3.17";
+  version = "0.3.19";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "langchain-ai";
     repo = "langchain";
     tag = "langchain-tests==${version}";
-    hash = "sha256-jhdCpZsRvCxDIfaZpdqAdx+rxJTU6QHDgNKc4w7XmR8=";
+    hash = "sha256-DSTngWRFseJ6kSAY7Lxxkh77QFr0jhHxG3mH89QmdxA=";
   };
 
   sourceRoot = "${src.name}/libs/standard-tests";
@@ -62,7 +65,12 @@ buildPythonPackage rec {
   ];
 
   passthru = {
-    inherit (langchain-core) updateScript;
+    passthru.updateScript = nix-update-script {
+      extraArgs = [
+        "--version-regex"
+        "langchain-tests==([0-9.]+)"
+      ];
+    };
   };
 
   meta = {

--- a/pkgs/development/python-modules/langchain-text-splitters/default.nix
+++ b/pkgs/development/python-modules/langchain-text-splitters/default.nix
@@ -18,14 +18,14 @@
 
 buildPythonPackage rec {
   pname = "langchain-text-splitters";
-  version = "0.3.7";
+  version = "0.3.8";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "langchain-ai";
     repo = "langchain";
     tag = "langchain-text-splitters==${version}";
-    hash = "sha256-tIX1nxmXU3xhJuM2Q3Tm4fbCoJwI0A8+G1aSyLcoNo0=";
+    hash = "sha256-Ia3ZZ94uLZUVr1/w4HLPZLM6u8leA4OJtAwUf7eSAE0=";
   };
 
   sourceRoot = "${src.name}/libs/text-splitters";
@@ -53,7 +53,7 @@ buildPythonPackage rec {
   passthru.updateScript = nix-update-script {
     extraArgs = [
       "--version-regex"
-      "^langchain-test-splitters==([0-9.]+)$"
+      "langchain-test-splitters==([0-9.]+)"
     ];
   };
 


### PR DESCRIPTION
Automated update per custom script. Also manual fixes to passthru.updateScript regexes.

* python3Packages.langchain-core: 0.3.56 -> 0.3.58 [diff](https://github.com/langchain-ai/langchain/compare/langchain-core%3D%3D0.3.56...langchain-core%3D%3D0.3.58)
* python3Packages.langchain-ollama: 0.3.1 -> 0.3.2 [diff](https://github.com/langchain-ai/langchain/compare/langchain-ollama%3D%3D0.3.1...langchain-ollama%3D%3D0.3.2)
* python3Packages.langchain-openai: 0.3.12 -> 0.3.16 [diff](https://github.com/langchain-ai/langchain/compare/langchain-openai%3D%3D0.3.12...langchain-openai%3D%3D0.3.16)
* python3Packages.langchain-tests: 0.3.17 -> 0.3.19 [diff](https://github.com/langchain-ai/langchain/compare/langchain-tests%3D%3D0.3.17...langchain-tests%3D%3D0.3.19)
* python3Packages.langchain-text-splitters: 0.3.7 -> 0.3.8 [diff](https://github.com/langchain-ai/langchain/compare/langchain-text-splitters%3D%3D0.3.7...langchain-text-splitters%253D%253D0.3.8)

EDIT: Dropped `langchain-chroma` update due to a broken build on Python313 on Darwin. Will update later.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [x] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
