### PR TITLE
everforest-gtk-theme: update source, parameterize build

### DIFF
--- a/pkgs/by-name/ev/everforest-gtk-theme/package.nix
+++ b/pkgs/by-name/ev/everforest-gtk-theme/package.nix
@@ -2,44 +2,133 @@
   lib,
   stdenvNoCC,
   fetchFromGitHub,
+  gnome-shell,
+  sassc,
   gnome-themes-extra,
   gtk-engine-murrine,
+  unstableGitUpdater,
+  # By default, install both dark and light themes and icon sets
+  colorVariants ? [
+    "dark"
+    "light"
+  ],
+  sizeVariants ? [ "standard" ],
+  themeVariants ? [ "default" ],
+  tweakVariants ? [ ],
+  iconVariants ? [
+    "dark"
+    "light"
+  ],
 }:
 
-stdenvNoCC.mkDerivation {
+let
   pname = "everforest-gtk-theme";
-  version = "0-unstable-2023-03-20";
-
-  src = fetchFromGitHub {
-    owner = "Fausto-Korpsvart";
-    repo = "Everforest-GTK-Theme";
-    rev = "8481714cf9ed5148694f1916ceba8fe21e14937b";
-    hash = "sha256-NO12ku8wnW/qMHKxi5TL/dqBxH0+cZbe+fU0iicb9JU=";
-  };
-
-  propagatedUserEnvPkgs = [
-    gtk-engine-murrine
+  colorVariantList = [
+    "dark"
+    "light"
   ];
-
-  buildInputs = [
-    gnome-themes-extra
+  sizeVariantList = [
+    "compact"
+    "standard"
   ];
+  themeVariantList = [
+    "default"
+    "green"
+    "grey"
+    "orange"
+    "pink"
+    "purple"
+    "red"
+    "teal"
+    "yellow"
+    "all"
+  ];
+  tweakVariantList = [
+    "soft"
+    "medium"
+    "black"
+    "float"
+    "outline"
+  ];
+  iconVariantList = [
+    "dark"
+    "light"
+  ];
+in
+lib.checkListOfEnum "${pname}: colorVariants" colorVariantList colorVariants lib.checkListOfEnum
+  "${pname}: sizeVariants"
+  sizeVariantList
+  sizeVariants
+  lib.checkListOfEnum
+  "${pname}: themeVariants"
+  themeVariantList
+  themeVariants
+  lib.checkListOfEnum
+  "${pname}: tweakVariants"
+  tweakVariantList
+  tweakVariants
+  lib.checkListOfEnum
+  "${pname}: iconVariants"
+  iconVariantList
+  iconVariants
 
-  dontBuild = true;
+  stdenvNoCC.mkDerivation
+  {
+    inherit pname;
+    version = "0-unstable-2025-04-24";
 
-  installPhase = ''
-    runHook preInstall
-    mkdir -p "$out/share/"{themes,icons}
-    cp -a icons/* "$out/share/icons/"
-    cp -a themes/* "$out/share/themes/"
-    runHook postInstall
-  '';
+    src = fetchFromGitHub {
+      owner = "Fausto-Korpsvart";
+      repo = "Everforest-GTK-Theme";
+      rev = "934ca11a4d38d6ef1f3854bb6950fa559e15e65c";
+      hash = "sha256-U5Qsr5RH+MfKuPgexAiyQiQfLfLS4cpSJqc/+jX/53s=";
+    };
 
-  meta = with lib; {
-    description = "Everforest colour palette for GTK";
-    homepage = "https://github.com/Fausto-Korpsvart/Everforest-GTK-Theme";
-    license = licenses.gpl3Only;
-    maintainers = with maintainers; [ jn-sena ];
-    platforms = platforms.unix;
-  };
-}
+    propagatedUserEnvPkgs = [ gtk-engine-murrine ];
+
+    nativeBuildInputs = [
+      gnome-shell
+      sassc
+    ];
+    buildInputs = [ gnome-themes-extra ];
+
+    dontBuild = true;
+
+    passthru.updateScript = unstableGitUpdater { };
+
+    # Scanning 60000+ icons can be very slow
+    dontPatchShebangs = true;
+
+    postPatch = ''
+      patchShebangs themes/install.sh
+    '';
+
+    installPhase = ''
+      runHook preInstall
+      mkdir -p $out/share/themes
+      cd themes
+      ./install.sh -n Everforest \
+      ${lib.optionalString (colorVariants != [ ]) "-c " + toString colorVariants} \
+      ${lib.optionalString (sizeVariants != [ ]) "-s " + toString sizeVariants} \
+      ${lib.optionalString (themeVariants != [ ]) "-t " + toString themeVariants} \
+      ${lib.optionalString (tweakVariants != [ ]) "--tweaks " + toString tweakVariants} \
+      -d "$out/share/themes"
+      cd ../icons
+      ${lib.optionalString (iconVariants != [ ]) ''
+        mkdir -p $out/share/icons
+        cp -a ${toString (map (v: "Everforest-${lib.toSentenceCase v}") iconVariants)} $out/share/icons/
+      ''}
+      runHook postInstall
+    '';
+
+    # Scanning 60000+ icons can be very slow
+    dontFixup = true;
+
+    meta = with lib; {
+      description = "Everforest colour palette for GTK";
+      homepage = "https://github.com/Fausto-Korpsvart/Everforest-GTK-Theme";
+      license = licenses.gpl3Only;
+      maintainers = with maintainers; [ jn-sena ];
+      platforms = platforms.unix;
+    };
+  }


### PR DESCRIPTION
The author of everforest-gtk-theme has many themes which share a common build system that has many options for design tweaks and icons. This commit copies the work done to the tokyonight-gtk-theme derivation to parameterize the build, allowing for much greater customization.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
