### PR TITLE
texi2html: fix Darwin build, add version check hook

### DIFF
--- a/pkgs/by-name/te/texi2html/package.nix
+++ b/pkgs/by-name/te/texi2html/package.nix
@@ -4,6 +4,7 @@
   fetchurl,
   perl,
   gettext,
+  versionCheckHook,
   buildPackages,
 }:
 
@@ -19,20 +20,26 @@ stdenv.mkDerivation rec {
   strictDeps = true;
 
   nativeBuildInputs = [
+    perl
+  ];
+
+  buildInputs = [
     gettext
     perl
   ];
-  buildInputs = [ perl ];
 
   postPatch = ''
-    patchShebangs separated_to_hash.pl
+    patchShebangs --build separated_to_hash.pl
   '';
 
-  postInstall = lib.optionalString (stdenv.buildPlatform != stdenv.hostPlatform) ''
-    for f in $out/bin/*; do
-      substituteInPlace $f --replace "${buildPackages.perl}" "${perl}"
-    done
+  postInstall = ''
+    patchShebangs --host --update $out/bin/*
   '';
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
 
   meta = with lib; {
     description = "Perl script which converts Texinfo source files to HTML output";

--- a/pkgs/by-name/te/texi2html/package.nix
+++ b/pkgs/by-name/te/texi2html/package.nix
@@ -8,13 +8,13 @@
   buildPackages,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "texi2html";
   version = "5.0";
 
   src = fetchurl {
-    url = "mirror://savannah/texi2html/${pname}-${version}.tar.bz2";
-    sha256 = "1yprv64vrlcbksqv25asplnjg07mbq38lfclp1m5lj8cw878pag8";
+    url = "mirror://savannah/texi2html/texi2html-${finalAttrs.version}.tar.bz2";
+    hash = "sha256-6KmLDuIMSVpquJQ5igZe9YAnLb1aFbGxnovRvInZ+fo=";
   };
 
   strictDeps = true;
@@ -41,12 +41,12 @@ stdenv.mkDerivation rec {
     versionCheckHook
   ];
 
-  meta = with lib; {
+  meta = {
     description = "Perl script which converts Texinfo source files to HTML output";
     mainProgram = "texi2html";
     homepage = "https://www.nongnu.org/texi2html/";
-    license = licenses.gpl2;
-    maintainers = [ maintainers.marcweber ];
-    platforms = platforms.unix;
+    license = lib.licenses.gpl3Plus;
+    maintainers = [ lib.maintainers.marcweber ];
+    platforms = lib.platforms.unix;
   };
-}
+})


### PR DESCRIPTION
Fixes #224761
Regressed in #97093

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).