### PR TITLE
beamPackages.mixRelease: support escript properly

### DIFF
--- a/pkgs/by-name/pr/protoc-gen-elixir/package.nix
+++ b/pkgs/by-name/pr/protoc-gen-elixir/package.nix
@@ -25,20 +25,7 @@ mixRelease rec {
     hash = "sha256-T1uL3xXXmCkobJJhS3p6xMrJUyiim3AMwaG87/Ix7A8=";
   };
 
-  buildInputs = [ erlang ];
-
-  postBuild = ''
-    mix do escript.build
-  '';
-
-  installPhase = ''
-    runHook preInstall
-
-    mkdir -p $out/bin
-    cp protoc-gen-elixir $out/bin
-
-    runHook postInstall
-  '';
+  escriptBinName = "protoc-gen-elixir";
 
   passthru.updateScript = nix-update-script { };
 

--- a/pkgs/development/beam-modules/ex_doc/default.nix
+++ b/pkgs/development/beam-modules/ex_doc/default.nix
@@ -30,6 +30,8 @@ mixRelease {
     elixir
     ;
 
+  escriptBinName = "ex_doc";
+
   stripDebug = true;
 
   mixFodDeps = fetchMixDeps {
@@ -37,25 +39,6 @@ mixRelease {
     inherit src version elixir;
     hash = "sha256-s4b6wuBJPdN0FPn76zbLCHzqJNEZ6E4nOyB1whUM2VY=";
   };
-
-  configurePhase = ''
-    runHook preConfigure
-    mix deps.compile --no-deps-check
-    runHook postConfigure
-  '';
-
-  buildPhase = ''
-    runHook preBuild
-    mix do escript.build
-    runHook postBuild
-  '';
-
-  installPhase = ''
-    runHook preInstall
-    mkdir -p $out/bin
-    cp -v ex_doc $out/bin
-    runHook postInstall
-  '';
 
   passthru = {
     tests = {


### PR DESCRIPTION
It is convenient to use `mixRelease` as a starting place for releasing an `escript` for a `mix` project, but prior to this PR you need to remember to do multiple things for that to work:
1. Perform the `mix do escript.build`.
3. Copy the resulting script to `$out/bin`.
4. Specify `erlang` as a `buildInput` so that the resulting script does not have non-deterministic behavior related to whatever `escript` binary happens to be in the path at runtime.

That third step is sneaky enough that it isn't even currently performed as part of the `ex_doc` package's build. You can see the following at the top of that package's output:
```
#! /usr/bin/env escript
```

This, of course, will entirely fail if `erlang` is not installed on the system and it may have unreliable results if the version of Erlang on the system is different than the one used to build `ex_doc`.

The changes in this PR allow building `escript` packages with ease. I've applied the new capability to both `ex_doc` and `protoc-gen-elixir` in separate commits.

The top of the `ex_doc` binary now correctly looks like:
```
/nix/store/5b9fywb7dskr3dpvv8x3gnkhs2i014ps-erlang-27.3.3/bin/escript
```

Does this make `mixRelease` do too much? I could see that argument. This could also be done as e.g. `beamPackages.escriptRelease` that built on `mixRelease` with some simple overrides; could be cleaner, but not sure it's worth the extra file. Plus, given `escript` is an Erlang thing, that particular name choice is probably not good because it doesn't imply the `mix` tool is involved at all.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
