### PR TITLE
swift: use `aarch64` instead of `arm64` on Linux

### DIFF
--- a/pkgs/development/compilers/swift/compiler/default.nix
+++ b/pkgs/development/compilers/swift/compiler/default.nix
@@ -72,7 +72,11 @@ let
     else
       targetPlatform.parsed.kernel.name;
 
-  swiftArch = stdenv.hostPlatform.darwinArch;
+  # This causes swiftPackages.XCTest to fail to build on aarch64-linux
+  # as I believe this is because Apple calls the architecture aarch64
+  # on Linux rather than arm64 when used with macOS.
+  swiftArch =
+    if hostPlatform.isDarwin then hostPlatform.darwinArch else targetPlatform.parsed.cpu.name;
 
   # On Darwin, a `.swiftmodule` is a subdirectory in `lib/swift/<OS>`,
   # containing binaries for supported archs. On other platforms, binaries are


### PR DESCRIPTION
Since #393213, a dependency of `swift`, `swift-corelibs-xctest` has been failing to build on `aarch64-linux` with this error:

```
[1/1] Linking Swift shared library libXCTest.so
FAILED: libXCTest.so CMakeFiles/XCTest.dir/Sources/XCTest/Private/WallClockTimeMetric.swift.o CMakeFiles/XCTest.dir/Sources/XCTest/Private/TestListing.swift.o CMakeFiles/XCTest.dir/Sources/XCTest/Private/XCTestCaseSuite.swift.o CMakeFiles/XCTest.dir/Sources/XCTest/Private/TestFiltering.swift.o CMakeFiles/XCTest.dir/Sources/XCTest/Private/XCTestInternalObservation.swift.o CMakeFiles/XCTest.dir/Sources/XCTest/Private/ObjectWrapper.swift.o CMakeFiles/XCTest.dir/Sources/XCTest/Private/PerformanceMeter.swift.o CMakeFiles/XCTest.dir/Sources/XCTest/Private/PrintObserver.swift.o CMakeFiles/XCTest.dir/Sources/XCTest/Private/ArgumentParser.swift.o CMakeFiles/XCTest.dir/Sources/XCTest/Private/SourceLocation.swift.o CMakeFiles/XCTest.dir/Sources/XCTest/Private/WaiterManager.swift.o CMakeFiles/XCTest.dir/Sources/XCTest/Private/IgnoredErrors.swift.o CMakeFiles/XCTest.dir/Sources/XCTest/Private/XCTestCase.TearDownBlocksState.swift.o CMakeFiles/XCTest.dir/Sources/XCTest/Public/XCTestRun.swift.o CMakeFiles/XCTest.dir/Sources/XCTest/Public/XCTestMain.swift.o CMakeFiles/XCTest.dir/Sources/XCTest/Public/XCTestCase.swift.o CMakeFiles/XCTest.dir/Sources/XCTest/Public/XCTestSuite.swift.o CMakeFiles/XCTest.dir/Sources/XCTest/Public/XCTestSuiteRun.swift.o CMakeFiles/XCTest.dir/Sources/XCTest/Public/XCTestErrors.swift.o CMakeFiles/XCTest.dir/Sources/XCTest/Public/XCTestObservation.swift.o CMakeFiles/XCTest.dir/Sources/XCTest/Public/XCTestCaseRun.swift.o CMakeFiles/XCTest.dir/Sources/XCTest/Public/XCAbstractTest.swift.o CMakeFiles/XCTest.dir/Sources/XCTest/Public/XCTestObservationCenter.swift.o CMakeFiles/XCTest.dir/Sources/XCTest/Public/XCTestCase+Performance.swift.o CMakeFiles/XCTest.dir/Sources/XCTest/Public/XCTAssert.swift.o CMakeFiles/XCTest.dir/Sources/XCTest/Public/XCTSkip.swift.o CMakeFiles/XCTest.dir/Sources/XCTest/Public/Asynchronous/XCTNSNotificationExpectation.swift.o CMakeFiles/XCTest.dir/Sources/XCTest/Public/Asynchronous/XCTNSPredicateExpectation.swift.o CMakeFiles/XCTest.dir/Sources/XCTest/Public/Asynchronous/XCTWaiter+Validation.swift.o CMakeFiles/XCTest.dir/Sources/XCTest/Public/Asynchronous/XCTWaiter.swift.o CMakeFiles/XCTest.dir/Sources/XCTest/Public/Asynchronous/XCTestCase+Asynchronous.swift.o CMakeFiles/XCTest.dir/Sources/XCTest/Public/Asynchronous/XCTestExpectation.swift.o swift/XCTest.swiftmodule 
: && /nix/store/jspnw1lj8arai5bafcrcfarfpd47689a-swift-wrapper-5.8/bin/swiftc -j 80 -num-threads 80 -emit-library -o libXCTest.so -module-name XCTest -module-link-name XCTest -emit-module -emit-module-path swift/XCTest.swiftmodule -emit-dependencies -DXCTest_EXPORTS -O -output-file-map CMakeFiles/XCTest.dir/Release/output-file-map.json  /build/swift-corelibs-xctest-5.8-src/Sources/XCTest/Private/WallClockTimeMetric.swift /build/swift-corelibs-xctest-5.8-src/Sources/XCTest/Private/TestListing.swift /build/swift-corelibs-xctest-5.8-src/Sources/XCTest/Private/XCTestCaseSuite.swift /build/swift-corelibs-xctest-5.8-src/Sources/XCTest/Private/TestFiltering.swift /build/swift-corelibs-xctest-5.8-src/Sources/XCTest/Private/XCTestInternalObservation.swift /build/swift-corelibs-xctest-5.8-src/Sources/XCTest/Private/ObjectWrapper.swift /build/swift-corelibs-xctest-5.8-src/Sources/XCTest/Private/PerformanceMeter.swift /build/swift-corelibs-xctest-5.8-src/Sources/XCTest/Private/PrintObserver.swift /build/swift-corelibs-xctest-5.8-src/Sources/XCTest/Private/ArgumentParser.swift /build/swift-corelibs-xctest-5.8-src/Sources/XCTest/Private/SourceLocation.swift /build/swift-corelibs-xctest-5.8-src/Sources/XCTest/Private/WaiterManager.swift /build/swift-corelibs-xctest-5.8-src/Sources/XCTest/Private/IgnoredErrors.swift /build/swift-corelibs-xctest-5.8-src/Sources/XCTest/Private/XCTestCase.TearDownBlocksState.swift /build/swift-corelibs-xctest-5.8-src/Sources/XCTest/Public/XCTestRun.swift /build/swift-corelibs-xctest-5.8-src/Sources/XCTest/Public/XCTestMain.swift /build/swift-corelibs-xctest-5.8-src/Sources/XCTest/Public/XCTestCase.swift /build/swift-corelibs-xctest-5.8-src/Sources/XCTest/Public/XCTestSuite.swift /build/swift-corelibs-xctest-5.8-src/Sources/XCTest/Public/XCTestSuiteRun.swift /build/swift-corelibs-xctest-5.8-src/Sources/XCTest/Public/XCTestErrors.swift /build/swift-corelibs-xctest-5.8-src/Sources/XCTest/Public/XCTestObservation.swift /build/swift-corelibs-xctest-5.8-src/Sources/XCTest/Public/XCTestCaseRun.swift /build/swift-corelibs-xctest-5.8-src/Sources/XCTest/Public/XCAbstractTest.swift /build/swift-corelibs-xctest-5.8-src/Sources/XCTest/Public/XCTestObservationCenter.swift /build/swift-corelibs-xctest-5.8-src/Sources/XCTest/Public/XCTestCase+Performance.swift /build/swift-corelibs-xctest-5.8-src/Sources/XCTest/Public/XCTAssert.swift /build/swift-corelibs-xctest-5.8-src/Sources/XCTest/Public/XCTSkip.swift /build/swift-corelibs-xctest-5.8-src/Sources/XCTest/Public/Asynchronous/XCTNSNotificationExpectation.swift /build/swift-corelibs-xctest-5.8-src/Sources/XCTest/Public/Asynchronous/XCTNSPredicateExpectation.swift /build/swift-corelibs-xctest-5.8-src/Sources/XCTest/Public/Asynchronous/XCTWaiter+Validation.swift /build/swift-corelibs-xctest-5.8-src/Sources/XCTest/Public/Asynchronous/XCTWaiter.swift /build/swift-corelibs-xctest-5.8-src/Sources/XCTest/Public/Asynchronous/XCTestCase+Asynchronous.swift /build/swift-corelibs-xctest-5.8-src/Sources/XCTest/Public/Asynchronous/XCTestExpectation.swift -no-toolchain-stdlib-rpath -Xlinker -soname -Xlinker libXCTest.so  -L /nix/store/yhf2lxfr8dpxhrr4s7nwv2zrd225d9w2-swift-corelibs-libdispatch-5.8/lib  -L /nix/store/a99c7z4mw7fk3m68a5hkkhk2zq4yn3yp-swift-corelibs-foundation-5.8/lib/swift/linux -Xlinker -rpath -Xlinker /nix/store/yhf2lxfr8dpxhrr4s7nwv2zrd225d9w2-swift-corelibs-libdispatch-5.8/lib:/nix/store/a99c7z4mw7fk3m68a5hkkhk2zq4yn3yp-swift-corelibs-foundation-5.8/lib/swift/linux:  /nix/store/yhf2lxfr8dpxhrr4s7nwv2zrd225d9w2-swift-corelibs-libdispatch-5.8/lib/libdispatch.so  /nix/store/a99c7z4mw7fk3m68a5hkkhk2zq4yn3yp-swift-corelibs-foundation-5.8/lib/swift/linux/libFoundation.so && :
/build/swift-corelibs-xctest-5.8-src/Sources/XCTest/Public/XCTestMain.swift:24:23: error: no such module 'Foundation'
    @_exported import Foundation
                      ^
ninja: build stopped: subcommand failed.
```

I believe this is because Swift uses `aarch64` on Linux rather than `arm64` as you can see from the install Swift page: https://www.swift.org/install/linux/amazonlinux/2/#latest

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
