### PR TITLE
kata-runtime: 3.7.0 -> 3.16.0

### DIFF
--- a/pkgs/by-name/ka/kata-runtime/kata-images.nix
+++ b/pkgs/by-name/ka/kata-runtime/kata-images.nix
@@ -16,8 +16,8 @@ let
 
   imageHash =
     {
-      "x86_64-linux" = "sha256-6ySKAqrbHDRgVlI7wm2p4Uw96ZMzUpP00liujxlruSM=";
-      "aarch64-linux" = "sha256-pEPkDXT4OunfN2sGb8Ru05tFHaBsYUcmG5Iy7yH4kX8=";
+      "x86_64-linux" = "sha256-7xDc5Rr3rP36zS3kpM2QEqOCtmka3EAnts4Z1h8MNWY=";
+      "aarch64-linux" = "sha256-8nLHTPetEfIrdtrpiT9Czcpf0NhL97TZ2DXyeBL04LA=";
     }
     ."${stdenv.hostPlatform.system}" or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
 

--- a/pkgs/by-name/ka/kata-runtime/package.nix
+++ b/pkgs/by-name/ka/kata-runtime/package.nix
@@ -11,7 +11,7 @@
 }:
 
 let
-  version = "3.7.0";
+  version = "3.16.0";
 
   kata-images = callPackage ./kata-images.nix { inherit version; };
 
@@ -34,7 +34,7 @@ buildGoModule rec {
     owner = "kata-containers";
     repo = "kata-containers";
     rev = version;
-    hash = "sha256-Ir+/ZZJHm6E+044wczU3UvL+Py9Wprgw2QKJaYyDrKU=";
+    hash = "sha256-+SppAF77NbXlSrBGvIm40AmNC12GrexbX7fAPBoDAcs=";
   };
 
   sourceRoot = "${src.name}/src/runtime";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
This is an upgrade of `kata-runtime` package from `3.7.0` to `3.16.0`, along with associated QEMU VM image whose kernel is now `6.12.22` (from `6.1.62`). I could not see any breaking changes, according to the major version and the releases page: https://github.com/kata-containers/kata-containers/releases

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [ ] [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - [ ] and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - [ ] or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - [ ] made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
  - [x] there are no package tests in the original package, but I tested that both `nix-build -A kata-runtime` and `nix-build -A kata-runtime.kata-images` complete successfully
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
  ```
   /nix/store/7s9q69sn8d95xg9rzdnh2h5hnck60q4z-kata-runtime-3.16.0/bin/kata-runtime --version
   kata-runtime  : 3.16.0
      commit   : <<unknown>>
      OCI specs: 1.1.0+dev
   
   /nix/store/7s9q69sn8d95xg9rzdnh2h5hnck60q4z-kata-runtime-3.16.0/bin/kata-monitor --version
   kata-monitor
    Version:       0.3.0
    Go version:    go1.24.2
    Git commit:
    OS/Arch:       linux/amd64
    
    /nix/store/7s9q69sn8d95xg9rzdnh2h5hnck60q4z-kata-runtime-3.16.0/bin/containerd-shim-kata-v2 --version
    Kata Containers containerd shim (Golang): id: "io.containerd.kata.v2", version: 3.16.0, commit:
    
    docker run --rm --runtime io.containerd.kata.v2 alpine uname -r
    6.12.22
   ```

- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
