### PR TITLE
anubis: split xess derivation into a separate package

### DIFF
--- a/pkgs/by-name/an/anubis-xess/package.nix
+++ b/pkgs/by-name/an/anubis-xess/package.nix
@@ -1,0 +1,35 @@
+{ buildNpmPackage, anubis }:
+
+buildNpmPackage {
+  pname = "${anubis.pname}-xess";
+  inherit (anubis) version src;
+
+  npmDepsHash = "sha256-hTKTTBmfMGv6I+4YbWrOt6F+qD6ysVYi+DEC1konBFk=";
+
+  buildPhase = ''
+    runHook preBuild
+
+    npx postcss ./xess/xess.css -o xess.min.css
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm644 xess.min.css $out/xess.min.css
+
+    runHook postInstall
+  '';
+
+  meta = anubis.meta // {
+    description = "Xess files for Anubis";
+    longDescription = ''
+      This package is consumed by the main `anubis` package to render the final
+      styling for the bot check page.
+
+      **It is not supposed to be used as a standalone package**, and it exists to
+      ensure Anubis' styling is override-able by downstreams.
+    '';
+  };
+}

--- a/pkgs/by-name/an/anubis/package.nix
+++ b/pkgs/by-name/an/anubis/package.nix
@@ -1,49 +1,27 @@
 {
   lib,
   buildGoModule,
-  buildNpmPackage,
   fetchFromGitHub,
-  nix-update-script,
   nixosTests,
   stdenv,
+
+  anubis-xess,
 
   esbuild,
   brotli,
   zstd,
 }:
-let
+
+buildGoModule (finalAttrs: {
   pname = "anubis";
   version = "1.18.0";
 
   src = fetchFromGitHub {
     owner = "TecharoHQ";
     repo = "anubis";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-grtzkNxgShbldjm+lnANbKVhkUrbwseAT1NaBL85mHg=";
   };
-
-  anubisXess = buildNpmPackage {
-    inherit version src;
-    pname = "${pname}-xess";
-
-    npmDepsHash = "sha256-hTKTTBmfMGv6I+4YbWrOt6F+qD6ysVYi+DEC1konBFk=";
-
-    buildPhase = ''
-      runHook preBuild
-      npx postcss ./xess/xess.css -o xess.min.css
-      runHook postBuild
-    '';
-
-    installPhase = ''
-      runHook preInstall
-      mkdir -p $out
-      cp xess.min.css $out
-      runHook postInstall
-    '';
-  };
-in
-buildGoModule (finalAttrs: {
-  inherit pname version src;
 
   vendorHash = "sha256-EOT/sdVINj9oO1jZHPYB3jQ+XApf9eCUKuMY0tV+vpg=";
 
@@ -72,27 +50,25 @@ buildGoModule (finalAttrs: {
   '';
 
   preBuild = ''
-    go generate ./... && ./web/build.sh && cp -r ${anubisXess}/xess.min.css ./xess
+    go generate ./... && ./web/build.sh && cp -r ${anubis-xess}/xess.min.css ./xess
   '';
 
   preCheck = ''
     export DONT_USE_NETWORK=1
   '';
 
-  passthru = {
-    tests = { inherit (nixosTests) anubis; };
-    updateScript = nix-update-script { };
-  };
+  passthru.tests = { inherit (nixosTests) anubis; };
 
   meta = {
     description = "Weighs the soul of incoming HTTP requests using proof-of-work to stop AI crawlers";
-    homepage = "https://github.com/TecharoHQ/anubis/";
+    homepage = "https://anubis.techaro.lol/";
     changelog = "https://github.com/TecharoHQ/anubis/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
       knightpp
       soopyc
       ryand56
+      sigmasquadron
     ];
     mainProgram = "anubis";
   };


### PR DESCRIPTION
Unfortunately, because the Xess file needs to be pre-processed and consumed by the final derivation, it couldn't be overridden if it was written in-line. This commit splits it into a separate `anubis-xess` package that can be overridden/overlayed.

This also adds myself as a maintainer for Anubis, and removes the `nix-update-script` call, since it was never necessary (because Anubis is hosted on GitHub), stopped working after e049c438a985eca2c9e2c6bf35fd6e3ea8b655ac, and it certainly won't work now. It also corrects the homepage URL.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
