### PR TITLE
feat(perlPackages): add CPAN packages required by LedgerSMB

### DIFF
--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -2359,12 +2359,23 @@ with self;
       url = "mirror://cpan/authors/id/P/PR/PREACTION/Beam-Emitter-1.007.tar.gz";
       hash = "sha256-cBmNscasPWIX2Nl8ZXfRZpVBijuM+q6FOIojUJ9GnZU=";
     };
-    buildInputs = [ TestAPI TestFatal TestLib ];
-    propagatedBuildInputs = [ ModuleRuntime Moo TypeTiny ];
+    buildInputs = [
+      TestAPI
+      TestFatal
+      TestLib
+    ];
+    propagatedBuildInputs = [
+      ModuleRuntime
+      Moo
+      TypeTiny
+    ];
     meta = {
       homepage = "https://github.com/preaction/Beam-Emitter";
       description = "Role for event emitting classes";
-      license = with lib.licenses; [ artistic1 gpl1Plus ];
+      license = with lib.licenses; [
+        artistic1
+        gpl1Plus
+      ];
     };
   };
 
@@ -2376,11 +2387,17 @@ with self;
       hash = "sha256-YSj9I8RZC/jYBYoBV6VgoiU3fDx7iZJYsD/BcZBZUdQ=";
     };
     buildInputs = [ TestFatal ];
-    propagatedBuildInputs = [ Moo TypeTiny ];
+    propagatedBuildInputs = [
+      Moo
+      TypeTiny
+    ];
     meta = {
       homepage = "https://github.com/preaction/Beam-Service";
       description = "Role for services to access Beam::Wire features";
-      license = with lib.licenses; [ artistic1 gpl1Plus ];
+      license = with lib.licenses; [
+        artistic1
+        gpl1Plus
+      ];
     };
   };
 
@@ -2391,12 +2408,31 @@ with self;
       url = "mirror://cpan/authors/id/P/PR/PREACTION/Beam-Wire-1.026.tar.gz";
       hash = "sha256-L+6L9WXeEQpGu0ZQAn6cdLjTaQqWlCdxEaJdwAI632c=";
     };
-    buildInputs = [ TestDeep TestDifferences TestException TestLib ];
-    propagatedBuildInputs = [ BeamEmitter BeamService ConfigAny DataDPath ModuleRuntime Moo PathTiny Throwable TypeTiny YAML ];
+    buildInputs = [
+      TestDeep
+      TestDifferences
+      TestException
+      TestLib
+    ];
+    propagatedBuildInputs = [
+      BeamEmitter
+      BeamService
+      ConfigAny
+      DataDPath
+      ModuleRuntime
+      Moo
+      PathTiny
+      Throwable
+      TypeTiny
+      YAML
+    ];
     meta = {
       homepage = "https://github.com/preaction/Beam-Wire";
       description = "Lightweight Dependency Injection Container";
-      license = with lib.licenses; [ artistic1 gpl1Plus ];
+      license = with lib.licenses; [
+        artistic1
+        gpl1Plus
+      ];
     };
   };
 
@@ -8086,11 +8122,19 @@ with self;
       hash = "sha256-mfRCbUWMW7jUxRDgwmKcioiuT0ZhwLHkXFVQNi+S7ME=";
     };
     buildInputs = [ TestDeep ];
-    propagatedBuildInputs = [ ClassXSAccessor IteratorUtil SubExporter aliased ];
+    propagatedBuildInputs = [
+      ClassXSAccessor
+      IteratorUtil
+      SubExporter
+      aliased
+    ];
     meta = {
       homepage = "http://metacpan.org/release/Data-DPath";
       description = "DPath is not XPath!";
-      license = with lib.licenses; [ artistic1 gpl1Plus ];
+      license = with lib.licenses; [
+        artistic1
+        gpl1Plus
+      ];
     };
   };
 
@@ -9080,7 +9124,10 @@ with self;
     meta = {
       homepage = "https://metacpan.org/release/DateTime-Format-Duration-ISO8601";
       description = "Parse and format ISO8601 duration";
-      license = with lib.licenses; [ artistic1 gpl1Plus ];
+      license = with lib.licenses; [
+        artistic1
+        gpl1Plus
+      ];
     };
   };
 
@@ -13824,7 +13871,10 @@ with self;
     propagatedBuildInputs = [ ParamsUtil ];
     meta = {
       description = "Find a file within a set of paths (like @INC or Java classpaths)";
-      license = with lib.licenses; [ artistic1 gpl1Plus ];
+      license = with lib.licenses; [
+        artistic1
+        gpl1Plus
+      ];
     };
   };
 
@@ -13838,7 +13888,10 @@ with self;
     propagatedBuildInputs = [ TestException ];
     meta = {
       description = "Recursive versions of mkdir() and rmdir() without as much overhead as File::Path";
-      license = with lib.licenses; [ artistic1 gpl1Plus ];
+      license = with lib.licenses; [
+        artistic1
+        gpl1Plus
+      ];
     };
   };
 
@@ -17941,7 +17994,10 @@ with self;
       url = "mirror://cpan/authors/id/R/RO/ROODE/Iterator-Util-0.02.tar.gz";
       hash = "sha256-YYLkiPHxlh2GU9a7PssSIndv8oNbUawSCRjFI4wetWM=";
     };
-    propagatedBuildInputs = [ ExceptionClass Iterator ];
+    propagatedBuildInputs = [
+      ExceptionClass
+      Iterator
+    ];
     meta = {
     };
   };
@@ -19282,11 +19338,23 @@ with self;
       hash = "sha256-UMQgOSWX4L9LARxdPsQ/Ft9BT0vT+SleaAERh0xPMZI=";
     };
     buildInputs = [ TestException ];
-    propagatedBuildInputs = [ ClassLoad DateTime DateTimeLocale Moo MooXClassAttribute TypeTiny UnicodeRegexSet namespaceautoclean ];
+    propagatedBuildInputs = [
+      ClassLoad
+      DateTime
+      DateTimeLocale
+      Moo
+      MooXClassAttribute
+      TypeTiny
+      UnicodeRegexSet
+      namespaceautoclean
+    ];
     meta = {
       homepage = "https://github.com/ThePilgrim/perlcldr";
       description = "A Module to create locale objects with localisation data from the CLDR";
-      license = with lib.licenses; [ artistic1 gpl1Plus ];
+      license = with lib.licenses; [
+        artistic1
+        gpl1Plus
+      ];
     };
   };
 
@@ -19300,7 +19368,10 @@ with self;
     propagatedBuildInputs = [ LocaleCLDR ];
     meta = with lib; {
       description = "CLDR data for the Ar locale";
-      license = with licenses; [ artistic1 gpl1Plus ];
+      license = with licenses; [
+        artistic1
+        gpl1Plus
+      ];
     };
   };
 
@@ -19314,7 +19385,10 @@ with self;
     propagatedBuildInputs = [ LocaleCLDR ];
     meta = with lib; {
       description = "CLDR data for the Bg locale";
-      license = with licenses; [ artistic1 gpl1Plus ];
+      license = with licenses; [
+        artistic1
+        gpl1Plus
+      ];
     };
   };
 
@@ -19328,7 +19402,10 @@ with self;
     propagatedBuildInputs = [ LocaleCLDR ];
     meta = with lib; {
       description = "CLDR data for the Ca locale";
-      license = with licenses; [ artistic1 gpl1Plus ];
+      license = with licenses; [
+        artistic1
+        gpl1Plus
+      ];
     };
   };
 
@@ -19342,7 +19419,10 @@ with self;
     propagatedBuildInputs = [ LocaleCLDR ];
     meta = with lib; {
       description = "CLDR data for the Cs locale";
-      license = with licenses; [ artistic1 gpl1Plus ];
+      license = with licenses; [
+        artistic1
+        gpl1Plus
+      ];
     };
   };
 
@@ -19356,7 +19436,10 @@ with self;
     propagatedBuildInputs = [ LocaleCLDR ];
     meta = with lib; {
       description = "CLDR data for the Da locale";
-      license = with licenses; [ artistic1 gpl1Plus ];
+      license = with licenses; [
+        artistic1
+        gpl1Plus
+      ];
     };
   };
 
@@ -19370,7 +19453,10 @@ with self;
     propagatedBuildInputs = [ LocaleCLDR ];
     meta = with lib; {
       description = "CLDR data for the De locale";
-      license = with licenses; [ artistic1 gpl1Plus ];
+      license = with licenses; [
+        artistic1
+        gpl1Plus
+      ];
     };
   };
 
@@ -19384,7 +19470,10 @@ with self;
     propagatedBuildInputs = [ LocaleCLDR ];
     meta = with lib; {
       description = "CLDR data for the El locale";
-      license = with licenses; [ artistic1 gpl1Plus ];
+      license = with licenses; [
+        artistic1
+        gpl1Plus
+      ];
     };
   };
 
@@ -19398,7 +19487,10 @@ with self;
     propagatedBuildInputs = [ LocaleCLDR ];
     meta = with lib; {
       description = "CLDR data for the En locale";
-      license = with licenses; [ artistic1 gpl1Plus ];
+      license = with licenses; [
+        artistic1
+        gpl1Plus
+      ];
     };
   };
 
@@ -19412,7 +19504,10 @@ with self;
     propagatedBuildInputs = [ LocaleCLDR ];
     meta = with lib; {
       description = "CLDR data for the Es locale";
-      license = with licenses; [ artistic1 gpl1Plus ];
+      license = with licenses; [
+        artistic1
+        gpl1Plus
+      ];
     };
   };
 
@@ -19426,7 +19521,10 @@ with self;
     propagatedBuildInputs = [ LocaleCLDR ];
     meta = with lib; {
       description = "CLDR data for the Et locale";
-      license = with licenses; [ artistic1 gpl1Plus ];
+      license = with licenses; [
+        artistic1
+        gpl1Plus
+      ];
     };
   };
 
@@ -19440,7 +19538,10 @@ with self;
     propagatedBuildInputs = [ LocaleCLDR ];
     meta = with lib; {
       description = "CLDR data for the Fi locale";
-      license = with licenses; [ artistic1 gpl1Plus ];
+      license = with licenses; [
+        artistic1
+        gpl1Plus
+      ];
     };
   };
 
@@ -19454,7 +19555,10 @@ with self;
     propagatedBuildInputs = [ LocaleCLDR ];
     meta = with lib; {
       description = "CLDR data for the Fr locale";
-      license = with licenses; [ artistic1 gpl1Plus ];
+      license = with licenses; [
+        artistic1
+        gpl1Plus
+      ];
     };
   };
 
@@ -19468,7 +19572,10 @@ with self;
     propagatedBuildInputs = [ LocaleCLDR ];
     meta = with lib; {
       description = "CLDR data for the Hu locale";
-      license = with licenses; [ artistic1 gpl1Plus ];
+      license = with licenses; [
+        artistic1
+        gpl1Plus
+      ];
     };
   };
 
@@ -19482,7 +19589,10 @@ with self;
     propagatedBuildInputs = [ LocaleCLDR ];
     meta = with lib; {
       description = "CLDR data for the Id locale";
-      license = with licenses; [ artistic1 gpl1Plus ];
+      license = with licenses; [
+        artistic1
+        gpl1Plus
+      ];
     };
   };
 
@@ -19496,7 +19606,10 @@ with self;
     propagatedBuildInputs = [ LocaleCLDR ];
     meta = with lib; {
       description = "CLDR data for the Is locale";
-      license = with licenses; [ artistic1 gpl1Plus ];
+      license = with licenses; [
+        artistic1
+        gpl1Plus
+      ];
     };
   };
 
@@ -19510,7 +19623,10 @@ with self;
     propagatedBuildInputs = [ LocaleCLDR ];
     meta = with lib; {
       description = "CLDR data for the It locale";
-      license = with licenses; [ artistic1 gpl1Plus ];
+      license = with licenses; [
+        artistic1
+        gpl1Plus
+      ];
     };
   };
 
@@ -19524,7 +19640,10 @@ with self;
     propagatedBuildInputs = [ LocaleCLDR ];
     meta = with lib; {
       description = "CLDR data for the Lt locale";
-      license = with licenses; [ artistic1 gpl1Plus ];
+      license = with licenses; [
+        artistic1
+        gpl1Plus
+      ];
     };
   };
 
@@ -19538,7 +19657,10 @@ with self;
     propagatedBuildInputs = [ LocaleCLDR ];
     meta = with lib; {
       description = "CLDR data for the Ms locale";
-      license = with licenses; [ artistic1 gpl1Plus ];
+      license = with licenses; [
+        artistic1
+        gpl1Plus
+      ];
     };
   };
 
@@ -19552,7 +19674,10 @@ with self;
     propagatedBuildInputs = [ LocaleCLDR ];
     meta = with lib; {
       description = "CLDR data for the Nb locale";
-      license = with licenses; [ artistic1 gpl1Plus ];
+      license = with licenses; [
+        artistic1
+        gpl1Plus
+      ];
     };
   };
 
@@ -19566,7 +19691,10 @@ with self;
     propagatedBuildInputs = [ LocaleCLDR ];
     meta = with lib; {
       description = "CLDR data for the Nl locale";
-      license = with licenses; [ artistic1 gpl1Plus ];
+      license = with licenses; [
+        artistic1
+        gpl1Plus
+      ];
     };
   };
 
@@ -19580,7 +19708,10 @@ with self;
     propagatedBuildInputs = [ LocaleCLDR ];
     meta = with lib; {
       description = "CLDR data for the Pl locale";
-      license = with licenses; [ artistic1 gpl1Plus ];
+      license = with licenses; [
+        artistic1
+        gpl1Plus
+      ];
     };
   };
 
@@ -19594,7 +19725,10 @@ with self;
     propagatedBuildInputs = [ LocaleCLDR ];
     meta = with lib; {
       description = "CLDR data for the Pt locale";
-      license = with licenses; [ artistic1 gpl1Plus ];
+      license = with licenses; [
+        artistic1
+        gpl1Plus
+      ];
     };
   };
 
@@ -19608,7 +19742,10 @@ with self;
     propagatedBuildInputs = [ LocaleCLDR ];
     meta = with lib; {
       description = "CLDR data for the Ru locale";
-      license = with licenses; [ artistic1 gpl1Plus ];
+      license = with licenses; [
+        artistic1
+        gpl1Plus
+      ];
     };
   };
 
