### PR TITLE
python312Packages.wandb: skip failing test on darwin

### DIFF
--- a/pkgs/development/python-modules/wandb/default.nix
+++ b/pkgs/development/python-modules/wandb/default.nix
@@ -357,6 +357,9 @@ buildPythonPackage rec {
       "test_matplotlib_plotly_with_multiple_axes"
       "test_matplotlib_to_plotly"
       "test_plotly_from_matplotlib_with_image"
+
+      # RuntimeError: *** -[__NSPlaceholderArray initWithObjects:count:]: attempt to insert nil object from objects[1]
+      "test_wandb_image_with_matplotlib_figure"
     ];
 
   pythonImportsCheck = [ "wandb" ];


### PR DESCRIPTION
## Things done

```
___________ test_wandb_image_with_matplotlib_figure[wandb_core-jpg] ____________
[gw4] darwin -- Python 3.12.10 /nix/store/vfdk6q81hdjqjfiqz8f92hibdck3kmn6-python3-3.12.10/bin/python3.12

file_type = 'jpg'

    @pytest.mark.parametrize("file_type", ["jpeg", "jpg", "png"])
    def test_wandb_image_with_matplotlib_figure(file_type):
>       fig = plt.figure()

/private/tmp/nix-build-python3.12-wandb-0.19.10.drv-0/source/tests/unit_tests/test_data_types.py:1543:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
/nix/store/yn407li79298qkww3lqs5fnrwnrixnd6-python3.12-matplotlib-3.10.1/lib/python3.12/site-packages/matplotlib/pyplot.py:1042: in figure
    manager = new_figure_manager(
/nix/store/yn407li79298qkww3lqs5fnrwnrixnd6-python3.12-matplotlib-3.10.1/lib/python3.12/site-packages/matplotlib/pyplot.py:552: in new_figure_manager
    return _get_backend_mod().new_figure_manager(*args, **kwargs)
/nix/store/yn407li79298qkww3lqs5fnrwnrixnd6-python3.12-matplotlib-3.10.1/lib/python3.12/site-packages/matplotlib/backend_bases.py:3501: in new_figure_manager
    return cls.new_figure_manager_given_figure(num, fig)
/nix/store/yn407li79298qkww3lqs5fnrwnrixnd6-python3.12-matplotlib-3.10.1/lib/python3.12/site-packages/matplotlib/backend_bases.py:3506: in new_figure_manager_given_figure
    return cls.FigureCanvas.new_manager(figure, num)
/nix/store/yn407li79298qkww3lqs5fnrwnrixnd6-python3.12-matplotlib-3.10.1/lib/python3.12/site-packages/matplotlib/backend_bases.py:1783: in new_manager
    return cls.manager_class.create_with_canvas(cls, figure, num)
/nix/store/yn407li79298qkww3lqs5fnrwnrixnd6-python3.12-matplotlib-3.10.1/lib/python3.12/site-packages/matplotlib/backend_bases.py:2654: in create_with_canvas
    return cls(canvas_class(figure), num)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = FigureManager object 0x318b0c410 wrapping NSWindow 0x313dcc920
canvas = FigureCanvas object 0x318ce3fd0 wrapping NSView 0x315415270, num = 1

    def __init__(self, canvas, num):
        self._shown = False
        _macosx.FigureManager.__init__(self, canvas)
        icon_path = str(cbook._get_data_path('images/matplotlib.pdf'))
>       _macosx.FigureManager.set_icon(icon_path)
E       RuntimeError: *** -[__NSPlaceholderArray initWithObjects:count:]: attempt to insert nil object from objects[1]

/nix/store/yn407li79298qkww3lqs5fnrwnrixnd6-python3.12-matplotlib-3.10.1/lib/python3.12/site-packages/matplotlib/backends/backend_macosx.py:155: RuntimeError
---------------------------- Captured stderr setup -----------------------------
Setting COVERAGE_FILE to /private/tmp/nix-build-python3.12-wandb-0.19.10.drv-0/source/.coverage
```

cc @samuela

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
