### PR TITLE
Add `noNakedPointer` option to the ocaml package

### DIFF
--- a/pkgs/development/compilers/ocaml/generic.nix
+++ b/pkgs/development/compilers/ocaml/generic.nix
@@ -30,6 +30,7 @@ in
   spaceTimeSupport ? false,
   unsafeStringSupport ? false,
   framePointerSupport ? false,
+  noNakedPointers ? false,
 }:
 
 assert useX11 -> safeX11 stdenv;
@@ -38,6 +39,7 @@ assert flambdaSupport -> lib.versionAtLeast version "4.03";
 assert spaceTimeSupport -> lib.versionAtLeast version "4.04" && lib.versionOlder version "4.12";
 assert unsafeStringSupport -> lib.versionAtLeast version "4.06" && lib.versionOlder version "5.0";
 assert framePointerSupport -> lib.versionAtLeast version "4.01";
+assert noNakedPointers -> lib.versionOlder version "5.0";
 
 let
   src =
@@ -112,7 +114,8 @@ stdenv.mkDerivation (
       ++ optionals (stdenv.hostPlatform != stdenv.buildPlatform && lib.versionOlder version "4.08") [
         "-host ${stdenv.hostPlatform.config}"
         "-target ${stdenv.targetPlatform.config}"
-      ];
+      ]
+      ++ optional noNakedPointers (flags "--disable-naked-pointers" "-no-naked-pointers");
     dontAddStaticConfigureFlags = lib.versionOlder version "4.08";
 
     # on aarch64-darwin using --host and --target causes the build to invoke

--- a/pkgs/development/compilers/ocaml/generic.nix
+++ b/pkgs/development/compilers/ocaml/generic.nix
@@ -39,7 +39,7 @@ assert flambdaSupport -> lib.versionAtLeast version "4.03";
 assert spaceTimeSupport -> lib.versionAtLeast version "4.04" && lib.versionOlder version "4.12";
 assert unsafeStringSupport -> lib.versionAtLeast version "4.06" && lib.versionOlder version "5.0";
 assert framePointerSupport -> lib.versionAtLeast version "4.01";
-assert noNakedPointers -> lib.versionOlder version "5.0";
+assert noNakedPointers -> lib.versionAtLeast version "4.02" && lib.versionOlder version "5.0";
 
 let
   src =


### PR DESCRIPTION
This PR exposes the `--disable-naked-pointers` flag of the configure script of OCaml 4. This flag has been removed in OCaml 5, where it essentially becomes the default behavior.

The [Ancient library](https://github.com/OCamlPro/ocaml-ancient) requires this flag for OCaml 4.

Note that some OCaml packages does not function properly with OCaml 4 when this flag is enabled. I’m not an expert in Nix, and I don't know how to prevent Nix users from installing these packages with this flag.

I believe these changes should not cause compilation crashes, as the `--disable-naked-pointers` flag only changes the runtime behavior of OCaml. This means that issues related to the flag would only occur during runtime, not at compile time.

I tested the PR with the flake on https://github.com/Halbaroth/ocaml-ancient/tree/update-nix-flake 

`ocamlc -config` returns `naked_pointers: false` as expected.