### PR TITLE
makeHardcodeGsettingsPatch: Add support for `schemaExistsFunction`

### DIFF
--- a/pkgs/build-support/make-hardcode-gsettings-patch/default.nix
+++ b/pkgs/build-support/make-hardcode-gsettings-patch/default.nix
@@ -27,6 +27,10 @@
     For example, `{ "org.gnome.evolution" = "EVOLUTION_SCHEMA_PATH"; }`
     hardcodes looking for `org.gnome.evolution` into `@EVOLUTION_SCHEMA_PATH@`.
 
+  - `schemaExistsFunction`: name of the function that is used for checking
+    if optional schema exists. Its invocation will be replaced with TRUE
+    for known schemas.
+
   - `patches`: A list of patches to apply before generating the patch.
 
   Example:
@@ -54,6 +58,7 @@
   src,
   patches ? [ ],
   schemaIdToVariableMapping,
+  schemaExistsFunction ? null,
 }:
 
 runCommand "hardcode-gsettings.patch"
@@ -71,6 +76,7 @@ runCommand "hardcode-gsettings.patch"
     patchPhase
     set -x
     cp ${builtins.toFile "glib-schema-to-var.json" (builtins.toJSON schemaIdToVariableMapping)} ./glib-schema-to-var.json
+    cp ${builtins.toFile "glib-schema-exists-function.json" (builtins.toJSON schemaExistsFunction)} ./glib-schema-exists-function.json
     git init
     git add -A
     spatch --sp-file "${./hardcode-gsettings.cocci}" --dir . --in-place

--- a/pkgs/build-support/make-hardcode-gsettings-patch/hardcode-gsettings.cocci
+++ b/pkgs/build-support/make-hardcode-gsettings-patch/hardcode-gsettings.cocci
@@ -34,6 +34,17 @@ def get_schema_directory(schema_id):
         return f'"@{schema_to_var[schema_id]}@"'
     raise Exception(f"Unknown schema path {schema_id!r}, please add it to ./glib-schema-to-var.json")
 
+
+@script:python schema_exists_fn@
+fn;
+@@
+import json
+
+with open("./glib-schema-exists-function.json") as fn_file:
+    if (fn := json.load(fn_file)):
+        coccinelle.fn = fn
+
+
 @find_cpp_constants@
 identifier const_name;
 expression val;
@@ -143,3 +154,12 @@ fresh identifier SCHEMA_DIRECTORY = script:python(SCHEMA_ID) { get_schema_direct
 +   schema = g_settings_schema_source_lookup(schema_source, SCHEMA_ID, FALSE);
 +   settings = g_settings_new_full(schema, NULL, PATH);
 +}
+
+
+@replace_schema_exists_fns depends on ever record_cpp_constants || never record_cpp_constants@
+// We want to run after #define constants have been collected but even if there are no #defines.
+expression SCHEMA_ID;
+identifier schema_exists_fn.fn;
+@@
+-fn(SCHEMA_ID)
++true

--- a/pkgs/by-name/gl/glib/package.nix
+++ b/pkgs/by-name/gl/glib/package.nix
@@ -31,7 +31,6 @@
   tzdata,
   desktop-file-utils,
   shared-mime-info,
-  makeHardcodeGsettingsPatch,
   testers,
   gobject-introspection,
   libsystemtap,
@@ -365,18 +364,6 @@ stdenv.mkDerivation (finalAttrs: {
       packageName = "glib";
       versionPolicy = "odd-unstable";
     };
-
-    mkHardcodeGsettingsPatch =
-      {
-        src,
-        glib-schema-to-var,
-      }:
-      builtins.trace
-        "glib.mkHardcodeGsettingsPatch is deprecated, please use makeHardcodeGsettingsPatch instead"
-        (makeHardcodeGsettingsPatch {
-          inherit src;
-          schemaIdToVariableMapping = glib-schema-to-var;
-        });
   };
 
   meta = with lib; {

--- a/pkgs/test/make-hardcode-gsettings-patch/default.nix
+++ b/pkgs/test/make-hardcode-gsettings-patch/default.nix
@@ -13,14 +13,16 @@ let
       expected,
       src,
       patches ? [ ],
-      schemaIdToVariableMapping,
+      args,
     }:
 
     let
-      patch = makeHardcodeGsettingsPatch ({
-        inherit src schemaIdToVariableMapping;
-        inherit patches;
-      });
+      patch = makeHardcodeGsettingsPatch (
+        args
+        // {
+          inherit src patches;
+        }
+      );
     in
     runCommandLocal "makeHardcodeGsettingsPatch-tests-${name}"
 
