### PR TITLE
python3Packages.typedload: init at 2.37

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -19959,6 +19959,17 @@
     github = "ppenguin";
     githubId = 17690377;
   };
+  ppentchev = {
+    name = "Peter Pentchev";
+    email = "roam@ringlet.net";
+    github = "ppentchev";
+    githubId = 453114;
+    keys = [
+      {
+        fingerprint = "2EE7 A7A5 17FC 124C F115  C354 651E EFB0 2527 DF13";
+      }
+    ];
+  };
   ppom = {
     name = "ppom";
     email = "ppom@ecomail.fr";

--- a/pkgs/development/python-modules/typedload/default.nix
+++ b/pkgs/development/python-modules/typedload/default.nix
@@ -23,7 +23,7 @@ buildPythonPackage rec {
 
   build-system = [ setuptools ];
 
-  preBuild = "python3 gensetup.py --pyproject.toml; rm -rf perftest;";
+  preBuild = "python${python.pythonVersion} gensetup.py --pyproject.toml; rm -rf perftest;";
 
   nativeCheckInputs = [
     attrs

--- a/pkgs/development/python-modules/typedload/default.nix
+++ b/pkgs/development/python-modules/typedload/default.nix
@@ -1,0 +1,45 @@
+{
+  attrs,
+  buildPythonPackage,
+  fetchFromGitea,
+  lib,
+  pytestCheckHook,
+  python,
+  setuptools,
+}:
+
+buildPythonPackage rec {
+  pname = "typedload";
+  version = "2.37";
+  pyproject = true;
+
+  src = fetchFromGitea {
+    domain = "codeberg.org";
+    owner = "ltworf";
+    repo = pname;
+    rev = version;
+    hash = "sha256-H7w2+yVsQPnvVD8Ro/Ibx5gECm/odF7ssV26JrXkN6w=";
+  };
+
+  build-system = [ setuptools ];
+
+  preBuild = "python3 gensetup.py --pyproject.toml; rm -rf perftest;";
+
+  nativeCheckInputs = [
+    attrs
+    pytestCheckHook
+  ];
+  disabledTestPaths =
+    [ ]
+    ++ lib.optionals (python.pythonOlder "3.10") [ "tests/test_orunion.py" ]
+    ++ lib.optionals (python.pythonOlder "3.12") [ "tests/test_typealias.py" ];
+
+  pythonImportsCheck = [ "typedload" ];
+
+  meta = with lib; {
+    homepage = "https://ltworf.github.io/typedload/";
+    description = "Load and dump json-like data into typed data structures";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ ppentchev ];
+  };
+}

--- a/pkgs/development/python-modules/typedload/default.nix
+++ b/pkgs/development/python-modules/typedload/default.nix
@@ -23,7 +23,7 @@ buildPythonPackage rec {
 
   build-system = [ setuptools ];
 
-  preBuild = "python${python.pythonVersion} gensetup.py --pyproject.toml; rm -rf perftest;";
+  preBuild = "${python.interpreter} gensetup.py --pyproject.toml; rm -rf perftest;";
 
   nativeCheckInputs = [
     attrs

--- a/pkgs/development/python-modules/typedload/default.nix
+++ b/pkgs/development/python-modules/typedload/default.nix
@@ -36,10 +36,11 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "typedload" ];
 
-  meta = with lib; {
+  meta = {
     homepage = "https://ltworf.github.io/typedload/";
+    changelog = "https://ltworf.codeberg.page/typedload/CHANGELOG.html";
     description = "Load and dump json-like data into typed data structures";
-    license = licenses.gpl3;
-    maintainers = with maintainers; [ ppentchev ];
+    license = lib.licenses.gpl3;
+    maintainers = with lib.maintainers; [ ppentchev ];
   };
 }

--- a/pkgs/development/python-modules/typedload/default.nix
+++ b/pkgs/development/python-modules/typedload/default.nix
@@ -16,7 +16,7 @@ buildPythonPackage rec {
   src = fetchFromGitea {
     domain = "codeberg.org";
     owner = "ltworf";
-    repo = pname;
+    repo = "typedload";
     rev = version;
     hash = "sha256-H7w2+yVsQPnvVD8Ro/Ibx5gECm/odF7ssV26JrXkN6w=";
   };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -18095,6 +18095,8 @@ self: super: with self; {
 
   typed-settings = callPackage ../development/python-modules/typed-settings { };
 
+  typedload = callPackage ../development/python-modules/typedload { };
+
   typedunits = callPackage ../development/python-modules/typedunits { };
 
   typeguard = callPackage ../development/python-modules/typeguard { };


### PR DESCRIPTION
Add the typedload Python package as found at https://pypi.org/projects/typedload so that Python programs and libraries can perform trivial deserialization of e.g. dataclasses from data loaded into Python structures. The typedload library is much more lightweight than more sophisticated frameworks like mashumaro.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - the package's unit tests are invoked using `pytestCheckHook`
[x]Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
  - since this is the initial version of typedload, there are no dependent packages; however, I have tested its use in other, as yet not included, packages of my own, e.g. [typed-format-version](https://gitlab.com/ppentchev/typed-format-version/-/commit/a662df279523c7372651da9980407afbf8cb8fc7)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
