### PR TITLE
nixos/postgrest: make unix-socket accessible for other services

### DIFF
--- a/nixos/modules/services/databases/postgrest.nix
+++ b/nixos/modules/services/databases/postgrest.nix
@@ -245,6 +245,10 @@ in
       lib.optional (cfg.settings.admin-server-port != null && cfg.settings.server-host != "127.0.0.1")
         "The PostgREST admin server is potentially listening on a public host. This may expose sensitive information via the `/config` endpoint.";
 
+    # Since we're using DynamicUser, we can't add the e.g. nginx user to
+    # a postgrest group, so the unix socket must be world-readable to make it useful.
+    services.postgrest.settings.service-unix-socket-mode = "666";
+
     systemd.services.postgrest = {
       description = "PostgREST";
 


### PR DESCRIPTION
As described in the code comment.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
