### PR TITLE
treewide: more accurate pandoc availability check

### DIFF
--- a/pkgs/build-support/trivial-builders/default.nix
+++ b/pkgs/build-support/trivial-builders/default.nix
@@ -367,17 +367,14 @@ rec {
         '';
 
       checkPhase =
-        # GHC (=> shellcheck) isn't supported on some platforms (such as risc-v)
-        # but we still want to use writeShellApplication on those platforms
         let
-          shellcheckSupported =
-            lib.meta.availableOn stdenv.buildPlatform shellcheck-minimal.compiler
-            && (builtins.tryEval shellcheck-minimal.compiler.outPath).success;
           excludeFlags = lib.optionals (excludeShellChecks != [ ]) [
             "--exclude"
             (lib.concatStringsSep "," excludeShellChecks)
           ];
-          shellcheckCommand = lib.optionalString shellcheckSupported ''
+          # GHC (=> shellcheck) isn't supported on some platforms (such as risc-v)
+          # but we still want to use writeShellApplication on those platforms
+          shellcheckCommand = lib.optionalString shellcheck-minimal.compiler.bootstrapAvailable ''
             # use shellcheck which does not include docs
             # pandoc takes long to build and documentation isn't needed for just running the cli
             ${lib.getExe shellcheck-minimal} ${

--- a/pkgs/by-name/fl/flac/package.nix
+++ b/pkgs/by-name/fl/flac/package.nix
@@ -6,11 +6,11 @@
   lib,
   libogg,
   nix-update-script,
-  pandoc,
+  buildPackages,
   pkg-config,
   stdenv,
   versionCheckHook,
-  enableManpages ? !stdenv.buildPlatform.isRiscV64 && !stdenv.buildPlatform.isLoongArch64,
+  enableManpages ? buildPackages.pandoc.compiler.bootstrapAvailable,
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "flac";
@@ -30,7 +30,7 @@ stdenv.mkDerivation (finalAttrs: {
     doxygen
     graphviz
     pkg-config
-  ] ++ lib.optional enableManpages pandoc;
+  ] ++ lib.optional enableManpages buildPackages.pandoc;
 
   buildInputs = [ libogg ];
 

--- a/pkgs/by-name/ni/nixos-firewall-tool/package.nix
+++ b/pkgs/by-name/ni/nixos-firewall-tool/package.nix
@@ -3,7 +3,7 @@
   lib,
   bash,
   installShellFiles,
-  shellcheck-minimal,
+  buildPackages,
 }:
 
 stdenvNoCC.mkDerivation {
@@ -14,7 +14,7 @@ stdenvNoCC.mkDerivation {
   strictDeps = true;
   buildInputs = [ bash ];
   nativeBuildInputs = [ installShellFiles ];
-  nativeCheckInputs = [ shellcheck-minimal ];
+  nativeCheckInputs = [ buildPackages.shellcheck-minimal ];
 
   postPatch = ''
     patchShebangs --host nixos-firewall-tool
@@ -26,10 +26,7 @@ stdenvNoCC.mkDerivation {
     installShellCompletion nixos-firewall-tool.{bash,fish}
   '';
 
-  # Skip shellcheck if GHC is not available, see writeShellApplication.
-  doCheck =
-    lib.meta.availableOn stdenvNoCC.buildPlatform shellcheck-minimal.compiler
-    && (builtins.tryEval shellcheck-minimal.compiler.outPath).success;
+  doCheck = buildPackages.shellcheck-minimal.compiler.bootstrapAvailable;
   checkPhase = ''
     shellcheck nixos-firewall-tool
   '';

--- a/pkgs/development/compilers/ghc/8.10.7.nix
+++ b/pkgs/development/compilers/ghc/8.10.7.nix
@@ -640,6 +640,8 @@ stdenv.mkDerivation (
 
       # Our Cabal compiler name
       haskellCompilerName = "ghc-${version}";
+
+      bootstrapAvailable = lib.meta.availableOn stdenv.buildPlatform bootPkgs.ghc;
     };
 
     meta = {

--- a/pkgs/development/compilers/ghc/common-hadrian.nix
+++ b/pkgs/development/compilers/ghc/common-hadrian.nix
@@ -838,6 +838,8 @@ stdenv.mkDerivation (
       # TODO(@sternenseemann): there's no stage0:exe:haddock target by default,
       # so haddock isn't available for GHC cross-compilers. Can we fix that?
       hasHaddock = stdenv.hostPlatform == stdenv.targetPlatform;
+
+      bootstrapAvailable = lib.meta.availableOn stdenv.buildPlatform bootPkgs.ghc;
     };
 
     meta = {

--- a/pkgs/development/compilers/ghc/common-make-native-bignum.nix
+++ b/pkgs/development/compilers/ghc/common-make-native-bignum.nix
@@ -645,6 +645,8 @@ stdenv.mkDerivation (
 
       # Our Cabal compiler name
       haskellCompilerName = "ghc-${version}";
+
+      bootstrapAvailable = lib.meta.availableOn stdenv.buildPlatform bootPkgs.ghc;
     };
 
     meta = {

--- a/pkgs/development/libraries/gssdp/1.6.nix
+++ b/pkgs/development/libraries/gssdp/1.6.nix
@@ -7,8 +7,8 @@
   pkg-config,
   gobject-introspection,
   vala,
-  enableManpages ? !stdenv.buildPlatform.isLoongArch64 && !stdenv.buildPlatform.isRiscV64,
-  pandoc,
+  buildPackages,
+  enableManpages ? buildPackages.pandoc.compiler.bootstrapAvailable,
   gi-docgen,
   python3,
   libsoup_3,
@@ -44,7 +44,7 @@ stdenv.mkDerivation rec {
     vala
     gi-docgen
     python3
-  ] ++ lib.optionals enableManpages [ pandoc ];
+  ] ++ lib.optionals enableManpages [ buildPackages.pandoc ];
 
   buildInputs = [
     libsoup_3

--- a/pkgs/development/libraries/nuspell/default.nix
+++ b/pkgs/development/libraries/nuspell/default.nix
@@ -3,11 +3,11 @@
   stdenv,
   fetchFromGitHub,
   cmake,
-  pandoc,
+  buildPackages,
   pkg-config,
   icu,
   catch2_3,
-  enableManpages ? !stdenv.buildPlatform.isRiscV64 && !stdenv.buildPlatform.isLoongArch64,
+  enableManpages ? buildPackages.pandoc.compiler.bootstrapAvailable,
 }:
 
 stdenv.mkDerivation rec {
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
       pkg-config
     ]
     ++ lib.optionals enableManpages [
-      pandoc
+      buildPackages.pandoc
     ];
 
   buildInputs = [ catch2_3 ];


### PR DESCRIPTION
The actual problem here is that there is no GHC bootstrap tarball for RISC-V or LoongArch, so the right thing to check here is whether the platform being used to build GHC has a bootstrap tarball available for it.  This way, we'll do the right thing in all cases where such a tarball isn't available, not just riscv64 and loongarch64.

Since we need to refer to (unspliced) buildPackages.pandoc in the enableManpages default, I've opted to remove the pandoc input that would be spliced in nativeBuildInputs and use buildPackages.pandoc explicitly there as well, to avoid confusingly having two different pandocs around.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
