### PR TITLE
python312Packages.dbt-common: fix build; 1.22.0 -> 1.23.0-unstable-2025-04-21; enable tests

### DIFF
--- a/pkgs/development/python-modules/dbt-common/default.nix
+++ b/pkgs/development/python-modules/dbt-common/default.nix
@@ -70,15 +70,6 @@ buildPythonPackage rec {
     pytest-mock
   ];
 
-  disabledTests = [
-    # Assertion errors (TODO: Notify upstream)
-    "test_create_print_json"
-    "test_events"
-    "test_extra_dict_on_event"
-  ];
-
-  doCheck = false;
-
   pythonImportsCheck = [ "dbt_common" ];
 
   meta = {

--- a/pkgs/development/python-modules/dbt-common/default.nix
+++ b/pkgs/development/python-modules/dbt-common/default.nix
@@ -1,7 +1,7 @@
 {
   lib,
   buildPythonPackage,
-  fetchPypi,
+  fetchFromGitHub,
 
   # build-system
   hatchling,
@@ -28,14 +28,14 @@
 
 buildPythonPackage rec {
   pname = "dbt-common";
-  version = "1.23.0";
+  version = "1.23.0-unstable-2025-04-21";
   pyproject = true;
 
-  # No tags on GitHub
-  src = fetchPypi {
-    pname = "dbt_common";
-    inherit version;
-    hash = "sha256-LsczRn2rTb9RVlGpNHznHkKJht3Lke1MLVCExeneouM=";
+  src = fetchFromGitHub {
+    owner = "dbt-labs";
+    repo = pname;
+    rev = "03e09c01f20573975e8e17776a4b7c9088b3f212"; # They don't tag releases
+    hash = "sha256-KqnwlFZZRYuWRflMzjrqCPBnzY9q/pPhceM2DGqz5bw=";
   };
 
   build-system = [ hatchling ];
@@ -77,7 +77,6 @@ buildPythonPackage rec {
     "test_extra_dict_on_event"
   ];
 
-  # No tests in the pypi archive
   doCheck = false;
 
   pythonImportsCheck = [ "dbt_common" ];

--- a/pkgs/development/python-modules/dbt-common/default.nix
+++ b/pkgs/development/python-modules/dbt-common/default.nix
@@ -70,6 +70,11 @@ buildPythonPackage rec {
     pytest-mock
   ];
 
+  disabledTests = [
+    # flaky test: https://github.com/dbt-labs/dbt-common/issues/280
+    "TestFindMatching"
+  ];
+
   pythonImportsCheck = [ "dbt_common" ];
 
   meta = {

--- a/pkgs/development/python-modules/dbt-common/default.nix
+++ b/pkgs/development/python-modules/dbt-common/default.nix
@@ -46,6 +46,7 @@ buildPythonPackage rec {
     # 0.6.x -> 0.7.2 doesn't seem too risky at a glance
     # https://pypi.org/project/isodate/0.7.2/
     "isodate"
+    "protobuf"
   ];
 
   dependencies = [

--- a/pkgs/development/python-modules/dbt-common/default.nix
+++ b/pkgs/development/python-modules/dbt-common/default.nix
@@ -28,14 +28,14 @@
 
 buildPythonPackage rec {
   pname = "dbt-common";
-  version = "1.22.0";
+  version = "1.23.0";
   pyproject = true;
 
   # No tags on GitHub
   src = fetchPypi {
     pname = "dbt_common";
     inherit version;
-    hash = "sha256-6cdTMVCCB6SNEUsQtzKUBnKuJgwfttl7o2+zBp8Fu5g=";
+    hash = "sha256-LsczRn2rTb9RVlGpNHznHkKJht3Lke1MLVCExeneouM=";
   };
 
   build-system = [ hatchling ];


### PR DESCRIPTION
Signed-off-by: Ihar Hrachyshka <ihar.hrachyshka@gmail.com>


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
