### PR TITLE
pdf4qt: 1.5.0.0 -> 1.5.1.0

### DIFF
--- a/pkgs/by-name/pd/pdf4qt/package.nix
+++ b/pkgs/by-name/pd/pdf4qt/package.nix
@@ -14,13 +14,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "pdf4qt";
-  version = "1.5.0.0";
+  version = "1.5.1.0";
 
   src = fetchFromGitHub {
     owner = "JakubMelka";
     repo = "PDF4QT";
-    rev = "v${finalAttrs.version}";
-    hash = "sha256-ELdmnOEKFGCtuf240R/0M6r8aPwRQiXurAxrqcCZvOI=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-Ysrz/uCSTFK5wGNdTXhpq6QVf7Ju1xWisNVUtBtdEjc=";
   };
 
   patches = [
@@ -29,19 +29,6 @@ stdenv.mkDerivation (finalAttrs: {
     # header files instead.
     ./find_lcms2_path.patch
   ];
-
-  # make calls to QString::arg compatible with Qt 6.9
-  # see https://doc-snapshots.qt.io/qt6-6.9/whatsnew69.html#new-features-in-qt-6-9
-  postPatch = ''
-    substituteInPlace Pdf4QtLibCore/sources/pdf{documentsanitizer,optimizer}.cpp \
-      --replace-fail \
-        '.arg(counter)' \
-        '.arg<PDFInteger>(counter)'
-    substituteInPlace Pdf4QtLibCore/sources/pdfoptimizer.cpp \
-      --replace-fail \
-        '.arg(bytesSaved)' \
-        '.arg<PDFInteger>(bytesSaved)'
-  '';
 
   nativeBuildInputs = [
     cmake
@@ -83,8 +70,9 @@ stdenv.mkDerivation (finalAttrs: {
       functionality based on PDF Reference 2.0.
     '';
     homepage = "https://jakubmelka.github.io";
-    license = lib.licenses.lgpl3Only;
-    mainProgram = "Pdf4QtViewerLite";
+    changelog = "https://github.com/JakubMelka/PDF4QT/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    mainProgram = "Pdf4QtViewer";
     maintainers = with lib.maintainers; [ aleksana ];
     platforms = lib.platforms.linux;
   };


### PR DESCRIPTION
https://github.com/JakubMelka/PDF4QT/releases/tag/v1.5.1.0
https://github.com/JakubMelka/PDF4QT/compare/refs/tags/v1.5.0.0...refs/tags/v1.5.1.0

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review`

---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 1 package built:</summary>
  <ul>
    <li>pdf4qt</li>
  </ul>
</details>

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc