### PR TITLE
nix-direnv: 3.0.6 -> 3.0.7

### DIFF
--- a/pkgs/by-name/ni/nix-direnv/package.nix
+++ b/pkgs/by-name/ni/nix-direnv/package.nix
@@ -11,13 +11,13 @@
 # https://github.com/abathur/resholve/issues/107
 resholve.mkDerivation rec {
   pname = "nix-direnv";
-  version = "3.0.6";
+  version = "3.0.7";
 
   src = fetchFromGitHub {
     owner = "nix-community";
     repo = "nix-direnv";
     rev = version;
-    hash = "sha256-oNqhPqgQT92yxbKmcgX4F3e2yTUPyXYG7b2xQm3TvQw=";
+    hash = "sha256-H59MMmyQ9Tl9CLKKkXIv2NZddrrJNLv8XOOI2e4pG64=";
   };
 
   installPhase = ''


### PR DESCRIPTION
`direnv` 2.36.0 [changed how logging worked][1]. As a result, the `$DIRENV_LOG_FORMAT` variable is no longer set when the `nix-direnv` `direnvrc` is sourced. Previously, setting `$DIRENV_LOG_FORMAT` to the empty string was [the recommended solution for disabling all log output][2]. Therefore, `nix-direnv`'s warnings are completely silenced when using the latest `direnv`.

`nix-direnv` 3.0.7 fixes this.

Warnings being silenced leads to very surprising behavior and output. We use an `.envrc` that looks like this:

    nix_direnv_manual_reload
    use flake

`nix_direnv_manual_reload` means that `use flake` is ignored unless a cache already exists. It's supposed to print a warning making this clear, which looks like this:

    $ direnv allow
    direnv: loading ~/my-repo/.envrc
    direnv: using flake
    direnv: nix-direnv: cache does not exist. use "nix-direnv-reload" to create it
    direnv: export ~PATH

However, with the latest `direnv`, it prints this output instead:

    $ direnv allow
    direnv: loading ~/my-repo/.envrc
    direnv: using flake
    direnv: export ~PATH

This is very misleading; it prints `using flake` as if it's loading the Flake, but actually nothing is happening and the Flake is being ignored entirely!

[1]: https://github.com/direnv/direnv/pull/1336
[2]: https://github.com/direnv/direnv/issues/68#issuecomment-42525172
[3]: https://github.com/nix-community/nix-direnv/commit/374b3282707db0355082578b435c21015a83edbd
[4]: https://github.com/nix-community/nix-direnv/issues/567


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
