### PR TITLE
freewheeling: fix build

### DIFF
--- a/pkgs/by-name/fr/freewheeling/package.nix
+++ b/pkgs/by-name/fr/freewheeling/package.nix
@@ -3,8 +3,6 @@
   stdenv,
   fetchFromGitHub,
   pkg-config,
-  autoreconfHook,
-  gnutls,
   freetype,
   fluidsynth,
   SDL,
@@ -18,11 +16,9 @@
   libSM,
   libsndfile,
   libogg,
-  libtool,
+  libX11,
+  nettle,
 }:
-let
-  makeSDLFlags = map (p: "-I${lib.getDev p}/include/SDL");
-in
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "freewheeling";
@@ -35,11 +31,8 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-xEZBE/7nUvK2hruqP6QQzlsIDmuniPZg7JEJkCEvzvU=";
   };
 
-  nativeBuildInputs = [
-    pkg-config
-    autoreconfHook
-    libtool
-  ];
+  nativeBuildInputs = [ pkg-config ];
+
   buildInputs = [
     freetype
     fluidsynth
@@ -54,20 +47,11 @@ stdenv.mkDerivation (finalAttrs: {
     libsndfile
     libogg
     libSM
-    (gnutls.overrideAttrs (oldAttrs: {
-      configureFlags = oldAttrs.configureFlags ++ [ "--enable-openssl-compatibility" ];
-    }))
+    libX11
+    nettle
   ];
-  env.NIX_CFLAGS_COMPILE = toString (
-    makeSDLFlags [
-      SDL
-      SDL_ttf
-      SDL_gfx
-    ]
-    ++ [ "-I${libxml2.dev}/include/libxml2" ]
-  );
 
-  hardeningDisable = [ "format" ];
+  env.NIX_CFLAGS_COMPILE = "-I${lib.getDev libxml2}/include/libxml2";
 
   meta = {
     description = "Live looping instrument with JACK and MIDI support";

--- a/pkgs/by-name/fr/freewheeling/package.nix
+++ b/pkgs/by-name/fr/freewheeling/package.nix
@@ -24,15 +24,15 @@ let
   makeSDLFlags = map (p: "-I${lib.getDev p}/include/SDL");
 in
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "freewheeling";
   version = "0.6.6";
 
   src = fetchFromGitHub {
     owner = "free-wheeling";
     repo = "freewheeling";
-    rev = "v${version}";
-    sha256 = "1xff5whr02cixihgd257dc70hnyf22j3zamvhsvg4lp7zq9l2in4";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-xEZBE/7nUvK2hruqP6QQzlsIDmuniPZg7JEJkCEvzvU=";
   };
 
   nativeBuildInputs = [
@@ -89,4 +89,4 @@ stdenv.mkDerivation rec {
     platforms = lib.platforms.linux;
     mainProgram = "fweelin";
   };
-}
+})


### PR DESCRIPTION
ZHF #403336

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review`

---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 1 package built:</summary>
  <ul>
    <li>freewheeling</li>
  </ul>
</details>

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc