### PR TITLE
amulet-map-editor: init at 0.10.44

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -24130,6 +24130,12 @@
     githubId = 1618946;
     name = "Tiago Castro";
   };
+  tibso = {
+    email = "thibaut.diels@proton.me";
+    github = "tibso";
+    githubId = 124144608;
+    name = "Thibaut Diels";
+  };
   tie = {
     name = "Ivan Trubach";
     email = "mr.trubach@icloud.com";

--- a/pkgs/by-name/am/amulet-map-editor/package.nix
+++ b/pkgs/by-name/am/amulet-map-editor/package.nix
@@ -1,0 +1,79 @@
+{
+  lib,
+  fetchFromGitHub,
+  python3,
+  nix-update-script,
+  writableTmpDirAsHomeHook,
+}:
+let
+  version = "0.10.44";
+in
+python3.pkgs.buildPythonApplication {
+  pname = "amulet-map-editor";
+  inherit version;
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "Amulet-Team";
+    repo = "Amulet-Map-Editor";
+    tag = version;
+    hash = "sha256-+6u7Ou+zyDkuyHZXH5J/pX3ygKJx2AsXJK+KmaIMSh0=";
+  };
+
+  build-system = with python3.pkgs; [
+    setuptools
+    wheel
+    cython
+    versioneer
+    numpy_1
+  ];
+
+  dependencies = with python3.pkgs; [
+    pillow
+    # need wxpython to use "numpy_1" instead of latest version
+    (wxpython.overridePythonAttrs (_: {
+      propagatedBuildInputs = [
+        numpy_1
+        pillow
+        six
+      ];
+    }))
+    pyopengl
+    pymctranslate
+    minecraft-resource-pack
+    amulet-core
+    amulet-nbt
+    platformdirs
+  ];
+
+  optional-dependencies = with python3.pkgs; {
+    dev = [
+      black
+      pre-commit
+    ];
+    docs = [
+      sphinx
+      sphinx-autodoc-typehints
+      sphinx-rtd-theme
+    ];
+  };
+
+  # "requirements.py" is asking for older versions
+  pythonRelaxDeps = [ "platformdirs" ];
+
+  pythonImportsCheck = [ "amulet_map_editor" ];
+  nativeCheckInputs = [
+    python3.pkgs.pytestCheckHook
+    writableTmpDirAsHomeHook
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Minecraft world editor and converter that supports all versions since Java 1.12 and Bedrock 1.7";
+    homepage = "https://github.com/Amulet-Team/Amulet-Map-Editor";
+    changelog = "https://github.com/Amulet-Team/Amulet-Map-Editor/releases/tag/${version}";
+    license = lib.licenses.unfree;
+    maintainers = with lib.maintainers; [ tibso ];
+  };
+}

--- a/pkgs/development/python-modules/amulet-core/default.nix
+++ b/pkgs/development/python-modules/amulet-core/default.nix
@@ -1,0 +1,97 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  pytestCheckHook,
+  writableTmpDirAsHomeHook,
+  pythonOlder,
+  nix-update-script,
+
+  # build-system
+  setuptools,
+  wheel,
+  cython,
+  versioneer,
+  numpy_1,
+
+  # dependencies
+  amulet-nbt,
+  amulet-leveldb,
+  pymctranslate,
+  lz4,
+  portalocker,
+  platformdirs,
+  black,
+  pre-commit,
+  sphinx,
+  sphinx-autodoc-typehints,
+  sphinx-rtd-theme,
+}:
+let
+  version = "1.9.30";
+in
+buildPythonPackage {
+  pname = "amulet-core";
+  inherit version;
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "Amulet-Team";
+    repo = "Amulet-Core";
+    tag = version;
+    hash = "sha256-r4i74vo/lLqeOgedaRniwQgqUBts4UwtbHJWgnd+mCM=";
+  };
+
+  disabled = pythonOlder "3.9";
+
+  build-system = [
+    setuptools
+    wheel
+    cython
+    versioneer
+    numpy_1
+  ];
+
+  dependencies = [
+    amulet-nbt
+    amulet-leveldb
+    pymctranslate
+    lz4
+    portalocker
+    platformdirs
+  ];
+
+  optional-dependencies = {
+    dev = [
+      black
+      pre-commit
+    ];
+    docs = [
+      sphinx
+      sphinx-autodoc-typehints
+      sphinx-rtd-theme
+    ];
+  };
+
+  # "requirements.py" is asking for older versions
+  pythonRelaxDeps = [
+    "portalocker"
+    "platformdirs"
+  ];
+
+  pythonImportsCheck = [ "amulet" ];
+  nativeCheckInputs = [
+    pytestCheckHook
+    writableTmpDirAsHomeHook
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Python library for reading and writing the Minecraft save formats";
+    homepage = "https://github.com/Amulet-Team/Amulet-Core";
+    changelog = "https://github.com/Amulet-Team/Amulet-Core/releases/tag/${version}";
+    license = lib.licenses.unfree;
+    maintainers = with lib.maintainers; [ tibso ];
+  };
+}

