### PR TITLE
sddm-tokyo-night: init at 0-unstable-2023-06-13

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -24805,6 +24805,11 @@
     githubId = 74688871;
     name = "Tochukwu Ahanonu";
   };
+  tohmais = {
+    github = "tohmais";
+    githubId = 48165643;
+    name = "tohmais";
+  };
   tomahna = {
     email = "kevin.rauscher@tomahna.fr";
     github = "Tomahna";

--- a/pkgs/data/themes/sddm-tokyo-night/default.nix
+++ b/pkgs/data/themes/sddm-tokyo-night/default.nix
@@ -1,0 +1,51 @@
+{
+  lib,
+  stdenvNoCC,
+  pkgs,
+  themeConfig ? null,
+}:
+stdenvNoCC.mkDerivation rec {
+  pname = "sddm-tokyo-night";
+  version = "0-unstable-2023-06-13";
+
+  src = pkgs.fetchFromGitHub {
+    owner = "siddrs";
+    repo = "tokyo-night-sddm";
+    rev = "320c8e74ade1e94f640708eee0b9a75a395697c6";
+    sha256 = "1gf074ypgc4r8pgljd8lydy0l5fajrl2pi2avn5ivacz4z7ma595";
+  };
+
+  dontWrapQtApps = true;
+
+  propagatedUserEnvPkgs = with pkgs.libsForQt5.qt5; [
+    qtquickcontrols2
+    qtgraphicaleffects
+    qtsvg
+  ];
+
+  installPhase =
+    let
+      iniFormat = pkgs.formats.ini { };
+      configFile = iniFormat.generate "" { General = themeConfig; };
+
+      basePath = "$out/share/sddm/themes/tokyo-night";
+    in
+    ''
+      mkdir -p ${basePath}
+      cp -r $src/* ${basePath}
+    ''
+    + lib.optionalString (themeConfig != null) ''
+      ln -sf ${configFile} ${basePath}/theme.conf.user
+    '';
+
+  meta = {
+    description = "Tokyo Night for SDDM";
+    homepage = "https://github.com/siddrs/tokyo-night-sddm";
+    license = with lib.licenses; [
+      lgpl21
+      gpl3Plus
+    ];
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ tohmais ];
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11422,6 +11422,8 @@ with pkgs;
 
   sddm-chili-theme = libsForQt5.callPackage ../data/themes/chili-sddm { };
 
+  sddm-tokyo-night = libsForQt5.callPackage ../data/themes/sddm-tokyo-night { };
+
   sddm-sugar-dark = libsForQt5.callPackage ../data/themes/sddm-sugar-dark { };
 
   sdrangel = qt6Packages.callPackage ../applications/radio/sdrangel { };


### PR DESCRIPTION
Added the SDDM theme, [tokyo-night-sddm](https://github.com/siddrs/tokyo-night-sddm), which is based on sugar dark. Edited the name slightly to be more consistent with other SDDM theme packages.

First time contributor, so please tell me if I screwed something up! Made a new PR because the original didn't follow commit guidelines.

I found using some of the other SDDM theme packages frustrating, so I'm using `propagatedUserEnvPkgs` instead of `propagatedBuildInputs` or similar. That means you install the theme by:
```nix
services.displayManager.sddm = {
  enable = true;  
  theme = "tokyo-night";
};

environment.systemPackages = [ pkgs.sddm-tokyo-night];
```
Instead of having to add the package to both `environment.systemPackages` **and** `services.displayManager.sddm.extraPackages`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
