### PR TITLE
projectlibre: 1.9.3 -> 1.9.8, move to pkgs/by-name

### DIFF
--- a/pkgs/by-name/pr/projectlibre/package.nix
+++ b/pkgs/by-name/pr/projectlibre/package.nix
@@ -2,30 +2,32 @@
   lib,
   stdenv,
   fetchgit,
+
   ant,
   jdk,
-  stripJavaArchivesHook,
   makeWrapper,
-  jre,
+  stripJavaArchivesHook,
+
   coreutils,
+  jre,
   which,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "projectlibre";
-  version = "1.9.3";
+  version = "1.9.8";
 
   src = fetchgit {
     url = "https://git.code.sf.net/p/projectlibre/code";
-    rev = "20814e88dc83694f9fc6780c2550ca5c8a87aa16"; # version 1.9.3 was not tagged
-    hash = "sha256-yXgYyy3jWxYMXKsNCRWdO78gYRmjKpO9U5WWU6PtwMU=";
+    rev = "0530be227f4a10c5545cce8d3db20ac5a4d76a66"; # version 1.9.8 was not tagged
+    hash = "sha256-eGoPtHy1XfPLnJXNDOMcek4spNKkNyZdby0IsZFZfME=";
   };
 
   nativeBuildInputs = [
     ant
     jdk
-    stripJavaArchivesHook
     makeWrapper
+    stripJavaArchivesHook
   ];
 
   runtimeDeps = [
@@ -33,8 +35,6 @@ stdenv.mkDerivation (finalAttrs: {
     coreutils
     which
   ];
-
-  env.JAVA_TOOL_OPTIONS = "-Dfile.encoding=UTF8";
 
   buildPhase = ''
     runHook preBuild
@@ -57,10 +57,10 @@ stdenv.mkDerivation (finalAttrs: {
     popd
 
     substituteInPlace $out/bin/projectlibre \
-        --replace-fail "/usr/share/projectlibre" "$out/share/projectlibre"
+      --replace-fail "/usr/share/projectlibre" "$out/share/projectlibre"
 
     wrapProgram $out/bin/projectlibre \
-        --prefix PATH : ${lib.makeBinPath finalAttrs.runtimeDeps}
+      --prefix PATH : ${lib.makeBinPath finalAttrs.runtimeDeps}
 
     runHook postInstall
   '';

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4259,11 +4259,6 @@ with pkgs;
 
   polaris-web = callPackage ../servers/polaris/web.nix { };
 
-  projectlibre = callPackage ../applications/misc/projectlibre {
-    jre = jre8;
-    jdk = jdk8;
-  };
-
   projectm_3 = libsForQt5.callPackage ../applications/audio/projectm_3 { };
 
   proxmark3 = libsForQt5.callPackage ../tools/security/proxmark3/default.nix { };


### PR DESCRIPTION
We are no longer forced to use `jdk8` after this version bump :)

I don't think `-Dfile.encoding=UTF8` is needed anymore, but I might be wrong.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
