### PR TITLE
turborepo-remote-cache: init at 2.6.1, nixos/turborepo-remote-cache: init

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2605.section.md
+++ b/nixos/doc/manual/release-notes/rl-2605.section.md
@@ -60,6 +60,8 @@
 
 - [udp-over-tcp](https://github.com/mullvad/udp-over-tcp), a tunnel for proxying UDP traffic over a TCP stream. Available as `services.udp-over-tcp`.
 
+- [turborepo-remote-cache](https://ducktors.github.io/turborepo-remote-cache/), an open-source implementation of the [Turborepo custom remote cache server](https://turbo.build/repo/docs/core-concepts/remote-caching#self-hosting). Available as [services.turborepo-remote-cache](options.html#opt-services.turborepo-remote-cache).
+
 - [Komodo Periphery](https://github.com/moghtech/komodo), a multi-server Docker and Git deployment agent by Komodo. Available as [services.komodo-periphery](#opt-services.komodo-periphery.enable).
 
 - [Shoko](https://shokoanime.com), an anime management system. Available as [services.shoko](#opt-services.shoko.enable).

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -609,6 +609,7 @@
   ./services/development/lorri.nix
   ./services/development/nixseparatedebuginfod2.nix
   ./services/development/rstudio-server/default.nix
+  ./services/development/turborepo-remote-cache.nix
   ./services/development/vsmartcard-vpcd.nix
   ./services/development/zammad.nix
   ./services/display-managers/cosmic-greeter.nix

--- a/nixos/modules/services/development/turborepo-remote-cache.nix
+++ b/nixos/modules/services/development/turborepo-remote-cache.nix
@@ -1,0 +1,131 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.services.turborepo-remote-cache;
+
+  inherit (lib)
+    boolToString
+    isBool
+    literalExpression
+    mapAttrs
+    mkEnableOption
+    mkIf
+    mkOption
+    mkPackageOption
+    types
+    ;
+in
+{
+  options.services.turborepo-remote-cache = {
+    enable = mkEnableOption "Turborepo Remote Cache" // {
+      description = ''
+        Enables the daemon for `turborepo-remote-cache`,
+        an open source implementation of the Turborepo custom remote cache server.
+      '';
+    };
+
+    package = mkPackageOption pkgs "turborepo-remote-cache" { };
+
+    environment = mkOption {
+      type = types.attrsOf (
+        types.nullOr (
+          types.oneOf [
+            types.bool
+            types.int
+            types.str
+          ]
+        )
+      );
+      default = { };
+      description = ''
+        Environment variables to set.
+
+        Turborepo-remote-cache is configured through the use of environment variables.
+        The available configuration options can be found in the [documentation][envvars].
+
+        [envvars]: https://ducktors.github.io/turborepo-remote-cache/environment-variables.html
+
+        Note that all environment variables set through this configuration
+        parameter will be readable by anyone with access to the host
+        machine. Therefore, sensitive information like {env}`TURBO_TOKEN`
+        should never be set using this configuration option, but should instead use
+        [](#opt-services.turborepo-remote-cache.environmentFile).
+        See the documentation for that option for more information.
+
+        Any environment variables specified in the
+        [](#opt-services.turborepo-remote-cache.environmentFile)
+        will supersede environment variables specified in this option.
+      '';
+
+      example = literalExpression ''
+        {
+          NODE_ENV = "production";
+          PORT = 8080;
+        }
+      '';
+    };
+
+    environmentFile = mkOption {
+      type = types.nullOr types.path;
+      default = null;
+      description = ''
+        Additional environment file as defined in {manpage}`systemd.exec(5)`.
+
+        Secrets like {env}`TURBO_TOKEN` may be passed to the
+        service without making them readable to everyone with access to
+        systemctl by using this configuration parameter.
+
+        Note that this file needs to be available on the host on which
+        `turborepo-remote-cache` is running.
+
+        See the [documentation][envvars]
+        and the [](#opt-services.turborepo-remote-cache.environment) configuration parameter
+        for further options.
+
+        [envvars]: https://ducktors.github.io/turborepo-remote-cache/environment-variables.html
+      '';
+      example = "/run/secrets/turborepo-remote-cache.env";
+    };
+
+    openFirewall = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        Open ports in the firewall for turborepo-remote-cache daemon.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    systemd.services.turborepo-remote-cache = {
+      serviceConfig = {
+        Restart = "always";
+        EnvironmentFile = cfg.environmentFile;
+        ExecStart = "${cfg.package}/bin/turborepo-remote-cache";
+
+        DynamicUser = true;
+        ProtectSystem = "strict";
+        ProtectHome = true;
+        NoNewPrivileges = true;
+        PrivateDevices = true;
+        PrivateTmp = true;
+      };
+      environment = mapAttrs (
+        name: value: if isBool value then boolToString value else toString value
+      ) cfg.environment;
+      wantedBy = [ "default.target" ];
+    };
+
+    networking.firewall.allowedTCPPorts =
+      let
+        # 3000 is the default port as specified in
+        # https://ducktors.github.io/turborepo-remote-cache/environment-variables.html
+        port = cfg.environment.PORT or 3000;
+      in
+      mkIf cfg.openFirewall [ port ];
+  };
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1663,6 +1663,7 @@ in
   tuliprox = runTest ./tuliprox.nix;
   tuned = runTest ./tuned.nix;
   tuptime = runTest ./tuptime.nix;
+  turborepo-remote-cache = runTest ./turborepo-remote-cache.nix;
   turbovnc-headless-server = runTest ./turbovnc-headless-server.nix;
   turn-rs = runTest ./turn-rs.nix;
   tusd = runTest ./tusd/default.nix;

--- a/nixos/tests/turborepo-remote-cache.nix
+++ b/nixos/tests/turborepo-remote-cache.nix
@@ -1,0 +1,65 @@
+{ lib, ... }:
+
+let
+  ports = {
+    turborepo-remote-cache = 8080;
+  };
+
+  token = "myrandomtoken";
+  team = "nixos-team";
+  # require('crypto').randomBytes(20).toString('hex');
+  artifactid = "82286e93a6f84e18a8fe4770c5a88b24653e7f59";
+in
+{
+  name = "turborepo-remote-cache";
+
+  nodes.machine = {
+    services.turborepo-remote-cache = {
+      enable = true;
+
+      environment = {
+        PORT = ports.turborepo-remote-cache;
+        TURBO_TEAM = team;
+        TURBO_TOKEN = token;
+      };
+    };
+  };
+
+  testScript = ''
+    import json
+
+    machine.wait_for_unit("turborepo-remote-cache.service")
+    machine.wait_for_open_port(${toString ports.turborepo-remote-cache})
+
+    def read_json(input):
+      try:
+        return json.loads(input)
+      except Exception as e:
+        print(input)
+        raise e
+
+    out = read_json(machine.succeed("""curl 127.0.0.1:${toString ports.turborepo-remote-cache}/v8/artifacts/status? \
+      -H 'Content-Type: application/json' \
+      -H "Authorization: Bearer ${token}"
+      """))
+
+    if out["status"] != "enabled":
+      raise Exception(f"status is not enabled in response: {out}")
+
+    out = read_json(machine.succeed("""curl -X PUT "127.0.0.1:${toString ports.turborepo-remote-cache}/v8/artifacts/${artifactid}?teamId=${team}" \
+      -H "Authorization: Bearer ${token}" \
+      -H "Content-Type: application/octet-stream" \
+      -d 'myartifact'"""))
+    if "urls" not in out:
+      raise Exception(f"'urls' not in response: {out}")
+
+    out = machine.succeed("""curl 127.0.0.1:${toString ports.turborepo-remote-cache}/v8/artifacts/${artifactid}?teamId=${team} \
+      -H 'Content-Type: application/json' \
+      -H "Authorization: Bearer ${token}"
+      """)
+    if out != "myartifact":
+      raise Exception(f"reponse in not 'myartifact': {out}")
+  '';
+
+  meta.maintainers = [ lib.maintainers.ibizaman ];
+}

--- a/pkgs/by-name/tu/turborepo-remote-cache/package.nix
+++ b/pkgs/by-name/tu/turborepo-remote-cache/package.nix
@@ -9,6 +9,7 @@
   fetchPnpmDeps,
   makeWrapper,
   nix-update-script,
+  nixosTests,
 }:
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "turborepo-remote-cache";
@@ -73,7 +74,10 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     runHook postInstall
   '';
 
-  passthru.updateScript = nix-update-script { };
+  passthru = {
+    tests = { inherit (nixosTests) turborepo-remote-cache; };
+    updateScript = nix-update-script { };
+  };
 
   meta = {
     homepage = "https://github.com/ducktors/turborepo-remote-cache";


### PR DESCRIPTION
https://ducktors.github.io/turborepo-remote-cache/

> An open-source implementation of the [Turborepo custom remote cache server](https://turbo.build/repo/docs/core-concepts/remote-caching#self-hosting). If Vercel’s official cache server isn’t a viable option, this server is an alternative for self-hosted deployments. It supports several storage providers and deploys environments.

I've been using this on an Hetzner machine for the past couple days.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
