### PR TITLE
Revert "labels: fix backport labels for CI workflows"

### DIFF
--- a/.github/labeler-no-sync.yml
+++ b/.github/labeler-no-sync.yml
@@ -28,8 +28,6 @@
       - any-glob-to-any-file:
         - .github/workflows/*
         - ci/**/*.*
-
-"backport release-24.11":
   - all:
     - head-branch:
       # r-ryantm's branches have this prefix.


### PR DESCRIPTION
This reverts commit 54331e1101775c0e8c0cdc642016ec1a79935cbb.

That didn't work, the labels job is failing with this now:

```
Error: YAMLException: duplicated mapping key (32:1)

 29 |         - .github/workflows/*
 30 |         - ci/**/*.*
 31 | 
 32 | "backport release-24.11":
------^
 33 |   - all:
 34 |     - head-branch:
Error: duplicated mapping key (32:1)

 29 |         - .github/workflows/*
 30 |         - ci/**/*.*
 31 | 
 32 | "backport release-24.11":
------^
 33 |   - all:
 34 |     - head-branch:
```

## Things done

- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