@@ -19622,7 +19759,10 @@ with self;
     propagatedBuildInputs = [ LocaleCLDR ];
     meta = with lib; {
       description = "CLDR data for the Sv locale";
-      license = with licenses; [ artistic1 gpl1Plus ];
+      license = with licenses; [
+        artistic1
+        gpl1Plus
+      ];
     };
   };
 
@@ -19636,7 +19776,10 @@ with self;
     propagatedBuildInputs = [ LocaleCLDR ];
     meta = with lib; {
       description = "CLDR data for the Tr locale";
-      license = with licenses; [ artistic1 gpl1Plus ];
+      license = with licenses; [
+        artistic1
+        gpl1Plus
+      ];
     };
   };
 
@@ -19650,7 +19793,10 @@ with self;
     propagatedBuildInputs = [ LocaleCLDR ];
     meta = with lib; {
       description = "CLDR data for the Uk locale";
-      license = with licenses; [ artistic1 gpl1Plus ];
+      license = with licenses; [
+        artistic1
+        gpl1Plus
+      ];
     };
   };
 
@@ -19664,7 +19810,10 @@ with self;
     propagatedBuildInputs = [ LocaleCLDR ];
     meta = with lib; {
       description = "CLDR data for the Zh locale";
-      license = with licenses; [ artistic1 gpl1Plus ];
+      license = with licenses; [
+        artistic1
+        gpl1Plus
+      ];
     };
   };
 
@@ -19816,7 +19965,12 @@ with self;
       url = "mirror://cpan/authors/id/D/DM/DMUEY/Locales-0.34.tar.gz";
       hash = "sha256-6k3c6fTc/5PSBeF7xYSCQJDXqlpbrtVjMFwm6IngkM0=";
     };
-    propagatedBuildInputs = [ FileSlurp ModuleWant StringUnicodeUTF8 TestCarp ];
+    propagatedBuildInputs = [
+      FileSlurp
+      ModuleWant
+      StringUnicodeUTF8
+      TestCarp
+    ];
     meta = {
       description = "Methods for getting localized CLDR language/territory names (and a subset of other data)";
     };
@@ -22971,7 +23125,10 @@ with self;
       url = "mirror://cpan/authors/id/D/DM/DMUEY/Module-Want-0.6.tar.gz";
       hash = "sha256-xyUkQjT1qncmI/7gDTDz9tnFOaQW3i2wXz7KU7O6Nt4=";
     };
-    propagatedBuildInputs = [ FilePathTiny TestCarp ];
+    propagatedBuildInputs = [
+      FilePathTiny
+      TestCarp
+    ];
     meta = {
       description = "Check @INC once for modules that you want but may not have";
     };
@@ -23894,15 +24051,21 @@ with self;
       url = "mirror://cpan/authors/id/D/DR/DROLSKY/MooseX-ClassAttribute-0.29.tar.gz";
       hash = "sha256-YUTHfFJ3DU+DHK22yto3ElyAs+T/yyRtp+6dVZIu5yU=";
     };
-    buildInputs = [ TestFatal TestRequires ];
-    propagatedBuildInputs = [ Moose namespaceautoclean namespaceclean ];
+    buildInputs = [
+      TestFatal
+      TestRequires
+    ];
+    propagatedBuildInputs = [
+      Moose
+      namespaceautoclean
+      namespaceclean
+    ];
     meta = {
       homepage = "http://metacpan.org/release/MooseX-ClassAttribute";
       description = "Declare class attributes Moose-style";
       license = lib.licenses.artistic2;
     };
   };
-
 
   MooseXStorageFormatJSONpm = buildPerlPackage {
     pname = "MooseX-Storage-Format-JSONpm";
@@ -24010,11 +24173,18 @@ with self;
       url = "mirror://cpan/authors/id/T/TO/TOBYINK/MooX-ClassAttribute-0.011.tar.gz";
       hash = "sha256-wLmKZi7ynJv2X0SknCR6VS6Jhic1oXimVoExgf0NQ/M=";
     };
-    propagatedBuildInputs = [ ExporterTiny Moo RoleTiny ];
+    propagatedBuildInputs = [
+      ExporterTiny
+      Moo
+      RoleTiny
+    ];
     meta = {
       homepage = "https://metacpan.org/release/MooX-ClassAttribute";
       description = "Declare class attributes Moose-style... but without Moose";
-      license = with lib.licenses; [ artistic1 gpl1Plus ];
+      license = with lib.licenses; [
+        artistic1
+        gpl1Plus
+      ];
     };
   };
 
@@ -27009,7 +27179,10 @@ with self;
     meta = {
       homepage = "https://github.com/rjbs/Number-Tolerant";
       description = "Tolerance ranges for inexact numbers";
-      license = with lib.licenses; [ artistic1 gpl1Plus ];
+      license = with lib.licenses; [
+        artistic1
+        gpl1Plus
+      ];
     };
   };
 
@@ -28122,7 +28295,12 @@ with self;
       hash = "sha256-zrqlPujd6TDNlFlrwfOseR1s4EtD9zITr/GOOiO19r8=";
     };
     buildInputs = [ TestException ];
-    propagatedBuildInputs = [ CarpClan DBDPg ListMoreUtils LogAny ];
+    propagatedBuildInputs = [
+      CarpClan
+      DBDPg
+      ListMoreUtils
+      LogAny
+    ];
     meta = {
       description = "A toolkit integrating intelligent PostgreSQL dbs into Perl objects";
       license = lib.licenses.bsd3;
@@ -28136,7 +28314,11 @@ with self;
       url = "mirror://cpan/authors/id/E/EH/EHUELS/PGObject-Simple-3.1.0.tar.gz";
       hash = "sha256-9qG1vjnqZw5r62gFR8/qVtDI04Z4I36Z4UVJVg0858M=";
     };
-    propagatedBuildInputs = [ CarpClan LogAny PGObject ];
+    propagatedBuildInputs = [
+      CarpClan
+      LogAny
+      PGObject
+    ];
     meta = {
       description = "Minimalist stored procedure mapper based on LedgerSMB's DBObject";
       license = lib.licenses.bsd3;
@@ -28151,7 +28333,13 @@ with self;
       hash = "sha256-scoiO8sjkzBA0/8WI66lYr10I/1jZgDo6NqYH4QdvHM=";
     };
     # nix-generate-from-cpan did not pick up required TestException dep
-    propagatedBuildInputs = [ CarpClan LogAny Moo TestException PGObjectSimple ];
+    propagatedBuildInputs = [
+      CarpClan
+      LogAny
+      Moo
+      TestException
+      PGObjectSimple
+    ];
     meta = {
       description = "Moo/Moose mappers for minimalist PGObject framework";
       license = lib.licenses.bsd3;
@@ -28179,7 +28367,13 @@ with self;
       url = "mirror://cpan/authors/id/E/EI/EINHVERFR/PGObject-Type-DateTime-2.1.1.tar.gz";
       hash = "sha256-UXCgDzbiILMHWZ3FaemhSSZKmUmB6Jz1vLqFQ951n1k=";
     };
-    propagatedBuildInputs = [ DateTime DateTimeTimeZone PGObject TermTable TestSimple ];
+    propagatedBuildInputs = [
+      DateTime
+      DateTimeTimeZone
+      PGObject
+      TermTable
+      TestSimple
+    ];
     meta = {
       description = "DateTime Wrappers for PGObject";
       license = lib.licenses.bsd3;
@@ -28194,7 +28388,11 @@ with self;
       hash = "sha256-9FG++wsSIQicvAtvYNFApT0uorV6ijXorWi0xft9odU=";
     };
     buildInputs = [ FileSlurp ];
-    propagatedBuildInputs = [ DBDPg PGObject RefUtil ];
+    propagatedBuildInputs = [
+      DBDPg
+      PGObject
+      RefUtil
+    ];
     meta = {
       description = "Wrapper for raw strings mapping to BYTEA columns";
       license = lib.licenses.bsd3;
@@ -28221,8 +28419,20 @@ with self;
       url = "mirror://cpan/authors/id/E/EH/EHUELS/PGObject-Util-DBAdmin-1.6.2.tar.gz";
       hash = "sha256-lMu6KNKVgpYvigwZ7w4GEpjIcpcog0r15AqQHt7kGtY=";
     };
-    buildInputs = [ PerlCritic PerlCriticStricterSubs TestException ];
-    propagatedBuildInputs = [ CaptureTiny DBDPg DBI LogAny Moo ScopeGuard namespaceclean ];
+    buildInputs = [
+      PerlCritic
+      PerlCriticStricterSubs
+      TestException
+    ];
+    propagatedBuildInputs = [
+      CaptureTiny
+      DBDPg
+      DBI
+      LogAny
+      Moo
+      ScopeGuard
+      namespaceclean
+    ];
     meta = {
       description = "PostgreSQL Database Management Facilities for PGObject";
       license = lib.licenses.bsd3;
@@ -28501,11 +28711,19 @@ with self;
       hash = "sha256-zeFNMUMEKUdE0q3ZIzhrMEf0MLx9Cn0mZAUqTtv8KgM=";
     };
     buildInputs = [ TestWarnings ];
-    propagatedBuildInputs = [ FilePathList ListMoreUtils PPI PerlCritic ];
+    propagatedBuildInputs = [
+      FilePathList
+      ListMoreUtils
+      PPI
+      PerlCritic
+    ];
     meta = {
       homepage = "http://perlcritic.com";
       description = "Perl::Critic plugin for stricter subroutine checking";
-      license = with lib.licenses; [ artistic1 gpl1Plus ];
+      license = with lib.licenses; [
+        artistic1
+        gpl1Plus
+      ];
     };
   };
 
@@ -28860,11 +29078,18 @@ with self;
       url = "mirror://cpan/authors/id/K/KA/KAZEBURO/Plack-Builder-Conditionals-0.05.tar.gz";
       hash = "sha256-TUyym5kmx76eTL4vnNPUdUJpxcQEaYh0Mx39Gdb6cIs=";
     };
-    propagatedBuildInputs = [ ListMoreUtils NetCIDRLite Plack ];
+    propagatedBuildInputs = [
+      ListMoreUtils
+      NetCIDRLite
+      Plack
+    ];
     meta = {
       homepage = "https://github.com/kazeburo/Plack-Builder-Conditionals";
       description = "Plack::Builder extension";
-      license = with lib.licenses; [ artistic1 gpl1Plus ];
+      license = with lib.licenses; [
+        artistic1
+        gpl1Plus
+      ];
     };
   };
 
@@ -29098,12 +29323,21 @@ with self;
       url = "mirror://cpan/authors/id/M/MO/MOZNION/Plack-Request-WithEncoding-0.14.tar.gz";
       hash = "sha256-+4xC1epaGPx+8Fv2TJolmU/PBZzV0EFFuxENBFj+tAc=";
     };
-    buildInputs = [ HTTPMessage ModuleBuildTiny ];
-    propagatedBuildInputs = [ HashMultiValue Plack ];
+    buildInputs = [
+      HTTPMessage
+      ModuleBuildTiny
+    ];
+    propagatedBuildInputs = [
+      HashMultiValue
+      Plack
+    ];
     meta = {
       homepage = "https://github.com/moznion/Plack-Request-WithEncoding";
       description = "Subclass of L<Plack::Request> which supports encoded requests";
-      license = with lib.licenses; [ artistic1 gpl1Plus ];
+      license = with lib.licenses; [
+        artistic1
+        gpl1Plus
+      ];
     };
   };
 
@@ -31236,8 +31470,23 @@ with self;
       url = "mirror://cpan/authors/id/D/DA/DAGOLDEN/Session-Storage-Secure-1.000.tar.gz";
       hash = "sha256-WLLwTrpWqZJElLs+3dQmr/p1w93tHFY/gpb8wT+OZms=";
     };
-    buildInputs = [ NumberTolerant TestDeep TestFatal ];
-    propagatedBuildInputs = [ CryptCBC CryptRijndael CryptURandom MathRandomISAACXS Moo MooXTypesMooseLike SerealDecoder SerealEncoder StringCompareConstantTime namespaceclean ];
+    buildInputs = [
+      NumberTolerant
+      TestDeep
+      TestFatal
+    ];
+    propagatedBuildInputs = [
+      CryptCBC
+      CryptRijndael
+      CryptURandom
+      MathRandomISAACXS
+      Moo
+      MooXTypesMooseLike
+      SerealDecoder
+      SerealEncoder
+      StringCompareConstantTime
+      namespaceclean
+    ];
     meta = {
       homepage = "https://github.com/dagolden/Session-Storage-Secure";
       description = "Encrypted, expiring, compressed, serialized session data with integrity";
@@ -32545,10 +32794,17 @@ with self;
       url = "mirror://cpan/authors/id/D/DM/DMUEY/String-UnicodeUTF8-0.23.tar.gz";
       hash = "sha256-NqYZfdb6S482FR3xAIZVyquN799qHo/uql45azbuRVo=";
     };
-    propagatedBuildInputs = [ BFlags ModuleWant StringUnquotemeta ];
+    propagatedBuildInputs = [
+      BFlags
+      ModuleWant
+      StringUnquotemeta
+    ];
     meta = {
       description = "Non-collation related unicode/utf-8 bytes string-type-agnostic utils that work as far back as perl 5.6";
-      license = with lib.licenses; [ artistic1 gpl1Plus ];
+      license = with lib.licenses; [
+        artistic1
+        gpl1Plus
+      ];
     };
   };
 
@@ -33885,7 +34141,10 @@ with self;
     };
     meta = {
       description = "Format a header and rows into a table";
-      license = with lib.licenses; [ artistic1 gpl1Plus ];
+      license = with lib.licenses; [
+        artistic1
+        gpl1Plus
+      ];
     };
   };
 
@@ -34070,7 +34329,10 @@ with self;
     buildInputs = [ TermTable ];
     meta = {
       description = "Basic utilities for writing tests";
-      license = with lib.licenses; [ artistic1 gpl1Plus ];
+      license = with lib.licenses; [
+        artistic1
+        gpl1Plus
+      ];
     };
   };
 
@@ -34997,7 +35259,10 @@ with self;
     };
     meta = {
       description = "Use libraries from a t/lib directory";
-      license = with lib.licenses; [ artistic1 gpl1Plus ];
+      license = with lib.licenses; [
+        artistic1
+        gpl1Plus
+      ];
     };
   };
 
