### PR TITLE
workflows/no-channel: run again when base changed

### DIFF
--- a/.github/workflows/no-channel.yml
+++ b/.github/workflows/no-channel.yml
@@ -4,14 +4,14 @@ on:
   pull_request_target:
     # Re-run should be triggered when the base branch is updated, instead of silently failing
     types: [opened, synchronize, reopened, edited]
-    branches:
-      - 'nixos-**'
-      - 'nixpkgs-**'
 
 permissions: {}
 
 jobs:
   fail:
+    if: |
+      startsWith(github.event.pull_request.base.ref, 'nixos-') ||
+      startsWith(github.event.pull_request.base.ref, 'nixpkgs-')
     name: "This PR is is targeting a channel branch"
     runs-on: ubuntu-24.04
     steps:


### PR DESCRIPTION
Because of the branches filter, the job would **not** re-run when only the base-branch was changed, thus leaving the contributor with a failed check.

With this change, the job should be triggered again and then skipped in this case, so the check in the list should be replaced with a skip.

Note, this also means that this step will show up in every PR as skipped, even when it was never failed before.

## Things done

- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
