### PR TITLE
auto-cpufreq: 2.5.0 -> 2.6.0

### DIFF
--- a/pkgs/by-name/au/auto-cpufreq/package.nix
+++ b/pkgs/by-name/au/auto-cpufreq/package.nix
@@ -2,7 +2,6 @@
   lib,
   python3Packages,
   fetchFromGitHub,
-  fetchpatch,
   replaceVars,
   gobject-introspection,
   wrapGAppsHook3,
@@ -12,14 +11,14 @@
 }:
 python3Packages.buildPythonPackage rec {
   pname = "auto-cpufreq";
-  version = "2.5.0";
+  version = "2.6.0";
   format = "pyproject";
 
   src = fetchFromGitHub {
     owner = "AdnanHodzic";
     repo = "auto-cpufreq";
     tag = "v${version}";
-    hash = "sha256-iDvgL5dQerQnu2ERKAWGvWppG7cQ/0uKEfVY93ItvO4=";
+    hash = "sha256-DEs6jbWYJFJgpaPtF5NT3DQs3erjzdm2brLNHpjrEPA=";
   };
 
   nativeBuildInputs = [
@@ -42,6 +41,9 @@ python3Packages.buildPythonPackage rec {
       poetry-dynamic-versioning
       setuptools
       pyinotify
+      urwid
+      pyasyncore
+      requests
     ]
     ++ [ getent ];
 
@@ -58,13 +60,6 @@ python3Packages.buildPythonPackage rec {
     ./prevent-install-and-copy.patch
     # patch to prevent update
     ./prevent-update.patch
-
-    # ps-util python package bounds are too strict for version 2.5.0
-    (fetchpatch {
-      name = "auto-cpufreq-2.5.0-ps-util-relax-constraints.patch";
-      url = "https://github.com/AdnanHodzic/auto-cpufreq/commit/8f026ac6497050c0e07c55b751c4b80401e932ec.patch";
-      sha256 = "sha256-hcEcuy7oW4fZgfOLSap3pnWk7H1Q757tgfl7HIUyWiM=";
-    })
   ];
 
   postPatch = ''

--- a/pkgs/by-name/au/auto-cpufreq/prevent-update.patch
+++ b/pkgs/by-name/au/auto-cpufreq/prevent-update.patch
@@ -111,25 +111,3 @@ index b51d55d..99eeed8 100755
  
  def new_update(custom_dir):
      os.chdir(custom_dir)
-diff --git c/poetry.lock i/poetry.lock
-index 0e6da84..b4936fe 100644
---- c/poetry.lock
-+++ i/poetry.lock
-@@ -1306,4 +1306,4 @@ test = ["big-O", "jaraco.functools", "jaraco.itertools", "jaraco.test", "more-it
- [metadata]
- lock-version = "2.0"
- python-versions = "^3.8"
--content-hash = "cad3783d04e35b66b241352e76631d0a83c8df3d286b113979ba34a65847f06c"
-+content-hash = "b21af52156d2d624602fe6941cf001abd7f8cf5b70b22ebfd7b7ad0dece1e39f"
-diff --git c/pyproject.toml i/pyproject.toml
-index 562a94b..cc44d8d 100644
---- c/pyproject.toml
-+++ i/pyproject.toml
-@@ -25,7 +25,6 @@ python = "^3.8"
- psutil = "^6.0.0"
- click = "^8.1.0"
- distro = "^1.8.0"
--requests = "^2.32.3"
- PyGObject = "^3.46.0"
- pyinotify = {git = "https://github.com/shadeyg56/pyinotify-3.12"}
- 


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

changelog: https://github.com/AdnanHodzic/auto-cpufreq/releases/tag/v2.6.0

Removed conflict patch and edited another that was conflicting with `poetry.lock`. Im opting to include `requests` as a dep
instead of patching it out of `pyproject.toml` and recalculating the `metadata.content-hash` when the `pyproject.toml` changes.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
