### PR TITLE
openclonk: drop non-mandatory dependency libXrandr

### DIFF
--- a/pkgs/by-name/op/openclonk/package.nix
+++ b/pkgs/by-name/op/openclonk/package.nix
@@ -23,7 +23,6 @@
   libogg,
   libpng,
   libvorbis,
-  libXrandr,
   openal,
   readline,
   SDL2,
@@ -86,7 +85,6 @@ stdenv.mkDerivation {
     libogg
     libpng
     libvorbis
-    libXrandr
     openal
     readline
     SDL2


### PR DESCRIPTION
The underlying missing libX11 dependency was solved by #403479.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
