### PR TITLE
otto-matic: unstable-2023-11-13 -> 4.0.1-unstable-2025-04-27, unbreak

### DIFF
--- a/pkgs/by-name/ot/otto-matic/package.nix
+++ b/pkgs/by-name/ot/otto-matic/package.nix
@@ -2,20 +2,22 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  SDL2,
+  sdl3,
+  libGL,
   cmake,
   makeWrapper,
+  unstableGitUpdater,
 }:
 
 stdenv.mkDerivation rec {
   pname = "OttoMatic";
-  version = "unstable-2023-11-13";
+  version = "4.0.1-unstable-2025-04-27";
 
   src = fetchFromGitHub {
     owner = "jorio";
-    repo = pname;
-    rev = "8a5411779762684066d3748fbf4d33747ca871a4";
-    hash = "sha256-cZ2gHNXmjMocfTgbA+0T2nwKs55ZMDoB+JTf0Qdqe8U=";
+    repo = "OttoMatic";
+    rev = "69f0111d1768abe56498bf8121f0f9cbc85aedd3";
+    hash = "sha256-7RpEVL3tNhEhkZYVjgsI6S+CQfyiz/ukroldrtohA4k=";
     fetchSubmodules = true;
   };
 
@@ -25,7 +27,8 @@ stdenv.mkDerivation rec {
   ];
 
   buildInputs = [
-    SDL2
+    sdl3
+    libGL
   ];
 
   installPhase = ''
@@ -38,15 +41,18 @@ stdenv.mkDerivation rec {
     wrapProgram $out/bin/OttoMatic --chdir "$out/share/OttoMatic"
     install -Dm644 $src/packaging/io.jor.ottomatic.desktop $out/share/applications/io.jor.ottomatic.desktop
     install -Dm644 $src/packaging/io.jor.ottomatic.png $out/share/pixmaps/io.jor.ottomatic.png
+
     runHook postInstall
   '';
 
-  meta = with lib; {
+  passthru.updateScript = unstableGitUpdater { };
+
+  meta = {
     description = "Port of Otto Matic, a 2001 Macintosh game by Pangea Software, for modern operating systems";
     homepage = "https://github.com/jorio/OttoMatic";
-    license = licenses.cc-by-sa-40;
-    maintainers = with maintainers; [ lux ];
-    platforms = platforms.linux;
+    license = lib.licenses.cc-by-sa-40;
+    maintainers = with lib.maintainers; [ lux ];
+    platforms = lib.platforms.linux;
     mainProgram = "OttoMatic";
   };
 }


### PR DESCRIPTION
fixes https://hydra.nixos.org/build/295018530
zhf https://github.com/NixOS/nixpkgs/issues/403336
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
