### PR TITLE
go_1_24: backport CL662496 to fix segfault at runtime

### DIFF
--- a/pkgs/development/compilers/go/1.24.nix
+++ b/pkgs/development/compilers/go/1.24.nix
@@ -12,6 +12,7 @@
   testers,
   skopeo,
   buildGo124Module,
+  fetchpatch2,
 }:
 
 let
@@ -49,6 +50,18 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   patches = [
+    # Backport "runtime: cleanup M vgetrandom state before dropping P" (CL 662496)
+    # to fix segfault in Go 1.24.
+    # https://go-review.googlesource.com/c/go/+/662496
+    # https://github.com/golang/go/issues/73141
+    # https://github.com/golang/go/issues/73144
+    # https://github.com/NixOS/nixpkgs/issues/392815
+    (fetchpatch2 {
+      name = "backport-cleanup-M-vgetrandom-state-before-dropping-P.patch";
+      url = "https://go.googlesource.com/go/+/0ab64e2caad9c09f6db3de23898a2294b07b9fd3^!?format=TEXT";
+      decode = "base64 -d";
+      hash = "sha256-XS4VACiMLaYxq1i3Wy26x0ifD9HoYajg7v4/RX42dsA=";
+    })
     (replaceVars ./iana-etc-1.17.patch {
       iana = iana-etc;
     })


### PR DESCRIPTION
The patch has been merged upstream and will be part of the next Go 1.24 release.

Fedora 42 did the same in https://src.fedoraproject.org/rpms/golang/c/782a5318128373eddf80085ee2898a4dd9eb5654?branch=rawhide

See https://go-review.googlesource.com/c/go/+/662496 and https://github.com/golang/go/issues/73141
and https://github.com/golang/go/issues/73144

Fixes https://github.com/NixOS/nixpkgs/issues/392815 (and possibly a lot more that haven't been reported yet).

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
