### PR TITLE
make-initrd-ng: fix file permissions

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1296,7 +1296,7 @@ in
   systemd-initrd-luks-unl0kr = handleTest ./systemd-initrd-luks-unl0kr.nix { };
   systemd-initrd-modprobe = handleTest ./systemd-initrd-modprobe.nix { };
   systemd-initrd-shutdown = handleTest ./systemd-shutdown.nix { systemdStage1 = true; };
-  systemd-initrd-simple = handleTest ./systemd-initrd-simple.nix { };
+  systemd-initrd-simple = runTest ./systemd-initrd-simple.nix;
   systemd-initrd-swraid = handleTest ./systemd-initrd-swraid.nix { };
   systemd-initrd-vconsole = handleTest ./systemd-initrd-vconsole.nix { };
   systemd-initrd-networkd = handleTest ./systemd-initrd-networkd.nix { };

--- a/nixos/tests/systemd-initrd-simple.nix
+++ b/nixos/tests/systemd-initrd-simple.nix
@@ -50,6 +50,9 @@ import ./make-test-python.nix (
           newAvail = machine.succeed("df --output=avail / | sed 1d")
 
           assert int(oldAvail) < int(newAvail), "File system did not grow"
+
+      with subtest("no warnings from systemd about write permissions"):
+          machine.fail("journalctl -b 0 | grep 'is marked world-writable, which is a security risk as it is executed with privileges'")
     '';
   }
 )

--- a/nixos/tests/systemd-initrd-simple.nix
+++ b/nixos/tests/systemd-initrd-simple.nix
@@ -1,17 +1,17 @@
-import ./make-test-python.nix (
-  { lib, pkgs, ... }:
-  {
-    name = "systemd-initrd-simple";
+{
+  name = "systemd-initrd-simple";
 
-    nodes.machine =
-      { pkgs, ... }:
-      {
-        testing.initrdBackdoor = true;
-        boot.initrd.systemd.enable = true;
-        virtualisation.fileSystems."/".autoResize = true;
-      };
+  nodes.machine =
+    { pkgs, ... }:
+    {
+      testing.initrdBackdoor = true;
+      boot.initrd.systemd.enable = true;
+      virtualisation.fileSystems."/".autoResize = true;
+    };
 
-    testScript = ''
+  testScript =
+    # python
+    ''
       import subprocess
 
       with subtest("testing initrd backdoor"):
@@ -54,5 +54,4 @@ import ./make-test-python.nix (
       with subtest("no warnings from systemd about write permissions"):
           machine.fail("journalctl -b 0 | grep 'is marked world-writable, which is a security risk as it is executed with privileges'")
     '';
-  }
-)
+}

--- a/pkgs/build-support/kernel/make-initrd-ng/src/main.rs
+++ b/pkgs/build-support/kernel/make-initrd-ng/src/main.rs
@@ -212,7 +212,7 @@ fn copy_file<
         }
 
         // Remove writable permissions
-        permissions.set_mode(permissions.mode() ^ 0o222);
+        permissions.set_mode(permissions.mode() & 0o555);
         fs::set_permissions(&target, permissions)
             .wrap_err_with(|| format!("failed to remove writable permissions for {:?}", target))?;
     };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

We want to strip the write bit from files after we copied them.
XOR is not the right operator for this, since if the bit is 0 in both
the actual permissions and the mask, then the result will be a 1.
So in practice, we were assigning write permissions for group and others
to all files and we were only stripping the write permissions of the
owner (since the owner had write permissions, and so the result of the
XOR is 0).

The correct thing to do is to AND with the maximum permissions that we
want to maintain (which is the inverse of what we want to strip), so
that only those bits are preserved and the others are always set to 0.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
