### PR TITLE
wfview: init at 2.10, {libsForQt5,kdePackages}.qcustomplot: init at 2.1.1

### DIFF
--- a/pkgs/by-name/wf/wfview/package.nix
+++ b/pkgs/by-name/wf/wfview/package.nix
@@ -1,0 +1,74 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitLab,
+  eigen,
+  hidapi,
+  libopus,
+  libpulseaudio,
+  portaudio,
+  qt6,
+  qt6Packages,
+  rtaudio,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "wfview";
+  version = "2.10";
+
+  src = fetchFromGitLab {
+    owner = "eliggett";
+    repo = "wfview";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-bFTblsDtFAakbSJfSfKgvoxd1DTSv++rxU6R3/uWo+4=";
+  };
+
+  patches = [
+    # Remove syscalls during build to make it reproducible
+    # We also need to adjust some header paths for darwin
+    ./remove-hard-encodings.patch
+  ];
+
+  buildInputs =
+    [
+      eigen
+      hidapi
+      libopus
+      portaudio
+      rtaudio
+      qt6.qtbase
+      qt6.qtserialport
+      qt6.qtmultimedia
+      qt6.qtwebsockets
+      qt6Packages.qcustomplot
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isLinux [
+      libpulseaudio
+    ];
+
+  nativeBuildInputs = with qt6; [
+    wrapQtAppsHook
+    qmake
+  ];
+
+  env.LANG = "C.UTF-8";
+
+  qmakeFlags = [ "wfview.pro" ];
+
+  postInstall = lib.optionalString stdenv.hostPlatform.isDarwin ''
+    mkdir -pv $out/Applications
+    mv -v "$out/bin/wfview.app" $out/Applications
+
+    # wrap executable to $out/bin
+    makeWrapper "$out/Applications/wfview.app/Contents/MacOS/wfview" "$out/bin/wfview"
+  '';
+
+  meta = {
+    description = "Open-source software for the control of modern Icom radios";
+    homepage = "https://wfview.org/";
+    license = lib.licenses.gpl3Only;
+    platforms = lib.platforms.unix;
+    mainProgram = "wfview";
+    maintainers = with lib.maintainers; [ Cryolitia ];
+  };
+})

