### PR TITLE
nim-2_2: remove left-over, unused, darwin.Security

### DIFF
--- a/pkgs/by-name/ni/nim-2_2/package.nix
+++ b/pkgs/by-name/ni/nim-2_2/package.nix
@@ -9,7 +9,6 @@
   openssl,
   pcre,
   nim-unwrapped-2_2 ? buildPackages.nim-unwrapped-2_2,
-  Security ? darwin.Security,
 }:
 
 let

--- a/pkgs/by-name/ni/nim-unwrapped-2_2/package.nix
+++ b/pkgs/by-name/ni/nim-unwrapped-2_2/package.nix
@@ -10,7 +10,6 @@
   readline,
   sqlite,
   darwin,
-  Security ? darwin.Security,
 }:
 
 let


### PR DESCRIPTION
Found after #404978

## Things done

- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
