### PR TITLE
libcgroup: fix static build

### DIFF
--- a/pkgs/by-name/li/libcgroup/package.nix
+++ b/pkgs/by-name/li/libcgroup/package.nix
@@ -5,7 +5,9 @@
   pam,
   bison,
   flex,
+  enableSystemd ? lib.meta.availableOn stdenv.hostPlatform systemdLibs,
   systemdLibs,
+  musl-fts,
   autoreconfHook,
 }:
 
@@ -21,15 +23,30 @@ stdenv.mkDerivation rec {
     hash = "sha256-kWW9ID/eYZH0O/Ge8pf3Cso4yu644R5EiQFYfZMcizs=";
   };
 
+  configureFlags =
+    [
+      (lib.enableFeature enableSystemd "systemd")
+    ]
+    # implicit declaration of function 'rpl_malloc', ; did you mean 'realloc'
+    #
+    # It looks like in case of cross-compilation, autoconf assumes that malloc of the
+    # target platform is broken.
+    ++ lib.optionals (!lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform) [
+      "ac_cv_func_malloc_0_nonnull=yes"
+      "ac_cv_func_realloc_0_nonnull=yes"
+    ];
+
   nativeBuildInputs = [
     autoreconfHook
     bison
     flex
   ];
-  buildInputs = [
-    pam
-    systemdLibs
-  ];
+  buildInputs =
+    [
+      pam
+    ]
+    ++ lib.optional enableSystemd systemdLibs
+    ++ lib.optional stdenv.hostPlatform.isMusl musl-fts;
 
   postPatch = ''
     substituteInPlace src/tools/Makefile.am \


### PR DESCRIPTION
# libcgroup: fix static build

```
libcgroup: fix static build
```

## Build info of packages affected directly
### libcgroup

<details><summary>content of libcgroup.out</summary>

```
/nix/store/zr3zb8if0jjdk0bz5fy4y268q5j0h3xa-libcgroup-3.2.0
├── bin
│   ├── cgclassify
│   ├── cgconfigparser
│   ├── cgcreate
│   ├── cgdelete
│   ├── cgexec
│   ├── cgget
│   ├── cgrulesengd
│   ├── cgset
│   ├── cgsnapshot
│   ├── cgxget
│   ├── cgxset
│   ├── libcgroup_systemd_idle_thread
│   ├── lscgroup
│   └── lssubsys
├── include
│   ├── libcgroup
│   │   ├── config.h
│   │   ├── error.h
│   │   ├── groups.h
│   │   ├── init.h
│   │   ├── iterators.h
│   │   ├── log.h
│   │   ├── systemd.h
│   │   ├── tasks.h
│   │   └── tools.h
│   └── libcgroup.h
├── lib
│   ├── libcgroup.la
│   ├── libcgroup.so -> libcgroup.so.0.0.0
│   ├── libcgroup.so.0 -> libcgroup.so.0.0.0
│   ├── libcgroup.so.0.0.0
│   ├── pkgconfig
│   │   └── libcgroup.pc
│   └── security
│       ├── pam_cgroup.la
│       └── pam_cgroup.so
├── sbin -> bin
└── share
    └── man
        ├── man1
        │   ├── cgclassify.1.gz
        │   ├── cgcreate.1.gz
        │   ├── cgdelete.1.gz
        │   ├── cgexec.1.gz
        │   ├── cgget.1.gz
        │   ├── cgset.1.gz
        │   ├── cgsnapshot.1.gz
        │   ├── cgxget.1.gz
        │   ├── cgxset.1.gz
        │   ├── lscgroup.1.gz
        │   └── lssubsys.1.gz
        ├── man5
        │   ├── cgconfig.conf.5.gz
        │   ├── cgred.conf.5.gz
        │   └── cgrules.conf.5.gz
        └── man8
            ├── cgconfigparser.8.gz
            └── cgrulesengd.8.gz

12 directories, 47 files
```
</details>

<details><summary>build log of libcgroup</summary>

