### PR TITLE
nixos-rebuild-ng: implement --transfer-mode flag

### DIFF
--- a/pkgs/by-name/ni/nixos-rebuild-ng/README.md
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/README.md
@@ -89,13 +89,11 @@ not possible to fix, please open an issue and we can discuss a solution.
   your password wrong, it will fail during activation (this can be improved
   though)
 - When `--build-host` and `--target-host` are used together, we will use `nix
-  copy` (or 2 `nix-copy-closure` if you're using Nix <2.18) instead of SSH'ing
-  to build host and using `nix-copy-closure --to target-host`. The reason for
-  this is documented in PR
+  copy` (or 2 `nix-copy-closure` if you're using Nix <2.18) by default instead
+  of SSH'ing to build host and using `nix-copy-closure --to target-host`. The
+  reason for this is documented in PR
   [#364698](https://github.com/NixOS/nixpkgs/pull/364698). If you do need the
-  previous behavior, you can simulate it using `ssh build-host --
-  nixos-rebuild-ng switch --target-host target-host`. If that is not the case,
-  please open an issue
+  previous behavior, you can use `--transfer-mode=bastion`
 - We do some additional validation of flags, like exiting with an error when
   `--build-host` or `--target-host` is used with `repl`, since the user could
   assume that the `repl` would be run remotely while it always run the local

--- a/pkgs/by-name/ni/nixos-rebuild-ng/nixos-rebuild.8.scd
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/nixos-rebuild.8.scd
@@ -25,6 +25,7 @@ _nixos-rebuild_ \[--verbose] [--max-jobs MAX_JOBS] [--cores CORES] [--log-format
 	\[--specialisation SPECIALISATION] [--rollback] [--upgrade] [--upgrade-all] [--json] [--ask-sudo-password] [--sudo] [--no-reexec]++
 	\[--image-variant VARIANT]++
 	\[--build-host BUILD_HOST] [--target-host TARGET_HOST]++
+	\[--transfer-mode {default,nix23,bastion}]++
 	\[{switch,boot,test,build,edit,repl,dry-build,dry-run,dry-activate,build-image,build-vm,build-vm-with-bootloader,list-generations}]
 
 # DESCRIPTION
@@ -248,6 +249,34 @@ It must be one of the following:
 	the given configuration but disregards the true architecture of the
 	target host. Hence the _nixpkgs.crossSystem_ setting has to match the
 	target platform or else activation will fail.
+
+*--transfer-mode* {default,nix23,bastion}
+	When *--build-host* and *--target-host* are used together, we need to
+	transfer the built closure from build host to target host for
+	activation. There are multiple strategies that can be used, and this
+	option allow selection of which mode you want to use.
+
+	- _default_: will use `nix copy --from <build_host> --to
+	  <target_host>`. Generally the most reliable method and works as long
+	  the localhost can access both build and target host, hence being the
+	  default if Nix >=2.18 is being used.
+
+	- _nix23_: will use `nix-copy-closure --from <build_host>` and
+	  `nix-copy-closure --to <target_host>`, so it first copies the built
+	  closure to the localhost and then copies it to target. Uses twice the
+	  bandwidth and needs enough storage in localhost to store the
+	  intermediate build, but works in Nix 2.3+. This is also the default
+	  mode if `nixos-rebuild-ng` is build with a version of Nix <2.18. This
+	  mode may be removed in future.
+
+	- _bastion_: will SSH to the build host and run `nix-copy-closure --to
+	  <target_host>`. Generally the most efficient method since it doesn't
+	  depend in the localhost network, however the build host needs to be
+	  configured to communicate with target host directly (e.g., having the
+	  keys in build host or configuring SSH Agent Forwarding, adding the
+	  target host to `authorized_keys`, etc). This was also the only mode
+	  available in legacy *nixos-rebuild*, so if you want to keep the same
+	  workflow this is the mode that should be used.
 
 *--use-substitutes*
 	When set, nixos-rebuild will add *--use-substitutes* to each invocation

--- a/pkgs/by-name/ni/nixos-rebuild-ng/nixos-rebuild.8.scd
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/nixos-rebuild.8.scd
@@ -274,9 +274,9 @@ It must be one of the following:
 	  depend in the localhost network, however the build host needs to be
 	  configured to communicate with target host directly (e.g., having the
 	  keys in build host or configuring SSH Agent Forwarding, adding the
-	  target host to `authorized_keys`, etc). This was also the only mode
-	  available in legacy *nixos-rebuild*, so if you want to keep the same
-	  workflow this is the mode that should be used.
+	  target host to `authorized_keys`) and also either support for
+	  password-less _sudo_ (with *--sudo* flag) or using an user with
+	  _root_ permissions if you want to activate the configuration.
 
 *--use-substitutes*
 	When set, nixos-rebuild will add *--use-substitutes* to each invocation

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/__init__.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/__init__.py
@@ -408,6 +408,7 @@ def execute(argv: list[str]) -> None:
             dry_run = action == Action.DRY_BUILD
             no_link = action in (Action.SWITCH, Action.BOOT)
             rollback = bool(args.rollback)
+            transfer_mode = TransferMode(args.transfer_mode)
 
             def validate_image_variant(variants: ImageVariants) -> None:
                 if args.image_variant not in variants:
@@ -502,7 +503,7 @@ def execute(argv: list[str]) -> None:
                     to_host=target_host,
                     from_host=build_host,
                     copy_flags=copy_flags,
-                    transfer_mode=TransferMode(args.transfer_mode),
+                    transfer_mode=transfer_mode,
                 )
                 if action in (Action.SWITCH, Action.BOOT):
                     nix.set_profile(
@@ -523,9 +524,11 @@ def execute(argv: list[str]) -> None:
                         path_to_config,
                         action,
                         target_host=target_host,
+                        build_host=build_host,
                         sudo=args.sudo,
                         specialisation=args.specialisation,
                         install_bootloader=args.install_bootloader,
+                        transfer_mode=transfer_mode,
                     )
                     print_result("Done. The new configuration is", path_to_config)
                 case Action.BUILD:

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/__init__.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/__init__.py
@@ -9,7 +9,15 @@ from typing import Final, assert_never
 
 from . import nix, tmpdir
 from .constants import EXECUTABLE, WITH_NIX_2_18, WITH_REEXEC, WITH_SHELL_FILES
-from .models import Action, BuildAttr, Flake, ImageVariants, NRError, Profile
+from .models import (
+    Action,
+    BuildAttr,
+    Flake,
+    ImageVariants,
+    NRError,
+    Profile,
+    TransferMode,
+)
 from .process import Remote, cleanup_ssh
 from .utils import Args, LogFormatter, tabulate
 
@@ -187,6 +195,12 @@ def get_parser() -> tuple[argparse.ArgumentParser, dict[str, argparse.ArgumentPa
         "--image-variant",
         help="Selects an image variant to build from the "
         + "config.system.build.images attribute of the given configuration",
+    )
+    main_parser.add_argument(
+        "--transfer-mode",
+        help="Transfer mode to be used when both --build-host and --target-host are used",
+        choices=TransferMode.values(),
+        default=TransferMode.DEFAULT if WITH_NIX_2_18 else TransferMode.NIX_2_3,
     )
     main_parser.add_argument("action", choices=Action.values(), nargs="?")
 
@@ -488,6 +502,7 @@ def execute(argv: list[str]) -> None:
                     to_host=target_host,
                     from_host=build_host,
                     copy_flags=copy_flags,
+                    transfer_mode=TransferMode(args.transfer_mode),
                 )
                 if action in (Action.SWITCH, Action.BOOT):
                     nix.set_profile(

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/models.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/models.py
@@ -41,9 +41,23 @@ class Action(Enum):
     def __str__(self) -> str:
         return self.value
 
-    @staticmethod
-    def values() -> list[str]:
-        return [a.value for a in Action]
+    @classmethod
+    def values(cls) -> list[str]:
+        return [a.value for a in cls]
+
+
+class TransferMode(Enum):
+    DEFAULT = "default"
+    NIX_2_3 = "nix23"
+    BASTION = "bastion"
+
+    @override
+    def __str__(self) -> str:
+        return self.value
+
+    @classmethod
+    def values(cls) -> list[str]:
+        return [a.value for a in cls]
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This is a new flag that will allow to change the strategy on how to do closure copies between 2 remote hosts. `--transfer-mode=default` and `--transfer-mode=nix23` were the 2 modes that were already implemented (and would change depending if Nix 2.18+ was being used or not).

~~`--transfer-mode=bastion` is a "new" mode. New in quotes because this is similar to the old mode use in `nixos-rebuild`. This mode SSH'd to the build host and starts the copy to the target host from the build host, a common setup in bastion hosts, hence the name. This mode technically is more efficient than the other 2, since the 2 remote hosts communicate directly, but it also means it needs additional setup, and hence it will not be the default.~~

Closes #403282.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
