### PR TITLE
[24.11]: ci/eval/compare: support optional byName argument

### DIFF
--- a/ci/eval/compare/default.nix
+++ b/ci/eval/compare/default.nix
@@ -9,6 +9,7 @@
   beforeResultDir,
   afterResultDir,
   touchedFilesJson,
+  byName ? false,
 }:
 let
   /*
@@ -119,6 +120,7 @@ let
   maintainers = import ./maintainers.nix {
     changedattrs = lib.attrNames (lib.groupBy (a: a.name) rebuildsPackagePlatformAttrs);
     changedpathsjson = touchedFilesJson;
+    inherit byName;
   };
 in
 runCommand "compare"

--- a/ci/eval/compare/maintainers.nix
+++ b/ci/eval/compare/maintainers.nix
@@ -53,9 +53,7 @@ let
     // {
       # TODO: Refactor this so we can ping entire teams instead of the individual members.
       # Note that this will require keeping track of GH team IDs in "maintainers/teams.nix".
-      maintainers =
-        meta.maintainers or [ ]
-        ++ lib.flatten (map (team: team.members or [ ]) (meta.teams or [ ]));
+      maintainers = meta.maintainers or [ ];
     }
   ) attrsWithPackages;
 

--- a/ci/eval/compare/maintainers.nix
+++ b/ci/eval/compare/maintainers.nix
@@ -41,7 +41,18 @@ let
   ) validPackageAttributes;
 
   attrsWithMaintainers = builtins.map (
-    pkg: pkg // { maintainers = (pkg.package.meta or { }).maintainers or [ ]; }
+    pkg:
+    let
+      meta = pkg.package.meta or { };
+    in
+    pkg
+    // {
+      # TODO: Refactor this so we can ping entire teams instead of the individual members.
+      # Note that this will require keeping track of GH team IDs in "maintainers/teams.nix".
+      maintainers =
+        meta.maintainers or [ ]
+        ++ lib.flatten (map (team: team.members or [ ]) (meta.teams or [ ]));
+    }
   ) attrsWithPackages;
 
   relevantFilenames =

--- a/ci/eval/compare/maintainers.nix
+++ b/ci/eval/compare/maintainers.nix
@@ -1,5 +1,9 @@
 # Almost directly vendored from https://github.com/NixOS/ofborg/blob/5a4e743f192fb151915fcbe8789922fa401ecf48/ofborg/src/maintainers.nix
-{ changedattrs, changedpathsjson }:
+{
+  changedattrs,
+  changedpathsjson,
+  byName ? false,
+}:
 let
   pkgs = import ../../.. {
     system = "x86_64-linux";
@@ -94,12 +98,13 @@ let
     pkg:
     builtins.map (maintainer: {
       id = maintainer.githubId;
+      inherit (maintainer) github;
       packageName = pkg.name;
       dueToFiles = pkg.filenames;
     }) pkg.maintainers
   ) attrsWithModifiedFiles;
 
-  byMaintainer = lib.groupBy (ping: toString ping.id) listToPing;
+  byMaintainer = lib.groupBy (ping: toString ping.${if byName then "github" else "id"}) listToPing;
 
   packagesPerMaintainer = lib.attrsets.mapAttrs (
     maintainer: packages: builtins.map (pkg: pkg.packageName) packages


### PR DESCRIPTION
This backports parts of #394797 and #402991 - purely for the cause of "we want no diff in workflows/ and ci/ to make backporting *other* changes easier".

My understanding is that those changes won't do much on stable, because there are no script using the argument, but they should also not do harm. Agreed, @winterqt?

## Things done

- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
