### PR TITLE
lib.modules: init `mkAliasDefinitionsWith`; simplify `doRename`; add `withLocation`

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -462,6 +462,7 @@ let
         mkBefore
         mkAfter
         mkAliasDefinitions
+        mkAliasDefinitionsWith
         mkAliasAndWrapDefinitions
         fixMergeModules
         mkRemovedOptionModule

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -500,6 +500,7 @@ let
         mkBefore
         mkAfter
         mkAliasDefinitions
+        mkAliasDefinitionsWith
         mkAliasAndWrapDefinitions
         fixMergeModules
         mkRemovedOptionModule

--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -1647,6 +1647,8 @@ let
   #
   mkAliasDefinitions = mkAliasDefinitionsWith {
     keepPriority = false;
+    # Set `keepLocation = false` to preserve existing behaviour. TODO: Should it be true?
+    keepLocation = false;
   };
 
   mkAliasAndWrapDefinitions =
@@ -1654,6 +1656,8 @@ let
     mkAliasDefinitionsWith {
       inherit wrap;
       keepPriority = false;
+      # Set `keepLocation = false` to preserve existing behaviour. TODO: Should it be true?
+      keepLocation = false;
     };
 
   # Similar to mkAliasAndWrapDefinitions but copies over the priority from the
@@ -1664,6 +1668,8 @@ let
     wrap:
     mkAliasDefinitionsWith {
       inherit wrap;
+      # Set `keepLocation = false` to preserve existing behaviour. TODO: Should it be true?
+      keepLocation = false;
     };
 
   /**
@@ -1704,6 +1710,10 @@ let
 
       : Whether to wrap definition with the option's overall priority (`true` by default)
 
+      `keepLocation` (Bool)
+
+      : Whether to preserve definitions original file location (`true` by default)
+
     `option` (Option or Any)
 
     : The option from which to copy definitions, if defined.
@@ -1712,7 +1722,7 @@ let
     # Type
 
     ```
-    mkAliasDefinitionsWith :: { wrap :: Function, keepPriority :: Bool } -> Option -> AttrSet
+    mkAliasDefinitionsWith :: { wrap :: Function, keepPriority :: Bool, keepLocation :: Bool } -> Option -> AttrSet
     ```
 
     # Example
@@ -1734,12 +1744,17 @@ let
     {
       wrap ? id,
       keepPriority ? true,
+      keepLocation ? true,
     }:
     option:
     let
       prio = option.highestPrio or defaultOverridePriority;
       wrapPrio = if keepPriority then mkOverride prio else id;
-      defs = map wrapPrio option.definitions;
+      defs =
+        if keepLocation then
+          map (def: mkDefinition (def // { value = wrapPrio def.value; })) option.definitionsWithLocations
+        else
+          map wrapPrio option.definitions;
     in
     mkIf option.isDefined (wrap (mkMerge defs));
 
@@ -2089,6 +2104,8 @@ let
       use,
       # Legacy option, enabled by default: whether to preserve the priority of definitions in `old`.
       withPriority ? true,
+      # Legacy option, enabled by default: whether to preserve the location of definitions in `old`.
+      keepLocation ? true,
       # A boolean that defines the `mkIf` condition for `to`.
       # If the condition evaluates to `true`, and the `to` path points into an
       # `attrsOf (submodule ...)`, then `doRename` would cause an empty module to
@@ -2158,6 +2175,7 @@ let
               "The option `${showOption from}' defined in ${showFiles fromOpt.files} has been renamed to `${showOption to}'.";
         })
         (mkAliasDefinitionsWith {
+          inherit keepLocation;
           keepPriority = withPriority;
           wrap = setAttrByPath to;
         } fromOpt)

--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -1645,20 +1645,103 @@ let
   # as a definition, as the new definition will not keep the mkOverride /
   # mkDefault properties of the previous option.
   #
-  mkAliasDefinitions = mkAliasAndWrapDefinitions id;
-  mkAliasAndWrapDefinitions = wrap: option: mkIf option.isDefined (wrap (mkMerge option.definitions));
+  mkAliasDefinitions = mkAliasDefinitionsWith {
+    keepPriority = false;
+  };
+
+  mkAliasAndWrapDefinitions =
+    wrap:
+    mkAliasDefinitionsWith {
+      inherit wrap;
+      keepPriority = false;
+    };
 
   # Similar to mkAliasAndWrapDefinitions but copies over the priority from the
   # option as well.
   #
   # If a priority is not set, it assumes a priority of defaultOverridePriority.
   mkAliasAndWrapDefsWithPriority =
-    wrap: option:
+    wrap:
+    mkAliasDefinitionsWith {
+      inherit wrap;
+    };
+
+  /**
+    A function which copies all definitions from one option to another.
+    This is useful for renaming options, and also for including properties from another module system, including sub-modules.
+
+    Naturally, definitions are only copied if the option is defined.
+    Supplying a non-option value is silently ignored, which allows using options which may not exist in the `options` set.
+
+    :::{.note}
+
+    This is different from taking the value of the option and using it as a definition, as the new definition will not keep the `mkOverride` / `mkDefault` properties of the previous option.
+
+    If the option you are copying does not have nested properties, or you need to perform some transformation to the value, you may prefer `mkDerivedConfig`, which preserves the option's _overall_ override priority.
+
+    :::
+
+    :::{.caution}
+
+    Copying definitions to an option with a different `type` may result in the unexpected merge semantics.
+
+    The original option's `type` is completely ignored when the target option merges its definitions.
+
+    :::
+
+    # Inputs
+
+    `config` (AttrSet)
+
+    : `wrap` (Any -> Any)
+
+      : A function to wrap the final `mkMerge` definition
+        (e.g. `setAttrByPath [ "foo" "bar" ]`) (default `lib.id`)
+
+        The argument is a `mkMerge` result, but should normally be treated as a black box.
+
+      `keepPriority` (Bool)
+
+      : Whether to wrap definition with the option's overall priority (`true` by default)
+
+    `option` (Option or Any)
+
+    : The option from which to copy definitions, if defined.
+      Non-option values are silently ignored.
+
+    # Type
+
+    ```
+    mkAliasDefinitionsWith :: { wrap :: Function, keepPriority :: Bool } -> Option -> AttrSet
+    ```
+
+    # Example
+
+    ```nix
+    { options, ... }:
+    {
+      # Use the `. or` operator when an option may not be present.
+      # (e.g. not in `imports` or the `modules` in `evalModules`/`submodule`)
+      # https://nix.dev/manual/nix/stable/language/operators#attribute-selection
+      config.foo.enable = mkAliasDefinitionsWith { } (options.bar.enable or { });
+
+      # Otherwise, for example, 'barbaz' must be declared in the current module set.
+      config.foobar.paths = mkAliasDefinitionsWith { } options.barbaz.paths;
+    }
+    ```
+  */
+  mkAliasDefinitionsWith =
+    {
+      wrap ? id,
+      keepPriority ? true,
+    }:
+    option:
     let
       prio = option.highestPrio or defaultOverridePriority;
