### PR TITLE
Fix running NixOS tests on darwin

### DIFF
--- a/nixos/doc/manual/redirects.json
+++ b/nixos/doc/manual/redirects.json
@@ -1865,6 +1865,9 @@
   "test-opt-meta.platforms": [
     "index.html#test-opt-meta.platforms"
   ],
+  "test-opt-meta.hydraPlatforms": [
+    "index.html#test-opt-meta.hydraPlatforms"
+  ],
   "test-opt-meta.timeout": [
     "index.html#test-opt-meta.timeout"
   ],

--- a/nixos/lib/testing/default.nix
+++ b/nixos/lib/testing/default.nix
@@ -9,15 +9,13 @@ let
     };
   runTest =
     module:
-    # Infra issue: virtualization on darwin doesn't seem to work yet.
-    lib.addMetaAttrs { hydraPlatforms = lib.platforms.linux; }
-      (evalTest (
-        { config, ... }:
-        {
-          imports = [ module ];
-          result = config.test;
-        }
-      )).config.result;
+    (evalTest (
+      { config, ... }:
+      {
+        imports = [ module ];
+        result = config.test;
+      }
+    )).config.result;
 
   testModules = [
     ./call-test.nix

--- a/nixos/lib/testing/meta.nix
+++ b/nixos/lib/testing/meta.nix
@@ -1,6 +1,6 @@
 { lib, ... }:
 let
-  inherit (lib) types mkOption;
+  inherit (lib) types mkOption literalExpression;
 in
 {
   options = {
@@ -11,38 +11,49 @@ in
         Not all [`meta`](https://nixos.org/manual/nixpkgs/stable/#chap-meta) attributes are supported, but more can be added as desired.
       '';
       apply = lib.filterAttrs (k: v: v != null);
-      type = types.submodule {
-        options = {
-          maintainers = lib.mkOption {
-            type = types.listOf types.raw;
-            default = [ ];
-            description = ''
-              The [list of maintainers](https://nixos.org/manual/nixpkgs/stable/#var-meta-maintainers) for this test.
-            '';
+      type = types.submodule (
+        { config, ... }:
+        {
+          options = {
+            maintainers = lib.mkOption {
+              type = types.listOf types.raw;
+              default = [ ];
+              description = ''
+                The [list of maintainers](https://nixos.org/manual/nixpkgs/stable/#var-meta-maintainers) for this test.
+              '';
+            };
+            timeout = lib.mkOption {
+              type = types.nullOr types.int;
+              default = 3600; # 1 hour
+              description = ''
+                The [{option}`test`](#test-opt-test)'s [`meta.timeout`](https://nixos.org/manual/nixpkgs/stable/#var-meta-timeout) in seconds.
+              '';
+            };
+            broken = lib.mkOption {
+              type = types.bool;
+              default = false;
+              description = ''
+                Sets the [`meta.broken`](https://nixos.org/manual/nixpkgs/stable/#var-meta-broken) attribute on the [{option}`test`](#test-opt-test) derivation.
+              '';
+            };
+            platforms = lib.mkOption {
+              type = types.listOf types.raw;
+              default = lib.platforms.linux ++ lib.platforms.darwin;
+              description = ''
+                Sets the [`meta.platforms`](https://nixos.org/manual/nixpkgs/stable/#var-meta-platforms) attribute on the [{option}`test`](#test-opt-test) derivation.
+              '';
+            };
+            hydraPlatforms = lib.mkOption {
+              type = types.listOf types.raw;
+              default = config.platforms;
+              defaultText = literalExpression "meta.platforms";
+              description = ''
+                Sets the [`meta.hydraPlatforms`](https://nixos.org/manual/nixpkgs/stable/#var-meta-hydraPlatforms) attribute on the [{option}`test`](#test-opt-test) derivation.
+              '';
+            };
           };
-          timeout = lib.mkOption {
-            type = types.nullOr types.int;
-            default = 3600; # 1 hour
-            description = ''
-              The [{option}`test`](#test-opt-test)'s [`meta.timeout`](https://nixos.org/manual/nixpkgs/stable/#var-meta-timeout) in seconds.
-            '';
-          };
-          broken = lib.mkOption {
-            type = types.bool;
-            default = false;
-            description = ''
-              Sets the [`meta.broken`](https://nixos.org/manual/nixpkgs/stable/#var-meta-broken) attribute on the [{option}`test`](#test-opt-test) derivation.
-            '';
-          };
-          platforms = lib.mkOption {
-            type = types.listOf types.raw;
-            default = lib.platforms.linux ++ lib.platforms.darwin;
-            description = ''
-              Sets the [`meta.platforms`](https://nixos.org/manual/nixpkgs/stable/#var-meta-platforms) attribute on the [{option}`test`](#test-opt-test) derivation.
-            '';
-          };
-        };
-      };
+        }
+      );
       default = { };
     };
   };

--- a/nixos/lib/testing/meta.nix
+++ b/nixos/lib/testing/meta.nix
@@ -1,6 +1,6 @@
 { lib, ... }:
 let
-  inherit (lib) types mkOption literalExpression;
+  inherit (lib) types mkOption literalMD;
 in
 {
   options = {
@@ -45,8 +45,10 @@ in
             };
             hydraPlatforms = mkOption {
               type = types.listOf types.raw;
-              default = config.platforms;
-              defaultText = literalExpression "meta.platforms";
+              # Ideally this would default to `platforms` again:
+              # default = config.platforms;
+              default = lib.platforms.linux;
+              defaultText = literalMD "`lib.platforms.linux` only, as the `hydra.nixos.org` build farm does not currently support virtualisation on Darwin.";
               description = ''
                 Sets the [`meta.hydraPlatforms`](https://nixos.org/manual/nixpkgs/stable/#var-meta-hydraPlatforms) attribute on the [{option}`test`](#test-opt-test) derivation.
               '';

--- a/nixos/lib/testing/meta.nix
+++ b/nixos/lib/testing/meta.nix
@@ -36,9 +36,7 @@ in
           };
           platforms = lib.mkOption {
             type = types.listOf types.raw;
-            # darwin could be added, but it would add VM tests that don't work on Hydra.nixos.org (so far)
-            # see https://github.com/NixOS/nixpkgs/pull/303597#issuecomment-2128782362
-            default = lib.platforms.linux;
+            default = lib.platforms.linux ++ lib.platforms.darwin;
             description = ''
               Sets the [`meta.platforms`](https://nixos.org/manual/nixpkgs/stable/#var-meta-platforms) attribute on the [{option}`test`](#test-opt-test) derivation.
             '';

--- a/nixos/lib/testing/meta.nix
+++ b/nixos/lib/testing/meta.nix
@@ -4,7 +4,7 @@ let
 in
 {
   options = {
-    meta = lib.mkOption {
+    meta = mkOption {
       description = ''
         The [`meta`](https://nixos.org/manual/nixpkgs/stable/#chap-meta) attributes that will be set on the returned derivations.
 
@@ -15,35 +15,35 @@ in
         { config, ... }:
         {
           options = {
-            maintainers = lib.mkOption {
+            maintainers = mkOption {
               type = types.listOf types.raw;
               default = [ ];
               description = ''
                 The [list of maintainers](https://nixos.org/manual/nixpkgs/stable/#var-meta-maintainers) for this test.
               '';
             };
-            timeout = lib.mkOption {
+            timeout = mkOption {
               type = types.nullOr types.int;
               default = 3600; # 1 hour
               description = ''
                 The [{option}`test`](#test-opt-test)'s [`meta.timeout`](https://nixos.org/manual/nixpkgs/stable/#var-meta-timeout) in seconds.
               '';
             };
-            broken = lib.mkOption {
+            broken = mkOption {
               type = types.bool;
               default = false;
               description = ''
                 Sets the [`meta.broken`](https://nixos.org/manual/nixpkgs/stable/#var-meta-broken) attribute on the [{option}`test`](#test-opt-test) derivation.
               '';
             };
-            platforms = lib.mkOption {
+            platforms = mkOption {
               type = types.listOf types.raw;
               default = lib.platforms.linux ++ lib.platforms.darwin;
               description = ''
                 Sets the [`meta.platforms`](https://nixos.org/manual/nixpkgs/stable/#var-meta-platforms) attribute on the [{option}`test`](#test-opt-test) derivation.
               '';
             };
-            hydraPlatforms = lib.mkOption {
+            hydraPlatforms = mkOption {
               type = types.listOf types.raw;
               default = config.platforms;
               defaultText = literalExpression "meta.platforms";

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -90,22 +90,12 @@ let
 
   inherit
     (rec {
-
-      metaModule = {
-        _file = "${__curPos.file}##metaModule";
-        meta = {
-          # Infra issue: virtualization on darwin doesn't seem to work yet.
-          hydraPlatforms = platforms.linux;
-        };
-      };
-
       doRunTest =
         arg:
         ((import ../lib/testing-python.nix { inherit system pkgs; }).evalTest {
           imports = [
             arg
             readOnlyPkgs
-            metaModule
           ];
         }).config.result;
       findTests =

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -90,12 +90,22 @@ let
 
   inherit
     (rec {
+
+      metaModule = {
+        _file = "${__curPos.file}##metaModule";
+        meta = {
+          # Infra issue: virtualization on darwin doesn't seem to work yet.
+          hydraPlatforms = platforms.linux;
+        };
+      };
+
       doRunTest =
         arg:
         ((import ../lib/testing-python.nix { inherit system pkgs; }).evalTest {
           imports = [
             arg
             readOnlyPkgs
+            metaModule
           ];
         }).config.result;
       findTests =


### PR DESCRIPTION
- Fixes https://github.com/NixOS/nixpkgs/pull/303597#issuecomment-2864151691

- :bulb:  Review with[ whitespace changes hidden](https://github.com/NixOS/nixpkgs/pull/405599/files?w=1)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
