### PR TITLE
pkl: Add native build using graalvm

### DIFF
--- a/pkgs/by-name/pk/pkl/disable_bad_tests.patch
+++ b/pkgs/by-name/pk/pkl/disable_bad_tests.patch
@@ -1,12 +1,11 @@
-diff --git i/pkl-cli/src/test/kotlin/org/pkl/cli/CliEvaluatorTest.kt w/pkl-cli/src/test/kotlin/org/pkl/cli/CliEvaluatorTest.kt
-index df88c423..ae1db500 100644
---- i/pkl-cli/src/test/kotlin/org/pkl/cli/CliEvaluatorTest.kt
-+++ w/pkl-cli/src/test/kotlin/org/pkl/cli/CliEvaluatorTest.kt
-@@ -1497,6 +1497,7 @@ result = someLib.x
-     assertThat(output).isEqualTo("result = 1\n")
-   }
- 
-+  @Disabled
-   @Test
-   fun `eval file with non-ASCII name`() {
-     val tempDirUri = tempDir.toUri()
+diff --git a/pkl-core/src/test/kotlin/org/pkl/core/LanguageSnippetTestsEngine.kt b/pkl-core/src/test/kotlin/org/pkl/core/LanguageSnippetTestsEngine.kt
+index 99cf9479..45269d6d 100644
+--- a/pkl-core/src/test/kotlin/org/pkl/core/LanguageSnippetTestsEngine.kt
++++ b/pkl-core/src/test/kotlin/org/pkl/core/LanguageSnippetTestsEngine.kt
+@@ -215,6 +215,7 @@ abstract class AbstractNativeLanguageSnippetTestsEngine : AbstractLanguageSnippe
+       // on the other hand, don't exclude /native/
+       Regex(".*/import1b\\.pkl"),
+       // URIs get rendered slightly differently (percent-encoded vs raw)
++      Regex(".*日本語.pkl"),
+       Regex(".*日本語_error\\.pkl"),
+     ) + exclusionsForThisJvm()

--- a/pkgs/by-name/pk/pkl/use_nix_graalvm_instead_of_download.patch
+++ b/pkgs/by-name/pk/pkl/use_nix_graalvm_instead_of_download.patch
@@ -1,0 +1,69 @@
+diff --git i/buildSrc/src/main/kotlin/BuildInfo.kt w/buildSrc/src/main/kotlin/BuildInfo.kt
+index 3020857b..54d0da41 100644
+--- i/buildSrc/src/main/kotlin/BuildInfo.kt
++++ w/buildSrc/src/main/kotlin/BuildInfo.kt
+@@ -100,10 +100,10 @@ open class BuildInfo(private val project: Project) {
+       File(homeDir, "${baseName}.$extension")
+     }
+
+-    val installDir: File by lazy { File(homeDir, baseName) }
++    val installDir: File by lazy { File("@graalvmDir@") }
+
+     val baseDir: String by lazy {
+-      if (os.isMacOsX) "$installDir/Contents/Home" else installDir.toString()
++      "@graalvmDir@"
+     }
+   }
+
+diff --git i/pkl-cli/pkl-cli.gradle.kts w/pkl-cli/pkl-cli.gradle.kts
+index facfeabb..7b48201f 100644
+--- i/pkl-cli/pkl-cli.gradle.kts
++++ w/pkl-cli/pkl-cli.gradle.kts
+@@ -313,7 +313,6 @@ fun Exec.configureExecutable(
+ /** Builds the pkl CLI for macOS/amd64. */
+ val macExecutableAmd64: TaskProvider<Exec> by
+   tasks.registering(Exec::class) {
+-    dependsOn(":installGraalVmAmd64")
+     configureExecutable(
+       buildInfo.graalVmAmd64,
+       layout.buildDirectory.file("executable/pkl-macos-amd64"),
+@@ -323,7 +322,6 @@ val macExecutableAmd64: TaskProvider<Exec> by
+ /** Builds the pkl CLI for macOS/aarch64. */
+ val macExecutableAarch64: TaskProvider<Exec> by
+   tasks.registering(Exec::class) {
+-    dependsOn(":installGraalVmAarch64")
+     configureExecutable(
+       buildInfo.graalVmAarch64,
+       layout.buildDirectory.file("executable/pkl-macos-aarch64"),
+@@ -334,7 +332,6 @@ val macExecutableAarch64: TaskProvider<Exec> by
+ /** Builds the pkl CLI for linux/amd64. */
+ val linuxExecutableAmd64: TaskProvider<Exec> by
+   tasks.registering(Exec::class) {
+-    dependsOn(":installGraalVmAmd64")
+     configureExecutable(
+       buildInfo.graalVmAmd64,
+       layout.buildDirectory.file("executable/pkl-linux-amd64"),
+@@ -349,7 +346,6 @@ val linuxExecutableAmd64: TaskProvider<Exec> by
+  */
+ val linuxExecutableAarch64: TaskProvider<Exec> by
+   tasks.registering(Exec::class) {
+-    dependsOn(":installGraalVmAarch64")
+     configureExecutable(
+       buildInfo.graalVmAarch64,
+       layout.buildDirectory.file("executable/pkl-linux-aarch64"),
+@@ -369,7 +365,6 @@ val linuxExecutableAarch64: TaskProvider<Exec> by
+  */
+ val alpineExecutableAmd64: TaskProvider<Exec> by
+   tasks.registering(Exec::class) {
+-    dependsOn(":installGraalVmAmd64")
+     configureExecutable(
+       buildInfo.graalVmAmd64,
+       layout.buildDirectory.file("executable/pkl-alpine-linux-amd64"),
+@@ -379,7 +374,6 @@ val alpineExecutableAmd64: TaskProvider<Exec> by
+
+ val windowsExecutableAmd64: TaskProvider<Exec> by
+   tasks.registering(Exec::class) {
+-    dependsOn(":installGraalVmAmd64")
+     configureExecutable(
+       buildInfo.graalVmAmd64,
+       layout.buildDirectory.file("executable/pkl-windows-amd64"),


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Continuing the work from #286658 and #402086 by adding support for building native pkl. On my machine, native build is on average twice as fast as the jpkl build.

I don't know much about building Java applications so I just pieced everything from patches in previous PRs.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