```
Running phase: unpackPhase
@nix { "action": "setPhase", "phase": "unpackPhase" }
unpacking source archive /nix/store/jhc1q90lw2xzfsvgkhjzy6i0a2skx94c-source
source root is source
Running phase: patchPhase
@nix { "action": "setPhase", "phase": "patchPhase" }
substituteStream() in derivation libcgroup-3.2.0: WARNING: '--replace' is deprecated, use --replace-{fail,warn,quiet}. (file 'src/tools/Makefile.am')
Running phase: autoreconfPhase
@nix { "action": "setPhase", "phase": "autoreconfPhase" }
autoreconf: export WARNINGS=
autoreconf: Entering directory '.'
autoreconf: configure.ac: not using Gettext
autoreconf: running: aclocal --force -I m4
autoreconf: configure.ac: tracing
autoreconf: configure.ac: creating directory build-aux
autoreconf: running: libtoolize --copy --force
libtoolize: putting auxiliary files in AC_CONFIG_AUX_DIR, 'build-aux'.
libtoolize: copying file 'build-aux/ltmain.sh'
libtoolize: putting macros in AC_CONFIG_MACRO_DIRS, 'm4'.
libtoolize: copying file 'm4/libtool.m4'
libtoolize: copying file 'm4/ltoptions.m4'
libtoolize: copying file 'm4/ltsugar.m4'
libtoolize: copying file 'm4/ltversion.m4'
libtoolize: copying file 'm4/lt~obsolete.m4'
autoreconf: configure.ac: not using Intltool
autoreconf: configure.ac: not using Gtkdoc
autoreconf: running: aclocal --force -I m4
autoreconf: running: /nix/store/kz7dz3kz0w2hzdq1rixh5qr90w3sn3gj-autoconf-2.72/bin/autoconf --force
configure.ac:33: warning: The macro 'AC_CONFIG_HEADER' is obsolete.
configure.ac:33: You should run autoupdate.
./lib/autoconf/status.m4:719: AC_CONFIG_HEADER is expanded from...
configure.ac:33: the top level
configure.ac:195: warning: AC_PROG_LEX without either yywrap or noyywrap is obsolete
./lib/autoconf/programs.m4:743: _AC_PROG_LEX is expanded from...
./lib/autoconf/programs.m4:736: AC_PROG_LEX is expanded from...
aclocal.m4:728: AM_PROG_LEX is expanded from...
configure.ac:195: the top level
configure.ac:203: warning: The macro 'AC_HEADER_STDC' is obsolete.
configure.ac:203: You should run autoupdate.
./lib/autoconf/headers.m4:663: AC_HEADER_STDC is expanded from...
configure.ac:203: the top level
autoreconf: running: /nix/store/kz7dz3kz0w2hzdq1rixh5qr90w3sn3gj-autoconf-2.72/bin/autoheader --force
autoreconf: running: automake --add-missing --copy --force-missing
configure.ac:29: installing 'build-aux/ar-lib'
configure.ac:29: installing 'build-aux/compile'
configure.ac:30: installing 'build-aux/config.guess'
configure.ac:30: installing 'build-aux/config.sub'
configure.ac:17: installing 'build-aux/install-sh'
configure.ac:17: installing 'build-aux/missing'
samples/c/Makefile.am: installing 'build-aux/depcomp'
configure.ac: installing 'build-aux/ylwrap'
parallel-tests: installing 'build-aux/test-driver'
autoreconf: 'build-aux/install-sh' is updated
autoreconf: Leaving directory '.'
Running phase: updateAutotoolsGnuConfigScriptsPhase
@nix { "action": "setPhase", "phase": "updateAutotoolsGnuConfigScriptsPhase" }
Updating Autotools / GNU config script to a newer upstream version: ./build-aux/config.sub
Updating Autotools / GNU config script to a newer upstream version: ./build-aux/config.guess
Running phase: configurePhase
@nix { "action": "setPhase", "phase": "configurePhase" }
fixing libtool script ./build-aux/ltmain.sh
./configure
patching script interpreter paths in ./configure
./configure: interpreter directive changed from "#! /bin/sh" to "/nix/store/9nw8b61s8lfdn8fkabxhbz0s775gjhbr-bash-5.2p37/bin/sh"
configure flags: --disable-static --disable-dependency-tracking --prefix=/nix/store/zr3zb8if0jjdk0bz5fy4y268q5j0h3xa-libcgroup-3.2.0 --enable-systemd
checking for a BSD-compatible install... /nix/store/h5rn37dd6vfvr9xb0jq85sq8hf6xchry-coreutils-9.6/bin/install -c
checking whether build environment is sane... yes
checking for a race-free mkdir -p... /nix/store/h5rn37dd6vfvr9xb0jq85sq8hf6xchry-coreutils-9.6/bin/mkdir -p
checking for gawk... gawk
checking whether make sets $(MAKE)... yes
checking whether make supports nested variables... yes
checking whether make supports nested variables... (cached) yes
checking whether make supports the include directive... yes (GNU style)
checking for gcc... gcc
checking whether the C compiler works... yes
checking for C compiler default output file name... a.out
checking for suffix of executables... 
checking whether we are cross compiling... no
checking for suffix of object files... o
checking whether the compiler supports GNU C... yes
checking whether gcc accepts -g... yes
checking for gcc option to enable C11 features... none needed
checking whether gcc understands -c and -o together... yes
checking dependency style of gcc... none
checking the archiver (ar) interface... ar
checking build system type... x86_64-pc-linux-gnu
checking host system type... x86_64-pc-linux-gnu
checking how to print strings... printf
checking for a sed that does not truncate output... /nix/store/bz6z6c26ajk870qxipxkkp8a6cympj3l-gnused-4.9/bin/sed
checking for grep that handles long lines and -e... /nix/store/8i12gp78n1m9z794miwbsclgyyp5nm5s-gnugrep-3.11/bin/grep
checking for egrep... /nix/store/8i12gp78n1m9z794miwbsclgyyp5nm5s-gnugrep-3.11/bin/grep -E
checking for fgrep... /nix/store/8i12gp78n1m9z794miwbsclgyyp5nm5s-gnugrep-3.11/bin/grep -F
checking for ld used by gcc... ld
checking if the linker (ld) is GNU ld... yes
checking for BSD- or MS-compatible name lister (nm)... nm
checking the name lister (nm) interface... BSD nm
checking whether ln -s works... yes
checking the maximum length of command line arguments... 1572864
checking how to convert x86_64-pc-linux-gnu file names to x86_64-pc-linux-gnu format... func_convert_file_noop
checking how to convert x86_64-pc-linux-gnu file names to toolchain format... func_convert_file_noop
checking for ld option to reload object files... -r
checking for file... file
checking for objdump... objdump
checking how to recognize dependent libraries... (cached) pass_all
checking for dlltool... no
checking how to associate runtime and link libraries... printf %s\n
checking for ranlib... ranlib
checking for archiver @FILE support... @
checking for strip... strip
checking command to parse nm output from gcc object... ok
checking for sysroot... no
checking for a working dd... /nix/store/h5rn37dd6vfvr9xb0jq85sq8hf6xchry-coreutils-9.6/bin/dd
checking how to truncate binary pipes... /nix/store/h5rn37dd6vfvr9xb0jq85sq8hf6xchry-coreutils-9.6/bin/dd bs=4096 count=1
checking for mt... no
checking if : is a manifest tool... no
checking for stdio.h... yes
checking for stdlib.h... yes
checking for string.h... yes
checking for inttypes.h... yes
checking for stdint.h... yes
checking for strings.h... yes
checking for sys/stat.h... yes
checking for sys/types.h... yes
checking for unistd.h... yes
checking for dlfcn.h... yes
checking for objdir... .libs
checking if gcc supports -fno-rtti -fno-exceptions... no
checking for gcc option to produce PIC... -fPIC -DPIC
checking if gcc PIC flag -fPIC -DPIC works... yes
checking if gcc static flag -static works... no
checking if gcc supports -c -o file.o... yes
checking if gcc supports -c -o file.o... (cached) yes
checking whether the gcc linker (ld -m elf_x86_64) supports shared libraries... yes
checking whether -lc should be explicitly linked in... no
checking dynamic linker characteristics... GNU/Linux ld.so
checking how to hardcode library paths into programs... immediate
checking whether stripping libraries is possible... yes
checking if libtool supports shared libraries... yes
checking whether to build shared libraries... yes
checking whether to build static libraries... no
checking whether the compiler supports GNU C++... yes
checking whether g++ accepts -g... yes
checking for g++ option to enable C++11 features... none needed
checking dependency style of g++... none
checking how to run the C++ preprocessor... g++ -E
checking for ld used by g++... ld -m elf_x86_64
checking if the linker (ld -m elf_x86_64) is GNU ld... yes
checking whether the g++ linker (ld -m elf_x86_64) supports shared libraries... yes
checking for g++ option to produce PIC... -fPIC -DPIC
checking if g++ PIC flag -fPIC -DPIC works... yes
checking if g++ static flag -static works... no
checking if g++ supports -c -o file.o... yes
checking if g++ supports -c -o file.o... (cached) yes
checking whether the g++ linker (ld -m elf_x86_64) supports shared libraries... yes
checking dynamic linker characteristics... (cached) GNU/Linux ld.so
checking how to hardcode library paths into programs... immediate
checking for gcc... (cached) gcc
checking whether the compiler supports GNU C... (cached) yes
checking whether gcc accepts -g... (cached) yes
checking for gcc option to enable C11 features... (cached) none needed
checking whether gcc understands -c and -o together... (cached) yes
checking dependency style of gcc... (cached) none
checking for bison... bison -y
checking for flex... flex
checking for lex output file root... lex.yy
checking for lex library... none needed
checking for library containing yywrap... no
checking whether yytext is a pointer... yes
checking for dirent.h that defines DIR... yes
checking for library containing opendir... none required
checking for egrep... (cached) /nix/store/8i12gp78n1m9z794miwbsclgyyp5nm5s-gnugrep-3.11/bin/grep -E
checking for limits.h... yes
checking for mntent.h... yes
checking for stdlib.h... (cached) yes
checking for string.h... (cached) yes
checking for sys/mount.h... yes
checking for unistd.h... (cached) yes
checking for _Bool... yes
checking for stdbool.h that conforms to C99 or later... yes
checking for an ANSI C-conforming const... yes
checking for uid_t... yes
checking for gid_t... yes
checking for inline... inline
checking for int64_t... yes
checking for pid_t... yes
checking for working chown... yes
checking for library containing getmntent... none required
checking for GNU libc compatible malloc... yes
checking for GNU libc compatible realloc... yes
checking whether lstat correctly handles trailing slash... yes
checking whether stat accepts an empty string... no
checking for getmntent... (cached) yes
checking for hasmntopt... yes
checking for memset... yes
checking for mkdir... yes
checking for rmdir... yes
checking for strdup... yes
checking for gcc options needed to detect all undeclared functions... none needed
checking whether strerror_r is declared... yes
checking whether strerror_r returns char *... yes
checking for library containing fts_open... none required
checking for pam_syslog in -lpam... yes
checking for security/pam_modules.h... yes
checking for security/pam_modutil.h... yes
checking for security/pam_ext.h... yes
checking for sd_bus_message_new_method_call in -lsystemd... yes
checking for systemd/sd-bus.h... yes
checking whether to build with code coverage support... no
checking that generated files are newer than configure... done
configure: creating ./config.status
config.status: creating Makefile
config.status: creating src/Makefile
config.status: creating src/daemon/Makefile
config.status: creating src/tools/Makefile
config.status: creating src/pam/Makefile
config.status: creating src/python/Makefile
config.status: creating scripts/Makefile
config.status: creating scripts/init.d/cgconfig
config.status: creating scripts/init.d/cgred
config.status: creating tests/Makefile
config.status: creating tests/ftests/Makefile
config.status: creating tests/gunit/Makefile
config.status: creating samples/Makefile
config.status: creating samples/c/Makefile
config.status: creating samples/cmdline/Makefile
config.status: creating samples/config/Makefile
config.status: creating samples/python/Makefile
config.status: creating include/Makefile
config.status: creating include/libcgroup/init.h
config.status: creating doc/Makefile
config.status: creating doc/man/Makefile
config.status: creating dist/Makefile
config.status: creating libcgroup.pc
config.status: creating dist/libcgroup.spec
config.status: creating config.h
config.status: executing depfiles commands
config.status: executing libtool commands
Running phase: buildPhase
@nix { "action": "setPhase", "phase": "buildPhase" }
build flags: SHELL=/nix/store/9nw8b61s8lfdn8fkabxhbz0s775gjhbr-bash-5.2p37/bin/bash
make  all-recursive
make[1]: Entering directory '/build/source'
Making all in dist
make[2]: Entering directory '/build/source/dist'
make[2]: Nothing to be done for 'all'.
make[2]: Leaving directory '/build/source/dist'
Making all in doc
make[2]: Entering directory '/build/source/doc'
Making all in man
make[3]: Entering directory '/build/source/doc/man'
make[3]: Nothing to be done for 'all'.
make[3]: Leaving directory '/build/source/doc/man'
make[3]: Entering directory '/build/source/doc'
make[3]: Nothing to be done for 'all-am'.
make[3]: Leaving directory '/build/source/doc'
make[2]: Leaving directory '/build/source/doc'
Making all in include
make[2]: Entering directory '/build/source/include'
make[2]: Nothing to be done for 'all'.
make[2]: Leaving directory '/build/source/include'
Making all in scripts
make[2]: Entering directory '/build/source/scripts'
make[2]: Nothing to be done for 'all'.
make[2]: Leaving directory '/build/source/scripts'
Making all in src
make[2]: Entering directory '/build/source/src'
  YACC     parse.c
/build/source/src/parse.y: warning: 4 shift/reduce conflicts [-Wconflicts-sr]
/build/source/src/parse.y: note: rerun with option '-Wcounterexamples' to generate conflict counterexamples
updating parse.h
make  all-recursive
make[3]: Entering directory '/build/source/src'
Making all in .
make[4]: Entering directory '/build/source/src'
  CC       libcgroup_systemd_idle_thread.o
  CCLD     libcgroup_systemd_idle_thread
  CC       libcgroup_la-parse.lo
  LEX      lex.c
  CC       libcgroup_la-lex.lo
  CC       libcgroup_la-api.lo
  CC       libcgroup_la-config.lo
  CC       libcgroup_la-wrapper.lo
  CC       libcgroup_la-log.lo
  CC       libcgroup_la-abstraction-common.lo
  CC       libcgroup_la-abstraction-map.lo
  CC       libcgroup_la-abstraction-cpu.lo
  CC       libcgroup_la-abstraction-cpuset.lo
  CC       libcgroup_la-systemd.lo
  CC       tools/libcgroup_la-cgxget.lo
  CC       tools/libcgroup_la-cgxset.lo
  CCLD     libcgroup.la
  CC       libcgroupfortesting_la-parse.lo
  CC       libcgroupfortesting_la-lex.lo
  CC       libcgroupfortesting_la-api.lo
  CC       libcgroupfortesting_la-config.lo
  CC       libcgroupfortesting_la-wrapper.lo
  CC       libcgroupfortesting_la-log.lo
  CC       libcgroupfortesting_la-abstraction-common.lo
  CC       libcgroupfortesting_la-abstraction-map.lo
  CC       libcgroupfortesting_la-abstraction-cpu.lo
  CC       libcgroupfortesting_la-abstraction-cpuset.lo
  CC       libcgroupfortesting_la-systemd.lo
  CCLD     libcgroupfortesting.la
libtool: warning: '-version-info/-version-number' is ignored for convenience libraries
make[4]: Leaving directory '/build/source/src'
Making all in daemon
make[4]: Entering directory '/build/source/src/daemon'
  CC       cgrulesengd-cgrulesengd.o
  CC       ../tools/cgrulesengd-tools-common.o
  CCLD     cgrulesengd
make[4]: Leaving directory '/build/source/src/daemon'
Making all in pam
make[4]: Entering directory '/build/source/src/pam'
  CC       pam_cgroup.lo
  CCLD     pam_cgroup.la
make[4]: Leaving directory '/build/source/src/pam'
Making all in tools
make[4]: Entering directory '/build/source/src/tools'
  CC       cgexec-cgexec.o
  CC       cgexec-tools-common.o
  CCLD     cgexec
  CC       cgclassify-cgclassify.o
  CC       cgclassify-tools-common.o
  CCLD     cgclassify
  CC       cgcreate-cgcreate.o
  CC       cgcreate-tools-common.o
  CCLD     cgcreate
  CC       cgset-cgset.o
  CC       cgset-tools-common.o
  CCLD     cgset
  CC       cgxset-cgxset.o
  CC       cgxset-tools-common.o
  CCLD     cgxset
  CC       cgget-cgget.o
  CC       cgget-tools-common.o
  CCLD     cgget
  CC       cgxget-cgxget.o
  CC       cgxget-tools-common.o
  CCLD     cgxget
  CC       cgdelete-cgdelete.o
  CC       cgdelete-tools-common.o
  CCLD     cgdelete
  CC       lssubsys-lssubsys.o
  CCLD     lssubsys
  CC       lscgroup-tools-common.o
  CC       lscgroup-lscgroup.o
  CCLD     lscgroup
  CC       cgsnapshot-cgsnapshot.o
  CCLD     cgsnapshot
  CC       cgconfigparser-cgconfig.o
  CC       cgconfigparser-tools-common.o
  CCLD     cgconfigparser
  CC       libcgset_la-cgset.lo
  CC       libcgset_la-tools-common.lo
  CCLD     libcgset.la
make[4]: Leaving directory '/build/source/src/tools'
make[3]: Leaving directory '/build/source/src'
make[2]: Leaving directory '/build/source/src'
Making all in tests
make[2]: Entering directory '/build/source/tests'
Making all in ftests
make[3]: Entering directory '/build/source/tests/ftests'
make[3]: Nothing to be done for 'all'.
make[3]: Leaving directory '/build/source/tests/ftests'
Making all in gunit
make[3]: Entering directory '/build/source/tests/gunit'
make[3]: Nothing to be done for 'all'.
make[3]: Leaving directory '/build/source/tests/gunit'
make[3]: Entering directory '/build/source/tests'
make[3]: Nothing to be done for 'all-am'.
make[3]: Leaving directory '/build/source/tests'
make[2]: Leaving directory '/build/source/tests'
Making all in samples
make[2]: Entering directory '/build/source/samples'
Making all in config
make[3]: Entering directory '/build/source/samples/config'
make[3]: Nothing to be done for 'all'.
make[3]: Leaving directory '/build/source/samples/config'
Making all in c
make[3]: Entering directory '/build/source/samples/c'
make[3]: Nothing to be done for 'all'.
make[3]: Leaving directory '/build/source/samples/c'
Making all in python
make[3]: Entering directory '/build/source/samples/python'
make[3]: Nothing to be done for 'all'.
make[3]: Leaving directory '/build/source/samples/python'
Making all in cmdline
make[3]: Entering directory '/build/source/samples/cmdline'
make[3]: Nothing to be done for 'all'.
make[3]: Leaving directory '/build/source/samples/cmdline'
make[3]: Entering directory '/build/source/samples'
make[3]: Nothing to be done for 'all-am'.
make[3]: Leaving directory '/build/source/samples'
make[2]: Leaving directory '/build/source/samples'
make[2]: Entering directory '/build/source'
make[2]: Leaving directory '/build/source'
make[1]: Leaving directory '/build/source'
Running phase: installPhase
@nix { "action": "setPhase", "phase": "installPhase" }
install flags: SHELL=/nix/store/9nw8b61s8lfdn8fkabxhbz0s775gjhbr-bash-5.2p37/bin/bash install
Making install in dist
make[1]: Entering directory '/build/source/dist'
make[2]: Entering directory '/build/source/dist'
make[2]: Nothing to be done for 'install-exec-am'.
make[2]: Nothing to be done for 'install-data-am'.
make[2]: Leaving directory '/build/source/dist'
make[1]: Leaving directory '/build/source/dist'
Making install in doc
make[1]: Entering directory '/build/source/doc'
Making install in man
make[2]: Entering directory '/build/source/doc/man'
make[3]: Entering directory '/build/source/doc/man'
make[3]: Nothing to be done for 'install-exec-am'.
 /nix/store/h5rn37dd6vfvr9xb0jq85sq8hf6xchry-coreutils-9.6/bin/mkdir -p '/nix/store/zr3zb8if0jjdk0bz5fy4y268q5j0h3xa-libcgroup-3.2.0/share/man/man1'
 /nix/store/h5rn37dd6vfvr9xb0jq85sq8hf6xchry-coreutils-9.6/bin/install -c -m 644 cgclassify.1 cgexec.1 cgcreate.1 cgset.1 cgget.1 cgdelete.1 lssubsys.1 lscgroup.1 cgsnapshot.1 cgxget.1 cgxset.1 '/nix/store/zr3zb8if0jjdk0bz5fy4y268q5j0h3xa-libcgroup-3.2.0/share/man/man1'
 /nix/store/h5rn37dd6vfvr9xb0jq85sq8hf6xchry-coreutils-9.6/bin/mkdir -p '/nix/store/zr3zb8if0jjdk0bz5fy4y268q5j0h3xa-libcgroup-3.2.0/share/man/man5'
 /nix/store/h5rn37dd6vfvr9xb0jq85sq8hf6xchry-coreutils-9.6/bin/install -c -m 644 cgconfig.conf.5 cgred.conf.5 cgrules.conf.5 '/nix/store/zr3zb8if0jjdk0bz5fy4y268q5j0h3xa-libcgroup-3.2.0/share/man/man5'
 /nix/store/h5rn37dd6vfvr9xb0jq85sq8hf6xchry-coreutils-9.6/bin/mkdir -p '/nix/store/zr3zb8if0jjdk0bz5fy4y268q5j0h3xa-libcgroup-3.2.0/share/man/man8'
 /nix/store/h5rn37dd6vfvr9xb0jq85sq8hf6xchry-coreutils-9.6/bin/install -c -m 644 cgconfigparser.8 cgrulesengd.8 '/nix/store/zr3zb8if0jjdk0bz5fy4y268q5j0h3xa-libcgroup-3.2.0/share/man/man8'
make[3]: Leaving directory '/build/source/doc/man'
make[2]: Leaving directory '/build/source/doc/man'
make[2]: Entering directory '/build/source/doc'
make[3]: Entering directory '/build/source/doc'
make[3]: Nothing to be done for 'install-exec-am'.
make[3]: Nothing to be done for 'install-data-am'.
make[3]: Leaving directory '/build/source/doc'
make[2]: Leaving directory '/build/source/doc'
make[1]: Leaving directory '/build/source/doc'
Making install in include
make[1]: Entering directory '/build/source/include'
make[2]: Entering directory '/build/source/include'
make[2]: Nothing to be done for 'install-exec-am'.
 /nix/store/h5rn37dd6vfvr9xb0jq85sq8hf6xchry-coreutils-9.6/bin/mkdir -p '/nix/store/zr3zb8if0jjdk0bz5fy4y268q5j0h3xa-libcgroup-3.2.0/include'
 /nix/store/h5rn37dd6vfvr9xb0jq85sq8hf6xchry-coreutils-9.6/bin/install -c -m 644  libcgroup.h '/nix/store/zr3zb8if0jjdk0bz5fy4y268q5j0h3xa-libcgroup-3.2.0/include/.'
 /nix/store/h5rn37dd6vfvr9xb0jq85sq8hf6xchry-coreutils-9.6/bin/mkdir -p '/nix/store/zr3zb8if0jjdk0bz5fy4y268q5j0h3xa-libcgroup-3.2.0/include/libcgroup'
 /nix/store/h5rn37dd6vfvr9xb0jq85sq8hf6xchry-coreutils-9.6/bin/install -c -m 644  libcgroup/error.h libcgroup/init.h libcgroup/groups.h libcgroup/tasks.h libcgroup/iterators.h libcgroup/config.h libcgroup/log.h libcgroup/tools.h libcgroup/systemd.h '/nix/store/zr3zb8if0jjdk0bz5fy4y268q5j0h3xa-libcgroup-3.2.0/include/libcgroup'
make[2]: Leaving directory '/build/source/include'
make[1]: Leaving directory '/build/source/include'
Making install in scripts
make[1]: Entering directory '/build/source/scripts'
make[2]: Entering directory '/build/source/scripts'
make  install-exec-hook
make[3]: Entering directory '/build/source/scripts'
make[3]: Nothing to be done for 'install-exec-hook'.
make[3]: Leaving directory '/build/source/scripts'
make[2]: Nothing to be done for 'install-data-am'.
make[2]: Leaving directory '/build/source/scripts'
make[1]: Leaving directory '/build/source/scripts'
Making install in src
make[1]: Entering directory '/build/source/src'
make  install-recursive
make[2]: Entering directory '/build/source/src'
Making install in .
make[3]: Entering directory '/build/source/src'
make[4]: Entering directory '/build/source/src'
 /nix/store/h5rn37dd6vfvr9xb0jq85sq8hf6xchry-coreutils-9.6/bin/mkdir -p '/nix/store/zr3zb8if0jjdk0bz5fy4y268q5j0h3xa-libcgroup-3.2.0/lib'
 /nix/store/9nw8b61s8lfdn8fkabxhbz0s775gjhbr-bash-5.2p37/bin/bash ../libtool   --mode=install /nix/store/h5rn37dd6vfvr9xb0jq85sq8hf6xchry-coreutils-9.6/bin/install -c   libcgroup.la '/nix/store/zr3zb8if0jjdk0bz5fy4y268q5j0h3xa-libcgroup-3.2.0/lib'
libtool: install: /nix/store/h5rn37dd6vfvr9xb0jq85sq8hf6xchry-coreutils-9.6/bin/install -c .libs/libcgroup.so.0.0.0 /nix/store/zr3zb8if0jjdk0bz5fy4y268q5j0h3xa-libcgroup-3.2.0/lib/libcgroup.so.0.0.0
libtool: install: (cd /nix/store/zr3zb8if0jjdk0bz5fy4y268q5j0h3xa-libcgroup-3.2.0/lib && { ln -s -f libcgroup.so.0.0.0 libcgroup.so.0 || { rm -f libcgroup.so.0 && ln -s libcgroup.so.0.0.0 libcgroup.so.0; }; })
libtool: install: (cd /nix/store/zr3zb8if0jjdk0bz5fy4y268q5j0h3xa-libcgroup-3.2.0/lib && { ln -s -f libcgroup.so.0.0.0 libcgroup.so || { rm -f libcgroup.so && ln -s libcgroup.so.0.0.0 libcgroup.so; }; })
libtool: install: /nix/store/h5rn37dd6vfvr9xb0jq85sq8hf6xchry-coreutils-9.6/bin/install -c .libs/libcgroup.lai /nix/store/zr3zb8if0jjdk0bz5fy4y268q5j0h3xa-libcgroup-3.2.0/lib/libcgroup.la
libtool: finish: PATH="/nix/store/kz7dz3kz0w2hzdq1rixh5qr90w3sn3gj-autoconf-2.72/bin:/nix/store/j9nmwa41glbq2spczvjg23ndqna78isi-automake-1.16.5/bin:/nix/store/c8d2fyykvq7pyjh6mmwvpfwyx7i6amx5-gettext-0.22.5/bin:/nix/store/0cpzncvjzccbydhwm59dp6d74agz5l3v-libtool-2.5.4/bin:/nix/store/d1ipqs39rrl13v33j2yibzw1k284higa-gnum4-1.4.19/bin:/nix/store/ahflikbm2kni7jz66nwy2f7agvk6il3s-file-5.46/bin:/nix/store/lgbc71zw66a1qvsy7fvj40cl5l3cv880-bison-3.8.2/bin:/nix/store/xbil0wbkn71zf55s0bfp9xi5pp7xg0wv-flex-2.6.4/bin:/nix/store/s2bpzn6i8v4873a7jp9m8jwwj99ylq0h-patchelf-0.15.0/bin:/nix/store/f0m6caffiykyvsjim9376a3hx2yj2ghj-gcc-wrapper-14.2.1.20250322/bin:/nix/store/qs54xir5n4vhhbi22aydbkvyyq4v8p0l-gcc-14.2.1.20250322/bin:/nix/store/lkgfphix3sgfsm38smsw38xk81h3f3ig-glibc-2.40-66-bin/bin:/nix/store/h5rn37dd6vfvr9xb0jq85sq8hf6xchry-coreutils-9.6/bin:/nix/store/i74bzbaq6i1bgy9frznv9n21b2z77nyd-binutils-wrapper-2.44/bin:/nix/store/hzw38c3f7s0w200cgk9645z53al7k8lw-binutils-2.44/bin:/nix/store/fcy06jrlqxqpg5003jx8wbbwb5mwgd75-linux-pam-1.6.1/bin:/nix/store/h5rn37dd6vfvr9xb0jq85sq8hf6xchry-coreutils-9.6/bin:/nix/store/7l0lfmx3pp9xs9i5q285vdjqy9hc0giv-findutils-4.10.0/bin:/nix/store/9q848nyysljzqgi1wd8hzj8yr7psh9xm-diffutils-3.10/bin:/nix/store/bz6z6c26ajk870qxipxkkp8a6cympj3l-gnused-4.9/bin:/nix/store/8i12gp78n1m9z794miwbsclgyyp5nm5s-gnugrep-3.11/bin:/nix/store/qi25cvn9j1xyvl9p7lp8nw9wqk5k648r-gawk-5.3.1/bin:/nix/store/x0yrczlkrid080mrgw4xrcq5r903djnf-gnutar-1.35/bin:/nix/store/0d3d2c8rk0qn1q9frxfsgzw6yp4cddph-gzip-1.13/bin:/nix/store/ssy7nai103s1q459qir4nsb8xj7abppn-bzip2-1.0.8-bin/bin:/nix/store/70d32kg7b61450yjdgkbfi6jdn3am65v-gnumake-4.4.1/bin:/nix/store/9nw8b61s8lfdn8fkabxhbz0s775gjhbr-bash-5.2p37/bin:/nix/store/mk5kbj9vrzkwbxshy5v3r206fidky0f5-patch-2.7.6/bin:/nix/store/b3jrsidhy02p43aprq4393d8lm9vz1k6-xz-5.8.1-bin/bin:/nix/store/zggxy4h431z5r0qi75gwllbyywk2y8xv-file-5.46/bin:/sbin" ldconfig -n /nix/store/zr3zb8if0jjdk0bz5fy4y268q5j0h3xa-libcgroup-3.2.0/lib
----------------------------------------------------------------------
Libraries have been installed in:
   /nix/store/zr3zb8if0jjdk0bz5fy4y268q5j0h3xa-libcgroup-3.2.0/lib

If you ever happen to want to link against installed libraries
in a given directory, LIBDIR, you must either use libtool, and
specify the full pathname of the library, or use the '-LLIBDIR'
flag during linking and do at least one of the following:
   - add LIBDIR to the 'LD_LIBRARY_PATH' environment variable
     during execution
   - add LIBDIR to the 'LD_RUN_PATH' environment variable
     during linking
   - use the '-Wl,-rpath -Wl,LIBDIR' linker flag

See any operating system documentation about shared libraries for
more information, such as the ld(1) and ld.so(8) manual pages.
----------------------------------------------------------------------
 /nix/store/h5rn37dd6vfvr9xb0jq85sq8hf6xchry-coreutils-9.6/bin/mkdir -p '/nix/store/zr3zb8if0jjdk0bz5fy4y268q5j0h3xa-libcgroup-3.2.0/bin'
  /nix/store/9nw8b61s8lfdn8fkabxhbz0s775gjhbr-bash-5.2p37/bin/bash ../libtool   --mode=install /nix/store/h5rn37dd6vfvr9xb0jq85sq8hf6xchry-coreutils-9.6/bin/install -c libcgroup_systemd_idle_thread '/nix/store/zr3zb8if0jjdk0bz5fy4y268q5j0h3xa-libcgroup-3.2.0/bin'
libtool: install: /nix/store/h5rn37dd6vfvr9xb0jq85sq8hf6xchry-coreutils-9.6/bin/install -c libcgroup_systemd_idle_thread /nix/store/zr3zb8if0jjdk0bz5fy4y268q5j0h3xa-libcgroup-3.2.0/bin/libcgroup_systemd_idle_thread
make[4]: Nothing to be done for 'install-data-am'.
make[4]: Leaving directory '/build/source/src'
make[3]: Leaving directory '/build/source/src'
Making install in daemon
make[3]: Entering directory '/build/source/src/daemon'
make[4]: Entering directory '/build/source/src/daemon'
 /nix/store/h5rn37dd6vfvr9xb0jq85sq8hf6xchry-coreutils-9.6/bin/mkdir -p '/nix/store/zr3zb8if0jjdk0bz5fy4y268q5j0h3xa-libcgroup-3.2.0/sbin'
  /nix/store/9nw8b61s8lfdn8fkabxhbz0s775gjhbr-bash-5.2p37/bin/bash ../../libtool   --mode=install /nix/store/h5rn37dd6vfvr9xb0jq85sq8hf6xchry-coreutils-9.6/bin/install -c cgrulesengd '/nix/store/zr3zb8if0jjdk0bz5fy4y268q5j0h3xa-libcgroup-3.2.0/sbin'
libtool: install: /nix/store/h5rn37dd6vfvr9xb0jq85sq8hf6xchry-coreutils-9.6/bin/install -c .libs/cgrulesengd /nix/store/zr3zb8if0jjdk0bz5fy4y268q5j0h3xa-libcgroup-3.2.0/sbin/cgrulesengd
make[4]: Nothing to be done for 'install-data-am'.
make[4]: Leaving directory '/build/source/src/daemon'
make[3]: Leaving directory '/build/source/src/daemon'
Making install in pam
make[3]: Entering directory '/build/source/src/pam'
make[4]: Entering directory '/build/source/src/pam'
make[4]: Nothing to be done for 'install-exec-am'.
 /nix/store/h5rn37dd6vfvr9xb0jq85sq8hf6xchry-coreutils-9.6/bin/mkdir -p '/nix/store/zr3zb8if0jjdk0bz5fy4y268q5j0h3xa-libcgroup-3.2.0/lib/security'
 /nix/store/9nw8b61s8lfdn8fkabxhbz0s775gjhbr-bash-5.2p37/bin/bash ../../libtool   --mode=install /nix/store/h5rn37dd6vfvr9xb0jq85sq8hf6xchry-coreutils-9.6/bin/install -c   pam_cgroup.la '/nix/store/zr3zb8if0jjdk0bz5fy4y268q5j0h3xa-libcgroup-3.2.0/lib/security'
libtool: warning: relinking 'pam_cgroup.la'
libtool: install: (cd /build/source/src/pam; /nix/store/9nw8b61s8lfdn8fkabxhbz0s775gjhbr-bash-5.2p37/bin/bash "/build/source/libtool"  --silent --tag CC --mode=relink gcc -g -O2 -Wall -module -avoid-version -o pam_cgroup.la -rpath /nix/store/zr3zb8if0jjdk0bz5fy4y268q5j0h3xa-libcgroup-3.2.0/lib/security pam_cgroup.lo ../../src/libcgroup.la -lpam -lsystemd )
libtool: install: /nix/store/h5rn37dd6vfvr9xb0jq85sq8hf6xchry-coreutils-9.6/bin/install -c .libs/pam_cgroup.soT /nix/store/zr3zb8if0jjdk0bz5fy4y268q5j0h3xa-libcgroup-3.2.0/lib/security/pam_cgroup.so
libtool: install: /nix/store/h5rn37dd6vfvr9xb0jq85sq8hf6xchry-coreutils-9.6/bin/install -c .libs/pam_cgroup.lai /nix/store/zr3zb8if0jjdk0bz5fy4y268q5j0h3xa-libcgroup-3.2.0/lib/security/pam_cgroup.la
libtool: finish: PATH="/nix/store/kz7dz3kz0w2hzdq1rixh5qr90w3sn3gj-autoconf-2.72/bin:/nix/store/j9nmwa41glbq2spczvjg23ndqna78isi-automake-1.16.5/bin:/nix/store/c8d2fyykvq7pyjh6mmwvpfwyx7i6amx5-gettext-0.22.5/bin:/nix/store/0cpzncvjzccbydhwm59dp6d74agz5l3v-libtool-2.5.4/bin:/nix/store/d1ipqs39rrl13v33j2yibzw1k284higa-gnum4-1.4.19/bin:/nix/store/ahflikbm2kni7jz66nwy2f7agvk6il3s-file-5.46/bin:/nix/store/lgbc71zw66a1qvsy7fvj40cl5l3cv880-bison-3.8.2/bin:/nix/store/xbil0wbkn71zf55s0bfp9xi5pp7xg0wv-flex-2.6.4/bin:/nix/store/s2bpzn6i8v4873a7jp9m8jwwj99ylq0h-patchelf-0.15.0/bin:/nix/store/f0m6caffiykyvsjim9376a3hx2yj2ghj-gcc-wrapper-14.2.1.20250322/bin:/nix/store/qs54xir5n4vhhbi22aydbkvyyq4v8p0l-gcc-14.2.1.20250322/bin:/nix/store/lkgfphix3sgfsm38smsw38xk81h3f3ig-glibc-2.40-66-bin/bin:/nix/store/h5rn37dd6vfvr9xb0jq85sq8hf6xchry-coreutils-9.6/bin:/nix/store/i74bzbaq6i1bgy9frznv9n21b2z77nyd-binutils-wrapper-2.44/bin:/nix/store/hzw38c3f7s0w200cgk9645z53al7k8lw-binutils-2.44/bin:/nix/store/fcy06jrlqxqpg5003jx8wbbwb5mwgd75-linux-pam-1.6.1/bin:/nix/store/h5rn37dd6vfvr9xb0jq85sq8hf6xchry-coreutils-9.6/bin:/nix/store/7l0lfmx3pp9xs9i5q285vdjqy9hc0giv-findutils-4.10.0/bin:/nix/store/9q848nyysljzqgi1wd8hzj8yr7psh9xm-diffutils-3.10/bin:/nix/store/bz6z6c26ajk870qxipxkkp8a6cympj3l-gnused-4.9/bin:/nix/store/8i12gp78n1m9z794miwbsclgyyp5nm5s-gnugrep-3.11/bin:/nix/store/qi25cvn9j1xyvl9p7lp8nw9wqk5k648r-gawk-5.3.1/bin:/nix/store/x0yrczlkrid080mrgw4xrcq5r903djnf-gnutar-1.35/bin:/nix/store/0d3d2c8rk0qn1q9frxfsgzw6yp4cddph-gzip-1.13/bin:/nix/store/ssy7nai103s1q459qir4nsb8xj7abppn-bzip2-1.0.8-bin/bin:/nix/store/70d32kg7b61450yjdgkbfi6jdn3am65v-gnumake-4.4.1/bin:/nix/store/9nw8b61s8lfdn8fkabxhbz0s775gjhbr-bash-5.2p37/bin:/nix/store/mk5kbj9vrzkwbxshy5v3r206fidky0f5-patch-2.7.6/bin:/nix/store/b3jrsidhy02p43aprq4393d8lm9vz1k6-xz-5.8.1-bin/bin:/nix/store/zggxy4h431z5r0qi75gwllbyywk2y8xv-file-5.46/bin:/sbin" ldconfig -n /nix/store/zr3zb8if0jjdk0bz5fy4y268q5j0h3xa-libcgroup-3.2.0/lib/security
----------------------------------------------------------------------
Libraries have been installed in:
   /nix/store/zr3zb8if0jjdk0bz5fy4y268q5j0h3xa-libcgroup-3.2.0/lib/security

If you ever happen to want to link against installed libraries
in a given directory, LIBDIR, you must either use libtool, and
specify the full pathname of the library, or use the '-LLIBDIR'
flag during linking and do at least one of the following:
   - add LIBDIR to the 'LD_LIBRARY_PATH' environment variable
     during execution
   - add LIBDIR to the 'LD_RUN_PATH' environment variable
     during linking
   - use the '-Wl,-rpath -Wl,LIBDIR' linker flag

See any operating system documentation about shared libraries for
more information, such as the ld(1) and ld.so(8) manual pages.
----------------------------------------------------------------------
make[4]: Leaving directory '/build/source/src/pam'
make[3]: Leaving directory '/build/source/src/pam'
Making install in tools
make[3]: Entering directory '/build/source/src/tools'
make[4]: Entering directory '/build/source/src/tools'
 /nix/store/h5rn37dd6vfvr9xb0jq85sq8hf6xchry-coreutils-9.6/bin/mkdir -p '/nix/store/zr3zb8if0jjdk0bz5fy4y268q5j0h3xa-libcgroup-3.2.0/bin'
  /nix/store/9nw8b61s8lfdn8fkabxhbz0s775gjhbr-bash-5.2p37/bin/bash ../../libtool   --mode=install /nix/store/h5rn37dd6vfvr9xb0jq85sq8hf6xchry-coreutils-9.6/bin/install -c cgexec cgclassify cgcreate cgset cgxset cgget cgxget cgdelete lssubsys lscgroup cgsnapshot '/nix/store/zr3zb8if0jjdk0bz5fy4y268q5j0h3xa-libcgroup-3.2.0/bin'
libtool: install: /nix/store/h5rn37dd6vfvr9xb0jq85sq8hf6xchry-coreutils-9.6/bin/install -c .libs/cgexec /nix/store/zr3zb8if0jjdk0bz5fy4y268q5j0h3xa-libcgroup-3.2.0/bin/cgexec
libtool: install: /nix/store/h5rn37dd6vfvr9xb0jq85sq8hf6xchry-coreutils-9.6/bin/install -c .libs/cgclassify /nix/store/zr3zb8if0jjdk0bz5fy4y268q5j0h3xa-libcgroup-3.2.0/bin/cgclassify
libtool: install: /nix/store/h5rn37dd6vfvr9xb0jq85sq8hf6xchry-coreutils-9.6/bin/install -c .libs/cgcreate /nix/store/zr3zb8if0jjdk0bz5fy4y268q5j0h3xa-libcgroup-3.2.0/bin/cgcreate
libtool: install: /nix/store/h5rn37dd6vfvr9xb0jq85sq8hf6xchry-coreutils-9.6/bin/install -c .libs/cgset /nix/store/zr3zb8if0jjdk0bz5fy4y268q5j0h3xa-libcgroup-3.2.0/bin/cgset
libtool: install: /nix/store/h5rn37dd6vfvr9xb0jq85sq8hf6xchry-coreutils-9.6/bin/install -c .libs/cgxset /nix/store/zr3zb8if0jjdk0bz5fy4y268q5j0h3xa-libcgroup-3.2.0/bin/cgxset
libtool: install: /nix/store/h5rn37dd6vfvr9xb0jq85sq8hf6xchry-coreutils-9.6/bin/install -c .libs/cgget /nix/store/zr3zb8if0jjdk0bz5fy4y268q5j0h3xa-libcgroup-3.2.0/bin/cgget
libtool: install: /nix/store/h5rn37dd6vfvr9xb0jq85sq8hf6xchry-coreutils-9.6/bin/install -c .libs/cgxget /nix/store/zr3zb8if0jjdk0bz5fy4y268q5j0h3xa-libcgroup-3.2.0/bin/cgxget
libtool: install: /nix/store/h5rn37dd6vfvr9xb0jq85sq8hf6xchry-coreutils-9.6/bin/install -c .libs/cgdelete /nix/store/zr3zb8if0jjdk0bz5fy4y268q5j0h3xa-libcgroup-3.2.0/bin/cgdelete
libtool: install: /nix/store/h5rn37dd6vfvr9xb0jq85sq8hf6xchry-coreutils-9.6/bin/install -c .libs/lssubsys /nix/store/zr3zb8if0jjdk0bz5fy4y268q5j0h3xa-libcgroup-3.2.0/bin/lssubsys
libtool: install: /nix/store/h5rn37dd6vfvr9xb0jq85sq8hf6xchry-coreutils-9.6/bin/install -c .libs/lscgroup /nix/store/zr3zb8if0jjdk0bz5fy4y268q5j0h3xa-libcgroup-3.2.0/bin/lscgroup
libtool: install: /nix/store/h5rn37dd6vfvr9xb0jq85sq8hf6xchry-coreutils-9.6/bin/install -c .libs/cgsnapshot /nix/store/zr3zb8if0jjdk0bz5fy4y268q5j0h3xa-libcgroup-3.2.0/bin/cgsnapshot
 /nix/store/h5rn37dd6vfvr9xb0jq85sq8hf6xchry-coreutils-9.6/bin/mkdir -p '/nix/store/zr3zb8if0jjdk0bz5fy4y268q5j0h3xa-libcgroup-3.2.0/sbin'
  /nix/store/9nw8b61s8lfdn8fkabxhbz0s775gjhbr-bash-5.2p37/bin/bash ../../libtool   --mode=install /nix/store/h5rn37dd6vfvr9xb0jq85sq8hf6xchry-coreutils-9.6/bin/install -c cgconfigparser '/nix/store/zr3zb8if0jjdk0bz5fy4y268q5j0h3xa-libcgroup-3.2.0/sbin'
libtool: install: /nix/store/h5rn37dd6vfvr9xb0jq85sq8hf6xchry-coreutils-9.6/bin/install -c .libs/cgconfigparser /nix/store/zr3zb8if0jjdk0bz5fy4y268q5j0h3xa-libcgroup-3.2.0/sbin/cgconfigparser
make  install-exec-hook
make[5]: Entering directory '/build/source/src/tools'
chmod +x /nix/store/zr3zb8if0jjdk0bz5fy4y268q5j0h3xa-libcgroup-3.2.0/bin/cgexec
make[5]: Leaving directory '/build/source/src/tools'
make[4]: Nothing to be done for 'install-data-am'.
make[4]: Leaving directory '/build/source/src/tools'
make[3]: Leaving directory '/build/source/src/tools'
make[2]: Leaving directory '/build/source/src'
make[1]: Leaving directory '/build/source/src'
Making install in tests
make[1]: Entering directory '/build/source/tests'
Making install in ftests
make[2]: Entering directory '/build/source/tests/ftests'
make[3]: Entering directory '/build/source/tests/ftests'
make[3]: Nothing to be done for 'install-exec-am'.
make[3]: Nothing to be done for 'install-data-am'.
make[3]: Leaving directory '/build/source/tests/ftests'
make[2]: Leaving directory '/build/source/tests/ftests'
Making install in gunit
make[2]: Entering directory '/build/source/tests/gunit'
make[3]: Entering directory '/build/source/tests/gunit'
make[3]: Nothing to be done for 'install-exec-am'.
make[3]: Nothing to be done for 'install-data-am'.
make[3]: Leaving directory '/build/source/tests/gunit'
make[2]: Leaving directory '/build/source/tests/gunit'
make[2]: Entering directory '/build/source/tests'
make[3]: Entering directory '/build/source/tests'
make[3]: Nothing to be done for 'install-exec-am'.
make[3]: Nothing to be done for 'install-data-am'.
make[3]: Leaving directory '/build/source/tests'
make[2]: Leaving directory '/build/source/tests'
make[1]: Leaving directory '/build/source/tests'
Making install in samples
make[1]: Entering directory '/build/source/samples'
Making install in config
make[2]: Entering directory '/build/source/samples/config'
make[3]: Entering directory '/build/source/samples/config'
make[3]: Nothing to be done for 'install-exec-am'.
make[3]: Nothing to be done for 'install-data-am'.
make[3]: Leaving directory '/build/source/samples/config'
make[2]: Leaving directory '/build/source/samples/config'
Making install in c
make[2]: Entering directory '/build/source/samples/c'
make[3]: Entering directory '/build/source/samples/c'
make[3]: Nothing to be done for 'install-exec-am'.
make[3]: Nothing to be done for 'install-data-am'.
make[3]: Leaving directory '/build/source/samples/c'
make[2]: Leaving directory '/build/source/samples/c'
Making install in python
make[2]: Entering directory '/build/source/samples/python'
make[3]: Entering directory '/build/source/samples/python'
make[3]: Nothing to be done for 'install-exec-am'.
make[3]: Nothing to be done for 'install-data-am'.
make[3]: Leaving directory '/build/source/samples/python'
make[2]: Leaving directory '/build/source/samples/python'
Making install in cmdline
make[2]: Entering directory '/build/source/samples/cmdline'
make[3]: Entering directory '/build/source/samples/cmdline'
make[3]: Nothing to be done for 'install-exec-am'.
make[3]: Nothing to be done for 'install-data-am'.
make[3]: Leaving directory '/build/source/samples/cmdline'
make[2]: Leaving directory '/build/source/samples/cmdline'
make[2]: Entering directory '/build/source/samples'
make[3]: Entering directory '/build/source/samples'
make[3]: Nothing to be done for 'install-exec-am'.
make[3]: Nothing to be done for 'install-data-am'.
make[3]: Leaving directory '/build/source/samples'
make[2]: Leaving directory '/build/source/samples'
make[1]: Leaving directory '/build/source/samples'
make[1]: Entering directory '/build/source'
make[2]: Entering directory '/build/source'
make[2]: Nothing to be done for 'install-exec-am'.
 /nix/store/h5rn37dd6vfvr9xb0jq85sq8hf6xchry-coreutils-9.6/bin/mkdir -p '/nix/store/zr3zb8if0jjdk0bz5fy4y268q5j0h3xa-libcgroup-3.2.0/lib/pkgconfig'
 /nix/store/h5rn37dd6vfvr9xb0jq85sq8hf6xchry-coreutils-9.6/bin/install -c -m 644 libcgroup.pc '/nix/store/zr3zb8if0jjdk0bz5fy4y268q5j0h3xa-libcgroup-3.2.0/lib/pkgconfig'
make[2]: Leaving directory '/build/source'
make[1]: Leaving directory '/build/source'
Running phase: fixupPhase
@nix { "action": "setPhase", "phase": "fixupPhase" }
shrinking RPATHs of ELF executables and libraries in /nix/store/zr3zb8if0jjdk0bz5fy4y268q5j0h3xa-libcgroup-3.2.0
shrinking /nix/store/zr3zb8if0jjdk0bz5fy4y268q5j0h3xa-libcgroup-3.2.0/bin/lssubsys
shrinking /nix/store/zr3zb8if0jjdk0bz5fy4y268q5j0h3xa-libcgroup-3.2.0/bin/cgget
shrinking /nix/store/zr3zb8if0jjdk0bz5fy4y268q5j0h3xa-libcgroup-3.2.0/bin/cgsnapshot
shrinking /nix/store/zr3zb8if0jjdk0bz5fy4y268q5j0h3xa-libcgroup-3.2.0/bin/libcgroup_systemd_idle_thread
shrinking /nix/store/zr3zb8if0jjdk0bz5fy4y268q5j0h3xa-libcgroup-3.2.0/bin/cgexec
shrinking /nix/store/zr3zb8if0jjdk0bz5fy4y268q5j0h3xa-libcgroup-3.2.0/bin/cgset
shrinking /nix/store/zr3zb8if0jjdk0bz5fy4y268q5j0h3xa-libcgroup-3.2.0/bin/cgxget
shrinking /nix/store/zr3zb8if0jjdk0bz5fy4y268q5j0h3xa-libcgroup-3.2.0/bin/cgxset
shrinking /nix/store/zr3zb8if0jjdk0bz5fy4y268q5j0h3xa-libcgroup-3.2.0/bin/cgdelete
shrinking /nix/store/zr3zb8if0jjdk0bz5fy4y268q5j0h3xa-libcgroup-3.2.0/bin/lscgroup
shrinking /nix/store/zr3zb8if0jjdk0bz5fy4y268q5j0h3xa-libcgroup-3.2.0/bin/cgcreate
shrinking /nix/store/zr3zb8if0jjdk0bz5fy4y268q5j0h3xa-libcgroup-3.2.0/bin/cgclassify
shrinking /nix/store/zr3zb8if0jjdk0bz5fy4y268q5j0h3xa-libcgroup-3.2.0/lib/libcgroup.so.0.0.0
shrinking /nix/store/zr3zb8if0jjdk0bz5fy4y268q5j0h3xa-libcgroup-3.2.0/lib/security/pam_cgroup.so
shrinking /nix/store/zr3zb8if0jjdk0bz5fy4y268q5j0h3xa-libcgroup-3.2.0/sbin/cgconfigparser
shrinking /nix/store/zr3zb8if0jjdk0bz5fy4y268q5j0h3xa-libcgroup-3.2.0/sbin/cgrulesengd
checking for references to /build/ in /nix/store/zr3zb8if0jjdk0bz5fy4y268q5j0h3xa-libcgroup-3.2.0...
gzipping man pages under /nix/store/zr3zb8if0jjdk0bz5fy4y268q5j0h3xa-libcgroup-3.2.0/share/man/
moving /nix/store/zr3zb8if0jjdk0bz5fy4y268q5j0h3xa-libcgroup-3.2.0/sbin/* to /nix/store/zr3zb8if0jjdk0bz5fy4y268q5j0h3xa-libcgroup-3.2.0/bin
patching script interpreter paths in /nix/store/zr3zb8if0jjdk0bz5fy4y268q5j0h3xa-libcgroup-3.2.0
stripping (with command strip and flags -S -p) in  /nix/store/zr3zb8if0jjdk0bz5fy4y268q5j0h3xa-libcgroup-3.2.0/lib /nix/store/zr3zb8if0jjdk0bz5fy4y268q5j0h3xa-libcgroup-3.2.0/bin /nix/store/zr3zb8if0jjdk0bz5fy4y268q5j0h3xa-libcgroup-3.2.0/sbin
```
</details>
