### PR TITLE
vrcx: 2025.03.01 -> 2025.05.09

### DIFF
--- a/pkgs/by-name/vr/vrcx/deps.json
+++ b/pkgs/by-name/vr/vrcx/deps.json
@@ -51,13 +51,13 @@
   },
   {
     "pname": "Microsoft.JavaScript.NodeApi",
-    "version": "0.9.5",
-    "hash": "sha256-IJjCix/X0rh+3Fc7eVxKyk0P/Ex5ItlAM4ugTG7OYo4="
+    "version": "0.9.11",
+    "hash": "sha256-1F2lG7ePVKy9QXMt76AWf64zj5o9upVik3//AqPaw7U="
   },
   {
     "pname": "Microsoft.JavaScript.NodeApi.Generator",
-    "version": "0.9.5",
-    "hash": "sha256-Me3fsW0tc00O8bCcItEjLvm2Tik6Xbc7FPBddaLim8w="
+    "version": "0.9.11",
+    "hash": "sha256-WAunMB3ksE0trHmohr+fTxGXiYNd553PUJoDaOSmLxo="
   },
   {
     "pname": "Microsoft.NETCore.Platforms",
@@ -116,8 +116,8 @@
   },
   {
     "pname": "Microsoft.Win32.SystemEvents",
-    "version": "9.0.2",
-    "hash": "sha256-WXgu8y2LT8OtQSVRojumtlTkJVjfvXeZ8N9iRKIW/lI="
+    "version": "9.0.4",
+    "hash": "sha256-vWObhv9e/nPVaMkEYb4lTlMmX/v4fluVWuHAtxYrUIQ="
   },
   {
     "pname": "NETStandard.Library",
@@ -370,6 +370,41 @@
     "hash": "sha256-jPnWzDcbufO51GLGjynWHy0b+5PBqNxM+VKmSrObeUw="
   },
   {
+    "pname": "runtime.win.Microsoft.Win32.Primitives",
+    "version": "4.3.0",
+    "hash": "sha256-ZnzR82+YDpNYf1GICTbzPjB20AjSy8dlRhfocK1FMEw="
+  },
+  {
+    "pname": "runtime.win.System.Console",
+    "version": "4.3.1",
+    "hash": "sha256-xhkY/NXkqEv2bieaeD9M2HxB48qDBz/XrD5FS6xm1MI="
+  },
+  {
+    "pname": "runtime.win.System.Diagnostics.Debug",
+    "version": "4.3.0",
+    "hash": "sha256-DpU+PGIUCtaK6gQEl/OWSO/JKg/TA9yeD01Zzxaxy5k="
+  },
+  {
+    "pname": "runtime.win.System.IO.FileSystem",
+    "version": "4.3.0",
+    "hash": "sha256-6JnGF9kj6jYd9xneKQdTvb3zNTSHdeWW/pr7vui0AbA="
+  },
+  {
+    "pname": "runtime.win.System.Net.Primitives",
+    "version": "4.3.0",
+    "hash": "sha256-jqUpP60h/kkampLU9Bt8T5gSDaVXwxPsOOTEVVKAPbY="
+  },
+  {
+    "pname": "runtime.win.System.Net.Sockets",
+    "version": "4.3.0",
+    "hash": "sha256-k2lTk08ryI2NSEI3IFlO0y2cltiT8TIhNnqHgeL8I1M="
+  },
+  {
+    "pname": "runtime.win.System.Runtime.Extensions",
+    "version": "4.3.0",
+    "hash": "sha256-+TMflNyjP+Lf5bge0xVN5AKxMAk4/caWY6zZrqtyAJw="
+  },
+  {
     "pname": "SharpDX",
     "version": "4.2.0",
     "hash": "sha256-EXEmBAIA+qoRjxMSrVpbHn0GfJCr9ucm8YttFjUhb8M="
@@ -391,18 +426,18 @@
   },
   {
     "pname": "SixLabors.Fonts",
-    "version": "2.0.8",
-    "hash": "sha256-ujiUYbg/uHYjJsLuljwK0kdaQHzrceZ+W6jgjCpv5LE="
+    "version": "2.1.3",
+    "hash": "sha256-lUTFK7OBtiXU1gyROax4GXDRvNj3aqgGlZZvicc37VQ="
   },
   {
     "pname": "SixLabors.ImageSharp",
-    "version": "3.1.6",
-    "hash": "sha256-FQjLyC4158F1GyhlKjzjGo6TxAu698rYWTY9lkko/fA="
+    "version": "3.1.8",
+    "hash": "sha256-cE9BQfbCvJ0Mf+fQiTD8elOZEPcfZHjDz2BHdiO+D08="
   },
   {
     "pname": "SixLabors.ImageSharp.Drawing",
-    "version": "2.1.5",
-    "hash": "sha256-n54bDQpp5i2V4LgMXuuq/bHHs6/7PyK8eSx0vJ2NHbA="
+    "version": "2.1.6",
+    "hash": "sha256-2VYoBw8XidjqFUS03EgxOq9vw/WRZjhF3z1pwfaSzUc="
   },
   {
     "pname": "sqlite-net-pcl",
@@ -451,8 +486,8 @@
   },
   {
     "pname": "System.CodeDom",
-    "version": "9.0.2",
-    "hash": "sha256-hNhCSyuD9/teTgFuX4zrBn/LWlijczwrMqv+r3/yfHI="
+    "version": "9.0.4",
+    "hash": "sha256-X8IDHw/ssp0vgPSnyM/tmDTb3poH6GLe+gZ4MR9qfho="
   },
   {
     "pname": "System.Collections",
@@ -536,8 +571,8 @@
   },
   {
     "pname": "System.Drawing.Common",
-    "version": "9.0.2",
-    "hash": "sha256-S7IMV4R/nWbZs/YCwI9UwwLHDP57NkfSEIaoYNbRq54="
+    "version": "9.0.4",
+    "hash": "sha256-taudg5yVeaNrgvD9LMEumByKE0G032jp9s9AGfKYI9A="
   },
   {
     "pname": "System.Globalization",
@@ -591,8 +626,8 @@
   },
   {
     "pname": "System.Management",
-    "version": "9.0.2",
-    "hash": "sha256-7FhGnAYgoJnPcHy+HbVdK/fD8ICSLAttLtueTLBoWZc="
+    "version": "9.0.4",
+    "hash": "sha256-+sW/NQELaBGjUfzndaNLPHKKQVdI1yOJMaqF4tV2SVY="
   },
   {
     "pname": "System.Memory",
@@ -760,6 +795,11 @@
     "hash": "sha256-/9ZCPIHLdhzq7OW4UKqTsR0O93jjHd6BRG1SRwgHE1g="
   },
   {
+    "pname": "System.Security.Claims",
+    "version": "4.3.0",
+    "hash": "sha256-Fua/rDwAqq4UByRVomAxMPmDBGd5eImRqHVQIeSxbks="
+  },
+  {
     "pname": "System.Security.Cryptography.Algorithms",
     "version": "4.3.0",
     "hash": "sha256-tAJvNSlczYBJ3Ed24Ae27a55tq/n4D3fubNQdwcKWA8="
@@ -805,6 +845,11 @@
     "hash": "sha256-BGgXMLUi5rxVmmChjIhcXUxisJjvlNToXlyaIbUxw40="
   },
   {
+    "pname": "System.Security.Principal",
+    "version": "4.3.0",
+    "hash": "sha256-rjudVUHdo8pNJg2EVEn0XxxwNo5h2EaYo+QboPkXlYk="
+  },
+  {
     "pname": "System.Security.Principal.Windows",
     "version": "4.3.0",
     "hash": "sha256-mbdLVUcEwe78p3ZnB6jYsizNEqxMaCAWI3tEQNhRQAE="
@@ -836,8 +881,8 @@
   },
   {
     "pname": "System.Text.Json",
-    "version": "9.0.2",
-    "hash": "sha256-kftKUuGgZtF4APmp77U79ws76mEIi+R9+DSVGikA5y8="
+    "version": "9.0.4",
+    "hash": "sha256-oIOqfOIIUXXVkfFiTCI9wwIJBETQqF7ZcOJv2iYuq1s="
   },
   {
     "pname": "System.Text.RegularExpressions",
@@ -858,6 +903,11 @@
     "pname": "System.Threading.Channels",
     "version": "8.0.0",
     "hash": "sha256-c5TYoLNXDLroLIPnlfyMHk7nZ70QAckc/c7V199YChg="
+  },
+  {
+    "pname": "System.Threading.Overlapped",
+    "version": "4.3.0",
+    "hash": "sha256-tUX099CChkqWiHyP/1e4jGYzZAjgIthMOdMmiOGMUNk="
   },
   {
     "pname": "System.Threading.Tasks",

--- a/pkgs/by-name/vr/vrcx/package.nix
+++ b/pkgs/by-name/vr/vrcx/package.nix
@@ -4,7 +4,7 @@
   buildDotnetModule,
   dotnetCorePackages,
   buildNpmPackage,
-  electron_34,
+  electron_35,
   makeWrapper,
   copyDesktopItems,
   makeDesktopItem,
@@ -12,17 +12,15 @@
 }:
 let
   pname = "vrcx";
