### PR TITLE
labels: fix backport labels for CI workflows

### DIFF
--- a/.github/labeler-no-sync.yml
+++ b/.github/labeler-no-sync.yml
@@ -28,6 +28,8 @@
       - any-glob-to-any-file:
         - .github/workflows/*
         - ci/**/*.*
+
+"backport release-24.11":
   - all:
     - head-branch:
       # r-ryantm's branches have this prefix.


### PR DESCRIPTION
This broke in #402304.

According to the upstream docs it's possible to use the same label multiple times, this should work.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
