### PR TITLE
labels: prevent labelling PRs to staging-next as backport

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -7,7 +7,8 @@
   - any:
     - base-branch:
       - '^release-'
-      - '^staging-'
+      - '^staging-\d'
+      - '^staging-next-\d'
 
 # NOTE: bsd, darwin and cross-compilation labels are handled by ofborg
 "6.topic: agda":


### PR DESCRIPTION
In #402332, I introduced the `4.workflow: backport` label, which should be applied to all PRs targeting stable branches. However, it was added to PRs targeting `staging-next` as well. Examples: #398213, #404293, #403479

This change should not do that anymore.

## Things done

- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
