### PR TITLE
brickstore: 2024.5.2 -> 2024.12.3

### DIFF
--- a/pkgs/by-name/br/brickstore/package.nix
+++ b/pkgs/by-name/br/brickstore/package.nix
@@ -16,13 +16,13 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "brickstore";
-  version = "2024.5.2";
+  version = "2024.12.3";
 
   src = fetchFromGitHub {
     owner = "rgriebl";
     repo = "brickstore";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-Bu9oNbZm3lx/CfYAReHyWe/kW+kaefDWeBtWLHOCORU=";
+    hash = "sha256-4sxPplZ1t8sSfwTCeeBtfU4U0gcE9FROt6dKvkfyO6Q=";
     fetchSubmodules = true;
   };
 
@@ -45,16 +45,14 @@ stdenv.mkDerivation (finalAttrs: {
     tbb
   ];
 
-  preConfigure = ''
-    sed -i '/^)$/d' cmake/BuildQCoro.cmake
+  patches = [
+    ./qcoro-cmake.patch # Don't have CMake fetch qcoro from github, get it from nixpkgs
+    ./qjsonvalue-include.patch # Add a required '#include <QtCore/QJsonValue>'
+  ];
 
+  # Since we get qcoro from nixpkgs instead, change the CMake file to reflect the right directory
+  preConfigure = ''
     substituteInPlace cmake/BuildQCoro.cmake \
-      --replace-fail 'FetchContent_Declare(' ' ' \
-      --replace-fail '    qcoro' ' ' \
-      --replace-fail '    GIT_REPOSITORY https://github.com/danvratil/qcoro.git' ' ' \
-      --replace-fail '    GIT_TAG        v''${QCORO_VERSION}' ' ' \
-      --replace-fail 'FetchContent_GetProperties(qcoro)' ' ' \
-      --replace-fail 'FetchContent_Populate(qcoro)' ' ' \
       --replace-fail \
         'add_subdirectory(''${qcoro_SOURCE_DIR} ''${qcoro_BINARY_DIR} EXCLUDE_FROM_ALL)' \
         'add_subdirectory(${qcoro.src} ${qcoro}bin/qcoro)'

--- a/pkgs/by-name/br/brickstore/qcoro-cmake.patch
+++ b/pkgs/by-name/br/brickstore/qcoro-cmake.patch
@@ -1,0 +1,20 @@
+diff --git a/cmake/BuildQCoro.cmake b/cmake/BuildQCoro.cmake
+index 941e813..41c88c6 100644
+--- a/cmake/BuildQCoro.cmake
++++ b/cmake/BuildQCoro.cmake
+@@ -14,14 +14,6 @@ if (BACKEND_ONLY)
+     set(QCORO_WITH_QML OFF)
+ endif()
+ 
+-FetchContent_Declare(
+-    qcoro
+-    GIT_REPOSITORY https://github.com/danvratil/qcoro.git
+-    GIT_TAG        v${QCORO_VERSION}
+-    SOURCE_SUBDIR  "NeedManualAddSubDir" # make it possible to add_subdirectory below
+-)
+-
+-FetchContent_MakeAvailable(qcoro)
+ 
+ set(mll ${CMAKE_MESSAGE_LOG_LEVEL})
+ if (NOT VERBOSE_FETCH)
+

--- a/pkgs/by-name/br/brickstore/qjsonvalue-include.patch
+++ b/pkgs/by-name/br/brickstore/qjsonvalue-include.patch
@@ -1,0 +1,12 @@
+diff --git a/src/bricklink/order.cpp b/src/bricklink/order.cpp
+index 14426e5b..59856f0c 100755
+--- a/src/bricklink/order.cpp
++++ b/src/bricklink/order.cpp
+@@ -16,6 +16,7 @@
+ #include <QtSql/QSqlError>
+ #include <QtSql/QSqlQueryModel>
+ #include <QtCore/QLoggingCategory>
++#include <QtCore/QJsonValue>
+ 
+ #include "bricklink/core.h"
+ #include "bricklink/io.h"


### PR DESCRIPTION
Update to its newest release
(https://github.com/rgriebl/brickstore/releases/tag/v2024.12.3) and refactored changing the qcoro CMake file to use patches for relevant parts

ZHF: https://github.com/NixOS/nixpkgs/issues/403336

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
