### PR TITLE
doas-keepenv: init at 1.0

### DIFF
--- a/pkgs/by-name/do/doas-keepenv/package.nix
+++ b/pkgs/by-name/do/doas-keepenv/package.nix
@@ -11,9 +11,11 @@ stdenv.mkDerivation {
   pname = "doas-keepenv";
   version = "1.0";
 
-  src = fetchurl {
-    url = "https://github.com/stas-badzi/doas-keepenv/archive/refs/tags/${version}.tar.gz";
-    sha256 = "sha256:15xh3dgw78v6mfgkqv6mphpw0bxxbg7jqrpkb4y5151a9xjc9962";
+  src = fetchFromGitHub {
+    owner = "stas-badzi";
+    repo = "doas-keepenv";
+    tag = "${version};
+    sha256 = "15xh3dgw78v6mfgkqv6mphpw0bxxbg7jqrpkb4y5151a9xjc9962";
   };
 
   buildInputs = [

--- a/pkgs/by-name/do/doas-keepenv/package.nix
+++ b/pkgs/by-name/do/doas-keepenv/package.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation {
   '';
 
   installPhase = ''
-    mkdir -p $out/bin/ $out/share/licenses/doas-keepenv $out/share/doc/doas-keepenv
+    mkdir -p $out/bin/
     install -m 755 doas-keepenv $out/bin
     wrapProgram $out/bin/doas-keepenv --prefix PATH : "${
       pkgs.lib.makeBinPath [

--- a/pkgs/by-name/do/doas-keepenv/package.nix
+++ b/pkgs/by-name/do/doas-keepenv/package.nix
@@ -4,7 +4,7 @@
   bash,
   coreutils,
   doas,
-  wrapProgram
+  wrapProgram,
 }:
 
 stdenv.mkDerivation rec {

--- a/pkgs/by-name/do/doas-keepenv/package.nix
+++ b/pkgs/by-name/do/doas-keepenv/package.nix
@@ -41,7 +41,7 @@ stdenv.mkDerivation {
   '';
 
   meta = {
-    description = "A bash script for running the doas command with keeping environment variables";
+    description = "A bash script for running the doas command while keeping environment variables";
     homepage = "https://github.com/stas-badzi/doas-keepenv";
     mainProgram = "doas-keepenv";
     license = lib.licenses.mit;

--- a/pkgs/by-name/do/doas-keepenv/package.nix
+++ b/pkgs/by-name/do/doas-keepenv/package.nix
@@ -32,8 +32,6 @@ stdenv.mkDerivation {
   installPhase = ''
     mkdir -p $out/bin/ $out/share/licenses/doas-keepenv $out/share/doc/doas-keepenv
     install -m 755 doas-keepenv $out/bin
-    install -Dm644 LICENSE $out/share/licenses/doas-keepenv
-    install -Dm644 README.md $out/share/doc/doas-keepenv
     wrapProgram $out/bin/doas-keepenv --prefix PATH : "${
       pkgs.lib.makeBinPath [
         pkgs.coreutils

--- a/pkgs/by-name/do/doas-keepenv/package.nix
+++ b/pkgs/by-name/do/doas-keepenv/package.nix
@@ -33,11 +33,11 @@ stdenv.mkDerivation {
   installPhase = ''
     mkdir -p $out/bin/
     install -m 755 doas-keepenv $out/bin
-    wrapProgram $out/bin/doas-keepenv --prefix PATH : "${
+    wrapProgram $out/bin/doas-keepenv --prefix PATH : ${
       lib.makeBinPath [
         coreutils
       ]
-    }:/run/wrappers/bin/doas"
+    }:/run/wrappers/bin/doas
   '';
 
   meta = {

--- a/pkgs/by-name/do/doas-keepenv/package.nix
+++ b/pkgs/by-name/do/doas-keepenv/package.nix
@@ -45,7 +45,7 @@ stdenv.mkDerivation {
     # don't add doas to path, 'cause we need the wrapper to funtion
   '';
 
-  meta = with lib; {
+  meta = {
     description = "A bash script for running the doas command with keeping environment variables";
     homepage = "https://github.com/stas-badzi/doas-keepenv";
     mainProgram = "doas-keepenv";

--- a/pkgs/by-name/do/doas-keepenv/package.nix
+++ b/pkgs/by-name/do/doas-keepenv/package.nix
@@ -5,13 +5,14 @@
   coreutils,
   doas,
   makeWrapper,
+  fetchurl
 }:
 
 stdenv.mkDerivation rec {
   pname = "doas-keepenv";
   version = "1.0-1";
 
-  src = fetchTarball {
+  src = fetchurl {
     url = "https://github.com/stas-badzi/doas-keepenv/archive/refs/tags/1.0.tar.gz";
     sha256 = "sha256:15xh3dgw78v6mfgkqv6mphpw0bxxbg7jqrpkb4y5151a9xjc9962";
   };
@@ -26,6 +27,10 @@ stdenv.mkDerivation rec {
     coreutils
     makeWrapper
   ];
+
+  buildPhase = ''
+
+  '';
 
   installPhase = ''
     mkdir -p $out/bin/ $out/share/licenses/doas-keepenv $out/share/doc/doas-keepenv

--- a/pkgs/by-name/do/doas-keepenv/package.nix
+++ b/pkgs/by-name/do/doas-keepenv/package.nix
@@ -10,7 +10,7 @@
 
 stdenv.mkDerivation {
   pname = "doas-keepenv";
-  version = "1.0-1";
+  version = "1.0";
 
   src = fetchurl {
     url = "https://github.com/stas-badzi/doas-keepenv/archive/refs/tags/1.0.tar.gz";

--- a/pkgs/by-name/do/doas-keepenv/package.nix
+++ b/pkgs/by-name/do/doas-keepenv/package.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation {
   src = fetchFromGitHub {
     owner = "stas-badzi";
     repo = "doas-keepenv";
-    tag = "${version};
+    tag = "${version}";
     sha256 = "15xh3dgw78v6mfgkqv6mphpw0bxxbg7jqrpkb4y5151a9xjc9962";
   };
 
@@ -33,11 +33,11 @@ stdenv.mkDerivation {
   installPhase = ''
     mkdir -p $out/bin/
     install -m 755 doas-keepenv $out/bin
-    wrapProgram $out/bin/doas-keepenv --prefix PATH : ${
+    wrapProgram $out/bin/doas-keepenv --prefix PATH : "${
       lib.makeBinPath [
         coreutils
       ]
-    }:/run/wrappers/bin/doas
+    }:/run/wrappers/bin/doas"
   '';
 
   meta = {

--- a/pkgs/by-name/do/doas-keepenv/package.nix
+++ b/pkgs/by-name/do/doas-keepenv/package.nix
@@ -34,8 +34,8 @@ stdenv.mkDerivation {
     mkdir -p $out/bin/
     install -m 755 doas-keepenv $out/bin
     wrapProgram $out/bin/doas-keepenv --prefix PATH : "${
-      pkgs.lib.makeBinPath [
-        pkgs.coreutils
+      lib.makeBinPath [
+        coreutils
       ]
     }:/run/wrappers/bin/doas"
   '';

--- a/pkgs/by-name/do/doas-keepenv/package.nix
+++ b/pkgs/by-name/do/doas-keepenv/package.nix
@@ -8,7 +8,7 @@
   fetchurl
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation {
   pname = "doas-keepenv";
   version = "1.0-1";
 

--- a/pkgs/by-name/do/doas-keepenv/package.nix
+++ b/pkgs/by-name/do/doas-keepenv/package.nix
@@ -34,12 +34,11 @@ stdenv.mkDerivation {
     install -m 755 doas-keepenv $out/bin
     install -Dm644 LICENSE $out/share/licenses/doas-keepenv
     install -Dm644 README.md $out/share/doc/doas-keepenv
-    wrapProgram $out/bin/doas-keepenv --prefix PATH : ${
-      lib.makeBinPath [
-        coreutils
+    wrapProgram $out/bin/doas-keepenv --prefix PATH : "${
+      pkgs.lib.makeBinPath [
+        pkgs.coreutils
       ]
-    }
-    # don't add doas to path, 'cause we need the wrapper to funtion
+    }:/run/wrappers/bin/doas"
   '';
 
   meta = {

--- a/pkgs/by-name/do/doas-keepenv/package.nix
+++ b/pkgs/by-name/do/doas-keepenv/package.nix
@@ -1,7 +1,6 @@
 {
   stdenv,
   lib,
-  bash,
   coreutils,
   doas,
   makeWrapper,
@@ -13,7 +12,7 @@ stdenv.mkDerivation {
   version = "1.0";
 
   src = fetchurl {
-    url = "https://github.com/stas-badzi/doas-keepenv/archive/refs/tags/1.0.tar.gz";
+    url = "https://github.com/stas-badzi/doas-keepenv/archive/refs/tags/${version}.tar.gz";
     sha256 = "sha256:15xh3dgw78v6mfgkqv6mphpw0bxxbg7jqrpkb4y5151a9xjc9962";
   };
 

--- a/pkgs/by-name/do/doas-keepenv/package.nix
+++ b/pkgs/by-name/do/doas-keepenv/package.nix
@@ -1,8 +1,13 @@
 {
-  pkgs ? import <nixpkgs> {}
+  stdenv,
+  lib,
+  bash,
+  coreutils,
+  doas,
+  wrapProgram
 }:
 
-pkgs.stdenv.mkDerivation rec {
+stdenv.mkDerivation rec {
   pname = "doas-keepenv";
   version = "%-!";
 
@@ -12,14 +17,14 @@ pkgs.stdenv.mkDerivation rec {
   };
 
   buildInputs = [
-    pkgs.bash
-    pkgs.coreutils
-    pkgs.doas
+    bash
+    coreutils
+    doas
   ];
 
   nativeBuildInputs = [
-    pkgs.coreutils
-    pkgs.makeWrapper
+    coreutils
+    makeWrapper
   ];
 
   installPhase = ''
@@ -27,18 +32,20 @@ pkgs.stdenv.mkDerivation rec {
     install -m 755 doas-keepenv $out/bin
     install -Dm644 LICENSE $out/share/licenses/doas-keepenv
     install -Dm644 README.md $out/share/doc/doas-keepenv
-    wrapProgram $out/bin/doas-keepenv --prefix PATH : ${pkgs.lib.makeBinPath [
-      pkgs.coreutils
-    ]}
+    wrapProgram $out/bin/doas-keepenv --prefix PATH : ${
+      lib.makeBinPath [
+        coreutils
+      ]
+    }
     # don't add doas to path, 'cause we need the wrapper to funtion
   '';
 
-  meta = with pkgs.lib; {
+  meta = with lib; {
     description = "A bash script for running the doas command with keeping environment variables";
     homepage = "https://github.com/stas-badzi/doas-keepenv";
     mainProgram = "doas-keepenv";
-    license = pkgs.lib.licenses.mit;
-    maintainers = with pkgs.lib.maintainers; [ stasbadzi ];
-    platforms = pkgs.lib.platforms.linux;
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ stasbadzi ];
+    platforms = lib.platforms.linux;
   };
 }

--- a/pkgs/by-name/do/doas-keepenv/package.nix
+++ b/pkgs/by-name/do/doas-keepenv/package.nix
@@ -18,13 +18,10 @@ stdenv.mkDerivation {
   };
 
   buildInputs = [
-    bash
-    coreutils
     doas
   ];
 
   nativeBuildInputs = [
-    coreutils
     makeWrapper
   ];
 

--- a/pkgs/by-name/do/doas-keepenv/package.nix
+++ b/pkgs/by-name/do/doas-keepenv/package.nix
@@ -4,15 +4,15 @@
   bash,
   coreutils,
   doas,
-  wrapProgram,
+  makeWrapper,
 }:
 
 stdenv.mkDerivation rec {
   pname = "doas-keepenv";
-  version = "%-!";
+  version = "1.0-1";
 
   src = fetchTarball {
-    url = "https://github.com/stas-badzi/doas-keepenv/archive/refs/tags/%.tar.gz";
+    url = "https://github.com/stas-badzi/doas-keepenv/archive/refs/tags/1.0.tar.gz";
     sha256 = "sha256:15xh3dgw78v6mfgkqv6mphpw0bxxbg7jqrpkb4y5151a9xjc9962";
   };
 

--- a/pkgs/by-name/do/doas-keepenv/package.nix
+++ b/pkgs/by-name/do/doas-keepenv/package.nix
@@ -22,14 +22,6 @@ pkgs.stdenv.mkDerivation rec {
     pkgs.makeWrapper
   ];
 
-  configurePhase = ''
-  
-  '';
-
-  buildPhase = ''
-    
-  '';
-
   installPhase = ''
     mkdir -p $out/bin/ $out/share/licenses/doas-keepenv $out/share/doc/doas-keepenv
     install -m 755 doas-keepenv $out/bin

--- a/pkgs/by-name/do/doas-keepenv/package.nix
+++ b/pkgs/by-name/do/doas-keepenv/package.nix
@@ -1,0 +1,52 @@
+{
+  pkgs ? import <nixpkgs> {}
+}:
+
+pkgs.stdenv.mkDerivation rec {
+  pname = "doas-keepenv";
+  version = "%-!";
+
+  src = fetchTarball {
+    url = "https://github.com/stas-badzi/doas-keepenv/archive/refs/tags/%.tar.gz";
+    sha256 = "sha256:15xh3dgw78v6mfgkqv6mphpw0bxxbg7jqrpkb4y5151a9xjc9962";
+  };
+
+  buildInputs = [
+    pkgs.bash
+    pkgs.coreutils
+    pkgs.doas
+  ];
+
+  nativeBuildInputs = [
+    pkgs.coreutils
+    pkgs.makeWrapper
+  ];
+
+  configurePhase = ''
+  
+  '';
+
+  buildPhase = ''
+    
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin/ $out/share/licenses/doas-keepenv $out/share/doc/doas-keepenv
+    install -m 755 doas-keepenv $out/bin
+    install -Dm644 LICENSE $out/share/licenses/doas-keepenv
+    install -Dm644 README.md $out/share/doc/doas-keepenv
+    wrapProgram $out/bin/doas-keepenv --prefix PATH : ${pkgs.lib.makeBinPath [
+      pkgs.coreutils
+    ]}
+    # don't add doas to path, 'cause we need the wrapper to funtion
+  '';
+
+  meta = with pkgs.lib; {
+    description = "A bash script for running the doas command with keeping environment variables";
+    homepage = "https://github.com/stas-badzi/doas-keepenv";
+    mainProgram = "doas-keepenv";
+    license = pkgs.lib.licenses.mit;
+    maintainers = with pkgs.lib.maintainers; [ stasbadzi ];
+    platforms = pkgs.lib.platforms.linux;
+  };
+}

--- a/pkgs/by-name/do/doas-keepenv/package.nix
+++ b/pkgs/by-name/do/doas-keepenv/package.nix
@@ -45,7 +45,7 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/stas-badzi/doas-keepenv";
     mainProgram = "doas-keepenv";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ stasbadzi ];
+    #maintainers = with lib.maintainers; [ stasbadzi ];
     platforms = lib.platforms.linux;
   };
 }

--- a/pkgs/by-name/do/doas-keepenv/package.nix
+++ b/pkgs/by-name/do/doas-keepenv/package.nix
@@ -11,11 +11,9 @@ stdenv.mkDerivation {
   pname = "doas-keepenv";
   version = "1.0";
 
-  src = fetchFromGitHub {
-    owner = "stas-badzi";
-    repo = "doas-keepenv";
-    tag = "${version}";
-    sha256 = "15xh3dgw78v6mfgkqv6mphpw0bxxbg7jqrpkb4y5151a9xjc9962";
+  src = fetchurl {
+    url = "https://github.com/stas-badzi/doas-keepenv/archive/refs/tags/1.0.tar.gz";
+    sha256 = "sha256:15xh3dgw78v6mfgkqv6mphpw0bxxbg7jqrpkb4y5151a9xjc9962";
   };
 
   buildInputs = [

--- a/pkgs/by-name/do/doas-keepenv/package.nix
+++ b/pkgs/by-name/do/doas-keepenv/package.nix
@@ -4,7 +4,7 @@
   coreutils,
   doas,
   makeWrapper,
-  fetchurl
+  fetchurl,
 }:
 
 stdenv.mkDerivation {
@@ -34,6 +34,7 @@ stdenv.mkDerivation {
     wrapProgram $out/bin/doas-keepenv --prefix PATH : "${
       lib.makeBinPath [
         coreutils
+        doas
       ]
     }:/run/wrappers/bin/doas"
   '';


### PR DESCRIPTION
Add doas-keepenv package [https://github.com/stas-badzi/doas-keepenv](https://github.com/stas-badzi/doas-keepenv),  A shell script for running the doas command with keeping environment variables - a `doas` version of `sudo -E`