### PR TITLE
alliance: Switch to GitHub repository, update to 2025

### DIFF
--- a/pkgs/by-name/al/alliance/package.nix
+++ b/pkgs/by-name/al/alliance/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   stdenv,
-  fetchFromGitLab,
+  fetchFromGitHub,
   xorgproto,
   motif,
   libX11,
@@ -16,17 +16,18 @@
 
 stdenv.mkDerivation {
   pname = "alliance";
-  version = "unstable-2022-01-13";
+  version = "unstable-2025-02-24";
 
-  src = fetchFromGitLab {
-    domain = "gitlab.lip6.fr";
-    owner = "vlsi-eda";
-    repo = "alliance";
-    rev = "ebece102e15c110fc79f1da50524c68fd9523f0c";
-    hash = "sha256-NGtE3ZmN9LrgXG4NIKrp7dFRVzrKMoudlPUtYYKrZjY=";
-  };
-
-  prePatch = "cd alliance/src";
+  src =
+    let
+      src = fetchFromGitHub {
+        owner = "lip6";
+        repo = "alliance";
+        rev = "a8502d32df0a4ad1bd29ab784c4332319669ecd2";
+        hash = "sha256-b2uaYZEzHMB3qCMRVANNnjTxr6OYb1Unswxjq5knYzM=";
+      };
+    in
+    "${src}/alliance/src";
 
   nativeBuildInputs = [
     libtool
@@ -43,16 +44,12 @@ stdenv.mkDerivation {
     bison
   ];
 
-  # Disable parallel build, errors:
-  #  ./pat_decl_y.y:736:5: error: expected '=', ...
-  enableParallelBuilding = false;
-
-  ALLIANCE_TOP = placeholder "out";
-
   configureFlags = [
-    "--prefix=${placeholder "out"}"
     "--enable-alc-shared"
   ];
+
+  # To avoid compiler error in LoadDataBase.c:366:27
+  env.NIX_CFLAGS_COMPILE = "-Wno-incompatible-pointer-types";
 
   postPatch = ''
     # texlive for docs seems extreme


### PR DESCRIPTION
GitHub is the source repository referenced by their website described in meta. The new version is no longer broken, and allows us to remove some flags. We need `-Wno-incompatible-pointer-types` now.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
