### PR TITLE
lean4: 4.18.0 -> 4.19.0

### DIFF
--- a/pkgs/by-name/le/lean4/mimalloc.patch
+++ b/pkgs/by-name/le/lean4/mimalloc.patch
@@ -1,0 +1,16 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -77,12 +77,8 @@
+ if (USE_MIMALLOC)
+   ExternalProject_add(mimalloc
+     PREFIX mimalloc
+-    GIT_REPOSITORY https://github.com/microsoft/mimalloc
+-    GIT_TAG v2.2.3
+-    # just download, we compile it as part of each stage as it is small
+-    CONFIGURE_COMMAND ""
+-    BUILD_COMMAND ""
++    SOURCE_DIR "MIMALLOC-SRC"
+     INSTALL_COMMAND "")
+   list(APPEND EXTRA_DEPENDS mimalloc)
+ endif()
+ 

--- a/pkgs/by-name/le/lean4/package.nix
+++ b/pkgs/by-name/le/lean4/package.nix
@@ -8,29 +8,51 @@
   cadical,
   pkg-config,
   libuv,
+  enableMimalloc ? true,
   perl,
   testers,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "lean4";
-  version = "4.18.0";
+  version = "4.19.0";
+
+  # Using a vendored version rather than nixpkgs' version to match the exact version required by
+  # Lean.  Apparently, even a slight version change can impact greatly the final performance.
+  mimalloc-src = fetchFromGitHub {
+    owner = "microsoft";
+    repo = "mimalloc";
+    tag = "v2.2.3";
+    hash = "sha256-B0gngv16WFLBtrtG5NqA2m5e95bYVcQraeITcOX9A74=";
+  };
 
   src = fetchFromGitHub {
     owner = "leanprover";
     repo = "lean4";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-1hVcRO9RbVUgoKTUTFXBqJZwt50/aw/P9dxUdI7RpCc=";
+    hash = "sha256-Iw5JSamrty9l6aJ2WwslAolSHfi2q0UO8P8HI1gp+j8=";
   };
 
-  postPatch = ''
-    substituteInPlace src/CMakeLists.txt \
-      --replace-fail 'set(GIT_SHA1 "")' 'set(GIT_SHA1 "${finalAttrs.src.tag}")'
+  postPatch =
+    let
+      pattern = "\${LEAN_BINARY_DIR}/../mimalloc/src/mimalloc";
+    in
+    ''
+      substituteInPlace src/CMakeLists.txt \
+        --replace-fail 'set(GIT_SHA1 "")' 'set(GIT_SHA1 "${finalAttrs.src.tag}")'
 
-    # Remove tests that fails in sandbox.
-    # It expects `sourceRoot` to be a git repository.
-    rm -rf src/lake/examples/git/
-  '';
+      # Remove tests that fails in sandbox.
+      # It expects `sourceRoot` to be a git repository.
+      rm -rf src/lake/examples/git/
+    ''
+    + (lib.optionalString enableMimalloc ''
+      substituteInPlace CMakeLists.txt \
+        --replace-fail 'MIMALLOC-SRC' '${finalAttrs.mimalloc-src}'
+      for file in src/CMakeLists.txt src/runtime/CMakeLists.txt; do
+        substituteInPlace "$file" \
+          --replace-fail '${pattern}' '${finalAttrs.mimalloc-src}'
+      done
+    '');
 
   preConfigure = ''
     patchShebangs stage0/src/bin/ src/bin/
@@ -52,9 +74,12 @@ stdenv.mkDerivation (finalAttrs: {
     perl
   ];
 
+  patches = [ ./mimalloc.patch ];
+
   cmakeFlags = [
     "-DUSE_GITHASH=OFF"
     "-DINSTALL_LICENSE=OFF"
+    "-DUSE_MIMALLOC=${if enableMimalloc then "ON" else "OFF"}"
   ];
 
   passthru.tests = {


### PR DESCRIPTION
Release notes:
- https://github.com/leanprover/lean4/releases/tag/v4.19.0
- https://github.com/leanprover/lean4/releases/tag/v4.19.0-rc3
- https://github.com/leanprover/lean4/releases/tag/v4.19.0-rc2
- https://github.com/leanprover/lean4/releases/tag/v4.19.0-rc1


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
