### PR TITLE
vscode-extensions.ms-dotnettools.csharp: fix patching and license

### DIFF
--- a/pkgs/applications/editors/vscode/extensions/ms-dotnettools.csharp/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/ms-dotnettools.csharp/default.nix
@@ -7,7 +7,10 @@
   openssl,
   libz,
   glibc,
+  libkrb5,
   coreutils,
+  jq,
+  patchelf,
 }:
 let
   extInfo = (
@@ -40,16 +43,18 @@ vscode-utils.buildVscodeMarketplaceExtension {
     inherit (extInfo) hash arch;
   };
 
-  nativeBuildInputs = lib.optionals stdenv.hostPlatform.isLinux [ autoPatchelfHook ];
-  buildInputs = lib.optionals stdenv.hostPlatform.isLinux [
-    (lib.getLib stdenv.cc.cc) # libstdc++.so.6
-    (lib.getLib glibc) # libgcc_s.so.1
-    (lib.getLib libz) # libz.so.1
+  nativeBuildInputs = lib.optionals stdenv.hostPlatform.isLinux [
+    autoPatchelfHook
+    jq
+    patchelf
   ];
-  runtimeDependencies = lib.optionals stdenv.hostPlatform.isLinux [
-    (lib.getLib openssl) # libopenssl.so.3
+  buildInputs = lib.optionals stdenv.hostPlatform.isLinux [
+    (lib.getLib glibc) # libgcc_s.so.1
     (lib.getLib icu) # libicui18n.so libicuuc.so
+    (lib.getLib libkrb5) # libgssapi_krb5.so
     (lib.getLib libz) # libz.so.1
+    (lib.getLib openssl) # libopenssl.so.3
+    (lib.getLib stdenv.cc.cc) # libstdc++.so.6
   ];
 
   postPatch = ''
@@ -59,17 +64,73 @@ vscode-utils.buildVscodeMarketplaceExtension {
 
   preFixup = ''
     (
+      set -euo pipefail
       shopt -s globstar
       shopt -s dotglob
+
+      # Fix all binaries.
       for file in "$out"/**/*; do
-        if [[ ! -f "$file" || "$file" == *.so || "$file" == *.dylib ]] ||
+        if [[ ! -f "$file" || "$file" == *.so || "$file" == *.a || "$file" == *.dylib ]] ||
             (! isELF "$file" && ! isMachO "$file"); then
             continue
         fi
 
         echo Making "$file" executable...
         chmod +x "$file"
+
+        ${lib.optionalString stdenv.hostPlatform.isLinux ''
+          # Add .NET deps if it is an apphost.
+          if grep 'You must install .NET to run this application.' "$file" > /dev/null; then
+            echo "Adding .NET needed libraries to: $file"
+            patchelf \
+              --add-needed libicui18n.so \
+              --add-needed libicuuc.so \
+              --add-needed libgssapi_krb5.so \
+              --add-needed libssl.so \
+              "$file"
+          fi
+        ''}
       done
+
+      ${lib.optionalString stdenv.hostPlatform.isLinux ''
+        # Add the ICU libraries as needed to the globalization DLLs.
+        for file in "$out"/**/{libcoreclr.so,*System.Globalization.Native.so}; do
+          echo "Adding ICU libraries to: $file"
+          patchelf \
+            --add-needed libicui18n.so \
+            --add-needed libicuuc.so \
+            "$file"
+        done
+
+        # Add the Kerberos libraries as needed to the native security DLL.
+        for file in "$out"/**/*System.Net.Security.Native.so; do
+          echo "Adding Kerberos libraries to: $file"
+          patchelf \
+            --add-needed libgssapi_krb5.so \
+            "$file"
+        done
+
+        # Add the OpenSSL libraries as needed to the OpenSSL native security DLL.
+        for file in "$out"/**/*System.Security.Cryptography.Native.OpenSsl.so; do
+          echo "Adding OpenSSL libraries to: $file"
+          patchelf \
+            --add-needed libssl.so \
+            "$file"
+        done
+
+        # Add the needed binaries to the apphost binaries.
+        for file in $(jq -r '.runtimeDependencies | map(select(.binaries != null) | .installPath + "/" + .binaries[]) | sort | unique | map(sub("/\\./"; "/")) | .[]' < "$out"/share/vscode/extensions/ms-dotnettools.csharp/package.json); do
+          [ -f "$out"/share/vscode/extensions/ms-dotnettools.csharp/"$file" ] || continue
+
+          echo "Adding .NET needed libraries to: $out/share/vscode/extensions/ms-dotnettools.csharp/$file"
+          patchelf \
+            --add-needed libicui18n.so \
+            --add-needed libicuuc.so \
+            --add-needed libgssapi_krb5.so \
+            --add-needed libssl.so \
+            "$out"/share/vscode/extensions/ms-dotnettools.csharp/"$file"
+        done
+      ''}
     )
   '';
 

--- a/pkgs/applications/editors/vscode/extensions/ms-dotnettools.csharp/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/ms-dotnettools.csharp/default.nix
@@ -139,7 +139,7 @@ vscode-utils.buildVscodeMarketplaceExtension {
   meta = {
     description = "Official C# support for Visual Studio Code";
     homepage = "https://github.com/dotnet/vscode-csharp";
-    license = lib.licenses.mit;
+    license = lib.licenses.unfree;
     maintainers = with lib.maintainers; [ ggg ];
     platforms = [
       "x86_64-linux"


### PR DESCRIPTION
Fix the patching of the binaries included in the extension to more closely match the patching we do in the .NET binary distribution packaging:
https://github.com/NixOS/nixpkgs/blob/65a965068e7f9a1b1766b9520957d8a1d2da1509/pkgs/development/compilers/dotnet/build-dotnet.nix#L169-L182

Also change the license to unfree because of the reason described in the commit that changed it:
> Initially the C# extension was fully open source and had the MIT license as it used OmniSharp, however, after changing to the Roslyn language server and adding the vsdbg binary, it has switched to a non-free license. It even has builtin guards against running on non-microsoft VSCode builds now.
> Some things in the C# extension can be built from source, but the debugging layer is fully based on vsdbg which is part of Visual Studio which is proprietary, so the extension as a whole is unfree because of it.

Fixes #398984.

cc: @corngood (since we discussed this patchelf-ing) and @superherointj (since you previously mentioned you'd like to be made aware of changes in this package)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