--- a/pkgs/by-name/wf/wfview/remove-hard-encodings.patch
+++ b/pkgs/by-name/wf/wfview/remove-hard-encodings.patch
@@ -1,0 +1,171 @@
+diff --git a/audioconverter.h b/audioconverter.h
+index d3cf510..308725d 100644
+--- a/audioconverter.h
++++ b/audioconverter.h
+@@ -20,13 +20,8 @@
+ #endif
+ 
+ /* Opus and Eigen */
+-#ifndef Q_OS_LINUX
+-#include "opus.h"
+-#include <Eigen/Eigen>
+-#else
+ #include "opus/opus.h"
+ #include <eigen3/Eigen/Eigen>
+-#endif
+ 
+ #include "wfviewtypes.h"
+ 
+diff --git a/audiodevices.h b/audiodevices.h
+index 3521eb5..0569e49 100644
+--- a/audiodevices.h
++++ b/audiodevices.h
+@@ -13,11 +13,7 @@
+ #include <QFontMetrics>
+ 
+ #include <portaudio.h>
+-#ifndef Q_OS_LINUX
+-#include "RtAudio.h"
+-#else
+ #include "rtaudio/RtAudio.h"
+-#endif
+ 
+ #include "wfviewtypes.h"
+ 
+diff --git a/rthandler.h b/rthandler.h
+index b422cc2..02b1117 100644
+--- a/rthandler.h
++++ b/rthandler.h
+@@ -6,11 +6,7 @@
+ #include <QThread>
+ #include <QMutex>
+ 
+-#ifndef Q_OS_LINUX
+-#include "RtAudio.h"
+-#else
+ #include "rtaudio/RtAudio.h"
+-#endif
+ 
+ 
+ #include <QAudioFormat>
+diff --git a/tciserver.h b/tciserver.h
+index 9b38886..af56763 100644
+--- a/tciserver.h
++++ b/tciserver.h
+@@ -9,13 +9,8 @@
+ #include "cachingqueue.h"
+ 
+ /* Opus and Eigen */
+-#ifndef Q_OS_LINUX
+-#include "opus.h"
+-#include <Eigen/Eigen>
+-#else
+ #include "opus/opus.h"
+ #include <eigen3/Eigen/Eigen>
+-#endif
+ 
+ #define TCI_AUDIO_LENGTH 4096
+ struct tciCommandStruct
+diff --git a/wfmain.h b/wfmain.h
+index 0404fda..e400a74 100644
+--- a/wfmain.h
++++ b/wfmain.h
+@@ -68,11 +68,7 @@
+ #include <memory>
+ 
+ #include <portaudio.h>
+-#ifndef Q_OS_LINUX
+-#include "RtAudio.h"
+-#else
+ #include "rtaudio/RtAudio.h"
+-#endif
+ 
+ #ifdef USB_CONTROLLER
+     #ifdef Q_OS_WIN
+diff --git a/wfview.pro b/wfview.pro
+index a0943bd..e8f97e1 100644
+--- a/wfview.pro
++++ b/wfview.pro
+@@ -62,10 +62,8 @@ win32:DEFINES += __WINDOWS_WASAPI__
+ #linux:DEFINES += __LINUX_OSS__
+ linux:DEFINES += __LINUX_PULSE__
+ macx:DEFINES += __MACOSX_CORE__
+-!linux:SOURCES += ../rtaudio/RTAudio.cpp
+-!linux:HEADERS += ../rtaudio/RTAUdio.h
+-!linux:INCLUDEPATH += ../rtaudio
+ 
++macx:LIBS += -lrtaudio
+ linux:LIBS += -lpulse -lpulse-simple -lrtaudio -lpthread -ludev
+ 
+ win32:INCLUDEPATH += ../portaudio/include
+@@ -107,8 +105,6 @@ win32:RC_ICONS = "resources/icons/Windows/wfview 512x512.ico"
+ 
+ macx{
+     ICON = resources/wfview.icns
+-    QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.15
+-    QMAKE_APPLE_DEVICE_ARCHS = x86_64 arm64
+     MY_ENTITLEMENTS.name = CODE_SIGN_ENTITLEMENTS
+     MY_ENTITLEMENTS.value = resources/wfview.entitlements
+     QMAKE_MAC_XCODE_SETTINGS += MY_ENTITLEMENTS
+@@ -120,8 +116,7 @@ macx{
+ 
+ QMAKE_TARGET_BUNDLE_PREFIX = org.wfview
+ 
+-!win32:DEFINES += HOST=\\\"`hostname`\\\" UNAME=\\\"`whoami`\\\"
+-!win32:DEFINES += GITSHORT="\\\"$(shell git -C \"$$PWD\" rev-parse --short HEAD)\\\""
++!win32:DEFINES += HOST=\\\"nixos\\\" UNAME=\\\"nix\\\" GITSHORT=\\\"0.0\\\"
+ 
+ win32:DEFINES += GITSHORT=\\\"$$system(git -C $$PWD rev-parse --short HEAD)\\\"
+ win32:DEFINES += HOST=\\\"$$system(hostname)\\\"
+@@ -169,19 +164,8 @@ macx:LIBS += -framework CoreAudio -framework CoreFoundation -lpthread -lopus
+ 
+ CONFIG(debug, release|debug) {
+ 
+-  macos:LIBS += -L ../qcustomplot/qcustomplot-sharedlib/build -lqcustomplotd
+-
+-  lessThan(QT_MAJOR_VERSION, 6) {
+-    linux:LIBS += $$system("/sbin/ldconfig -p | awk '/libQCustomPlotd.so/ {print \"-lQCustomPlotd\"}'")
+-    linux:LIBS += $$system("/sbin/ldconfig -p | awk '/libqcustomplotd2.so/ {print \"-lqcustomplotd2\"}'")
+-    linux:LIBS += $$system("/sbin/ldconfig -p | awk '/libqcustomplotd.so/ {print \"-lqcustomplotd\"}'")
+-
+-  } else {
+-    linux:LIBS += $$system("/sbin/ldconfig -p | awk '/libQCustomPlotdQt6.so/ {print \"-lQCustomPlotdQt6\"}'")
+-    linux:LIBS += $$system("/sbin/ldconfig -p | awk '/libqcustomplotd2qt6.so/ {print \"-lqcustomplotd2qt6\"}'")
+-    linux:LIBS += $$system("/sbin/ldconfig -p | awk '/libqcustomplotdqt6.so/ {print \"-lqcustomplotdqt6\"}'")
+-  }
+-
++  macos:LIBS += -lqcustomplotd
++  linux:LIBS += -lqcustomplotd
+   win32 {
+     contains(QMAKE_TARGET.arch, x86_64) {
+       LIBS += -L../opus/win32/VS2015/x64/DebugDLL/
+@@ -211,17 +195,8 @@ CONFIG(debug, release|debug) {
+   }
+ } else {
+ 
+-  macos:LIBS += -L ../qcustomplot/qcustomplot-sharedlib/build -lqcustomplot
+-
+-  lessThan(QT_MAJOR_VERSION, 6) {
+-    linux:LIBS += $$system("/sbin/ldconfig -p | awk '/libQCustomPlot.so/ {print \"-lQCustomPlot\"}'")
+-    linux:LIBS += $$system("/sbin/ldconfig -p | awk '/libqcustomplot2.so/ {print \"-lqcustomplot2\"}'")
+-    linux:LIBS += $$system("/sbin/ldconfig -p | awk '/libqcustomplot.so/ {print \"-lqcustomplot\"}'")
+-  } else {
+-    linux:LIBS += $$system("/sbin/ldconfig -p | awk '/libQCustomPlotQt6.so/ {print \"-lQCustomPlotQt6\"}'")
+-    linux:LIBS += $$system("/sbin/ldconfig -p | awk '/libqcustomplot2qt6.so/ {print \"-lqcustomplot2qt6\"}'")
+-    linux:LIBS += $$system("/sbin/ldconfig -p | awk '/libqcustomplotqt6.so/ {print \"-lqcustomplotqt6\"}'")
+-  }
++  macos:LIBS += -lqcustomplot
++  linux:LIBS += -lqcustomplot
+   win32 {
+     contains(QMAKE_TARGET.arch, x86_64) {
+       LIBS += -L../opus/win32/VS2015/x64/ReleaseDLL/
+@@ -264,9 +239,6 @@ win32:LIBS += -lopus -lole32 -luser32
+ #macx:HEADERS += ../qcustomplot/qcustomplot.h
+ 
+ win32:INCLUDEPATH += ../qcustomplot
+-!linux:INCLUDEPATH += ../opus/include
+-!linux:INCLUDEPATH += ../eigen
+-!linux:INCLUDEPATH += ../r8brain-free-src
+ 
+ INCLUDEPATH += resampler
+ 

--- a/pkgs/development/libraries/qcustomplot/default.nix
+++ b/pkgs/development/libraries/qcustomplot/default.nix
@@ -1,0 +1,68 @@
+{
+  stdenv,
+  lib,
+  fetchFromGitLab,
+  fetchurl,
+  fixDarwinDylibNames,
+  qtbase,
+  qmake,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "qcustomplot";
+  version = "2.1.1";
+
+  srcs = [
+    (fetchFromGitLab {
+      owner = "ecme2";
+      repo = "QCustomPlot";
+      tag = "v${finalAttrs.version}";
+      hash = "sha256-BW8H/vDbhK3b8t8oB92icEBemzcdRdrIz2aKqlUi6UU=";
+    })
+    (fetchurl {
+      url = "https://www.qcustomplot.com/release/${finalAttrs.version}/QCustomPlot-source.tar.gz";
+      hash = "sha256-Xi0i3sd5248B81fL2yXlT7z5ca2u516ujXrSRESHGC8=";
+    })
+  ];
+
+  sourceRoot = ".";
+
+  buildInputs = [ qtbase ];
+
+  nativeBuildInputs =
+    [
+      qmake
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [
+      fixDarwinDylibNames
+    ];
+
+  env.LANG = "C.UTF-8";
+
+  qmakeFlags = [ "sharedlib/sharedlib-compilation/sharedlib-compilation.pro" ];
+
+  dontWrapQtApps = true;
+
+  postUnpack = ''
+    cp -rv source/* .
+    cp -rv qcustomplot-source/* .
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    install -vDm 644 "qcustomplot.h" -t "$out/include/"
+    install -vdm 755 "$out/lib/"
+    cp -av libqcustomplot*${stdenv.hostPlatform.extensions.sharedLibrary}* "$out/lib/"
+
+    runHook postInstall
+  '';
+
+  meta = {
+    homepage = "https://qtcustomplot.com/";
+    description = "Qt C++ widget for plotting and data visualization";
+    license = lib.licenses.gpl3Plus;
+    platforms = lib.platforms.unix;
+    maintainers = with lib.maintainers; [ Cryolitia ];
+  };
+})

--- a/pkgs/top-level/qt5-packages.nix
+++ b/pkgs/top-level/qt5-packages.nix
@@ -247,6 +247,8 @@ makeScopeWithSplicing' {
 
         qcsxcad = callPackage ../development/libraries/science/electronics/qcsxcad { };
 
+        qcustomplot = callPackage ../development/libraries/qcustomplot { };
+
         qjson = callPackage ../development/libraries/qjson { };
 
         qmltermwidget = callPackage ../development/libraries/qmltermwidget { };

--- a/pkgs/top-level/qt6-packages.nix
+++ b/pkgs/top-level/qt6-packages.nix
@@ -86,6 +86,7 @@ makeScopeWithSplicing' {
         inherit (qt6) qtbase qt5compat;
       };
       qcoro = callPackage ../development/libraries/qcoro { };
+      qcustomplot = callPackage ../development/libraries/qcustomplot { };
       qgpgme = callPackage ../development/libraries/gpgme { };
       qmlbox2d = callPackage ../development/libraries/qmlbox2d { };
       packagekit-qt = callPackage ../tools/package-management/packagekit/qt.nix { };


### PR DESCRIPTION
[wfview](https://gitlab.com/eliggett/wfview) is a program that allows many modern Icom ham radio transceivers (such as the IC-7300, IC-9700, IC-7610, IC-R8600, the IC-705, and many others) to be controlled via a computer. wfview shows the gorgeous spectrum display on whatever display is connected, including projectors, touch screens, and TVs. wfview allows for full radio control from a computer keyboard and basic control from a numeric keypad. wfview can run on hardware ranging from the $35 Raspberry Pi to laptops to desktops. wfview runs on recent versions of Linux, macOS, and Windows. wfview supports rig control over ethernet/wifi as well as over the traditional USB serial CIV bus. wfview also allows older radios to be accessed over the internet, for full control and low-latency audio streaming.

Website: https://wfview.org/about/

Also introduce its dependency qcustomplot

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
