### PR TITLE
eduvpn-client: 4.4.0 -> 4.5.0

### DIFF
--- a/pkgs/by-name/ed/eduvpn-client/package.nix
+++ b/pkgs/by-name/ed/eduvpn-client/package.nix
@@ -1,6 +1,6 @@
 {
   lib,
-  fetchurl,
+  fetchFromGitea,
   gdk-pixbuf,
   gobject-introspection,
   gtk3,
@@ -13,12 +13,15 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "eduvpn-client";
-  version = "4.4.0";
+  version = "4.5.0";
   format = "pyproject";
 
-  src = fetchurl {
-    url = "https://codeberg.org/eduVPN/linux-app/releases/download/${version}/python-${pname}-${version}.tar.xz";
-    hash = "sha256-IHRIjryAIeGcFqz5BMWsE0/gClaSmnwWhjc1f1c69vk=";
+  src = fetchFromGitea {
+    domain = "codeberg.org";
+    owner = "eduVPN";
+    repo = "linux-app";
+    rev = version;
+    hash = "sha256-cm1N/Z6/9zyhWBYUIUIYeB+KphHl+89MD4M9mO/tNMg=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/li/libeduvpn-common/package.nix
+++ b/pkgs/by-name/li/libeduvpn-common/package.nix
@@ -6,11 +6,11 @@
 
 buildGoModule rec {
   pname = "libeduvpn-common";
-  version = "2.1.0";
+  version = "3.0.0";
 
   src = fetchurl {
-    url = "https://github.com/eduvpn/eduvpn-common/releases/download/${version}/eduvpn-common-${version}.tar.xz";
-    hash = "sha256-OgcinEeKMDtZj3Tw+7cMsF385ZZTBR/J5dqIihDTlj8=";
+    url = "https://codeberg.org/eduVPN/eduvpn-common/releases/download/${version}/eduvpn-common-${version}.tar.xz";
+    hash = "sha256-aQpOoY3rDF9DeQ/8tRYdBs4s2IdwAe62y9KfXPMsb4k=";
   };
 
   vendorHash = null;


### PR DESCRIPTION
- https://codeberg.org/eduVPN/linux-app/releases/tag/4.5.0

The new `eduvpn-client` version requires an updated `libeduvpn-common`, so the library is updated accordingly.

## Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
