### PR TITLE
Install dllcamlzip.so into the stublibs directory

### DIFF
--- a/pkgs/development/ocaml-modules/camlzip/default.nix
+++ b/pkgs/development/ocaml-modules/camlzip/default.nix
@@ -63,8 +63,6 @@ stdenv.mkDerivation {
 
   inherit (param) patches;
 
-  createFindlibDestdir = true;
-
   postPatch =
     param.postPatchInit
     + ''
@@ -77,6 +75,10 @@ stdenv.mkDerivation {
     "all"
     "allopt"
   ];
+
+  preInstall = ''
+    mkdir -p $out/lib/ocaml/${ocaml.version}/site-lib/stublibs
+  '';
 
   postInstall = ''
     ln -s $out/lib/ocaml/${ocaml.version}/site-lib/{,caml}zip


### PR DESCRIPTION
camlzip installs `dllcamlzip.so` in `site-lib/zip` but dune expects to find it in `site-lib/stublibs`. It causes `dune utop` to crash: 
```
File "_none_", line 1:
Error: I/O error: dllcamlzip.so: No such file or directory
```

MRE:
- `flake.nix`:
```nix 
{
  description = "mre";

  inputs = {
    # nixpkgs.url = "github:Halbaroth/nixpkgs/camlzip-stublibs";
    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
    flake-utils.url = "github:numtide/flake-utils";
  };

  outputs = { self, nixpkgs, flake-utils, ... }@inputs:
    flake-utils.lib.eachDefaultSystem (system:
      let
        pkgs = nixpkgs.legacyPackages.${system};
        ocamlPackages = pkgs.ocamlPackages;
      in
      {
        devShells.default = pkgs.mkShell {
          packages = with ocamlPackages; [
            findlib
            ocaml 
            dune_3 
            camlzip
            utop
          ];
      };
  });
}
```  
- `dune-project`
```
(lang dune 3.0)
```
- `dune`
```dune 
(library
 (name mre)
 (libraries camlzip))
```
The commands to reproduce the issue:
``` 
nix develop 
dune utop
```
After switching nixpkgs sources in the flake, it works as expected :)
