### PR TITLE
ldc: Fix compiler and output crashing on macOS Sequoia 15.4

### DIFF
--- a/pkgs/by-name/ld/ldc/bootstrap.nix
+++ b/pkgs/by-name/ld/ldc/bootstrap.nix
@@ -14,13 +14,17 @@ let
   OS = if hostPlatform.isDarwin then "osx" else hostPlatform.parsed.kernel.name;
   ARCH =
     if hostPlatform.isDarwin && hostPlatform.isAarch64 then "arm64" else hostPlatform.parsed.cpu.name;
-  version = "1.30.0";
+  # Work around macOS Sequoia 15.4 segfault by downgrading the bootstrap compiler - see:
+  # - https://github.com/NixOS/nixpkgs/issues/398443
+  # - https://github.com/dlang/dmd/issues/21126#issuecomment-2775948553
+  # TODO: Remove this when bootstrap can be upgraded to a fixed version (>= 1.41.0-beta2)?
+  version = if hostPlatform.isDarwin then "1.28.1" else "1.30.0";
   hashes = {
     # Get these from `nix store prefetch-file https://github.com/ldc-developers/ldc/releases/download/v1.19.0/ldc2-1.19.0-osx-x86_64.tar.xz` etc..
-    osx-x86_64 = "sha256-AAWZvxuZC82xvrW6fpYm783TY+H8k3DvqE94ZF1yjmk=";
+    osx-x86_64 = "sha256-mqQ+hNlDePOGX2mwgEEzHGiOAx3SxfNA6x8+ML3qYmw=";
     linux-x86_64 = "sha256-V4TUzEfQhFrwiX07dHOgjdAoGkzausCkhnQIQNAU/eE=";
     linux-aarch64 = "sha256-kTeglub75iv/jWWNPCn15aCGAbmck0RQl6L7bFOUu7Y=";
-    osx-arm64 = "sha256-Nb/owBdIeroB9jLMDvwjo8bvsTC9vFyJPLMTOMsSAd4=";
+    osx-arm64 = "sha256-m93rGywncBnPEWslcrXuGBnZ+Z/mNgLIaevkL/uBOu0=";
   };
 in
 stdenv.mkDerivation {

--- a/pkgs/by-name/ld/ldc/package.nix
+++ b/pkgs/by-name/ld/ldc/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  fetchpatch,
   callPackage,
   makeWrapper,
   removeReferencesTo,
@@ -44,6 +45,17 @@ stdenv.mkDerivation (finalAttrs: {
 
   # https://issues.dlang.org/show_bug.cgi?id=19553
   hardeningDisable = [ "fortify" ];
+
+  # Fix output programs segfaulting on macOS Sequoia 15.4 - see:
+  # https://github.com/NixOS/nixpkgs/issues/398443
+  # https://github.com/ldc-developers/ldc/issues/4899
+  # TODO: Remove this when upgrading to a fixed version (>= 1.41.0-beta2)
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/ldc-developers/ldc/commit/60079c3b596053b1a70f9f2e0cf38a287089df56.patch";
+      hash = "sha256-Y/5+zt5ou9rzU7rLJq2OqUxMDvC7aSFS6AsPeDxNATQ=";
+    })
+  ];
 
   postPatch =
     ''


### PR DESCRIPTION
Currently, programs built with LDC get a segfault on macOS 15.4, before they've even reached `main`. (See ldc-developers/ldc#4899.) Upstream has merged the fix, but it hasn't made it into a release yet. This commit fixes the problem by:
- Downgrading the bootstrap compiler to 1.28.1, so that the final compiler itself can run correctly, and
- Backporting the `druntime` [fix][] into the final compiler, so that its _output_ can run correctly.

Resolves #398443, at least for `ldc`. `dmd` uses `druntime` as well, and thus would have the same issue (dlang/dmd#21126), but it's currently `broken` on Darwin for unrelated reasons, so I can't test any fix there.

[fix]: https://github.com/ldc-developers/ldc/commit/60079c3b596053b1a70f9f2e0cf38a287089df56

ZHF: #403336
(Wasn't thinking of it as specifically a ZHF thing when I submitted it - it hadn't popped up on https://zh.fail yet - but I guess it counts.)


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
