### PR TITLE
check-meta: filter nulls out of {maintainers,teams}Position

### DIFF
--- a/pkgs/stdenv/generic/check-meta.nix
+++ b/pkgs/stdenv/generic/check-meta.nix
@@ -26,6 +26,7 @@ let
     isAttrs
     isString
     mapAttrs
+    filterAttrs
     ;
 
   inherit (lib.lists)
@@ -593,11 +594,12 @@ let
         )
       ] ++ optional (hasOutput "man") "man";
     }
-    // {
-      # CI scripts look at these to determine pings.
+    // (filterAttrs (_: v: v != null) {
+      # CI scripts look at these to determine pings. Note that we should filter nulls out of this,
+      # or nix-env complains: https://github.com/NixOS/nix/blob/2.18.8/src/nix-env/nix-env.cc#L963
       maintainersPosition = builtins.unsafeGetAttrPos "maintainers" (attrs.meta or { });
       teamsPosition = builtins.unsafeGetAttrPos "teams" (attrs.meta or { });
-    }
+    })
     // attrs.meta or { }
     # Fill `meta.position` to identify the source location of the package.
     // optionalAttrs (pos != null) {


### PR DESCRIPTION
Note that Nix checks for this when it's querying meta, resulting in warnings from nixpkgs-review like:

`derivation 'pql-0.2.0' has invalid meta attribute 'teamsPosition'`

https://github.com/NixOS/nix/blob/2.18.8/src/nix-env/nix-env.cc#L963

Before:

```
nix-repl> legacyPackages.x86_64-linux.pql.meta
{
  available = true;
  broken = false;
  description = "Pipelined Query Language";
  homepage = "https://github.com/runreveal/pql";
  insecure = false;
  license = { ... };
  mainProgram = "pql";
  maintainers = [ ... ];
  maintainersPosition = { ... };
  name = "pql-0.2.0";
  outputsToInstall = [ ... ];
  platforms = [ ... ];
  position = "/nix/store/jxkbcrpqpj4b04g7vjn9zn5a8iq2xaay-source/pkgs/by-name/pq/pql/package.nix:26";
  teamsPosition = null;
  unfree = false;
  unsupported = false;
}
```

After:

```
nix-repl> legacyPackages.x86_64-linux.pql.meta
{
  available = true;
  broken = false;
  description = "Pipelined Query Language";
  homepage = "https://github.com/runreveal/pql";
  insecure = false;
  license = { ... };
  mainProgram = "pql";
  maintainers = [ ... ];
  maintainersPosition = { ... };
  name = "pql-0.2.0";
  outputsToInstall = [ ... ];
  platforms = [ ... ];
  position = "/nix/store/a2a78i7vwdq163l4yl24sv6vyrva48xs-source/pkgs/by-name/pq/pql/package.nix:26";
  unfree = false;
  unsupported = false;
}
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
