### PR TITLE
x11docker: 7.6.0 -> 7.6.0-unstable-2024-04-04

### DIFF
--- a/pkgs/by-name/x1/x11docker/package.nix
+++ b/pkgs/by-name/x1/x11docker/package.nix
@@ -11,15 +11,23 @@
   ps,
   mount,
   iproute2,
+  python3,
+  jq,
+  wmctrl,
+  xdotool,
+  xclip,
+  xpra,
+  weston,
+  xwayland,
 }:
 stdenv.mkDerivation rec {
   pname = "x11docker";
-  version = "7.6.0";
+  version = "7.6.0-unstable-2024-04-04";
   src = fetchFromGitHub {
     owner = "mviereck";
     repo = "x11docker";
-    rev = "v${version}";
-    sha256 = "sha256-DehAWrEvoE/zWbfjQmF5Z7HTaQL5WMA/279Ee1Xm47g=";
+    rev = "cb29a996597839239e482409b895353b1097ce3b";
+    sha256 = "sha256-NYMr2XZ4m6uvuIGO+nzX2ksxtVLJL4zy/JebxeAvqD4=";
   };
   nativeBuildInputs = [ makeWrapper ];
 
@@ -41,6 +49,17 @@ stdenv.mkDerivation rec {
           xorg.xdpyinfo
           xorg.xhost
           xorg.xinit
+          python3
+          jq
+          xorg.libxcvt
+          wmctrl
+          xdotool
+          xclip
+          xpra
+          xorg.xrandr
+          xorg.xauth
+          weston
+          xwayland
         ]
       }"
   '';


### PR DESCRIPTION
Updating x11docker to latest master for bugfixes. Also adding missing dependencies.

The existing package in nixpkgs doesn't declare all the required dependencies, so some dependencies are used from PATH instead. This causes problems when e.g. trying to find python finds pyenv shims, and x11docker doesn't know how to handle that. So we add the missing dependencies, based on https://github.com/NixOS/nixpkgs/pull/224723 and the declared dependencies in x11docker's documentation.

However, the latest release has [a bug](https://github.com/mviereck/x11docker/issues/493) - which has been [fixed in master](https://github.com/mviereck/x11docker/pull/525) - in how it uses jq, which is triggered by adding the missing dependencies. So we update to the latest master as well.

Fixes https://github.com/NixOS/nixpkgs/issues/211836.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).