### PR TITLE
kid3: enable build flag WITH_MP4V2

### DIFF
--- a/pkgs/by-name/ki/kid3/package.nix
+++ b/pkgs/by-name/ki/kid3/package.nix
@@ -88,7 +88,10 @@ stdenv.mkDerivation (finalAttrs: {
       ]
     );
 
-  cmakeFlags = [ (lib.cmakeFeature "WITH_APPS" apps) ];
+  cmakeFlags = [
+    (lib.cmakeFeature "WITH_APPS" apps)
+    (lib.cmakeFeature "WITH_MP4V2" "ON")
+  ];
 
   env = {
     DOCBOOKDIR = "${docbook_xsl}/xml/xsl/docbook/";

--- a/pkgs/by-name/ki/kid3/package.nix
+++ b/pkgs/by-name/ki/kid3/package.nix
@@ -90,7 +90,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   cmakeFlags = [
     (lib.cmakeFeature "WITH_APPS" apps)
-    (lib.cmakeFeature "WITH_MP4V2" "ON")
+    (lib.cmakeBool "WITH_MP4V2" true)
   ];
 
   env = {


### PR DESCRIPTION
Support for editing m4b chapters was added to kid3 with v3.9.2, but this feature requires the Mp4v2Metadata plugin, which is only built when WITH_MP4V2=ON is added to the build flags.
https://invent.kde.org/multimedia/kid3/-/releases/v3.9.2
https://docs.kde.org/trunk5/en/kid3/kid3/commands.html#mp4-chapters
https://github.com/KDE/kid3/blob/master/INSTALL


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
