### PR TITLE
netgen: add support for Darwin platform

### DIFF
--- a/pkgs/by-name/ne/netgen/package.nix
+++ b/pkgs/by-name/ne/netgen/package.nix
@@ -137,8 +137,11 @@ stdenv.mkDerivation (finalAttrs: {
     python3Packages.pytest
     python3Packages.pytest-check
     python3Packages.pytest-mpi
+    python3Packages.pythonImportsCheckHook
     mpiCheckPhaseHook
   ];
+
+  pythonImportsCheck = [ "netgen" ];
 
   passthru = {
     inherit avxSupport avx2Support avx512Support;

--- a/pkgs/by-name/ne/netgen/package.nix
+++ b/pkgs/by-name/ne/netgen/package.nix
@@ -146,6 +146,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     homepage = "https://ngsolve.org";
+    downloadPage = "https://github.com/NGSolve/netgen";
     description = "Atomatic 3d tetrahedral mesh generator";
     license = with lib.licenses; [
       lgpl2Plus

--- a/pkgs/by-name/ne/netgen/package.nix
+++ b/pkgs/by-name/ne/netgen/package.nix
@@ -3,7 +3,6 @@
   stdenv,
   fetchFromGitHub,
   fetchpatch2,
-  makeWrapper,
   cmake,
   python3Packages,
   mpi,
@@ -85,7 +84,6 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [
     cmake
-    makeWrapper
     python3Packages.pybind11-stubgen
   ];
 

--- a/pkgs/by-name/ne/netgen/package.nix
+++ b/pkgs/by-name/ne/netgen/package.nix
@@ -3,6 +3,10 @@
   stdenv,
   fetchFromGitHub,
   fetchpatch2,
+  libicns,
+  imagemagick,
+  makeDesktopItem,
+  copyDesktopItems,
   cmake,
   python3Packages,
   mpi,
@@ -92,9 +96,11 @@ stdenv.mkDerivation (finalAttrs: {
     '';
 
   nativeBuildInputs = [
+    libicns
+    imagemagick
     cmake
     python3Packages.pybind11-stubgen
-  ];
+  ] ++ lib.optional stdenv.hostPlatform.isLinux copyDesktopItems;
 
   buildInputs = [
     metis
@@ -139,14 +145,41 @@ stdenv.mkDerivation (finalAttrs: {
 
   __darwinAllowLocalNetworking = true;
 
-  postInstall = lib.optionalString stdenv.hostPlatform.isDarwin ''
-    rm $out/bin/{Netgen1,startup.sh}
-    mkdir -p $out/Applications/${finalAttrs.pname}.app/Contents/{MacOS,Resouces}
-    substituteInPlace $out/Info.plist --replace-fail "Netgen1" "netgen"
-    mv $out/Info.plist $out/Applications/${finalAttrs.pname}.app/Contents
-    mv $out/Netgen.icns $out/Applications/${finalAttrs.pname}.app/Contents/Resouces
-    ln -s $out/bin/netgen $out/Applications/${finalAttrs.pname}.app/Contents/MacOS/netgen
-  '';
+  desktopItems = [
+    (makeDesktopItem {
+      name = "netgen";
+      exec = "netgen";
+      comment = finalAttrs.meta.description;
+      desktopName = "Netgen Mesh Generator";
+      genericName = "3D Mesh Generator";
+      categories = [ "Science" ];
+      icon = "netgen";
+    })
+  ];
+
+  postInstall =
+    lib.optionalString stdenv.hostPlatform.isDarwin ''
+      rm $out/bin/{Netgen1,startup.sh}
+      mkdir -p $out/Applications/${finalAttrs.pname}.app/Contents/{MacOS,Resouces}
+      substituteInPlace $out/Info.plist --replace-fail "Netgen1" "netgen"
+      mv $out/Info.plist $out/Applications/${finalAttrs.pname}.app/Contents
+      mv $out/Netgen.icns $out/Applications/${finalAttrs.pname}.app/Contents/Resouces
+      ln -s $out/bin/netgen $out/Applications/${finalAttrs.pname}.app/Contents/MacOS/netgen
+    ''
+    + lib.optionalString stdenv.hostPlatform.isLinux ''
+      # Extract pngs from the Apple icon image and create
+      # the missing ones from the 512x512 image.
+      icns2png --extract ../netgen.icns
+      for size in 16 24 32 48 64 128 256 512; do
+        mkdir -pv $out/share/icons/hicolor/"$size"x"$size"/apps
+        if [ -e netgen_"$size"x"$size"x32.png ]
+        then
+          mv netgen_"$size"x"$size"x32.png $out/share/icons/hicolor/"$size"x"$size"/apps/netgen.png
+        else
+          convert -resize "$size"x"$size" netgen_512x512x32.png $out/share/icons/hicolor/"$size"x"$size"/apps/netgen.png
+        fi
+      done;
+    '';
 
   doInstallCheck = true;
 

--- a/pkgs/by-name/ne/netgen/package.nix
+++ b/pkgs/by-name/ne/netgen/package.nix
@@ -65,28 +65,31 @@ stdenv.mkDerivation (finalAttrs: {
       url = "${patchSource}/include_stdlib.patch";
       hash = "sha256-W+NgGBuy/UmzVbPTSqR8FRUlyN/9dl9l9e9rxKklmIc=";
     })
-    (fetchpatch2 {
-      url = "${patchSource}/fix-version.patch";
-      hash = "sha256-CT98Wq3UufB81z/jYLiH9nXvt+QzoZ7210OeuFXCfmc=";
-    })
   ];
 
   # when generating python stub file utilizing system python pybind11_stubgen module
   # cmake need to inherit pythonpath
   postPatch =
     ''
-    substituteInPlace python/CMakeLists.txt \
-      --replace-fail ''\'''${CMAKE_INSTALL_PREFIX}/''${NG_INSTALL_DIR_PYTHON}' \
-                     ''\'''${CMAKE_INSTALL_PREFIX}/''${NG_INSTALL_DIR_PYTHON}:$ENV{PYTHONPATH}'
+      sed -i '/-DBDIR=''\'''${CMAKE_CURRENT_BINARY_DIR}/a\
+      -DNETGEN_VERSION_GIT=''\'''${NETGEN_VERSION_GIT}
+      ' CMakeLists.txt
 
-    substituteInPlace ng/ng.tcl ng/onetcl.cpp \
-      --replace-fail "libnggui" "$out/lib/libnggui"
+      substituteInPlace python/CMakeLists.txt \
+        --replace-fail ''\'''${CMAKE_INSTALL_PREFIX}/''${NG_INSTALL_DIR_PYTHON}' \
+                       ''\'''${CMAKE_INSTALL_PREFIX}/''${NG_INSTALL_DIR_PYTHON}:$ENV{PYTHONPATH}'
+
+      substituteInPlace ng/ng.tcl ng/onetcl.cpp \
+        --replace-fail "libnggui" "$out/lib/libnggui"
+
+      substituteInPlace ng/Togl2.1/CMakeLists.txt \
+        --replace-fail "/usr/bin/gcc" "$CC"
     ''
     + lib.optionalString (!stdenv.hostPlatform.isx86_64) ''
       # mesh generation differs on x86_64 and aarch64 platform
       # test_tutorials will fail on aarch64 platform
       rm tests/pytest/test_tutorials.py
-  '';
+    '';
 
   nativeBuildInputs = [
     cmake
@@ -115,6 +118,12 @@ stdenv.mkDerivation (finalAttrs: {
 
   cmakeFlags = [
     (lib.cmakeFeature "NETGEN_VERSION_GIT" "v${finalAttrs.version}-0")
+    (lib.cmakeFeature "NG_INSTALL_DIR_BIN" "bin")
+    (lib.cmakeFeature "NG_INSTALL_DIR_LIB" "lib")
+    (lib.cmakeFeature "NG_INSTALL_DIR_CMAKE" "lib/cmake/${finalAttrs.pname}")
+    (lib.cmakeFeature "NG_INSTALL_DIR_PYTHON" python3Packages.python.sitePackages)
+    (lib.cmakeFeature "NG_INSTALL_DIR_RES" "share")
+    (lib.cmakeFeature "NG_INSTALL_DIR_INCLUDE" "include")
     (lib.cmakeFeature "CMAKE_CXX_FLAGS" archFlags)
     (lib.cmakeBool "USE_MPI" true)
     (lib.cmakeBool "USE_MPI4PY" true)
@@ -127,6 +136,17 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.cmakeBool "BUILD_TESTING" finalAttrs.finalPackage.doInstallCheck)
     (lib.cmakeBool "ENABLE_UNIT_TESTS" finalAttrs.finalPackage.doInstallCheck)
   ];
+
+  __darwinAllowLocalNetworking = true;
+
+  postInstall = lib.optionalString stdenv.hostPlatform.isDarwin ''
+    rm $out/bin/{Netgen1,startup.sh}
+    mkdir -p $out/Applications/${finalAttrs.pname}.app/Contents/{MacOS,Resouces}
+    substituteInPlace $out/Info.plist --replace-fail "Netgen1" "netgen"
+    mv $out/Info.plist $out/Applications/${finalAttrs.pname}.app/Contents
+    mv $out/Netgen.icns $out/Applications/${finalAttrs.pname}.app/Contents/Resouces
+    ln -s $out/bin/netgen $out/Applications/${finalAttrs.pname}.app/Contents/MacOS/netgen
+  '';
 
   doInstallCheck = true;
 
@@ -163,10 +183,7 @@ stdenv.mkDerivation (finalAttrs: {
       boost
       publicDomain
     ];
-    platforms = [
-      "x86_64-linux"
-      "aarch64-linux"
-    ];
+    platforms = lib.platforms.unix;
     mainProgram = "netgen";
     maintainers = with lib.maintainers; [ qbisi ];
   };


### PR DESCRIPTION


## Things done

Tested the main gui program netgen on darwin platform, works fine. 

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
