### PR TITLE
the-way: pull source from github to be able to run unit tests

### DIFF
--- a/pkgs/by-name/th/the-way/package.nix
+++ b/pkgs/by-name/th/the-way/package.nix
@@ -1,7 +1,8 @@
 {
   lib,
+  stdenv,
   rustPlatform,
-  fetchCrate,
+  fetchFromGitHub,
   installShellFiles,
 }:
 
@@ -9,9 +10,11 @@ rustPlatform.buildRustPackage rec {
   pname = "the-way";
   version = "0.20.3";
 
-  src = fetchCrate {
-    inherit pname version;
-    hash = "sha256-/vG5LkQiA8iPP+UV1opLeJwbYfmzqYwpsoMizpGT98o=";
+  src = fetchFromGitHub {
+    owner = "out-of-cheese-error";
+    repo = "the-way";
+    tag = "v${version}";
+    hash = "sha256-zsfk5APxbnssMKud9xGc70N+57LSc+vk6sSb2XzFUyA=";
   };
 
   useFetchCargoVendor = true;
@@ -19,9 +22,10 @@ rustPlatform.buildRustPackage rec {
 
   nativeBuildInputs = [ installShellFiles ];
 
+  doCheck = !stdenv.hostPlatform.isDarwin;
   useNextest = true;
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     $out/bin/the-way config default tmp.toml
     for shell in bash fish zsh; do
       THE_WAY_CONFIG=tmp.toml $out/bin/the-way complete $shell > the-way.$shell
@@ -35,6 +39,7 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/out-of-cheese-error/the-way";
     changelog = "https://github.com/out-of-cheese-error/the-way/blob/v${version}/CHANGELOG.md";
     license = with licenses; [ mit ];
+    platforms = lib.platforms.unix;
     maintainers = with maintainers; [
       figsoda
       numkem


### PR DESCRIPTION
In the last successful build it was already running 0 tests and there was a warning saying `no tests to run -- this will become an error in the future` (https://hydra.nixos.org/build/280526310/nixlog/1/tail). This future seems to have come and the build is therefore failing now.

By using the standard cargoCheckHook it still runs 0 tests but doesn't error because of it. It felt more correct to fix it this way rather than setting `doCheck = false;`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
