### PR TITLE
ty: init at 0.0.1-alpha.5

### DIFF
--- a/pkgs/by-name/ty/ty/package.nix
+++ b/pkgs/by-name/ty/ty/package.nix
@@ -1,0 +1,88 @@
+{
+  lib,
+  stdenv,
+  rustPlatform,
+  fetchFromGitHub,
+
+  # nativeBuildInputs
+  installShellFiles,
+
+  buildPackages,
+  versionCheckHook,
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "ty";
+  version = "0.0.1-alpha.5";
+
+  src = fetchFromGitHub {
+    owner = "astral-sh";
+    repo = "ty";
+    tag = finalAttrs.version;
+    fetchSubmodules = true;
+    hash = "sha256-F3q6IpS7dk0jISG+aREKpPxwWHO5UdSfslOnclYa0R8=";
+  };
+
+  # For Darwin platforms, remove the integration test for file notifications,
+  # as these tests fail in its sandboxes.
+  postPatch = lib.optionalString stdenv.hostPlatform.isDarwin ''
+    rm ${finalAttrs.cargoRoot}/crates/ty/tests/file_watching.rs
+  '';
+
+  cargoRoot = "ruff";
+  buildAndTestSubdir = finalAttrs.cargoRoot;
+
+  cargoBuildFlags = [ "--package=ty" ];
+
+  cargoHash = "sha256-NXhO+xYHCz269jxEuiB8yMgaX21Z8wAySVl9XOc7W60=";
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  # `ty`'s tests use `insta-cmd`, which depends on the structure of the `target/` directory,
+  # and also fails to find the environment variable `$CARGO_BIN_EXE_ty`, which leads to tests failing.
+  # Instead, we specify the path ourselves and forgo the lookup.
+  # As the patches occur solely in test code, they have no effect on the packaged `ty` binary itself.
+  #
+  # `stdenv.hostPlatform.rust.cargoShortTarget` is taken from `cargoSetupHook`'s `installPhase`,
+  # which constructs a path as below to reference the built binary.
+  preCheck = ''
+    export CARGO_BIN_EXE_ty="$PWD"/target/${stdenv.hostPlatform.rust.cargoShortTarget}/release/ty
+  '';
+
+  # All the packages referenced in `crates/ty/README.md`, plus `crates/ty` itself.
+  cargoTestFlags = [
+    "--package=ty" # CLI tests; file-watching tests only on Linux platforms
+    "--package=ty_python_semantic" # core type checking tests
+    "--package=ty_test" # test framework tests
+  ];
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgramArg = "--version";
+  doInstallCheck = true;
+
+  postInstall = lib.optionalString (stdenv.hostPlatform.emulatorAvailable buildPackages) (
+    let
+      emulator = stdenv.hostPlatform.emulator buildPackages;
+    in
+    ''
+      installShellCompletion --cmd ty \
+        --bash <(${emulator} $out/bin/ty generate-shell-completion bash) \
+        --fish <(${emulator} $out/bin/ty generate-shell-completion fish) \
+        --zsh <(${emulator} $out/bin/ty generate-shell-completion zsh)
+    ''
+  );
+
+  passthru = {
+    updateScript = nix-update-script { extraArgs = [ "--version=unstable" ]; };
+  };
+
+  meta = {
+    description = "Extremely fast Python type checker and language server, written in Rust";
+    homepage = "https://github.com/astral-sh/ty";
+    changelog = "https://github.com/astral-sh/ty/blob/${finalAttrs.version}/CHANGELOG.md";
+    license = lib.licenses.mit;
+    mainProgram = "ty";
+    maintainers = [ lib.maintainers.bengsparks ];
+  };
+})


### PR DESCRIPTION
Adds Astral's type-checker `ty` to nixpkgs.

After asking around on the Discord server, I was told that the project's structure will not change until the preview release that is upcoming on the 16th May, so I decided to go ahead and create packages for `ty` ~~and `python3Packages.ty`.~~

~~I'd like to gather preliminary feedback before updating this package on the release day, so I've opened this PR as a means of doing so.~~

Since https://github.com/astral-sh/ty/pull/334/ was merged (swaps the phrases "pre-release software" for "preview") 1 day before `0.0.1-alpha.1` was released, I am inclined to believe that the preview release is now here.
Now that 25.05 has branched off as of 4h ago, I think the next wave of reviews for the newest version can roll in! 😎 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
