### PR TITLE
lib/cli: add toCommandLine

### DIFF
--- a/doc/release-notes/rl-2511.section.md
+++ b/doc/release-notes/rl-2511.section.md
@@ -360,3 +360,5 @@
   See the neovim help page [`:help startup`](https://neovim.io/doc/user/starting.html#startup) for more information, as well as [the nixpkgs neovim wrapper documentation](#neovim-custom-configuration).
 
 - `cloudflare-ddns`: Added package cloudflare-ddns.
+
+- `lib.cli.toCommandLine`, `lib.cli.toCommandLineShell`, `lib.cli.toCommandLineGNU` and `lib.cli.toCommandLineShellGNU` have been added to address multiple issues in `lib.cli.toGNUCommandLine` and `lib.cli.toGNUCommandLineShell`.

--- a/doc/release-notes/rl-2511.section.md
+++ b/doc/release-notes/rl-2511.section.md
@@ -353,6 +353,8 @@
   - `number`
   - `numbers.*`
 
+- `lib.cli.toGNUCommandLine` and `lib.cli.toGNUCommandLineShell` have been deprecated in favor of `lib.cli.toCommandLine`, `lib.cli.toCommandLineShell`, `lib.cli.toCommandLineGNU` and `lib.cli.toCommandLineShellGNU`.
+
 ### Additions and Improvements {#sec-nixpkgs-release-25.11-lib-additions-improvements}
 
 - `neovim`: Added support for the `vim.o.exrc` option, the `VIMINIT` environment variable, and sourcing of `sysinit.vim`.

--- a/lib/cli.nix
+++ b/lib/cli.nix
@@ -40,7 +40,9 @@
     :::
   */
   toGNUCommandLineShell =
-    options: attrs: lib.escapeShellArgs (lib.cli.toGNUCommandLine options attrs);
+    lib.warnIf (lib.oldestSupportedReleaseIsAtLeast 2511)
+      "lib.cli.toGNUCommandLineShell is deprecated, please use lib.cli.toCommandLineShell or lib.cli.toCommandLineShellGNU instead."
+      (options: attrs: lib.escapeShellArgs (lib.cli.toGNUCommandLine options attrs));
 
   /**
     Automatically convert an attribute set to a list of command-line options.
@@ -114,40 +116,44 @@
     :::
   */
   toGNUCommandLine =
-    {
-      mkOptionName ? k: if builtins.stringLength k == 1 then "-${k}" else "--${k}",
+    lib.warnIf (lib.oldestSupportedReleaseIsAtLeast 2511)
+      "lib.cli.toGNUCommandLine is deprecated, please use lib.cli.toCommandLine or lib.cli.toCommandLineShellGNU instead."
+      (
+        {
+          mkOptionName ? k: if builtins.stringLength k == 1 then "-${k}" else "--${k}",
 
-      mkBool ? k: v: lib.optional v (mkOptionName k),
+          mkBool ? k: v: lib.optional v (mkOptionName k),
 
-      mkList ? k: v: lib.concatMap (mkOption k) v,
+          mkList ? k: v: lib.concatMap (mkOption k) v,
 
-      mkOption ?
-        k: v:
-        if v == null then
-          [ ]
-        else if optionValueSeparator == null then
-          [
-            (mkOptionName k)
-            (lib.generators.mkValueStringDefault { } v)
-          ]
-        else
-          [ "${mkOptionName k}${optionValueSeparator}${lib.generators.mkValueStringDefault { } v}" ],
+          mkOption ?
+            k: v:
+            if v == null then
+              [ ]
+            else if optionValueSeparator == null then
+              [
+                (mkOptionName k)
+                (lib.generators.mkValueStringDefault { } v)
+              ]
+            else
+              [ "${mkOptionName k}${optionValueSeparator}${lib.generators.mkValueStringDefault { } v}" ],
 
-      optionValueSeparator ? null,
-    }:
-    options:
-    let
-      render =
-        k: v:
-        if builtins.isBool v then
-          mkBool k v
-        else if builtins.isList v then
-          mkList k v
-        else
-          mkOption k v;
+          optionValueSeparator ? null,
+        }:
+        options:
+        let
+          render =
+            k: v:
+            if builtins.isBool v then
+              mkBool k v
+            else if builtins.isList v then
+              mkList k v
+            else
+              mkOption k v;
 
-    in
-    builtins.concatLists (lib.mapAttrsToList render options);
+        in
+        builtins.concatLists (lib.mapAttrsToList render options)
+      );
 
   /**
     Converts the given attributes into a single shell-escaped command-line string.

--- a/lib/cli.nix
+++ b/lib/cli.nix
@@ -1,6 +1,6 @@
 { lib }:
 
-rec {
+{
   /**
     Automatically convert an attribute set to command-line options.
 
@@ -20,6 +20,7 @@ rec {
     : The attributes to transform into arguments.
 
     # Examples
+
     :::{.example}
     ## `lib.cli.toGNUCommandLineShell` usage example
 
@@ -38,7 +39,8 @@ rec {
 
     :::
   */
-  toGNUCommandLineShell = options: attrs: lib.escapeShellArgs (toGNUCommandLine options attrs);
+  toGNUCommandLineShell =
+    options: attrs: lib.escapeShellArgs (lib.cli.toGNUCommandLine options attrs);
 
   /**
     Automatically convert an attribute set to a list of command-line options.
@@ -55,7 +57,7 @@ rec {
 
     : The attributes to transform into arguments.
 
-    # Options
+    ## Options
 
     `mkOptionName`
 
@@ -85,6 +87,7 @@ rec {
     This is useful if the command requires equals, for example, `-c=5`.
 
     # Examples
+
     :::{.example}
     ## `lib.cli.toGNUCommandLine` usage example
 
@@ -145,4 +148,186 @@ rec {
 
     in
     builtins.concatLists (lib.mapAttrsToList render options);
+
+  /**
+    Converts the given attributes into a single shell-escaped command-line string.
+    Similar to `toCommandLineGNU`, but returns a single escaped string instead of an array of arguments.
+    For further reference see: [`lib.cli.toCommandLineGNU`](#function-library-lib.cli.toCommandLineGNU)
+  */
+  toCommandLineShellGNU =
+    options: attrs: lib.escapeShellArgs (lib.cli.toCommandLineGNU options attrs);
+
+  /**
+    Converts an attribute set into a list of GNU-style command line options.
+
+    `toCommandLineGNU` returns a list of string arguments.
+
+    # Inputs
+
+    `options`
+
+    : Options, see below.
+
+    `attrs`
+
+    : The attributes to transform into arguments.
+
+    ## Options
+
+    `isLong`
+
+    : A function that determines whether an option is long or short.
+
+    `explicitBool`
+
+    : Whether or not boolean option arguments should be formatted explicitly.
+
+    `formatArg`
+
+    : A function that turns the option argument into a string.
+
+    # Examples
+
+    :::{.example}
+    ## `lib.cli.toCommandLineGNU` usage example
+
+    ```nix
+    lib.cli.toCommandLineGNU {} {
+      v = true;
+      verbose = [true true false null];
+      i = ".bak";
+      testsuite = ["unit" "integration"];
+      e = ["s/a/b/" "s/b/c/"];
+      n = false;
+      data = builtins.toJSON {id = 0;};
+    }
+    => [
+      "--data={\"id\":0}"
+      "-es/a/b/"
+      "-es/b/c/"
+      "-i.bak"
+      "--testsuite=unit"
+      "--testsuite=integration"
+      "-v"
+      "--verbose"
+      "--verbose"
+    ]
+    ```
+
+    :::
+  */
+  toCommandLineGNU =
+    {
+      isLong ? optionName: builtins.stringLength optionName > 1,
+      explicitBool ? false,
+      formatArg ? lib.generators.mkValueStringDefault { },
+    }:
+    let
+      optionFormat = optionName: {
+        option = if isLong optionName then "--${optionName}" else "-${optionName}";
+        sep = if isLong optionName then "=" else "";
+        inherit explicitBool formatArg;
+      };
+    in
+    lib.cli.toCommandLine optionFormat;
+
+  /**
+    Converts the given attributes into a single shell-escaped command-line string.
+    Similar to `toCommandLine`, but returns a single escaped string instead of an array of arguments.
+    For further reference see: [`lib.cli.toCommandLine`](#function-library-lib.cli.toCommandLine)
+  */
+  toCommandLineShell =
+    optionFormat: attrs: lib.escapeShellArgs (lib.cli.toCommandLine optionFormat attrs);
+
+  /**
+    Converts an attribute set into a list of command line options.
+
+    `toCommandLine` returns a list of string arguments.
+
+    # Inputs
+
+    `optionFormat`
+
+    : The option format that describes how options and their arguments should be formatted.
+
+    `attrs`
+
+    : The attributes to transform into arguments.
+
+    # Examples
+    :::{.example}
+    ## `lib.cli.toCommandLine` usage example
+
+    ```nix
+    let
+      optionFormat = optionName: {
+        option = "-${optionName}";
+        sep = "=";
+        explicitBool = true;
+      };
+    in lib.cli.toCommandLine optionFormat {
+      v = true;
+      verbose = [true true false null];
+      i = ".bak";
+      testsuite = ["unit" "integration"];
+      e = ["s/a/b/" "s/b/c/"];
+      n = false;
+      data = builtins.toJSON {id = 0;};
+    }
+    => [
+      "-data={\"id\":0}"
+      "-e=s/a/b/"
+      "-e=s/b/c/"
+      "-i=.bak"
+      "-n=false"
+      "-testsuite=unit"
+      "-testsuite=integration"
+      "-v=true"
+      "-verbose=true"
+      "-verbose=true"
+      "-verbose=false"
+    ]
+    ```
+
+    :::
+  */
+  toCommandLine =
+    optionFormat: attrs:
+    let
+      handlePair =
+        k: v:
+        if k == "" then
+          lib.throw "lib.cli.toCommandLine only accepts non-empty option names."
+        else if builtins.isList v then
+          builtins.concatMap (handleOption k) v
+        else
+          handleOption k v;
+
+      handleOption = k: renderOption (optionFormat k) k;
+
+      renderOption =
+        {
+          option,
+          sep,
+          explicitBool,
+          formatArg ? lib.generators.mkValueStringDefault { },
+        }:
+        k: v:
+        if v == null || (!explicitBool && v == false) then
+          [ ]
+        else if !explicitBool && v == true then
+          [ option ]
+        else
+          let
+            arg = formatArg v;
+          in
+          if sep != null then
+            [ "${option}${sep}${arg}" ]
+          else
+            [
+              option
+              arg
+            ];
+    in
+    builtins.concatLists (lib.mapAttrsToList handlePair attrs);
 }

