### PR TITLE
nixosTests: fix pure eval by setting system to null

### DIFF
--- a/nixos/tests/boot.nix
+++ b/nixos/tests/boot.nix
@@ -65,6 +65,7 @@ let
 
   iso =
     (import ../lib/eval-config.nix {
+      system = null;
       modules = [
         ../modules/installer/cd-dvd/installation-cd-minimal.nix
         ../modules/testing/test-instrumentation.nix
@@ -74,6 +75,7 @@ let
 
   sd =
     (import ../lib/eval-config.nix {
+      system = null;
       modules = [
         ../modules/installer/sd-card/sd-image-x86_64.nix
         ../modules/testing/test-instrumentation.nix
@@ -111,6 +113,7 @@ let
     let
       config =
         (import ../lib/eval-config.nix {
+          system = null;
           modules = [
             ../modules/installer/netboot/netboot.nix
             ../modules/testing/test-instrumentation.nix

--- a/nixos/tests/ec2.nix
+++ b/nixos/tests/ec2.nix
@@ -12,6 +12,7 @@ with import common/ec2.nix { inherit makeTest pkgs; };
 let
   imageCfg =
     (import ../lib/eval-config.nix {
+      system = null;
       modules = [
         ../maintainers/scripts/ec2/amazon-image.nix
         ../modules/testing/test-instrumentation.nix

--- a/nixos/tests/image-contents.nix
+++ b/nixos/tests/image-contents.nix
@@ -14,6 +14,7 @@ with import common/ec2.nix { inherit makeTest pkgs; };
 let
   config =
     (import ../lib/eval-config.nix {
+      system = null;
       modules = [
         ../modules/testing/test-instrumentation.nix
         ../modules/profiles/qemu-guest.nix

--- a/nixos/tests/openstack-image.nix
+++ b/nixos/tests/openstack-image.nix
@@ -12,6 +12,7 @@ with import common/ec2.nix { inherit makeTest pkgs; };
 let
   image =
     (import ../lib/eval-config.nix {
+      system = null;
       modules = [
         ../maintainers/scripts/openstack/openstack-image.nix
         ../modules/testing/test-instrumentation.nix

--- a/nixos/tests/systemd-machinectl.nix
+++ b/nixos/tests/systemd-machinectl.nix
@@ -26,6 +26,7 @@ import ./make-test-python.nix (
 
     containerSystem =
       (import ../lib/eval-config.nix {
+        system = null;
         modules = [ container ];
       }).config.system.build.toplevel;
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Accidentally discovered #331873 introduced a regression with pure eval. It would produce an error similar to:
```
       … while evaluating the option `_module.freeformType':

       (stack trace truncated; use '--show-trace' to show the full, detailed trace)

       error: attribute 'currentSystem' missing
       at /nix/store/ay6b1sz0585wyxhh139wfaivpks6n4j0-source/nixos/lib/eval-config.nix:15:12:
           14|   #     of a breaking change. To set it modularly, pass `null`.
           15|   system ? builtins.currentSystem,
             |            ^
           16|   # !!! is this argument needed any more? The pkgs argument can
```
To fix this, we set `system = null` since we should be pulling the system from within the module or when we're setting `pkgs`.

Adding @roberth for review since he merged it.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
