### PR TITLE
syncthing-macos: init at 1.29.2-2

### DIFF
--- a/pkgs/by-name/sy/syncthing-macos/package.nix
+++ b/pkgs/by-name/sy/syncthing-macos/package.nix
@@ -1,0 +1,39 @@
+{
+  lib,
+  fetchurl,
+  stdenv,
+  undmg,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "syncthing-macos";
+  version = "1.29.2-2";
+
+  src = fetchurl {
+    url = "https://github.com/syncthing/syncthing-macos/releases/download/v${finalAttrs.version}/Syncthing-${finalAttrs.version}.dmg";
+    hash = "sha256-KbUpc2gymxkhkpSvIpy2fF3xAKsDqHHwlfUB8BF8+Sc=";
+  };
+
+  nativeBuildInputs = [ undmg ];
+
+  sourceRoot = "Syncthing.app";
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/Applications/${finalAttrs.sourceRoot}
+    cp -R . $out/Applications/${finalAttrs.sourceRoot}
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Official frugal and native macOS Syncthing application bundle";
+    homepage = "https://github.com/syncthing/syncthing-macos";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ Enzime ];
+    hydraPlatforms = [ ]; # no building required
+    platforms = lib.platforms.darwin;
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+  };
+})


### PR DESCRIPTION
> Official frugal and native macOS Syncthing application bundle

> `syncthing-macos` is a [frugal](https://en.wikipedia.org/wiki/Frugality) [native](https://en.wikipedia.org/wiki/Native_(computing)) macOS [Syncthing](https://syncthing.net/) tray application bundle. It bundles its own Syncthing instance and wraps Syncthing background process, making it behave more like a native macOS application and less like a command-line utility with a web browser interface.

https://github.com/syncthing/syncthing-macos

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
