### PR TITLE
i4tools: init at 3.07.001

### DIFF
--- a/pkgs/by-name/i4/i4tools/package.nix
+++ b/pkgs/by-name/i4/i4tools/package.nix
@@ -1,0 +1,93 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  rpmextract,
+  autoPatchelfHook,
+  makeWrapper,
+
+  p11-kit,
+  glibc,
+  libGL,
+  xorg,
+}:
+
+let
+  version = "3.07.001";
+  src = fetchurl {
+    # The URL is taken from update check API, which is updated by the updater script.
+    # The version number in this URL does not need to be interpolated string for this reason.
+    # It somehow is HTTP instead of HTTPS, but should not matter because of the hash check.
+    url = "http://d.updater.i4.cn/i4linux/deb/i4tools_v3.07.001.rpm";
+    hash = "sha256-OJiCsAc57ympqMJ+U53Q/sZ8/PmZUpTEQWGmo4u0jj0=";
+  };
+in
+stdenv.mkDerivation {
+  inherit version src;
+  pname = "i4tools";
+
+  nativeBuildInputs = [
+    rpmextract
+    autoPatchelfHook
+    makeWrapper
+    p11-kit
+  ];
+
+  sourceRoot = src.name;
+  unpackCmd = ''
+    mkdir $sourceRoot && pushd $sourceRoot
+    rpmextract $src
+    popd
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/opt
+    phome=$out/opt/i4Tools
+    cp -a opt/apps/cn.i4Tools $phome
+
+    mkdir -p $out/bin
+    makeWrapper $phome/run.sh $out/bin/i4Tools \
+      --suffix LD_LIBRARY_PATH : ${
+        lib.makeLibraryPath (
+          [
+            glibc
+            libGL
+          ]
+          ++ (with xorg; [
+            libX11
+            libXext
+          ])
+        )
+      }
+
+    mkdir -p $out/share/icons/hicolor/scalable/apps
+    ln -s $phome/resources/logo.svg $out/share/icons/hicolor/scalable/apps/i4Tools.svg
+    mkdir -p $out/share/pixmaps
+    ln -s $phome/resources/logo.png $out/share/pixmaps/i4Tools.png
+    mkdir -p $out/share/applications
+    cp opt/apps/cn.i4Tools/cn.i4Tools.desktop $out/share/applications/i4Tools.desktop
+
+    runHook postInstall
+  '';
+
+  postFixup = ''
+    desktop=$out/share/applications/i4Tools.desktop
+    sed -i "/Version=.*/d" $desktop
+    sed -i "s|Exec=.*|Exec=i4Tools %u|" $desktop
+    sed -i "s|Icon=.*|Icon=i4Tools|" $desktop
+  '';
+
+  passthru.updateScript = ./update.sh;
+
+  meta = {
+    description = "iOS device management tool";
+    homepage = "https://www.i4.cn";
+    license = lib.licenses.unfree;
+    platforms = [ "x86_64-linux" ];
+    maintainers = with lib.maintainers; [ ulysseszhan ];
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    mainProgram = "i4Tools";
+  };
+}

--- a/pkgs/by-name/i4/i4tools/update.sh
+++ b/pkgs/by-name/i4/i4tools/update.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p curl common-updater-scripts
+
+set -eu -o pipefail
+
+attr=i4tools
+currentVersion=$(nix-instantiate --eval --strict --attr $attr.version | tr -d '"')
+
+api() {
+    curl "https://app4.i4.cn/linuxUpdatelogJson.xhtml?type=0&pc_vs=$currentVersion"
+}
+
+info=$(api | jq -r '.[0]')
+version=$(echo "$info" | jq -r '.version')
+if [ "$version" = "null" ]; then
+    echo "Error: Unable to fetch the latest version from the API."
+    exit 1
+fi
+if [ "$version" = "$currentVersion" ]; then
+    echo "i4tools is already at the latest version: $version"
+    exit 0
+fi
+
+url=$(echo "$info" | jq -r '.urlRpm')
+update-source-version $attr $version "" $url


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
A powerful iOS device management tool. The only available UI language is Chinese.

Currently I cannot make it work with my iPad (though other tools such as ifuse and imobiledevice work), so maybe someone can try to use it to connect their iOS device.

It seems that this tool relies on the usbmuxd service, but the official documentation never mentioned that (and it indeed does not depend on the usbmuxd service on other distributions such as Debian and Arch).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
