### PR TITLE
readeck: 0.17.1 -> 0.18.2

### DIFF
--- a/nixos/modules/services/web-apps/readeck.nix
+++ b/nixos/modules/services/web-apps/readeck.nix
@@ -68,7 +68,6 @@ in
         ExecStart = "${lib.getExe cfg.package} serve -config ${configFile}";
         ProtectSystem = "full";
         SystemCallArchitectures = "native";
-        MemoryDenyWriteExecute = true;
         NoNewPrivileges = true;
         PrivateTmp = true;
         PrivateDevices = true;
@@ -89,7 +88,6 @@ in
         ProtectKernelTunables = true;
         LockPersonality = true;
         Restart = "on-failure";
-
       };
     };
   };

--- a/pkgs/by-name/re/readeck/package.nix
+++ b/pkgs/by-name/re/readeck/package.nix
@@ -1,14 +1,14 @@
 {
+  lib,
   fetchFromGitea,
   fetchNpmDeps,
   buildGoModule,
   nodejs,
   npmHooks,
-  lib,
+  python3,
 }:
 
 let
-
   file-compose = buildGoModule {
     pname = "file-compose";
     version = "unstable-2023-10-21";
@@ -27,19 +27,20 @@ in
 
 buildGoModule rec {
   pname = "readeck";
-  version = "0.17.1";
+  version = "0.18.2";
 
   src = fetchFromGitea {
     domain = "codeberg.org";
     owner = "readeck";
     repo = "readeck";
     tag = version;
-    hash = "sha256-+GgjR1mxD93bFNaLeDuEefPlQEV9jNgFIo8jTAxphyo=";
+    hash = "sha256-geKhug1sQ51i+6qw2LVzW8lXyvre6AlVHWvGlEXWki8=";
   };
 
   nativeBuildInputs = [
     nodejs
     npmHooks.npmConfigHook
+    (python3.withPackages (ps: with ps; [ babel ]))
   ];
 
   npmRoot = "web";
@@ -48,9 +49,12 @@ buildGoModule rec {
 
   preBuild = ''
     make web-build
+    python3 locales/messages.py compile
     ${file-compose}/bin/file-compose -format json docs/api/api.yaml docs/assets/api.json
     go run ./tools/docs docs/src docs/assets
   '';
+
+  subPackages = [ "." ];
 
   tags = [
     "netgo"
@@ -66,6 +70,7 @@ buildGoModule rec {
     "-X"
     "codeberg.org/readeck/readeck/configs.version=${version}"
   ];
+
   overrideModAttrs = oldAttrs: {
     # Do not add `npmConfigHook` to `goModules`
     nativeBuildInputs = lib.remove npmHooks.npmConfigHook oldAttrs.nativeBuildInputs;
@@ -75,18 +80,17 @@ buildGoModule rec {
 
   npmDeps = fetchNpmDeps {
     src = "${src}/web";
-    hash = "sha256-7fRSkXKAMEC7rFmSF50DM66SVhV68g93PMBjrtkd9/E=";
+    hash = "sha256-3MVrzpilJKptT0iRBQx2Cl0iKVoOJu5cBT987U1/C1k=";
   };
 
-  vendorHash = "sha256-O/ZrpT6wTtPwBDUCAmR0XHRgQmd46/MPvWNE0EvD3bg=";
+  vendorHash = "sha256-RjU3PW7GeMkQE0oHkI4EmFNr4HT3vRyFITUzYX9AHpw=";
 
   meta = {
     description = "Web application that lets you save the readable content of web pages you want to keep forever.";
     mainProgram = "readeck";
     homepage = "https://readeck.org/";
-    changelog = "https://github.com/readeck/readeck/releases/tag/${version}";
+    changelog = "https://codeberg.org/readeck/readeck/releases/tag/${version}";
     license = lib.licenses.agpl3Only;
     maintainers = with lib.maintainers; [ julienmalka ];
   };
-
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

1. update to 0.18.2 and fix module. https://codeberg.org/readeck/readeck/releases/tag/0.18.0
    > New SQLite, CGO-free driver. Important: it won't run with MemoryDenyWriteExecute=yes in the systemd service file.
1. Fix missing translation.
1. Remove useless binaries from bin.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
