### PR TITLE
haproxy: add support for `aws-lc`

### DIFF
--- a/pkgs/by-name/ha/haproxy/package.nix
+++ b/pkgs/by-name/ha/haproxy/package.nix
@@ -9,23 +9,30 @@
   nixosTests,
   zlib,
   libxcrypt,
-  wolfssl,
+  aws-lc,
   libressl,
-  quictls,
   openssl,
+  quictls,
+  wolfssl,
   lua5_4,
   pcre2,
 }:
 
 assert lib.assertOneOf "sslLibrary" sslLibrary [
-  "quictls"
-  "openssl"
+  "aws-lc"
   "libressl"
+  "openssl"
+  "quictls"
   "wolfssl"
 ];
 let
   sslPkgs = {
-    inherit quictls openssl libressl;
+    inherit
+      aws-lc
+      libressl
+      openssl
+      quictls
+      ;
     wolfssl = wolfssl.override {
       variant = "haproxy";
       extraConfigureFlags = [ "--enable-quic" ];
@@ -76,6 +83,9 @@ stdenv.mkDerivation (finalAttrs: {
       "SSL_INC=${lib.getDev sslPkg}/include"
       "SSL_LIB=${lib.getDev sslPkg}/lib"
       "USE_QUIC=yes"
+    ]
+    ++ lib.optionals (sslLibrary == "aws-lc") [
+      "USE_OPENSSL_AWSLC=true"
     ]
     ++ lib.optionals (sslLibrary == "openssl") [
       "USE_QUIC_OPENSSL_COMPAT=yes"

--- a/pkgs/by-name/ha/haproxy/package.nix
+++ b/pkgs/by-name/ha/haproxy/package.nix
@@ -104,7 +104,6 @@ stdenv.mkDerivation (finalAttrs: {
       "LUA_INC=${lua5_4}/include"
     ]
     ++ lib.optionals stdenv.hostPlatform.isLinux [
-      "USE_SYSTEMD=yes"
       "USE_GETADDRINFO=1"
     ]
     ++ lib.optionals withPrometheusExporter [


### PR DESCRIPTION
Support using `aws-lc` as SSL library.

The NixOS test works fine when using `aws-lc` as `sslLibrary`: 

```nix
{ haproxy }:
(haproxy.override { sslLibrary = "aws-lc"; }).tests.haproxy
```

Also remove the no longer existing `USE_SYSTEMD` flag: https://github.com/haproxy/haproxy/commit/15845247db4527f1cc594b48e60e9b99bc4a498f

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
