### PR TITLE
treewide: mkDerivation rec {} -> mkDerivation (finalAttrs: {})

### DIFF
--- a/pkgs/data/fonts/emojione/default.nix
+++ b/pkgs/data/fonts/emojione/default.nix
@@ -10,14 +10,14 @@
   scfbuild,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "emojione";
   version = "1.4";
 
   src = fetchFromGitHub {
     owner = "eosrei";
     repo = "emojione-color-font";
-    rev = "v${version}";
+    tag = "v${finalAttrs.version}";
     sha256 = "1781kxfbhnvylypbkwxc3mx6hi0gcjisfjr9cf0jdz4d1zkf09b3";
   };
 
@@ -63,4 +63,4 @@ stdenv.mkDerivation rec {
     license = licenses.cc-by-40;
     maintainers = with maintainers; [ abbradar ];
   };
-}
+})

--- a/pkgs/data/fonts/liberation-fonts/default.nix
+++ b/pkgs/data/fonts/liberation-fonts/default.nix
@@ -21,7 +21,7 @@ let
       nativeBuildInputs,
       postPatch ? null,
     }:
-    stdenv.mkDerivation rec {
+    stdenv.mkDerivation {
       pname = "liberation-fonts";
       inherit version;
 
@@ -38,7 +38,7 @@ let
 
         for i in ${toString docsToInstall}; do
           # not all docs exist in all versions
-          install -m444 -Dt $out/share/doc/${pname}-${version} $i || true
+          install -m444 -Dt $out/share/doc/liberation-fonts-${version} $i || true
         done
       '';
 

--- a/pkgs/data/fonts/maple-font/default.nix
+++ b/pkgs/data/fonts/maple-font/default.nix
@@ -15,11 +15,11 @@ let
       hash,
       desc,
     }:
-    stdenv.mkDerivation rec {
+    stdenv.mkDerivation (finalAttrs: {
       inherit pname;
       version = "7.2";
       src = fetchurl {
-        url = "https://github.com/subframe7536/Maple-font/releases/download/v${version}/${pname}.zip";
+        url = "https://github.com/subframe7536/Maple-font/releases/download/v${finalAttrs.version}/${pname}.zip";
         inherit hash;
       };
 
@@ -42,7 +42,7 @@ let
         platforms = platforms.all;
         maintainers = with maintainers; [ oluceps ];
       };
-    };
+    });
 
   typeVariants = {
     truetype = {

--- a/pkgs/data/fonts/tex-gyre-math/default.nix
+++ b/pkgs/data/fonts/tex-gyre-math/default.nix
@@ -43,7 +43,7 @@ let
     let
       dotless_version = builtins.replaceStrings [ "." ] [ "" ] version;
     in
-    stdenv.mkDerivation rec {
+    stdenv.mkDerivation (finalAttrs: {
       name = "tex-gyre-${variant}-math-${version}";
       inherit version;
 
@@ -54,7 +54,7 @@ let
 
       installPhase = ''
         install -m444 -Dt $out/share/fonts/opentype opentype/*.otf
-        install -m444 -Dt $out/share/doc/${name}    doc/*.txt
+        install -m444 -Dt $out/share/doc/${finalAttrs.name}    doc/*.txt
       '';
 
       outputHashAlgo = "sha256";
@@ -75,6 +75,6 @@ let
         maintainers = with maintainers; [ siddharthist ];
         platforms = platforms.all;
       };
-    };
+    });
 in
 lib.mapAttrs mkVariant variants

--- a/pkgs/data/icons/papirus-maia-icon-theme/default.nix
+++ b/pkgs/data/icons/papirus-maia-icon-theme/default.nix
@@ -10,13 +10,13 @@
   hicolor-icon-theme,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation {
   pname = "papirus-maia-icon-theme";
   version = "2019-07-26";
 
   src = fetchFromGitHub {
     owner = "Ste74";
-    repo = pname;
+    repo = "papirus-maia-icon-theme";
     rev = "90d47c817cc0edeed8b5a90335e669948ff4a116";
     sha256 = "0d6lvdg5nw5wfaq8lxszcws174vg12ywkrqzn6czimhmhp48jf5p";
   };

--- a/pkgs/data/icons/tango-icon-theme/default.nix
+++ b/pkgs/data/icons/tango-icon-theme/default.nix
@@ -12,12 +12,12 @@
   hicolor-icon-theme,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "tango-icon-theme";
   version = "0.8.90";
 
   src = fetchurl {
-    url = "http://tango.freedesktop.org/releases/tango-icon-theme-${version}.tar.gz";
+    url = "http://tango.freedesktop.org/releases/tango-icon-theme-${finalAttrs.version}.tar.gz";
     sha256 = "13n8cpml71w6zfm2jz5fa7r1z18qlzk4gv07r6n1in2p5l1xi63f";
   };
 
@@ -50,4 +50,4 @@ stdenv.mkDerivation rec {
     platforms = platforms.linux;
     license = licenses.publicDomain;
   };
-}
+})

--- a/pkgs/data/sgml+xml/stylesheets/xslt/docbook-xsl/default.nix
+++ b/pkgs/data/sgml+xml/stylesheets/xslt/docbook-xsl/default.nix
@@ -21,12 +21,12 @@ let
     }:
     let
       legacySuffix = lib.optionalString (suffix != "-nons") "-ns";
-      self = stdenv.mkDerivation rec {
+      self = stdenv.mkDerivation (finalAttrs: {
         inherit pname;
         version = "1.79.2";
 
         src = fetchurl {
-          url = "https://github.com/docbook/xslt10-stylesheets/releases/download/release%2F${version}/docbook-xsl${suffix}-${version}.tar.bz2";
+          url = "https://github.com/docbook/xslt10-stylesheets/releases/download/release%2F${finalAttrs.version}/docbook-xsl${suffix}-${finalAttrs.version}.tar.bz2";
           inherit sha256;
         };
 
@@ -51,7 +51,8 @@ let
 
             # Add legacy sourceforge.net URIs to the catalog
             (replaceVars ./catalog-legacy-uris.patch {
-              inherit legacySuffix suffix version;
+              inherit legacySuffix suffix;
+              inherit (finalAttrs) version;
             })
           ]
           ++ lib.optionals withManOptDedupPatch [
@@ -90,7 +91,7 @@ let
           maintainers = [ ];
           platforms = lib.platforms.all;
         };
-      };
+      });
     in
     self;
 

--- a/pkgs/data/themes/adwaita-qt/default.nix
+++ b/pkgs/data/themes/adwaita-qt/default.nix
@@ -12,7 +12,7 @@
   useQt6 ? false,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "adwaita-qt";
   version = "1.4.2";
 
@@ -23,8 +23,8 @@ stdenv.mkDerivation rec {
 
   src = fetchFromGitHub {
     owner = "FedoraQt";
-    repo = pname;
-    rev = version;
+    repo = "adwaita-qt";
+    rev = finalAttrs.version;
     sha256 = "sha256-K/+SL52C+M2OC4NL+mhBnm/9BwH0KNNTGIDmPwuUwkM=";
   };
 
@@ -71,4 +71,4 @@ stdenv.mkDerivation rec {
     maintainers = [ ];
     platforms = platforms.all;
   };
-}
+})

--- a/pkgs/data/themes/ant-theme/ant-bloody.nix
+++ b/pkgs/data/themes/ant-theme/ant-bloody.nix
@@ -8,12 +8,12 @@
 let
   themeName = "Ant-Bloody";
 in
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "ant-bloody-theme";
   version = "1.3.0";
 
   src = fetchurl {
-    url = "https://github.com/EliverLara/${themeName}/releases/download/v${version}/${themeName}.tar";
+    url = "https://github.com/EliverLara/${themeName}/releases/download/v${finalAttrs.version}/${themeName}.tar";
     sha256 = "0rrz50kmzjmqj17hvrw67pbaclwxv85i5m08s7842iky6dnn5z8s";
   };
 
@@ -36,4 +36,4 @@ stdenv.mkDerivation rec {
     platforms = platforms.all;
     maintainers = with maintainers; [ alexarice ];
   };
-}
+})

--- a/pkgs/data/themes/ant-theme/ant-nebula.nix
+++ b/pkgs/data/themes/ant-theme/ant-nebula.nix
@@ -8,12 +8,12 @@
 let
   themeName = "Ant-Nebula";
 in
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "ant-nebula-theme";
   version = "1.3.0";
 
   src = fetchurl {
-    url = "https://github.com/EliverLara/${themeName}/releases/download/v${version}/${themeName}.tar";
+    url = "https://github.com/EliverLara/${themeName}/releases/download/v${finalAttrs.version}/${themeName}.tar";
     sha256 = "1xpgw577nmgjk547mg2vvv0gdai60srgncykm5pb1w8dnlk69jbz";
   };
 
@@ -36,4 +36,4 @@ stdenv.mkDerivation rec {
     platforms = platforms.all;
     maintainers = with maintainers; [ alexarice ];
   };
-}
+})

--- a/pkgs/data/themes/ant-theme/ant.nix
+++ b/pkgs/data/themes/ant-theme/ant.nix
@@ -8,12 +8,12 @@
 let
   themeName = "Ant";
 in
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "ant-theme";
   version = "1.3.0";
 
   src = fetchurl {
-    url = "https://github.com/EliverLara/${themeName}/releases/download/v${version}/${themeName}.tar";
+    url = "https://github.com/EliverLara/${themeName}/releases/download/v${finalAttrs.version}/${themeName}.tar";
     sha256 = "1r795v96ywzcb4dq08q2fdbmfia32g36cc512mhy41s8fb1a47dz";
   };
 
@@ -36,4 +36,4 @@ stdenv.mkDerivation rec {
     platforms = platforms.all;
     maintainers = with maintainers; [ alexarice ];
   };
-}
+})

--- a/pkgs/data/themes/graphite-kde-theme/default.nix
+++ b/pkgs/data/themes/graphite-kde-theme/default.nix
@@ -8,13 +8,13 @@
   gitUpdater,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation {
   pname = "graphite-kde-theme";
   version = "unstable-2023-10-25";
 
   src = fetchFromGitHub {
     owner = "vinceliuice";
-    repo = pname;
+    repo = "graphite-kde-theme";
     rev = "33cc85c49c424dfcba73e6ee84b0dc7fb9e52566";
     hash = "sha256-iQGT2x0wY2EIuYw/a1MB8rT9BxiqWrOyBo6EGIJwsFw=";
   };

--- a/pkgs/data/themes/gtk-theme-framework/default.nix
+++ b/pkgs/data/themes/gtk-theme-framework/default.nix
@@ -5,14 +5,14 @@
   lib,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "gtk-theme-framework";
   version = "0.2.3";
 
   src = fetchFromGitHub {
     owner = "jaxwilko";
-    repo = pname;
-    rev = "v${version}";
+    repo = "gtk-theme-framework";
+    rev = "v${finalAttrs.version}";
     sha256 = "1z5s5rsgiypanf2z0avaisbflnvwrc8aiy5qskrsvbbaja63jy3s";
   };
 
@@ -38,4 +38,4 @@ stdenv.mkDerivation rec {
     license = licenses.gpl3Only;
     maintainers = [ ];
   };
-}
+})

--- a/pkgs/data/themes/kwin-decorations/kde-rounded-corners/default.nix
+++ b/pkgs/data/themes/kwin-decorations/kde-rounded-corners/default.nix
@@ -12,14 +12,14 @@
   lib,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "kde-rounded-corners";
   version = "0.7.2";
 
   src = fetchFromGitHub {
     owner = "matinlotfali";
     repo = "KDE-Rounded-Corners";
-    rev = "v${version}";
+    rev = "v${finalAttrs.version}";
     hash = "sha256-idcQ4ANud31qOCmEnPvKjstK9fCp6+cwcmSO7/8aCaY=";
   };
 
@@ -42,4 +42,4 @@ stdenv.mkDerivation rec {
     license = licenses.gpl3Only;
     maintainers = with maintainers; [ devusb ];
   };
-}
+})

--- a/pkgs/data/themes/kwin-decorations/sierra-breeze-enhanced/default.nix
+++ b/pkgs/data/themes/kwin-decorations/sierra-breeze-enhanced/default.nix
@@ -15,14 +15,14 @@ let
   qt5Version = "1.3.3";
   qt5Sha256 = "sha256-zTUTsSzy4p0Y7RPOidCtxTjjyvPRyWSQCxA5sUzXcLc=";
 in
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "sierra-breeze-enhanced";
   version = if useQt5 then qt5Version else latestVersion;
 
   src = fetchFromGitHub {
     owner = "kupiqu";
     repo = "SierraBreezeEnhanced";
-    rev = if version == "2.1.0" then "V.2.1.0" else "V${version}";
+    rev = if finalAttrs.version == "2.1.0" then "V.2.1.0" else "V${finalAttrs.version}";
     sha256 = if useQt5 then qt5Sha256 else latestSha256;
   };
 
@@ -46,4 +46,4 @@ stdenv.mkDerivation rec {
     license = licenses.gpl3Only;
     maintainers = with maintainers; [ A1ca7raz ];
   };
-}
+})

--- a/pkgs/data/themes/layan-kde/default.nix
+++ b/pkgs/data/themes/layan-kde/default.nix
@@ -8,13 +8,13 @@
   gitUpdater,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation {
   pname = "layan-kde";
   version = "unstable-2023-09-30";
 
   src = fetchFromGitHub {
     owner = "vinceliuice";
-    repo = pname;
+    repo = "layan-kde";
     rev = "7ab7cd7461dae8d8d6228d3919efbceea5f4272c";
     hash = "sha256-Wh8tZcQEdTTlgtBf4ovapojHcpPBZDDkWOclmxZv9zA=";
   };

--- a/pkgs/data/themes/plata/default.nix
+++ b/pkgs/data/themes/plata/default.nix
@@ -31,14 +31,14 @@
   destructionColor ? null, # Tertiary color for 'destructive' buttons (Default: #F44336 = Red500)
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "plata-theme";
   version = "0.9.9";
 
   src = fetchFromGitLab {
     owner = "tista500";
     repo = "plata-theme";
-    rev = version;
+    tag = finalAttrs.version;
     sha256 = "1iwvlv9qcrjyfbzab00vjqafmp3vdybz1hi02r6lwbgvwyfyrifk";
   };
 
@@ -107,4 +107,4 @@ stdenv.mkDerivation rec {
     platforms = platforms.linux;
     maintainers = [ maintainers.tadfisher ];
   };
-}
+})

--- a/pkgs/data/themes/utterly-nord-plasma/default.nix
+++ b/pkgs/data/themes/utterly-nord-plasma/default.nix
@@ -9,13 +9,13 @@
   plasma-workspace,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation {
   pname = "utterly-nord-plasma";
   version = "3.2";
 
   src = fetchFromGitHub {
     owner = "HimDek";
-    repo = pname;
+    repo = "utterly-nord-plasma";
     rev = "e513b4dfeddd587a34bfdd9ba6b1d1eac8ecadf5";
     hash = "sha256-moLgBFR+BgoiEBzV3y/LA6JZfLHrG1weL1+h8LN9ztA=";
   };

--- a/pkgs/games/90secondportraits/default.nix
+++ b/pkgs/games/90secondportraits/default.nix
@@ -29,12 +29,12 @@ let
   ];
 
 in
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   inherit pname desktopItems;
   version = "1.01b";
 
   src = fetchurl {
-    url = "https://github.com/SimonLarsen/90-Second-Portraits/releases/download/${version}/${pname}-${version}.love";
+    url = "https://github.com/SimonLarsen/90-Second-Portraits/releases/download/${finalAttrs.version}/${pname}-${finalAttrs.version}.love";
     sha256 = "0jj3k953r6vb02212gqcgqpb4ima87gnqgls43jmylxq2mcm33h5";
   };
 
@@ -67,5 +67,4 @@ stdenv.mkDerivation rec {
     ];
     downloadPage = "http://tangramgames.dk/games/90secondportraits";
   };
-
-}
+})

--- a/pkgs/games/amoeba/data.nix
+++ b/pkgs/games/amoeba/data.nix
@@ -4,12 +4,12 @@
   fetchurl,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "amoeba-data";
   version = "1.1";
 
   src = fetchurl {
-    url = "http://http.debian.net/debian/pool/non-free/a/amoeba-data/amoeba-data_${version}.orig.tar.gz";
+    url = "http://http.debian.net/debian/pool/non-free/a/amoeba-data/amoeba-data_${finalAttrs.version}.orig.tar.gz";
     sha256 = "1bgclr1v63n14bj9nwzm5zxg48nm0cla9bq1rbd5ylxra18k0jbg";
   };
 
@@ -25,4 +25,4 @@ stdenv.mkDerivation rec {
     maintainers = [ maintainers.dezgeg ];
     platforms = platforms.all;
   };
-}
+})

--- a/pkgs/games/amoeba/default.nix
+++ b/pkgs/games/amoeba/default.nix
@@ -14,18 +14,18 @@
   installShellFiles,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "amoeba";
   version = "1.1";
   debver = "31";
 
   srcs = [
     (fetchurl {
-      url = "http://http.debian.net/debian/pool/contrib/a/amoeba/amoeba_${version}.orig.tar.gz";
+      url = "http://http.debian.net/debian/pool/contrib/a/amoeba/amoeba_${finalAttrs.version}.orig.tar.gz";
       hash = "sha256-NT6oMuAlTcVZEnYjMCF+BD+k3/w7LfWEmj6bkQln3sM=";
     })
     (fetchurl {
-      url = "http://http.debian.net/debian/pool/contrib/a/amoeba/amoeba_${version}-${debver}.debian.tar.xz";
+      url = "http://http.debian.net/debian/pool/contrib/a/amoeba/amoeba_${finalAttrs.version}-${finalAttrs.debver}.debian.tar.xz";
       hash = "sha256-Ga/YeXbPXjkG/6qd9Z201d14Hlj/Je6DxgzeIQOqrWc=";
     })
   ];
@@ -67,4 +67,4 @@ stdenv.mkDerivation rec {
     maintainers = [ maintainers.dezgeg ];
     platforms = platforms.linux;
   };
-}
+})

--- a/pkgs/games/arx-libertatis/default.nix
+++ b/pkgs/games/arx-libertatis/default.nix
@@ -32,14 +32,14 @@ let
     ;
 in
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "arx-libertatis";
   version = "1.2.1";
 
   src = fetchFromGitHub {
     owner = "arx";
     repo = "ArxLibertatis";
-    rev = version;
+    tag = finalAttrs.version;
     sha256 = "GBJcsibolZP3oVOTSaiVqG2nMmvXonKTp5i/0NNODKY=";
   };
 
@@ -96,5 +96,4 @@ stdenv.mkDerivation rec {
     maintainers = with maintainers; [ rnhmjoj ];
     platforms = platforms.linux;
   };
-
-}
+})

--- a/pkgs/games/chiaki-ng/default.nix
+++ b/pkgs/games/chiaki-ng/default.nix
@@ -35,14 +35,14 @@
   xxHash,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "chiaki-ng";
   version = "1.9.7";
 
   src = fetchFromGitHub {
     owner = "streetpea";
     repo = "chiaki-ng";
-    rev = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-dAb4RGRCC6pCpfLxUJO7pFnqNm1icaU3v1n+HhJILe0=";
     fetchSubmodules = true;
   };
@@ -126,4 +126,4 @@ stdenv.mkDerivation rec {
     platforms = platforms.linux;
     mainProgram = "chiaki";
   };
-}
+})

--- a/pkgs/games/construo/default.nix
+++ b/pkgs/games/construo/default.nix
@@ -10,12 +10,12 @@
   libglut ? null,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "construo";
   version = "0.2.3";
 
   src = fetchurl {
-    url = "https://github.com/Construo/construo/releases/download/v${version}/${pname}-${version}.tar.gz";
+    url = "https://github.com/Construo/construo/releases/download/v${finalAttrs.version}/${finalAttrs.pname}-${finalAttrs.version}.tar.gz";
     sha256 = "1wmj527hbj1qv44cdsj6ahfjrnrjwg2dp8gdick8nd07vm062qxa";
   };
 
@@ -40,4 +40,4 @@ stdenv.mkDerivation rec {
     homepage = "http://fs.fsf.org/construo/";
     license = lib.licenses.gpl3;
   };
-}
+})

--- a/pkgs/games/crawl/default.nix
+++ b/pkgs/games/crawl/default.nix
@@ -25,21 +25,21 @@
   buildPackages,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "crawl${lib.optionalString tileMode "-tiles"}";
   version = "0.32.1";
 
   src = fetchFromGitHub {
     owner = "crawl";
     repo = "crawl";
-    rev = version;
+    tag = finalAttrs.version;
     hash = "sha256-jhjFC8+A2dQomMwKZPSiEViXeQpty2Dk9alDcNsLvq0=";
   };
 
   # Patch hard-coded paths and remove force library builds
   postPatch = ''
     substituteInPlace crawl-ref/source/util/find_font \
-      --replace '/usr/share/fonts /usr/local/share/fonts /usr/*/lib/X11/fonts' '${fontsPath}/share/fonts'
+      --replace '/usr/share/fonts /usr/local/share/fonts /usr/*/lib/X11/fonts' '${finalAttrs.fontsPath}/share/fonts'
     substituteInPlace crawl-ref/source/windowmanager-sdl.cc \
       --replace 'SDL_image.h' 'SDL2/SDL_image.h'
   '';
@@ -74,7 +74,7 @@ stdenv.mkDerivation rec {
   preBuild =
     ''
       cd crawl-ref/source
-      echo "${version}" > util/release_ver
+      echo "${finalAttrs.version}" > util/release_ver
       patchShebangs 'util'
       patchShebangs util/gen-mi-enum
       rm -rf contrib
@@ -137,4 +137,4 @@ stdenv.mkDerivation rec {
     ];
     maintainers = [ maintainers.abbradar ];
   };
-}
+})

--- a/pkgs/games/cutemaze/default.nix
+++ b/pkgs/games/cutemaze/default.nix
@@ -10,12 +10,12 @@
   qtsvg,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "cutemaze";
   version = "1.3.5";
 
   src = fetchurl {
-    url = "https://gottcode.org/cutemaze/cutemaze-${version}.tar.bz2";
+    url = "https://gottcode.org/cutemaze/cutemaze-${finalAttrs.version}.tar.bz2";
     hash = "sha256-a+QIOD0TB0AGnqIUgtkMBZuPUCQbXp4NtZ6b0vk/J0c=";
   };
 
@@ -57,4 +57,4 @@ stdenv.mkDerivation rec {
     maintainers = with maintainers; [ dotlambda ];
     platforms = platforms.unix;
   };
-}
+})

