### PR TITLE
tasks/filesystems/btrfs: Use fully qualified lib namespace instead of inherit it

### DIFF
--- a/nixos/modules/tasks/filesystems/btrfs.nix
+++ b/nixos/modules/tasks/filesystems/btrfs.nix
@@ -7,21 +7,6 @@
 }:
 
 let
-  inherit (lib)
-    mkEnableOption
-    mkOption
-    types
-    mkMerge
-    mkIf
-    optionals
-    mkDefault
-    nameValuePair
-    listToAttrs
-    filterAttrs
-    mapAttrsToList
-    foldl'
-    ;
-
   inInitrd = config.boot.initrd.supportedFilesystems.btrfs or false;
   inSystem = config.boot.supportedFilesystems.btrfs or false;
 
@@ -37,10 +22,10 @@ in
     # One could also do regular btrfs balances, but that shouldn't be necessary
     # during normal usage and as long as the filesystems aren't filled near capacity
     services.btrfs.autoScrub = {
-      enable = mkEnableOption "regular btrfs scrub";
+      enable = lib.mkEnableOption "regular btrfs scrub";
 
-      fileSystems = mkOption {
-        type = types.listOf types.path;
+      fileSystems = lib.mkOption {
+        type = lib.types.listOf lib.types.path;
         example = [ "/" ];
         description = ''
           List of paths to btrfs filesystems to regularly call {command}`btrfs scrub` on.
@@ -51,9 +36,9 @@ in
         '';
       };
 
-      interval = mkOption {
+      interval = lib.mkOption {
         default = "monthly";
-        type = types.str;
+        type = lib.types.str;
         example = "weekly";
         description = ''
           Systemd calendar expression for when to scrub btrfs filesystems.
@@ -68,40 +53,40 @@ in
     };
   };
 
-  config = mkMerge [
-    (mkIf enableBtrfs {
+  config = lib.mkMerge [
+    (lib.mkIf enableBtrfs {
       system.fsPackages = [ pkgs.btrfs-progs ];
     })
 
-    (mkIf inInitrd {
+    (lib.mkIf inInitrd {
       boot.initrd.kernelModules = [ "btrfs" ];
       boot.initrd.availableKernelModules =
         [ "crc32c" ]
-        ++ optionals (config.boot.kernelPackages.kernel.kernelAtLeast "5.5") [
+        ++ lib.optionals (config.boot.kernelPackages.kernel.kernelAtLeast "5.5") [
           # Needed for mounting filesystems with new checksums
           "xxhash_generic"
           "blake2b_generic"
           "sha256_generic" # Should be baked into our kernel, just to be sure
         ];
 
-      boot.initrd.extraUtilsCommands = mkIf (!config.boot.initrd.systemd.enable) ''
+      boot.initrd.extraUtilsCommands = lib.mkIf (!config.boot.initrd.systemd.enable) ''
         copy_bin_and_libs ${pkgs.btrfs-progs}/bin/btrfs
         ln -sv btrfs $out/bin/btrfsck
         ln -sv btrfsck $out/bin/fsck.btrfs
       '';
 
-      boot.initrd.extraUtilsCommandsTest = mkIf (!config.boot.initrd.systemd.enable) ''
+      boot.initrd.extraUtilsCommandsTest = lib.mkIf (!config.boot.initrd.systemd.enable) ''
         $out/bin/btrfs --version
       '';
 
-      boot.initrd.postDeviceCommands = mkIf (!config.boot.initrd.systemd.enable) ''
+      boot.initrd.postDeviceCommands = lib.mkIf (!config.boot.initrd.systemd.enable) ''
         btrfs device scan
       '';
 
       boot.initrd.systemd.initrdBin = [ pkgs.btrfs-progs ];
     })
 
-    (mkIf enableAutoScrub {
+    (lib.mkIf enableAutoScrub {
       assertions = [
         {
           assertion = cfgScrub.enable -> (cfgScrub.fileSystems != [ ]);
@@ -120,15 +105,17 @@ in
         let
           isDeviceInList = list: device: builtins.filter (e: e.device == device) list != [ ];
 
-          uniqueDeviceList = foldl' (acc: e: if isDeviceInList acc e.device then acc else acc ++ [ e ]) [ ];
+          uniqueDeviceList = lib.foldl' (
+            acc: e: if isDeviceInList acc e.device then acc else acc ++ [ e ]
+          ) [ ];
         in
-        mkDefault (
+        lib.mkDefault (
           map (e: e.mountPoint) (
             uniqueDeviceList (
-              mapAttrsToList (name: fs: {
+              lib.mapAttrsToList (name: fs: {
                 mountPoint = fs.mountPoint;
                 device = fs.device;
-              }) (filterAttrs (name: fs: fs.fsType == "btrfs") config.fileSystems)
+              }) (lib.filterAttrs (name: fs: fs.fsType == "btrfs") config.fileSystems)
             )
           )
         );
@@ -144,7 +131,7 @@ in
             let
               fs' = utils.escapeSystemdPath fs;
             in
-            nameValuePair "btrfs-scrub-${fs'}" {
+            lib.nameValuePair "btrfs-scrub-${fs'}" {
               description = "regular btrfs scrub timer on ${fs}";
 
               wantedBy = [ "timers.target" ];
@@ -155,7 +142,7 @@ in
               };
             };
         in
-        listToAttrs (map scrubTimer cfgScrub.fileSystems);
+        lib.listToAttrs (map scrubTimer cfgScrub.fileSystems);
 
       systemd.services =
         let
@@ -164,7 +151,7 @@ in
             let
               fs' = utils.escapeSystemdPath fs;
             in
-            nameValuePair "btrfs-scrub-${fs'}" {
+            lib.nameValuePair "btrfs-scrub-${fs'}" {
               description = "btrfs scrub on ${fs}";
               documentation = [ "man:btrfs-scrub(8)" ];
               # scrub prevents suspend2ram or proper shutdown
@@ -190,7 +177,7 @@ in
               };
             };
         in
-        listToAttrs (map scrubService cfgScrub.fileSystems);
+        lib.listToAttrs (map scrubService cfgScrub.fileSystems);
     })
   ];
 }

--- a/nixos/modules/tasks/filesystems/btrfs.nix
+++ b/nixos/modules/tasks/filesystems/btrfs.nix
@@ -12,8 +12,7 @@ let
 
   cfgScrub = config.services.btrfs.autoScrub;
 
-  enableAutoScrub = cfgScrub.enable;
-  enableBtrfs = inInitrd || inSystem || enableAutoScrub;
+  enableBtrfs = inInitrd || inSystem || cfgScrub.enable;
 
 in
 
@@ -86,7 +85,7 @@ in
       boot.initrd.systemd.initrdBin = [ pkgs.btrfs-progs ];
     })
 
-    (lib.mkIf enableAutoScrub {
+    (lib.mkIf cfgScrub.enable {
       assertions = [
         {
           assertion = cfgScrub.enable -> (cfgScrub.fileSystems != [ ]);


### PR DESCRIPTION
just code refactor

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
