### PR TITLE
catspeak: init at 0.4.0

### DIFF
--- a/pkgs/by-name/ca/catspeak/package.nix
+++ b/pkgs/by-name/ca/catspeak/package.nix
@@ -4,24 +4,24 @@
   rustPlatform,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "catspeak";
   version = "0.4.0";
 
   src = fetchFromGitHub {
     owner = "SchweGELBin";
     repo = "catspeak";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-2NYYnhIsfE889fvbTimPVTy6dCR+i/1WaGT4Dhfuyno=";
   };
 
   cargoHash = "sha256-8PATds7OaD7/8FQ6XDKrCMdTcpZwi453UYq9dX/sSBk=";
 
-  meta = with lib; {
+  meta = {
     description = "A cowsay like program of a speaking cat, written in rust.";
     homepage = "https://github.com/SchweGELBin/catspeak";
-    changelog = "https://github.com/SchweGELBin/catspeak/blob/main/CHANGELOG.md";
-    license = licenses.mit;
-    maintainers = with maintainers; [ SchweGELBin ];
+    changelog = "https://github.com/SchweGELBin/catspeak/blob/v${finalAttrs.version}/CHANGELOG.md";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ SchweGELBin ];
   };
-}
+})

--- a/pkgs/by-name/ca/catspeak/package.nix
+++ b/pkgs/by-name/ca/catspeak/package.nix
@@ -1,0 +1,27 @@
+{
+  lib,
+  fetchFromGitHub,
+  rustPlatform,
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "catspeak";
+  version = "0.4.0";
+
+  src = fetchFromGitHub {
+    owner = "SchweGELBin";
+    repo = "catspeak";
+    tag = "v${version}";
+    hash = "sha256-2NYYnhIsfE889fvbTimPVTy6dCR+i/1WaGT4Dhfuyno=";
+  };
+
+  cargoHash = "sha256-8PATds7OaD7/8FQ6XDKrCMdTcpZwi453UYq9dX/sSBk=";
+
+  meta = with lib; {
+    description = "A cowsay like program of a speaking cat, written in rust.";
+    homepage = "https://github.com/SchweGELBin/catspeak";
+    changelog = "https://github.com/SchweGELBin/catspeak/blob/main/CHANGELOG.md";
+    license = licenses.mit;
+    maintainers = with maintainers; [ SchweGELBin ];
+  };
+}

--- a/pkgs/by-name/ca/catspeak/package.nix
+++ b/pkgs/by-name/ca/catspeak/package.nix
@@ -18,7 +18,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   cargoHash = "sha256-8PATds7OaD7/8FQ6XDKrCMdTcpZwi453UYq9dX/sSBk=";
 
   meta = {
-    description = "A cowsay like program of a speaking cat, written in rust.";
+    description = "Cowsay like program of a speaking cat";
     homepage = "https://github.com/SchweGELBin/catspeak";
     changelog = "https://github.com/SchweGELBin/catspeak/blob/v${finalAttrs.version}/CHANGELOG.md";
     license = lib.licenses.mit;

--- a/pkgs/by-name/ca/catspeak/package.nix
+++ b/pkgs/by-name/ca/catspeak/package.nix
@@ -22,6 +22,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     homepage = "https://github.com/SchweGELBin/catspeak";
     changelog = "https://github.com/SchweGELBin/catspeak/blob/v${finalAttrs.version}/CHANGELOG.md";
     license = lib.licenses.mit;
+    mainProgram = "catspeak";
     maintainers = with lib.maintainers; [ SchweGELBin ];
   };
 })


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

https://github.com/SchweGELBin/catspeak/releases/tag/v0.4.0

A [cowsay](https://github.com/piuccio/cowsay) like program of a speaking cat, written in rust.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
