### PR TITLE
ponyc: arm64 and Darwin ZHF fixes

### DIFF
--- a/pkgs/by-name/po/ponyc/disable-networking-tests.patch
+++ b/pkgs/by-name/po/ponyc/disable-networking-tests.patch
@@ -1,16 +1,42 @@
+From e49f97eb4b0fd27b26437638db7984fbcfd3a14f Mon Sep 17 00:00:00 2001
+From: Morgan Jones <me@numin.it>
+Date: Sun, 4 May 2025 15:46:07 -0700
+Subject: [PATCH] net: disable tests in the Nix sandbox
+
+---
+ packages/net/_test.pony | 19 +------------------
+ 1 file changed, 1 insertion(+), 18 deletions(-)
+
 diff --git a/packages/net/_test.pony b/packages/net/_test.pony
-index 9044dfb1..f0ea10f7 100644
+index 05462eb2..c0c6cdfa 100644
 --- a/packages/net/_test.pony
 +++ b/packages/net/_test.pony
-@@ -26,11 +26,6 @@ actor \nodoc\ Main is TestList
-       test(_TestTCPThrottle)
-     end
+@@ -15,25 +15,8 @@ actor \nodoc\ Main is TestList
+   new make() => None
  
+   fun tag tests(test: PonyTest) =>
+-    // Tests below function across all systems and are listed alphabetically
++    // (@numinit): only this test works in the Nix sandbox:
+     test(_TestTCPConnectionFailed)
+-    test(_TestTCPExpect)
+-    test(_TestTCPExpectOverBufferSize)
+-    test(_TestTCPMute)
+-    test(_TestTCPProxy)
+-    test(_TestTCPUnmute)
+-    test(_TestTCPWritev)
+-
+-    // Tests below exclude windows and are listed alphabetically
+-    ifdef not windows then
+-      test(_TestTCPConnectionToClosedServerFailed)
+-      test(_TestTCPThrottle)
+-    end
+-
 -    // Tests below exclude osx and are listed alphabetically
 -    ifdef not osx then
 -      test(_TestBroadcast)
 -    end
--
+ 
  class \nodoc\ _TestPing is UDPNotify
    let _h: TestHelper
-   let _ip: NetAddress
+-- 
+2.47.0

--- a/pkgs/by-name/po/ponyc/disable-process-tests.patch
+++ b/pkgs/by-name/po/ponyc/disable-process-tests.patch
@@ -1,0 +1,26 @@
+From 77d703b11d298f6be88b04f7e8ca85de139e82be Mon Sep 17 00:00:00 2001
+From: Morgan Jones <me@numin.it>
+Date: Mon, 5 May 2025 20:34:02 -0700
+Subject: [PATCH] process: disable KillLongRunningChild test
+
+---
+ packages/process/_test.pony | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/packages/process/_test.pony b/packages/process/_test.pony
+index fe9fdb04..756588f9 100644
+--- a/packages/process/_test.pony
++++ b/packages/process/_test.pony
+@@ -18,7 +18,8 @@ actor \nodoc\ Main is TestList
+     test(_TestChdir)
+     test(_TestExpect)
+     test(_TestFileExecCapabilityIsRequired)
+-    test(_TestKillLongRunningChild)
++    // (@booxter/@numinit) Appears to be flaky.
++    // test(_TestKillLongRunningChild)
+     test(_TestLongRunningChild)
+     test(_TestNonExecutablePathResultsInExecveError)
+     test(_TestPrintvOrdering)
+-- 
+2.47.0
+


### PR DESCRIPTION
Fix -fpic/-fPIC on arm64. Re-enable tests on Darwin with a new patch.

Fixes ZHF: https://zh.fail/failed/by-maintainer/numinit.html

Resolves #403967.

----

Extremely cursed compiler fact: apparently -fpic and -fPIC are different.

```
/nix/store/ix9mh0yqi95fhnqw87sww35jgjwl7wg1-binutils-2.44/bin/ld: compiler_serialisation.cc:(.text+0x48): warning: too many GOT entries for -fpic, please recompile with -fPIC
/nix/store/ix9mh0yqi95fhnqw87sww35jgjwl7wg1-binutils-2.44/bin/ld: final link failed
```

https://tldp.org/HOWTO/Program-Library-HOWTO/shared-libraries.html

> Use -fPIC or -fpic to generate code. Whether to use -fPIC or -fpic to generate code is target-dependent. The -fPIC choice always works, but may produce larger code than -fpic (mnenomic to remember this is that PIC is in a larger case, so it may produce larger amounts of code). Using -fpic option usually generates smaller and faster code, but will have platform-dependent limitations, such as the number of globally visible symbols or the size of the code. The linker will tell you whether it fits when you create the shared library. When in doubt, I choose -fPIC, because it always works.

Oh man, [we're so back](https://en.wikipedia.org/wiki/Intel_Memory_Model#Memory_models)

----

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
