### PR TITLE
python3Packages.reinkpy: init at 2.240918.1-unstable-2025-04-28

### DIFF
--- a/pkgs/development/python-modules/reinkpy/default.nix
+++ b/pkgs/development/python-modules/reinkpy/default.nix
@@ -1,0 +1,60 @@
+{
+  lib,
+  buildPythonPackage,
+  pythonOlder,
+  fetchFromGitea,
+  setuptools,
+  setuptools-scm,
+  pyusb,
+  asciimatics,
+  pysnmp,
+  zeroconf,
+}:
+
+buildPythonPackage {
+  pname = "reinkpy";
+  version = "2.250428.0"; # The proper version would be 2.240918.1-unstable-2025-04-28 but then the package no longer compiles
+  pyproject = true;
+  disabled = pythonOlder "3.11";
+
+  src = fetchFromGitea {
+    domain = "codeberg.org";
+    owner = "atufi";
+    repo = "reinkpy";
+    rev = "101e90e35b589bdab92a9f5a0cf81f1358dbd109";
+    hash = "sha256-6GNi5bmCA62ZYc96EF0p2bD1jyFm18pktv3THQfkovE=";
+  };
+
+  build-system = [
+    setuptools
+    setuptools-scm
+  ];
+
+  dependencies = [
+    # USB
+    pyusb
+
+    # UI
+    asciimatics
+
+    # Network (not working, see longDescription below)
+    pysnmp
+    zeroconf
+  ];
+
+  pythonImportsCheck = [ "reinkpy" ];
+
+  strictDeps = true;
+
+  meta = with lib; {
+    description = "Waste ink counter resetter for some (EPSON) printers";
+    longDescription = ''
+      Note that the networking portion of this package does not work currently, as Nixpkgs has incompatible versions of some libraries.
+      See https://codeberg.org/atufi/reinkpy/issues/29 and https://codeberg.org/atufi/reinkpy/issues/27 for two issues that are caused by this.
+      This should be fixed, once https://codeberg.org/atufi/reinkpy/issues/28 has been closed.
+    '';
+    homepage = "https://codeberg.org/atufi/reinkpy";
+    license = licenses.agpl3Plus;
+    maintainers = with maintainers; [ Luflosi ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -14942,6 +14942,8 @@ self: super: with self; {
 
   reikna = callPackage ../development/python-modules/reikna { };
 
+  reinkpy = callPackage ../development/python-modules/reinkpy { };
+
   related = callPackage ../development/python-modules/related { };
 
   relatorio = callPackage ../development/python-modules/relatorio { };


### PR DESCRIPTION
I successfully used this package to reset the waste ink counter of my EPSON ET-2720 printer.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc