### PR TITLE
Allow nix-output-monitor to be optional

### DIFF
--- a/pkgs/by-name/nh/nh/package.nix
+++ b/pkgs/by-name/nh/nh/package.nix
@@ -7,14 +7,14 @@
   fetchFromGitHub,
   nix-update-script,
   nvd,
-  nix-output-monitor,
+  # Make optional as nom is AGPL. This mirrors nix-community/nh/package.nix
+  use-nom ? true,
+  nix-output-monitor ? null,
   buildPackages,
 }:
+assert use-nom -> nix-output-monitor != null;
 let
-  runtimeDeps = [
-    nvd
-    nix-output-monitor
-  ];
+  runtimeDeps = [ nvd ] ++ lib.optionals use-nom [ nix-output-monitor ];
 in
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "nh";


### PR DESCRIPTION
Allow `nix-output-monitor` to be optional.

This mirrors https://github.com/nix-community/nh/blob/master/package.nix

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