-      defsWithPrio = map (mkOverride prio) option.definitions;
+      wrapPrio = if keepPriority then mkOverride prio else id;
+      defs = map wrapPrio option.definitions;
     in
-    mkIf option.isDefined (wrap (mkMerge defsWithPrio));
+    mkIf option.isDefined (wrap (mkMerge defs));
 
   mkAliasIfDef =
     lib.warn "Usage of 'mkAliasIfDef' has been deprecated. Use 'mkIf option.isDefined' instead."
@@ -2074,12 +2157,10 @@ let
             optional (warn && fromOpt.isDefined)
               "The option `${showOption from}' defined in ${showFiles fromOpt.files} has been renamed to `${showOption to}'.";
         })
-        (
-          if withPriority then
-            mkAliasAndWrapDefsWithPriority (setAttrByPath to) fromOpt
-          else
-            mkAliasAndWrapDefinitions (setAttrByPath to) fromOpt
-        )
+        (mkAliasDefinitionsWith {
+          keepPriority = withPriority;
+          wrap = setAttrByPath to;
+        } fromOpt)
       ]);
     };
 
@@ -2334,6 +2415,7 @@ private
     mkAliasAndWrapDefinitions
     mkAliasAndWrapDefsWithPriority
     mkAliasDefinitions
+    mkAliasDefinitionsWith
     mkAliasIfDef
     mkAliasOptionModule
     mkAliasOptionModuleMD

--- a/lib/tests/modules.sh
+++ b/lib/tests/modules.sh
@@ -310,6 +310,12 @@ checkConfigOutput '^true$' config.enable ./alias-with-priority.nix
 checkConfigOutput '^true$' config.enableAlias ./alias-with-priority.nix
 checkConfigOutput '^false$' config.enable ./alias-with-priority-can-override.nix
 checkConfigOutput '^false$' config.enableAlias ./alias-with-priority-can-override.nix
+checkConfigOutput '^"main-defs"$' options.lines.definitionsWithLocations.0.file ./alias-with-location.nix
+checkConfigOutput '^"alias-defs"$' options.lines.definitionsWithLocations.1.file ./alias-with-location.nix
+checkConfigOutput '^"alias-defs"$' options.linesAlias.definitionsWithLocations.0.file ./alias-with-location.nix
+checkConfigOutput '^"hello"$' options.lines.definitions.0 ./alias-with-location.nix
+checkConfigOutput '^"world"$' options.lines.definitions.1 ./alias-with-location.nix
+checkConfigOutput '^"world"$' options.linesAlias.definitions.0 ./alias-with-location.nix
 
 # Check mkPackageOption
 checkConfigOutput '^"hello"$' config.package.pname ./declare-mkPackageOption.nix

--- a/lib/tests/modules.sh
+++ b/lib/tests/modules.sh
@@ -412,6 +412,12 @@ checkConfigOutput '^true$' config.enable ./alias-with-priority.nix
 checkConfigOutput '^true$' config.enableAlias ./alias-with-priority.nix
 checkConfigOutput '^false$' config.enable ./alias-with-priority-can-override.nix
 checkConfigOutput '^false$' config.enableAlias ./alias-with-priority-can-override.nix
