### PR TITLE
hercules-ci-*.nix: 2.24 -> 2.28

### DIFF
--- a/pkgs/development/haskell-modules/configuration-nix.nix
+++ b/pkgs/development/haskell-modules/configuration-nix.nix
@@ -1317,7 +1317,7 @@ builtins.intersectAttrs super {
     overrideCabal
       (old: {
         passthru = old.passthru or { } // {
-          nixPackage = pkgs.nixVersions.nix_2_24;
+          nixPackage = pkgs.nixVersions.nix_2_28;
         };
       })
       (

--- a/pkgs/development/haskell-modules/replacements-by-name/hercules-ci-agent.nix
+++ b/pkgs/development/haskell-modules/replacements-by-name/hercules-ci-agent.nix
@@ -80,8 +80,8 @@
 }:
 mkDerivation {
   pname = "hercules-ci-agent";
-  version = "0.10.5";
-  sha256 = "ab1c2370dbfdca7d7b67cb1985648edabf40d99f01b88a98d6961a2706c0e591";
+  version = "0.10.6";
+  sha256 = "5551c8eda390b48da6801f8f8580dc770e6e2fa2adf467ea7afd174748816fd6";
   isLibrary = true;
   isExecutable = true;
   setupHaskellDepends = [

--- a/pkgs/development/haskell-modules/replacements-by-name/hercules-ci-cnix-expr.nix
+++ b/pkgs/development/haskell-modules/replacements-by-name/hercules-ci-cnix-expr.nix
@@ -30,8 +30,8 @@
 }:
 mkDerivation {
   pname = "hercules-ci-cnix-expr";
-  version = "0.3.6.5";
-  sha256 = "0adbd451815bb6ea7388c0477fe6e114e0ba019819027709855e7834aedcb6df";
+  version = "0.4.0.0";
+  sha256 = "ba6dadda0a14e456780df018a610209ef288ed6562ad5843cb8d19d38fc026ed";
   setupHaskellDepends = [
     base
     Cabal

--- a/pkgs/development/haskell-modules/replacements-by-name/hercules-ci-cnix-store.nix
+++ b/pkgs/development/haskell-modules/replacements-by-name/hercules-ci-cnix-store.nix
@@ -24,8 +24,8 @@
 }:
 mkDerivation {
   pname = "hercules-ci-cnix-store";
-  version = "0.3.6.1";
-  sha256 = "35e3d21f9bbc1c83187af22a2532d227fc42a5cf3cf683a86be7bb7180f10d5e";
+  version = "0.3.7.0";
+  sha256 = "6feba2a6e1a267bc69b67962ed6eaa3510b1ae31c411fdb4e6670763d175d3b1";
   setupHaskellDepends = [
     base
     Cabal


### PR DESCRIPTION
This is a "megarepo" update where dependents rely on the exact version of their dependency internally, hence the single commit. (The bindings had an interface change)

The commonality of these updates is support for the new Nix version, hence the title, but this also fixes a linking issue involving the nixVersion symbol.

    dlopen(/nix/store/448nl79c6bci4pqxhq22g2gb3d8qwljw-nix-2.24.14/lib/libnixmain.dylib, 0x0005): symbol not found in flat namespace '__ZN3nix10nixVersionE'


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s) (`hercules-ci-agent`, `cachix`, `hci`)
  - [x] x86_64-linux
  - [ ] aarch64-linux (in progress building ghc...)
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