--- a/pkgs/games/deliantra/arch.nix
+++ b/pkgs/games/deliantra/arch.nix
@@ -5,12 +5,12 @@
   deliantra-server,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "deliantra-arch";
   version = "3.1";
 
   src = fetchurl {
-    url = "http://dist.schmorp.de/deliantra/${pname}-${version}.tar.xz";
+    url = "http://dist.schmorp.de/deliantra/${finalAttrs.pname}-${finalAttrs.version}.tar.xz";
     sha256 = "1xzhv48g90hwkzgx9nfjm81ivg6hchkik9ldimi8ijb4j393kvsz";
   };
 
@@ -30,4 +30,4 @@ stdenv.mkDerivation rec {
     platforms = platforms.linux;
     maintainers = with maintainers; [ ToxicFrog ];
   };
-}
+})

--- a/pkgs/games/deliantra/maps.nix
+++ b/pkgs/games/deliantra/maps.nix
@@ -5,12 +5,12 @@
   deliantra-server,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "deliantra-maps";
   version = "3.1";
 
   src = fetchurl {
-    url = "http://dist.schmorp.de/deliantra/${pname}-${version}.tar.xz";
+    url = "http://dist.schmorp.de/deliantra/${finalAttrs.pname}-${finalAttrs.version}.tar.xz";
     sha256 = "0zbwzya28s1xpnbrmqkqvfrzns03zdjd8a9w9nk665aif6rw2zbz";
   };
 
