### PR TITLE
etherpad-lite: init at 2.3.0

### DIFF
--- a/pkgs/by-name/et/etherpad-lite/dont-fail-on-plugins-json.patch
+++ b/pkgs/by-name/et/etherpad-lite/dont-fail-on-plugins-json.patch
@@ -1,0 +1,19 @@
+diff --git a/src/static/js/pluginfw/installer.ts b/src/static/js/pluginfw/installer.ts
+index c605378e1..27e3e487b 100644
+--- a/src/static/js/pluginfw/installer.ts
++++ b/src/static/js/pluginfw/installer.ts
+@@ -83,7 +83,13 @@ export const checkForMigration = async () => {
+   try {
+     await fs.access(installedPluginsPath, fs.constants.F_OK);
+   } catch (err) {
+-    await migratePluginsFromNodeModules();
++    logger.info(`${installedPluginsPath} not found, creating using current node modules`);
++    try {
++      await migratePluginsFromNodeModules();
++    } catch (err2) {
++      logger.warn(`unable to create ${installedPluginsPath}, skipping plugin migrations`);
++      return;
++    }
+   }
+ 
+   /*

--- a/pkgs/by-name/et/etherpad-lite/outdir.patch
+++ b/pkgs/by-name/et/etherpad-lite/outdir.patch
@@ -1,0 +1,51 @@
+From e881a383b38d4d80ee28c17a14b5de58889245de Mon Sep 17 00:00:00 2001
+From: Alexandre Iooss <erdnaxe@crans.org>
+Date: Tue, 5 Nov 2024 16:30:33 +0100
+Subject: [PATCH] Use temporary directory for esbuild
+
+---
+ src/node/hooks/express/specialpages.ts | 11 +++++------
+
+diff --git a/src/node/hooks/express/specialpages.ts b/src/node/hooks/express/specialpages.ts
+index 2e26eaa0cee..31d5138e67c 100644
+--- a/src/node/hooks/express/specialpages.ts
++++ b/src/node/hooks/express/specialpages.ts
+@@ -3,6 +3,7 @@
+ import path from 'node:path';
+ const eejs = require('../../eejs')
+ import fs from 'node:fs';
++import os from 'node:os';
+ const fsp = fs.promises;
+ const toolbar = require('../../utils/toolbar');
+ const hooks = require('../../../static/js/pluginfw/hooks');
+@@ -89,7 +90,7 @@ const convertTypescript = (content: string) => {
+   const outputRaw = buildSync({
+     stdin: {
+       contents: content,
+-      resolveDir: path.join(settings.root, 'var','js'),
++      resolveDir: settings.root,
+       loader: 'js'
+     },
+     alias:{
+@@ -222,7 +223,7 @@ const convertTypescriptWatched = (content: string, cb: (output:string, hash: str
+   build({
+     stdin: {
+       contents: content,
+-      resolveDir: path.join(settings.root, 'var','js'),
++      resolveDir: settings.root,
+       loader: 'js'
+     },
+     alias:{
+@@ -276,10 +277,8 @@ exports.expressCreateServer = async (hookName: string, args: ArgsExpressType, cb
+       settings,
+     })
+ 
+-
+-
+-  const outdir = path.join(settings.root, 'var','js')
+-  // Create the outdir if it doesn't exist
++  // Create a temporary directory to store runtime-built JS files
++  const outdir = path.join(os.tmpdir(), 'js');
+   if (!fs.existsSync(outdir)) {
+     fs.mkdirSync(outdir);
+   }

--- a/pkgs/by-name/et/etherpad-lite/package.nix
+++ b/pkgs/by-name/et/etherpad-lite/package.nix
@@ -1,0 +1,96 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  nix-update-script,
+  pnpm_9,
+  makeWrapper,
+  nodejs,
+}:
+
+let
+  pnpm = pnpm_9;
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "etherpad-lite";
+  version = "2.3.0";
+
+  src = fetchFromGitHub {
+    owner = "ether";
+    repo = "etherpad-lite";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-OomZ1oziEGgLJfYyfkHZOPRHfrrWc4XLAsZA4cn0btA=";
+  };
+
+  patches = [
+    ./outdir.patch
+    # etherpad expects to read and write $out/lib/var/installed_plugins.json
+    # FIXME: this patch disables plugin support
+    ./dont-fail-on-plugins-json.patch
+  ];
+
+  pnpmDeps = pnpm.fetchDeps {
+    inherit (finalAttrs) pname version src;
+    hash = "sha256-nhiPopGLCeCHiqEQ3solwuLwkDnHTH3otbxIJmbuQAA=";
+  };
+
+  nativeBuildInputs = [
+    pnpm.configHook
+    makeWrapper
+  ];
+
+  buildInputs = [
+    nodejs
+  ];
+
+  buildPhase = ''
+    runHook preBuild
+    NODE_ENV="production" pnpm run build:etherpad
+    runHook postBuild
+  '';
+
+  preInstall = ''
+    # remove unnecessary files
+    rm node_modules/.modules.yaml
+    pnpm prune --prod --ignore-scripts
+    find -type f \( -name "*.d.ts" -o -name "*.map" \) -exec rm -rf {} +
+
+    # remove non-deterministic files
+    rm node_modules/.modules.yaml
+  '';
+
+  # Upstream scripts uses `pnpm run prod` which is equivalent to
+  # `cross-env NODE_ENV=production node --require tsx/cjs node/server.ts`
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/{lib/etherpad-lite,bin}
+    cp -r node_modules ui src doc admin $out/lib/etherpad-lite
+    makeWrapper ${lib.getExe nodejs} $out/bin/etherpad-lite \
+      --inherit-argv0 \
+      --add-flags "--require tsx/cjs $out/lib/etherpad-lite/node_modules/ep_etherpad-lite/node/server.ts" \
+      --suffix PATH : "${lib.makeBinPath [ pnpm ]}" \
+      --set NODE_PATH "$out/lib/node_modules:$out/lib/etherpad-lite/node_modules/ep_etherpad-lite/node_modules" \
+      --set-default NODE_ENV production
+    find $out/lib -xtype l -delete
+    runHook postInstall
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Modern really-real-time collaborative document editor";
+    longDescription = ''
+      Etherpad is a real-time collaborative editor scalable to thousands of simultaneous real time users.
+      It provides full data export capabilities, and runs on your server, under your control.
+    '';
+    homepage = "https://etherpad.org/";
+    changelog = "https://github.com/ether/etherpad-lite/blob/${finalAttrs.src.rev}/CHANGELOG.md";
+    maintainers = with lib.maintainers; [
+      erdnaxe
+      f2k1de
+    ];
+    license = lib.licenses.asl20;
+    mainProgram = "etherpad-lite";
+    platforms = lib.platforms.unix;
+  };
+})


### PR DESCRIPTION
same as #353814, but newer version


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
