### PR TITLE
ocamlPackages.junit: 2.0.2 → 2.3.0

### DIFF
--- a/pkgs/development/ocaml-modules/junit/alcotest.nix
+++ b/pkgs/development/ocaml-modules/junit/alcotest.nix
@@ -1,19 +1,20 @@
 {
   buildDunePackage,
+  lib,
+  ocaml,
   junit,
   alcotest,
 }:
 
-buildDunePackage ({
+buildDunePackage {
   pname = "junit_alcotest";
 
   inherit (junit) src version meta;
-  duneVersion = "3";
 
   propagatedBuildInputs = [
     junit
     alcotest
   ];
 
-  doCheck = false; # 2 tests fail: 1) "Test with unexpected exception"; 2) "with wrong result";
-})
+  doCheck = lib.versionAtLeast ocaml.version "4.12";
+}

--- a/pkgs/development/ocaml-modules/junit/default.nix
+++ b/pkgs/development/ocaml-modules/junit/default.nix
@@ -8,11 +8,11 @@
 
 buildDunePackage (rec {
   pname = "junit";
-  version = "2.0.2";
+  version = "2.3.0";
 
   src = fetchurl {
     url = "https://github.com/Khady/ocaml-junit/releases/download/${version}/junit-${version}.tbz";
-    sha256 = "00bbx5j8vsy9fqbc04xa3lsalaxicirmbczr65bllfk1afv43agx";
+    hash = "sha256-j+4lfuQEWq8z8ik/zfA5phWqv8km+tGEzqG/63cbhTM=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/ocaml-modules/junit/ounit.nix
+++ b/pkgs/development/ocaml-modules/junit/ounit.nix
@@ -1,18 +1,17 @@
 {
   buildDunePackage,
   junit,
-  ounit,
+  ounit2,
 }:
 
 buildDunePackage ({
   pname = "junit_ounit";
 
   inherit (junit) src version meta;
-  duneVersion = "3";
 
   propagatedBuildInputs = [
     junit
-    ounit
+    ounit2
   ];
 
   doCheck = true;


### PR DESCRIPTION
## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
