### PR TITLE
python3Packages.auto-lazy-imports: init at 0.4.2

### DIFF
--- a/pkgs/development/python-modules/auto-lazy-imports/default.nix
+++ b/pkgs/development/python-modules/auto-lazy-imports/default.nix
@@ -1,0 +1,88 @@
+{
+  lib,
+  python,
+  buildPythonPackage,
+  fetchFromGitHub,
+  hatchling,
+  hatch-autorun,
+  pytestCheckHook,
+  runCommand,
+}:
+
+buildPythonPackage rec {
+  pname = "auto-lazy-imports"; # matches pypi
+  version = "0.4.2";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "hmiladhia";
+    repo = "lazyimports";
+    tag = "v${version}";
+    hash = "sha256-DPk/fupBuYmm7Xy5+qFkqeRoglflECuX8A0C2ncARhI=";
+  };
+
+  build-system = [
+    hatchling
+    hatch-autorun
+  ];
+
+  pythonImportsCheck = [
+    "lazyimports"
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  preInstallCheck = ''
+    if [[ -f "$out/${python.sitePackages}"/hatch_autorun_auto_lazy_imports.pth ]]; then
+      echo >&2 "Found hatch_autorun_auto_lazy_imports.pth in site-packages"
+    else
+      echo >&2 "ERROR: no hatch_autorun_auto_lazy_imports.pth file found in site-packages, please re-check derivation assumptions"
+      false
+    fi
+  '';
+
+  preCheck = ''
+    # Makes python load the .pth file in site-packages
+    export NIX_PYTHONPATH="$out/${python.sitePackages}''${NIX_PYTHONPATH:+:"$NIX_PYTHONPATH"}"
+  '';
+
+  # check if NIX_PYTHONPATH is properly set in downstream environments
+  passthru.tests = {
+    check-autorun-pyenv =
+      runCommand "${pname}-check-autorun-pyenv"
+        {
+          nativeBuildInputs = [
+            (python.withPackages (ps: [
+              ps.auto-lazy-imports
+              ps.pytest
+            ]))
+          ];
+        }
+        ''
+          pytest ${src}/tests && touch $out
+        '';
+
+    # TODO: this requires user to set NIX_PYTHONPATH
+    # check-autorun-env =
+    #   runCommand "${pname}-check-autorun-env"
+    #     {
+    #       nativeBuildInputs = [
+    #         python
+    #         python.pkgs.auto-lazy-imports
+    #         python.pkgs.pytest
+    #       ];
+    #     }
+    #     ''
+    #       pytest ${src}/tests && touch $out
+    #     '';
+  };
+
+  meta = {
+    description = "Enable lazy imports using native python syntax";
+    homepage = "https://github.com/hmiladhia/lazyimports";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ pbsds ];
+  };
+}

--- a/pkgs/development/python-modules/hatch-autorun/default.nix
+++ b/pkgs/development/python-modules/hatch-autorun/default.nix
@@ -1,0 +1,52 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  hatch-vcs,
+  hatchling,
+  pytestCheckHook,
+  build,
+}:
+
+buildPythonPackage rec {
+  pname = "hatch-autorun";
+  version = "1.1.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "ofek";
+    repo = "hatch-autorun";
+    tag = "v${version}";
+    hash = "sha256-79k3KolvmjGf8ubCQMhtOH5+OeqQrmz2Q6r0ZG98424=";
+  };
+
+  build-system = [
+    hatch-vcs
+    hatchling
+  ];
+
+  dependencies = [
+    hatchling
+  ];
+
+  pythonImportsCheck = [
+    "hatch_autorun"
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    build
+  ];
+
+  disabledTestPaths = [
+    # requires network via invoking pip
+    "tests/test_build.py"
+  ];
+
+  meta = {
+    description = "Hatch build hook plugin to inject code that will automatically run";
+    homepage = "https://github.com/ofek/hatch-autorun";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ pbsds ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6186,6 +6186,8 @@ self: super: with self; {
 
   hatasmota = callPackage ../development/python-modules/hatasmota { };
 
+  hatch-autorun = callPackage ../development/python-modules/hatch-autorun { };
+
   hatch-babel = callPackage ../development/python-modules/hatch-babel { };
 
   hatch-fancy-pypi-readme = callPackage ../development/python-modules/hatch-fancy-pypi-readme { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1114,6 +1114,8 @@ self: super: with self; {
 
   authres = callPackage ../development/python-modules/authres { };
 
+  auto-lazy-imports = callPackage ../development/python-modules/auto-lazy-imports { };
+
   autobahn = callPackage ../development/python-modules/autobahn { };
 
   autocommand = callPackage ../development/python-modules/autocommand { };


### PR DESCRIPTION
- **python3Packages.hatch-autorun: init at 1.1.0**
- **python3Packages.auto-lazy-imports: init at 0.4.2**

I got halfway in implementing this library myself when i stumbled upon the quite new https://github.com/hmiladhia/lazyimports.
Also packages https://github.com/ofek/hatch-autorun.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