--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -3106,6 +3106,86 @@ runTests {
     expected = "-X PUT --data '{\"id\":0}' --retry 3 --url https://example.com/foo --url https://example.com/bar --verbose";
   };
 
+  testToCommandLine = {
+    expr =
+      let
+        optionFormat = optionName: {
+          option = "-${optionName}";
+          sep = "=";
+          explicitBool = true;
+        };
+      in
+      cli.toCommandLine optionFormat {
+        v = true;
+        verbose = [
+          true
+          true
+          false
+          null
+        ];
+        i = ".bak";
+        testsuite = [
+          "unit"
+          "integration"
+        ];
+        e = [
+          "s/a/b/"
+          "s/b/c/"
+        ];
+        n = false;
+        data = builtins.toJSON { id = 0; };
+      };
+
+    expected = [
+      "-data={\"id\":0}"
+      "-e=s/a/b/"
+      "-e=s/b/c/"
+      "-i=.bak"
+      "-n=false"
+      "-testsuite=unit"
+      "-testsuite=integration"
+      "-v=true"
+      "-verbose=true"
+      "-verbose=true"
+      "-verbose=false"
+    ];
+  };
+
+  testToCommandLineGNU = {
+    expr = cli.toCommandLineGNU { } {
+      v = true;
+      verbose = [
+        true
+        true
+        false
+        null
+      ];
+      i = ".bak";
+      testsuite = [
+        "unit"
+        "integration"
+      ];
+      e = [
+        "s/a/b/"
+        "s/b/c/"
+      ];
+      n = false;
+      data = builtins.toJSON { id = 0; };
+    };
+
+    expected = [
+      "--data={\"id\":0}"
+      "-es/a/b/"
+      "-es/b/c/"
+      "-i.bak"
+      "--testsuite=unit"
+      "--testsuite=integration"
+      "-v"
+      "--verbose"
+      "--verbose"
+    ];
+  };
+
   testSanitizeDerivationNameLeadingDots = testSanitizeDerivationName {
     name = "..foo";
     expected = "foo";

--- a/nixos/modules/hardware/printers.nix
+++ b/nixos/modules/hardware/printers.nix
@@ -10,7 +10,7 @@ let
   ensurePrinter =
     p:
     let
-      args = lib.cli.toGNUCommandLineShell { } (
+      args = lib.cli.toCommandLineShellGNU { } (
         {
           p = p.name;
           v = p.deviceUri;

--- a/nixos/modules/services/finance/libeufin/common.nix
+++ b/nixos/modules/services/finance/libeufin/common.nix
@@ -48,7 +48,7 @@ libeufinComponent:
             DynamicUser = true;
             ExecStart =
               let
-                args = lib.cli.toGNUCommandLineShell { } {
+                args = lib.cli.toCommandLineShellGNU { } {
                   c = configFile;
                   L = if cfg.debug then "debug" else null;
                 };
@@ -80,7 +80,7 @@ libeufinComponent:
             initialAccountRegistration = lib.concatMapStringsSep "\n" (
               account:
               let
-                args = lib.cli.toGNUCommandLineShell { } {
+                args = lib.cli.toCommandLineShellGNU { } {
                   c = configFile;
                   inherit (account) username password name;
                   payto_uri = "payto://x-taler-bank/${bankHost}/${account.username}?receiver-name=${account.name}";
@@ -90,7 +90,7 @@ libeufinComponent:
               "${lib.getExe' cfg.package "libeufin-bank"} create-account ${args}"
             ) cfg.initialAccounts;
 
-            args = lib.cli.toGNUCommandLineShell { } {
+            args = lib.cli.toCommandLineShellGNU { } {
               c = configFile;
               L = if cfg.debug then "debug" else null;
             };

--- a/nixos/modules/services/hardware/undervolt.nix
+++ b/nixos/modules/services/hardware/undervolt.nix
@@ -16,7 +16,7 @@ let
         limit != null && window != null
       ) "Both power limit and window must be set";
       "${toString limit} ${toString window}";
-  cliArgs = lib.cli.toGNUCommandLine { } {
+  cliArgs = lib.cli.toCommandLineGNU { } {
     inherit (cfg)
       verbose
       temp

--- a/nixos/modules/services/home-automation/ebusd.nix
+++ b/nixos/modules/services/home-automation/ebusd.nix
@@ -170,7 +170,7 @@ in
         serviceConfig = {
           ExecStart =
             let
-              args = lib.cli.toGNUCommandLineShell { optionValueSeparator = "="; } (
+              args = lib.cli.toCommandLineShellGNU { } (
                 lib.foldr (a: b: a // b) { } [
                   {
                     inherit (cfg)

--- a/nixos/modules/services/mail/mailpit.nix
+++ b/nixos/modules/services/mail/mailpit.nix
@@ -22,7 +22,7 @@ let
 
   isNonNull = v: v != null;
   genCliFlags =
-    settings: concatStringsSep " " (cli.toGNUCommandLine { } (filterAttrs (const isNonNull) settings));
+    settings: concatStringsSep " " (cli.toCommandLineGNU { } (filterAttrs (const isNonNull) settings));
 in
 {
   options.services.mailpit.instances = mkOption {

--- a/nixos/modules/services/misc/paperless.nix
+++ b/nixos/modules/services/misc/paperless.nix
@@ -686,7 +686,7 @@ in
           path = [ manage ];
           script = ''
             paperless-manage document_exporter ${cfg.exporter.directory} ${
-              lib.cli.toGNUCommandLineShell { } cfg.exporter.settings
+              lib.cli.toCommandLineShellGNU { } cfg.exporter.settings
             }
           '';
         };

--- a/nixos/modules/services/networking/gns3-server.nix
+++ b/nixos/modules/services/networking/gns3-server.nix
@@ -187,7 +187,7 @@ in
 
       systemd.services.gns3-server =
         let
-          commandArgs = lib.cli.toGNUCommandLineShell { } {
+          commandArgs = lib.cli.toCommandLineShellGNU { } {
             config = "/etc/gns3/gns3_server.conf";
             pid = "/run/gns3/server.pid";
             log = cfg.log.file;

--- a/nixos/modules/services/networking/hylafax/systemd.nix
+++ b/nixos/modules/services/networking/hylafax/systemd.nix
@@ -14,7 +14,13 @@ let
     mkMerge
     optional
     ;
-  inherit (lib.cli) toGNUCommandLine;
+  inherit (lib.cli) toCommandLine;
+
+  optionFormat = optionName: {
+    option = "-${optionName}";
+    sep = null;
+    explicitBool = false;
+  };
 
   cfg = config.services.hylafax;
   mapModems = lib.forEach (lib.attrValues cfg.modems);
@@ -23,9 +29,7 @@ let
     prefix: program: posArg: options:
     let
       start = "${prefix}${cfg.package}/spool/bin/${program}";
-      optionsList = toGNUCommandLine { mkOptionName = k: "-${k}"; } (
-        { q = cfg.spoolAreaPath; } // options
-      );
+      optionsList = toCommandLine optionFormat ({ q = cfg.spoolAreaPath; } // options);
       posArgList = optional (posArg != null) posArg;
     in
     "${start} ${escapeShellArgs (optionsList ++ posArgList)}";

--- a/nixos/modules/services/networking/newt.nix
+++ b/nixos/modules/services/networking/newt.nix
@@ -83,7 +83,7 @@ in
       };
       # the flag values will all be overwritten if also defined in the env file
       serviceConfig = {
-        ExecStart = "${lib.getExe cfg.package} ${lib.cli.toGNUCommandLineShell { } cfg.settings}";
+        ExecStart = "${lib.getExe cfg.package} ${lib.cli.toCommandLineShellGNU { } cfg.settings}";
         DynamicUser = true;
         StateDirectory = "newt";
         StateDirectoryMode = "0700";

--- a/nixos/modules/services/networking/syncthing.nix
+++ b/nixos/modules/services/networking/syncthing.nix
@@ -947,7 +947,7 @@ in
           ExecStart =
             let
               args = lib.escapeShellArgs (
-                (lib.cli.toGNUCommandLine { } {
+                (lib.cli.toCommandLineGNU { } {
                   "no-browser" = true;
                   "gui-address" = (if isUnixGui then "unix://" else "") + cfg.guiAddress;
                   "config" = cfg.configDir;

--- a/nixos/modules/services/networking/wstunnel.nix
+++ b/nixos/modules/services/networking/wstunnel.nix
@@ -26,7 +26,7 @@ let
         str
         (listOf str)
       ]);
-    generate = lib.cli.toGNUCommandLineShell { };
+    generate = lib.cli.toCommandLineShellGNU { };
   };
 
   hostPortToString = { host, port, ... }: "${host}:${toString port}";

--- a/nixos/modules/services/security/tsidp.nix
+++ b/nixos/modules/services/security/tsidp.nix
@@ -164,7 +164,7 @@ in
           Type = "simple";
           ExecStart =
             let
-              args = lib.cli.toGNUCommandLineShell { mkOptionName = k: "-${k}"; } {
+              args = lib.cli.toCommandLineShellGNU { } {
                 dir = stateDir;
                 hostname = cfg.settings.hostName;
                 port = cfg.settings.port;

--- a/nixos/modules/services/system/earlyoom.nix
+++ b/nixos/modules/services/system/earlyoom.nix
@@ -179,7 +179,7 @@ in
       serviceConfig.EnvironmentFile = "";
 
       environment.EARLYOOM_ARGS =
-        lib.cli.toGNUCommandLineShell { } {
+        lib.cli.toCommandLineShellGNU { } {
           m =
             "${toString cfg.freeMemThreshold}"
             + optionalString (cfg.freeMemKillThreshold != null) ",${toString cfg.freeMemKillThreshold}";

--- a/nixos/modules/services/system/self-deploy.nix
+++ b/nixos/modules/services/system/self-deploy.nix
@@ -179,7 +179,7 @@ in
         ${gitWithRepo} checkout FETCH_HEAD
 
         nix-build${renderNixArgs cfg.nixArgs} ${
-          lib.cli.toGNUCommandLineShell { } {
+          lib.cli.toCommandLineShellGNU { } {
             attr = cfg.nixAttribute;
             out-link = outPath;
           }

--- a/nixos/modules/services/web-apps/c2fmzq-server.nix
+++ b/nixos/modules/services/web-apps/c2fmzq-server.nix
@@ -25,10 +25,8 @@ let
           str
         ])
       );
-    generate = lib.cli.toGNUCommandLineShell {
-      mkBool = k: v: [
-        "--${k}=${if v then "true" else "false"}"
-      ];
+    generate = lib.cli.toCommandLineShellGNU {
+      explicitBool = true;
     };
   };
 in

--- a/nixos/modules/services/web-apps/libretranslate.nix
+++ b/nixos/modules/services/web-apps/libretranslate.nix
@@ -146,7 +146,7 @@ in
           Type = "simple";
           ExecStart = ''
             ${cfg.package}/bin/libretranslate ${
-              lib.cli.toGNUCommandLineShell { } (
+              lib.cli.toCommandLineShellGNU { } (
                 cfg.extraArgs
                 // {
                   inherit (cfg) host port threads;

--- a/nixos/modules/services/web-apps/zitadel.nix
+++ b/nixos/modules/services/web-apps/zitadel.nix
@@ -207,7 +207,7 @@ in
         configFile = settingsFormat.generate "config.yaml" cfg.settings;
         stepsFile = settingsFormat.generate "steps.yaml" cfg.steps;
 
-        args = lib.cli.toGNUCommandLineShell { } {
+        args = lib.cli.toCommandLineShellGNU { } {
           config = cfg.extraSettingsPaths ++ [ configFile ];
           steps = cfg.extraStepsPaths ++ [ stepsFile ];
           masterkeyFile = cfg.masterKeyFile;

--- a/nixos/modules/services/web-servers/fcgiwrap.nix
+++ b/nixos/modules/services/web-servers/fcgiwrap.nix
@@ -151,7 +151,7 @@ in
       serviceConfig = {
         ExecStart = ''
           ${pkgs.fcgiwrap}/sbin/fcgiwrap ${
-            cli.toGNUCommandLineShell { } (
+            cli.toCommandLineShellGNU { } (
               {
                 c = cfg.process.prefork;
               }

--- a/nixos/modules/system/boot/systemd/journald-gateway.nix
+++ b/nixos/modules/system/boot/systemd/journald-gateway.nix
@@ -8,7 +8,7 @@
 let
   cfg = config.services.journald.gateway;
 
-  cliArgs = lib.cli.toGNUCommandLineShell { } {
+  cliArgs = lib.cli.toCommandLineShellGNU { } {
     # If either of these are null / false, they are not passed in the command-line
     inherit (cfg)
       cert

--- a/nixos/modules/system/boot/systemd/journald-remote.nix
+++ b/nixos/modules/system/boot/systemd/journald-remote.nix
@@ -9,7 +9,7 @@ let
   cfg = config.services.journald.remote;
   format = pkgs.formats.systemd { };
 
-  cliArgs = lib.cli.toGNUCommandLineShell { } {
+  cliArgs = lib.cli.toCommandLineShellGNU { } {
     inherit (cfg) output;
     # "-3" specifies the file descriptor from the .socket unit.
     "listen-${cfg.listen}" = "-3";

--- a/nixos/modules/virtualisation/containerd.nix
+++ b/nixos/modules/virtualisation/containerd.nix
@@ -90,7 +90,7 @@ in
         ++ lib.optional config.boot.zfs.enabled config.boot.zfs.package;
       serviceConfig = {
         ExecStart = ''${pkgs.containerd}/bin/containerd ${
-          lib.concatStringsSep " " (lib.cli.toGNUCommandLine { } cfg.args)
+          lib.concatStringsSep " " (lib.cli.toCommandLineGNU { } cfg.args)
         }'';
         Delegate = "yes";
         KillMode = "process";

--- a/nixos/modules/virtualisation/virtualbox-image.nix
+++ b/nixos/modules/virtualisation/virtualbox-image.nix
@@ -252,8 +252,8 @@ in
           --ostype ${if pkgs.stdenv.hostPlatform.system == "x86_64-linux" then "Linux26_64" else "Linux26"}
         VBoxManage modifyvm "$vmName" \
           --memory ${toString cfg.memorySize} \
-          ${lib.cli.toGNUCommandLineShell { } cfg.params}
-        VBoxManage storagectl "$vmName" ${lib.cli.toGNUCommandLineShell { } cfg.storageController}
+          ${lib.cli.toCommandLineShellGNU { } cfg.params}
+        VBoxManage storagectl "$vmName" ${lib.cli.toCommandLineShellGNU { } cfg.storageController}
         VBoxManage storageattach "$vmName" --storagectl ${cfg.storageController.name} --port 0 --device 0 --type hdd \
           --medium disk.vdi
         ${lib.optionalString (cfg.extraDisk != null) ''

--- a/pkgs/build-support/writers/scripts.nix
+++ b/pkgs/build-support/writers/scripts.nix
@@ -812,7 +812,13 @@ rec {
       strip ? true,
     }:
     let
-      nimCompileCmdArgs = lib.cli.toGNUCommandLineShell { optionValueSeparator = ":"; } (
+      optionFormat = optionName: {
+        option = "--${optionName}";
+        sep = ":";
+        explicitBool = false;
+      };
+
+      nimCompileCmdArgs = lib.cli.toCommandLineShell optionFormat (
         {
           d = "release";
           nimcache = ".";

--- a/pkgs/by-name/an/antora/test/default.nix
+++ b/pkgs/by-name/an/antora/test/default.nix
@@ -43,7 +43,7 @@ stdenvNoCC.mkDerivation {
       # The --to-dir and --ui-bundle-url options are not included in the
       # playbook due to Antora and Nix limitations.
       antora ${
-        lib.cli.toGNUCommandLineShell { } {
+        lib.cli.toCommandLineShellGNU { } {
           cache-dir = "$(mktemp --directory)";
           extension = if antora-lunr-extension-test then antora-lunr-extension else false;
           to-dir = placeholder "out";

--- a/pkgs/by-name/li/lightway/package.nix
+++ b/pkgs/by-name/li/lightway/package.nix
@@ -21,7 +21,7 @@ rustPlatform.buildRustPackage {
 
   cargoHash = "sha256-RFlac10XFJXT3Giayy31kZ3Nn1Q+YsPt/zCdkSV0Atk=";
 
-  cargoBuildFlags = lib.cli.toGNUCommandLine { } {
+  cargoBuildFlags = lib.cli.toCommandLineGNU { } {
     package = [
       "lightway-client"
       "lightway-server"

--- a/pkgs/development/interpreters/dhall/build-dhall-package.nix
+++ b/pkgs/development/interpreters/dhall/build-dhall-package.nix
@@ -101,7 +101,7 @@ runCommand name { inherit dependencies; } ''
     mkdir -p $out/${dataDhall}
 
     XDG_DATA_HOME=$out/${data} ${dhall-docs}/bin/dhall-docs --output-link $out/docs ${
-      lib.cli.toGNUCommandLineShell { } {
+      lib.cli.toCommandLineShellGNU { } {
         base-import-url = baseImportUrl;
 
         input = documentationRoot;


### PR DESCRIPTION
This PR adds `lib.cli.toCommandLine`, which addresses multiple issues present in `lib.cli.toGNUCommandLine`, as outlined in #404121.  
Changing the existing `lib.cli.toGNUCommandLine` risks introducing breaking changes if anyone is currently relying on its behavior, so we can use this opportunity to improve the function interface as well. The original interface is very low-level, which makes it rather resistant to many types of changes, especially if we want to avoid breaking backwards compatibility. I think a more abstract interface makes sense for the use case that this function intends to serve.

The `lib.cli.toCommandLine` function that this PR adds takes the option format as an argument, meaning that it can be extended with different option formats down the line. Currently, this PR adds the GNU option format in the form of `lib.cli.toCommandLineGNU`.

Here's a usage example:

```
nix-repl> lib.cli.toCommandLineGNU {} {verbose = [true true false null]; i = ".bak"; testsuite = ["unit" "integration"];}
[
  "-i.bak"
  "--testsuite=unit"
  "--testsuite=integration"
  "--verbose"
  "--verbose"
]
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
