### PR TITLE
nixos/postgresql: remove recoveryConfig option

### DIFF
--- a/nixos/modules/services/databases/postgresql.nix
+++ b/nixos/modules/services/databases/postgresql.nix
@@ -90,6 +90,12 @@ in
       "extraConfig"
     ] "Use services.postgresql.settings instead.")
 
+    (mkRemovedOptionModule [
+      "services"
+      "postgresql"
+      "recoveryConfig"
+    ] "PostgreSQL v12+ doesn't support recovery.conf.")
+
     (mkRenamedOptionModule
       [ "services" "postgresql" "logLinePrefix" ]
       [ "services" "postgresql" "settings" "log_line_prefix" ]
@@ -588,14 +594,6 @@ in
         '';
       };
 
-      recoveryConfig = mkOption {
-        type = types.nullOr types.lines;
-        default = null;
-        description = ''
-          Contents of the {file}`recovery.conf` file.
-        '';
-      };
-
       superUser = mkOption {
         type = types.str;
         default = "postgres";
@@ -741,10 +739,6 @@ in
         fi
 
         ln -sfn "${configFile}/postgresql.conf" "${cfg.dataDir}/postgresql.conf"
-        ${optionalString (cfg.recoveryConfig != null) ''
-          ln -sfn "${pkgs.writeText "recovery.conf" cfg.recoveryConfig}" \
-            "${cfg.dataDir}/recovery.conf"
-        ''}
       '';
 
       # Wait for PostgreSQL to be ready to accept connections.


### PR DESCRIPTION
Since v12, PostgreSQL doesn't support recovery.conf anymore and fails to start up when this option is set:

```
FATAL:  using recovery command file "recovery.conf" is not supported
```

This is documented at: https://www.postgresql.org/docs/current/recovery-config.html

## Things done


- Built on platform(s)
  - [x] x86_64-linux
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
