### PR TITLE
fetchgit: add preFetch hook

### DIFF
--- a/doc/build-helpers/fetchers.chapter.md
+++ b/doc/build-helpers/fetchers.chapter.md
@@ -773,9 +773,14 @@ Additionally, the following optional arguments can be given:
 
 : Whether to fetch LFS objects.
 
+*`preFetch`* (String)
+
+: Shell code to be executed before the repository has been fetched, to allow
+  changing the environment the fetcher runs in.
+
 *`postFetch`* (String)
 
-: Shell code executed after the file has been fetched successfully.
+: Shell code executed after the repository has been fetched successfully.
   This can do things like check or transform the file.
 
 *`leaveDotGit`* (Boolean)

--- a/pkgs/build-support/fetchgit/builder.sh
+++ b/pkgs/build-support/fetchgit/builder.sh
@@ -6,6 +6,8 @@
 
 echo "exporting $url (rev $rev) into $out"
 
+runHook preFetch
+
 $SHELL $fetcher --builder --url "$url" --out "$out" --rev "$rev" --name "$name" \
   ${leaveDotGit:+--leave-dotGit} \
   ${fetchLFS:+--fetch-lfs} \

--- a/pkgs/build-support/fetchgit/default.nix
+++ b/pkgs/build-support/fetchgit/default.nix
@@ -38,6 +38,11 @@ lib.makeOverridable (
       nonConeMode ? false,
       name ? null,
       nativeBuildInputs ? [ ],
+      # Shell code executed before the file has been fetched.  This, in
+      # particular, can do things like set NIX_PREFETCH_GIT_CHECKOUT_HOOK to
+      # run operations between the checkout completing and deleting the .git
+      # directory.
+      preFetch ? "",
       # Shell code executed after the file has been fetched
       # successfully. This can do things like check or transform the file.
       postFetch ? "",
@@ -75,7 +80,6 @@ lib.makeOverridable (
       server admins start using the new version?
     */
 
-    assert deepClone -> leaveDotGit;
     assert nonConeMode -> (sparseCheckout != [ ]);
 
     let
@@ -130,6 +134,7 @@ lib.makeOverridable (
           deepClone
           branchName
           nonConeMode
+          preFetch
           postFetch
           ;
         rev = revWithTag;


### PR DESCRIPTION
This allows running code to change the environment before the nix-prefetch-git script is run.  In particular, it allows setting things like NIX_PREFETCH_GIT_CHECKOUT_HOOK, which allows additional code to be run before deleting the .git directory.

This also means there's potentially value in performing a deep clone then removing the .git directory, so remove the assertion that prevents doing so.

My specific use case is building Git from source: when using the source in Git's own Git repository, it doesn't contain some of the files that are included in the distribution packages that Nixpkgs' `git` package builds from, and which need the `.git` directory to exist to build. Setting `leaveDotGit` and doing things in `postFetch` works, but means the build does a bunch of additional work to make the `.git` directory more deterministic. Setting `NIX_PREFETCH_GIT_CHECKOUT_HOOK` to do this step means the `.git` gets removed as normal, but not until the quick steps that need the `.git` directory have completed.


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Run tests.fetchgit on x86_64-linux
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
- [x] Updated fetcher documentation.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
