### PR TITLE
dotnet: expose update.sh under generate-dotnet-sdk

### DIFF
--- a/pkgs/development/compilers/dotnet/default.nix
+++ b/pkgs/development/compilers/dotnet/default.nix
@@ -11,7 +11,7 @@
   recurseIntoAttrs,
   generateSplicesForMkScope,
   makeScopeWithSplicing',
-  stdenvNoCC,
+  writeScriptBin,
 }:
 
 let
@@ -69,6 +69,11 @@ let
       // lib.mapAttrs' (k: v: lib.nameValuePair "${k}-bin" v) dotnet-bin
       // {
         inherit callPackage fetchNupkg buildDotnetSdk;
+
+        generate-dotnet-sdk = writeScriptBin "generate-dotnet-sdk" (
+          # Don't include current nixpkgs in the exposed version. We want to make the script runnable without nixpkgs repo.
+          builtins.replaceStrings [ " -I nixpkgs=./." ] [ "" ] (builtins.readFile ./update.sh)
+        );
 
         # Convert a "stdenv.hostPlatform.system" to a dotnet RID
         systemToDotnetRid =


### PR DESCRIPTION
Problem in short:
- when I try to combine unwrapped (e.g. `dotnetCorePackages.sdk_8_0-bin.unwrapped`) dotnet sdks they don't have `nix-support` folder and `combinePackages` crashes because we try to copy non-existing folder

Solution:
- check if nix-support exists before copying

Longer explanation:
I maintain my own repo of dotnet SDKs for nixos. Mainly because updates on nixpkgs are too slow and sometimes I just need version X.Y.Z as soon as it's released.
I create my packages using something like this:
```nix
  makeDotnetSdk =
    orig: version: url:
    orig.overrideAttrs (oldAttrs: {
      inherit version;
      src = fetchurl url;
    });

makeDotnetSdk dotnetCorePackages.sdk_8_0-bin.unwrapped "9.0.203" {
    url = "https://dotnetcli.azureedge.net/dotnet/Sdk/9.0.203/dotnet-sdk-9.0.203-osx-x64.tar.gz";
    sha256 = "0nh6zgp85ch54cl7hqxhqzg9awgaz55yxsdzffxgab57vqyvl7qn";
  };
```

SDKs created that way work fine for me, but they don't contain `nix-support` folder. As said above, when using combinePackages on those (or just on plain `dotnetCorePackages.sdk_8_0-bin.unwrapped`), I cannot combine them due to script crashing when trying to copy nix-support.

This PR solves this issue

EDIT:
The aim of this PR changed after the discussion below. Now it's about exposing the internal `update.sh` script to be able to generate input files for `buildDotnetSdk` outside of nixpkgs since `buildDotnetSdk` is already exposed but (according to my knowledge) there's no "exposed" way to actually generate input files to this function.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [x] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
