### PR TITLE
[staging] {nixos/}systemd: enable BTF; enable {nsresourced,mountfsd}

### DIFF
--- a/nixos/modules/system/boot/systemd.nix
+++ b/nixos/modules/system/boot/systemd.nix
@@ -205,6 +205,14 @@ let
     "dbus-org.freedesktop.portable1.service"
     "systemd-portabled.service"
   ]
+  ++ optionals cfg.package.withNsresourced [
+    "systemd-nsresourced.service"
+    "systemd-nsresourced.socket"
+  ]
+  ++ optionals cfg.package.withMountfsd [
+    "systemd-mountfsd.service"
+    "systemd-mountfsd.socket"
+  ]
   ++ [
     "systemd-exit.service"
     "systemd-update-done.service"

--- a/pkgs/os-specific/linux/kernel/manual-config.nix
+++ b/pkgs/os-specific/linux/kernel/manual-config.nix
@@ -183,14 +183,15 @@ lib.makeOverridable (
         ];
 
       in
-      (optionalAttrs isModular {
+      {
         outputs = [
           "out"
           "dev"
+        ]
+        ++ optionals isModular [
           "modules"
         ];
-      })
-      // {
+
         __structuredAttrs = true;
 
         passthru = rec {
@@ -445,10 +446,11 @@ lib.makeOverridable (
         # which trips the broken symlink check. So, just skip it. We'll know if it explodes.
         dontCheckForBrokenSymlinks = true;
 
-        postInstall = optionalString isModular ''
+        postInstall = ''
           mkdir -p $dev
           cp vmlinux $dev/
-
+        ''
+        + optionalString isModular ''
           mkdir -p $dev/lib/modules/${modDirVersion}/build/scripts
           cp -rL ../scripts/gdb/ $dev/lib/modules/${modDirVersion}/build/scripts
 
@@ -478,10 +480,10 @@ lib.makeOverridable (
           for f in arch/powerpc/lib/crtsavres.o arch/arm64/kernel/ftrace-mod.o; do
             if [ -f "$buildRoot/$f" ]; then
               cp $buildRoot/$f $dev/lib/modules/${modDirVersion}/build/$f
-            fi
+             fi
           done
 
-          # !!! No documentation on how much of the source tree must be kept
+            # !!! No documentation on how much of the source tree must be kept
           # If/when kernel builds fail due to missing files, you can add
           # them here. Note that we may see packages requiring headers
           # from drivers/ in the future; it adds 50M to keep all of its

--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -165,6 +165,8 @@
   withUserDb ? true,
   withUtmp ? !stdenv.hostPlatform.isMusl,
   withVmspawn ? true,
+  withNsresourced ? true,
+  withMountfsd ? true,
   # kernel-install shouldn't usually be used on NixOS, but can be useful, e.g. for
   # building disk images for non-NixOS systems. To save users from trying to use it
   # on their live NixOS system, we disable it by default.
@@ -196,6 +198,7 @@ assert withImportd -> (withGcrypt || withOpenSSL);
 assert withUkify -> (withEfi && withBootloader);
 assert withRepart -> withCryptsetup;
 assert withBootloader -> withEfi;
+assert withNsresourced -> withLibBPF;
 
 let
   wantCurl = withRemote || withImportd;
@@ -603,6 +606,8 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.mesonBool "hwdb" withHwdb)
     (lib.mesonBool "timedated" withTimedated)
     (lib.mesonBool "timesyncd" withTimesyncd)
+    (lib.mesonBool "nsresourced" withNsresourced)
+    (lib.mesonBool "mountfsd" withMountfsd)
     (lib.mesonBool "userdb" withUserDb)
     (lib.mesonBool "coredump" withCoredump)
     (lib.mesonBool "firstboot" withFirstboot)
@@ -941,6 +946,8 @@ stdenv.mkDerivation (finalAttrs: {
       withPortabled
       withSysupdate
       withTimedated
+      withNsresourced
+      withMountfsd
       withTpm2Tss
       withUtmp
       util-linux

--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -18,6 +18,7 @@
   glibcLocales,
   autoPatchelfHook,
   fetchpatch,
+  callPackage,
 
   # glib is only used during tests (test-bus-gvariant, test-bus-marshal)
   glib,
@@ -86,6 +87,10 @@
   # closure of GHC via emscripten and jdk.
   bpftools,
   libbpf,
+
+  # vmlinux.h file containing the kernel's BTF information,
+  # used throughout systemd's BPF programs.
+  vmlinux-btf ? callPackage ./vmlinux-btf.nix { },
 
   # Needed to produce a ukify that works for cross compiling UKIs.
   targetPackages,
@@ -615,6 +620,10 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.mesonBool "b_pie" true)
 
   ]
+  ++ lib.optionals withLibBPF [
+    (lib.mesonOption "vmlinux-h" "provided")
+    (lib.mesonOption "vmlinux-h-path" "${vmlinux-btf}/vmlinux.h")
+  ]
   ++ lib.optionals (withShellCompletions == false) [
     (lib.mesonOption "bashcompletiondir" "no")
     (lib.mesonOption "zshcompletiondir" "no")
@@ -936,6 +945,7 @@ stdenv.mkDerivation (finalAttrs: {
       withUtmp
       util-linux
       kmod
+      vmlinux-btf
       ;
 
     kbd = kbd';

--- a/pkgs/os-specific/linux/systemd/vmlinux-btf.nix
+++ b/pkgs/os-specific/linux/systemd/vmlinux-btf.nix
@@ -1,0 +1,60 @@
+{
+  lib,
+  linuxManualConfig,
+  linuxConfig,
+  mergeKernelConfigs,
+  linuxHeaders,
+  bpftools,
+  runCommand,
+  writeText,
+}:
+let
+  # Create a minimal kernel config file, which is sufficient for the BTF
+  # that systemd uses.
+  configfile =
+    let
+      baseConfig = linuxConfig {
+        inherit (linuxHeaders) src;
+        makeTarget = "allnoconfig";
+      };
+      extraConfig = writeText "systemd-btf.config" ''
+        CONFIG_BPF=y
+        CONFIG_BPF_SYSCALL=y
+        CONFIG_BPF_JIT=y
+        CONFIG_BPF_JIT_ALWAYS_ON=y
+        CONFIG_BPF_JIT_DEFAULT_ON=y
+        CONFIG_CGROUPS=y
+        CONFIG_CGROUP_BPF=y
+        CONFIG_DEBUG_KERNEL=y
+        CONFIG_DEBUG_INFO=y
+        CONFIG_DEBUG_INFO_DWARF_TOOLCHAIN_DEFAULT=y
+        CONFIG_DEBUG_INFO_BTF=y
+      '';
+    in
+    mergeKernelConfigs {
+      configs = [
+        baseConfig
+        extraConfig
+      ];
+      inherit (linuxHeaders) src;
+    };
+
+  # The actual kernel ELF.
+  vmlinux = linuxManualConfig {
+    inherit (linuxHeaders) version src;
+    inherit configfile;
+  };
+in
+runCommand "systemd-btf"
+  {
+    inherit (linuxHeaders) version;
+    nativeBuildInputs = [
+      bpftools
+    ];
+    meta.description = "BTF for systemd";
+    passthru.kernel = vmlinux;
+  }
+  ''
+    mkdir -p $out
+    bpftool btf dump file ${vmlinux.dev}/vmlinux format c > $out/vmlinux.h
+  ''

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10752,6 +10752,8 @@ with pkgs;
     withVmspawn = false;
     withQrencode = false;
     withLibarchive = false;
+    withNsresourced = false;
+    withMountfsd = false;
   };
   systemdLibs = systemdMinimal.override {
     pname = "systemd-minimal-libs";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10480,7 +10480,12 @@ with pkgs;
 
   linuxKernel = recurseIntoAttrs (callPackage ./linux-kernels.nix { });
 
-  inherit (linuxKernel) buildLinux linuxConfig kernelPatches;
+  inherit (linuxKernel)
+    buildLinux
+    linuxConfig
+    mergeKernelConfigs
+    kernelPatches
+    ;
 
   linuxPackagesFor = linuxKernel.packagesFor;
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Re-target of #404715 against staging.

This adds support for rootless systemd-nspawn containers on NixOS by doing a few things:
- Changing the `linuxManualConfig` builder by unconditionally emitting a `vmlinux` ELF in the `dev` output, not just when `CONFIG_MODULES=y` (also removing an IFD requirement for that).
- Adding BTF information for the systemd package's BPF programs, which are a prerequisite for `nsresourced` and `mountfsd`. This is achieved by building a minimal custom kernel, generating a `vmlinux.h` file from that, and consuming that in systemd. This does not create a strong dependency between the systemd package and a specific kernel version, as 
the header file is only used for initial compilation, and BPF symbols are being relocated at runtime later on using BPF CO-RE.
- Adding toggles for the `systemd-{nsresourced,mountfsd}` binaries in the systemd package. These are passed-through, to be consumed by the NixOS module.
- Conditionally enabling the aforementioned units in the NixOS module for systemd.

Change can be quickly verified by the following pre-change and post-change:
```sh
sudo $(nix build .#systemd.out --print-out-paths --no-link)/lib/systemd/systemd-nsresourced
```

Prior to the change, this will show:
```
Not setting up BPF subsystem, as functionality has been disabled at compile time.
```

After the change:
```
userns-restrict BPF-LSM program userns_restrict_path_chown attached.
userns-restrict BPF-LSM program userns_restrict_path_mkdir attached.
userns-restrict BPF-LSM program userns_restrict_path_mknod attached.
userns-restrict BPF-LSM program userns_restrict_path_symlink attached.
userns-restrict BPF-LSM program userns_restrict_path_link attached.
userns-restrict BPF-LSM program userns_restrict_free_user_ns attached.
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
