### PR TITLE
libpkcs11-dnie: init at 1.6.8-1

### DIFF
--- a/pkgs/by-name/li/libpkcs11-dnie/package.nix
+++ b/pkgs/by-name/li/libpkcs11-dnie/package.nix
@@ -1,0 +1,94 @@
+{
+  stdenv,
+  fetchurl,
+  rpm,
+  lib,
+  cpio,
+  libassuan,
+  libgpg-error,
+  pcsclite,
+}:
+
+let
+  libassuan_2_5_7 = libassuan.overrideAttrs (oldAttrs: {
+    src = fetchurl {
+      url = "https://www.gnupg.org/ftp/gcrypt/libassuan/libassuan-2.5.7.tar.bz2";
+      sha256 = "sha256-AQMIH/wng4ouUEeRU8oQXoc9PWXYqVkygunJTH5q+3Y=";
+    };
+  });
+in
+
+stdenv.mkDerivation rec {
+  pname = "libpkcs11-dnie";
+  version = "1.6.8-1";
+
+  src = fetchurl {
+    url = "https://www.dnielectronico.es/descargas/distribuciones_linux/libpkcs11-dnie-${version}.x86_64.rpm";
+    sha256 = "8081e17e827f3dbf89db3f6fb73bc021962c6d5e98b327ee4a20bcabb778a231";
+  };
+
+  dontUnpack = true;
+  nativeBuildInputs = [
+    rpm
+    cpio
+  ];
+
+  buildInputs = [
+    libassuan_2_5_7
+    libgpg-error
+    pcsclite.lib
+    stdenv.cc.cc.lib
+  ];
+
+  installPhase = ''
+    mkdir -p $out
+
+    rpm2cpio $src | cpio -idmv
+
+    mkdir -p $out/lib
+    cp -r ./usr/lib64/* $out/lib
+
+    mkdir -p $out/share
+    cp -r ./usr/share/* $out/share
+
+    # Changing library targets and search paths
+    patchelf --set-rpath ${pcsclite.lib}/lib:${stdenv.cc.cc.lib}/lib $out/lib/libpkcs11-dnie-cryptopp.so.0.0.0
+    patchelf --set-rpath ${pcsclite.lib}/lib $out/lib/libpkcs11-dnie-asn1.so.0.0.0
+    patchelf --set-rpath ${pcsclite.lib}/lib $out/lib/libpkcs11-dnie-asn1skeletons.so.0.0.0
+    patchelf --set-rpath ${pcsclite.lib}/lib:${stdenv.cc.cc.lib}/lib:${libassuan_2_5_7}/lib:${libgpg-error}/lib:$out/lib $out/lib/libpkcs11-dnie.so
+
+    echo -e "\033[38;5;214m\n[!] Important information for using DNIe / Información importante para usar el DNIe:\n
+    [!] For complete installation instructions, please consult $out/share/libpkcs11-dnie/install_dnie/launch.html
+    [!] The libpkcs11-dnie.so resides in $out/lib/libpkcs11-dnie.so\033[0m"
+
+    echo -e "\033[38;5;214m
+    [!] Para instrucciones completas, consultar: $out/share/libpkcs11-dnie/install_dnie/launch.html
+    [!] La librería libpkcs11-dnie.so se encuentra en: $out/lib/libpkcs11-dnie.so"
+
+    echo -e '\033[38;5;214m
+    [!] If you are on NixOS, you should use the option programs.firefox.policies.SecurityDevices to add the module declaratively:
+    [!] After rebuilding your configuration, you might have to reboot your machine.
+
+    services.pcscd.enable = true;
+    programs.firefox = {
+      enable = true;
+      policies = {
+        SecurityDevices = {
+          Add = {
+            "PKCS#11 DNIe" = "''${pkgs.libpkcs11-dnie}/lib/libpkcs11-dnie.so";
+          };
+        };
+      };
+    };
+    \033[0m'
+
+  '';
+
+  meta = {
+    description = "PKCS#11 module for electronic identification with the Spanish DNIe";
+    homepage = "https://www.dnielectronico.es/PortalDNIe/PRF1_Cons02.action?pag=REF_1112";
+    maintainers = with lib.maintainers; [ alexland7219 ];
+
+    license = lib.licenses.unfreeRedistributable;
+  };
+}


### PR DESCRIPTION
Add libpkcs11-dnie, the PKCS#11 module for identification using Spanish [DNIe](https://www.dnielectronico.es/PortalDNIe/PRF1_Cons02.action?pag=REF_1112) (National Identity document).

After installation of the package, the user is shown a couple options to finish with the installation: 

- Manually add the libpkcs11-dnie.so module to Firefox (location of library is shown).
- If the user is on NixOS, declaratively add the module (the necessary changes to be made are shown).

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`) (Does not apply)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
