### PR TITLE
botan: 3.6.1 -> 3.8.1

### DIFF
--- a/pkgs/by-name/es/esdm/package.nix
+++ b/pkgs/by-name/es/esdm/package.nix
@@ -23,13 +23,13 @@
   drngChaCha20 ? false, # set the default drng callback
   ais2031 ? false, # set the seeding strategy to be compliant with AIS 20/31
   sp80090c ? false, # set compliance with NIST SP800-90C
-  cryptoBackend ? "botan", # set backend for hash and drbg operations
+  cryptoBackend ? "builtin", # set backend for hash and drbg operations
   linuxDevFiles ? true, # enable linux /dev/random and /dev/urandom support
   linuxGetRandom ? true, # enable linux getrandom support
   hashSha512 ? false, # set the conditioning hash: SHA2-512
   hashSha3_512 ? true, # set the conditioning hash: SHA3-512
-  openSSLRandProvider ? true, # build ESDM provider for OpenSSL 3.x
-  botanRng ? true, # build ESDM class for Botan 3.x
+  openSSLRandProvider ? false, # build ESDM provider for OpenSSL 3.x
+  botanRng ? false, # build ESDM class for Botan 3.x
 
   # client-related options (handle with care, consult source code and meson options)
   # leave as is if in doubt
@@ -56,10 +56,7 @@
 
 assert drngHashDrbg != drngChaCha20;
 assert hashSha512 != hashSha3_512;
-assert
-  cryptoBackend == "openssl"
-  || cryptoBackend == "botan"
-  || cryptoBackend == "builtin" "Unsupported ESDM crypto backend";
+assert cryptoBackend == "openssl" || cryptoBackend == "botan" || cryptoBackend == "builtin";
 
 stdenv.mkDerivation rec {
   pname = "esdm";

--- a/pkgs/development/libraries/botan/default.nix
+++ b/pkgs/development/libraries/botan/default.nix
@@ -7,8 +7,22 @@
   bzip2,
   zlib,
   jitterentropy,
+  darwin,
+  esdm,
+  tpm2-tss,
   static ? stdenv.hostPlatform.isStatic, # generates static libraries *only*
+
+  # build ESDM RNG plugin
+  with_esdm ? false,
+  # useful, but have to disable tests for now, as /dev/tpmrm0 is not accessible
+  with_tpm2 ? false,
+  # only allow BSI approved algorithms, FFI and SHAKE for XMSS
+  with_bsi_policy ? false,
+  # only allow NIST approved algorithms
+  with_fips140_policy ? false,
 }:
+
+assert (!with_bsi_policy && !with_fips140_policy) || (with_bsi_policy != with_fips140_policy);
 
 let
   common =
@@ -50,9 +64,14 @@ let
           bzip2
           zlib
         ]
-
+        ++ lib.optionals (stdenv.hostPlatform.isLinux && with_tpm2) [
+          tpm2-tss
+        ]
         ++ lib.optionals (lib.versionAtLeast version "3.6.0") [
           jitterentropy
+        ]
+        ++ lib.optionals (lib.versionAtLeast version "3.7.0" && with_esdm) [
+          esdm
         ];
 
       buildTargets =
@@ -77,8 +96,22 @@ let
         ++ lib.optionals stdenv.cc.isClang [
           "--cc=clang"
         ]
+        ++ lib.optionals (stdenv.hostPlatform.isLinux && with_tpm2) [
+          "--with-tpm2"
+        ]
         ++ lib.optionals (lib.versionAtLeast version "3.6.0") [
           "--enable-modules=jitter_rng"
+        ]
+        ++ lib.optionals (lib.versionAtLeast version "3.7.0" && with_esdm) [
+          "--enable-modules=esdm_rng"
+        ]
+        ++ lib.optionals (lib.versionAtLeast version "3.8.0" && with_bsi_policy) [
+          "--module-policy=bsi"
+          "--enable-module=ffi"
+          "--enable-module=shake"
+        ]
+        ++ lib.optionals (lib.versionAtLeast version "3.8.0" && with_fips140_policy) [
+          "--module-policy=fips140"
         ];
 
       configurePhase = ''
@@ -115,8 +148,8 @@ let
 in
 {
   botan3 = common {
-    version = "3.6.1";
-    hash = "sha256-fLhXXYjSMsdxdHadf54ku0REQWBYWYbuvWbnScuakIk=";
+    version = "3.8.1";
+    hash = "sha256-sDloHUuGGi9YU3Rti6gG9VPiOGntctie2/o8Pb+hfmg=";
   };
 
   botan2 = common {


### PR DESCRIPTION
- Update botan to 3.8.1 including performance optimizations for elliptic curves.
- Fix build of esdm with botan 3.8.1

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
