### PR TITLE
sequential: init at 2.6.0

### DIFF
--- a/pkgs/by-name/se/sequential/package.nix
+++ b/pkgs/by-name/se/sequential/package.nix
@@ -1,0 +1,35 @@
+{
+  lib,
+  fetchurl,
+  stdenvNoCC,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "sequential";
+  version = "2.6.0";
+
+  buildDate = "2024-09-07.14.59.00";
+
+  src = fetchurl {
+    url = "https://github.com/chuchusoft/Sequential/releases/download/v${finalAttrs.version}/Sequential.app.${finalAttrs.buildDate}.tar.xz";
+    hash = "sha256-tgpzMAHw266UhKo43GIHFCx/SDq/zIJkWz1TPYTeTzI=";
+  };
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/Applications/Sequential.app
+    cp -R Sequential.app $out/Applications
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "macOS native comic reader and image viewer";
+    homepage = "https://github.com/chuchusoft/Sequential";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ Enzime ];
+    platforms = lib.platforms.darwin;
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+  };
+})


### PR DESCRIPTION
> Sequential is an image and comic viewer for macOS. It can display images in folders, PDF files, and archives of these formats: ZIP CBZ RAR CBR 7z.
> 
> This is a modernized build of Sequential for Intel and Apple Silicon Macs running 10.14 (Intel) or 11.4 (Apple Silicon) or later.

https://github.com/chuchusoft/Sequential

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
