### PR TITLE
python312Packages.depyf: 0.18.0 -> 0.19.0

### DIFF
--- a/pkgs/development/python-modules/depyf/default.nix
+++ b/pkgs/development/python-modules/depyf/default.nix
@@ -1,20 +1,33 @@
 {
   lib,
+  stdenv,
   buildPythonPackage,
-  fetchPypi,
+  fetchFromGitHub,
+
+  # build-system
+  setuptools,
+
+  # dependencies
   astor,
   dill,
   filelock,
+
+  # tests
   pytestCheckHook,
+  torch,
+  pythonAtLeast,
 }:
 
 buildPythonPackage rec {
   pname = "depyf";
-  version = "0.18.0";
+  version = "0.19.0";
+  pyproject = true;
 
-  src = fetchPypi {
-    inherit pname version;
-    hash = "sha256-uZ8MODvpSa5F1dYG/kRMcfN1tVpXuNayDnhWZw1SEw0=";
+  src = fetchFromGitHub {
+    owner = "thuml";
+    repo = "depyf";
+    tag = "v${version}";
+    hash = "sha256-AGM5Pm0hhqOX9CY7dFijZLqhWmY7xnmKWakh4MUtOMs=";
   };
 
   # don't try to read git commit
@@ -23,19 +36,51 @@ buildPythonPackage rec {
       --replace-fail 'commit_id = get_git_commit_id()' 'commit_id = None'
   '';
 
-  propagatedBuildInputs = [
+  build-system = [
+    setuptools
+  ];
+
+  dependencies = [
     astor
     dill
     filelock
   ];
 
-  nativeCheckInputs = [ pytestCheckHook ];
+  nativeCheckInputs = [
+    pytestCheckHook
+    torch
+  ];
+
+  disabledTestPaths =
+    [
+      #     if self.quitting: raise BdbQuit
+      # E   bdb.BdbQuit
+      "tests/test_pytorch/test_pytorch.py"
+    ]
+    ++ lib.optionals (pythonAtLeast "3.13") [
+
+      # depyf.decompiler.DecompilationError: DecompilationError: Failed to decompile instruction ...
+      # NotImplementedError: Unsupported instruction: LOAD_FAST_LOAD_FAST
+      "tests/test_code_owner.py"
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [
+      # E   torch._dynamo.exc.BackendCompilerFailed: backend='inductor' raised:
+      # E   CppCompileError: C++ compile error
+      "tests/test_pytorch/test_export.py"
+      "tests/test_pytorch/test_logging.py"
+      "tests/test_pytorch/test_simple_graph.py"
+    ];
+
+  # All remaining tests fail with:
+  # ValueError: invalid literal for int() with base 10: 'L1'
+  doCheck = !(pythonAtLeast "3.13");
 
   pythonImportsCheck = [ "depyf" ];
 
-  meta = with lib; {
+  meta = {
     description = "Decompile python functions, from bytecode to source code";
     homepage = "https://github.com/thuml/depyf";
-    license = licenses.mit;
+    changelog = "https://github.com/thuml/depyf/releases/tag/v${version}";
+    license = lib.licenses.mit;
   };
 }

--- a/pkgs/development/python-modules/vllm/default.nix
+++ b/pkgs/development/python-modules/vllm/default.nix
@@ -427,5 +427,11 @@ buildPythonPackage rec {
       happysalada
       lach
     ];
+    badPlatforms = [
+      # CMake Error at cmake/cpu_extension.cmake:78 (find_isa):
+      # find_isa Function invoked with incorrect arguments for function named:
+      # find_isa
+      "x86_64-darwin"
+    ];
   };
 }


### PR DESCRIPTION
## Things done

Diff: https://github.com/thuml/depyf/compare/v0.18.0...v0.19.0
Changelog: https://github.com/thuml/depyf/releases/tag/v0.19.0

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