-  version = "2025.03.01";
+  version = "2025.05.09";
   dotnet = dotnetCorePackages.dotnet_9;
-  electron = electron_34;
+  electron = electron_35;
 
   src = fetchFromGitHub {
     owner = "vrcx-team";
     repo = "VRCX";
-    # v2025.03.01 tag is actually behind a few commits, namely the one that bumps the version (so it complains about not being up-to-date)
-    #tag = "v${version}";
-    rev = "1980eeb4cccebfcf33826d44b7833a9aa6f5a955";
-    hash = "sha256-HiFcHnytynWYbeUd+KsG38dLU1FhDu0VD3JPT3kUO6s=";
+    tag = "v${version}";
+    hash = "sha256-sqdDucjERHC5YykisFDiBOJw40snsldBcuCH1FAahSo=";
   };
 
   backend = buildDotnetModule {
@@ -47,7 +45,7 @@ in
 buildNpmPackage {
   inherit pname version src;
 
-  npmDepsHash = "sha256-2ZU+9NPPx3GbU75XfjVroZCpjXr7IK2HtEIqLJLOjyw=";
+  npmDepsHash = "sha256-sXWKsW9vPyq1oK9ysJod3uAUOICsK/TBLbSekT1SO+k=";
   npmFlags = [ "--ignore-scripts" ];
   makeCacheWritable = true;
 


### PR DESCRIPTION
This PR updates vrcx from 2025.03.01 to 2025.05.09

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
