### PR TITLE
chromium,chromedriver: 136.0.7103.59 -> 136.0.7103.92

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/info.json
+++ b/pkgs/applications/networking/browsers/chromium/info.json
@@ -1,10 +1,10 @@
 {
   "chromium": {
-    "version": "136.0.7103.59",
+    "version": "136.0.7103.92",
     "chromedriver": {
-      "version": "136.0.7103.49",
-      "hash_darwin": "sha256-n9gOEQmMBzeoSj8Mxum2UnKe6yrmUjMKLXRD2ty8upw=",
-      "hash_darwin_aarch64": "sha256-q3iz4fAUcXyoDP4fS5vDAuEIZWftwJhlfkwDUhR57Cc="
+      "version": "136.0.7103.93",
+      "hash_darwin": "sha256-6u+hJWBZZlqjc81Hs/5dL6csWP3QiWzQvfW3O+bfaaA=",
+      "hash_darwin_aarch64": "sha256-b4MfxITtIwqV41Jc5Hv42WgOt1+U6dNjIvSDG4VNqw8="
     },
     "deps": {
       "depot_tools": {
@@ -20,8 +20,8 @@
     "DEPS": {
       "src": {
         "url": "https://chromium.googlesource.com/chromium/src.git",
-        "rev": "d4b493843f5f23217df99a83aa28747602841382",
-        "hash": "sha256-5SKNNEPYSAxQUWtcCq/LW7gxGjjEhuw0Uxo1ob+F7to=",
+        "rev": "cb81a4cc5087a8303a6c8827ee2b80b71d26e334",
+        "hash": "sha256-mySbSMnbM/KBEGnOyJKJMr4WD4PNgIDDeNK0fTPfcnI=",
         "recompress": true
       },
       "src/third_party/clang-format/script": {
@@ -641,8 +641,8 @@
       },
       "src/third_party/sqlite/src": {
         "url": "https://chromium.googlesource.com/chromium/deps/sqlite.git",
-        "rev": "567495a62a62dc013888500526e82837d727fe01",
-        "hash": "sha256-ltl3OTk/wZPSj3yYthNlKd3mBxef6l5uW6UYTwebNek="
+        "rev": "8a22b25ad7244abaf07e372cc6dc97e041d663a9",
+        "hash": "sha256-1vAGAF3idxgHGaqb5gT5k3KIGC2H3gqC3RTVU2ZRf4A="
       },
       "src/third_party/swiftshader": {
         "url": "https://swiftshader.googlesource.com/SwiftShader.git",


### PR DESCRIPTION
https://chromereleases.googleblog.com/2025/05/stable-channel-update-for-desktop.html

This update includes 2 security fixes.

CVEs:
CVE-2025-4372

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
