### PR TITLE
dbgate: 6.3.3 -> 6.4.1, improve update script

### DIFF
--- a/pkgs/by-name/db/dbgate/package.nix
+++ b/pkgs/by-name/db/dbgate/package.nix
@@ -8,25 +8,25 @@
 
 let
   pname = "dbgate";
-  version = "6.3.3";
+  version = "6.4.1";
   src =
     fetchurl
       {
         aarch64-linux = {
           url = "https://github.com/dbgate/dbgate/releases/download/v${version}/dbgate-${version}-linux_arm64.AppImage";
-          hash = "sha256-H4ACPBLmZ78JOCxgx/ZuP8yawh8XK9EN+CZh12uLf8g=";
+          hash = "sha256-GL/wJCr7VkfyoOusDXHdubOiaLgloxExqu3D41f5+4w=";
         };
         x86_64-linux = {
           url = "https://github.com/dbgate/dbgate/releases/download/v${version}/dbgate-${version}-linux_x86_64.AppImage";
-          hash = "sha256-lsQ3/O2Jr4VQ7pusiUYgUPiXu5WHEzLiUf+vmKC0tEo=";
+          hash = "sha256-VWG3Xwm7PFgt+7BpJGG/Q6UtRx/F/RE31mMFGAJBV3A=";
         };
         x86_64-darwin = {
           url = "https://github.com/dbgate/dbgate/releases/download/v${version}/dbgate-${version}-mac_x64.dmg";
-          hash = "sha256-1mO/wlvV+zaB7gLJcl8WfD9SnHdio8eXXHboyYBsWzU=";
+          hash = "sha256-GFH63KdA3JWkGIac8OmyY5mktAWE8mpvh4yjWJcX+kE=";
         };
         aarch64-darwin = {
           url = "https://github.com/dbgate/dbgate/releases/download/v${version}/dbgate-${version}-mac_universal.dmg";
-          hash = "sha256-EFKjPJZ2sghPFNYO/A3Ow2GTFyuTcB85VAuQZFn6Q3U=";
+          hash = "sha256-fK+mGogr8mdBpg9tGK23zNDv7zr9DJWq8Yq+5ddduXY=";
         };
       }
       .${stdenv.hostPlatform.system} or (throw "dbgate: ${stdenv.hostPlatform.system} is unsupported.");

--- a/pkgs/by-name/db/dbgate/update.sh
+++ b/pkgs/by-name/db/dbgate/update.sh
@@ -3,9 +3,11 @@
 
 set -euo pipefail
 
-currentVersion=$(nix-instantiate --eval -E "with import ./. {}; dbgate.version or (lib.getVersion dbgate)" | tr -d '"')
+BASEDIR="$(dirname "$0")/../../../.."
+
+currentVersion=$(nix-instantiate --eval -E "with import $BASEDIR {}; dbgate.version or (lib.getVersion dbgate)" | tr -d '"')
 nix-update dbgate
-latestVersion=$(nix-instantiate --eval -E "with import ./. {}; dbgate.version or (lib.getVersion dbgate)" | tr -d '"')
+latestVersion=$(nix-instantiate --eval -E "with import $BASEDIR {}; dbgate.version or (lib.getVersion dbgate)" | tr -d '"')
 
 if [[ "$currentVersion" == "$latestVersion" ]]; then
     echo "package is up-to-date: $currentVersion"
@@ -17,6 +19,6 @@ for system in \
     aarch64-linux \
     x86_64-darwin \
     aarch64-darwin; do
-    hash=$(nix hash convert --to sri --hash-algo sha256 $(nix-prefetch-url $(nix-instantiate --eval -E "with import ./. {}; dbgate.src.url" --system "$system" | tr -d '"')))
-    update-source-version dbgate $latestVersion $hash --system=$system --ignore-same-version
+    hash=$(nix hash convert --to sri --hash-algo sha256 $(nix-prefetch-url $(nix-instantiate --eval -E "with import $BASEDIR {}; dbgate.src.url" --system "$system" | tr -d '"')))
+    (cd $BASEDIR && update-source-version dbgate $latestVersion $hash --system=$system --ignore-same-version)
 done


### PR DESCRIPTION
Diff: https://github.com/dbgate/dbgate/compare/v6.3.3...v6.4.1

~~Fix update script which was broken since the package was moved to `by-name`~~

Make the script runnable from any directory now, not only the root of nixpkgs

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
