### PR TITLE
nh: allow nix-output-monitor to be optional

### DIFF
--- a/pkgs/by-name/nh/nh/package.nix
+++ b/pkgs/by-name/nh/nh/package.nix
@@ -7,14 +7,13 @@
   fetchFromGitHub,
   nix-update-script,
   nvd,
+  # Make optional as nom is AGPL. This mirrors nix-community/nh/package.nix
+  use-nom ? true,
   nix-output-monitor,
   buildPackages,
 }:
 let
-  runtimeDeps = [
-    nvd
-    nix-output-monitor
-  ];
+  runtimeDeps = [ nvd ] ++ lib.optionals use-nom [ nix-output-monitor ];
 in
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "nh";


### PR DESCRIPTION
nh: allow nix-output-monitor to be optional