### PR TITLE
devmode: copy symlinks when syncing

### DIFF
--- a/pkgs/by-name/de/devmode/package.nix
+++ b/pkgs/by-name/de/devmode/package.nix
@@ -55,6 +55,7 @@ let
         --chmod=u=rwX \
         --delete-before \
         --delay-updates \
+        --links \
         $out_link/ \
         $serve/
     else


### PR DESCRIPTION
Encountered in https://github.com/ngi-nix/ngipkgs/pull/1001#discussion_r2073580850

There, the `fonts` directory is a symlink, but without the `--links` flag, rsync will not copy it in the [build-and-copy](https://github.com/NixOS/nixpkgs/blob/3730d8a308f94996a9ba7c7138ede69c1b9ac4ae/pkgs/by-name/de/devmode/package.nix#L42) phase.

```shellSession
$ nix build .#overview
$ ls -l result/
lrwxrwxrwx   - root  1 Jan  1970  fonts -> /nix/store/05wkyrdmdr1n7mmlv6mpasbnxzvkqq3g-fonts
.r--r--r-- 18k root  1 Jan  1970  index.html
dr-xr-xr-x   - root  1 Jan  1970  project
.r--r--r-- 14k root  1 Jan  1970  style.css
```

```shellSession
server  GET /fonts/IBMPlexSans-Text.woff2 404 0.484 ms - 167
server  GET /fonts/IBMPlexSans-Bold.woff2 404 0.312 ms - 167
server  GET /fonts/IBMPlexSans-Medium.woff2 404 0.355 ms - 169
server  GET /fonts/IBMPlexMono-Text.woff2 404 0.446 ms - 167
server  GET /fonts/IBMPlexSans-Text.otf 404 0.650 ms - 165
server  GET /fonts/IBMPlexSans-Bold.otf 404 0.783 ms - 165
server  GET /fonts/IBMPlexSans-Medium.otf 404 0.935 ms - 167
server  GET /fonts/IBMPlexMono-Text.otf 404 0.857 ms - 165
server  GET /fonts/IBMPlexSans-Regular.woff2 404 0.414 ms - 170
server  GET /fonts/IBMPlexMono-Regular.woff2 404 0.429 ms - 170
server  GET /fonts/IBMPlexSans-Regular.otf 404 0.702 ms - 168
server  GET /fonts/IBMPlexMono-Regular.otf 404 0.794 ms - 168
```

With this change, symlinks are copied as symlinks and the server successfully finds the fonts:

```shellSession
server  GET /fonts/IBMPlexSans-Text.woff2 200 1.693 ms - 67928
server  GET /fonts/IBMPlexSans-Bold.woff2 200 1.985 ms - 64248
server  GET /fonts/IBMPlexSans-Medium.woff2 200 2.682 ms - 68732
server  GET /fonts/IBMPlexMono-Text.woff2 200 2.124 ms - 48588
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
