### PR TITLE
python312Packages.blocksat-cli: fix dependencies & tests

### DIFF
--- a/pkgs/development/python-modules/blocksat-cli/default.nix
+++ b/pkgs/development/python-modules/blocksat-cli/default.nix
@@ -29,6 +29,12 @@ buildPythonPackage rec {
     hash = "sha256-7lSK9IGu/K03xSDxZv+BSTJwLrQoHs+POBq/ixYTVR4=";
   };
 
+  # Upstream setup.py installs both the CLI and GUI versions.
+  # To pull only the required dependencyes, either setup_cli.py or setup_gui.py should be used.
+  postPatch = ''
+    mv setup_cli.py setup.py
+  '';
+
   pythonRelaxDeps = [ "pyasyncore" ];
 
   build-system = [ setuptools ];
@@ -48,7 +54,12 @@ buildPythonPackage rec {
     "test_monitor_get_stats"
     "test_monitor_update_with_reporting_enabled"
     "test_erasure_recovery"
+    # Non-NixOS package managers are not present in the build environment.
+    "test_parse_upgradable_list_apt"
+    "test_parse_upgradable_list_dnf"
   ];
+
+  disabledTestPaths = [ "blocksatgui/tests/" ];
 
   pythonImportsCheck = [ "blocksatcli" ];
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage
-->

## Things done

- Use `setup_cli.py` instead of `setup.py` to pull only CLI dependencies. `setup.py` also includes GUI dependencies, which include `pyside6` which is not needed for the CLI: https://github.com/Blockstream/satellite/blob/384754f4bca6b168c90656b2c2e0f218d9302ddb/setup.py#L27-L31
- Disabled GUI tests
- Disabled CLI tests that require OS package managers to be installed (`apt` and `dnf`).

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