@@ -30,4 +30,4 @@ stdenv.mkDerivation rec {
     platforms = platforms.linux;
     maintainers = with maintainers; [ ToxicFrog ];
   };
-}
+})

--- a/pkgs/games/deliantra/server.nix
+++ b/pkgs/games/deliantra/server.nix
@@ -36,12 +36,12 @@ let
     YAMLLibYAML
   ];
 in
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "deliantra-server";
   version = "3.1";
 
   src = fetchurl {
-    url = "http://dist.schmorp.de/deliantra/${pname}-${version}.tar.xz";
+    url = "http://dist.schmorp.de/deliantra/${finalAttrs.pname}-${finalAttrs.version}.tar.xz";
     sha256 = "0v0m2m9fxq143aknh7jb3qj8bnpjrs3bpbbx07c18516y3izr71d";
   };
 
@@ -90,4 +90,4 @@ stdenv.mkDerivation rec {
     platforms = platforms.linux;
     maintainers = with maintainers; [ ToxicFrog ];
   };
-}
+})

--- a/pkgs/games/doom-ports/slade/default.nix
+++ b/pkgs/games/doom-ports/slade/default.nix
@@ -19,14 +19,14 @@
   wrapGAppsHook3,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "slade";
   version = "3.2.7";
 
   src = fetchFromGitHub {
     owner = "sirjuddington";
     repo = "SLADE";
-    rev = version;
+    rev = finalAttrs.version;
     hash = "sha256-+i506uzO2q/9k7en6CKs4ui9gjszrMOYwW+V9W5Lvns=";
   };
 
@@ -71,4 +71,4 @@ stdenv.mkDerivation rec {
     platforms = lib.platforms.linux;
     maintainers = with lib.maintainers; [ abbradar ];
   };
-}
+})

--- a/pkgs/games/doom-ports/zandronum/fmod.nix
+++ b/pkgs/games/doom-ports/zandronum/fmod.nix
@@ -16,20 +16,20 @@ let
   ];
 
 in
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "fmod";
   version = "4.44.64";
-  shortVersion = builtins.replaceStrings [ "." ] [ "" ] version;
+  shortVersion = builtins.replaceStrings [ "." ] [ "" ] finalAttrs.version;
 
   src = fetchurl (
     if stdenv.hostPlatform.isLinux then
       {
-        url = "https://zdoom.org/files/fmod/fmodapi${shortVersion}linux.tar.gz";
+        url = "https://zdoom.org/files/fmod/fmodapi${finalAttrs.shortVersion}linux.tar.gz";
         sha256 = "047hk92xapwwqj281f4zwl0ih821rrliya70gfj82sdfjh9lz8i1";
       }
     else
       {
-        url = "https://zdoom.org/files/fmod/fmodapi${shortVersion}mac-installer.dmg";
+        url = "https://zdoom.org/files/fmod/fmodapi${finalAttrs.shortVersion}mac-installer.dmg";
         sha256 = "1m1y4cpcwpkl8x31d3s68xzp107f343ma09w2437i2adn5y7m8ii";
       }
   );
@@ -42,8 +42,8 @@ stdenv.mkDerivation rec {
 
   installPhase =
     lib.optionalString stdenv.hostPlatform.isLinux ''
-      install -Dm755 api/lib/libfmodex${bits}-${version}.so $out/lib/libfmodex-${version}.so
-      ln -s libfmodex-${version}.so $out/lib/libfmodex.so
+      install -Dm755 api/lib/libfmodex${bits}-${finalAttrs.version}.so $out/lib/libfmodex-${finalAttrs.version}.so
+      ln -s libfmodex-${finalAttrs.version}.so $out/lib/libfmodex.so
       patchelf --set-rpath ${libPath} $out/lib/libfmodex.so
     ''
     + lib.optionalString stdenv.hostPlatform.isDarwin ''
@@ -65,4 +65,4 @@ stdenv.mkDerivation rec {
     ];
     maintainers = [ maintainers.lassulus ];
   };
-}
+})

--- a/pkgs/games/duckmarines/default.nix
+++ b/pkgs/games/duckmarines/default.nix
@@ -8,7 +8,7 @@
   makeDesktopItem,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "duckmarines";
   version = "1.0c";
 