@@ -38179,7 +38444,10 @@ with self;
     };
     meta = {
       description = "Subtraction and Intersection of Character Sets in Unicode Regular Expressions";
-      license = with lib.licenses; [ artistic1 gpl1Plus ];
+      license = with lib.licenses; [
+        artistic1
+        gpl1Plus
+      ];
     };
   };
 

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -19358,459 +19358,701 @@ with self;
     };
   };
 
-  LocaleCLDRLocalesAr = buildPerlPackage {
+  LocaleCLDRLocalesAr = buildPerlModule {
     pname = "Locale-CLDR-Locales-Ar";
     version = "0.46.0";
     src = fetchurl {
       url = "mirror://cpan/authors/id/J/JG/JGNI/Locale-CLDR-Locales-Ar-v0.46.0.tar.gz";
-      sha256 = "04sbjh38gh0qhl1rzqs52ix6hjw6sbrlh04bnpd36d8fwmzi29wv";
+      hash = "sha256-mycRf+UONTPatYsASPPShktoehRF458DhRjAhwaUSxM=";
     };
-    propagatedBuildInputs = [ LocaleCLDR ];
-    meta = with lib; {
-      description = "CLDR data for the Ar locale";
-      license = with licenses; [
+    buildInputs = [ TestException ];
+    propagatedBuildInputs = [
+      DateTime
+      LocaleCLDR
+      Moo
+      MooXClassAttribute
+      TypeTiny
+    ];
+    meta = {
+      homepage = "https://github.com/ThePilgrim/perlcldr";
+      description = "Locale::CLDR - Data Package ( Perl localization data for Arabic )";
+      license = with lib.licenses; [
         artistic1
         gpl1Plus
       ];
     };
   };
 
-  LocaleCLDRLocalesBg = buildPerlPackage {
+  LocaleCLDRLocalesBg = buildPerlModule {
     pname = "Locale-CLDR-Locales-Bg";
     version = "0.46.0";
     src = fetchurl {
       url = "mirror://cpan/authors/id/J/JG/JGNI/Locale-CLDR-Locales-Bg-v0.46.0.tar.gz";
-      sha256 = "1qj9dzna6ycaqfwd1qr4xhi0lmbxi4p6vdx710z29pin2a717k20";
+      hash = "sha256-QMwTjhI23iQ+CKe3bS6JfVUKIuwk49C4w4p5o+xvSeI=";
     };
-    propagatedBuildInputs = [ LocaleCLDR ];
-    meta = with lib; {
-      description = "CLDR data for the Bg locale";
-      license = with licenses; [
+    buildInputs = [ TestException ];
+    propagatedBuildInputs = [
+      DateTime
+      LocaleCLDR
+      Moo
+      MooXClassAttribute
+      TypeTiny
+    ];
+    meta = {
+      homepage = "https://github.com/ThePilgrim/perlcldr";
+      description = "Locale::CLDR - Data Package ( Perl localization data for Bulgarian )";
+      license = with lib.licenses; [
         artistic1
         gpl1Plus
       ];
     };
   };
 
-  LocaleCLDRLocalesCa = buildPerlPackage {
+  LocaleCLDRLocalesCa = buildPerlModule {
     pname = "Locale-CLDR-Locales-Ca";
     version = "0.46.0";
     src = fetchurl {
       url = "mirror://cpan/authors/id/J/JG/JGNI/Locale-CLDR-Locales-Ca-v0.46.0.tar.gz";
-      sha256 = "1l7v0a1qcbp6f6swr8q80y9j3pwy8xw3j60s0xzskcjkvszcvi9v";
+      hash = "sha256-O8XNvt5Tsql/BxoYOXhHnt8hkwcIo8y1ceYuhoMC+9A=";
     };
-    propagatedBuildInputs = [ LocaleCLDR ];
-    meta = with lib; {
-      description = "CLDR data for the Ca locale";
-      license = with licenses; [
+    buildInputs = [ TestException ];
+    propagatedBuildInputs = [
+      DateTime
+      LocaleCLDR
+      Moo
+      MooXClassAttribute
+      TypeTiny
+    ];
+    meta = {
+      homepage = "https://github.com/ThePilgrim/perlcldr";
+      description = "Locale::CLDR - Data Package ( Perl localization data for Catalan )";
+      license = with lib.licenses; [
         artistic1
         gpl1Plus
       ];
     };
   };
 
-  LocaleCLDRLocalesCs = buildPerlPackage {
+  LocaleCLDRLocalesCs = buildPerlModule {
     pname = "Locale-CLDR-Locales-Cs";
     version = "0.46.0";
     src = fetchurl {
       url = "mirror://cpan/authors/id/J/JG/JGNI/Locale-CLDR-Locales-Cs-v0.46.0.tar.gz";
-      sha256 = "0y1qbkhyrac9v58nnbw2211ks36i50jl3z25n8idygpycbh34zni";
+      hash = "sha256-0X4y4GL+Pt8iskX8QSUo0Qw9QxCCL2tR2Ymp7OFcOHg=";
     };
-    propagatedBuildInputs = [ LocaleCLDR ];
-    meta = with lib; {
-      description = "CLDR data for the Cs locale";
-      license = with licenses; [
+    buildInputs = [ TestException ];
+    propagatedBuildInputs = [
+      DateTime
+      LocaleCLDR
+      Moo
+      MooXClassAttribute
+      TypeTiny
+    ];
+    meta = {
+      homepage = "https://github.com/ThePilgrim/perlcldr";
+      description = "Locale::CLDR - Data Package ( Perl localization data for Czech )";
+      license = with lib.licenses; [
         artistic1
         gpl1Plus
       ];
     };
   };
 
-  LocaleCLDRLocalesDa = buildPerlPackage {
+  LocaleCLDRLocalesDa = buildPerlModule {
     pname = "Locale-CLDR-Locales-Da";
     version = "0.46.0";
     src = fetchurl {
       url = "mirror://cpan/authors/id/J/JG/JGNI/Locale-CLDR-Locales-Da-v0.46.0.tar.gz";
-      sha256 = "0ki0j7ly2fbgkfxbgc99ziqlkmq0a3z2xpvzhqzz6rhj2vng6klp";
+      hash = "sha256-l07z7BYSZvM/hn/fLv5QANdJcfwpsbe6m2854emRIE4=";
     };
-    propagatedBuildInputs = [ LocaleCLDR ];
-    meta = with lib; {
-      description = "CLDR data for the Da locale";
-      license = with licenses; [
+    buildInputs = [ TestException ];
+    propagatedBuildInputs = [
+      DateTime
+      LocaleCLDR
+      Moo
+      MooXClassAttribute
+      TypeTiny
+    ];
+    meta = {
+      homepage = "https://github.com/ThePilgrim/perlcldr";
+      description = "Locale::CLDR - Data Package ( Perl localization data for Danish )";
+      license = with lib.licenses; [
         artistic1
         gpl1Plus
       ];
     };
   };
 
-  LocaleCLDRLocalesDe = buildPerlPackage {
+  LocaleCLDRLocalesDe = buildPerlModule {
     pname = "Locale-CLDR-Locales-De";
     version = "0.46.0";
     src = fetchurl {
       url = "mirror://cpan/authors/id/J/JG/JGNI/Locale-CLDR-Locales-De-v0.46.0.tar.gz";
-      sha256 = "0rbrkqa502y63nsgww3c1z1ysvgwkcrirnzzy1ym1q1z1idmq7mz";
+      hash = "sha256-vx5cWww/4FB98P/bHDOb/G3tww9scP60HcYLUBSeeWU=";
     };
-    propagatedBuildInputs = [ LocaleCLDR ];
-    meta = with lib; {
-      description = "CLDR data for the De locale";
-      license = with licenses; [
+    buildInputs = [ TestException ];
+    propagatedBuildInputs = [
+      DateTime
+      LocaleCLDR
+      Moo
+      MooXClassAttribute
+      TypeTiny
+    ];
+    meta = {
+      homepage = "https://github.com/ThePilgrim/perlcldr";
+      description = "Locale::CLDR - Data Package ( Perl localization data for German )";
+      license = with lib.licenses; [
         artistic1
         gpl1Plus
       ];
     };
   };
 
-  LocaleCLDRLocalesEl = buildPerlPackage {
+  LocaleCLDRLocalesEl = buildPerlModule {
     pname = "Locale-CLDR-Locales-El";
     version = "0.46.0";
     src = fetchurl {
       url = "mirror://cpan/authors/id/J/JG/JGNI/Locale-CLDR-Locales-El-v0.46.0.tar.gz";
-      sha256 = "10ls1cpyi0gkykm67i70gkzimwwly5l1p0g9zkg5lwlk30ibwvr4";
+      hash = "sha256-JG++IhiTclre/OmBG2jxlPMa/3zgxGPq9POB6C8LmoI=";
     };
-    propagatedBuildInputs = [ LocaleCLDR ];
-    meta = with lib; {
-      description = "CLDR data for the El locale";
-      license = with licenses; [
+    buildInputs = [ TestException ];
+    propagatedBuildInputs = [
+      DateTime
+      LocaleCLDR
+      Moo
+      MooXClassAttribute
+      TypeTiny
+    ];
+    meta = {
+      homepage = "https://github.com/ThePilgrim/perlcldr";
+      description = "Locale::CLDR - Data Package ( Perl localization data for Greek )";
+      license = with lib.licenses; [
         artistic1
         gpl1Plus
       ];
     };
   };
 
-  LocaleCLDRLocalesEn = buildPerlPackage {
+  LocaleCLDRLocalesEn = buildPerlModule {
     pname = "Locale-CLDR-Locales-En";
     version = "0.46.0";
     src = fetchurl {
       url = "mirror://cpan/authors/id/J/JG/JGNI/Locale-CLDR-Locales-En-v0.46.0.tar.gz";
-      sha256 = "0lcp364ns3dj7ggd90w0rhkfdgwps78x1dh8g13gwppzysq5y431";
+      hash = "sha256-YRBfsPb/Xv5GeAi20NHRl7/mJsyAg9TeO7INbYkZl1E=";
     };
-    propagatedBuildInputs = [ LocaleCLDR ];
-    meta = with lib; {
-      description = "CLDR data for the En locale";
-      license = with licenses; [
+    buildInputs = [ TestException ];
+    propagatedBuildInputs = [
+      DateTime
+      LocaleCLDR
+      Moo
+      MooXClassAttribute
+      TypeTiny
+    ];
+    meta = {
+      homepage = "https://github.com/ThePilgrim/perlcldr";
+      description = "Locale::CLDR - Data Package ( Perl localization data for English )";
+      license = with lib.licenses; [
         artistic1
         gpl1Plus
       ];
     };
   };
 
-  LocaleCLDRLocalesEs = buildPerlPackage {
+  LocaleCLDRLocalesEs = buildPerlModule {
     pname = "Locale-CLDR-Locales-Es";
     version = "0.46.0";
     src = fetchurl {
       url = "mirror://cpan/authors/id/J/JG/JGNI/Locale-CLDR-Locales-Es-v0.46.0.tar.gz";
-      sha256 = "094mis7wgir5f9d3nsx0wvq759zs3svd8i05r1rphfxdyq0m513m";
+      hash = "sha256-dYRSAfatO3hzyAVE1LYe+qdy8OagaztaciXHx4+OlSQ=";
     };
-    propagatedBuildInputs = [ LocaleCLDR ];
-    meta = with lib; {
-      description = "CLDR data for the Es locale";
-      license = with licenses; [
+    buildInputs = [ TestException ];
+    propagatedBuildInputs = [
+      DateTime
+      LocaleCLDR
+      Moo
+      MooXClassAttribute
+      TypeTiny
+    ];
+    meta = {
+      homepage = "https://github.com/ThePilgrim/perlcldr";
+      description = "Locale::CLDR - Data Package ( Perl localization data for Spanish )";
+      license = with lib.licenses; [
         artistic1
         gpl1Plus
       ];
     };
   };
 
-  LocaleCLDRLocalesEt = buildPerlPackage {
+  LocaleCLDRLocalesEt = buildPerlModule {
     pname = "Locale-CLDR-Locales-Et";
     version = "0.46.0";
     src = fetchurl {
       url = "mirror://cpan/authors/id/J/JG/JGNI/Locale-CLDR-Locales-Et-v0.46.0.tar.gz";
-      sha256 = "0khin62c036vqbqn6v12pgb4n3mlshwgjyvh3dw9jzc8xziwmpnk";
+      hash = "sha256-097K4++IfZl4G3B7+TjUtA5L1rsibGPxwtsMwISxEU4=";
     };
-    propagatedBuildInputs = [ LocaleCLDR ];
-    meta = with lib; {
-      description = "CLDR data for the Et locale";
-      license = with licenses; [
+    buildInputs = [ TestException ];
+    propagatedBuildInputs = [
+      DateTime
+      LocaleCLDR
+      Moo
+      MooXClassAttribute
+      TypeTiny
+    ];
+    meta = {
+      homepage = "https://github.com/ThePilgrim/perlcldr";
+      description = "Locale::CLDR - Data Package ( Perl localization data for Estonian )";
+      license = with lib.licenses; [
         artistic1
         gpl1Plus
       ];
     };
   };
 
-  LocaleCLDRLocalesFi = buildPerlPackage {
+  LocaleCLDRLocalesFi = buildPerlModule {
     pname = "Locale-CLDR-Locales-Fi";
     version = "0.46.0";
     src = fetchurl {
       url = "mirror://cpan/authors/id/J/JG/JGNI/Locale-CLDR-Locales-Fi-v0.46.0.tar.gz";
-      sha256 = "173a2yphbk0dq90nig9rchwsvdlkpk4d9gravrm6kgzz033kq9bj";
+      hash = "sha256-ciU8xwD/v2lq3iq/1Mi8k7atOWQ5vWhBwg3MBa8Xapw=";
     };
-    propagatedBuildInputs = [ LocaleCLDR ];
-    meta = with lib; {
-      description = "CLDR data for the Fi locale";
-      license = with licenses; [
+    buildInputs = [ TestException ];
+    propagatedBuildInputs = [
+      DateTime
+      LocaleCLDR
+      Moo
+      MooXClassAttribute
+      TypeTiny
+    ];
+    meta = {
+      homepage = "https://github.com/ThePilgrim/perlcldr";
+      description = "Locale::CLDR - Data Package ( Perl localization data for Finnish )";
+      license = with lib.licenses; [
         artistic1
         gpl1Plus
       ];
     };
   };
 
-  LocaleCLDRLocalesFr = buildPerlPackage {
+  LocaleCLDRLocalesFr = buildPerlModule {
     pname = "Locale-CLDR-Locales-Fr";
     version = "0.46.0";
     src = fetchurl {
       url = "mirror://cpan/authors/id/J/JG/JGNI/Locale-CLDR-Locales-Fr-v0.46.0.tar.gz";
-      sha256 = "02b4r3fli897b40y16bm6izzsav17nc8fy01jd0cy9zq02d9n97m";
+      hash = "sha256-9SSbmgD4J89AkwF4h5g9YSv9fzR1meABWSehSN3IZAk=";
     };
-    propagatedBuildInputs = [ LocaleCLDR ];
-    meta = with lib; {
-      description = "CLDR data for the Fr locale";
-      license = with licenses; [
+    buildInputs = [ TestException ];
+    propagatedBuildInputs = [
+      DateTime
+      LocaleCLDR
+      Moo
+      MooXClassAttribute
+      TypeTiny
+    ];
+    meta = {
+      homepage = "https://github.com/ThePilgrim/perlcldr";
+      description = "Locale::CLDR - Data Package ( Perl localization data for French )";
+      license = with lib.licenses; [
         artistic1
         gpl1Plus
       ];
     };
   };
 
-  LocaleCLDRLocalesHu = buildPerlPackage {
+  LocaleCLDRLocalesHu = buildPerlModule {
     pname = "Locale-CLDR-Locales-Hu";
     version = "0.46.0";
     src = fetchurl {
       url = "mirror://cpan/authors/id/J/JG/JGNI/Locale-CLDR-Locales-Hu-v0.46.0.tar.gz";
-      sha256 = "1k1zkbbvc4yayz4q7qbrjdnr53gg3ayjc1l8si6789549cnbwq3x";
+      hash = "sha256-fWC+LEukJHRM1IgGJr0a742SbZN54YPJ98oTtteaP8w=";
     };
-    propagatedBuildInputs = [ LocaleCLDR ];
-    meta = with lib; {
-      description = "CLDR data for the Hu locale";
-      license = with licenses; [
+    buildInputs = [ TestException ];
+    propagatedBuildInputs = [
+      DateTime
+      LocaleCLDR
+      Moo
+      MooXClassAttribute
+      TypeTiny
+    ];
+    meta = {
+      homepage = "https://github.com/ThePilgrim/perlcldr";
+      description = "Locale::CLDR - Data Package ( Perl localization data for Hungarian )";
+      license = with lib.licenses; [
         artistic1
         gpl1Plus
       ];
     };
   };
 
-  LocaleCLDRLocalesId = buildPerlPackage {
+  LocaleCLDRLocalesId = buildPerlModule {
     pname = "Locale-CLDR-Locales-Id";
     version = "0.46.0";
     src = fetchurl {
       url = "mirror://cpan/authors/id/J/JG/JGNI/Locale-CLDR-Locales-Id-v0.46.0.tar.gz";
-      sha256 = "0cfb7n88kvp9qxwmvmk7gwh8gby9d3fq4axrhv8k1nfq7vv7p2zz";
+      hash = "sha256-/4t79j7Y2TDRhrkrgt1oya+HIH9n1l15x+nuiZA9yzE=";
     };
-    propagatedBuildInputs = [ LocaleCLDR ];
-    meta = with lib; {
-      description = "CLDR data for the Id locale";
-      license = with licenses; [
+    buildInputs = [ TestException ];
+    propagatedBuildInputs = [
+      DateTime
+      LocaleCLDR
+      Moo
+      MooXClassAttribute
+      TypeTiny
+    ];
+    meta = {
+      homepage = "https://github.com/ThePilgrim/perlcldr";
+      description = "Locale::CLDR - Data Package ( Perl localization data for Indonesian )";
+      license = with lib.licenses; [
         artistic1
         gpl1Plus
       ];
     };
   };
 
-  LocaleCLDRLocalesIs = buildPerlPackage {
+  LocaleCLDRLocalesIs = buildPerlModule {
     pname = "Locale-CLDR-Locales-Is";
     version = "0.46.0";
     src = fetchurl {
       url = "mirror://cpan/authors/id/J/JG/JGNI/Locale-CLDR-Locales-Is-v0.46.0.tar.gz";
-      sha256 = "12mi9kcv51h74ahm0c0sl2hff10yr32yrdzxh2ivpv9jidi4qv58";
+      hash = "sha256-qGxMYosy7bujgP237MXIHgTnoKAaMFChIgeGstlMsYo=";
     };
-    propagatedBuildInputs = [ LocaleCLDR ];
-    meta = with lib; {
-      description = "CLDR data for the Is locale";
-      license = with licenses; [
+    buildInputs = [ TestException ];
+    propagatedBuildInputs = [
+      DateTime
+      LocaleCLDR
+      Moo
+      MooXClassAttribute
+      TypeTiny
+    ];
+    meta = {
+      homepage = "https://github.com/ThePilgrim/perlcldr";
+      description = "Locale::CLDR - Data Package ( Perl localization data for Icelandic )";
+      license = with lib.licenses; [
         artistic1
         gpl1Plus
       ];
     };
   };
 
-  LocaleCLDRLocalesIt = buildPerlPackage {
+  LocaleCLDRLocalesIt = buildPerlModule {
     pname = "Locale-CLDR-Locales-It";
     version = "0.46.0";
     src = fetchurl {
       url = "mirror://cpan/authors/id/J/JG/JGNI/Locale-CLDR-Locales-It-v0.46.0.tar.gz";
-      sha256 = "04f24zfhg25ccrkpaj4dx41s5x2ckgh6nmzfy3df32l3lwdrdqhj";
+      hash = "sha256-EuKWG6eDiuHa8O5Xa+CbTPSiA+mNSHVnZqyIB90nwhE=";
     };
-    propagatedBuildInputs = [ LocaleCLDR ];
-    meta = with lib; {
-      description = "CLDR data for the It locale";
-      license = with licenses; [
+    buildInputs = [ TestException ];
+    propagatedBuildInputs = [
+      DateTime
+      LocaleCLDR
+      Moo
+      MooXClassAttribute
+      TypeTiny
+    ];
+    meta = {
+      homepage = "https://github.com/ThePilgrim/perlcldr";
+      description = "Locale::CLDR - Data Package ( Perl localization data for Italian )";
+      license = with lib.licenses; [
         artistic1
         gpl1Plus
       ];
     };
   };
 
-  LocaleCLDRLocalesLt = buildPerlPackage {
+  LocaleCLDRLocalesLt = buildPerlModule {
     pname = "Locale-CLDR-Locales-Lt";
     version = "0.46.0";
     src = fetchurl {
       url = "mirror://cpan/authors/id/J/JG/JGNI/Locale-CLDR-Locales-Lt-v0.46.0.tar.gz";
-      sha256 = "1lllzgjzi37ar0s0b7jqvfqrcqqyxac4pgq6wbaf6s3s3d9lz1jv";
+      hash = "sha256-W4ZPUxt6aOPU4ga/S5jqHmOWsdtYngU0yOqM+OX7lNI=";
     };
-    propagatedBuildInputs = [ LocaleCLDR ];
-    meta = with lib; {
-      description = "CLDR data for the Lt locale";
-      license = with licenses; [
+    buildInputs = [ TestException ];
+    propagatedBuildInputs = [
+      DateTime
+      LocaleCLDR
+      Moo
+      MooXClassAttribute
+      TypeTiny
+    ];
+    meta = {
+      homepage = "https://github.com/ThePilgrim/perlcldr";
+      description = "Locale::CLDR - Data Package ( Perl localization data for Lithuanian )";
+      license = with lib.licenses; [
         artistic1
         gpl1Plus
       ];
     };
   };
 
-  LocaleCLDRLocalesMs = buildPerlPackage {
+  LocaleCLDRLocalesMs = buildPerlModule {
     pname = "Locale-CLDR-Locales-Ms";
     version = "0.46.0";
     src = fetchurl {
       url = "mirror://cpan/authors/id/J/JG/JGNI/Locale-CLDR-Locales-Ms-v0.46.0.tar.gz";
-      sha256 = "121f4m5hz4bhhavhrvzl22zkwpcrxh7cb8i37wr689qs1q8sr4bz";
+      hash = "sha256-f5GsEQ4aJ2QyPyOixQ7smV0+vxD07wy3gnCRD0slLog=";
     };
-    propagatedBuildInputs = [ LocaleCLDR ];
-    meta = with lib; {
-      description = "CLDR data for the Ms locale";
-      license = with licenses; [
+    buildInputs = [ TestException ];
+    propagatedBuildInputs = [
+      DateTime
+      LocaleCLDR
+      Moo
+      MooXClassAttribute
+      TypeTiny
+    ];
+    meta = {
+      homepage = "https://github.com/ThePilgrim/perlcldr";
+      description = "Locale::CLDR - Data Package ( Perl localization data for Malay )";
+      license = with lib.licenses; [
         artistic1
         gpl1Plus
       ];
     };
   };
 
-  LocaleCLDRLocalesNb = buildPerlPackage {
+  LocaleCLDRLocalesNb = buildPerlModule {
     pname = "Locale-CLDR-Locales-Nb";
     version = "0.46.0";
     src = fetchurl {
       url = "mirror://cpan/authors/id/J/JG/JGNI/Locale-CLDR-Locales-Nb-v0.46.0.tar.gz";
-      sha256 = "0xcf8p0ha6zbf65d7nf2a9cx78mfb17i011lqmsb8j2ry5ihxdnv";
+      hash = "sha256-27YOY/FZSLR0xTQEEE9YrqLTWVLC2dOKcesbBcFFjnU=";
     };
-    propagatedBuildInputs = [ LocaleCLDR ];
-    meta = with lib; {
-      description = "CLDR data for the Nb locale";
-      license = with licenses; [
+    buildInputs = [ TestException ];
+    propagatedBuildInputs = [
+      DateTime
+      LocaleCLDR
+      LocaleCLDRLocalesNo
+      Moo
+      MooXClassAttribute
+      TypeTiny
+    ];
+    meta = {
+      homepage = "https://github.com/ThePilgrim/perlcldr";
+      description = "Locale::CLDR - Data Package ( Perl localization data for Norwegian Bokml )";
+      license = with lib.licenses; [
         artistic1
         gpl1Plus
       ];
     };
   };
 
-  LocaleCLDRLocalesNl = buildPerlPackage {
+  LocaleCLDRLocalesNl = buildPerlModule {
     pname = "Locale-CLDR-Locales-Nl";
     version = "0.46.0";
     src = fetchurl {
       url = "mirror://cpan/authors/id/J/JG/JGNI/Locale-CLDR-Locales-Nl-v0.46.0.tar.gz";
-      sha256 = "196gx0r4d4lsifhhcrbbrqarjcwv9iad8c5r9cw2zbk45xdkh03a";
+      hash = "sha256-agA4Wy9kri84S7kw1FRMmzOZFc5rZQahi5qSRjLoz6Q=";
     };
-    propagatedBuildInputs = [ LocaleCLDR ];
-    meta = with lib; {
-      description = "CLDR data for the Nl locale";
-      license = with licenses; [
+    buildInputs = [ TestException ];
+    propagatedBuildInputs = [
+      DateTime
+      LocaleCLDR
+      Moo
+      MooXClassAttribute
+      TypeTiny
+    ];
+    meta = {
+      homepage = "https://github.com/ThePilgrim/perlcldr";
+      description = "Locale::CLDR - Data Package ( Perl localization data for Dutch )";
+      license = with lib.licenses; [
         artistic1
         gpl1Plus
       ];
     };
   };
 
-  LocaleCLDRLocalesPl = buildPerlPackage {
+  LocaleCLDRLocalesNo = buildPerlModule {
+    pname = "Locale-CLDR-Locales-No";
+    version = "0.46.0";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/J/JG/JGNI/Locale-CLDR-Locales-No-v0.46.0.tar.gz";
+      hash = "sha256-p5+h0USizdgXQD/v9mktiYmhDqj9S/eI7Jh9DKXue0k=";
+    };
+    buildInputs = [ TestException ];
+    propagatedBuildInputs = [
+      DateTime
+      LocaleCLDR
+      Moo
+      MooXClassAttribute
+      TypeTiny
+    ];
+    meta = {
+      homepage = "https://github.com/ThePilgrim/perlcldr";
+      description = "Locale::CLDR - Data Package ( Perl localization data for Norwegian )";
+      license = with lib.licenses; [
+        artistic1
+        gpl1Plus
+      ];
+    };
+  };
+
+  LocaleCLDRLocalesPl = buildPerlModule {
     pname = "Locale-CLDR-Locales-Pl";
     version = "0.46.0";
     src = fetchurl {
       url = "mirror://cpan/authors/id/J/JG/JGNI/Locale-CLDR-Locales-Pl-v0.46.0.tar.gz";
-      sha256 = "07ickr23wq6v95838mn795qc9m9iznx63v25yczg25w3dw65725n";
+      hash = "sha256-tohTDG+DF/E+80XsYbr9MdXEcEnHVjRQSdtgPkSeLB4=";
     };
-    propagatedBuildInputs = [ LocaleCLDR ];
-    meta = with lib; {
-      description = "CLDR data for the Pl locale";
-      license = with licenses; [
+    buildInputs = [ TestException ];
+    propagatedBuildInputs = [
+      DateTime
+      LocaleCLDR
+      Moo
+      MooXClassAttribute
+      TypeTiny
+    ];
+    meta = {
+      homepage = "https://github.com/ThePilgrim/perlcldr";
+      description = "Locale::CLDR - Data Package ( Perl localization data for Polish )";
+      license = with lib.licenses; [
         artistic1
         gpl1Plus
       ];
     };
   };
 
-  LocaleCLDRLocalesPt = buildPerlPackage {
+  LocaleCLDRLocalesPt = buildPerlModule {
     pname = "Locale-CLDR-Locales-Pt";
     version = "0.46.0";
     src = fetchurl {
       url = "mirror://cpan/authors/id/J/JG/JGNI/Locale-CLDR-Locales-Pt-v0.46.0.tar.gz";
-      sha256 = "13n53v1hyv5dlmfbwv0844s78js8div8dpm895grq9g7pqf6nd0w";
+      hash = "sha256-HDRrHL7nJZxfSajehnZsSEt0NCEIbL5cpa1sD8MexY4=";
     };
-    propagatedBuildInputs = [ LocaleCLDR ];
-    meta = with lib; {
-      description = "CLDR data for the Pt locale";
-      license = with licenses; [
+    buildInputs = [ TestException ];
+    propagatedBuildInputs = [
+      DateTime
+      LocaleCLDR
+      Moo
+      MooXClassAttribute
+      TypeTiny
+    ];
+    meta = {
+      homepage = "https://github.com/ThePilgrim/perlcldr";
+      description = "Locale::CLDR - Data Package ( Perl localization data for Portuguese )";
+      license = with lib.licenses; [
         artistic1
         gpl1Plus
       ];
     };
   };
 
-  LocaleCLDRLocalesRu = buildPerlPackage {
+  LocaleCLDRLocalesRu = buildPerlModule {
     pname = "Locale-CLDR-Locales-Ru";
     version = "0.46.0";
     src = fetchurl {
       url = "mirror://cpan/authors/id/J/JG/JGNI/Locale-CLDR-Locales-Ru-v0.46.0.tar.gz";
-      sha256 = "19nyv65r4aq6ri1k3npzrlwlfl6ggs29fif8jdanpyqbd5hifpjj";
+      hash = "sha256-Ul4XYWkL+2tVk8hFl4R+z1BHOc3/2jFDzAYrkovZ3qY=";
     };
-    propagatedBuildInputs = [ LocaleCLDR ];
-    meta = with lib; {
-      description = "CLDR data for the Ru locale";
-      license = with licenses; [
+    buildInputs = [ TestException ];
+    propagatedBuildInputs = [
+      DateTime
+      LocaleCLDR
+      Moo
+      MooXClassAttribute
+      TypeTiny
+    ];
+    meta = {
+      homepage = "https://github.com/ThePilgrim/perlcldr";
+      description = "Locale::CLDR - Data Package ( Perl localization data for Russian )";
+      license = with lib.licenses; [
         artistic1
         gpl1Plus
       ];
     };
   };
 
-  LocaleCLDRLocalesSv = buildPerlPackage {
+  LocaleCLDRLocalesSv = buildPerlModule {
     pname = "Locale-CLDR-Locales-Sv";
     version = "0.46.0";
     src = fetchurl {
       url = "mirror://cpan/authors/id/J/JG/JGNI/Locale-CLDR-Locales-Sv-v0.46.0.tar.gz";
-      sha256 = "0acdjz3n29x9i6qz99bh9mdgif8y217j2ivylvddry6cyhsljxvj";
+      hash = "sha256-cndJNfTM+Nzapn5HIU8QHrn4Wk1wpfSxiaknYceXjSk=";
     };
-    propagatedBuildInputs = [ LocaleCLDR ];
-    meta = with lib; {
-      description = "CLDR data for the Sv locale";
-      license = with licenses; [
+    buildInputs = [ TestException ];
+    propagatedBuildInputs = [
+      DateTime
+      LocaleCLDR
+      Moo
+      MooXClassAttribute
+      TypeTiny
+    ];
+    meta = {
+      homepage = "https://github.com/ThePilgrim/perlcldr";
+      description = "Locale::CLDR - Data Package ( Perl localization data for Swedish )";
+      license = with lib.licenses; [
         artistic1
         gpl1Plus
       ];
     };
   };
 
-  LocaleCLDRLocalesTr = buildPerlPackage {
+  LocaleCLDRLocalesTr = buildPerlModule {
     pname = "Locale-CLDR-Locales-Tr";
     version = "0.46.0";
     src = fetchurl {
       url = "mirror://cpan/authors/id/J/JG/JGNI/Locale-CLDR-Locales-Tr-v0.46.0.tar.gz";
-      sha256 = "1614ahdzwfqc7qws08rxm1axx1dms0540asm5pj13hbr86s7cdk7";
+      hash = "sha256-ZzZ2tEF5wRHkLVUrQArQtYXeVag9I6A5Pgw7/htUJJg=";
     };
-    propagatedBuildInputs = [ LocaleCLDR ];
-    meta = with lib; {
-      description = "CLDR data for the Tr locale";
-      license = with licenses; [
+    buildInputs = [ TestException ];
+    propagatedBuildInputs = [
+      DateTime
+      LocaleCLDR
+      Moo
+      MooXClassAttribute
+      TypeTiny
+    ];
+    meta = {
+      homepage = "https://github.com/ThePilgrim/perlcldr";
+      description = "Locale::CLDR - Data Package ( Perl localization data for Turkish )";
+      license = with lib.licenses; [
         artistic1
         gpl1Plus
       ];
     };
   };
 
-  LocaleCLDRLocalesUk = buildPerlPackage {
+  LocaleCLDRLocalesUk = buildPerlModule {
     pname = "Locale-CLDR-Locales-Uk";
     version = "0.46.0";
     src = fetchurl {
       url = "mirror://cpan/authors/id/J/JG/JGNI/Locale-CLDR-Locales-Uk-v0.46.0.tar.gz";
-      sha256 = "0l0my33c0a1h727qb89kh2fmjrxfhdhg4rhlrvmamh6x1jnv2ap2";
+      hash = "sha256-4iqxrQzdwKrqzhRm8mCDrmdZnYAzoYWPODAowMbwFVA=";
     };
-    propagatedBuildInputs = [ LocaleCLDR ];
-    meta = with lib; {
-      description = "CLDR data for the Uk locale";
-      license = with licenses; [
+    buildInputs = [ TestException ];
+    propagatedBuildInputs = [
+      DateTime
+      LocaleCLDR
+      Moo
+      MooXClassAttribute
+      TypeTiny
+    ];
+    meta = {
+      homepage = "https://github.com/ThePilgrim/perlcldr";
+      description = "Locale::CLDR - Data Package ( Perl localization data for Ukrainian )";
+      license = with lib.licenses; [
         artistic1
         gpl1Plus
       ];
     };
   };
 
-  LocaleCLDRLocalesZh = buildPerlPackage {
+  LocaleCLDRLocalesZh = buildPerlModule {
     pname = "Locale-CLDR-Locales-Zh";
     version = "0.46.0";
     src = fetchurl {
       url = "mirror://cpan/authors/id/J/JG/JGNI/Locale-CLDR-Locales-Zh-v0.46.0.tar.gz";
-      sha256 = "1igh5qna28ccym6z5i18kx9vc2kavi49agkd2rkh6r3xsl3q3c53";
+      hash = "sha256-o7CBB9V9ZANnFm0+lUjcagq2U58oxPJN9YwhoSwu8MU=";
     };
-    propagatedBuildInputs = [ LocaleCLDR ];
-    meta = with lib; {
-      description = "CLDR data for the Zh locale";
-      license = with licenses; [
+    buildInputs = [ TestException ];
+    propagatedBuildInputs = [
+      DateTime
+      LocaleCLDR
+      Moo
+      MooXClassAttribute
+      TypeTiny
+    ];
+    meta = {
+      homepage = "https://github.com/ThePilgrim/perlcldr";
+      description = "Locale::CLDR - Data Package ( Perl localization data for Chinese )";
+      license = with lib.licenses; [
         artistic1
         gpl1Plus
       ];

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -1641,6 +1641,18 @@ with self;
     };
   };
 
+  ArrayPrintCols = buildPerlPackage {
+    pname = "Array-PrintCols";
+    version = "2.6";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/A/AK/AKSTE/Array-PrintCols-2.6.tar.gz";
+      hash = "sha256-y2gzCcX8p1UaK+HDkY5GgnZX+Xwb/bhpgiKzJfEdVeE=";
+    };
+    propagatedBuildInputs = [ FileShareDir ];
+    meta = {
+    };
+  };
+
   ArrayRefElem = buildPerlPackage {
     pname = "Array-RefElem";
     version = "1.00";
@@ -2337,6 +2349,54 @@ with self;
         artistic1
         gpl1Only
       ];
+    };
+  };
+
+  BeamEmitter = buildPerlPackage {
+    pname = "Beam-Emitter";
+    version = "1.007";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/P/PR/PREACTION/Beam-Emitter-1.007.tar.gz";
+      hash = "sha256-cBmNscasPWIX2Nl8ZXfRZpVBijuM+q6FOIojUJ9GnZU=";
+    };
+    buildInputs = [ TestAPI TestFatal TestLib ];
+    propagatedBuildInputs = [ ModuleRuntime Moo TypeTiny ];
+    meta = {
+      homepage = "https://github.com/preaction/Beam-Emitter";
+      description = "Role for event emitting classes";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
+  };
+
+  BeamService = buildPerlPackage {
+    pname = "Beam-Service";
+    version = "0.001";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/P/PR/PREACTION/Beam-Service-0.001.tar.gz";
+      hash = "sha256-YSj9I8RZC/jYBYoBV6VgoiU3fDx7iZJYsD/BcZBZUdQ=";
+    };
+    buildInputs = [ TestFatal ];
+    propagatedBuildInputs = [ Moo TypeTiny ];
+    meta = {
+      homepage = "https://github.com/preaction/Beam-Service";
+      description = "Role for services to access Beam::Wire features";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
+  };
+
+  BeamWire = buildPerlPackage {
+    pname = "Beam-Wire";
+    version = "1.026";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/P/PR/PREACTION/Beam-Wire-1.026.tar.gz";
+      hash = "sha256-L+6L9WXeEQpGu0ZQAn6cdLjTaQqWlCdxEaJdwAI632c=";
+    };
+    buildInputs = [ TestDeep TestDifferences TestException TestLib ];
+    propagatedBuildInputs = [ BeamEmitter BeamService ConfigAny DataDPath ModuleRuntime Moo PathTiny Throwable TypeTiny YAML ];
+    meta = {
+      homepage = "https://github.com/preaction/Beam-Wire";
+      description = "Lightweight Dependency Injection Container";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 
@@ -8018,6 +8078,22 @@ with self;
     };
   };
 
+  DataDPath = buildPerlPackage {
+    pname = "Data-DPath";
+    version = "0.60";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/S/SC/SCHWIGON/Data-DPath-0.60.tar.gz";
+      hash = "sha256-mfRCbUWMW7jUxRDgwmKcioiuT0ZhwLHkXFVQNi+S7ME=";
+    };
+    buildInputs = [ TestDeep ];
+    propagatedBuildInputs = [ ClassXSAccessor IteratorUtil SubExporter aliased ];
+    meta = {
+      homepage = "http://metacpan.org/release/Data-DPath";
+      description = "DPath is not XPath!";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
+  };
+
   DataDump = buildPerlPackage {
     pname = "Data-Dump";
     version = "1.25";
@@ -8990,6 +9066,21 @@ with self;
         artistic1
         gpl1Plus
       ];
+    };
+  };
+
+  DateTimeFormatDurationISO8601 = buildPerlPackage {
+    pname = "DateTime-Format-Duration-ISO8601";
+    version = "0.008";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/P/PE/PERLANCAR/DateTime-Format-Duration-ISO8601-0.008.tar.gz";
+      hash = "sha256-LAFPeyuZCriWt236zy3Vhi1fN1nj4NJN0Y31a3eEbIs=";
+    };
+    propagatedBuildInputs = [ DateTime ];
+    meta = {
+      homepage = "https://metacpan.org/release/DateTime-Format-Duration-ISO8601";
+      description = "Parse and format ISO8601 duration";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 
@@ -13723,6 +13814,34 @@ with self;
     };
   };
 
+  FilePathList = buildPerlPackage {
+    pname = "File-PathList";
+    version = "1.04";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/A/AD/ADAMK/File-PathList-1.04.tar.gz";
+      hash = "sha256-4+J5nzvO6uSZL+MeqJLDTpFB+SN1mM+tvImCTt56Ziw=";
+    };
+    propagatedBuildInputs = [ ParamsUtil ];
+    meta = {
+      description = "Find a file within a set of paths (like @INC or Java classpaths)";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
+  };
+
+  FilePathTiny = buildPerlPackage {
+    pname = "File-Path-Tiny";
+    version = "1.0";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/D/DM/DMUEY/File-Path-Tiny-1.0.tar.gz";
+      hash = "sha256-LsF42juYmeS0ZquLce27K/I6Awfr4C/seqH1gm9h9Vo=";
+    };
+    propagatedBuildInputs = [ TestException ];
+    meta = {
+      description = "Recursive versions of mkdir() and rmdir() without as much overhead as File::Path";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
+  };
+
   FilePid = buildPerlPackage {
     pname = "File-Pid";
     version = "1.01";
@@ -17803,6 +17922,30 @@ with self;
     };
   };
 
+  Iterator = buildPerlPackage {
+    pname = "Iterator";
+    version = "0.03";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/R/RO/ROODE/Iterator-0.03.tar.gz";
+      hash = "sha256-W4igQ06wSSe9CmXm+SDzrmrDmzIucuGxlwGLcLDO+H8=";
+    };
+    propagatedBuildInputs = [ ExceptionClass ];
+    meta = {
+    };
+  };
+
+  IteratorUtil = buildPerlPackage {
+    pname = "Iterator-Util";
+    version = "0.02";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/R/RO/ROODE/Iterator-Util-0.02.tar.gz";
+      hash = "sha256-YYLkiPHxlh2GU9a7PssSIndv8oNbUawSCRjFI4wetWM=";
+    };
+    propagatedBuildInputs = [ ExceptionClass Iterator ];
+    meta = {
+    };
+  };
+
   GeographyCountries = buildPerlPackage {
     pname = "Geography-Countries";
     version = "2009041301";
@@ -18204,6 +18347,20 @@ with self;
         gpl1Plus
       ];
       mainProgram = "validjson";
+    };
+  };
+
+  JSONSchemaValidator = buildPerlPackage {
+    pname = "JSONSchema-Validator";
+    version = "0.011";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/P/PU/PUTINTSEV/JSONSchema-Validator-0.011.tar.gz";
+      hash = "sha256-7ZH3OWhWZ4lF/CQloufF4340U+AQW2SKVJXzbPOepAw=";
+    };
+    propagatedBuildInputs = [ URI ];
+    meta = {
+      description = "Validator for JSON Schema Draft4/Draft6/Draft7 and OpenAPI Specification 3.0";
+      license = lib.licenses.mit;
     };
   };
 
@@ -19117,6 +19274,22 @@ with self;
     };
   };
 
+  LocaleCLDR = buildPerlModule {
+    pname = "Locale-CLDR";
+    version = "0.46.0";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/J/JG/JGNI/Locale-CLDR-v0.46.0.tar.gz";
+      hash = "sha256-UMQgOSWX4L9LARxdPsQ/Ft9BT0vT+SleaAERh0xPMZI=";
+    };
+    buildInputs = [ TestException ];
+    propagatedBuildInputs = [ ClassLoad DateTime DateTimeLocale Moo MooXClassAttribute TypeTiny UnicodeRegexSet namespaceautoclean ];
+    meta = {
+      homepage = "https://github.com/ThePilgrim/perlcldr";
+      description = "A Module to create locale objects with localisation data from the CLDR";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
+  };
+
   LocaleCodes = buildPerlPackage {
     pname = "Locale-Codes";
     version = "3.76";
@@ -19255,6 +19428,19 @@ with self;
         artistic1
         gpl1Plus
       ];
+    };
+  };
+
+  Locales = buildPerlPackage {
+    pname = "Locales";
+    version = "0.34";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/D/DM/DMUEY/Locales-0.34.tar.gz";
+      hash = "sha256-6k3c6fTc/5PSBeF7xYSCQJDXqlpbrtVjMFwm6IngkM0=";
+    };
+    propagatedBuildInputs = [ FileSlurp ModuleWant StringUnicodeUTF8 TestCarp ];
+    meta = {
+      description = "Methods for getting localized CLDR language/territory names (and a subset of other data)";
     };
   };
 
@@ -20888,6 +21074,24 @@ with self;
     };
   };
 
+  MathRandomISAACXS = buildPerlModule {
+    pname = "Math-Random-ISAAC-XS";
+    version = "1.004";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/J/JA/JAWNSY/Math-Random-ISAAC-XS-1.004.tar.gz";
+      hash = "sha256-mveQ65LRxjMNM8baqN7PipxdzIe4F3nWsS4UuTHDuHs=";
+    };
+    buildInputs = [ TestNoWarnings ];
+    meta = {
+      homepage = "http://search.cpan.org/dist/Math-Random-ISAAC-XS";
+      description = "C implementation of the ISAAC PRNG algorithm";
+      # nix-generate-from-cpan detected lib.licenses.unfreeDistribute
+      # According to https://metacpan.org/pod/Math::Random::ISAAC::XS#COPYRIGHT-AND-LICENSE
+      # the intent is PublicDomain
+      license = lib.licenses.publicDomain;
+    };
+  };
+
   MathRandomMTAuto = buildPerlPackage {
     pname = "Math-Random-MT-Auto";
     version = "6.23";
@@ -22382,6 +22586,19 @@ with self;
     };
   };
 
+  ModuleWant = buildPerlPackage {
+    pname = "Module-Want";
+    version = "0.6";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/D/DM/DMUEY/Module-Want-0.6.tar.gz";
+      hash = "sha256-xyUkQjT1qncmI/7gDTDz9tnFOaQW3i2wXz7KU7O6Nt4=";
+    };
+    propagatedBuildInputs = [ FilePathTiny TestCarp ];
+    meta = {
+      description = "Check @INC once for modules that you want but may not have";
+    };
+  };
+
   MojoDOM58 = buildPerlPackage {
     pname = "Mojo-DOM58";
     version = "3.001";
@@ -23292,6 +23509,23 @@ with self;
     };
   };
 
+  MooseXClassAttribute = buildPerlPackage {
+    pname = "MooseX-ClassAttribute";
+    version = "0.29";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/D/DR/DROLSKY/MooseX-ClassAttribute-0.29.tar.gz";
+      hash = "sha256-YUTHfFJ3DU+DHK22yto3ElyAs+T/yyRtp+6dVZIu5yU=";
+    };
+    buildInputs = [ TestFatal TestRequires ];
+    propagatedBuildInputs = [ Moose namespaceautoclean namespaceclean ];
+    meta = {
+      homepage = "http://metacpan.org/release/MooseX-ClassAttribute";
+      description = "Declare class attributes Moose-style";
+      license = lib.licenses.artistic2;
+    };
+  };
+
+
   MooseXStorageFormatJSONpm = buildPerlPackage {
     pname = "MooseX-Storage-Format-JSONpm";
     version = "0.093094";
@@ -23388,6 +23622,21 @@ with self;
         artistic1
         gpl1Plus
       ];
+    };
+  };
+
+  MooXClassAttribute = buildPerlPackage {
+    pname = "MooX-ClassAttribute";
+    version = "0.011";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/T/TO/TOBYINK/MooX-ClassAttribute-0.011.tar.gz";
+      hash = "sha256-wLmKZi7ynJv2X0SknCR6VS6Jhic1oXimVoExgf0NQ/M=";
+    };
+    propagatedBuildInputs = [ ExporterTiny Moo RoleTiny ];
+    meta = {
+      homepage = "https://metacpan.org/release/MooX-ClassAttribute";
+      description = "Declare class attributes Moose-style... but without Moose";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 
@@ -26371,6 +26620,21 @@ with self;
     };
   };
 
+  NumberTolerant = buildPerlPackage {
+    pname = "Number-Tolerant";
+    version = "1.710";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/R/RJ/RJBS/Number-Tolerant-1.710.tar.gz";
+      hash = "sha256-/da5NOoDSk9hdQ8OON1m33xWWvHtiJHu98XM3mBHo84=";
+    };
+    propagatedBuildInputs = [ SubExporter ];
+    meta = {
+      homepage = "https://github.com/rjbs/Number-Tolerant";
+      description = "Tolerance ranges for inexact numbers";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
+  };
+
   NumberWithError = buildPerlPackage {
     pname = "Number-WithError";
     version = "1.01";
@@ -27472,6 +27736,121 @@ with self;
     };
   };
 
+  PGObject = buildPerlPackage {
+    pname = "PGObject";
+    version = "2.4.0";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/E/EI/EINHVERFR/PGObject-2.4.0.tar.gz";
+      hash = "sha256-zrqlPujd6TDNlFlrwfOseR1s4EtD9zITr/GOOiO19r8=";
+    };
+    buildInputs = [ TestException ];
+    propagatedBuildInputs = [ CarpClan DBDPg ListMoreUtils LogAny ];
+    meta = {
+      description = "A toolkit integrating intelligent PostgreSQL dbs into Perl objects";
+      license = lib.licenses.bsd3;
+    };
+  };
+
+  PGObjectSimple = buildPerlPackage {
+    pname = "PGObject-Simple";
+    version = "3.1.0";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/E/EH/EHUELS/PGObject-Simple-3.1.0.tar.gz";
+      hash = "sha256-9qG1vjnqZw5r62gFR8/qVtDI04Z4I36Z4UVJVg0858M=";
+    };
+    propagatedBuildInputs = [ CarpClan LogAny PGObject ];
+    meta = {
+      description = "Minimalist stored procedure mapper based on LedgerSMB's DBObject";
+      license = lib.licenses.bsd3;
+    };
+  };
+
+  PGObjectSimpleRole = buildPerlPackage {
+    pname = "PGObject-Simple-Role";
+    version = "2.1.1";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/E/EH/EHUELS/PGObject-Simple-Role-2.1.1.tar.gz";
+      hash = "sha256-scoiO8sjkzBA0/8WI66lYr10I/1jZgDo6NqYH4QdvHM=";
+    };
+    # nix-generate-from-cpan did not pick up required TestException dep
+    propagatedBuildInputs = [ CarpClan LogAny Moo TestException PGObjectSimple ];
+    meta = {
+      description = "Moo/Moose mappers for minimalist PGObject framework";
+      license = lib.licenses.bsd3;
+    };
+  };
+
+  PGObjectTypeBigFloat = buildPerlPackage {
+    pname = "PGObject-Type-BigFloat";
+    version = "2.001001";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/E/EH/EHUELS/PGObject-Type-BigFloat-2.001001.tar.gz";
+      hash = "sha256-d0WNl9+MdXvgi5YMqxFKK+sxNVLLJEEjXF6f09CwxVE=";
+    };
+    propagatedBuildInputs = [ PGObject ];
+    meta = {
+      description = "Math::BigFloat wrappers for PGObject classes";
+      license = lib.licenses.bsd3;
+    };
+  };
+
+  PGObjectTypeDateTime = buildPerlPackage {
+    pname = "PGObject-Type-DateTime";
+    version = "2.1.1";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/E/EI/EINHVERFR/PGObject-Type-DateTime-2.1.1.tar.gz";
+      hash = "sha256-UXCgDzbiILMHWZ3FaemhSSZKmUmB6Jz1vLqFQ951n1k=";
+    };
+    propagatedBuildInputs = [ DateTime DateTimeTimeZone PGObject TermTable TestSimple ];
+    meta = {
+      description = "DateTime Wrappers for PGObject";
+      license = lib.licenses.bsd3;
+    };
+  };
+
+  PGObjectTypeByteString = buildPerlPackage {
+    pname = "PGObject-Type-ByteString";
+    version = "1.2.3";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/E/EH/EHUELS/PGObject-Type-ByteString-1.2.3.tar.gz";
+      hash = "sha256-9FG++wsSIQicvAtvYNFApT0uorV6ijXorWi0xft9odU=";
+    };
+    buildInputs = [ FileSlurp ];
+    propagatedBuildInputs = [ DBDPg PGObject RefUtil ];
+    meta = {
+      description = "Wrapper for raw strings mapping to BYTEA columns";
+      license = lib.licenses.bsd3;
+    };
+  };
+
+  PGObjectUtilDBMethod = buildPerlPackage {
+    pname = "PGObject-Util-DBMethod";
+    version = "1.01.000";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/E/EH/EHUELS/PGObject-Util-DBMethod-1.01.000.tar.gz";
+      hash = "sha256-J0zHJ4dO9wEDzzvKiaIGzC2FJD5WolZdErvR7lkbSAQ=";
+    };
+    meta = {
+      description = "Declarative stored procedure <-> object mappings for the PGObject Framework";
+      license = lib.licenses.bsd3;
+    };
+  };
+
+  PGObjectUtilDBAdmin = buildPerlPackage {
+    pname = "PGObject-Util-DBAdmin";
+    version = "1.6.2";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/E/EH/EHUELS/PGObject-Util-DBAdmin-1.6.2.tar.gz";
+      hash = "sha256-lMu6KNKVgpYvigwZ7w4GEpjIcpcog0r15AqQHt7kGtY=";
+    };
+    buildInputs = [ PerlCritic PerlCriticStricterSubs TestException ];
+    propagatedBuildInputs = [ CaptureTiny DBDPg DBI LogAny Moo ScopeGuard namespaceclean ];
+    meta = {
+      description = "PostgreSQL Database Management Facilities for PGObject";
+      license = lib.licenses.bsd3;
+    };
+  };
+
   PDFBuilder = buildPerlPackage {
     pname = "PDF-Builder";
     version = "3.025";
@@ -27733,6 +28112,22 @@ with self;
       description = "Some add-on policies for Perl::Critic";
       homepage = "https://user42.tuxfamily.org/perl-critic-pulp/index.html";
       license = with lib.licenses; [ gpl3Plus ];
+    };
+  };
+
+  PerlCriticStricterSubs = buildPerlModule {
+    pname = "Perl-Critic-StricterSubs";
+    version = "0.08";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/P/PE/PETDANCE/Perl-Critic-StricterSubs-0.08.tar.gz";
+      hash = "sha256-zeFNMUMEKUdE0q3ZIzhrMEf0MLx9Cn0mZAUqTtv8KgM=";
+    };
+    buildInputs = [ TestWarnings ];
+    propagatedBuildInputs = [ FilePathList ListMoreUtils PPI PerlCritic ];
+    meta = {
+      homepage = "http://perlcritic.com";
+      description = "Perl::Critic plugin for stricter subroutine checking";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 
@@ -28080,6 +28475,21 @@ with self;
     };
   };
 
+  PlackBuilderConditionals = buildPerlModule {
+    pname = "Plack-Builder-Conditionals";
+    version = "0.05";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/K/KA/KAZEBURO/Plack-Builder-Conditionals-0.05.tar.gz";
+      hash = "sha256-TUyym5kmx76eTL4vnNPUdUJpxcQEaYh0Mx39Gdb6cIs=";
+    };
+    propagatedBuildInputs = [ ListMoreUtils NetCIDRLite Plack ];
+    meta = {
+      homepage = "https://github.com/kazeburo/Plack-Builder-Conditionals";
+      description = "Plack::Builder extension";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
+  };
+
   PlackMiddlewareAuthDigest = buildPerlModule {
     pname = "Plack-Middleware-Auth-Digest";
     version = "0.05";
@@ -28300,6 +28710,22 @@ with self;
         artistic1
         gpl1Plus
       ];
+    };
+  };
+
+  PlackRequestWithEncoding = buildPerlModule {
+    pname = "Plack-Request-WithEncoding";
+    version = "0.14";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/M/MO/MOZNION/Plack-Request-WithEncoding-0.14.tar.gz";
+      hash = "sha256-+4xC1epaGPx+8Fv2TJolmU/PBZzV0EFFuxENBFj+tAc=";
+    };
+    buildInputs = [ HTTPMessage ModuleBuildTiny ];
+    propagatedBuildInputs = [ HashMultiValue Plack ];
+    meta = {
+      homepage = "https://github.com/moznion/Plack-Request-WithEncoding";
+      description = "Subclass of L<Plack::Request> which supports encoded requests";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 
@@ -30425,6 +30851,22 @@ with self;
     };
   };
 
+  SessionStorageSecure = buildPerlPackage {
+    pname = "Session-Storage-Secure";
+    version = "1.000";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/D/DA/DAGOLDEN/Session-Storage-Secure-1.000.tar.gz";
+      hash = "sha256-WLLwTrpWqZJElLs+3dQmr/p1w93tHFY/gpb8wT+OZms=";
+    };
+    buildInputs = [ NumberTolerant TestDeep TestFatal ];
+    propagatedBuildInputs = [ CryptCBC CryptRijndael CryptURandom MathRandomISAACXS Moo MooXTypesMooseLike SerealDecoder SerealEncoder StringCompareConstantTime namespaceclean ];
+    meta = {
+      homepage = "https://github.com/dagolden/Session-Storage-Secure";
+      description = "Encrypted, expiring, compressed, serialized session data with integrity";
+      license = lib.licenses.asl20;
+    };
+  };
+
   SetInfinite = buildPerlPackage {
     pname = "Set-Infinite";
     version = "0.65";
@@ -31715,6 +32157,32 @@ with self;
         artistic1
         gpl1Plus
       ];
+    };
+  };
+
+  StringUnicodeUTF8 = buildPerlPackage {
+    pname = "String-UnicodeUTF8";
+    version = "0.23";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/D/DM/DMUEY/String-UnicodeUTF8-0.23.tar.gz";
+      hash = "sha256-NqYZfdb6S482FR3xAIZVyquN799qHo/uql45azbuRVo=";
+    };
+    propagatedBuildInputs = [ BFlags ModuleWant StringUnquotemeta ];
+    meta = {
+      description = "Non-collation related unicode/utf-8 bytes string-type-agnostic utils that work as far back as perl 5.6";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
+  };
+
+  StringUnquotemeta = buildPerlPackage {
+    pname = "String-Unquotemeta";
+    version = "0.1";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/D/DM/DMUEY/String-Unquotemeta-0.1.tar.gz";
+      hash = "sha256-kxqvvTsJA5n9wkFtqIFWdkR/MMSaKOGBND9Mfr79rWM=";
+    };
+    meta = {
+      description = "Undo what quotemeta() does, nothing more nothing less";
     };
   };
 
@@ -33032,18 +33500,14 @@ with self;
 
   TermTable = buildPerlPackage {
     pname = "Term-Table";
-    version = "0.017";
+    version = "0.024";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/E/EX/EXODIST/Term-Table-0.017.tar.gz";
-      hash = "sha256-8R20JorYBE9uGhrJU0ygzTrXecQAb/83+uUA25j6yRo=";
+      url = "mirror://cpan/authors/id/E/EX/EXODIST/Term-Table-0.024.tar.gz";
+      hash = "sha256-UiiFOMOwUUvNK2H2RWhsJWYZ5WpCGumS4rdtMZJ8Ts4=";
     };
-    propagatedBuildInputs = [ Importer ];
     meta = {
       description = "Format a header and rows into a table";
-      license = with lib.licenses; [
-        artistic1
-        gpl1Plus
-      ];
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 
@@ -33218,6 +33682,20 @@ with self;
     };
   };
 
+  TestSimple = buildPerlPackage {
+    pname = "Test-Simple";
+    version = "1.302211";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/E/EX/EXODIST/Test-Simple-1.302211.tar.gz";
+      hash = "sha256-wM9pdEE07ML8vSd3rhI70TWGgpWgA02h0DpxJXTNmmI=";
+    };
+    buildInputs = [ TermTable ];
+    meta = {
+      description = "Basic utilities for writing tests";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
+  };
+
   Test2Suite = buildPerlPackage {
     pname = "Test2-Suite";
     version = "0.000156";
@@ -33308,6 +33786,20 @@ with self;
         artistic1
         gpl1Plus
       ];
+    };
+  };
+
+  TestAPI = buildPerlPackage {
+    pname = "Test-API";
+    version = "0.010";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/D/DA/DAGOLDEN/Test-API-0.010.tar.gz";
+      hash = "sha256-fmA08OspMU0x0zVIKBBqzidF8hYM08FEOim2j1PKIxM=";
+    };
+    meta = {
+      homepage = "https://github.com/dagolden/Test-API";
+      description = "Test a list of subroutines provided by a module";
+      license = lib.licenses.asl20;
     };
   };
 
@@ -33405,6 +33897,18 @@ with self;
       description = "Provides a bits_is() subroutine for testing binary data";
       homepage = "https://metacpan.org/release/Test-Bits";
       license = with lib.licenses; [ artistic2 ];
+    };
+  };
+
+  TestCarp = buildPerlPackage {
+    pname = "Test-Carp";
+    version = "0.2";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/D/DM/DMUEY/Test-Carp-0.2.tar.gz";
+      hash = "sha256-jQ6o7evIGzukEorY7yI4t2oZk9tdQ0dYzq7DNreudDw=";
+    };
+    meta = {
+      description = "Test your code for calls to Carp functions";
     };
   };
 
@@ -34103,6 +34607,19 @@ with self;
         gpl1Plus
       ];
       mainProgram = "kwalitee-metrics";
+    };
+  };
+
+  TestLib = buildPerlPackage {
+    pname = "Test-Lib";
+    version = "0.003";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/H/HA/HAARG/Test-Lib-0.003.tar.gz";
+      hash = "sha256-2EtI2SVny6PQr7HoF1qrg2v6ioOOGayQgMq8Lj+dyfU=";
+    };
+    meta = {
+      description = "Use libraries from a t/lib directory";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
     };
   };
 
@@ -37275,6 +37792,19 @@ with self;
     };
   };
 
+  UnicodeRegexSet = buildPerlPackage {
+    pname = "Unicode-Regex-Set";
+    version = "0.04";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/S/SA/SADAHIRO/Unicode-Regex-Set-0.04.tar.gz";
+      hash = "sha256-aJu9nQmVS/H1rZKG6qO63F+v6Hf6pQcXueaClLAVTQw=";
+    };
+    meta = {
+      description = "Subtraction and Intersection of Character Sets in Unicode Regular Expressions";
+      license = with lib.licenses; [ artistic1 gpl1Plus ];
+    };
+  };
+
   UnicodeString = buildPerlPackage {
     pname = "Unicode-String";
     version = "2.10";
@@ -39277,7 +39807,6 @@ with self;
   TextTabsWrap = null; # part of Perl 5.22
   DigestSHA = null;
   "if" = null;
-  TestSimple = null;
   AttributeHandlers = null; # part of Perl 5.26
   base = null; # part of Perl 5.26
   CPANMeta = null; # part of Perl 5.26

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -19290,6 +19290,384 @@ with self;
     };
   };
 
+  LocaleCLDRLocalesAr = buildPerlPackage {
+    pname = "Locale-CLDR-Locales-Ar";
+    version = "0.46.0";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/J/JG/JGNI/Locale-CLDR-Locales-Ar-v0.46.0.tar.gz";
+      sha256 = "04sbjh38gh0qhl1rzqs52ix6hjw6sbrlh04bnpd36d8fwmzi29wv";
+    };
+    propagatedBuildInputs = [ LocaleCLDR ];
+    meta = with lib; {
+      description = "CLDR data for the Ar locale";
+      license = with licenses; [ artistic1 gpl1Plus ];
+    };
+  };
+
+  LocaleCLDRLocalesBg = buildPerlPackage {
+    pname = "Locale-CLDR-Locales-Bg";
+    version = "0.46.0";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/J/JG/JGNI/Locale-CLDR-Locales-Bg-v0.46.0.tar.gz";
+      sha256 = "1qj9dzna6ycaqfwd1qr4xhi0lmbxi4p6vdx710z29pin2a717k20";
+    };
+    propagatedBuildInputs = [ LocaleCLDR ];
+    meta = with lib; {
+      description = "CLDR data for the Bg locale";
+      license = with licenses; [ artistic1 gpl1Plus ];
+    };
+  };
+
+  LocaleCLDRLocalesCa = buildPerlPackage {
+    pname = "Locale-CLDR-Locales-Ca";
+    version = "0.46.0";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/J/JG/JGNI/Locale-CLDR-Locales-Ca-v0.46.0.tar.gz";
+      sha256 = "1l7v0a1qcbp6f6swr8q80y9j3pwy8xw3j60s0xzskcjkvszcvi9v";
+    };
+    propagatedBuildInputs = [ LocaleCLDR ];
+    meta = with lib; {
+      description = "CLDR data for the Ca locale";
+      license = with licenses; [ artistic1 gpl1Plus ];
+    };
+  };
+
+  LocaleCLDRLocalesCs = buildPerlPackage {
+    pname = "Locale-CLDR-Locales-Cs";
+    version = "0.46.0";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/J/JG/JGNI/Locale-CLDR-Locales-Cs-v0.46.0.tar.gz";
+      sha256 = "0y1qbkhyrac9v58nnbw2211ks36i50jl3z25n8idygpycbh34zni";
+    };
+    propagatedBuildInputs = [ LocaleCLDR ];
+    meta = with lib; {
+      description = "CLDR data for the Cs locale";
+      license = with licenses; [ artistic1 gpl1Plus ];
+    };
+  };
+
+  LocaleCLDRLocalesDa = buildPerlPackage {
+    pname = "Locale-CLDR-Locales-Da";
+    version = "0.46.0";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/J/JG/JGNI/Locale-CLDR-Locales-Da-v0.46.0.tar.gz";
+      sha256 = "0ki0j7ly2fbgkfxbgc99ziqlkmq0a3z2xpvzhqzz6rhj2vng6klp";
+    };
+    propagatedBuildInputs = [ LocaleCLDR ];
+    meta = with lib; {
+      description = "CLDR data for the Da locale";
+      license = with licenses; [ artistic1 gpl1Plus ];
+    };
+  };
+
+  LocaleCLDRLocalesDe = buildPerlPackage {
+    pname = "Locale-CLDR-Locales-De";
+    version = "0.46.0";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/J/JG/JGNI/Locale-CLDR-Locales-De-v0.46.0.tar.gz";
+      sha256 = "0rbrkqa502y63nsgww3c1z1ysvgwkcrirnzzy1ym1q1z1idmq7mz";
+    };
+    propagatedBuildInputs = [ LocaleCLDR ];
+    meta = with lib; {
+      description = "CLDR data for the De locale";
+      license = with licenses; [ artistic1 gpl1Plus ];
+    };
+  };
+
+  LocaleCLDRLocalesEl = buildPerlPackage {
+    pname = "Locale-CLDR-Locales-El";
+    version = "0.46.0";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/J/JG/JGNI/Locale-CLDR-Locales-El-v0.46.0.tar.gz";
+      sha256 = "10ls1cpyi0gkykm67i70gkzimwwly5l1p0g9zkg5lwlk30ibwvr4";
+    };
+    propagatedBuildInputs = [ LocaleCLDR ];
+    meta = with lib; {
+      description = "CLDR data for the El locale";
+      license = with licenses; [ artistic1 gpl1Plus ];
+    };
+  };
+
+  LocaleCLDRLocalesEn = buildPerlPackage {
+    pname = "Locale-CLDR-Locales-En";
+    version = "0.46.0";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/J/JG/JGNI/Locale-CLDR-Locales-En-v0.46.0.tar.gz";
+      sha256 = "0lcp364ns3dj7ggd90w0rhkfdgwps78x1dh8g13gwppzysq5y431";
+    };
+    propagatedBuildInputs = [ LocaleCLDR ];
+    meta = with lib; {
+      description = "CLDR data for the En locale";
+      license = with licenses; [ artistic1 gpl1Plus ];
+    };
+  };
+
+  LocaleCLDRLocalesEs = buildPerlPackage {
+    pname = "Locale-CLDR-Locales-Es";
+    version = "0.46.0";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/J/JG/JGNI/Locale-CLDR-Locales-Es-v0.46.0.tar.gz";
+      sha256 = "094mis7wgir5f9d3nsx0wvq759zs3svd8i05r1rphfxdyq0m513m";
+    };
+    propagatedBuildInputs = [ LocaleCLDR ];
+    meta = with lib; {
+      description = "CLDR data for the Es locale";
+      license = with licenses; [ artistic1 gpl1Plus ];
+    };
+  };
+
+  LocaleCLDRLocalesEt = buildPerlPackage {
+    pname = "Locale-CLDR-Locales-Et";
+    version = "0.46.0";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/J/JG/JGNI/Locale-CLDR-Locales-Et-v0.46.0.tar.gz";
+      sha256 = "0khin62c036vqbqn6v12pgb4n3mlshwgjyvh3dw9jzc8xziwmpnk";
+    };
+    propagatedBuildInputs = [ LocaleCLDR ];
+    meta = with lib; {
+      description = "CLDR data for the Et locale";
+      license = with licenses; [ artistic1 gpl1Plus ];
+    };
+  };
+
+  LocaleCLDRLocalesFi = buildPerlPackage {
+    pname = "Locale-CLDR-Locales-Fi";
+    version = "0.46.0";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/J/JG/JGNI/Locale-CLDR-Locales-Fi-v0.46.0.tar.gz";
+      sha256 = "173a2yphbk0dq90nig9rchwsvdlkpk4d9gravrm6kgzz033kq9bj";
+    };
+    propagatedBuildInputs = [ LocaleCLDR ];
+    meta = with lib; {
+      description = "CLDR data for the Fi locale";
+      license = with licenses; [ artistic1 gpl1Plus ];
+    };
+  };
+
+  LocaleCLDRLocalesFr = buildPerlPackage {
+    pname = "Locale-CLDR-Locales-Fr";
+    version = "0.46.0";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/J/JG/JGNI/Locale-CLDR-Locales-Fr-v0.46.0.tar.gz";
+      sha256 = "02b4r3fli897b40y16bm6izzsav17nc8fy01jd0cy9zq02d9n97m";
+    };
+    propagatedBuildInputs = [ LocaleCLDR ];
+    meta = with lib; {
+      description = "CLDR data for the Fr locale";
+      license = with licenses; [ artistic1 gpl1Plus ];
+    };
+  };
+
+  LocaleCLDRLocalesHu = buildPerlPackage {
+    pname = "Locale-CLDR-Locales-Hu";
+    version = "0.46.0";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/J/JG/JGNI/Locale-CLDR-Locales-Hu-v0.46.0.tar.gz";
+      sha256 = "1k1zkbbvc4yayz4q7qbrjdnr53gg3ayjc1l8si6789549cnbwq3x";
+    };
+    propagatedBuildInputs = [ LocaleCLDR ];
+    meta = with lib; {
+      description = "CLDR data for the Hu locale";
+      license = with licenses; [ artistic1 gpl1Plus ];
+    };
+  };
+
+  LocaleCLDRLocalesId = buildPerlPackage {
+    pname = "Locale-CLDR-Locales-Id";
+    version = "0.46.0";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/J/JG/JGNI/Locale-CLDR-Locales-Id-v0.46.0.tar.gz";
+      sha256 = "0cfb7n88kvp9qxwmvmk7gwh8gby9d3fq4axrhv8k1nfq7vv7p2zz";
+    };
+    propagatedBuildInputs = [ LocaleCLDR ];
+    meta = with lib; {
+      description = "CLDR data for the Id locale";
+      license = with licenses; [ artistic1 gpl1Plus ];
+    };
+  };
+
+  LocaleCLDRLocalesIs = buildPerlPackage {
+    pname = "Locale-CLDR-Locales-Is";
+    version = "0.46.0";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/J/JG/JGNI/Locale-CLDR-Locales-Is-v0.46.0.tar.gz";
+      sha256 = "12mi9kcv51h74ahm0c0sl2hff10yr32yrdzxh2ivpv9jidi4qv58";
+    };
+    propagatedBuildInputs = [ LocaleCLDR ];
+    meta = with lib; {
+      description = "CLDR data for the Is locale";
+      license = with licenses; [ artistic1 gpl1Plus ];
+    };
+  };
+
+  LocaleCLDRLocalesIt = buildPerlPackage {
+    pname = "Locale-CLDR-Locales-It";
+    version = "0.46.0";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/J/JG/JGNI/Locale-CLDR-Locales-It-v0.46.0.tar.gz";
+      sha256 = "04f24zfhg25ccrkpaj4dx41s5x2ckgh6nmzfy3df32l3lwdrdqhj";
+    };
+    propagatedBuildInputs = [ LocaleCLDR ];
+    meta = with lib; {
+      description = "CLDR data for the It locale";
+      license = with licenses; [ artistic1 gpl1Plus ];
+    };
+  };
+
+  LocaleCLDRLocalesLt = buildPerlPackage {
+    pname = "Locale-CLDR-Locales-Lt";
+    version = "0.46.0";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/J/JG/JGNI/Locale-CLDR-Locales-Lt-v0.46.0.tar.gz";
+      sha256 = "1lllzgjzi37ar0s0b7jqvfqrcqqyxac4pgq6wbaf6s3s3d9lz1jv";
+    };
+    propagatedBuildInputs = [ LocaleCLDR ];
+    meta = with lib; {
+      description = "CLDR data for the Lt locale";
+      license = with licenses; [ artistic1 gpl1Plus ];
+    };
+  };
+
+  LocaleCLDRLocalesMs = buildPerlPackage {
+    pname = "Locale-CLDR-Locales-Ms";
+    version = "0.46.0";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/J/JG/JGNI/Locale-CLDR-Locales-Ms-v0.46.0.tar.gz";
+      sha256 = "121f4m5hz4bhhavhrvzl22zkwpcrxh7cb8i37wr689qs1q8sr4bz";
+    };
+    propagatedBuildInputs = [ LocaleCLDR ];
+    meta = with lib; {
+      description = "CLDR data for the Ms locale";
+      license = with licenses; [ artistic1 gpl1Plus ];
+    };
+  };
+
+  LocaleCLDRLocalesNb = buildPerlPackage {
+    pname = "Locale-CLDR-Locales-Nb";
+    version = "0.46.0";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/J/JG/JGNI/Locale-CLDR-Locales-Nb-v0.46.0.tar.gz";
+      sha256 = "0xcf8p0ha6zbf65d7nf2a9cx78mfb17i011lqmsb8j2ry5ihxdnv";
+    };
+    propagatedBuildInputs = [ LocaleCLDR ];
+    meta = with lib; {
+      description = "CLDR data for the Nb locale";
+      license = with licenses; [ artistic1 gpl1Plus ];
+    };
+  };
+
+  LocaleCLDRLocalesNl = buildPerlPackage {
+    pname = "Locale-CLDR-Locales-Nl";
+    version = "0.46.0";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/J/JG/JGNI/Locale-CLDR-Locales-Nl-v0.46.0.tar.gz";
+      sha256 = "196gx0r4d4lsifhhcrbbrqarjcwv9iad8c5r9cw2zbk45xdkh03a";
+    };
+    propagatedBuildInputs = [ LocaleCLDR ];
+    meta = with lib; {
+      description = "CLDR data for the Nl locale";
+      license = with licenses; [ artistic1 gpl1Plus ];
+    };
+  };
+
+  LocaleCLDRLocalesPl = buildPerlPackage {
+    pname = "Locale-CLDR-Locales-Pl";
+    version = "0.46.0";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/J/JG/JGNI/Locale-CLDR-Locales-Pl-v0.46.0.tar.gz";
+      sha256 = "07ickr23wq6v95838mn795qc9m9iznx63v25yczg25w3dw65725n";
+    };
+    propagatedBuildInputs = [ LocaleCLDR ];
+    meta = with lib; {
+      description = "CLDR data for the Pl locale";
+      license = with licenses; [ artistic1 gpl1Plus ];
+    };
+  };
+
+  LocaleCLDRLocalesPt = buildPerlPackage {
+    pname = "Locale-CLDR-Locales-Pt";
+    version = "0.46.0";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/J/JG/JGNI/Locale-CLDR-Locales-Pt-v0.46.0.tar.gz";
+      sha256 = "13n53v1hyv5dlmfbwv0844s78js8div8dpm895grq9g7pqf6nd0w";
+    };
+    propagatedBuildInputs = [ LocaleCLDR ];
+    meta = with lib; {
+      description = "CLDR data for the Pt locale";
+      license = with licenses; [ artistic1 gpl1Plus ];
+    };
+  };
+
+  LocaleCLDRLocalesRu = buildPerlPackage {
+    pname = "Locale-CLDR-Locales-Ru";
+    version = "0.46.0";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/J/JG/JGNI/Locale-CLDR-Locales-Ru-v0.46.0.tar.gz";
+      sha256 = "19nyv65r4aq6ri1k3npzrlwlfl6ggs29fif8jdanpyqbd5hifpjj";
+    };
+    propagatedBuildInputs = [ LocaleCLDR ];
+    meta = with lib; {
+      description = "CLDR data for the Ru locale";
+      license = with licenses; [ artistic1 gpl1Plus ];
+    };
+  };
+
+  LocaleCLDRLocalesSv = buildPerlPackage {
+    pname = "Locale-CLDR-Locales-Sv";
+    version = "0.46.0";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/J/JG/JGNI/Locale-CLDR-Locales-Sv-v0.46.0.tar.gz";
+      sha256 = "0acdjz3n29x9i6qz99bh9mdgif8y217j2ivylvddry6cyhsljxvj";
+    };
+    propagatedBuildInputs = [ LocaleCLDR ];
+    meta = with lib; {
+      description = "CLDR data for the Sv locale";
+      license = with licenses; [ artistic1 gpl1Plus ];
+    };
+  };
+
+  LocaleCLDRLocalesTr = buildPerlPackage {
+    pname = "Locale-CLDR-Locales-Tr";
+    version = "0.46.0";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/J/JG/JGNI/Locale-CLDR-Locales-Tr-v0.46.0.tar.gz";
+      sha256 = "1614ahdzwfqc7qws08rxm1axx1dms0540asm5pj13hbr86s7cdk7";
+    };
+    propagatedBuildInputs = [ LocaleCLDR ];
+    meta = with lib; {
+      description = "CLDR data for the Tr locale";
+      license = with licenses; [ artistic1 gpl1Plus ];
+    };
+  };
+
+  LocaleCLDRLocalesUk = buildPerlPackage {
+    pname = "Locale-CLDR-Locales-Uk";
+    version = "0.46.0";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/J/JG/JGNI/Locale-CLDR-Locales-Uk-v0.46.0.tar.gz";
+      sha256 = "0l0my33c0a1h727qb89kh2fmjrxfhdhg4rhlrvmamh6x1jnv2ap2";
+    };
+    propagatedBuildInputs = [ LocaleCLDR ];
+    meta = with lib; {
+      description = "CLDR data for the Uk locale";
+      license = with licenses; [ artistic1 gpl1Plus ];
+    };
+  };
+
+  LocaleCLDRLocalesZh = buildPerlPackage {
+    pname = "Locale-CLDR-Locales-Zh";
+    version = "0.46.0";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/J/JG/JGNI/Locale-CLDR-Locales-Zh-v0.46.0.tar.gz";
+      sha256 = "1igh5qna28ccym6z5i18kx9vc2kavi49agkd2rkh6r3xsl3q3c53";
+    };
+    propagatedBuildInputs = [ LocaleCLDR ];
+    meta = with lib; {
+      description = "CLDR data for the Zh locale";
+      license = with licenses; [ artistic1 gpl1Plus ];
+    };
+  };
+
   LocaleCodes = buildPerlPackage {
     pname = "Locale-Codes";
     version = "3.76";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -6974,17 +6974,16 @@ with self;
 
   CryptCBC = buildPerlPackage {
     pname = "Crypt-CBC";
-    version = "2.33";
+    version = "3.04";
     src = fetchurl {
-      url = "mirror://cpan/authors/id/L/LD/LDS/Crypt-CBC-2.33.tar.gz";
-      hash = "sha256-anDeIbbMfysQAGfo4Yjblm6agAG122+pdufLWylK5kU=";
+      url = "mirror://cpan/authors/id/L/LD/LDS/Crypt-CBC-3.04.tar.gz";
+      hash = "sha256-QCbFfQ2/ZJbA1WGibxYbdj07jt81ETnAc0kuIbX7zgc=";
     };
+    propagatedBuildInputs = [
+      CryptPBKDF2
+      CryptX
+    ];
     meta = {
-      description = "Encrypt Data with Cipher Block Chaining Mode";
-      license = with lib.licenses; [
-        artistic1
-        gpl1Plus
-      ];
     };
   };
 
@@ -18517,6 +18516,53 @@ with self;
     };
   };
 
