### PR TITLE
np2kai: 0.86rev22 -> 0.86rev22-unstable-2024-12-22

### DIFF
--- a/pkgs/by-name/np/np2kai/package.nix
+++ b/pkgs/by-name/np/np2kai/package.nix
@@ -2,32 +2,23 @@
   stdenv,
   lib,
   fetchFromGitHub,
-  enable16Bit ? true,
-  enable32Bit ? true,
-
-  enableSDL ? true,
-  withSDLVersion ? "2",
-  SDL,
-  SDL_ttf,
-  SDL_mixer,
+  unstableGitUpdater,
+  writeShellApplication,
+  cmake,
+  fontconfig,
+  freetype,
+  glib,
+  gtk2,
+  libusb1,
+  libX11,
+  openssl,
+  pkg-config,
   SDL2,
   SDL2_ttf,
   SDL2_mixer,
 
+  enable16Bit ? true,
   enableX11 ? stdenv.hostPlatform.isLinux,
-  automake,
-  autoconf,
-  autoconf-archive,
-  libtool,
-  pkg-config,
-  unzip,
-  gtk2,
-  libusb1,
-  libXxf86vm,
-  nasm,
-  libICE,
-  libSM,
-
   # HAXM build succeeds but the binary segfaults, seemingly due to the missing HAXM kernel module
   # Enable once there is a HAXM kernel module option in NixOS? Or somehow bind it to the system kernel having HAXM?
   # Or leave it disabled by default?
@@ -35,198 +26,104 @@
   enableHAXM ? false,
 }:
 
-assert lib.assertMsg (
-  enable16Bit || enable32Bit
-) "Must enable 16-Bit and/or 32-Bit system variant.";
-assert lib.assertMsg (enableSDL || enableX11) "Must enable SDL and/or X11 graphics interfaces.";
-assert lib.assertOneOf "withSDLVersion" withSDLVersion [
-  "1"
-  "2"
-];
-assert enableHAXM -> (lib.assertMsg enableX11 "Must enable X11 graphics interface for HAXM build.");
-let
-  inherit (lib) optional optionals optionalString;
-  inherit (lib.strings) concatStringsSep concatMapStringsSep;
-  isSDL2 = (withSDLVersion == "2");
-  sdlInfix = optionalString isSDL2 "2";
-  sdlDeps1 = [
-    SDL
-    SDL_ttf
-    SDL_mixer
-  ];
-  sdlDeps2 = [
-    SDL2
-    SDL2_ttf
-    SDL2_mixer
-  ];
-  sdlDepsBuildonly = if isSDL2 then sdlDeps1 else sdlDeps2;
-  sdlDepsTarget = if isSDL2 then sdlDeps2 else sdlDeps1;
-  sdlMakefileSuffix =
-    if stdenv.hostPlatform.isWindows then
-      "win"
-    else if stdenv.hostPlatform.isDarwin then
-      "mac"
-    else
-      "unix";
-  sdlMakefiles = concatMapStringsSep " " (x: x + "." + sdlMakefileSuffix) (
-    optionals enable16Bit [
-      "Makefile"
-    ]
-    ++ optionals enable32Bit [
-      "Makefile21"
-    ]
-  );
-  sdlBuildFlags = concatStringsSep " " (
-    optionals enableSDL [
-      "SDL_VERSION=${withSDLVersion}"
-    ]
-  );
-  sdlBins = concatStringsSep " " (
-    optionals enable16Bit [
-      "np2kai"
-    ]
-    ++ optionals enable32Bit [
-      "np21kai"
-    ]
-  );
-  x11ConfigureFlags = concatStringsSep " " (
-    (
-      if ((enableHAXM && (enable16Bit || enable32Bit)) || (enable16Bit && enable32Bit)) then
-        [
-          "--enable-build-all"
-        ]
-      else if enableHAXM then
-        [
-          "--enable-haxm"
-        ]
-      else if enable32Bit then
-        [
-          "--enable-ia32"
-        ]
-      else
-        [ ]
-    )
-    ++ optionals (!isSDL2) [
-      "--enable-sdl"
-      "--enable-sdlmixer"
-      "--enable-sdlttf"
-
-      "--enable-sdl2=no"
-      "--enable-sdl2mixer=no"
-      "--enable-sdl2ttf=no"
-    ]
-  );
-  x11BuildFlags = concatStringsSep " " [
-    "SDL2_CONFIG=sdl2-config"
-    "SDL_CONFIG=sdl-config"
-    "SDL_CFLAGS=\"$(sdl${sdlInfix}-config --cflags)\""
-    "SDL_LIBS=\"$(sdl${sdlInfix}-config --libs) -lSDL${sdlInfix}_mixer -lSDL${sdlInfix}_ttf\""
-  ];
-  x11Bins = concatStringsSep " " (
-    optionals enable16Bit [
-      "xnp2kai"
-    ]
-    ++ optionals enable32Bit [
-      "xnp21kai"
-    ]
-    ++ optionals enableHAXM [
-      "xnp21kai_haxm"
-    ]
-  );
-in
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "np2kai";
-  version = "0.86rev22"; # update src.rev to commit rev accordingly
+  version = "0.86rev22-unstable-2024-12-22";
 
   src = fetchFromGitHub {
     owner = "AZO234";
     repo = "NP2kai";
-    rev = "4a317747724669343e4c33ebdd34783fb7043221";
-    sha256 = "0kxysxhx6jyk82mx30ni0ydzmwdcbnlxlnarrlq018rsnwb4md72";
+    rev = "da219658c24c610ba82d5a07ea9897e8e0eef670";
+    hash = "sha256-b0KOfqUgVtFuZxw8js6JCnzMh6Wh+f7o/IHcD6TiG1s=";
   };
 
-  configurePhase =
-    ''
-      export GIT_VERSION=${builtins.substring 0 7 src.rev}
-    ''
-    + optionalString enableParallelBuilding ''
-      appendToVar buildFlags "-j$NIX_BUILD_CORES"
-    ''
-    + optionalString enableX11 ''
-      cd x11
-      substituteInPlace Makefile.am \
-        --replace 'GIT_VERSION :=' 'GIT_VERSION ?='
-      ./autogen.sh ${x11ConfigureFlags}
-      ./configure ${x11ConfigureFlags}
-      cd ..
-    '';
+  # Don't require Git
+  # Use SDL2(_*) targets for correct includedirs
+  # Add return type in ancient code
+  postPatch = ''
+    substituteInPlace CMakeLists.txt \
+      --replace-fail 'if(NOT git_result EQUAL 0)' 'if(FALSE)' \
+      --replace-fail "\''${SDL2_DEFINE}" "" \
+      --replace-fail "\''${SDL2_INCLUDE_DIR}" "" \
+      --replace-fail "\''${SDL2_LIBRARY}" "SDL2::SDL2" \
+      --replace-fail "\''${SDL2_MIXER_DEFINE}" "" \
+      --replace-fail "\''${SDL2_MIXER_INCLUDE_DIR}" "" \
+      --replace-fail "\''${SDL2_MIXER_LIBRARY}" "SDL2_mixer::SDL2_mixer" \
+      --replace-fail "\''${SDL2_TTF_DEFINE}" "" \
+      --replace-fail "\''${SDL2_TTF_INCLUDE_DIR}" "" \
+      --replace-fail "\''${SDL2_TTF_LIBRARY}" "SDL2_ttf::SDL2_ttf" \
+
+    substituteInPlace x/cmserial.c \
+      --replace-fail 'convert_np2tocm(UINT port, UINT8* param, UINT32* speed) {' 'int convert_np2tocm(UINT port, UINT8* param, UINT32* speed) {'
+    substituteInPlace x/gtk2/gtk_menu.c \
+      --replace-fail 'xmenu_visible_item(MENU_HDL hdl, const char *name, BOOL onoff)' 'int xmenu_visible_item(MENU_HDL hdl, const char *name, BOOL onoff)'
+  '';
+
+  strictDeps = true;
 
   nativeBuildInputs =
