### PR TITLE
[24.11] grafana-image-renderer: 3.12.1 -> 3.12.5

### DIFF
--- a/pkgs/by-name/gr/grafana-image-renderer/package.json
+++ b/pkgs/by-name/gr/grafana-image-renderer/package.json
@@ -30,7 +30,7 @@
     "@hapi/boom": "^10.0.0",
     "@puppeteer/browsers": "^2.3.1",
     "chokidar": "^3.5.2",
-    "dompurify": "^2.5.4",
+    "dompurify": "^3.2.4",
     "express": "^4.21.1",
     "express-prom-bundle": "^6.5.0",
     "jimp": "^0.22.12",
@@ -49,24 +49,24 @@
   },
   "devDependencies": {
     "@grafana/eslint-config": "^6.0.0",
-    "@types/dompurify": "2.3.4",
+    "@types/dompurify": "^3.2.0",
     "@types/express": "^4.17.14",
     "@types/jest": "^29.5.12",
     "@types/jsdom": "20.0.0",
     "@types/multer": "^1.4.7",
-    "@types/node": "^18.7.18",
+    "@types/node": "^20.17.27",
     "@types/pixelmatch": "^5.2.6",
     "@types/supertest": "^2.0.15",
     "@typescript-eslint/eslint-plugin": "5.37.0",
     "@typescript-eslint/parser": "5.37.0",
-    "axios": "1.7.4",
+    "@yao-pkg/pkg": "^6.3.0",
+    "axios": "1.8.2",
     "cross-env": "7.0.3",
     "eslint": "8.23.1",
     "fast-png": "^6.2.0",
     "jest": "^29.7.0",
     "jsonwebtoken": "^9.0.2",
     "lint-staged": "13.0.3",
-    "pkg": "^5.8.1",
     "prettier": "2.7.1",
     "supertest": "^7.0.0",
     "ts-jest": "^29.1.1",
@@ -88,6 +88,6 @@
   },
   "bin": "build/app.js",
   "engines": {
-    "node": ">= 18"
+    "node": ">= 20"
   }
 }

--- a/pkgs/by-name/gr/grafana-image-renderer/package.nix
+++ b/pkgs/by-name/gr/grafana-image-renderer/package.nix
@@ -14,18 +14,18 @@
 
 mkYarnPackage rec {
   pname = "grafana-image-renderer";
-  version = "3.12.1";
+  version = "3.12.5";
 
   src = fetchFromGitHub {
     owner = "grafana";
     repo = "grafana-image-renderer";
     rev = "v${version}";
-    hash = "sha256-j01C5h8RKZi/jcJyzXqgw0sAiBdVphi1kLxgqygVhkg=";
+    hash = "sha256-dcWmMcvWwG4wGEEyFKa1R0jGGpK5x1F5Amr74JzJaLE=";
   };
 
   offlineCache = fetchYarnDeps {
     yarnLock = src + "/yarn.lock";
-    hash = "sha256-eYn69tlwCu3ohSCFdifMifvLgHgogv9aq6n8N363Hbw=";
+    hash = "sha256-BBu+vOO0UgX3L7Svj0HgVKHR2lSe4tD6c9HDgJZdhHU=";
   };
 
   packageJSON = ./package.json;


### PR DESCRIPTION
ChangeLog:
* https://github.com/grafana/grafana-image-renderer/blob/v3.12.3/CHANGELOG.md#3123-2025-03-12
* https://github.com/grafana/grafana-image-renderer/releases/tag/v3.12.4
* https://github.com/grafana/grafana-image-renderer/releases/tag/v3.12.5

I decided against downgrading Node to v20, apparently, their downgrade is due to a matter of Windows packaging[1].

[1] https://github.com/grafana/grafana-image-renderer/pull/619

Cherry-picked from d0ea799ea0570577bf1c8ccf4c758151f5cd81a6 & ff2bc96567010b849e7307dfb767f7890f929180


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
