### PR TITLE
labels: add backport label for automatic browser updates (take 2)

### DIFF
--- a/.github/labeler-no-sync.yml
+++ b/.github/labeler-no-sync.yml
@@ -28,5 +28,38 @@
       - any-glob-to-any-file:
         - .github/workflows/*
         - ci/**/*.*
+  - all:
+    - head-branch:
+      # r-ryantm's branches have this prefix.
+      - ^auto-update/
+    - changed-files:
+      - any-glob-to-any-file:
+        # Browser updates should always be backported.
+        - pkgs/applications/kde/angelfish.nix
+        - pkgs/applications/kde/falkon.nix
+        - pkgs/applications/kde/konqueror.nix
+        - pkgs/applications/networking/browsers/**/*
+        - pkgs/by-name/br/brave/**/*
+        # Added in December 2024, uncomment for 25.05
+        # - pkgs/by-name/ca/catalyst-browser/**/*
+        - pkgs/by-name/ch/chawan/**/*
+        - pkgs/by-name/di/dillo-plus/**/*
+        - pkgs/by-name/di/dillo/**/*
+        - pkgs/by-name/ed/edbrowse/**/*
+        - pkgs/by-name/ep/epiphany/**/*
+        - pkgs/by-name/go/google-chrome/**/*
+        - pkgs/by-name/ly/lynx/**/*
+        - pkgs/by-name/mi/microsoft-edge/**/*
+        - pkgs/by-name/mi/midori-unwrapped/**/*
+        - pkgs/by-name/mu/mullvad-browser/**/*
+        - pkgs/by-name/op/opera/**/*
+        - pkgs/by-name/to/tor-browser/**/*
+        - pkgs/by-name/vi/vimb-unwrapped/**/*
+        - pkgs/by-name/w3/w3m/**/*
+        - pkgs/desktops/lomiri/applications/morph-browser/**/*
+        - pkgs/development/libraries/webkitgtk/**/*
+        - pkgs/kde/gear/angelfish/**/*
+        - pkgs/kde/gear/falkon/**/*
+        - pkgs/kde/gear/konqueror/**/*
 
 # keep-sorted end


### PR DESCRIPTION
Browser updates should always be backported for security reasons, so let's make our life a bit easier by adding the backport label for r-ryantm's PRs automatically.

Draft for now, because this doesn't work as is. This was applied in #402304 and reverted in #404405. Parking for now.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
