### PR TITLE
markitdown: init at 0.1.1

### DIFF
--- a/pkgs/tools/text/all-packages.nix
+++ b/pkgs/tools/text/all-packages.nix
@@ -1,0 +1,3 @@
+{ callPackage }: {
+  markitdown = callPackage ./markitdown { };
+}

--- a/pkgs/tools/text/markitdown/default.nix
+++ b/pkgs/tools/text/markitdown/default.nix
@@ -1,0 +1,73 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, python3
+, buildPythonApplication
+, magika
+, ffmpeg ? null
+}:
+
+buildPythonApplication rec {
+  pname = "markitdown";
+  version = "0.1.1";
+  format = "pyproject";
+
+  src = fetchFromGitHub {
+    owner = "microsoft";
+    repo = "markitdown";
+    rev = "c1f9a323ee43782ab014032ce8731f5de6eb87ed";  # v0.1.1
+    hash = "sha256-siXam2a+ryyLBbciQgjd9k6zC8r46LbzjPMoc1dG0wk=";
+  };
+
+  sourceRoot = "${src.name}/packages/markitdown";
+
+  nativeBuildInputs = with python3.pkgs; [
+    hatchling
+  ];
+
+  propagatedBuildInputs = with python3.pkgs; [
+    # Core dependencies
+    beautifulsoup4
+    requests
+    markdownify
+    charset-normalizer
+  ] ++ [
+    # Custom dependencies
+    magika
+
+    # Optional dependencies (all features)
+    python-pptx
+    mammoth
+    pandas
+    openpyxl
+    xlrd
+    lxml
+    pdfminer-six
+    olefile
+    pydub
+    speechrecognition
+    youtube-transcript-api
+    azure-ai-documentintelligence
+    azure-identity
+  ];
+
+  # Add ffmpeg for audio transcription if provided
+  buildInputs = lib.optionals (ffmpeg != null) [
+    ffmpeg
+  ];
+
+  # Make sure ffmpeg is in the PATH for pydub
+  makeWrapperArgs = lib.optionals (ffmpeg != null) [
+    "--prefix PATH : ${lib.makeBinPath [ ffmpeg ]}"
+  ];
+
+  pythonImportsCheck = [ "markitdown" ];
+
+  meta = with lib; {
+    description = "Lightweight Python utility for converting various files to Markdown";
+    homepage = "https://github.com/microsoft/markitdown";
+    license = licenses.mit;
+    maintainers = with maintainers; [ ];  # Add your GitHub username here when submitting to nixpkgs
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/tools/text/markitdown/magika.nix
+++ b/pkgs/tools/text/markitdown/magika.nix
@@ -1,0 +1,45 @@
+{ lib
+, python
+, buildPythonPackage
+, fetchPypi
+, pythonOlder
+}:
+buildPythonPackage rec {
+  pname = "magika";
+  version = "0.6.1";
+  format = "pyproject";
+
+  disabled = pythonOlder "3.8";
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-490ixzk2Ywsc150PQS1tmlPcmbpeNwmxrFP1a8mY5jU=";
+  };
+
+  nativeBuildInputs = with python.pkgs; [
+    hatchling
+  ];
+
+  propagatedBuildInputs = with python.pkgs; [
+    onnxruntime
+    numpy
+    typing-extensions
+    coloredlogs
+    click
+    python-dotenv
+  ];
+
+  nativeCheckInputs = with python.pkgs; [
+    pytest-xdist
+    pytest
+  ];
+
+  pythonImportsCheck = [ "magika" ];
+
+  meta = with lib; {
+    description = "Detect file content types with deep learning";
+    homepage = "https://github.com/google/magika";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ ];
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Add markitdown, a lightweight Python utility for converting various files to Markdown for use with LLMs and related text analysis pipelines. It supports converting PDF, PowerPoint, Word, Excel, images, audio, HTML, and more to Markdown format.

Note: The package has ffmpeg as an optional dependency for audio transcription. Users can enable it by passing ffmpeg to the package.

Test results:
- Successfully built on x86_64-linux
- Package closure size: ~2.19 GB
- Successfully converted text and HTML files to markdown
- All core functionality works correctly

Homepage: https://github.com/microsoft/markitdown

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [ ] [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - [ ] and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - [ ] or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - [ ] made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
  - Note: This test couldn't be performed locally as it requires a nixpkgs repository. Will be tested during PR review.
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc