### PR TITLE
nixos/cloudflared-service: Add support for token based tunnels 

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3372,6 +3372,12 @@
     github = "bmwalters";
     githubId = 4380777;
   };
+  bn = {
+    github = "bn-c";
+    githubId = 149229524;
+    name = "Bach Nguyen";
+    email = "root.bachnc@gmail.com";
+  };
   bnlrnz = {
     github = "bnlrnz";
     githubId = 11310385;

--- a/nixos/modules/services/networking/cloudflared.nix
+++ b/nixos/modules/services/networking/cloudflared.nix
@@ -330,7 +330,7 @@ in
         after = [ "cloudflared-tunnel-${name}.service" ];
         unitConfig.StopWhenUnneeded = true;
       }
-    ) config.services.cloudflared.tunnels;
+    ) cfg.tunnels;
 
     systemd.services = lib.mapAttrs' (
       name: tunnel:
@@ -406,7 +406,7 @@ in
 
         environment.TUNNEL_ORIGIN_CERT = lib.mkIf (certFile != null) ''%d/cert.pem'';
       }
-    ) config.services.cloudflared.tunnels;
+    ) cfg.tunnels;
   };
 
   meta.maintainers = with lib.maintainers; [

--- a/nixos/modules/services/networking/cloudflared.nix
+++ b/nixos/modules/services/networking/cloudflared.nix
@@ -203,7 +203,8 @@ in
               inherit certificateFile originRequest;
 
               credentialsFile = lib.mkOption {
-                type = lib.types.path;
+                type = with lib.types; nullOr path;
+                default = null;
                 description = ''
                   Credential file.
 
@@ -223,6 +224,20 @@ in
                   rules configured via the Cloudflare dashboard.
                 '';
                 example = "eyJhIj...zUzZg==";
+              };
+
+              tokenFile = lib.mkOption {
+                type = with lib.types; nullOr path;
+                default = null;
+                description = ''
+                  Cloudflare tunnel tokenFile to use instead of a configuration file.
+                  If set, the tunnel will be run using `cloudflared tunnel run --token-file <tokenFile>`.
+                  This option is mutually exclusive with the config file-based approach
+                  (which requires `credentialsFile`).
+                  Note: Using a tokenFile bypasses locally defined ingress rules and uses
+                  rules configured via the Cloudflare dashboard.
+                '';
+                example = "/path/to/my/token_file";
               };
 
               warp-routing = {
@@ -245,6 +260,7 @@ in
                   See `service`.
                 '';
                 example = "http_status:404";
+                default = "http_status:404";
               };
 
               ingress = lib.mkOption {
@@ -322,6 +338,24 @@ in
   };
 
   config = lib.mkIf cfg.enable {
+    warnings = lib.mapAttrsToList (
+      name: tunnel:
+      if tunnel.token != null then
+        "[cloudflared-service | ${name}] Tunnel is using raw token value, which is world-readable!"
+      else
+        ""
+    ) cfg.tunnels;
+
+    assertions = lib.mapAttrsToList (name: tunnel: {
+      assertion =
+        (lib.count (x: !builtins.isNull x) [
+          tunnel.token
+          tunnel.tokenFile
+          tunnel.credentialsFile
+        ]) <= 1;
+      message = "[cloudflared-service | ${name}] You must specify AT MOST ONE of 'token', 'tokenFile', or 'credentialsFile'.";
+    }) cfg.tunnels;
+
     systemd.targets = lib.mapAttrs' (
       name: tunnel:
       lib.nameValuePair "cloudflared-tunnel-${name}" {
@@ -335,8 +369,6 @@ in
     systemd.services = lib.mapAttrs' (
       name: tunnel:
       let
-        isTokenBased = tunnel.token != null;
-
         filterConfig = lib.attrsets.filterAttrsRecursive (
           _: v:
           !builtins.elem v [
@@ -352,7 +384,7 @@ in
         ingressesSet = filterIngressSet tunnel.ingress;
         ingressesStr = filterIngressStr tunnel.ingress;
 
-        fullConfig = lib.mkIf (!isTokenBased) (filterConfig {
+        fullConfig = filterConfig {
           tunnel = name;
           credentials-file = "/run/credentials/cloudflared-tunnel-${name}.service/credentials.json";
           warp-routing = filterConfig tunnel.warp-routing;
@@ -370,7 +402,7 @@ in
               service = lib.getAttr key ingressesStr;
             }) (lib.attrNames ingressesStr))
             ++ [ { service = tunnel.default; } ];
-        });
+        };
 
         mkConfigFile = pkgs.writeText "cloudflared.yml" (builtins.toJSON fullConfig);
         certFile = if (tunnel.certificateFile != null) then tunnel.certificateFile else cfg.certificateFile;
@@ -388,16 +420,15 @@ in
         serviceConfig = {
           RuntimeDirectory = "cloudflared-tunnel-${name}";
           RuntimeDirectoryMode = "0400";
-          LoadCredential = lib.mkIf (!isTokenBased) (
-            [
-              "credentials.json:${tunnel.credentialsFile}"
-            ]
-            ++ (lib.optional (certFile != null) "cert.pem:certFile")
-          );
+          LoadCredential = [
+            (lib.optional (tunnel.credentialsFile != null) ("credentials.json:${tunnel.credentialsFile}"))
+          ] ++ (lib.optional (certFile != null) "cert.pem:${certFile}");
 
           ExecStart =
-            if isTokenBased then
+            if tunnel.token != null then
               "${cfg.package}/bin/cloudflared tunnel run --token ${lib.escapeShellArg tunnel.token}"
+            else if tunnel.tokenFile != null then
+              "${cfg.package}/bin/cloudflared tunnel run --token-file ${lib.escapeShellArg tunnel.token}"
             else
               "${cfg.package}/bin/cloudflared tunnel --config=${mkConfigFile} --no-autoupdate run";
           Restart = "on-failure";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

I'm trying to add support for creating cloudflared managed tunnels using token instead of credential files, similar to how it is used in docker:  `docker run cloudflare/cloudflared:latest tunnel --no-autoupdate run --token <token>` 

Based on my discussion with @LoCrealloc ([here](https://github.com/NixOS/nixpkgs/issues/404270#issuecomment-2850240480)). They suggested adding token as a mutually exclusive attribute to `credentialsFile`. 

I have got it to work using `lib.mkIf (!isTokenBased)` but unsure how to implement error message for conflicting configs. 

Sorry for the tag, but I'd appreciate feedback from the maintainers as well (@bbigras @anpin), cheers! :smiley: 



## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
