### PR TITLE
pmars: Fix FTBFS due to ncurses change

### DIFF
--- a/pkgs/by-name/pm/pmars/0003-fix-ncurses-opaque-WINDOW.patch
+++ b/pkgs/by-name/pm/pmars/0003-fix-ncurses-opaque-WINDOW.patch
@@ -1,0 +1,57 @@
+diff '--color=auto' -ruN a/src/curdisp.c b/src/curdisp.c
+--- a/src/curdisp.c	2025-05-08 23:23:48.070346219 +0200
++++ b/src/curdisp.c	2025-05-08 23:29:33.851400436 +0200
+@@ -28,12 +28,6 @@
+ #include "sim.h"
+ #endif
+ 
+-/* For window structure in BSD 4.4/Curses 8.x library */
+-#ifdef BSD44
+-#define _curx curx
+-#define _cury cury
+-#endif
+-
+ typedef struct win_st {
+   WINDOW *win;
+   int     page;
+@@ -428,18 +422,18 @@
+           str--;
+           maxchar++;
+           leaveok(curwin, TRUE);
+-          if (ox = curwin->_curx) {
++          if (ox = getcurx(curwin)) {
+ #if 0
+ #ifdef ATTRIBUTE
+-            mvwaddch(curwin, curwin->_cury, --ox, ' ' | attr);
++            mvwaddch(curwin, getcury(curwin), --ox, ' ' | attr);
+ #else
+-            mvwaddch(curwin, curwin->_cury, --ox, ' ');
++            mvwaddch(curwin, getcury(curwin), --ox, ' ');
+ #endif
+ #endif                                /* 0 */
+-            mvwaddch(curwin, curwin->_cury, --ox, ' ');
+-            wmove(curwin, curwin->_cury, ox);
++            mvwaddch(curwin, getcury(curwin), --ox, ' ');
++            wmove(curwin, getcury(curwin), ox);
+           } else {
+-            oy = curwin->_cury - 1;
++            oy = getcury(curwin) - 1;
+ #if 0
+ #ifdef ATTRIBUTE
+             mvwaddch(curwin, oy, COLS - 1, ' ' | attr);
+@@ -470,12 +464,12 @@
+           if (ox--)
+ #if 0
+ #ifdef ATTRIBUTE
+-            mvwaddch(curwin, curwin->_cury, ox, ' ' | attr);
++            mvwaddch(curwin, getcury(curwin), ox, ' ' | attr);
+ #else
+-            mvwaddch(curwin, curwin->_cury, ox, ' ');
++            mvwaddch(curwin, getcury(curwin), ox, ' ');
+ #endif
+ #endif                                /* 0 */
+-          mvwaddch(curwin, curwin->_cury, ox, ' ');
++          mvwaddch(curwin, getcury(curwin), ox, ' ');
+           else
+ #if 0
+ #ifdef ATTRIBUTE

--- a/pkgs/by-name/pm/pmars/package.nix
+++ b/pkgs/by-name/pm/pmars/package.nix
@@ -35,6 +35,9 @@ stdenv.mkDerivation (finalAttrs: {
 
     # call to undeclared function 'sighandler' & undefined sighandler on Darwin
     ./0002-fix-sighandler.patch
+
+    # ncurses' WINDOW struct was turned opaque for outside code, use functions for accessing values instead
+    ./0003-fix-ncurses-opaque-WINDOW.patch
   ];
 
   postPatch = ''


### PR DESCRIPTION
`WINDOW` struct was turned opaque in recent versions, meaning that direct access to struct members is no longer supported. Add patch to replace direct access with calls to getter functions.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
