### PR TITLE
linuxPackages.mwprocapture: 1.3.0.4390 -> 1.3.4418

### DIFF
--- a/pkgs/os-specific/linux/mwprocapture/default.nix
+++ b/pkgs/os-specific/linux/mwprocapture/default.nix
@@ -18,12 +18,12 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "mwprocapture";
-  subVersion = "4390";
-  version = "1.3.0.${subVersion}-${kernel.version}";
+  subVersion = "1.3.4418";
+  version = "${subVersion}-${kernel.version}";
 
   src = fetchurl {
     url = "https://www.magewell.com/files/drivers/ProCaptureForLinux_${subVersion}.tar.gz";
-    sha256 = "sha256-a2cU7PYQh1KR5eeMhMNx2Sc3HHd7QvCG9+BoJyVPp1Y=";
+    sha256 = "sha256-ZUqJkARhaMo9aZOtUMEdiHEbEq10lJO6MkGjEDnfx1g=";
   };
 
   nativeBuildInputs = kernel.moduleBuildDependencies;
@@ -65,11 +65,12 @@ stdenv.mkDerivation rec {
       "$out"/bin/mwcap-info
   '';
 
-  meta = with lib; {
+  meta = {
     homepage = "https://www.magewell.com/";
     description = "Linux driver for the Magewell Pro Capture family";
-    license = licenses.unfreeRedistributable;
-    maintainers = with maintainers; [ flexiondotorg ];
-    platforms = platforms.linux;
+    license = lib.licenses.unfreeRedistributable;
+    maintainers = with lib.maintainers; [ flexiondotorg ];
+    platforms = lib.platforms.linux;
+    broken = lib.versionAtLeast kernel.version "6.15";
   };
 }


### PR DESCRIPTION
Version V1.3.0.4390 of mwprocapture (the Linux driver for the Magewell Pro Capture family) FTBFS when building against Linux 6.12 and newer.

Magewell offers a revised driver. *Note the version numbering has changed in this release*. This pull request updates the driver version to 1.3.4418, which is compatible with past kernel releases and Linux 6.12 to 6.14.

Vendor change log:
- Fix the compatibility issue of the kernel driver for RHEL9.4.
- Add the preset function for contrast/brightness/saturation/hue values.
- Support the installation of drivers in a Secure Boot environment.

## Marked broken for Linux 6.15 and newer

**However, since I first submitted this pull request, Linux 6.15 has been released, and the mwprocapture does not build against Linux 6.15 and newer. I have marked the mwprocapture driver as broken on Linux 6.15 and newer while I chase a fix with Magewell.**

Tested using a Magewell Pro Capture Dual HDMI (11080) and Magewell Pro Capture Quad HDMI (11100) on NixOS 24.11 and 25.05 using Linux 6.12. This fixes #403297

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review`
Commit: `df63fc5655c4a9de81b5e3b0d6d78d85e6076a33`

---
### `x86_64-linux`
<details>
  <summary>:fast_forward: 3 packages marked as broken and skipped:</summary>
  <ul>
    <li>linuxKernel.packages.linux_5_4_hardened.mwprocapture</li>
    <li>linuxKernel.packages.linux_6_15.mwprocapture</li>
    <li>linuxKernel.packages.linux_latest_libre.mwprocapture</li>
  </ul>
</details>
<details>
  <summary>:white_check_mark: 21 packages built:</summary>
  <ul>
    <li>linuxKernel.packages.linux_5_10.mwprocapture</li>
    <li>linuxKernel.packages.linux_5_10_hardened.mwprocapture</li>
    <li>linuxKernel.packages.linux_5_15.mwprocapture</li>
    <li>linuxKernel.packages.linux_5_15_hardened.mwprocapture</li>
    <li>linuxKernel.packages.linux_5_4.mwprocapture</li>
    <li>linuxKernel.packages.linux_6_1.mwprocapture</li>
    <li>linuxKernel.packages.linux_6_12.mwprocapture</li>
    <li>linuxKernel.packages.linux_hardened.mwprocapture (linuxKernel.packages.linux_6_12_hardened.mwprocapture)</li>
    <li>linuxKernel.packages.linux_6_13.mwprocapture</li>
    <li>linuxKernel.packages.linux_6_13_hardened.mwprocapture</li>
    <li>linuxKernel.packages.linux_6_14.mwprocapture</li>
    <li>linuxKernel.packages.linux_6_14_hardened.mwprocapture</li>
    <li>linuxKernel.packages.linux_6_1_hardened.mwprocapture</li>
    <li>linuxKernel.packages.linux_6_6.mwprocapture</li>
    <li>linuxKernel.packages.linux_6_6_hardened.mwprocapture</li>
    <li>linuxKernel.packages.linux_ham.mwprocapture</li>
    <li>linuxKernel.packages.linux_libre.mwprocapture</li>
    <li>linuxKernel.packages.linux_lqx.mwprocapture</li>
    <li>linuxKernel.packages.linux_xanmod.mwprocapture</li>
    <li>linuxKernel.packages.linux_xanmod_latest.mwprocapture (linuxKernel.packages.linux_xanmod_stable.mwprocapture)</li>
    <li>linuxKernel.packages.linux_zen.mwprocapture</li>
  </ul>
</details>

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
