### PR TITLE
nix-prefetch-pijul: init

### DIFF
--- a/pkgs/build-support/fetchpijul/nix-prefetch-pijul
+++ b/pkgs/build-support/fetchpijul/nix-prefetch-pijul
@@ -1,0 +1,137 @@
+#!/bin/sh
+set -eu
+
+name="fetchpijul"
+remote=
+channel="main"
+change=
+state=
+exp_hash=
+
+usage() {
+	echo "Usage: nix-prefetch-pijul [options] [REMOTE] [STATE [EXPECTED-HASH]]"
+	echo
+	echo "Options:"
+	echo "	--name <NAME>        Symbolic store path name to use for the result."
+	echo "	--remote <REMOTE>    URL for the Pijul repository."
+	echo "	--change <CHANGE>    Clone a specific change."
+	echo "	--state <STATE>      Clone a specific state."
+	echo "	--channel <CHANNEL>  Channel name (default: ‘main’)."
+	echo "	--hash <HASH>        Expected hash."
+	echo "	--help               Show this help message."
+}
+
+# Argument parsing
+while [ $# -gt 0 ]; do
+	case "$1" in
+		--name)
+			name="$2"; shift 2 ;;
+		--remote)
+			remote="$2"; shift 2 ;;
+		--channel)
+			channel="$2"; shift 2 ;;
+		--change)
+			change="$2"; shift 2 ;;
+		--state)
+			state="$2"; shift 2 ;;
+		--hash)
+			exp_hash="$2"; shift 2 ;;
+		--help)
+			usage; exit 0 ;;
+		*)
+			# Positional arguments
+			if [ -z "$remote" ]; then
+				remote="$1"
+				shift
+			elif [ -z "$state" ]; then
+				state="$1"
+				shift
+			elif [ -z "$exp_hash" ]; then
+				exp_hash="$1"
+				shift
+			else
+				echo "Error: Too many arguments" >&2
+				usage
+				exit 1
+			fi
+			;;
+	esac
+done
+
+if [ -z "$remote" ]; then
+	echo "Error: URL for remote is required." >&2
+	echo >&2
+	usage
+	exit 1
+elif [ -n "$change" -a -n "$state" ]; then
+	echo "Error: Only one of ‘change’ or ‘state’ can be set" >&2
+	echo >&2
+	usage
+	exit 1
+fi
+
+hash=
+hash_algo="${NIX_HASH_ALGO:-"sha256"}"
+hash_format="${hashFormat:-"--base32"}"
+final_path=
+
+# If the hash was given, a file with that hash may already be in the
+# store.
+if [ -n "$exp_hash" ]; then
+	final_path=$(nix-store --print-fixed-path --recursive "$hash_algo" "$exp_hash" "$name")
+	if ! nix-store --check-validity "$final_path" 2> /dev/null; then
+		final_path=""
+	fi
+	hash="$exp_hash"
+fi
+
+# If we don’t know the hash or a path with that hash doesn’t exist,
+# download the file and add it to the store.
+if [ -z "$final_path" ]; then
+	tmp_clone="$(realpath "$(mktemp -d --tmpdir pijul-clone-tmp-XXXXXXXX)")"
+	trap "rm -rf \"$tmp_clone\"" EXIT
+
+	clone_args="--channel $channel"
+	if [ -n "$change" ]; then
+		clone_args="$clone_args --change $change"
+	elif [ -n "$state" ]; then
+		clone_args="$clone_args --state $state"
+	fi
+
+	cd "$tmp_clone"
+	pijul clone $clone_args "$remote" "$name"
+	rm -rf "$tmp_clone/$name/.pijul"
+
+	hash="$(nix-hash --type "$hash_algo" "$hash_format" "$tmp_clone/$name")"
+	final_path=$(nix-store --add-fixed --recursive "$hash_algo" "$tmp_clone/$name")
+
+	if [ -n "$exp_hash" -a "$exp_hash" != "$hash" ]; then
+		echo "Hash mismatch for “$remote” @ “$channel”" >&2
+		echo "Expected: $exp_hash" >&2
+		echo "Got:      $hash" >&2
+		exit 1
+	fi
+fi
+
+json_escape() {
+	printf '%s' "$1" | jq -Rs .
+}
+
+cat <<EOF
+{
+	"remote": $(json_escape "$remote"),
+	"channel": $(json_escape "$channel"),
+EOF
+if [ -n "$change" ]; then cat <<EOF
+	"change": "$(json_escape "$change")",
+EOF
+elif [ -n "$state" ]; then cat <<EOF
+	"state": "$(json_escape "$state")",
+EOF
+fi; cat <<EOF
+	"path": "$final_path",
+	$(json_escape "$hash_algo"): $(json_escape "$hash"),
+	"hash": "$(nix-hash --to-sri --type "$hash_algo" "$hash")"
+}
+EOF
+# vim: noet ci pi sts=0

--- a/pkgs/tools/package-management/nix-prefetch-scripts/default.nix
+++ b/pkgs/tools/package-management/nix-prefetch-scripts/default.nix
@@ -5,6 +5,7 @@
   buildEnv,
   bash,
   breezy,
+  cacert,
   coreutils,
   cvs,
   findutils,
@@ -12,7 +13,9 @@
   git,
   git-lfs,
   gnused,
+  jq,
   mercurial,
+  pijul,
   subversion,
 }:
 
@@ -73,6 +76,11 @@ rec {
   nix-prefetch-svn = mkPrefetchScript "svn" ../../../build-support/fetchsvn/nix-prefetch-svn [
     subversion
   ];
+  nix-prefetch-pijul = mkPrefetchScript "pijul" ../../../build-support/fetchpijul/nix-prefetch-pijul [
+    pijul
+    cacert
+    jq
+  ];
 
   nix-prefetch-scripts = buildEnv {
     name = "nix-prefetch-scripts";
@@ -83,6 +91,7 @@ rec {
       nix-prefetch-git
       nix-prefetch-hg
       nix-prefetch-svn
+      nix-prefetch-pijul
     ];
 
     meta = with lib; {


### PR DESCRIPTION
This appears to meet the basic requirements for Pijul when I tested the options. I can’t say my shell skills are anything more than ‘adequate’ so feedback is appreciated.

One difference is that Nixpkgs’s `fetchpijul` uses the term `url`, however, `pijul clone --help` uses the term `remote`.

<!--
^ Please summarize the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

[^1]

[^1]: Please consider [giving up MS GitHub](https://sfconservancy.org/GiveUpGitHub/) or offering a non-proprietary, non-US-corporate-controlled mirror for this free software project. I wish to delete this Microsoft account in the future, but I need more projects like this to support alternative methods to send patches & contribute.
