### PR TITLE
{opentabletdriver,libinput}: Install quirks

### DIFF
--- a/nixos/modules/services/hardware/libinput.nix
+++ b/nixos/modules/services/hardware/libinput.nix
@@ -435,7 +435,10 @@ in
 
     services.xserver.modules = [ pkgs.xorg.xf86inputlibinput ];
 
-    environment.systemPackages = [ pkgs.xorg.xf86inputlibinput ];
+    environment.systemPackages = [
+      pkgs.xorg.xf86inputlibinput
+      pkgs.libinput.out
+    ];
 
     environment.etc =
       let

--- a/pkgs/by-name/op/opentabletdriver/package.nix
+++ b/pkgs/by-name/op/opentabletdriver/package.nix
@@ -100,6 +100,10 @@ buildDotnetModule (finalAttrs: {
 
     install -Dm644 $src/OpenTabletDriver.UX/Assets/otd.png -t $out/share/pixmaps
 
+    # Copy libinput quirks
+    mkdir -p $out/share/libinput
+    cp eng/linux/Generic/usr/share/libinput/* $out/share/libinput
+
     # Generate udev rules from source
     mkdir -p $out/lib/udev/rules.d
     ./generate-rules.sh > $out/lib/udev/rules.d/70-opentabletdriver.rules

--- a/pkgs/development/libraries/libinput/Allow-changing-quirks-directory.diff
+++ b/pkgs/development/libraries/libinput/Allow-changing-quirks-directory.diff
@@ -1,0 +1,43 @@
+diff --git a/meson.build b/meson.build
+index 68fb91ee..f12f96c4 100644
+--- a/meson.build
++++ b/meson.build
+@@ -25,6 +25,11 @@ endif
+ dir_udev_callouts = dir_udev
+ dir_udev_rules    = dir_udev / 'rules.d'
+ 
++dir_quirks = get_option('quirks-dir')
++if dir_quirks == ''
++	dir_quirks = dir_data
++endif
++
+ # Collection of man pages, we'll append to that
+ src_man = files()
+ 
+@@ -335,9 +340,9 @@ libfilter = static_library('filter', src_libfilter,
+ dep_libfilter = declare_dependency(link_with : libfilter)
+ 
+ ############ libquirks.a #############
+-libinput_data_path = dir_data
++libinput_data_path = dir_quirks
+ libinput_data_override_path = dir_overrides / 'local-overrides.quirks'
+-config_h.set_quoted('LIBINPUT_QUIRKS_DIR', dir_data)
++config_h.set_quoted('LIBINPUT_QUIRKS_DIR', dir_quirks)
+ config_h.set_quoted('LIBINPUT_QUIRKS_OVERRIDE_FILE', libinput_data_override_path)
+ 
+ config_h.set_quoted('LIBINPUT_QUIRKS_SRCDIR', dir_src_quirks)
+diff --git a/meson_options.txt b/meson_options.txt
+index 047647f7..7d4c0d7d 100644
+--- a/meson_options.txt
++++ b/meson_options.txt
+@@ -2,6 +2,10 @@ option('udev-dir',
+        type: 'string',
+        value: '',
+        description: 'udev base directory [default=$prefix/lib/udev]')
++option('quirks-dir',
++       type: 'string',
++       value: '',
++       description: 'directory to load quirks from [default=$prefix/$datadir/libinput]')
+ option('epoll-dir',
+        type: 'string',
+        value: '',

--- a/pkgs/development/libraries/libinput/default.nix
+++ b/pkgs/development/libraries/libinput/default.nix
@@ -66,6 +66,7 @@ stdenv.mkDerivation rec {
   };
 
   patches = [
+    ./Allow-changing-quirks-directory.diff
     ./udev-absolute-path.patch
   ];
 
@@ -116,6 +117,7 @@ stdenv.mkDerivation rec {
     (mkFlag documentationSupport "documentation")
     (mkFlag eventGUISupport "debug-gui")
     (mkFlag testsSupport "tests")
+    "-Dquirks-dir=/run/current-system/sw/share/libinput"
     "--sysconfdir=/etc"
     "--libexecdir=${placeholder "bin"}/libexec"
   ];


### PR DESCRIPTION
The OpenTabletDriver previously does not install the libinput quirks, so with Artist Mode on Wayland the tablet inputs would be smoothed. This PR changes the libinput package to allow installing quirks, and the opentabletdriver package to install the quirk.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
