### PR TITLE
python3Packages.sdwire: init

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -26045,6 +26045,12 @@
     githubId = 93639059;
     name = "wattmto";
   };
+  watwea = {
+    email = "aaditya.watwe@gmail.com";
+    github = "watwea";
+    githubId = 45186715;
+    name = "Aaditya Watwe";
+  };
   waynr = {
     name = "Wayne Warren";
     email = "wayne.warren.s@gmail.com";

--- a/pkgs/development/python-modules/sdwire-cli/default.nix
+++ b/pkgs/development/python-modules/sdwire-cli/default.nix
@@ -1,0 +1,52 @@
+{
+  lib,
+  adafruit-board-toolkit,
+  buildPythonPackage,
+  click,
+  fetchFromGitHub,
+  poetry-core,
+  pyftdi,
+  pyudev,
+  pyusb,
+  pythonOlder,
+  semver,
+  ...
+}@args:
+
+buildPythonPackage rec {
+  pname = "sdwire";
+  version = "0.2.3";
+  pyproject = true;
+
+  disabled = pythonOlder "3.10";
+
+  src = fetchFromGitHub {
+    owner = "Badger-Embedded";
+    repo = "sdwire-cli";
+    rev = "0.2.3";
+    hash = "sha256-xsNKBOpJAtS02++dEfKZ2fVYDie6ycr9Xm9FO4uedMk=";
+  };
+
+  build-system = [ poetry-core ];
+
+  dependencies = [
+    adafruit-board-toolkit
+    click
+    pyftdi
+    pyudev
+    pyusb
+    semver
+  ];
+
+  pythonRelaxDeps = [ "pyftdi" ];
+
+  pythonImportsCheck = [ "sdwire" ];
+
+  meta = with lib; {
+    description = "CLI for Badgerd SDWire Devices";
+    homepage = "https://github.com/Badger-Embedded/sdwire-cli";
+    changelog = "https://github.com/Badger-Embedded/sdwire-cli/releases/tag/${version}";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ watwea ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -15568,6 +15568,10 @@ self: super: with self; {
 
   sdnotify = callPackage ../development/python-modules/sdnotify { };
 
+  sdwire = sdwire-cli;
+
+  sdwire-cli = callPackage ../development/python-modules/sdwire-cli { };
+
   seaborn = callPackage ../development/python-modules/seaborn { };
 
   seabreeze = callPackage ../development/python-modules/seabreeze { };


### PR DESCRIPTION
Adds the `sdwire-cli` and `adafruit-board-toolkit` (dependency for sdwire) python package(s).

Result of running to list the connected SDWire3 on a Linux NixOS laptop:
```
$ sudo nix run /data/awatwe/sources/forks/nixpkgs/#python3Packages.sdwire -- --debug list
Serial			Product Info		Block Dev
20120501030900000:1.108	[0bda::0316]		/dev/sda

$ lsblk | grep sda
sda                                             8:0    1  29.7G  0 disk
├─sda1                                          8:1    1    32M  0 part  /run/media/awatwe/BOOT
└─sda2                                          8:2    1   3.7G  0 part  /run/media/awatwe/rootfs

$ sudo nix run /data/awatwe/sources/forks/nixpkgs/#python3Packages.sdwire -- --debug switch target
INFO:sdwire.backend.utils:1 sdwire/sdwirec device detected

$ lsblk | grep sda

$ sudo nix run /data/awatwe/sources/forks/nixpkgs/#python3Packages.sdwire -- --debug switch host
INFO:sdwire.backend.utils:1 sdwire/sdwirec device detected

$ lsblk | grep sda
sda                                             8:0    1  29.7G  0 disk
├─sda1                                          8:1    1    32M  0 part  /run/media/awatwe/BOOT
└─sda2                                          8:2    1   3.7G  0 part  /run/media/awatwe/rootfs

$ sudo nix run /data/awatwe/sources/forks/nixpkgs/#python3Packages.sdwire -- --debug list
Serial			Product Info		Block Dev
20120501030900000:1.108	[0bda::0316]		/dev/sda
```


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [X] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
