### PR TITLE
[24.11] postgresql_16: 16.8 -> 16.9

### DIFF
--- a/pkgs/servers/sql/postgresql/16.nix
+++ b/pkgs/servers/sql/postgresql/16.nix
@@ -1,7 +1,7 @@
 import ./generic.nix {
-  version = "16.8";
-  rev = "refs/tags/REL_16_8";
-  hash = "sha256-nVUGBuvCDFXozTyEDAAQa+IR3expCdztH90J68FhAXQ=";
+  version = "16.9";
+  rev = "refs/tags/REL_16_9";
+  hash = "sha256-CLLCT4wiCWeLqMdtGdXM2/DtlENLWSey6nNtOcfNPRw=";
   muslPatches = {
     dont-use-locale-a = {
       url = "https://git.alpinelinux.org/aports/plain/main/postgresql16/dont-use-locale-a-on-musl.patch?id=08a24be262339fd093e641860680944c3590238e";


### PR DESCRIPTION
Split from #405012.

Backport of #405012

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] x86_64-linux JIT
  - [ ] x86_64-linux pkgsMusl
  - [ ] x86_64-linux pkgsMusl JIT
  - [x] aarch64-linux
  - [x] aarch64-linux JIT
  - [ ] x86_64-darwin
  - [ ] x86_64-darwin JIT
  - [x] aarch64-darwin
  - [x] aarch64-darwin JIT
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
