### PR TITLE
postgresql: 13.20 -> 13.21, 14.17 -> 14.18, 15.12 -> 15.13, 16.8 -> 16.9, 17.4 -> 17.5

### DIFF
--- a/pkgs/servers/sql/postgresql/13.nix
+++ b/pkgs/servers/sql/postgresql/13.nix
@@ -1,7 +1,7 @@
 import ./generic.nix {
-  version = "13.20";
-  rev = "refs/tags/REL_13_20";
-  hash = "sha256-GkDtzqwjMJipvr0wykM9Z5Tb0R7WgJA/PGPTVUXxf7Q=";
+  version = "13.21";
+  rev = "refs/tags/REL_13_21";
+  hash = "sha256-je3nC8zymK9pIISWSv/hMNeloYuiB7ulLinWFzqAWFc=";
   muslPatches = {
     disable-test-collate-icu-utf8 = {
       url = "https://git.alpinelinux.org/aports/plain/main/postgresql13/disable-test-collate.icu.utf8.patch?id=69faa146ec9fff3b981511068f17f9e629d4688b";

--- a/pkgs/servers/sql/postgresql/14.nix
+++ b/pkgs/servers/sql/postgresql/14.nix
@@ -1,7 +1,7 @@
 import ./generic.nix {
-  version = "14.17";
-  rev = "refs/tags/REL_14_17";
-  hash = "sha256-BvmfxHHTcxRkWZoawvHanQeAuqHnQIh77RQjxPo5fuI=";
+  version = "14.18";
+  rev = "refs/tags/REL_14_18";
+  hash = "sha256-pGPTq4I8WQnysVh3hHi/1Fto5vqtIbdGBu7EyBonIoo=";
   muslPatches = {
     disable-test-collate-icu-utf8 = {
       url = "https://git.alpinelinux.org/aports/plain/main/postgresql14/disable-test-collate.icu.utf8.patch?id=56999e6d0265ceff5c5239f85fdd33e146f06cb7";

--- a/pkgs/servers/sql/postgresql/15.nix
+++ b/pkgs/servers/sql/postgresql/15.nix
@@ -1,7 +1,7 @@
 import ./generic.nix {
-  version = "15.12";
-  rev = "refs/tags/REL_15_12";
-  hash = "sha256-6my9UzW05iYwTWR9y/VTZ1RQVNudavMFfUT9dpUQ15o=";
+  version = "15.13";
+  rev = "refs/tags/REL_15_13";
+  hash = "sha256-6guX2ms54HhJJ0MoHfQb5MI9qrcA0niJ06oa1glsFuY=";
   muslPatches = {
     dont-use-locale-a = {
       url = "https://git.alpinelinux.org/aports/plain/main/postgresql15/dont-use-locale-a-on-musl.patch?id=f424e934e6d076c4ae065ce45e734aa283eecb9c";

--- a/pkgs/servers/sql/postgresql/16.nix
+++ b/pkgs/servers/sql/postgresql/16.nix
@@ -1,7 +1,7 @@
 import ./generic.nix {
-  version = "16.8";
-  rev = "refs/tags/REL_16_8";
-  hash = "sha256-nVUGBuvCDFXozTyEDAAQa+IR3expCdztH90J68FhAXQ=";
+  version = "16.9";
+  rev = "refs/tags/REL_16_9";
+  hash = "sha256-CLLCT4wiCWeLqMdtGdXM2/DtlENLWSey6nNtOcfNPRw=";
   muslPatches = {
     dont-use-locale-a = {
       url = "https://git.alpinelinux.org/aports/plain/main/postgresql16/dont-use-locale-a-on-musl.patch?id=08a24be262339fd093e641860680944c3590238e";

--- a/pkgs/servers/sql/postgresql/17.nix
+++ b/pkgs/servers/sql/postgresql/17.nix
@@ -1,7 +1,7 @@
 import ./generic.nix {
-  version = "17.4";
-  rev = "refs/tags/REL_17_4";
-  hash = "sha256-TEpvX28chR3CXiOQsNY12t8WfM9ywoZVX1e/6mj9DqE=";
+  version = "17.5";
+  rev = "refs/tags/REL_17_5";
+  hash = "sha256-jWV7hglu7IPMZbqHrZVZHLbZYjVuDeut7nH50aSQIBc=";
   muslPatches = {
     dont-use-locale-a = {
       url = "https://git.alpinelinux.org/aports/plain/main/postgresql17/dont-use-locale-a-on-musl.patch?id=d69ead2c87230118ae7f72cef7d761e761e1f37e";


### PR DESCRIPTION
The new minor releases have been "stamped", but not tagged, yet. Thus pointing at the commit hashes for now - the tags will appear later this week on the same, so it will be possible to change them without rebuilds.

Release notes are not published, yet, but available through git:
https://github.com/postgres/postgres/blob/5e2f3df49d4298c6097789364a5a53be172f6e85/doc/src/sgml/release-17.sgml

There is one CVE:

> While unlikely, a SIGSEGV crash could occur if an incomplete multibyte character appeared at the end of memory. This was possible both in the server and in libpq-using applications. (CVE-2025-4207)

Doesn't seem critical.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] x86_64-linux pkgsMusl
  - [x] x86_64-linux pkgsStatic
  - [x] x86_64-linux pkgsCross.x86_64-freebsd
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
