### PR TITLE
networkmanager: Remove unnecessary patching out of `python_path`

### DIFF
--- a/pkgs/tools/networking/networkmanager/default.nix
+++ b/pkgs/tools/networking/networkmanager/default.nix
@@ -134,8 +134,6 @@ stdenv.mkDerivation (finalAttrs: {
         gnused
         ;
       inherit runtimeShell;
-      # patch context
-      OUTPUT = null;
     })
 
     # Meson does not support using different directories during build and

--- a/pkgs/tools/networking/networkmanager/fix-paths.patch
+++ b/pkgs/tools/networking/networkmanager/fix-paths.patch
@@ -31,26 +31,6 @@ index f3441508ab..7cde8d7d39 100644
                  log_domain  = LOGD_IP6;
              }
          }
-diff --git a/src/libnm-client-impl/meson.build b/src/libnm-client-impl/meson.build
-index 3dd2338a82..de75cc040b 100644
---- a/src/libnm-client-impl/meson.build
-+++ b/src/libnm-client-impl/meson.build
-@@ -190,7 +190,6 @@ if enable_introspection
-       input: [gen_infos_cmd, libnm_gir[0]] + libnm_core_settings_sources,
-       output: 'nm-property-infos-' + name + '.xml',
-       command: [
--        python_path,
-         gen_infos_cmd,
-         name,
-         '@OUTPUT@',
-@@ -206,7 +205,6 @@ if enable_introspection
-         'env',
-         'GI_TYPELIB_PATH=' + gi_typelib_path,
-         'LD_LIBRARY_PATH=' + ld_library_path,
--        python_path,
-         gen_gir_cmd,
-         '--lib-path', meson.current_build_dir(),
-         '--gir', libnm_gir[0],
 diff --git a/src/libnmc-base/nm-vpn-helpers.c b/src/libnmc-base/nm-vpn-helpers.c
 index cbe76f5f1c..8515f94994 100644
 --- a/src/libnmc-base/nm-vpn-helpers.c
@@ -88,43 +68,3 @@ index cbe76f5f1c..8515f94994 100644
  
      oc_argv[oc_argc++] = path;
      oc_argv[oc_argc++] = "--authenticate";
-diff --git a/src/libnmc-setting/meson.build b/src/libnmc-setting/meson.build
-index 4d5079dfb3..5a15447fde 100644
---- a/src/libnmc-setting/meson.build
-+++ b/src/libnmc-setting/meson.build
-@@ -9,7 +9,6 @@ if enable_docs
-     input: [merge_cmd, nm_settings_docs_xml_gir['nmcli'], nm_property_infos_xml['nmcli']],
-     output: 'settings-docs-input.xml',
-     command: [
--      python_path,
-       merge_cmd,
-       '@OUTPUT@',
-       nm_property_infos_xml['nmcli'],
-@@ -23,7 +22,6 @@ if enable_docs
-     input: [gen_cmd, settings_docs_input_xml],
-     output: 'settings-docs.h',
-     command: [
--      python_path,
-       gen_cmd,
-       '--output', '@OUTPUT@',
-       '--xml', settings_docs_input_xml
-diff --git a/src/tests/client/meson.build b/src/tests/client/meson.build
-index 5686a1c174..cfb6649a21 100644
---- a/src/tests/client/meson.build
-+++ b/src/tests/client/meson.build
-@@ -6,7 +6,6 @@ test(
-   args: [
-     build_root,
-     source_root,
--    python_path,
-     '--',
-     'TestNmcli',
-   ],
-@@ -23,7 +22,6 @@ if enable_nm_cloud_setup
-     args: [
-       build_root,
-       source_root,
--      python_path,
-       '--',
-       'TestNmCloudSetup',
-     ],


### PR DESCRIPTION
It builds without it nowadays.

Possibly thanks to https://gitlab.freedesktop.org/NetworkManager/NetworkManager/-/commit/9158f4165f748bbf2f346dee0941f28d26392bdf

Extracted out of https://github.com/NixOS/nixpkgs/pull/386514

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