+checkConfigOutput '^"main-defs"$' options.lines.definitionsWithLocations.0.file ./alias-with-location.nix
+checkConfigOutput '^"alias-defs"$' options.lines.definitionsWithLocations.1.file ./alias-with-location.nix
+checkConfigOutput '^"alias-defs"$' options.linesAlias.definitionsWithLocations.0.file ./alias-with-location.nix
+checkConfigOutput '^"hello"$' options.lines.definitions.0 ./alias-with-location.nix
+checkConfigOutput '^"world"$' options.lines.definitions.1 ./alias-with-location.nix
+checkConfigOutput '^"world"$' options.linesAlias.definitions.0 ./alias-with-location.nix
 
 # Check mkPackageOption
 checkConfigOutput '^"hello"$' config.package.pname ./declare-mkPackageOption.nix

--- a/lib/tests/modules/alias-with-location.nix
+++ b/lib/tests/modules/alias-with-location.nix
@@ -1,0 +1,39 @@
+# This is a test to show that mkAliasOptionModule sets the location correctly
+# for aliased definitions.
+
+{ lib, ... }:
+
+let
+  inherit (lib)
+    mkAliasOptionModule
+    mkOption
+    setDefaultModuleLocation
+    types
+    ;
+in
+
+{
+  # A simple option that can merge multiple str definitions
+  options.lines = mkOption {
+    type = types.lines;
+    default = "";
+    description = ''
+      Some descriptive text
+    '';
+  };
+
+  imports = [
+    # Create an alias for the "lines" option.
+    (mkAliasOptionModule [ "linesAlias" ] [ "lines" ])
+
+    # Define the aliased option.
+    (setDefaultModuleLocation "alias-defs" {
+      linesAlias = "world";
+    })
+
+    # Define the normal (non-aliased) option.
+    (setDefaultModuleLocation "main-defs" {
+      lines = "hello";
+    })
+  ];
+}

--- a/lib/tests/modules/alias-with-priority-can-override.nix
+++ b/lib/tests/modules/alias-with-priority-can-override.nix
@@ -26,18 +26,6 @@ in
         Some descriptive text
       '';
     };
-
-    # mkAliasOptionModule sets warnings, so this has to be defined.
-    warnings = mkOption {
-      internal = true;
-      default = [ ];
-      type = types.listOf types.str;
-      example = [ "The `foo' service is deprecated and will go away soon!" ];
-      description = ''
-        This option allows modules to show warnings to users during
-        the evaluation of the system configuration.
-      '';
-    };
   };
 
   imports = [

--- a/lib/tests/modules/alias-with-priority.nix
+++ b/lib/tests/modules/alias-with-priority.nix
@@ -26,18 +26,6 @@ in
         Some descriptive text
       '';
     };
-
-    # mkAliasOptionModule sets warnings, so this has to be defined.
-    warnings = mkOption {
-      internal = true;
-      default = [ ];
-      type = types.listOf types.str;
-      example = [ "The `foo' service is deprecated and will go away soon!" ];
-      description = ''
-        This option allows modules to show warnings to users during
-        the evaluation of the system configuration.
-      '';
-    };
   };
 
   imports = [


### PR DESCRIPTION
This PR refactors `doRename`, `mkAliasDefinitions`, `mkAliasAndWrapDefinitions`, & `mkAliasAndWrapDefsWithPriority` to use a new common/shared configurable implementation: `mkAliasDefinitionsWith`

I've tried to introduce this function with a modern nix doc-comment, but I'm struggling to work out what the "current"/"correct" format is for function docs, as there's a lot of varying styles in existing docs. Feedback welcome on the best way to format and structure the doc-comment.

I've used the new configurable function to also implement a new `withLocation` option, which preserves the definition's original `file` location, using `lib.mkDefinition`. This is added and tested in a dedicated commit, but can be moved to another PR if preferred.

---

- **lib.modules: init `mkAliasDefinitionsWith`; simplify `doRename`**

Combine the impl of `mkAliasDefinitions` and `mkAliasAndWrapDefinitions` into a new function `mkAliasDefinitionsWith`.

This simplifies the `withPriority` condition in `doRename`.

- **lib.modules.mkAliasDefinitionsWith: add `withLocation` option**

Preserves the original file location of the transferred definitions.

Preserve definition locations by default in `doRename`.

Preserve the old behaviour in: `mkAliasDefinitions`, `mkAliasAndWrapDefinitions`, & `mkAliasAndWrapDefsWithPriority`

- **lib/tests/modules: remove unnecessary `warning` options from alias tests**

`mkRenamedOptionModule` can set the `warnings` option, if it is declared. `mkAliasOptionModule` will never define any warnings.

In either case, it is unnecessary to declare the option if we aren't _reading_ any warnings in the test.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - For functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
    - [x] `nix-build ./lib/tests/release.nix`
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