@@ -54,10 +56,12 @@ in
   basic = mkTest {
     name = "basic";
     src = ./fixtures/example-project;
-    schemaIdToVariableMapping = {
-      "org.gnome.evolution-data-server.addressbook" = "EDS";
-      "org.gnome.evolution.calendar" = "EVO";
-      "org.gnome.seahorse.nautilus.window" = "SEANAUT";
+    args = {
+      schemaIdToVariableMapping = {
+        "org.gnome.evolution-data-server.addressbook" = "EDS";
+        "org.gnome.evolution.calendar" = "EVO";
+        "org.gnome.seahorse.nautilus.window" = "SEANAUT";
+      };
     };
     expected = ./fixtures/example-project-patched;
   };
@@ -69,9 +73,26 @@ in
       # Avoid using wrapper function, which the generator cannot handle.
       ./fixtures/example-project-wrapped-settings-constructor-resolve.patch
     ];
-    schemaIdToVariableMapping = {
-      "org.gnome.evolution-data-server.addressbook" = "EDS";
+    args = {
+      schemaIdToVariableMapping = {
+        "org.gnome.evolution-data-server.addressbook" = "EDS";
+      };
     };
     expected = ./fixtures/example-project-wrapped-settings-constructor-patched;
   };
+
+  existsFn = mkTest {
+    name = "exists-fn";
+    src = ./fixtures/example-project;
+    args = {
+      schemaIdToVariableMapping = {
+        "org.gnome.evolution-data-server.addressbook" = "EDS";
+        "org.gnome.evolution.calendar" = "EVO";
+        "org.gnome.seahorse.nautilus.window" = "SEANAUT";
+      };
+      schemaExistsFunction = "e_ews_common_utils_gsettings_schema_exists";
+    };
+    expected = ./fixtures/example-project-patched-with-exists-fn;
+  };
+
 }

--- a/pkgs/test/make-hardcode-gsettings-patch/fixtures/example-project-patched-with-exists-fn/main.c
+++ b/pkgs/test/make-hardcode-gsettings-patch/fixtures/example-project-patched-with-exists-fn/main.c
@@ -74,7 +74,7 @@ void schema_id_with_path() {
 }
 
 void exists_fn_guard() {
-  if (!e_ews_common_utils_gsettings_schema_exists("org.gnome.evolution.calendar")) {
+  if (!true) {
     return;
   }
 
@@ -89,7 +89,7 @@ void exists_fn_guard() {
 }
 
 void exists_fn_nested() {
-  if (e_ews_common_utils_gsettings_schema_exists("org.gnome.evolution.calendar")) {
+  if (true) {
     g_autoptr(GSettings) settings = NULL;
     {
       g_autoptr(GSettingsSchemaSource) schema_source;
@@ -102,7 +102,7 @@ void exists_fn_nested() {
 }
 
 void exists_fn_unknown() {
-  if (e_ews_common_utils_gsettings_schema_exists("org.gnome.foo")) {
+  if (true) {
     g_autoptr(GSettings) settings = NULL;
     {
       g_autoptr(GSettingsSchemaSource) schema_source;

--- a/pkgs/test/make-hardcode-gsettings-patch/fixtures/example-project/main.c
+++ b/pkgs/test/make-hardcode-gsettings-patch/fixtures/example-project/main.c
@@ -37,6 +37,29 @@ void schema_id_with_path() {
   g_object_unref(settings);
 }
 
+void exists_fn_guard() {
+  if (!e_ews_common_utils_gsettings_schema_exists("org.gnome.evolution.calendar")) {
+    return;
+  }
+
+  g_autoptr(GSettings) settings = NULL;
+  settings = g_settings_new("org.gnome.evolution.calendar");
+}
+
+void exists_fn_nested() {
+  if (e_ews_common_utils_gsettings_schema_exists("org.gnome.evolution.calendar")) {
+    g_autoptr(GSettings) settings = NULL;
+    settings = g_settings_new("org.gnome.evolution.calendar");
+  }
+}
+
+void exists_fn_unknown() {
+  if (e_ews_common_utils_gsettings_schema_exists("org.gnome.foo")) {
+    g_autoptr(GSettings) settings = NULL;
+    settings = g_settings_new("org.gnome.evolution.calendar");
+  }
+}
+
 int main() {
   schema_id_literal();
   schema_id_from_constant();
@@ -44,6 +67,9 @@ int main() {
   schema_id_with_backend();
   schema_id_with_backend_and_path();
   schema_id_with_path();
+  exists_fn_guard();
+  exists_fn_nested();
+  exists_fn_unknown();
 
   return 0;
 }


### PR DESCRIPTION
evolution-ews introduced a check for optional schemas, which would skip our hardcoded code paths.
https://gitlab.gnome.org/GNOME/evolution-ews/-/commit/a0c514bd345c67fe0fd2ed6ef48a25649b1f4d8e

Let’s update the semantic patch to also replace the invocations of specified `schemaExistsFunction` for known schemas with `true`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Tested, as applicable:
  - Makes `evolution-ews` update work properly https://github.com/NixOS/nixpkgs/pull/405225
  - All in-tree uses produce the same patch.
  - Ran `tests.makeHardcodeGsettingsPatch`.
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
