### PR TITLE
python3Packages.thinc: 9.1.1 -> 8.3.6, revert fixes python3Packages.spacy

### DIFF
--- a/pkgs/development/python-modules/spacy/default.nix
+++ b/pkgs/development/python-modules/spacy/default.nix
@@ -144,7 +144,5 @@ buildPythonPackage rec {
     license = lib.licenses.mit;
     maintainers = [ ];
     mainProgram = "spacy";
-    # Cython.Compiler.Errors.CompileError: spacy/ml/parser_model.pyx
-    broken = true;
   };
 }

--- a/pkgs/development/python-modules/thinc/default.nix
+++ b/pkgs/development/python-modules/thinc/default.nix
@@ -6,7 +6,7 @@
   catalogue,
   confection,
   cymem,
-  cython_0,
+  cython,
   fetchPypi,
   hypothesis,
   mock,
@@ -22,23 +22,18 @@
 
 buildPythonPackage rec {
   pname = "thinc";
-  version = "9.1.1";
+  version = "8.3.6";
   pyproject = true;
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-IfrimG13d6bwULkEbcnqsRhS8cmpl9zJAy8+zCJ4Sko=";
+    hash = "sha256-SZg/m33cQ0OpUyaUqRGN0hbXpgBSCiGEmkO2wmjsbK0=";
   };
-
-  postPatch = ''
-    substituteInPlace pyproject.toml setup.cfg \
-      --replace-fail "blis>=1.0.0,<1.1.0" blis
-  '';
 
   build-system = [
     blis
     cymem
-    cython_0
+    cython
     murmurhash
     numpy
     preshed


### PR DESCRIPTION
The `pyproject.toml` of `spaCY==3.8.5` (latest version, present in nixpkgs) currently requires `"thinc>=8.3.4,<8.4.0",`.
https://github.com/explosion/spaCy/blob/master/pyproject.toml

The file `pkgs/development/python-modules/thinc/default.nix` currently packages version `9.1.1`.

## Things done

This branch returns the version `8.3.6` of `thinc` into `nixpkgs` as `thinc_8` and makes `spacy` use it, which solved the compilation issue in my experiments.

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
