### PR TITLE
release.nix: don't use special treatment for more package sets

### DIFF
--- a/pkgs/os-specific/darwin/xcode/default.nix
+++ b/pkgs/os-specific/darwin/xcode/default.nix
@@ -46,6 +46,7 @@ let
         description = "Apple's XCode SDK";
         license = licenses.unfree;
         platforms = platforms.darwin ++ platforms.linux;
+        hydraPlatforms = [ ];
         sourceProvenance = [ sourceTypes.binaryNativeCode ];
       };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5498,7 +5498,7 @@ with pkgs;
 
   gwt240 = callPackage ../development/compilers/gwt/2.4.0.nix { };
 
-  idrisPackages = dontRecurseIntoAttrs (
+  idrisPackages = recurseIntoAttrs (
     callPackage ../development/idris-modules {
       idris-no-deps = haskellPackages.idris;
       pkgs = pkgs.__splicedPackages;
@@ -9615,9 +9615,11 @@ with pkgs;
 
   ### DEVELOPMENT / LIBRARIES / AGDA
 
-  agdaPackages = callPackage ./agda-packages.nix {
-    inherit (haskellPackages) Agda;
-  };
+  agdaPackages = recurseIntoAttrs (
+    callPackage ./agda-packages.nix {
+      inherit (haskellPackages) Agda;
+    }
+  );
   agda = agdaPackages.agda;
 
   ### DEVELOPMENT / LIBRARIES / BASH
@@ -10758,7 +10760,7 @@ with pkgs;
   # Even though this is a set of packages not single package, use `callPackage`
   # not `callPackages` so the per-package callPackages don't have their
   # `.override` clobbered. C.F. `llvmPackages` which does the same.
-  darwin = recurseIntoAttrs (callPackage ./darwin-packages.nix { });
+  darwin = callPackage ./darwin-packages.nix { };
 
   displaylink = callPackage ../os-specific/linux/displaylink {
     inherit (linuxPackages) evdi;

--- a/pkgs/top-level/darwin-packages.nix
+++ b/pkgs/top-level/darwin-packages.nix
@@ -44,175 +44,177 @@ makeScopeWithSplicing' {
       impure-cmds = pkgs.callPackage ../os-specific/darwin/impure-cmds { };
     in
 
-    impure-cmds
-    // apple-source-packages
-    // {
+    lib.recurseIntoAttrs (
+      impure-cmds
+      // apple-source-packages
+      // {
 
-      inherit (self.adv_cmds) ps;
+        inherit (self.adv_cmds) ps;
 
-      binutils-unwrapped = callPackage ../os-specific/darwin/binutils {
-        inherit (pkgs) cctools;
-        inherit (pkgs.llvmPackages) clang-unwrapped llvm llvm-manpages;
-      };
+        binutils-unwrapped = callPackage ../os-specific/darwin/binutils {
+          inherit (pkgs) cctools;
+          inherit (pkgs.llvmPackages) clang-unwrapped llvm llvm-manpages;
+        };
 
-      binutils = pkgs.wrapBintoolsWith {
-        inherit (targetPackages) libc;
-        bintools = self.binutils-unwrapped;
-      };
+        binutils = pkgs.wrapBintoolsWith {
+          inherit (targetPackages) libc;
+          bintools = self.binutils-unwrapped;
+        };
 
-      # x86-64 Darwin gnat-bootstrap emits assembly
-      # with MOVQ as the mnemonic for quadword interunit moves
-      # such as `movq %rbp, %xmm0`.
-      # The clang integrated assembler recognises this as valid,
-      # but unfortunately the cctools.gas GNU assembler does not;
-      # it instead uses MOVD as the mnemonic.
-      # The assembly that a GCC build emits is determined at build time
-      # and cannot be changed afterwards.
-      #
-      # To build GNAT on x86-64 Darwin, therefore,
-      # we need both the clang _and_ the cctools.gas assemblers to be available:
-      # the former to build at least the stage1 compiler,
-      # and the latter at least to be detectable
-      # as the target for the final compiler.
-      binutilsDualAs-unwrapped = pkgs.buildEnv {
-        name = "${lib.getName self.binutils-unwrapped}-dualas-${lib.getVersion self.binutils-unwrapped}";
-        paths = [
-          self.binutils-unwrapped
-          (lib.getOutput "gas" pkgs.cctools)
-        ];
-      };
+        # x86-64 Darwin gnat-bootstrap emits assembly
+        # with MOVQ as the mnemonic for quadword interunit moves
+        # such as `movq %rbp, %xmm0`.
+        # The clang integrated assembler recognises this as valid,
+        # but unfortunately the cctools.gas GNU assembler does not;
+        # it instead uses MOVD as the mnemonic.
+        # The assembly that a GCC build emits is determined at build time
+        # and cannot be changed afterwards.
+        #
+        # To build GNAT on x86-64 Darwin, therefore,
+        # we need both the clang _and_ the cctools.gas assemblers to be available:
+        # the former to build at least the stage1 compiler,
+        # and the latter at least to be detectable
+        # as the target for the final compiler.
+        binutilsDualAs-unwrapped = pkgs.buildEnv {
+          name = "${lib.getName self.binutils-unwrapped}-dualas-${lib.getVersion self.binutils-unwrapped}";
+          paths = [
+            self.binutils-unwrapped
+            (lib.getOutput "gas" pkgs.cctools)
+          ];
+        };
 
-      binutilsDualAs = self.binutils.override {
-        bintools = self.binutilsDualAs-unwrapped;
-      };
+        binutilsDualAs = self.binutils.override {
+          bintools = self.binutilsDualAs-unwrapped;
+        };
 
-      binutilsNoLibc = pkgs.wrapBintoolsWith {
-        libc = targetPackages.preLibcHeaders;
-        bintools = self.binutils-unwrapped;
-      };
+        binutilsNoLibc = pkgs.wrapBintoolsWith {
+          libc = targetPackages.preLibcHeaders;
+          bintools = self.binutils-unwrapped;
+        };
 
-      # Removes propagated packages from the stdenv, so those packages can be built without depending upon themselves.
-      bootstrapStdenv = mkBootstrapStdenv pkgs.stdenv;
+        # Removes propagated packages from the stdenv, so those packages can be built without depending upon themselves.
+        bootstrapStdenv = mkBootstrapStdenv pkgs.stdenv;
 
-      libSystem = callPackage ../os-specific/darwin/libSystem { };
+        libSystem = callPackage ../os-specific/darwin/libSystem { };
 
-      DarwinTools = callPackage ../os-specific/darwin/DarwinTools { };
+        DarwinTools = callPackage ../os-specific/darwin/DarwinTools { };
 
-      libunwind = callPackage ../os-specific/darwin/libunwind { };
+        libunwind = callPackage ../os-specific/darwin/libunwind { };
 
-      sigtool = callPackage ../os-specific/darwin/sigtool { };
+        sigtool = callPackage ../os-specific/darwin/sigtool { };
 
-      signingUtils = callPackage ../os-specific/darwin/signing-utils { };
+        signingUtils = callPackage ../os-specific/darwin/signing-utils { };
 
-      autoSignDarwinBinariesHook = pkgs.makeSetupHook {
-        name = "auto-sign-darwin-binaries-hook";
-        propagatedBuildInputs = [ self.signingUtils ];
-      } ../os-specific/darwin/signing-utils/auto-sign-hook.sh;
+        autoSignDarwinBinariesHook = pkgs.makeSetupHook {
+          name = "auto-sign-darwin-binaries-hook";
+          propagatedBuildInputs = [ self.signingUtils ];
+        } ../os-specific/darwin/signing-utils/auto-sign-hook.sh;
 
-      iosSdkPkgs = callPackage ../os-specific/darwin/xcode/sdk-pkgs.nix {
-        buildIosSdk = buildPackages.darwin.iosSdkPkgs.sdk;
-        targetIosSdkPkgs = targetPackages.darwin.iosSdkPkgs;
-        inherit (pkgs.llvmPackages) clang-unwrapped;
-      };
+        iosSdkPkgs = callPackage ../os-specific/darwin/xcode/sdk-pkgs.nix {
+          buildIosSdk = buildPackages.darwin.iosSdkPkgs.sdk;
+          targetIosSdkPkgs = targetPackages.darwin.iosSdkPkgs;
+          inherit (pkgs.llvmPackages) clang-unwrapped;
+        };
 
-      lsusb = callPackage ../os-specific/darwin/lsusb { };
+        lsusb = callPackage ../os-specific/darwin/lsusb { };
 
-      openwith = callPackage ../os-specific/darwin/openwith { };
+        openwith = callPackage ../os-specific/darwin/openwith { };
 
-      trash = callPackage ../os-specific/darwin/trash { };
+        trash = callPackage ../os-specific/darwin/trash { };
 
-      inherit (self.file_cmds) xattr;
+        inherit (self.file_cmds) xattr;
 
-      inherit (pkgs.callPackages ../os-specific/darwin/xcode { })
-        xcode_8_1
-        xcode_8_2
-        xcode_9_1
-        xcode_9_2
-        xcode_9_3
-        xcode_9_4
-        xcode_9_4_1
-        xcode_10_1
-        xcode_10_2
-        xcode_10_2_1
-        xcode_10_3
-        xcode_11
-        xcode_11_1
-        xcode_11_2
-        xcode_11_3_1
-        xcode_11_4
-        xcode_11_5
-        xcode_11_6
-        xcode_11_7
-        xcode_12
-        xcode_12_0_1
-        xcode_12_1
-        xcode_12_2
-        xcode_12_3
-        xcode_12_4
-        xcode_12_5
-        xcode_12_5_1
-        xcode_13
-        xcode_13_1
-        xcode_13_2
-        xcode_13_3
-        xcode_13_3_1
-        xcode_13_4
-        xcode_13_4_1
-        xcode_14
-        xcode_14_1
-        xcode_15
-        xcode_15_0_1
-        xcode_15_1
-        xcode_15_2
-        xcode_15_3
-        xcode_15_4
-        xcode_16
-        xcode_16_1
-        xcode_16_2
-        xcode_16_3
-        xcode_16_4
-        xcode
-        requireXcode
-        ;
+        inherit (pkgs.callPackages ../os-specific/darwin/xcode { })
+          xcode_8_1
+          xcode_8_2
+          xcode_9_1
+          xcode_9_2
+          xcode_9_3
+          xcode_9_4
+          xcode_9_4_1
+          xcode_10_1
+          xcode_10_2
+          xcode_10_2_1
+          xcode_10_3
+          xcode_11
+          xcode_11_1
+          xcode_11_2
+          xcode_11_3_1
+          xcode_11_4
+          xcode_11_5
+          xcode_11_6
+          xcode_11_7
+          xcode_12
+          xcode_12_0_1
+          xcode_12_1
+          xcode_12_2
+          xcode_12_3
+          xcode_12_4
+          xcode_12_5
+          xcode_12_5_1
+          xcode_13
+          xcode_13_1
+          xcode_13_2
+          xcode_13_3
+          xcode_13_3_1
+          xcode_13_4
+          xcode_13_4_1
+          xcode_14
+          xcode_14_1
+          xcode_15
+          xcode_15_0_1
+          xcode_15_1
+          xcode_15_2
+          xcode_15_3
+          xcode_15_4
+          xcode_16
+          xcode_16_1
+          xcode_16_2
+          xcode_16_3
+          xcode_16_4
+          xcode
+          requireXcode
+          ;
 
-      xcodeProjectCheckHook = pkgs.makeSetupHook {
-        name = "xcode-project-check-hook";
-        propagatedBuildInputs = [ pkgs.pkgsBuildHost.openssl ];
-      } ../os-specific/darwin/xcode-project-check-hook/setup-hook.sh;
+        xcodeProjectCheckHook = pkgs.makeSetupHook {
+          name = "xcode-project-check-hook";
+          propagatedBuildInputs = [ pkgs.pkgsBuildHost.openssl ];
+        } ../os-specific/darwin/xcode-project-check-hook/setup-hook.sh;
 
-      # See doc/packages/darwin-builder.section.md
-      linux-builder = lib.makeOverridable (
-        { modules }:
-        let
-          toGuest = builtins.replaceStrings [ "darwin" ] [ "linux" ];
+        # See doc/packages/darwin-builder.section.md
+        linux-builder = lib.makeOverridable (
+          { modules }:
+          let
+            toGuest = builtins.replaceStrings [ "darwin" ] [ "linux" ];
 
-          nixos = import ../../nixos {
-            configuration = {
-              imports = [
-                ../../nixos/modules/profiles/nix-builder-vm.nix
-              ]
-              ++ modules;
+            nixos = import ../../nixos {
+              configuration = {
+                imports = [
+                  ../../nixos/modules/profiles/nix-builder-vm.nix
+                ]
+                ++ modules;
 
-              # If you need to override this, consider starting with the right Nixpkgs
-              # in the first place, ie change `pkgs` in `pkgs.darwin.linux-builder`.
-              # or if you're creating new wiring that's not `pkgs`-centric, perhaps use the
-              # macos-builder profile directly.
-              virtualisation.host = { inherit pkgs; };
+                # If you need to override this, consider starting with the right Nixpkgs
+                # in the first place, ie change `pkgs` in `pkgs.darwin.linux-builder`.
+                # or if you're creating new wiring that's not `pkgs`-centric, perhaps use the
+                # macos-builder profile directly.
+                virtualisation.host = { inherit pkgs; };
 
-              nixpkgs.hostPlatform = lib.mkDefault (toGuest stdenv.hostPlatform.system);
+                nixpkgs.hostPlatform = lib.mkDefault (toGuest stdenv.hostPlatform.system);
+              };
+
+              system = null;
             };
 
-            system = null;
-          };
+          in
+          nixos.config.system.build.macos-builder-installer
+        ) { modules = [ ]; };
 
-        in
-        nixos.config.system.build.macos-builder-installer
-      ) { modules = [ ]; };
+        linux-builder-x86_64 = self.linux-builder.override {
+          modules = [ { nixpkgs.hostPlatform = "x86_64-linux"; } ];
+        };
 
-      linux-builder-x86_64 = self.linux-builder.override {
-        modules = [ { nixpkgs.hostPlatform = "x86_64-linux"; } ];
-      };
-
-    }
+      }
+    )
   );
 }

--- a/pkgs/top-level/release.nix
+++ b/pkgs/top-level/release.nix
@@ -395,8 +395,6 @@ let
                 haskell-language-server
                 ;
             });
-        idrisPackages = packagePlatforms pkgs.idrisPackages;
-        agdaPackages = packagePlatforms pkgs.agdaPackages;
 
         pkgsLLVM.stdenv = [
           "x86_64-linux"
@@ -419,16 +417,8 @@ let
           "aarch64-linux"
         ];
 
-        # Language packages disabled in https://github.com/NixOS/nixpkgs/commit/ccd1029f58a3bb9eca32d81bf3f33cb4be25cc66
-
-        #emacsPackages = packagePlatforms pkgs.emacsPackages;
-        #rPackages = packagePlatforms pkgs.rPackages;
+        # Fails CI in its current state
         ocamlPackages = { };
-        perlPackages = { };
-
-        darwin = packagePlatforms pkgs.darwin // {
-          xcode = { };
-        };
       };
       mapTestOn-packages = if attrNamesOnly then packageJobs else mapTestOn packageJobs;
     in


### PR DESCRIPTION
We have `recurseForDerivations` so lets make use of that and not do some special treatment.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
