### PR TITLE
python312Packages.torch: fix tests

### DIFF
--- a/pkgs/development/python-modules/torch/tests/mk-runtime-check.nix
+++ b/pkgs/development/python-modules/torch/tests/mk-runtime-check.nix
@@ -3,10 +3,9 @@
   feature,
   libraries,
   versionAttr,
-  pythonPackages,
 }:
 
-(cudaPackages.writeGpuTestPython.override { python3Packages = pythonPackages; })
+cudaPackages.writeGpuTestPython
   {
     inherit feature;
     inherit libraries;

--- a/pkgs/development/python-modules/torch/tests/mk-torch-compile-check.nix
+++ b/pkgs/development/python-modules/torch/tests/mk-torch-compile-check.nix
@@ -4,13 +4,12 @@
   lib,
   libraries,
   name ? if feature == null then "torch-compile-cpu" else "torch-compile-${feature}",
-  pythonPackages,
   stdenv,
 }:
 let
   deviceStr = if feature == null then "" else '', device="cuda"'';
 in
-(cudaPackages.writeGpuTestPython.override { python3Packages = pythonPackages; })
+cudaPackages.writeGpuTestPython
   {
     inherit name feature libraries;
     makeWrapperArgs = [


### PR DESCRIPTION
## Things done

Currently failing with:
```
error:
       … while calling the 'derivationStrict' builtin
         at <nix/derivation-internal.nix>:37:12:
           36|
           37|   strict = derivationStrict drvAttrs;
             |            ^
           38|

       … while evaluating derivation 'test-torch-compile-cpu'
         whose name attribute is located at /home/gaetan/nix/nixpkgs/pkgs/stdenv/generic/make-derivation.nix:439:13

       … while evaluating attribute 'nativeBuildInputs' of derivation 'test-torch-compile-cpu'
         at /home/gaetan/nix/nixpkgs/pkgs/stdenv/generic/make-derivation.nix:491:13:
          490|             depsBuildBuild = elemAt (elemAt dependencies 0) 0;
          491|             nativeBuildInputs = elemAt (elemAt dependencies 0) 1;
             |             ^
          492|             depsBuildTarget = elemAt (elemAt dependencies 0) 2;

       (stack trace truncated; use '--show-trace' to show the full, detailed trace)

       error: Alias pythonPackages is still in python-packages.nix
```

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
