### PR TITLE
python313Packages.django_5: 5.1.8 -> 5.1.9

### DIFF
--- a/pkgs/development/python-modules/django/5.nix
+++ b/pkgs/development/python-modules/django/5.nix
@@ -44,7 +44,7 @@
 
 buildPythonPackage rec {
   pname = "django";
-  version = "5.1.8";
+  version = "5.1.9";
   pyproject = true;
 
   disabled = pythonOlder "3.10";
@@ -53,7 +53,7 @@ buildPythonPackage rec {
     owner = "django";
     repo = "django";
     rev = "refs/tags/${version}";
-    hash = "sha256-TZjqB9khEHnkkxYvAC/RzAvOIwdemh0uT4UVdosMq6M=";
+    hash = "sha256-uBP6MoVjPUtNu6KxLjaYmKTN42JIUCTJSuSnQWSxyQU=";
   };
 
   patches =
@@ -82,9 +82,6 @@ buildPythonPackage rec {
     ];
 
   postPatch = ''
-    substituteInPlace pyproject.toml \
-      --replace-fail "setuptools>=61.0.0,<69.3.0" setuptools
-
     substituteInPlace tests/utils_tests/test_autoreload.py \
       --replace-fail "/usr/bin/python" "${python.interpreter}"
   '';


### PR DESCRIPTION
Fixes CVE-2025-32873.
https://www.djangoproject.com/weblog/2025/may/07/security-releases/

https://docs.djangoproject.com/en/dev/releases/5.1.9/


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review pr 405061`

---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 58 packages built:</summary>
  <ul>
    <li>glitchtip</li>
    <li>healthchecks</li>
    <li>netbox (netbox_4_2)</li>
    <li>netbox_4_1</li>
    <li>paperless-ngx</li>
    <li>paperless-ngx.dist</li>
    <li>pretalx</li>
    <li>pretalx.dist</li>
    <li>pretalx.static</li>
    <li>python312Packages.django-apscheduler</li>
    <li>python312Packages.django-apscheduler.dist</li>
    <li>python312Packages.django_5</li>
    <li>python312Packages.django_5.dist</li>
    <li>python312Packages.netbox-attachments</li>
    <li>python312Packages.netbox-attachments.dist</li>
    <li>python312Packages.netbox-bgp</li>
    <li>python312Packages.netbox-bgp.dist</li>
    <li>python312Packages.netbox-contract</li>
    <li>python312Packages.netbox-contract.dist</li>
    <li>python312Packages.netbox-documents</li>
    <li>python312Packages.netbox-documents.dist</li>
    <li>python312Packages.netbox-floorplan-plugin</li>
    <li>python312Packages.netbox-floorplan-plugin.dist</li>
    <li>python312Packages.netbox-interface-synchronization</li>
    <li>python312Packages.netbox-interface-synchronization.dist</li>
    <li>python312Packages.netbox-napalm-plugin</li>
    <li>python312Packages.netbox-napalm-plugin.dist</li>
    <li>python312Packages.netbox-plugin-prometheus-sd</li>
    <li>python312Packages.netbox-plugin-prometheus-sd.dist</li>
    <li>python312Packages.netbox-qrcode</li>
    <li>python312Packages.netbox-qrcode.dist</li>
    <li>python312Packages.netbox-reorder-rack</li>
    <li>python312Packages.netbox-reorder-rack.dist</li>
    <li>python312Packages.netbox-routing</li>
    <li>python312Packages.netbox-routing.dist</li>
    <li>python312Packages.netbox-topology-views</li>
    <li>python312Packages.netbox-topology-views.dist</li>
    <li>python313Packages.django-apscheduler</li>
    <li>python313Packages.django-apscheduler.dist</li>
    <li>python313Packages.django_5</li>
    <li>python313Packages.django_5.dist</li>
    <li>python313Packages.netbox-bgp</li>
    <li>python313Packages.netbox-bgp.dist</li>
    <li>python313Packages.netbox-documents</li>
    <li>python313Packages.netbox-documents.dist</li>
    <li>python313Packages.netbox-interface-synchronization</li>
    <li>python313Packages.netbox-interface-synchronization.dist</li>
    <li>python313Packages.netbox-plugin-prometheus-sd</li>
    <li>python313Packages.netbox-plugin-prometheus-sd.dist</li>
    <li>python313Packages.netbox-qrcode</li>
    <li>python313Packages.netbox-qrcode.dist</li>
    <li>python313Packages.netbox-reorder-rack</li>
    <li>python313Packages.netbox-reorder-rack.dist</li>
    <li>python313Packages.netbox-routing</li>
    <li>python313Packages.netbox-routing.dist</li>
    <li>weblate</li>
    <li>weblate.dist</li>
    <li>weblate.static</li>
  </ul>
</details>
---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
