### PR TITLE
cpp-netlib: pin boost to 186, unbreak on darwin

### DIFF
--- a/pkgs/by-name/cp/cpp-netlib/0001-Compatibility-with-boost-1.83.patch
+++ b/pkgs/by-name/cp/cpp-netlib/0001-Compatibility-with-boost-1.83.patch
@@ -1,0 +1,33 @@
+From 8be99f5972826c25378bccb9fbd7291623c7b2a7 Mon Sep 17 00:00:00 2001
+From: Moraxyc <i@qaq.li>
+Date: Fri, 9 May 2025 13:39:17 +0800
+Subject: [PATCH] Compatibility with boost 1.83
+
+---
+ boost/network/protocol/http/server/impl/parsers.ipp | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/boost/network/protocol/http/server/impl/parsers.ipp b/boost/network/protocol/http/server/impl/parsers.ipp
+index c31e60e..3272c2f 100755
+--- a/boost/network/protocol/http/server/impl/parsers.ipp
++++ b/boost/network/protocol/http/server/impl/parsers.ipp
+@@ -13,6 +13,7 @@
+ #include <tuple>
+ #include <boost/fusion/include/std_tuple.hpp>
+ #include <boost/network/protocol/http/message/header.hpp>
++#include <boost/regex/pending/unicode_iterator.hpp>
+ 
+ #ifdef BOOST_NETWORK_NO_LIB
+ #ifndef BOOST_NETWORK_INLINE
+@@ -32,7 +33,7 @@ typedef std::basic_string<uint32_t> u32_string;
+ template <>  // <typename Attrib, typename T, typename Enable>
+ struct assign_to_container_from_value<std::string, u32_string, void> {
+   static void call(u32_string const& val, std::string& attr) {
+-    u32_to_u8_iterator<u32_string::const_iterator> begin = val.begin(),
++    boost::u32_to_u8_iterator<u32_string::const_iterator> begin = val.begin(),
+                                                    end = val.end();
+     for (; begin != end; ++begin) attr += *begin;
+   }
+-- 
+2.48.1
+

--- a/pkgs/by-name/cp/cpp-netlib/package.nix
+++ b/pkgs/by-name/cp/cpp-netlib/package.nix
@@ -3,11 +3,15 @@
   stdenv,
   fetchFromGitHub,
   cmake,
-  boost181,
+  boost186,
   openssl,
+  llvmPackages_18,
 }:
-
-stdenv.mkDerivation rec {
+let
+  # std::char_traits has been removed
+  stdenvForCppNetlib = if stdenv.hostPlatform.isDarwin then llvmPackages_18.stdenv else stdenv;
+in
+stdenvForCppNetlib.mkDerivation rec {
   pname = "cpp-netlib";
   version = "0.13.0-final";
 
@@ -19,9 +23,15 @@ stdenv.mkDerivation rec {
     fetchSubmodules = true;
   };
 
+  patches = [
+    # 'u32_to_u8_iterator' was not declared
+    ./0001-Compatibility-with-boost-1.83.patch
+  ];
+
   nativeBuildInputs = [ cmake ];
   buildInputs = [
-    boost181
+    # io_service.hpp has been removed in boost 1.87+
+    boost186
     openssl
   ];
 


### PR DESCRIPTION
Fixes https://hydra.nixos.org/build/296283466

ZHF #403336

* Backporting upstream patch [cpp-netlib#902](https://github.com/cpp-netlib/cpp-netlib/pull/902) to restore compatibility with Boost 1.83+, where `u32_to_u8_iterator` was undefined unless explicitly included.
* Pinning `LLVM` to version 18 on Darwin to address the removal of `std::char_traits` in newer Clang versions.
* Updating Boost dependency to `boost186`, since headers like `io_service.hpp` were removed in Boost 1.87+.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
