### PR TITLE
pympress: 1.8.5 -> 1.8.6, modernize, unbreak

### DIFF
--- a/pkgs/by-name/py/pympress/package.nix
+++ b/pkgs/by-name/py/pympress/package.nix
@@ -2,7 +2,7 @@
   lib,
   stdenv,
   python3Packages,
-  fetchPypi,
+  fetchFromGitHub,
   wrapGAppsHook3,
   gtk3,
   gobject-introspection,
@@ -15,13 +15,30 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "pympress";
-  version = "1.8.5";
+  version = "1.8.6";
 
-  src = fetchPypi {
-    inherit version;
-    pname = "pympress";
-    hash = "sha256-Kb05EV0F8lTamTq7pC1UoOkYf04s58NjMksVE2xTC/Y=";
+  src = fetchFromGitHub {
+    owner = "cimbali";
+    repo = "pympress";
+    tag = "v${version}";
+    hash = "sha256-rIlYd5SMWYeqdMHyW3d1ggKnUMCJCDP5uw25d7zG2DU=";
   };
+
+  build-system = with python3Packages; [
+    setuptools
+    babel
+  ];
+
+  dependencies =
+    with python3Packages;
+    [
+      watchdog
+      pycairo
+      pygobject3
+    ]
+    ++ lib.optional withVLC [
+      python-vlc
+    ];
 
   nativeBuildInputs = [
     wrapGAppsHook3
@@ -44,23 +61,13 @@ python3Packages.buildPythonApplication rec {
       gst_all_1.gst-vaapi
     ];
 
-  propagatedBuildInputs =
-    with python3Packages;
-    [
-      pycairo
-      pygobject3
-      setuptools
-      watchdog
-    ]
-    ++ lib.optional withVLC python-vlc;
-
   doCheck = false; # there are no tests
 
-  meta = with lib; {
+  meta = {
     description = "Simple yet powerful PDF reader designed for dual-screen presentations";
     mainProgram = "pympress";
-    license = licenses.gpl2Plus;
+    license = lib.licenses.gpl2Plus;
     homepage = "https://cimbali.github.io/pympress/";
-    maintainers = [ maintainers.tbenst ];
+    maintainers = with lib.maintainers; [ tbenst ];
   };
 }


### PR DESCRIPTION
Includes:
- Update from version 1.8.5 to 1.8.6
- Build from source
- Modernize
- Fixes: https://hydra.nixos.org/build/295745904 (For ZHF: #403336)
- Closes: #402528


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
