### PR TITLE
fix(ci/eval-stats): resolve prResult symlink

### DIFF
--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -219,7 +219,7 @@ jobs:
           # Use the target branch to get accurate maintainer info
           nix-build target/ci -A eval.compare \
             --arg beforeResultDir ./targetResult \
-            --arg afterResultDir ./prResult \
+            --arg afterResultDir $(realpath prResult) \
             --arg touchedFilesJson ./touched-files.json \
             -o comparison
 

--- a/ci/eval/compare/cmp-stats.py
+++ b/ci/eval/compare/cmp-stats.py
@@ -60,6 +60,7 @@ def load_all_metrics(directory: Path) -> dict:
     return metrics
 
 def dataframe_to_markdown(df: pd.DataFrame) -> str:
+    df = df.sort_values(by=df.columns[0], ascending=True)
     markdown_lines = []
 
     # Header (get column names and format them)


### PR DESCRIPTION
### Fixes the performance stats report.

The problem that can be observed is that the prResult seems to not contain a `/stats` subdirectory. So also this PR should also omit the performance report, because the eval.yaml from master is executed.

I tested the solution [here](https://github.com/hsjobeki/nixpkgs/actions/runs/14887350172)

This seems to be caused because prResult is a symlink pointing into the nix-store. Weirdly calling `Path(prResult).resolve()` in python inside the derivation doesn't work. 

in constrast i now used `realpath` directly which works.

I didn't manage to find the exact root-cause why `realpath` and `resolve()` behave differently. Here are some of my guesses:

- realpath (shell): resolves symlinks fully and immediately, returning an absolute path to the actual directory or file.
- Path.resolve() (Python): attempts the same, but behaves more conservatively
- The Python interpreter runs in a sandboxed environment, where symlink resolution doesn't always behave as in normal environments.

## Things done

- [x] Fixed resolving the stats directory correctly 
- [x] Alphabetical sorting of the output

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