--- a/pkgs/development/python-modules/amulet-leveldb/default.nix
+++ b/pkgs/development/python-modules/amulet-leveldb/default.nix
@@ -1,0 +1,85 @@
+{
+  lib,
+  fetchFromGitHub,
+  buildPythonPackage,
+  pythonOlder,
+  pytestCheckHook,
+  nix-update-script,
+  zlib,
+
+  # build-system
+  setuptools,
+  wheel,
+  cython,
+  versioneer,
+
+  # dependencies
+  black,
+  pre-commit,
+  sphinx,
+  sphinx-autodoc-typehints,
+  sphinx-rtd-theme,
+}:
+let
+  version = "1.0.2";
+in
+buildPythonPackage {
+  pname = "amulet-leveldb";
+  inherit version;
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "Amulet-Team";
+    repo = "Amulet-LevelDB";
+    tag = version;
+    hash = "sha256-7VJb5TEa3GcwNEZYrnwP3yMWdpxkHeFcydCCeHiB3+w=";
+    fetchSubmodules = true;
+
+    postFetch = ''
+      # De-vendor zlib
+      rm -r $out/zlib
+    '';
+  };
+
+  disabled = pythonOlder "3.8";
+
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace-fail "versioneer.get_version()" "'${version}'"
+  '';
+
+  build-system = [
+    setuptools
+    wheel
+    cython
+    versioneer
+  ];
+
+  buildInputs = [ zlib ];
+
+  optional-dependencies = {
+    dev = [
+      black
+      pre-commit
+    ];
+    docs = [
+      sphinx
+      sphinx-autodoc-typehints
+      sphinx-rtd-theme
+    ];
+  };
+
+  pythonImportsCheck = [ "leveldb" ];
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Cython wrapper for Mojang's custom LevelDB";
+    homepage = "https://github.com/Amulet-Team/Amulet-LevelDB";
+    changelog = "https://github.com/Amulet-Team/Amulet-LevelDB/releases/tag/${version}";
+    # polyform license: https://github.com/Amulet-Team/Amulet-LevelDB/blob/3.0/LICENSE
+    license = lib.licenses.unfree;
+    maintainers = with lib.maintainers; [ tibso ];
+  };
+}

--- a/pkgs/development/python-modules/amulet-nbt/default.nix
+++ b/pkgs/development/python-modules/amulet-nbt/default.nix
@@ -1,0 +1,79 @@
+{
+  lib,
+  fetchFromGitHub,
+  buildPythonPackage,
+  pytestCheckHook,
+  nix-update-script,
+
+  # build-system
+  setuptools,
+  cython,
+  numpy_1,
+  versioneer,
+
+  # dependencies
+  mutf8,
+  black,
+  pre-commit,
+  sphinx,
+  sphinx-autodoc-typehints,
+  sphinx-rtd-theme,
+}:
+let
+  version = "2.1.5";
+in
+buildPythonPackage {
+  pname = "amulet-nbt";
+  inherit version;
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "Amulet-Team";
+    repo = "Amulet-NBT";
+    tag = version;
+    hash = "sha256-sxA/kijsDoql5jWuY7rzVjAmeVNFP0YNGCeb8wkztwY=";
+  };
+
+  build-system = [
+    setuptools
+    cython
+    versioneer
+    numpy_1
+  ];
+
+  dependencies = [ mutf8 ];
+
+  optional-dependencies = {
+    dev = [
+      black
+      pre-commit
+    ];
+    docs = [
+      sphinx
+      sphinx-autodoc-typehints
+      sphinx-rtd-theme
+    ];
+  };
+
+  pythonImportsCheck = [ "amulet_nbt" ];
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  # Directory conflicting with tests
+  preCheck = ''
+    rm -r amulet_nbt
+  '';
+
+  # Looks like a forgotten unimplemented test
+  disabledTests = [ "BaseTypeTest" ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Python library for reading and writing binary NBT and stringified NBT";
+    homepage = "https://github.com/Amulet-Team/Amulet-NBT";
+    changelog = "https://github.com/Amulet-Team/Amulet-NBT/releases/tag/${version}";
+    # polyform license: https://github.com/Amulet-Team/Amulet-NBT/blob/5.0/LICENSE
+    license = lib.licenses.unfree;
+    maintainers = with lib.maintainers; [ tibso ];
+  };
+}