+  LaTeXDriver = buildPerlPackage {
+    pname = "LaTeX-Driver";
+    version = "1.2.0";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/E/EH/EHUELS/LaTeX-Driver-1.2.0.tar.gz";
+      hash = "sha256-X7gXBy71tnnwOEXjsk2tLxNqxyRjNspH0hfAuOhMzPk=";
+    };
+    propagatedBuildInputs = [
+      CaptureTiny
+      ClassAccessor
+      ExceptionClass
+      FileSlurp
+      Filepushd
+      LogAny
+      Readonly
+    ];
+    buildInputs = [ pkgs.texliveFull ];
+    meta = {
+      description = "Latex driver";
+      license = with lib.licenses; [
+        artistic1
+        gpl1Plus
+      ];
+    };
+  };
+
+  LaTeXEncode = buildPerlPackage {
+    pname = "LaTeX-Encode";
+    version = "0.092.0";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/E/EI/EINHVERFR/LaTeX-Encode-0.092.0.tar.gz";
+      hash = "sha256-rKC5eg+0ff7kdAkld390CQAzV3d9/aaMABwR+0Y7ZfE=";
+    };
+    buildInputs = [ CarpAlways ];
+    propagatedBuildInputs = [
+      HTMLParser
+      Readonly
+    ];
+    meta = {
+      description = "Encode characters for LaTeX formatting";
+      license = with lib.licenses; [
+        artistic1
+        gpl1Plus
+      ];
+    };
+  };
+
   LatexIndent = buildPerlPackage rec {
     pname = "latexindent.pl";
     version = "3.21";
@@ -18543,6 +18589,29 @@ with self;
       description = "Perl script to add indentation to LaTeX files";
       homepage = "https://github.com/cmhughes/latexindent.pl";
       license = lib.licenses.gpl3Plus;
+    };
+  };
+
+  LaTeXTable = buildPerlPackage {
+    pname = "LaTeX-Table";
+    version = "1.0.6";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/L/LI/LIMAONE/LaTeX-Table-v1.0.6.tar.gz";
+      hash = "sha256-1sypAdR4fGRuimpjPEQ5LhrpdXv/axigaxPyMV15Qz8=";
+    };
+    buildInputs = [ TestNoWarnings ];
+    propagatedBuildInputs = [
+      ModulePluggable
+      Moose
+      MooseXFollowPBP
+      TemplateToolkit
+    ];
+    meta = {
+      description = "Perl extension for the automatic generation of LaTeX tables";
+      license = with lib.licenses; [
+        artistic1
+        gpl1Plus
+      ];
     };
   };
 
