### PR TITLE
crystal: set SOURCE_DATE_EPOCH if the file exists

### DIFF
--- a/pkgs/development/compilers/crystal/default.nix
+++ b/pkgs/development/compilers/crystal/default.nix
@@ -96,6 +96,7 @@ let
         "docs"
         "release=1"
       ],
+      hasEpochFile ? true, # Available since 1.13.0 https://github.com/crystal-lang/crystal/pull/14574
     }:
     stdenv.mkDerivation (finalAttrs: {
       pname = "crystal";
@@ -164,12 +165,16 @@ let
         '';
 
       # Defaults are 4
-      preBuild = ''
-        export CRYSTAL_WORKERS=$NIX_BUILD_CORES
-        export threads=$NIX_BUILD_CORES
-        export CRYSTAL_CACHE_DIR=$TMP
-        export MACOSX_DEPLOYMENT_TARGET=10.11
-      '';
+      preBuild =
+        ''
+          export CRYSTAL_WORKERS=$NIX_BUILD_CORES
+          export threads=$NIX_BUILD_CORES
+          export CRYSTAL_CACHE_DIR=$TMP
+          export MACOSX_DEPLOYMENT_TARGET=10.11
+        ''
+        + lib.optionalString hasEpochFile ''
+          export SOURCE_DATE_EPOCH="$(<src/SOURCE_DATE_EPOCH)"
+        '';
 
       strictDeps = true;
       nativeBuildInputs = [
@@ -299,6 +304,7 @@ rec {
     sha256 = "sha256-BBEDWqFtmFUNj0kuGBzv71YHO3KjxV4d2ySTCD4HhLc=";
     binary = binaryCrystal_1_10;
     llvmPackages = llvmPackages_15;
+    hasEpochFile = false;
   };
 
   crystal_1_14 = generic {

--- a/pkgs/development/compilers/crystal/default.nix
+++ b/pkgs/development/compilers/crystal/default.nix
@@ -96,7 +96,6 @@ let
         "docs"
         "release=1"
       ],
-      hasEpochFile ? true, # Available since 1.13.0 https://github.com/crystal-lang/crystal/pull/14574
     }:
     stdenv.mkDerivation (finalAttrs: {
       pname = "crystal";
@@ -165,16 +164,17 @@ let
         '';
 
       # Defaults are 4
-      preBuild =
-        ''
-          export CRYSTAL_WORKERS=$NIX_BUILD_CORES
-          export threads=$NIX_BUILD_CORES
-          export CRYSTAL_CACHE_DIR=$TMP
-          export MACOSX_DEPLOYMENT_TARGET=10.11
-        ''
-        + lib.optionalString hasEpochFile ''
+      preBuild = ''
+        export CRYSTAL_WORKERS=$NIX_BUILD_CORES
+        export threads=$NIX_BUILD_CORES
+        export CRYSTAL_CACHE_DIR=$TMP
+        export MACOSX_DEPLOYMENT_TARGET=10.11
+
+        # Available since 1.13.0 https://github.com/crystal-lang/crystal/pull/14574
+        if [[ -f src/SOURCE_DATE_EPOCH ]]; then
           export SOURCE_DATE_EPOCH="$(<src/SOURCE_DATE_EPOCH)"
-        '';
+        fi
+      '';
 
       strictDeps = true;
       nativeBuildInputs = [
@@ -299,12 +299,12 @@ rec {
     };
   };
 
+  # When removing this version, also remove checks for src/SOURCE_DATE_EPOCH existence
   crystal_1_11 = generic {
     version = "1.11.2";
     sha256 = "sha256-BBEDWqFtmFUNj0kuGBzv71YHO3KjxV4d2ySTCD4HhLc=";
     binary = binaryCrystal_1_10;
     llvmPackages = llvmPackages_15;
-    hasEpochFile = false;
   };
 
   crystal_1_14 = generic {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Fixes #306765 with using https://github.com/crystal-lang/crystal/pull/14574

Before

```console
> ./result-bin/bin/crystal --version
Crystal 1.15.1 (1980-01-01)

LLVM: 18.1.8
Default target: x86_64-unknown-linux-gnu
```

After

```console
> ./result-bin/bin/crystal --version
Crystal 1.15.1 (2025-02-04)

LLVM: 18.1.8
Default target: x86_64-unknown-linux-gnu
```

It displays the date of https://github.com/crystal-lang/crystal/releases/tag/1.15.1

Their [pre-built binary](https://github.com/crystal-lang/crystal/releases/download/1.15.1/crystal-1.15.1-1-linux-x86_64-bundled.tar.gz) returned value on Ubuntu is follows

```
> ./crystal --version
Crystal 1.15.1 [89944bf17] (2025-02-04)

LLVM: 18.1.6
Default target: x86_64-unknown-linux-gnu
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [x] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

cc: @straight-shoota

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