--- a/pkgs/development/python-modules/minecraft-resource-pack/default.nix
+++ b/pkgs/development/python-modules/minecraft-resource-pack/default.nix
@@ -1,0 +1,86 @@
+{
+  lib,
+  fetchFromGitHub,
+  buildPythonPackage,
+  pythonOlder,
+  nix-update-script,
+
+  # build-system
+  setuptools,
+  wheel,
+  versioneer,
+
+  # dependencies
+  pillow,
+  numpy_1,
+  amulet-nbt,
+  platformdirs,
+  black,
+  mypy,
+  pre-commit,
+  sphinx,
+  sphinx-autodoc-typehints,
+  sphinx-rtd-theme,
+}:
+let
+  version = "1.4.6";
+in
+buildPythonPackage {
+  pname = "minecraft-resource-pack";
+  inherit version;
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "gentlegiantJGC";
+    repo = "Minecraft-Model-Reader";
+    tag = version;
+    hash = "sha256-i+c5QSvGQeB5APBzN5JJ6uFohR2volX4D9qkuRQeig4=";
+  };
+
+  disabled = pythonOlder "3.9";
+
+  build-system = [
+    setuptools
+    wheel
+    versioneer
+  ];
+
+  dependencies = [
+    pillow
+    numpy_1
+    amulet-nbt
+    platformdirs
+  ];
+
+  optional-dependencies = {
+    dev = [
+      black
+      mypy
+      pre-commit
+    ];
+    docs = [
+      sphinx
+      sphinx-autodoc-typehints
+      sphinx-rtd-theme
+    ];
+  };
+
+  # "requirements.py" is asking for older versions
+  pythonRelaxDeps = [ "platformdirs" ];
+
+  pythonImportsCheck = [ "minecraft_model_reader" ];
+
+  # Tests are broken
+  doCheck = false;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Load block models from resource packs";
+    homepage = "https://github.com/gentlegiantJGC/Minecraft-Model-Reader";
+    changelog = "https://github.com/gentlegiantJGC/Minecraft-Model-Reader/releases/tag/${version}";
+    # polyform license: https://github.com/gentlegiantJGC/Minecraft-Model-Reader/blob/master/LICENSE
+    license = lib.licenses.unfree;
+    maintainers = with lib.maintainers; [ tibso ];
+  };
+}

