### PR TITLE
bt-dualboot: init at 1.0.1

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2605.section.md
+++ b/nixos/doc/manual/release-notes/rl-2605.section.md
@@ -36,6 +36,8 @@
 
 - [Komodo Periphery](https://github.com/moghtech/komodo), a multi-server Docker and Git deployment agent by Komodo. Available as [services.komodo-periphery](#opt-services.komodo-periphery.enable).
 
+- [bt-dualboot](https://github.com/x2es/bt-dualboot), a tool for copying Bluetooth pairing keys from Linux to Windows on dualboot systems. Available as [services.bt-dualboot](#opt-services.bt-dualboot.enable).
+
 - [Shoko](https://shokoanime.com), an anime management system. Available as [services.shoko](#opt-services.shoko.enable).
 
 ## Backward Incompatibilities {#sec-release-26.05-incompatibilities}

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -819,6 +819,7 @@
   ./services/misc/bees.nix
   ./services/misc/bepasty.nix
   ./services/misc/blenderfarm.nix
+  ./services/misc/bt-dualboot.nix
   ./services/misc/calibre-server.nix
   ./services/misc/canto-daemon.nix
   ./services/misc/cfdyndns.nix

--- a/nixos/modules/services/misc/bt-dualboot.nix
+++ b/nixos/modules/services/misc/bt-dualboot.nix
@@ -1,0 +1,99 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.services.bt-dualboot;
+
+  escapedMountPoint = lib.pipe cfg.mountPoint [
+    lib.strings.normalizePath
+    (lib.removePrefix "/")
+    (lib.removeSuffix "/")
+    (builtins.replaceStrings [ "/" ] [ "-" ])
+  ];
+
+in
+{
+
+  meta.maintainers = [ lib.maintainers.bmrips ];
+
+  options.services.bt-dualboot = {
+    enable = lib.mkEnableOption "{command}`bt-dualboot`";
+    package = lib.mkPackageOption pkgs "bt-dualboot" { };
+    mountPoint = lib.mkOption {
+      type = with lib.types; nullOr str;
+      default = null;
+      example = "/mnt";
+      description = ''
+        The mount point of the Windows data partition. By default,
+        {command}`bt-dualboot` will recognize and use mount Windows partitions
+        automatically.
+      '';
+    };
+    registryBackups = {
+      enable = lib.mkOption {
+        type = lib.types.bool;
+        default = true;
+        description = ''
+          Whether to backup the Windows Registry before modifying it.
+        '';
+      };
+      retentionPeriod = lib.mkOption {
+        type = with lib.types; nullOr str;
+        default = null;
+        example = "4 weeks";
+        description = ''
+          For how long the registry backups are retained.
+
+          Values have to be formatted according to the 'age' field of {manpage}`tmpfiles.d(5)`.
+          Set it to `null` to retain backups forever.
+        '';
+      };
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+
+    assertions = [
+      {
+        assertion = config.services.hardware.bluetooth.enable;
+        message = ''
+          services.bt-dualboot: `services.hardware.bluetooth` has to be enabled
+          since otherwise, there are no bluetooth pairing keys to be synced.
+        '';
+      }
+    ];
+
+    environment.systemPackages = [ cfg.package ];
+
+    systemd.services.bt-dualboot = {
+      description = "Copy bluetooth pairing keys to Windows before shutdown";
+      wantedBy = [ "multi-user.target" ];
+
+      # Use `RemainAfterExit` and `ExecStop` to run on shutdown
+      serviceConfig = {
+        Type = "oneshot";
+        RemainAfterExit = true;
+        ExecStop =
+          "${pkgs.bt-dualboot}/bin/bt-dualboot --sync-all"
+          + (if cfg.registryBackups.enable then " --backup" else " --no-backup")
+          + lib.optionalString (cfg.mountPoint != null) " --win ${cfg.mountPoint}";
+      };
+    }
+    // lib.optionalAttrs (cfg.mountPoint != null) {
+      requires = [ "${escapedMountPoint}.mount" ];
+      after = [ "${escapedMountPoint}.mount" ];
+    };
+
+    systemd.tmpfiles.settings.bt-dualboot."/var/backup/bt-dualboot/".e.age =
+      let
+        backups = cfg.registryBackups;
+      in
+      lib.mkIf (backups.enable && backups.retentionPeriod != null) backups.retentionPeriod;
+
+  };
+
+}

--- a/pkgs/by-name/bt/bt-dualboot/package.nix
+++ b/pkgs/by-name/bt/bt-dualboot/package.nix
@@ -1,0 +1,44 @@
+{
+  lib,
+  python3Packages,
+  fetchFromGitHub,
+  chntpw,
+  versionCheckHook,
+  nix-update-script,
+  runCommand,
+}:
+
+python3Packages.buildPythonApplication (finalAttrs: {
+  pname = "bt-dualboot";
+  version = "1.0.1";
+  format = "pyproject";
+  strictDeps = true;
+
+  src = fetchFromGitHub {
+    owner = "x2es";
+    repo = "bt-dualboot";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-/V94RMBseJ1fMe6YaCImHKYmwPzFNE+C5+xoiMj2Vl4=";
+  };
+
+  build-system = [ python3Packages.poetry-core ];
+  dependencies = [ chntpw ];
+  nativeBuildInputs = [ versionCheckHook ];
+
+  pythonImportsCheck = [ "bt_dualboot" ];
+  passthru.tests.help = runCommand "help" { } ''
+    ${lib.getExe finalAttrs} --help >/dev/null
+    touch $out
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Sync Bluetooth for dualboot Linux and Windows";
+    homepage = "https://github.com/x2es/bt-dualboot";
+    license = lib.licenses.mit;
+    mainProgram = "bt-dualboot";
+    maintainers = [ lib.maintainers.bmrips ];
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
Add a derivation and a NixOS service for [bt-dualboot](https://github.com/x2es/bt-dualboot), a tool for copying Bluetooth pairing keys from Linux to Windows on dualboot systems.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

I have been testing `bt-dualboot` the corresponding NixOS service for roughly a year by now and did not encounter any errors. I am not sure whether I missed an opportunity for a NixOS test because I have never written any.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
