### PR TITLE
or-tools: Restore abseil-cpp and protobuf pins to fix build failure

### DIFF
--- a/pkgs/by-name/or/or-tools/package.nix
+++ b/pkgs/by-name/or/or-tools/package.nix
@@ -1,5 +1,5 @@
 {
-  abseil-cpp,
+  abseil-cpp_202407,
   bzip2,
   cbc,
   cmake,
@@ -11,7 +11,7 @@
   highs,
   lib,
   pkg-config,
-  protobuf,
+  protobuf_29,
   python3,
   re2,
   stdenv,
@@ -20,6 +20,17 @@
   zlib,
 }:
 
+let
+  # OR-Tools strictly requires specific versions of abseil-cpp and
+  # protobuf. Do not un-pin these, even if you're upgrading them to
+  # what might happen to be the latest version at the current moment;
+  # future upgrades *will* break the build.
+  abseil-cpp = abseil-cpp_202407;
+  protobuf = protobuf_29.override { inherit abseil-cpp; };
+  python-protobuf = python3.pkgs.protobuf5.override { inherit protobuf; };
+  pybind11-protobuf = python3.pkgs.pybind11-protobuf.override { inherit protobuf; };
+
+in
 stdenv.mkDerivation (finalAttrs: {
   pname = "or-tools";
   version = "9.12";
@@ -104,7 +115,7 @@ stdenv.mkDerivation (finalAttrs: {
     python3.pkgs.absl-py
     python3.pkgs.pybind11
     python3.pkgs.pybind11-abseil
-    python3.pkgs.pybind11-protobuf
+    pybind11-protobuf
     python3.pkgs.pytest
     python3.pkgs.scipy
     python3.pkgs.setuptools
@@ -116,7 +127,7 @@ stdenv.mkDerivation (finalAttrs: {
     abseil-cpp
     highs
     protobuf
-    python3.pkgs.protobuf
+    python-protobuf
     python3.pkgs.immutabledict
     python3.pkgs.numpy
     python3.pkgs.pandas


### PR DESCRIPTION
OR-Tools strictly requires specific versions of abseil-cpp and protobuf, but the pins were removed in #397405, and now it fails to build due to incompatible upgrades of these dependencies. Restore the pins to fix the build failure.

https://hydra.nixos.org/job/nixos/trunk-combined/nixpkgs.or-tools.x86_64-linux
https://hydra.nixos.org/build/295971138/nixlog/5

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
