### PR TITLE
[24.11]: workflows/keep-sorted: make it fail

### DIFF
--- a/.github/workflows/keep-sorted.yml
+++ b/.github/workflows/keep-sorted.yml
@@ -36,5 +36,6 @@ jobs:
         run: "nix-env -f '<nixpkgs>' -iAP keep-sorted jq"
 
       - name: Check that Nix files are sorted
+        shell: bash
         run: |
           git ls-files | xargs keep-sorted --mode lint | jq --raw-output '.[] | "Please make sure any new entries in \(.path) are sorted alphabetically."'


### PR DESCRIPTION
Backport for #404450

The "sort python-packages" commit doesn't need to be backported, none of the new additions to the file were, so the file is still sorted here.