-    sdlDepsBuildonly
-    ++ optionals enableX11 [
-      automake
-      autoconf
-      autoconf-archive
-      libtool
+    [
+      cmake
+    ]
+    ++ lib.optionals enableX11 [
       pkg-config
-      unzip
-      nasm
     ];
 
   buildInputs =
-    sdlDepsTarget
-    ++ optionals enableX11 [
-      gtk2
-      libICE
-      libSM
+    [
       libusb1
-      libXxf86vm
+      openssl
+      SDL2
+      SDL2_ttf
+      SDL2_mixer
+    ]
+    ++ lib.optionals enableX11 [
+      fontconfig
+      freetype
+      glib
+      gtk2
+      libX11
     ];
+
+  cmakeFlags = [
+    (lib.cmakeBool "BUILD_SDL" true)
+    (lib.cmakeBool "BUILD_X" enableX11)
+    (lib.cmakeBool "BUILD_HAXM" enableHAXM)
+    (lib.cmakeBool "BUILD_I286" enable16Bit)
+
+    (lib.cmakeBool "USE_SDL" true)
+    (lib.cmakeBool "USE_SDL2" true)
+    (lib.cmakeBool "USE_SDL_MIXER" true)
+    (lib.cmakeBool "USE_SDL_TTF" true)
+    (lib.cmakeBool "USE_X" enableX11)
+    (lib.cmakeBool "USE_HAXM" enableHAXM)
+  ];
 
   enableParallelBuilding = true;
 
-  # TODO Remove when bumping past rev22
-  env.NIX_CFLAGS_COMPILE = lib.optionalString stdenv.hostPlatform.isDarwin "-D_DARWIN_C_SOURCE";
+  env = {
+    NP2KAI_VERSION = finalAttrs.version;
+    NP2KAI_HASH = builtins.substring 0 7 finalAttrs.src.rev;
+    # GCC 14 incompatibility
+    NIX_CFLAGS_COMPILE = "-Wno-error=incompatible-pointer-types";
+  };
 
-  buildPhase =
-    optionalString enableSDL ''
-      cd sdl2
-      for mkfile in ${sdlMakefiles}; do
-        substituteInPlace $mkfile \
-          --replace 'GIT_VERSION :=' 'GIT_VERSION ?='
-        echo make -f $mkfile $buildFlags ${sdlBuildFlags} clean
-        make -f $mkfile $buildFlags ${sdlBuildFlags} clean
-        make -f $mkfile $buildFlags ${sdlBuildFlags}
-      done
-      cd ..
-    ''
-    + optionalString enableX11 ''
-      cd x11
-      make $buildFlags ${x11BuildFlags}
-      cd ..
-    '';
+  passthru.updateScript = unstableGitUpdater {
+    # 0.86 version prefix is implied, add it back for our versioning
+    tagConverter = lib.getExe (writeShellApplication {
+      name = "update-np2kai";
+      text = ''
+        sed -e 's/^rev\./0.86rev/g'
+      '';
+    });
+  };
 
-  installPhase =
-    optionalString enableSDL ''
-      cd sdl2
-      for emu in ${sdlBins}; do
-        install -D -m 755 $emu $out/bin/$emu
-      done
-      cd ..
-    ''
-    + optionalString enableX11 ''
-      cd x11
-      for emu in ${x11Bins}; do
-        install -D -m 755 $emu $out/bin/$emu
-      done
-      cd ..
-    '';
-
-  meta = with lib; {
+  meta = {
     description = "PC-9801 series emulator";
     homepage = "https://github.com/AZO234/NP2kai";
-    license = licenses.mit;
-    maintainers = with maintainers; [ OPNA2608 ];
-    platforms = platforms.x86;
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ OPNA2608 ];
+    mainProgram = "${if enableX11 then "x" else "sdl"}np21kai";
+    platforms = lib.platforms.x86;
   };
-}
+})


### PR DESCRIPTION
Fixes building on Linux & Darwin, and makes the code ***alot*** more comprehensible.

![Bildschirmfoto_2025-05-08_23-02-42](https://github.com/user-attachments/assets/3831388a-eb90-4147-874d-ff67786bfea5)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
