### PR TITLE
btcpayserver: 2.1.0 -> 2.1.1

### DIFF
--- a/pkgs/by-name/bt/btcpayserver/deps.json
+++ b/pkgs/by-name/bt/btcpayserver/deps.json
@@ -46,8 +46,8 @@
   },
   {
     "pname": "BTCPayServer.Hwi",
-    "version": "2.0.2",
-    "hash": "sha256-CUq68FosFJyUtjjpnONhqQEXjtC9mF7zmkRjZnGwA1I="
+    "version": "2.0.6",
+    "hash": "sha256-LEj2R9hFQVCBol91l1ICn13z8rxT9iVkKT4krFskzLM="
   },
   {
     "pname": "BTCPayServer.Lightning.All",
@@ -701,43 +701,18 @@
   },
   {
     "pname": "NBitcoin",
-    "version": "5.0.40",
-    "hash": "sha256-cEu9luoct9YiL80z16THezZcaHgSPf6UU4Rz5QmyH+c="
-  },
-  {
-    "pname": "NBitcoin",
-    "version": "6.0.8",
-    "hash": "sha256-pfJRCSVAdh87SmEKeAYg7TNoGpQDtf026N+V0bL/ILk="
-  },
-  {
-    "pname": "NBitcoin",
-    "version": "7.0.31",
-    "hash": "sha256-sybd3AOGVlN7U6rLuWSi1kVxtBeaXb8iy786gc0CIh4="
-  },
-  {
-    "pname": "NBitcoin",
     "version": "7.0.45",
     "hash": "sha256-hWgtvAJvONk6jg1WiytE6M+ExkQJUCwO6cyVA6JE+8w="
   },
   {
     "pname": "NBitcoin",
-    "version": "7.0.46",
-    "hash": "sha256-c5KHQ/TYGBTMoKKKo7XYR8r7VTJlaU0ZW6KqWRMjh2Y="
-  },
-  {
-    "pname": "NBitcoin",
-    "version": "7.0.48",
-    "hash": "sha256-IbiCGHu1cug4kDzwS+vpTqX4jYifxWegFpIctjb/bOA="
-  },
-  {
-    "pname": "NBitcoin",
-    "version": "7.0.49",
-    "hash": "sha256-0MQSBeQahSX9s1PPFWengy5J8pWiKR48Vx7dsh3I2p4="
-  },
-  {
-    "pname": "NBitcoin",
     "version": "7.0.50",
     "hash": "sha256-l3H70u5OAbd2hevX/yeVBdQyee/dUn5mp4iGvTnTcjk="
+  },
+  {
+    "pname": "NBitcoin",
+    "version": "8.0.8",
+    "hash": "sha256-gpbxlfE7TN7mUOcWF9+r8htQTc19KqAuzsVaG5RYa3A="
   },
   {
     "pname": "NBitcoin.Altcoins",

--- a/pkgs/by-name/bt/btcpayserver/package.nix
+++ b/pkgs/by-name/bt/btcpayserver/package.nix
@@ -14,7 +14,7 @@ buildDotnetModule rec {
     owner = "btcpayserver";
     repo = "btcpayserver";
     tag = "v${version}";
-    sha256 = "sha256-5zvxLEQbKTcslcpq1JRgY/L0XWnQ4UyFWww6SGcTtcs=";
+    hash = "sha256-5zvxLEQbKTcslcpq1JRgY/L0XWnQ4UyFWww6SGcTtcs=";
   };
 
   projectFile = "BTCPayServer/BTCPayServer.csproj";

--- a/pkgs/by-name/bt/btcpayserver/package.nix
+++ b/pkgs/by-name/bt/btcpayserver/package.nix
@@ -8,13 +8,13 @@
 
 buildDotnetModule rec {
   pname = "btcpayserver";
-  version = "2.1.0";
+  version = "2.1.1";
 
   src = fetchFromGitHub {
     owner = "btcpayserver";
     repo = "btcpayserver";
     tag = "v${version}";
-    sha256 = "sha256-vojRe64STkCKNn/es5+TyBAXvSBXkjjGLbykuKTEa5k=";
+    sha256 = "sha256-5zvxLEQbKTcslcpq1JRgY/L0XWnQ4UyFWww6SGcTtcs=";
   };
 
   projectFile = "BTCPayServer/BTCPayServer.csproj";

--- a/pkgs/by-name/nb/nbxplorer/package.nix
+++ b/pkgs/by-name/nb/nbxplorer/package.nix
@@ -13,7 +13,7 @@ buildDotnetModule rec {
     owner = "dgarage";
     repo = "NBXplorer";
     rev = "v${version}";
-    sha256 = "sha256-RTkKyckdAv6+wJSlDlR+Q8fw0aZEbi4AwB+OPHI7TR4=";
+    hash = "sha256-RTkKyckdAv6+wJSlDlR+Q8fw0aZEbi4AwB+OPHI7TR4=";
   };
 
   projectFile = "NBXplorer/NBXplorer.csproj";

--- a/pkgs/by-name/nb/nbxplorer/package.nix
+++ b/pkgs/by-name/nb/nbxplorer/package.nix
@@ -12,7 +12,7 @@ buildDotnetModule rec {
   src = fetchFromGitHub {
     owner = "dgarage";
     repo = "NBXplorer";
-    rev = "v${version}";
+    tag = "v${version}";
     hash = "sha256-RTkKyckdAv6+wJSlDlR+Q8fw0aZEbi4AwB+OPHI7TR4=";
   };
 


### PR DESCRIPTION
- [x] The [nix-bitcoin VM test](https://gist.github.com/erikarvstedt/a326e074f08c6226018a709ce4ad51fb) succeeds on `x86_64-linux`.

Notes for reviewers:
You can verify GPG signatures with `refetch=1 pkgs/by-name/bt/btcpayserver/update.sh`.

cc @prusnak