### PR TITLE
beets: 2.2.0 -> 2.3.0

### DIFF
--- a/pkgs/tools/audio/beets/default.nix
+++ b/pkgs/tools/audio/beets/default.nix
@@ -44,12 +44,12 @@ lib.makeExtensible (
 
     beets-unstable = callPackage ./common.nix {
       inherit python3Packages;
-      version = "2.2.0-unstable-2025-03-12";
+      version = "2.3.0";
       src = fetchFromGitHub {
         owner = "beetbox";
         repo = "beets";
-        rev = "670a3bcd17a46883c71cf07dd313fcd0dff4be9d";
-        hash = "sha256-hSY7FhpPL4poOY1/gqk7oLNgQ7KA/MJqx50xOLIP0QA=";
+        rev = "250b0da900c095a09bedc1a0717381010c01a3c6";
+        hash = "sha256-mH3m2O+q5Ys9DJD3ulmhViyf/VPEpHevjmNerVe327s=";
       };
     };
 

--- a/pkgs/tools/audio/beets/default.nix
+++ b/pkgs/tools/audio/beets/default.nix
@@ -4,7 +4,6 @@
   config,
   fetchFromGitHub,
   python3Packages,
-  fetchpatch,
 }:
 /*
   ** To customize the enabled beets plugins, use the pluginOverrides input to the
@@ -21,24 +20,8 @@
 */
 let
   extraPatches = [
-    (fetchpatch {
-      # Already on master. TODO: remove when updating to the next release
-      # Issue: https://github.com/beetbox/beets/issues/5527
-      # PR: https://github.com/beetbox/beets/pull/5650
-      name = "fix-im-backend";
-      url = "https://github.com/beetbox/beets/commit/1f938674015ee71431fe9bd97c2214f58473efd2.patch";
-      hash = "sha256-koCYeiUhk1ifo6CptOSu3p7Nz0FFUeiuArTknM/tpVQ=";
-      excludes = [
-        "docs/changelog.rst"
-      ];
-    })
     # Bash completion fix for Nix
     ./patches/bash-completion-always-print.patch
-    # Remove after next release.
-    (fetchpatch {
-      url = "https://github.com/beetbox/beets/commit/bcc79a5b09225050ce7c88f63dfa56f49f8782a8.patch?full_index=1";
-      hash = "sha256-Y2Q5Co3UlDGKuzfxUvdUY3rSMNpsBoDW03ZWZOfzp3Y=";
-    })
   ];
 in
 lib.makeExtensible (
@@ -48,12 +31,12 @@ lib.makeExtensible (
 
     beets-stable = callPackage ./common.nix rec {
       inherit python3Packages extraPatches;
-      version = "2.2.0";
+      version = "2.3.0";
       src = fetchFromGitHub {
         owner = "beetbox";
         repo = "beets";
         tag = "v${version}";
-        hash = "sha256-jhwXRgUUQJgQ/PLwvY1UfHCJ9UC8DcdBpE/janao0RM=";
+        hash = "sha256-mH3m2O+q5Ys9DJD3ulmhViyf/VPEpHevjmNerVe327s=";
       };
     };
 

--- a/pkgs/tools/audio/beets/default.nix
+++ b/pkgs/tools/audio/beets/default.nix
@@ -56,6 +56,7 @@ lib.makeExtensible (
     alternatives = callPackage ./plugins/alternatives.nix { beets = self.beets-minimal; };
     audible = callPackage ./plugins/audible.nix { beets = self.beets-minimal; };
     copyartifacts = callPackage ./plugins/copyartifacts.nix { beets = self.beets-minimal; };
+    filetote = callPackage ./plugins/filetote.nix { beets = self.beets-minimal; };
   }
   // lib.optionalAttrs config.allowAliases {
     extrafiles = throw "extrafiles is unmaintained since 2020 and broken since beets 2.0.0";

--- a/pkgs/tools/audio/beets/plugins/alternatives.nix
+++ b/pkgs/tools/audio/beets/plugins/alternatives.nix
@@ -8,14 +8,14 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "beets-alternatives";
-  version = "0.13.2";
+  version = "0.13.3";
   pyproject = true;
 
   src = fetchFromGitHub {
     repo = "beets-alternatives";
     owner = "geigerzaehler";
     tag = "v${version}";
-    hash = "sha256-OoQsP+QVIOnSA4oy1a8JJ3VeCUS+GR8sPPOysvmRMqI=";
+    hash = "sha256-j56AzbpZFACXy5KqafE8PCC+zM6pXrxr/rWy9UjZPQg=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/tools/audio/beets/plugins/audible.nix
+++ b/pkgs/tools/audio/beets/plugins/audible.nix
@@ -17,19 +17,21 @@ python3Packages.buildPythonApplication rec {
     hash = "sha256-Sds16h+W9t7N755ADPXXDi+SxwouBMxP9ApUqaXedqY=";
   };
 
+  nativeBuildInputs = [
+    beets
+  ];
+
   pythonRelaxDeps = true;
 
   build-system = with python3Packages; [
     hatchling
   ];
 
-  dependencies =
-    [ beets ]
-    ++ (with python3Packages; [
-      markdownify
-      natsort
-      tldextract
-    ]);
+  dependencies = with python3Packages; [
+    markdownify
+    natsort
+    tldextract
+  ];
 
   passthru = {
     updateScript = nix-update-script { };

--- a/pkgs/tools/audio/beets/plugins/copyartifacts.nix
+++ b/pkgs/tools/audio/beets/plugins/copyartifacts.nix
@@ -19,7 +19,6 @@ python3Packages.buildPythonApplication rec {
   };
 
   postPatch = ''
-    sed -i -e '/install_requires/,/\]/{/beets/d}' setup.py
     sed -i -e '/namespace_packages/d' setup.py
     printf 'from pkgutil import extend_path\n__path__ = extend_path(__path__, __name__)\n' >beetsplug/__init__.py
 
@@ -28,13 +27,15 @@ python3Packages.buildPythonApplication rec {
     sed -i -e 's/util\.py3_path/os.fsdecode/g' tests/_common.py
   '';
 
+  nativeBuildInputs = [
+    beets
+  ];
   build-system = with python3Packages; [ setuptools ];
 
   dependencies = with python3Packages; [ six ];
 
   nativeCheckInputs = [
     python3Packages.pytestCheckHook
-    beets
     writableTmpDirAsHomeHook
   ];
 

--- a/pkgs/tools/audio/beets/plugins/copyartifacts.nix
+++ b/pkgs/tools/audio/beets/plugins/copyartifacts.nix
@@ -30,9 +30,14 @@ python3Packages.buildPythonApplication rec {
   nativeBuildInputs = [
     beets
   ];
-  build-system = with python3Packages; [ setuptools ];
 
-  dependencies = with python3Packages; [ six ];
+  build-system = with python3Packages; [
+    setuptools
+  ];
+
+  dependencies = with python3Packages; [
+    six
+  ];
 
   nativeCheckInputs = [
     python3Packages.pytestCheckHook

--- a/pkgs/tools/audio/beets/plugins/filetote.nix
+++ b/pkgs/tools/audio/beets/plugins/filetote.nix
@@ -1,0 +1,83 @@
+{
+  lib,
+  fetchFromGitHub,
+  python3Packages,
+  beets,
+  beetsPackages,
+  writableTmpDirAsHomeHook,
+}:
+
+python3Packages.buildPythonApplication rec {
+  pname = "beets-filetote";
+  version = "1.0.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "gtronset";
+    repo = "beets-filetote";
+    tag = "v${version}";
+    hash = "sha256-LTJwZI/kQc+Iv0y8jAi5Xdh4wLEwbTA9hV76ndQsQzU=";
+  };
+
+  postPatch = ''
+    substituteInPlace pyproject.toml --replace-fail "poetry-core<2.0.0" "poetry-core"
+  '';
+
+  nativeBuildInputs = [
+    beets
+  ];
+
+  build-system = [ python3Packages.poetry-core ];
+
+  dependencies = with python3Packages; [
+    mediafile
+    reflink
+    toml
+    typeguard
+  ];
+
+  optional-dependencies = {
+    lint = with python3Packages; [
+      black
+      check-manifest
+      flake8
+      flake8-bugbear
+      flake8-bugbear-pyi
+      isort
+      mypy
+      pylint
+      typing_extensions
+    ];
+    test = with python3Packages; [
+      beetsPackages.audible
+      mediafile
+      pytest
+      reflink
+      toml
+      typeguard
+    ];
+    dev = optional-dependencies.lint ++ optional-dependencies.test ++ [ python3Packages.tox ];
+  };
+
+  pytestFlagsArray = [ "-r fEs" ];
+
+  disabledTestPaths = [
+    "tests/test_cli_operation.py"
+    "tests/test_pruning.py"
+    "tests/test_version.py"
+  ];
+
+  nativeCheckInputs = [
+    python3Packages.pytestCheckHook
+    writableTmpDirAsHomeHook
+  ] ++ optional-dependencies.test;
+
+  meta = with lib; {
+    description = "Beets plugin to move non-music files during the import process";
+    homepage = "https://github.com/gtronset/beets-filetote";
+    changelog = "https://github.com/gtronset/beets-filetote/blob/${src.rev}/CHANGELOG.md";
+    maintainers = with maintainers; [ dansbandit ];
+    license = licenses.mit;
+    inherit (beets.meta) platforms;
+  };
+}


### PR DESCRIPTION
## Description of changes


## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