@@ -19,8 +19,8 @@ stdenv.mkDerivation rec {
 
   desktopItem = makeDesktopItem {
     name = "duckmarines";
-    exec = pname;
-    icon = icon;
+    exec = "duckmarines";
+    icon = finalAttrs.icon;
     comment = "Duck-themed action puzzle video game";
     desktopName = "Duck Marines";
     genericName = "duckmarines";
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
   };
 
   src = fetchurl {
-    url = "https://github.com/SimonLarsen/${pname}/releases/download/v${version}/${pname}-1.0c.love";
+    url = "https://github.com/SimonLarsen/${finalAttrs.pname}/releases/download/v${finalAttrs.version}/${finalAttrs.pname}-1.0c.love";
     sha256 = "1rvgpkvi4h9zhc4fwb4knhsa789yjcx4a14fi4vqfdyybhvg5sh9";
   };
 
@@ -44,13 +44,14 @@ stdenv.mkDerivation rec {
     mkdir -p $out/bin
     mkdir -p $out/share/games/lovegames
 
-    cp -v ${src} $out/share/games/lovegames/${pname}.love
+    cp -v $src $out/share/games/lovegames/duckmarines.love
 
-    makeWrapper ${love}/bin/love $out/bin/${pname} --add-flags $out/share/games/lovegames/${pname}.love
+    makeWrapper ${love}/bin/love $out/bin/duckmarines \
+        --add-flags $out/share/games/lovegames/duckmarines.love
 
-    chmod +x $out/bin/${pname}
+    chmod +x $out/bin/duckmarines
     mkdir -p $out/share/applications
-    ln -s ${desktopItem}/share/applications/* $out/share/applications/
+    ln -s ${finalAttrs.desktopItem}/share/applications/* $out/share/applications/
   '';
 
   meta = with lib; {
@@ -61,5 +62,4 @@ stdenv.mkDerivation rec {
     license = licenses.free;
     downloadPage = "http://tangramgames.dk/games/duckmarines";
   };
-
-}
+})

--- a/pkgs/games/dwarf-fortress/dwarf-therapist/default.nix
+++ b/pkgs/games/dwarf-fortress/dwarf-therapist/default.nix
@@ -14,7 +14,7 @@
   hash ? dfVersions.therapist.git.outputHash,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation {
   pname = "dwarf-therapist";
 
   inherit version;

--- a/pkgs/games/dwarf-fortress/soundsense.nix
+++ b/pkgs/games/dwarf-fortress/soundsense.nix
@@ -15,13 +15,13 @@
   },
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   version = "2016-1_196";
   dfVersion = "0.44.12";
   inherit soundPack;
   pname = "soundsense";
   src = fetchzip {
-    url = "https://df.zweistein.cz/soundsense/soundSense_${version}.zip";
+    url = "https://df.zweistein.cz/soundsense/soundSense_${finalAttrs.version}.zip";
     hash = "sha256-c+LOUxmJaZ3VqVOBYSQypiZxWyNAXOlRQVD3QZPReb4=";
   };
   nativeBuildInputs = [ dos2unix ];
@@ -35,7 +35,7 @@ stdenv.mkDerivation rec {
     ln -s $out/soundsense/dfhack $out/hack
     ln -s $soundPack $out/soundsense/packs
   '';
-  passthru = { inherit version dfVersion; };
+  passthru = { inherit (finalAttrs) version dfVersion; };
   meta = {
     description = "Plays sound based on Dwarf Fortress game logs";
     maintainers = with lib.maintainers; [
@@ -46,4 +46,4 @@ stdenv.mkDerivation rec {
     platforms = lib.platforms.all;
     homepage = "https://df.zweistein.cz/soundsense";
   };
-}
+})

--- a/pkgs/games/dxx-rebirth/assets.nix
+++ b/pkgs/games/dxx-rebirth/assets.nix
@@ -11,12 +11,12 @@ let
     let
       pname = "descent${toString ver}";
     in
-    stdenv.mkDerivation rec {
-      name = "${pname}-assets-${version}";
+    stdenv.mkDerivation (finalAttrs: {
+      name = "${pname}-assets-${finalAttrs.version}";
       version = "2.0.0.7";
 
       src = requireFile rec {
-        name = "setup_descent12_${version}.exe";
+        name = "setup_descent12_${finalAttrs.version}.exe";
         sha256 = "1r1drbfda6czg21f9qqiiwgnkpszxgmcn5bafp5ljddh34swkn3f";
         message = ''
           While the Descent ${toString ver} game engine is free, the game assets are not.
@@ -55,7 +55,7 @@ let
         maintainers = with maintainers; [ peterhoeg ];
         hydraPlatforms = [ ];
       };
-    };
+    });
 
 in
 {

--- a/pkgs/games/flightgear/default.nix
+++ b/pkgs/games/flightgear/default.nix
@@ -37,7 +37,7 @@
 
 let
   version = "2024.1.1";
-  data = stdenv.mkDerivation rec {
+  data = stdenv.mkDerivation {
     pname = "flightgear-data";
     inherit version;
 
@@ -52,11 +52,11 @@ let
 
     installPhase = ''
       mkdir -p "$out/share/FlightGear"
-      cp ${src}/* -a "$out/share/FlightGear/"
+      cp $src/* -a "$out/share/FlightGear/"
     '';
   };
 in
-stdenv.mkDerivation rec {
+stdenv.mkDerivation {
   pname = "flightgear";
   # inheriting data for `nix-prefetch-url -A pkgs.flightgear.data.src`
   inherit version data;

--- a/pkgs/games/fltrator/default.nix
+++ b/pkgs/games/fltrator/default.nix
@@ -8,12 +8,12 @@
   libjpeg,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "fltrator";
   version = "2.3";
 
   src = fetchurl {
-    url = "mirror://sourceforge/fltrator/fltrator-${version}-code.zip";
+    url = "mirror://sourceforge/fltrator/fltrator-${finalAttrs.version}-code.zip";
     sha256 = "125aqq1sfrm0c9cm6gyylwdmc8xrb0rjf563xvw7q28sdbl6ayp7";
   };
 
@@ -60,5 +60,4 @@ stdenv.mkDerivation rec {
     maintainers = [ maintainers.marius851000 ];
     license = licenses.gpl3;
   };
-
-}
+})

--- a/pkgs/games/freeciv/default.nix
+++ b/pkgs/games/freeciv/default.nix
@@ -33,14 +33,14 @@
   sqlite,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "freeciv";
   version = "3.1.4";
 
   src = fetchFromGitHub {
     owner = "freeciv";
     repo = "freeciv";
-    rev = "R${lib.replaceStrings [ "." ] [ "_" ] version}";
+    rev = "R${lib.replaceStrings [ "." ] [ "_" ] finalAttrs.version}";
     hash = "sha256-lT3sXD5lFjG/63eBXEG+rU9idem/8kXfUXj6iB3AGOg=";
   };
 
@@ -137,4 +137,4 @@ stdenv.mkDerivation rec {
     hydraPlatforms = lib.platforms.linux; # sdl-config times out on darwin
     broken = qtClient && stdenv.hostPlatform.isDarwin; # Missing Qt5 development files
   };
-}
+})

--- a/pkgs/games/garden-of-coloured-lights/default.nix
+++ b/pkgs/games/garden-of-coloured-lights/default.nix
@@ -7,7 +7,7 @@
   allegro,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "garden-of-coloured-lights";
   version = "1.0.9";
 
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
   '';
 
   src = fetchurl {
-    url = "mirror://sourceforge/garden/${version}/garden-${version}.tar.gz";
+    url = "mirror://sourceforge/garden/${finalAttrs.version}/garden-${finalAttrs.version}.tar.gz";
     sha256 = "1qsj4d7r22m5f9f5f6cyvam1y5q5pbqvy5058r7w0k4s48n77y6s";
   };
 
@@ -40,5 +40,4 @@ stdenv.mkDerivation rec {
     maintainers = [ ];
     license = licenses.gpl3;
   };
-
-}
+})

--- a/pkgs/games/iortcw/sp.nix
+++ b/pkgs/games/iortcw/sp.nix
@@ -12,20 +12,20 @@
   makeWrapper,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "iortcw-sp";
   version = "1.51c";
 
   src = fetchFromGitHub {
     owner = "iortcw";
     repo = "iortcw";
-    rev = version;
+    tag = finalAttrs.version;
     sha256 = "0g5wgqb1gm34pd05dj2i8nj3qhsz0831p3m7bsgxpjcg9c00jpyw";
   };
 
   enableParallelBuilding = true;
 
-  sourceRoot = "${src.name}/SP";
+  sourceRoot = "${finalAttrs.src.name}/SP";
 
   makeFlags = [
     "USE_INTERNAL_LIBS=0"
@@ -60,10 +60,10 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with lib; {
+    inherit (finalAttrs.src.meta) homepage;
     description = "Single player version of game engine for Return to Castle Wolfenstein";
-    homepage = src.meta.homepage;
     license = licenses.gpl3;
     platforms = platforms.linux;
     maintainers = with maintainers; [ rjpcasalino ];
   };
-}
+})

--- a/pkgs/games/koboredux/default.nix
+++ b/pkgs/games/koboredux/default.nix
@@ -51,7 +51,7 @@ let
 
 in
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation {
   inherit pname version;
 
   src = [ main_src ] ++ optional useProprietaryAssets assets_src;

--- a/pkgs/games/leela-zero/default.nix
+++ b/pkgs/games/leela-zero/default.nix
@@ -10,14 +10,14 @@
   zlib,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "leela-zero";
   version = "0.17";
 
   src = fetchFromGitHub {
     owner = "gcp";
     repo = "leela-zero";
-    rev = "v${version}";
+    rev = "v${finalAttrs.version}";
     hash = "sha256-AQRp2rkL9KCZdsJN6uz2Y+3kV4lyRLYjWn0p7UOjBMw=";
     fetchSubmodules = true;
   };
@@ -44,4 +44,4 @@ stdenv.mkDerivation rec {
     ];
     platforms = platforms.linux;
   };
-}
+})

--- a/pkgs/games/libremines/default.nix
+++ b/pkgs/games/libremines/default.nix
@@ -8,14 +8,14 @@
   qtwayland,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "libremines";
   version = "2.0.1";
 
   src = fetchFromGitHub {
     owner = "Bollos00";
-    repo = pname;
-    rev = "v${version}";
+    repo = "libremines";
+    rev = "v${finalAttrs.version}";
     hash = "sha256-TQwjEgtqAvKnrpia6VloRgFwtq5TNDmxU+ZWjtEK/n8=";
   };
 
@@ -45,4 +45,4 @@ stdenv.mkDerivation rec {
     maintainers = with maintainers; [ aleksana ];
     platforms = platforms.unix;
   };
-}
+})

--- a/pkgs/games/lincity/default.nix
+++ b/pkgs/games/lincity/default.nix
@@ -12,12 +12,12 @@
   zlib,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "lincity";
   version = "1.13.1";
 
   src = fetchurl {
-    url = "mirror://sourceforge/lincity/${pname}-${version}.tar.gz";
+    url = "mirror://sourceforge/lincity/${finalAttrs.pname}-${finalAttrs.version}.tar.gz";
     sha256 = "0p81wl7labyfb6rgp0hi42l2akn3n7r2bnxal1wyvjylzw8vsk3v";
   };
 
@@ -77,4 +77,4 @@ stdenv.mkDerivation rec {
     # ../lcintl.h:14:10: fatal error: 'libintl.h' file not found
     broken = stdenv.hostPlatform.isDarwin;
   };
-}
+})

--- a/pkgs/games/linthesia/default.nix
+++ b/pkgs/games/linthesia/default.nix
@@ -18,7 +18,7 @@
   wrapGAppsHook3,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "linthesia";
   version = "unstable-2023-05-23";
 
@@ -55,9 +55,9 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "Game of playing music using a MIDI keyboard following a MIDI file";
     mainProgram = "linthesia";
-    inherit (src.meta) homepage;
+    inherit (finalAttrs.src.meta) homepage;
     license = licenses.gpl2Plus;
     platforms = platforms.linux;
     maintainers = [ ];
   };
-}
+})

--- a/pkgs/games/liquidwar/5.nix
+++ b/pkgs/games/liquidwar/5.nix
@@ -4,11 +4,11 @@
   fetchurl,
   allegro,
 }:
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   version = "5.6.5";
   pname = "liquidwar5";
   src = fetchurl {
-    url = "http://www.ufoot.org/download/liquidwar/v5/${version}/liquidwar-${version}.tar.gz";
+    url = "http://www.ufoot.org/download/liquidwar/v5/${finalAttrs.version}/liquidwar-${finalAttrs.version}.tar.gz";
     sha256 = "2tCqhN1BbK0FVCHtm0DfOe+ueNPfdZwFg8ZMVPfy/18=";
   };
 
@@ -33,4 +33,4 @@ stdenv.mkDerivation rec {
     license = licenses.gpl2Plus;
     platforms = platforms.linux;
   };
-}
+})

--- a/pkgs/games/liquidwar/default.nix
+++ b/pkgs/games/liquidwar/default.nix
@@ -28,12 +28,12 @@
   pkg-config,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "liquidwar6";
   version = "0.6.3902";
 
   src = fetchurl {
-    url = "mirror://gnu/liquidwar6/${pname}-${version}.tar.gz";
+    url = "mirror://gnu/liquidwar6/${finalAttrs.pname}-${finalAttrs.version}.tar.gz";
     sha256 = "1976nnl83d8wspjhb5d5ivdvdxgb8lp34wp54jal60z4zad581fn";
   };
 
@@ -90,4 +90,4 @@ stdenv.mkDerivation rec {
     license = licenses.gpl3Plus;
     platforms = platforms.linux;
   };
-}
+})

--- a/pkgs/games/mudlet/default.nix
+++ b/pkgs/games/mudlet/default.nix
@@ -55,14 +55,14 @@ let
     ]
   );
 in
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "mudlet";
   version = "4.17.2";
 
   src = fetchFromGitHub {
     owner = "Mudlet";
     repo = "Mudlet";
-    rev = "Mudlet-${version}";
+    tag = "Mudlet-${finalAttrs.version}";
     fetchSubmodules = true;
     hash = "sha256-K75frptePKfHeGQNXaX4lKsLwO6Rs6AAka6hvP8MA+k=";
   };
@@ -175,4 +175,4 @@ stdenv.mkDerivation rec {
     license = licenses.gpl2Plus;
     mainProgram = "mudlet";
   };
-}
+})

--- a/pkgs/games/nethack/default.nix
+++ b/pkgs/games/nethack/default.nix
@@ -47,7 +47,7 @@ let
   ];
 
 in
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   version = "3.6.7";
   pname =
     if x11Mode then
@@ -58,8 +58,8 @@ stdenv.mkDerivation rec {
       "nethack";
 
   src = fetchurl {
-    url = "https://nethack.org/download/${version}/nethack-${
-      lib.replaceStrings [ "." ] [ "" ] version
+    url = "https://nethack.org/download/${finalAttrs.version}/nethack-${
+      lib.replaceStrings [ "." ] [ "" ] finalAttrs.version
     }-src.tgz";
     sha256 = "sha256-mM9n323r+WaKYXRaqEwJvKs2Ll0z9blE7FFV1E0qrLI=";
   };
@@ -230,4 +230,4 @@ stdenv.mkDerivation rec {
     maintainers = with maintainers; [ abbradar ];
     mainProgram = "nethack";
   };
-}
+})

--- a/pkgs/games/npush/default.nix
+++ b/pkgs/games/npush/default.nix
@@ -5,12 +5,12 @@
   ncurses,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "npush";
   version = "0.7";
 
   src = fetchurl {
-    url = "mirror://sourceforge/project/npush/${pname}/${version}/${pname}-${version}.tgz";
+    url = "mirror://sourceforge/project/npush/${finalAttrs.pname}/${finalAttrs.version}/${finalAttrs.pname}-${finalAttrs.version}.tgz";
     hash = "sha256-8hbSsyeehzd4T3fUhDyebyI/oTHOHr3a8ArYAquivNk=";
   };
 
@@ -51,4 +51,4 @@ stdenv.mkDerivation rec {
     maintainers = with maintainers; [ ];
     platforms = with platforms; unix;
   };
-}
+})

--- a/pkgs/games/openloco/default.nix
+++ b/pkgs/games/openloco/default.nix
@@ -27,21 +27,21 @@ let
   };
 
 in
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "openloco";
   version = "25.02";
 
   src = fetchFromGitHub {
     owner = "OpenLoco";
     repo = "OpenLoco";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-RsiEYBNx+Lf7OyyyCShQmgtwBuxDrZkRCYCbMmZ8ZMM=";
   };
 
   postPatch = ''
     # the upstream build process determines the version tag from git; since we
     # are not using a git checkout, we patch it manually
-    sed -i '/#define NAME "OpenLoco"/a#define OPENLOCO_VERSION_TAG "${version}"' src/OpenLoco/src/Version.cpp
+    sed -i '/#define NAME "OpenLoco"/a#define OPENLOCO_VERSION_TAG "${finalAttrs.version}"' src/OpenLoco/src/Version.cpp
 
     # prefetch sfl header sources
     grep -q 'GIT_TAG \+${sfl-src.tag}' thirdparty/CMakeLists.txt
@@ -79,4 +79,4 @@ stdenv.mkDerivation rec {
     platforms = lib.platforms.linux;
     maintainers = with lib.maintainers; [ icewind1991 ];
   };
-}
+})

--- a/pkgs/games/openmw/default.nix
+++ b/pkgs/games/openmw/default.nix
@@ -64,14 +64,14 @@ let
   });
 
 in
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "openmw";
   version = "0.48.0";
 
   src = fetchFromGitLab {
     owner = "OpenMW";
     repo = "openmw";
-    rev = "${pname}-${version}";
+    rev = "${finalAttrs.pname}-${finalAttrs.version}";
     hash = "sha256-zkjVt3GfQZsFXl2Ht3lCuQtDMYQWxhdFO4aGSb3rsyo=";
   };
 
@@ -130,4 +130,4 @@ stdenv.mkDerivation rec {
     ];
     platforms = platforms.linux ++ platforms.darwin;
   };
-}
+})

--- a/pkgs/games/openttd/default.nix
+++ b/pkgs/games/openttd/default.nix
@@ -53,12 +53,12 @@ let
     sha256 = "sha256-Cgrg2m+uTODFg39mKgX+hE8atV7v5bVyZd716vSZB8M=";
   };
 in
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "openttd";
   version = "14.1";
 
   src = fetchzip {
-    url = "https://cdn.openttd.org/openttd-releases/${version}/${pname}-${version}-source.tar.xz";
+    url = "https://cdn.openttd.org/openttd-releases/${finalAttrs.version}/${finalAttrs.pname}-${finalAttrs.version}-source.tar.xz";
     hash = "sha256-YT4IE/rJ9pnpeMWKbOra6AbSUwW19RwOKlXkxwoMeKY=";
   };
 
@@ -150,4 +150,4 @@ stdenv.mkDerivation rec {
       fpletz
     ];
   };
-}
+})

--- a/pkgs/games/orthorobot/default.nix
+++ b/pkgs/games/orthorobot/default.nix
@@ -12,14 +12,14 @@
   zip,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "orthorobot";
   version = "1.1.1";
 
   src = fetchFromGitHub {
     owner = "Stabyourself";
-    repo = pname;
-    rev = "v${version}";
+    repo = "orthorobot";
+    rev = "v${finalAttrs.version}";
     sha256 = "1ca6hvd890kxmamsmsfiqzw15ngsvb4lkihjb6kabgmss61a6s5p";
   };
 
@@ -31,8 +31,8 @@ stdenv.mkDerivation rec {
   desktopItems = [
     (makeDesktopItem {
       name = "orthorobot";
-      exec = pname;
-      icon = icon;
+      exec = "orthorobot";
+      icon = finalAttrs.icon;
       comment = "Robot game";
       desktopName = "Orthorobot";
       genericName = "orthorobot";
@@ -75,4 +75,4 @@ stdenv.mkDerivation rec {
     license = licenses.free;
     downloadPage = "https://stabyourself.net/orthorobot/";
   };
-}
+})

--- a/pkgs/games/quake2/yquake2/default.nix
+++ b/pkgs/games/quake2/yquake2/default.nix
@@ -30,14 +30,14 @@ let
       ;
   };
 
-  yquake2 = stdenv.mkDerivation rec {
+  yquake2 = stdenv.mkDerivation (finalAttrs: {
     pname = "yquake2";
     version = "8.50";
 
     src = fetchFromGitHub {
       owner = "yquake2";
       repo = "yquake2";
-      rev = "QUAKE2_${builtins.replaceStrings [ "." ] [ "_" ] version}";
+      rev = "QUAKE2_${builtins.replaceStrings [ "." ] [ "_" ] finalAttrs.version}";
       sha256 = "sha256-PR/Xw/u5auGFrrXnRsl2bAkOt8/JZWY3uGNfTHomAj8=";
     };
 
@@ -101,7 +101,7 @@ let
       platforms = platforms.unix;
       maintainers = with maintainers; [ tadfisher ];
     };
-  };
+  });
 
 in
 {

--- a/pkgs/games/quake2/yquake2/games.nix
+++ b/pkgs/games/quake2/yquake2/games.nix
@@ -30,7 +30,7 @@ let
 
   toDrv =
     title: data:
-    stdenv.mkDerivation rec {
+    stdenv.mkDerivation (finalAttrs: {
       inherit (data)
         id
         version
@@ -42,16 +42,16 @@ let
       pname = "yquake2-${title}";
 
       src = fetchFromGitHub {
-        inherit sha256;
+        inherit (finalAttrs) sha256;
         owner = "yquake2";
         repo = data.id;
-        rev = "${lib.toUpper id}_${builtins.replaceStrings [ "." ] [ "_" ] version}";
+        rev = "${lib.toUpper finalAttrs.id}_${builtins.replaceStrings [ "." ] [ "_" ] finalAttrs.version}";
       };
 
       installPhase = ''
         runHook preInstall
-        mkdir -p $out/lib/yquake2/${id}
-        cp release/* $out/lib/yquake2/${id}
+        mkdir -p $out/lib/yquake2/${finalAttrs.id}
+        cp release/* $out/lib/yquake2/${finalAttrs.id}
         runHook postInstall
       '';
 
@@ -62,7 +62,7 @@ let
         platforms = platforms.unix;
         maintainers = with maintainers; [ tadfisher ];
       };
-    };
+    });
 
 in
 lib.mapAttrs toDrv games

--- a/pkgs/games/quakespasm/default.nix
+++ b/pkgs/games/quakespasm/default.nix
@@ -20,16 +20,16 @@
   useSDL2 ? stdenv.hostPlatform.isDarwin, # TODO: CoreAudio fails to initialize with SDL 1.x for some reason.
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "quakespasm";
   version = "0.96.3";
 
   src = fetchurl {
-    url = "mirror://sourceforge/quakespasm/quakespasm-${version}.tar.gz";
+    url = "mirror://sourceforge/quakespasm/quakespasm-${finalAttrs.version}.tar.gz";
     sha256 = "sha256-tXjWzkpPf04mokRY8YxLzI04VK5iUuuZgu6B2V5QGA4=";
   };
 
-  sourceRoot = "${pname}-${version}/Quake";
+  sourceRoot = "${finalAttrs.pname}-${finalAttrs.version}/Quake";
 
   patches = lib.optionals stdenv.hostPlatform.isDarwin [
     # Makes Darwin Makefile use system libraries instead of ones from app bundle
@@ -130,4 +130,4 @@ stdenv.mkDerivation rec {
     maintainers = with maintainers; [ mikroskeem ];
     mainProgram = "quake";
   };
-}
+})

--- a/pkgs/games/rogue/default.nix
+++ b/pkgs/games/rogue/default.nix
@@ -5,15 +5,15 @@
   ncurses,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "rogue";
   version = "5.4.4";
 
   src = fetchurl {
     urls = [
-      "https://src.fedoraproject.org/repo/pkgs/rogue/rogue${version}-src.tar.gz/033288f46444b06814c81ea69d96e075/rogue${version}-src.tar.gz"
-      "http://ftp.vim.org/ftp/pub/ftp/os/Linux/distr/slitaz/sources/packages-cooking/r/rogue${version}-src.tar.gz"
-      "http://rogue.rogueforge.net/files/rogue${lib.versions.majorMinor version}/rogue${version}-src.tar.gz"
+      "https://src.fedoraproject.org/repo/pkgs/rogue/rogue${finalAttrs.version}-src.tar.gz/033288f46444b06814c81ea69d96e075/rogue${finalAttrs.version}-src.tar.gz"
+      "http://ftp.vim.org/ftp/pub/ftp/os/Linux/distr/slitaz/sources/packages-cooking/r/rogue${finalAttrs.version}-src.tar.gz"
+      "http://rogue.rogueforge.net/files/rogue${lib.versions.majorMinor finalAttrs.version}/rogue${finalAttrs.version}-src.tar.gz"
     ];
     sha256 = "18g81274d0f7sr04p7h7irz0d53j6kd9j1y3zbka1gcqq0gscdvx";
   };
@@ -28,4 +28,4 @@ stdenv.mkDerivation rec {
     license = licenses.bsd3;
     maintainers = [ ];
   };
-}
+})

--- a/pkgs/games/rott/default.nix
+++ b/pkgs/games/rott/default.nix
@@ -22,12 +22,12 @@ let
   '';
 
 in
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "rott";
   version = "1.1.2";
 
   src = fetchurl {
-    url = "https://icculus.org/rott/releases/${pname}-${version}.tar.gz";
+    url = "https://icculus.org/rott/releases/${finalAttrs.pname}-${finalAttrs.version}.tar.gz";
     sha256 = "1zr7v5dv2iqx40gzxbg8mhac7fxz3kqf28y6ysxv1xhjqgl1c98h";
   };
 
@@ -38,7 +38,7 @@ stdenv.mkDerivation rec {
     SDL_mixer
   ];
 
-  sourceRoot = "rott-${version}/rott";
+  sourceRoot = "rott-${finalAttrs.version}/rott";
 
   makeFlags = [
     "SHAREWARE=${if buildShareware then "1" else "0"}"
@@ -71,4 +71,4 @@ stdenv.mkDerivation rec {
     maintainers = with maintainers; [ sander ];
     platforms = platforms.all;
   };
-}
+})

--- a/pkgs/games/scummvm/default.nix
+++ b/pkgs/games/scummvm/default.nix
@@ -23,14 +23,14 @@
   nix-update-script,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "scummvm";
   version = "2.9.0";
 
   src = fetchFromGitHub {
     owner = "scummvm";
     repo = "scummvm";
-    rev = "v${version}";
+    rev = "v${finalAttrs.version}";
     hash = "sha256-4/h1bzauYWNvG7skn6afF79t0KEdgYLZoeqeqRudH7I=";
   };
 
@@ -92,4 +92,4 @@ stdenv.mkDerivation rec {
     maintainers = [ maintainers.peterhoeg ];
     platforms = platforms.unix;
   };
-}
+})

--- a/pkgs/games/sgt-puzzles/default.nix
+++ b/pkgs/games/sgt-puzzles/default.nix
@@ -16,12 +16,12 @@
   isMobile ? false,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "sgt-puzzles";
   version = "20250303.7da4641";
 
   src = fetchurl {
-    url = "http://www.chiark.greenend.org.uk/~sgtatham/puzzles/puzzles-${version}.tar.gz";
+    url = "http://www.chiark.greenend.org.uk/~sgtatham/puzzles/puzzles-${finalAttrs.version}.tar.gz";
     hash = "sha256-fwphR47zUV+H+Avjco0Dlb94TeH+s6v81MU/H+mbEAk=";
   };
 
@@ -59,7 +59,7 @@ stdenv.mkDerivation rec {
         --set-key Type --set-value Application \
         --set-key Exec --set-value $i \
         --set-key Name --set-value $i \
-        --set-key Comment --set-value "${meta.description}" \
+        --set-key Comment --set-value "${finalAttrs.meta.description}" \
         --set-key Categories --set-value "Game;LogicGame;X-sgt-puzzles;" \
         --set-key Icon --set-value $out/share/icons/hicolor/96x96/apps/$i-96d24.png \
         $i.desktop
@@ -72,7 +72,7 @@ stdenv.mkDerivation rec {
       --set-key Icon --set-value $out/share/icons/hicolor/48x48/apps/sgt-puzzles_map \
       sgt-puzzles.directory
 
-    install -Dm644 ${sgt-puzzles-menu} -t $out/etc/xdg/menus/applications-merged/
+    install -Dm644 ${finalAttrs.sgt-puzzles-menu} -t $out/etc/xdg/menus/applications-merged/
   '';
 
   passthru = {
@@ -98,4 +98,4 @@ stdenv.mkDerivation rec {
     platforms = platforms.linux;
     homepage = "https://www.chiark.greenend.org.uk/~sgtatham/puzzles/";
   };
-}
+})

--- a/pkgs/games/soi/default.nix
+++ b/pkgs/games/soi/default.nix
@@ -12,13 +12,13 @@
   SDL,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "soi";
   version = "0.1.2";
 
   src = fetchurl {
-    url = "mirror://sourceforge/project/soi/Spheres%20of%20Influence-${version}-Source.tar.bz2";
-    name = "${pname}-${version}.tar.bz2";
+    url = "mirror://sourceforge/project/soi/Spheres%20of%20Influence-${finalAttrs.version}-Source.tar.bz2";
+    name = "${finalAttrs.pname}-${finalAttrs.version}.tar.bz2";
     sha256 = "03c3wnvhd42qh8mi68lybf8nv6wzlm1nx16d6pdcn2jzgx1j2lzd";
   };
 
@@ -45,4 +45,4 @@ stdenv.mkDerivation rec {
     license = licenses.free;
     downloadPage = "https://sourceforge.net/projects/soi/files/";
   };
-}
+})

--- a/pkgs/games/speed-dreams/default.nix
+++ b/pkgs/games/speed-dreams/default.nix
@@ -40,7 +40,7 @@ let
   version = "2.3.0-r8786";
   shortVersion = builtins.substring 0 5 version;
 in
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   inherit version;
   pname = "speed-dreams";
 
@@ -68,9 +68,9 @@ stdenv.mkDerivation rec {
 
   postUnpack = ''
     echo Unpacking data
-    tar -xf ${cars-and-tracks}
-    tar -xf ${more-cars-and-tracks}
-    tar -xf ${wip-cars-and-tracks}
+    tar -xf ${finalAttrs.cars-and-tracks}
+    tar -xf ${finalAttrs.more-cars-and-tracks}
+    tar -xf ${finalAttrs.wip-cars-and-tracks}
   '';
 
   preBuild = ''
@@ -154,4 +154,4 @@ stdenv.mkDerivation rec {
     platforms = lib.platforms.linux;
     hydraPlatforms = [ ];
   };
-}
+})

--- a/pkgs/games/spring/default.nix
+++ b/pkgs/games/spring/default.nix
@@ -28,12 +28,12 @@
   withAI ? true, # support for AI Interfaces and Skirmish AIs
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "spring";
   version = "106.0";
 
   src = fetchurl {
-    url = "https://springrts.com/dl/buildbot/default/master/${version}/source/spring_${version}_src.tar.gz";
+    url = "https://springrts.com/dl/buildbot/default/master/${finalAttrs.version}/source/spring_${finalAttrs.version}_src.tar.gz";
     sha256 = "sha256-mSA4ioIv68NMEB72lYnwDb1QOuWr1VHwu4+grAoHlV0=";
   };
 
@@ -104,4 +104,4 @@ stdenv.mkDerivation rec {
     platforms = [ "x86_64-linux" ];
     broken = true;
   };
-}
+})

--- a/pkgs/games/spring/springlobby.nix
+++ b/pkgs/games/spring/springlobby.nix
@@ -24,12 +24,12 @@
   jsoncpp,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "springlobby";
   version = "0.273";
 
   src = fetchurl {
-    url = "https://springlobby.springrts.com/dl/stable/springlobby-${version}.tar.bz2";
+    url = "https://springlobby.springrts.com/dl/stable/springlobby-${finalAttrs.version}.tar.bz2";
     sha256 = "sha256-XkU6i6ABCgw3H9vJu0xjHRO1BglueYM1LyJxcZdOrDk=";
   };
 
@@ -81,4 +81,4 @@ stdenv.mkDerivation rec {
       "x86_64-linux"
     ];
   };
-}
+})

--- a/pkgs/games/starsector/default.nix
+++ b/pkgs/games/starsector/default.nix
@@ -12,12 +12,12 @@
   writeScript,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "starsector";
   version = "0.98a-RC7";
 
   src = fetchzip {
-    url = "https://f005.backblazeb2.com/file/fractalsoftworks/release/starsector_linux-${version}.zip";
+    url = "https://f005.backblazeb2.com/file/fractalsoftworks/release/starsector_linux-${finalAttrs.version}.zip";
     sha256 = "sha256-qA4/9AvRWBOIbNKA9U8U7PoPmIwz8wgJZyYFln7LZHw=";
   };
 
@@ -38,7 +38,7 @@ stdenv.mkDerivation rec {
       name = "starsector";
       exec = "starsector";
       icon = "starsector";
-      comment = meta.description;
+      comment = finalAttrs.meta.description;
       genericName = "starsector";
       desktopName = "Starsector";
       categories = [ "Game" ];
@@ -65,7 +65,7 @@ stdenv.mkDerivation rec {
           xorg.xrandr
         ]
       } \
-      --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath buildInputs} \
+      --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath finalAttrs.buildInputs} \
       --run 'mkdir -p ''${XDG_DATA_HOME:-~/.local/share}/starsector' \
       --chdir "$out/share/starsector"
     ln -s $out/share/starsector/starsector.sh $out/bin/starsector
@@ -92,7 +92,7 @@ stdenv.mkDerivation rec {
     #!nix-shell -i bash -p curl gnugrep common-updater-scripts
     set -eou pipefail;
     version=$(curl -s https://fractalsoftworks.com/preorder/ | grep -oP "https://f005.backblazeb2.com/file/fractalsoftworks/release/starsector_linux-\K.*?(?=\.zip)" | head -1)
-    update-source-version ${pname} "$version" --file=./pkgs/games/starsector/default.nix
+    update-source-version ${finalAttrs.pname} "$version" --file=./pkgs/games/starsector/default.nix
   '';
 
   meta = with lib; {
@@ -105,4 +105,4 @@ stdenv.mkDerivation rec {
       rafaelrc
     ];
   };
-}
+})

--- a/pkgs/games/stuntrally/default.nix
+++ b/pkgs/games/stuntrally/default.nix
@@ -33,20 +33,20 @@ let
   };
 in
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "stuntrally";
   version = "2.7";
 
   src = fetchFromGitHub {
     owner = "stuntrally";
     repo = "stuntrally";
-    rev = version;
+    tag = finalAttrs.version;
     hash = "sha256-0Eh9ilIHSh/Uz8TuPnXxLQfy7KF7qqNXUgBXQUCz9ys=";
   };
   tracks = fetchFromGitHub {
     owner = "stuntrally";
     repo = "tracks";
-    rev = version;
+    tag = finalAttrs.version;
     hash = "sha256-fglm1FetFGHM/qGTtpxDb8+k2iAREn5DQR5GPujuLms=";
   };
 
@@ -59,7 +59,7 @@ stdenv.mkDerivation rec {
 
   preConfigure = ''
     rmdir data/tracks
-    ln -s ${tracks}/ data/tracks
+    ln -s ${finalAttrs.tracks}/ data/tracks
   '';
 
   nativeBuildInputs = [
@@ -90,4 +90,4 @@ stdenv.mkDerivation rec {
     maintainers = with maintainers; [ pSub ];
     platforms = platforms.linux;
   };
-}
+})

--- a/pkgs/games/tibia/default.nix
+++ b/pkgs/games/tibia/default.nix
@@ -9,12 +9,14 @@
   libGL,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "tibia";
   version = "10.90";
 
   src = fetchurl {
-    url = "http://static.tibia.com/download/tibia${lib.replaceStrings [ "." ] [ "" ] version}.tgz";
+    url = "http://static.tibia.com/download/tibia${
+      lib.replaceStrings [ "." ] [ "" ] finalAttrs.version
+    }.tgz";
     sha256 = "11mkh2dynmbpay51yfaxm5dmcys3rnpk579s9ypfkhblsrchbkhx";
   };
 
@@ -70,4 +72,4 @@ stdenv.mkDerivation rec {
     platforms = [ "i686-linux" ];
     maintainers = [ ];
   };
-}
+})

--- a/pkgs/games/ue4demos/default.nix
+++ b/pkgs/games/ue4demos/default.nix
@@ -17,7 +17,7 @@ let
 
   buildDemo =
     { name, src }:
-    stdenv.mkDerivation rec {
+    stdenv.mkDerivation (finalAttrs: {
       inherit name src;
 
       nativeBuildInputs = [
@@ -43,7 +43,7 @@ let
         binary=$(find . -executable -type f)
         patchelf \
           --set-interpreter $interpreter \
-          --set-rpath ${rtdeps} \
+          --set-rpath ${finalAttrs.rtdeps} \
           "$binary"
 
         # Workaround on
@@ -69,7 +69,7 @@ let
         platforms = [ "x86_64-linux" ];
         license = lib.licenses.unfree;
       };
-    };
+    });
 
 in
 {

--- a/pkgs/games/vcmi/default.nix
+++ b/pkgs/games/vcmi/default.nix
@@ -27,14 +27,14 @@
   vcmi,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "vcmi";
   version = "1.6.8";
 
   src = fetchFromGitHub {
     owner = "vcmi";
     repo = "vcmi";
-    rev = version;
+    tag = finalAttrs.version;
     fetchSubmodules = true;
     hash = "sha256-k6tkylNXEzU+zzYoFWtx+AkoHQzAwbBxPB2DVevsryw=";
   };
@@ -100,7 +100,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "Open-source engine for Heroes of Might and Magic III";
     homepage = "https://vcmi.eu";
-    changelog = "https://github.com/vcmi/vcmi/blob/${src.rev}/ChangeLog.md";
+    changelog = "https://github.com/vcmi/vcmi/blob/${finalAttrs.src.rev}/ChangeLog.md";
     license = with licenses; [
       gpl2Plus
       cc-by-sa-40
@@ -109,4 +109,4 @@ stdenv.mkDerivation rec {
     platforms = platforms.linux;
     mainProgram = "vcmilauncher";
   };
-}
+})

--- a/pkgs/games/vessel/default.nix
+++ b/pkgs/games/vessel/default.nix
@@ -8,22 +8,22 @@
   runtimeShell,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "vessel";
   version = "12082012";
 
   goBuyItNow = ''
     We cannot download the full version automatically, as you require a license.
     Once you bought a license, you need to add your downloaded version to the nix store.
-    You can do this by using "nix-prefetch-url file://\$PWD/vessel-${version}-bin" in the
+    You can do this by using "nix-prefetch-url file://\$PWD/vessel-${finalAttrs.version}-bin" in the
     directory where you saved it.
   '';
 
   src =
     if (stdenv.hostPlatform.isi686) then
       requireFile {
-        message = goBuyItNow;
-        name = "vessel-${version}-bin";
+        message = finalAttrs.goBuyItNow;
+        name = "vessel-${finalAttrs.version}-bin";
         sha256 = "1vpwcrjiln2mx43h7ib3jnccyr3chk7a5x2bw9kb4lw8ycygvg96";
       }
     else
@@ -100,5 +100,4 @@ stdenv.mkDerivation rec {
     license = licenses.unfree;
     maintainers = with maintainers; [ jcumming ];
   };
-
-}
+})

--- a/pkgs/games/warsow/default.nix
+++ b/pkgs/games/warsow/default.nix
@@ -6,12 +6,12 @@
   makeWrapper,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "warsow";
   version = "2.1.2";
 
   src = fetchurl {
-    url = "http://warsow.net/${pname}-${version}.tar.gz";
+    url = "http://warsow.net/${finalAttrs.pname}-${finalAttrs.version}.tar.gz";
     sha256 = "07y2airw5qg3s1bf1c63a6snjj22riz0mqhk62jmfm9nrarhavrc";
   };
 
@@ -44,4 +44,4 @@ stdenv.mkDerivation rec {
     ];
     platforms = warsow-engine.meta.platforms;
   };
-}
+})

--- a/pkgs/games/xonotic/default.nix
+++ b/pkgs/games/xonotic/default.nix
@@ -83,7 +83,7 @@ let
     startupNotify = false;
   };
 
-  xonotic-unwrapped = stdenv.mkDerivation rec {
+  xonotic-unwrapped = stdenv.mkDerivation (finalAttrs: {
     pname = "xonotic${variant}-unwrapped";
     inherit version;
 
@@ -117,7 +117,7 @@ let
     # "debug", "release", "profile"
     target = "release";
 
-    dontStrip = target != "release";
+    dontStrip = finalAttrs.target != "release";
 
     postConfigure = ''
       pushd ../d0_blind_id
@@ -128,13 +128,13 @@ let
     buildPhase =
       (
         lib.optionalString withDedicated ''
-          make -j $NIX_BUILD_CORES sv-${target}
+          make -j $NIX_BUILD_CORES sv-${finalAttrs.target}
         ''
         + lib.optionalString withGLX ''
-          make -j $NIX_BUILD_CORES cl-${target}
+          make -j $NIX_BUILD_CORES cl-${finalAttrs.target}
         ''
         + lib.optionalString withSDL ''
-          make -j $NIX_BUILD_CORES sdl-${target}
+          make -j $NIX_BUILD_CORES sdl-${finalAttrs.target}
         ''
       )
       + ''
@@ -205,7 +205,7 @@ let
             --add-needed ${libtheora}/lib/libtheora.so \
             $out/bin/xonotic-sdl
       '';
-  };
+  });
 
 in
 rec {

--- a/pkgs/games/xpilot/bloodspilot-client.nix
+++ b/pkgs/games/xpilot/bloodspilot-client.nix
@@ -12,12 +12,12 @@
   SDL_image,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   version = "1.5.0";
   pname = "bloodspilot-client";
 
   src = fetchurl {
-    url = "mirror://sourceforge/project/bloodspilot/client-sdl/v${version}/bloodspilot-client-sdl-${version}.tar.gz";
+    url = "mirror://sourceforge/project/bloodspilot/client-sdl/v${finalAttrs.version}/bloodspilot-client-sdl-${finalAttrs.version}.tar.gz";
     sha256 = "1qwl95av5an2zl01m7saj6fyy49xpixga7gbn4lwbpgpqs1rbwxj";
   };
 
@@ -44,4 +44,4 @@ stdenv.mkDerivation rec {
     maintainers = [ lib.maintainers.raskin ];
     platforms = lib.platforms.linux;
   };
-}
+})

--- a/pkgs/games/xpilot/bloodspilot-server.nix
+++ b/pkgs/games/xpilot/bloodspilot-server.nix
@@ -5,12 +5,12 @@
   expat,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "bloodspilot-xpilot-fxi-server";
   version = "1.4.6";
 
   src = fetchurl {
-    url = "mirror://sourceforge/project/bloodspilot/server/server%20v${version}/xpilot-${version}fxi.tar.gz";
+    url = "mirror://sourceforge/project/bloodspilot/server/server%20v${finalAttrs.version}/xpilot-${finalAttrs.version}fxi.tar.gz";
     sha256 = "0d7hnpshifq6gy9a0g6il6h1hgqqjyys36n8w84hr8d4nhg4d1ji";
   };
 
@@ -31,4 +31,4 @@ stdenv.mkDerivation rec {
     maintainers = [ maintainers.raskin ];
     platforms = platforms.linux;
   };
-}
+})

--- a/pkgs/games/xpilot/default.nix
+++ b/pkgs/games/xpilot/default.nix
@@ -14,11 +14,11 @@
   zlib,
   libXxf86misc,
 }:
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "xpilot-ng";
   version = "4.7.3";
   src = fetchurl {
-    url = "mirror://sourceforge/xpilot/xpilot_ng/${pname}-${version}/${pname}-${version}.tar.gz";
+    url = "mirror://sourceforge/xpilot/xpilot_ng/${finalAttrs.pname}-${finalAttrs.version}/${finalAttrs.pname}-${finalAttrs.version}.tar.gz";
     sha256 = "02a7pnp88kh88fzda5q8mzlckk6y9r5fw47j00h26wbsfly0k1zj";
   };
   buildInputs = [
@@ -47,4 +47,4 @@ stdenv.mkDerivation rec {
     maintainers = [ maintainers.raskin ];
     platforms = platforms.linux;
   };
-}
+})

--- a/pkgs/kde/misc/kio-extras-kf5/default.nix
+++ b/pkgs/kde/misc/kio-extras-kf5/default.nix
@@ -16,12 +16,12 @@
 }:
 # kio-extras-kf5 is kind of part of Gear, but also not released all the time,
 # so handle it separately.
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "kio-extras-kf5";
   version = "24.02.2";
 
   src = fetchurl {
-    url = "mirror://kde/stable/release-service/${version}/src/kio-extras-kf5-${version}.tar.xz";
+    url = "mirror://kde/stable/release-service/${finalAttrs.version}/src/kio-extras-kf5-${finalAttrs.version}.tar.xz";
     hash = "sha256-qar1jzuALINBu6HOuVBU+RUFnqRH9Z/8e5M8ynGxKsk=";
   };
 
@@ -64,4 +64,4 @@ stdenv.mkDerivation rec {
   ];
 
   meta = kio-extras.meta;
-}
+})

--- a/pkgs/kde/third-party/applet-window-buttons6/default.nix
+++ b/pkgs/kde/third-party/applet-window-buttons6/default.nix
@@ -10,14 +10,14 @@
   libplasma,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "applet-window-buttons6";
   version = "0.14.0";
 
   src = fetchFromGitHub {
     owner = "moodyhunter";
     repo = "applet-window-buttons6";
-    rev = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-HnlgBQKT99vVkl6DWqMkN8Vz+QzzZBGj5tqOJ22VkJ8=";
   };
 
@@ -41,4 +41,4 @@ stdenv.mkDerivation rec {
     license = licenses.gpl2Only;
     maintainers = with maintainers; [ A1ca7raz ];
   };
-}
+})

--- a/pkgs/kde/third-party/koi/default.nix
+++ b/pkgs/kde/third-party/koi/default.nix
@@ -8,19 +8,19 @@
   kwidgetsaddons,
   wrapQtAppsHook,
 }:
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "koi";
   version = "0.4";
 
   src = fetchFromGitHub {
     owner = "baduhai";
     repo = "Koi";
-    rev = version;
+    tag = finalAttrs.version;
     sha256 = "sha256-ip7e/Sz/l5UiTFUTLJPorPO7NltE2Isij2MCmvHZV40=";
   };
 
   # See https://github.com/baduhai/Koi/blob/master/development/Nix%20OS/dev.nix
-  sourceRoot = "${src.name}/src";
+  sourceRoot = "${finalAttrs.src.name}/src";
   nativeBuildInputs = [
     cmake
     wrapQtAppsHook
@@ -52,4 +52,4 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/baduhai/Koi";
     maintainers = with lib.maintainers; [ fnune ];
   };
-}
+})


### PR DESCRIPTION
- my own attempt upon #400544

This is the first pr of a probably long chain, removing over 80 `stdenv.mkDerivation rec` pattern. I could not find a way to automate it, so I did it manually using the following command:
```
grep -r "stdenv.mkDerivation rec {" pkgs/games | filterpath | xargs -i nvim {} 
```

The derivation were not edited further than strictly required, with only `repo = pname` and `rev` -> `tag` being corrected (as they involved direct rec usage).

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
