### PR TITLE
nixos/systemd-initrd: deprecate strip

### DIFF
--- a/nixos/modules/system/boot/systemd/initrd.nix
+++ b/nixos/modules/system/boot/systemd/initrd.nix
@@ -132,13 +132,20 @@ let
   initialRamdisk = pkgs.makeInitrdNG {
     name = "initrd-${kernel-name}";
     inherit (config.boot.initrd) compressor compressorArgs prepend;
-    inherit (cfg) strip;
 
     contents = lib.filter ({ source, ... }: !lib.elem source cfg.suppressedStorePaths) cfg.storePaths;
   };
 
 in
 {
+  imports = [
+    (lib.mkRemovedOptionModule [ "boot" "initrd" "systemd" "strip" ] ''
+      The option to strip ELF files in initrd has been removed.
+      It only saved ~1MiB of initramfs size, but caused a few issues
+      like unloadable kernel modules.
+    '')
+  ];
+
   options.boot.initrd.systemd = {
     enable = mkEnableOption "systemd in initrd" // {
       description = ''
@@ -206,19 +213,6 @@ in
       '';
       type = utils.systemdUtils.types.initrdStorePath;
       default = [ ];
-    };
-
-    strip = mkOption {
-      description = ''
-        Whether to completely strip executables and libraries copied to the initramfs.
-
-        Setting this to false may save on the order of 30MiB on the
-        machine building the system (by avoiding a binutils
-        reference), at the cost of ~1MiB of initramfs size. This puts
-        this option firmly in the territory of micro-optimisation.
-      '';
-      type = types.bool;
-      default = true;
     };
 
     extraBin = mkOption {

--- a/pkgs/build-support/kernel/make-initrd-ng-tool.nix
+++ b/pkgs/build-support/kernel/make-initrd-ng-tool.nix
@@ -1,10 +1,6 @@
 {
   rustPlatform,
   lib,
-  makeWrapper,
-  patchelf,
-  glibc,
-  binutils,
 }:
 
 rustPlatform.buildRustPackage {

--- a/pkgs/build-support/kernel/make-initrd-ng.nix
+++ b/pkgs/build-support/kernel/make-initrd-ng.nix
@@ -20,8 +20,6 @@ in
   # Name of the derivation (not of the resulting file!)
   name ? "initrd",
 
-  strip ? true,
-
   # Program used to compress the cpio archive; use "cat" for no compression.
   # This can also be a function which takes a package set and returns the path to the compressor,
   # such as `pkgs: "${pkgs.lzop}/bin/lzop"`.
@@ -95,15 +93,10 @@ runCommand name
     passAsFile = [ "contents" ];
     contents = builtins.toJSON contents;
 
-    nativeBuildInputs =
-      [
-        makeInitrdNGTool
-        cpio
-      ]
-      ++ lib.optional makeUInitrd ubootTools
-      ++ lib.optional strip binutils;
-
-    STRIP = if strip then "${pkgsBuildHost.binutils.targetPrefix}strip" else null;
+    nativeBuildInputs = [
+      makeInitrdNGTool
+      cpio
+    ] ++ lib.optional makeUInitrd ubootTools;
   })
   ''
     mkdir -p ./root/var/empty


### PR DESCRIPTION
closes: #368249

This is described as a "micro-optimization" anyways, and can cause breakage.

it should default to false
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
