### PR TITLE
space2meta: init at 0.2.0

### DIFF
--- a/pkgs/by-name/sp/space2meta/package.nix
+++ b/pkgs/by-name/sp/space2meta/package.nix
@@ -5,7 +5,7 @@
   cmake,
 }:
 
-stdenv.mkDerivation( finalAttrs: {
+stdenv.mkDerivation (finalAttrs: {
   pname = "space2meta";
   version = "0.2.0";
 

--- a/pkgs/by-name/sp/space2meta/package.nix
+++ b/pkgs/by-name/sp/space2meta/package.nix
@@ -5,15 +5,15 @@
   cmake,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation( finalAttrs: {
   pname = "space2meta";
   version = "0.2.0";
 
   src = fetchFromGitLab {
     group = "interception";
     owner = "linux/plugins";
-    repo = pname;
-    rev = "v${version}";
+    repo = "space2meta";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-MvpIe230I0TNzTO6ol1+DrpcFgqw0gF9Z22WMQLujb4=";
   };
 
@@ -21,10 +21,10 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     homepage = "https://gitlab.com/interception/linux/plugins/space2meta";
-    description = "Turn your space key into the meta key (a.k.a. win key, OS key, super key) when chorded to another key (on key release only).";
+    description = "space2meta is a plugin for interception-tools to convert space key to meta key";
     mainProgram = "space2meta";
     license = licenses.mit;
     maintainers = [ maintainers.vyp ];
     platforms = platforms.linux;
   };
-}
+})

--- a/pkgs/tools/inputmethods/interception-tools/space2meta.nix
+++ b/pkgs/tools/inputmethods/interception-tools/space2meta.nix
@@ -1,0 +1,30 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitLab,
+  cmake,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "space2meta";
+  version = "0.2.0";
+
+  src = fetchFromGitLab {
+    group = "interception";
+    owner = "linux/plugins";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-MvpIe230I0TNzTO6ol1+DrpcFgqw0gF9Z22WMQLujb4=";
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  meta = with lib; {
+    homepage = "https://gitlab.com/interception/linux/plugins/space2meta";
+    description = "Turn your space key into the meta key (a.k.a. win key, OS key, super key) when chorded to another key (on key release only).";
+    mainProgram = "space2meta";
+    license = licenses.mit;
+    maintainers = [ maintainers.vyp ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2702,7 +2702,7 @@ with pkgs;
     dual-function-keys =
       callPackage ../tools/inputmethods/interception-tools/dual-function-keys.nix
         { };
-    space2meta = callPackage ../tools/inputmethods/interception-tools/space2meta.nix { };
+    space2meta = callPackage ../by-name/sp/space2meta/package.nix { };
   };
 
   blacken-docs = with python3Packages; toPythonApplication blacken-docs;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2702,6 +2702,7 @@ with pkgs;
     dual-function-keys =
       callPackage ../tools/inputmethods/interception-tools/dual-function-keys.nix
         { };
+    space2meta = callPackage ../tools/inputmethods/interception-tools/space2meta.nix { };
   };
 
   blacken-docs = with python3Packages; toPythonApplication blacken-docs;


### PR DESCRIPTION
This change adds a missing interception-tools plugin [space2meta](https://gitlab.com/interception/linux/plugins/space2meta)

As with the other plugins, this plugin is an accommodation for people with thumb or wrist issues like carpel tunnel. I find it particularly useful for tiling window managers where you might find yourself hitting the "meta" key frequently.

Without space2meta, you can almost emulate the same effect using the "dual function keys" plugin, already in the tree, however the effect is not perfect with the dual function keys.

In my personal experience with the "dual function keys" plugin to use the space key as a meta key, I find that if I type too quickly, I will accidently trigger the key that I intend to only be triggered if chorded. I miss the functionality of space2meta.

Do be careful reviewing; I am a novice Nix-er.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


edit:
I have contributed previously to the ZFS artciles on the nixos wiki, but I have not reviewed any PRs or issues for the nixpkgs repo. What a great idea! I'll add to my to-do list to do a couple of reviews.
