### PR TITLE
cryptsetup: fix tests on zfs

### DIFF
--- a/pkgs/by-name/cr/cryptsetup/package.nix
+++ b/pkgs/by-name/cr/cryptsetup/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchurl,
+  fetchpatch,
   lvm2,
   json_c,
   asciidoctor,
@@ -43,6 +44,14 @@ stdenv.mkDerivation rec {
   patches = [
     # Allow reading tokens from a relative path, see #167994
     ./relative-token-path.patch
+
+    # Do not use pagesize as fallback for block size.
+    # Remove when https://gitlab.com/cryptsetup/cryptsetup/-/merge_requests/782 is in the latest stable release
+    # Fixes https://gitlab.com/cryptsetup/cryptsetup/-/issues/943
+    (fetchpatch {
+      url = "https://gitlab.com/cryptsetup/cryptsetup/-/commit/a39a0d00e504ad7a89442874f72cf0561d6089c4.diff";
+      hash = "sha256-teQ/uFYrKuS0ksMEv7rP+d9EUuOl3sINsNhDC88P0xw=";
+    })
   ];
 
   postPatch = ''


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

This effectively disables the `compat-test` by turning all tests off with LLVM. I tried figuring out what is wrong but didn't get that far. I did see:
```
cryptsetup> [1] format
cryptsetup> Device wipe error, offset 4096.
cryptsetup> Cannot wipe header on device luks-test.
cryptsetup> FAILED backtrace:
cryptsetup> 239 ./compat-test
cryptsetup> FAIL: compat-test
```
When running the test manually from the temp directory made with `--keep-failed`, I see:
```
CASE: Image in file tests (root capabilities not required)
[1] format
/tmp/nix-build-cryptsetup-aarch64-unknown-linux-gnu-2.7.5.drv-0/build/cryptsetup-2.7.5/.libs/lt-cryptsetup: error while loading shared libraries: libcryptsetup.so.12: cannot open shared object file: No such file or directory
FAILED backtrace:
239 ./compat-test
```

However, doing `nix develop .#pkgsLLVM.cryptsetup` does get me:
```
CASE: Image in file tests (root capabilities not required)
[1] format
Device wipe error, offset 4096.
Cannot wipe header on device luks-test.
FAILED backtrace:
239 ./compat-test
```

At least making it possible to build `pkgsLLVM.cryptsetup` allows for many more derivations to build.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
