### PR TITLE
grig: fix for hamlib-4.6.2

### DIFF
--- a/pkgs/by-name/gr/grig/0001-Fix-grig-for-hamlib-4.6.2.patch
+++ b/pkgs/by-name/gr/grig/0001-Fix-grig-for-hamlib-4.6.2.patch
@@ -1,25 +1,3 @@
-diff --git a/src/main.c b/src/main.c
-index d16a7f7..2c596e9 100644
---- a/src/main.c
-+++ b/src/main.c
-@@ -125,7 +125,7 @@ static gint        grig_app_delete     (GtkWidget *, GdkEvent *, gpointer);
- static void        grig_app_destroy    (GtkWidget *, gpointer);
- static void        grig_show_help      (void);
- static void        grig_show_version   (void);
--static gint        grig_list_add       (const struct rig_caps *, void *);
-+static gint        grig_list_add       (struct rig_caps *, void *);
- static gint        grig_list_compare   (gconstpointer, gconstpointer);
- static void        grig_sig_handler    (int sig);
- 
-@@ -729,7 +729,7 @@ grig_list_rigs ()
-  * \sa grig_list_rigs, grig_list_compare
-  */
- static gint
--grig_list_add (const struct rig_caps *caps, void *array)
-+grig_list_add (struct rig_caps *caps, void *array)
- {
- 	grig_rig_info_t *info;
- 
 diff --git a/src/rig-selector.c b/src/rig-selector.c
 index 425d41a..e040c0e 100644
 --- a/src/rig-selector.c

--- a/pkgs/by-name/gr/grig/package.nix
+++ b/pkgs/by-name/gr/grig/package.nix
@@ -46,6 +46,9 @@ stdenv.mkDerivation rec {
     homepage = "https://groundstation.sourceforge.net/grig/";
     license = licenses.gpl2;
     platforms = platforms.linux;
-    maintainers = with maintainers; [ melling ];
+    maintainers = with maintainers; [
+      melling
+      mafo
+    ];
   };
 }

--- a/pkgs/by-name/gr/grig/package.nix
+++ b/pkgs/by-name/gr/grig/package.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
 
   patches = [
     # https://github.com/fillods/grig/issues/22
-    ./0001-Fix-grig-for-hamlib-4.6.x.patch
+    ./0001-Fix-grig-for-hamlib-4.6.2.patch
   ];
 
   nativeBuildInputs = [


### PR DESCRIPTION
## Things done
* Fix grig build for hamlib-4.6.2.
* Add mafo as maintainer

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