--- a/pkgs/development/python-modules/pymctranslate/default.nix
+++ b/pkgs/development/python-modules/pymctranslate/default.nix
@@ -1,0 +1,76 @@
+{
+  lib,
+  fetchFromGitHub,
+  buildPythonPackage,
+  pythonOlder,
+  pytestCheckHook,
+  nix-update-script,
+
+  # build-system
+  setuptools,
+  wheel,
+  versioneer,
+
+  # dependencies
+  numpy_1,
+  amulet-nbt,
+  black,
+  pre-commit,
+  sphinx,
+  sphinx-autodoc-typehints,
+  sphinx-rtd-theme,
+}:
+let
+  version = "1.2.35";
+in
+buildPythonPackage {
+  pname = "pymctranslate";
+  inherit version;
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "gentlegiantJGC";
+    repo = "PyMCTranslate";
+    tag = version;
+    hash = "sha256-JMF2SDi7QixCB+wcX2RVPbvPjU3rHcyXlIaR0TPHH98=";
+  };
+
+  disabled = pythonOlder "3.9";
+
+  build-system = [
+    setuptools
+    wheel
+    versioneer
+  ];
+
+  dependencies = [
+    numpy_1
+    amulet-nbt
+  ];
+
+  optional-dependencies = {
+    dev = [
+      black
+      pre-commit
+    ];
+    docs = [
+      sphinx
+      sphinx-autodoc-typehints
+      sphinx-rtd-theme
+    ];
+  };
+
+  pythonImportsCheck = [ "PyMCTranslate" ];
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Minecraft data translation system";
+    homepage = "https://github.com/gentlegiantJGC/PyMCTranslate";
+    changelog = "https://github.com/gentlegiantJGC/PyMCTranslate/releases/tag/${version}";
+    # polyform license: https://github.com/gentlegiantJGC/PyMCTranslate/blob/main/LICENSE
+    license = lib.licenses.unfree;
+    maintainers = with lib.maintainers; [ tibso ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8699,6 +8699,8 @@ self: super: with self; {
 
   mindsdb-evaluator = callPackage ../development/python-modules/mindsdb-evaluator { };
 
+  minecraft-resource-pack = callPackage ../development/python-modules/minecraft-resource-pack { };
+
   minexr = callPackage ../development/python-modules/minexr { };
 
   miniaudio = callPackage ../development/python-modules/miniaudio {

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -12570,6 +12570,8 @@ self: super: with self; {
 
   pymc = callPackage ../development/python-modules/pymc { };
 
+  pymctranslate = callPackage ../development/python-modules/pymctranslate { };
+
   pymdown-extensions = callPackage ../development/python-modules/pymdown-extensions { };
 
   pymdstat = callPackage ../development/python-modules/pymdstat { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -634,6 +634,8 @@ self: super: with self; {
 
   amshan = callPackage ../development/python-modules/amshan { };
 
+  amulet-core = callPackage ../development/python-modules/amulet-core { };
+
   amulet-leveldb = callPackage ../development/python-modules/amulet-leveldb { };
 
   amulet-nbt = callPackage ../development/python-modules/amulet-nbt { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -634,6 +634,8 @@ self: super: with self; {
 
   amshan = callPackage ../development/python-modules/amshan { };
 
+  amulet-leveldb = callPackage ../development/python-modules/amulet-leveldb { };
+
   amulet-nbt = callPackage ../development/python-modules/amulet-nbt { };
 
   anchor-kr = callPackage ../development/python-modules/anchor-kr { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -634,6 +634,8 @@ self: super: with self; {
 
   amshan = callPackage ../development/python-modules/amshan { };
 
+  amulet-nbt = callPackage ../development/python-modules/amulet-nbt { };
+
   anchor-kr = callPackage ../development/python-modules/anchor-kr { };
 
   ancp-bids = callPackage ../development/python-modules/ancp-bids { };


### PR DESCRIPTION
This PR adds the Amulet Map Editor package to Nixpkgs.
This application is a map editor for the video game Minecraft.

The application has `python-modules` dependencies that I also added individually, in case people want to use them for some Minecraft Python projects.

This closes [#201016](https://github.com/NixOS/nixpkgs/issues/201016)

And I suppose also closes [#356035](https://github.com/NixOS/nixpkgs/pull/356035)
Some peeps on Discord told me there was already a PR for this package, but silly me must have forgotten to check for a previous PR. So I've quickly added some stuff from the other PR (thank you @pluiedev) but I did not include stuff like tests and Sphinx docs stuff because I haven't looked into those yet, so I don't know how those things work.
Tell me if I need to add those for this PR.

The application works and is usable, although there are some UI rendering issues related to `wxpython`, which make the application hard to use. The application devs are aware of the UI issues (seems to be related to this issue [#127](https://github.com/Amulet-Team/Amulet-Map-Editor/issues/127)) and they seem to occur for any linux user (so also for other distros).
The devs are working on replacing `wxpython` to fix the UI issues.

## Things done

- Added myself to `maintainers.list`
- Added `amulet` to `licenses.list`
- Added the `amulet-map-editor` application

The following `python-modules` were also added:
- amulet-core
- amulet-leveldb
- amulet-nbt
- minecraft-resource-pack
- pymctranslate

Building and testing:

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
