### PR TITLE
ghostty-bin: init at 1.1.3

### DIFF
--- a/pkgs/by-name/gh/ghostty-bin/package.nix
+++ b/pkgs/by-name/gh/ghostty-bin/package.nix
@@ -1,0 +1,108 @@
+{
+  lib,
+  stdenvNoCC,
+  _7zz,
+  fetchurl,
+  makeBinaryWrapper,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "ghostty-bin";
+  version = "1.1.3";
+
+  src = fetchurl {
+    url = "https://release.files.ghostty.org/${finalAttrs.version}/Ghostty.dmg";
+    hash = "sha256-ZOUUGI9UlZjxZtbctvjfKfMz6VTigXKikB6piKFPJkc=";
+  };
+
+  sourceRoot = ".";
+
+  nativeBuildInputs = [
+    _7zz
+    makeBinaryWrapper
+  ];
+
+  postInstall = ''
+    mkdir -p $out/Applications
+    mv Ghostty.app $out/Applications/
+    makeWrapper $out/Applications/Ghostty.app/Contents/MacOS/ghostty $out/bin/ghostty
+  '';
+
+  /**
+     Ghostty really likes all of it's resources to be in the same directory, so link them back after we split them
+
+     - https://github.com/ghostty-org/ghostty/blob/4b4d4062dfed7b37424c7210d1230242c709e990/src/os/resourcesdir.zig#L11-L52
+     - https://github.com/ghostty-org/ghostty/blob/4b4d4062dfed7b37424c7210d1230242c709e990/src/termio/Exec.zig#L745-L750
+     - https://github.com/ghostty-org/ghostty/blob/4b4d4062dfed7b37424c7210d1230242c709e990/src/termio/Exec.zig#L818-L834
+
+     terminfo and shell integration should also be installable on remote machines
+
+     ```nix
+     { pkgs, ... }: {
+       environment.systemPackages = [ pkgs.ghostty.terminfo ];
+
+       programs.bash = {
+         interactiveShellInit = ''
+           if [[ "$TERM" == "xterm-ghostty" ]]; then
+             builtin source ${pkgs.ghostty.shell_integration}/bash/ghostty.bash
+           fi
+         '';
+       };
+     }
+     ```
+
+     On linux we can move the original files and make symlinks to them
+     but on darwin (when using the .app bundle) we need to copy the files
+     in order to maintain signed integrity
+  */
+  resourceDir = "${placeholder "out"}/Applications/Ghostty.app/Contents/Resources";
+  postFixup = ''
+    mkdir -p $terminfo/share
+    cp -r $resourceDir/terminfo $terminfo/share/terminfo
+
+    cp -r $resourceDir/ghostty/shell-integration $shell_integration
+
+    cp -r $resourceDir/vim/vimfiles $vim
+  '';
+
+  # Usually the multiple-outputs hook would take care of this, but
+  # our manpages are in the .app bundle
+  preFixup = ''
+    mkdir -p $man/share
+    cp -r $resourceDir/man $man/share/man
+  '';
+
+  outputs = [
+    "out"
+    "man"
+    "shell_integration"
+    "terminfo"
+    "vim"
+  ];
+
+  meta = {
+    description = "Fast, native, feature-rich terminal emulator pushing modern features";
+    longDescription = ''
+      Ghostty is a terminal emulator that differentiates itself by being
+      fast, feature-rich, and native. While there are many excellent terminal
+      emulators available, they all force you to choose between speed,
+      features, or native UIs. Ghostty provides all three.
+    '';
+    homepage = "https://ghostty.org/";
+    downloadPage = "https://ghostty.org/download";
+    changelog = "https://ghostty.org/docs/install/release-notes/${
+      builtins.replaceStrings [ "." ] [ "-" ] finalAttrs.version
+    }";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ Enzime ];
+    mainProgram = "ghostty";
+    outputsToInstall = [
+      "out"
+      "man"
+      "shell_integration"
+      "terminfo"
+    ];
+    platforms = lib.platforms.darwin;
+    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+  };
+})


### PR DESCRIPTION
Supersedes #371984

This package is useful as I wish to be able to install Ghostty from Nixpkgs using `nix-darwin` through `environment.systemPackages`, rather than having to use Homebrew or manually install the DMG.

The auto updater can be disabled in the Ghostty configuration option [`auto-update`](https://ghostty.org/docs/config/reference#auto-update) which can be configured through `programs.ghostty.settings` in home-manager.

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
