### PR TITLE
nelm: init at 1.3.0

### DIFF
--- a/pkgs/by-name/ne/nelm/package.nix
+++ b/pkgs/by-name/ne/nelm/package.nix
@@ -1,0 +1,68 @@
+{
+  buildGoModule,
+  buildPackages,
+  fetchFromGitHub,
+  installShellFiles,
+  lib,
+  stdenv,
+  versionCheckHook,
+}:
+buildGoModule (finalAttrs: {
+  pname = "nelm";
+  version = "1.3.0";
+
+  src = fetchFromGitHub {
+    owner = "werf";
+    repo = "nelm";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-voSGwr4wpei9U5L/6uAcapjNZ5CVn49mwngfsXMcxB0=";
+  };
+
+  vendorHash = "sha256-kLFQtRAsxA7fdQIgpa0eV3hSpX5pAGT1DTGeGkawvVk=";
+
+  subPackages = [ "cmd/nelm" ];
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X github.com/werf/nelm/internal/common.Brand=Nelm"
+    "-X github.com/werf/nelm/internal/common.Version=${finalAttrs.version}"
+  ];
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  preCheck = ''
+    # Test all packages.
+    unset subPackages
+  '';
+
+  postInstall = lib.optionalString (stdenv.hostPlatform.emulatorAvailable buildPackages) (
+    let
+      emulator = stdenv.hostPlatform.emulator buildPackages;
+    in
+    ''
+      for shell in bash fish zsh; do
+        installShellCompletion \
+          --cmd nelm \
+          --$shell <(${emulator} $out/bin/nelm completion $shell)
+      done
+    ''
+  );
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+  versionCheckProgramArg = "version";
+
+  meta = {
+    description = "Kubernetes deployment tool, alternative to Helm 3";
+    longDescription = ''
+      Nelm is a Helm 3 alternative. It is a Kubernetes deployment tool that
+      manages Helm Charts and deploys them to Kubernetes.
+    '';
+    homepage = "https://github.com/werf/nelm";
+    changelog = "https://github.com/werf/nelm/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.asl20;
+    maintainers = [ lib.maintainers.azahi ];
+    mainProgram = "nelm";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Nelm is a Helm 3 alternative. It is a Kubernetes deployment tool that manages Helm Charts and deploys them to Kubernetes. It is also the deployment engine of [werf](https://github.com/werf/werf). Nelm can do (almost) everything that Helm does, but better, and even quite some on top of it.


https://github.com/werf/nelm
[Blogpost](https://itnext.io/finally-a-viable-helm-replacement-388d538f9e1f) ([alt](https://scribe.rip/m/global-identity-2?redirectUrl=https%3A%2F%2Fitnext.io%2Ffinally-a-viable-helm-replacement-388d538f9e1f))

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
