### PR TITLE
fastfetch: optional zfs support

### DIFF
--- a/pkgs/by-name/fa/fastfetch/package.nix
+++ b/pkgs/by-name/fa/fastfetch/package.nix
@@ -38,6 +38,7 @@
   xorg,
   yyjson,
   zlib,
+  zfs,
   # Feature flags
   audioSupport ? true,
   brightnessSupport ? true,
@@ -54,6 +55,7 @@
   waylandSupport ? true,
   x11Support ? true,
   xfceSupport ? true,
+  zfsSupport ? false,
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "fastfetch";
@@ -175,6 +177,10 @@ stdenv.mkDerivation (finalAttrs: {
           #  Needed for XFWM theme and XFCE Terminal font.
           xfce.xfconf
         ]
+        ++ lib.optionals zfsSupport [
+          # Needed for zpool module
+          zfs
+        ]
       );
 
       macosDeps = lib.optionals stdenv.hostPlatform.isDarwin [
@@ -198,6 +204,8 @@ stdenv.mkDerivation (finalAttrs: {
       (lib.cmakeBool "ENABLE_CHAFA" imageSupport)
 
       (lib.cmakeBool "ENABLE_SQLITE3" sqliteSupport)
+
+      (lib.cmakeBool "ENABLE_LIBZFS" zfsSupport)
     ]
     ++ lib.optionals stdenv.hostPlatform.isLinux [
       (lib.cmakeBool "ENABLE_PULSE" audioSupport)
@@ -270,7 +278,7 @@ stdenv.mkDerivation (finalAttrs: {
     longDescription = ''
       Fast and highly customizable system info script.
 
-      Feature flags (all default to 'true' except rpmSupport and flashfetchSupport):
+      Feature flags (all default to 'true' except rpmSupport, flashfetchSupport and zfsSupport):
       * audioSupport: PulseAudio functionality
       * brightnessSupport: External display brightness detection via DDCUtil
       * dbusSupport: DBus functionality for Bluetooth, WiFi, player & media detection
@@ -286,6 +294,7 @@ stdenv.mkDerivation (finalAttrs: {
       * waylandSupport: Wayland display detection
       * x11Support: X11 display information
       * xfceSupport: XFCE integration for theme and terminal font detection
+      * zfsSupport: zpool information
     '';
   };
 })


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
This adds the `zfsSupport` flag to allow support for zfs. It is disabled by default. This enables support for the zpool module.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