@@ -24787,6 +24856,20 @@ with self;
         artistic1
         gpl1Plus
       ];
+    };
+  };
+
+  MooseXFollowPBP = buildPerlPackage {
+    pname = "MooseX-FollowPBP";
+    version = "0.05";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/D/DR/DROLSKY/MooseX-FollowPBP-0.05.tar.gz";
+      hash = "sha256-+zJJUee+IimfX2iLPsNJHaRzYPnEojpZtrko0o0+IEc=";
+    };
+    propagatedBuildInputs = [ Moose ];
+    meta = {
+      description = "Name your accessors get_foo() and set_foo()";
+      license = lib.licenses.artistic2;
     };
   };
 
@@ -34032,6 +34115,24 @@ with self;
     };
   };
 
+  TemplatePluginLatex = buildPerlPackage {
+    pname = "Template-Plugin-Latex";
+    version = "3.12";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/E/EH/EHUELS/Template-Plugin-Latex-3.12.tar.gz";
+      hash = "sha256-NyvGpY3OeDKzhrfgxlKKfg7luaQ91xyvzZ2j6B/2+9U=";
+    };
+    propagatedBuildInputs = [
+      LaTeXDriver
+      LaTeXEncode
+      LaTeXTable
+      TemplateToolkit
+    ];
+    meta = {
+      description = "Latex support for the Template Toolkit";
+    };
+  };
+
   TemplateTimer = buildPerlPackage {
     pname = "Template-Timer";
     version = "1.00";
@@ -36910,6 +37011,23 @@ with self;
         gpl1Plus
       ];
       mainProgram = "test-yaml";
+    };
+  };
+
+  TeXEncode = buildPerlPackage {
+    pname = "TeX-Encode";
+    version = "2.010";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/A/AT/ATHREEF/TeX-Encode-2.010.tar.gz";
+      hash = "sha256-P1j5CO4nK0Q4zzOGRpQct9UgHk6/XnvzNdcNb7tzmc8=";
+    };
+    meta = {
+      homepage = "https://github.com/athreef/TeX-Encode";
+      description = "Encode/decode Perl utf-8 strings into TeX";
+      license = with lib.licenses; [
+        artistic1
+        gpl1Plus
+      ];
     };
   };
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Added a bunch of CPAN modules that the [LedgerSMB](https://ledgersmb.org) program needs, as a first step to creating a package for it. I also updated several existing CPAN modules that could no longer be loaded because the CPAN mirrors were returning 404.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
