### PR TITLE
nixos/paperless: expose manage package 

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2505.section.md
+++ b/nixos/doc/manual/release-notes/rl-2505.section.md
@@ -279,7 +279,7 @@
   As the `service.locate.localuser` option only applied when using findutil's `locate`, it has also been removed.
 
 - `services.paperless` now installs `paperless-manage` as a normal system package instead of creating a symlink in `/var/lib/paperless`.
-  It is now exposed as a read-only option via `services.paperless.manage`. `paperless-manage` now also changes to the appropriate user when being executed.
+  `paperless-manage` now also changes to the appropriate user when being executed.
 
 - The `gotenberg` package has been updated to 8.16.0, which brings breaking changes to the configuration from version 8.13.0. See the [upstream release notes](https://github.com/gotenberg/gotenberg/releases/tag/v8.13.0)
   for that release to get all the details. The `services.gotenberg` module has been updated appropriately to ensure your configuration is valid with this new release.

--- a/nixos/doc/manual/release-notes/rl-2505.section.md
+++ b/nixos/doc/manual/release-notes/rl-2505.section.md
@@ -562,8 +562,9 @@
 
 - There is a new set of NixOS test tools for testing virtual Wi-Fi networks in many different topologies. See the {option}`services.vwifi` module, {option}`services.kismet` NixOS test, and [manual](https://nixos.org/manual/nixpkgs/unstable/#sec-nixos-test-wifi) for documentation and examples.
 
-- The paperless module now has an option for regular automatic export of
-  documents data using the integrated document exporter.
+- The paperless module now has an option for regular automatic export of documents data using the integrated document exporter.
+
+- Exposed the `paperless-manage` script package via the `services.paperless.manage` read-only option.
 
 - New options for the declarative configuration of the user space part of ALSA have been introduced under [hardware.alsa](options.html#opt-hardware.alsa.enable), including setting the default capture and playback device, defining sound card aliases and volume controls.
   Note: these are intended for users not running a sound server like PulseAudio or PipeWire, but having ALSA as their only sound system.

--- a/nixos/doc/manual/release-notes/rl-2505.section.md
+++ b/nixos/doc/manual/release-notes/rl-2505.section.md
@@ -279,7 +279,7 @@
   As the `service.locate.localuser` option only applied when using findutil's `locate`, it has also been removed.
 
 - `services.paperless` now installs `paperless-manage` as a normal system package instead of creating a symlink in `/var/lib/paperless`.
-  `paperless-manage` now also changes to the appropriate user when being executed.
+  It is now exposed as a read-only option via `services.paperless.manage`. `paperless-manage` now also changes to the appropriate user when being executed.
 
 - The `gotenberg` package has been updated to 8.16.0, which brings breaking changes to the configuration from version 8.13.0. See the [upstream release notes](https://github.com/gotenberg/gotenberg/releases/tag/v8.13.0)
   for that release to get all the details. The `services.gotenberg` module has been updated appropriately to ensure your configuration is valid with this new release.

--- a/nixos/modules/services/misc/paperless.nix
+++ b/nixos/modules/services/misc/paperless.nix
@@ -373,7 +373,6 @@ in
       description = ''
         The package derivation for the `paperless-manage` wrapper script.
         Useful for other modules that need to add this specific script to a service's PATH.
-        This is automatically set when `services.paperless.enable` is true.
       '';
     };
   };

--- a/nixos/modules/services/misc/paperless.nix
+++ b/nixos/modules/services/misc/paperless.nix
@@ -367,7 +367,7 @@ in
       '';
     };
 
-    manageScriptPackage = lib.mkOption {
+    manage = lib.mkOption {
       type = lib.types.package;
       readOnly = true;
       description = ''
@@ -381,7 +381,7 @@ in
   config = lib.mkIf cfg.enable (
     lib.mkMerge [
       {
-        services.paperless.manageScriptPackage = manage;
+        services.paperless.manage = manage;
         environment.systemPackages = [ manage ];
 
         services.redis.servers.paperless.enable = lib.mkIf enableRedis true;

--- a/nixos/modules/services/misc/paperless.nix
+++ b/nixos/modules/services/misc/paperless.nix
@@ -366,11 +366,22 @@ in
         Whether to configure Tika and Gotenberg to process Office and e-mail files with OCR.
       '';
     };
+
+    manageScriptPackage = lib.mkOption {
+      type = lib.types.package;
+      readOnly = true;
+      description = ''
+        The package derivation for the `paperless-manage` wrapper script.
+        Useful for other modules that need to add this specific script to a service's PATH.
+        This is automatically set when `services.paperless.enable` is true.
+      '';
+    };
   };
 
   config = lib.mkIf cfg.enable (
     lib.mkMerge [
       {
+        services.paperless.manageScriptPackage = manage;
         environment.systemPackages = [ manage ];
 
         services.redis.servers.paperless.enable = lib.mkIf enableRedis true;


### PR DESCRIPTION
Add the package output `manage` for `services.paperless` so that it can be used in scripts where the system path is not available.

Use-case: I'm running a backup script that does not have the system path available. I wanted to somehow access the `paperless-manage` cli but had to rely on this workaround:
```nix
{
  lib,
  config,
  pkgs,
  inputs,
  ...
}:

with lib;

let
  cfg = config.services.restic-backup-paperless;

  getPaperlessManagePackage = lib.findFirst (
    p:
    (
      p ? name && builtins.isString p.name && builtins.match "paperless-manage(-[0-9.]+)?$" p.name != null
    )
  ) null config.environment.systemPackages;

in
{
  options.services.restic-backup-paperless = {
    enable = mkEnableOption "Enable Restic backup service for Actual Budget";
  };

  config = mkIf cfg.enable {
    services.restic-hetzner.backups = {
      paperless = {
        enable = true;
        repoPath = "paperless";

        prepare = {
          enable = true;
          user = "root";
          group = "root";
          script = ''
            set -e
            echo "Running paperless-manage document_exporter for job 'paperless' in $(pwd)..."

            paperless-manage document_exporter  --compare-checksums --delete ../export

            echo "Prepare/document_exporter script finished for job 'paperless'."
          '';
          path = [
            getPaperlessManagePackage
            pkgs.bash
          ];
        };

        backup = {
          sourcePath = ".";
          schedule = {
            onCalendar = "*-*-* 03:15:00";
          };
        };
      };
    };
  };
}
```

with this change this should be able to remove `getPaperlessManagePackage` and just use:
```nix
          path = [
            config.services.paperless.manage
            pkgs.bash
          ];
```


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
