### PR TITLE
tbb_2021_11_0: fix static builds

### DIFF
--- a/pkgs/development/libraries/tbb/2020_3.nix
+++ b/pkgs/development/libraries/tbb/2020_3.nix
@@ -124,6 +124,7 @@ stdenv.mkDerivation rec {
     '';
     platforms = platforms.unix;
     maintainers = with maintainers; [
+      silvanshade
       thoughtpolice
       tmarkus
     ];

--- a/pkgs/development/libraries/tbb/2022_0.nix
+++ b/pkgs/development/libraries/tbb/2022_0.nix
@@ -85,6 +85,7 @@ stdenv.mkDerivation rec {
     '';
     platforms = platforms.unix ++ platforms.windows;
     maintainers = with maintainers; [
+      silvanshade
       thoughtpolice
       tmarkus
     ];

--- a/pkgs/development/libraries/tbb/default.nix
+++ b/pkgs/development/libraries/tbb/default.nix
@@ -98,6 +98,7 @@ stdenv.mkDerivation rec {
     '';
     platforms = platforms.unix ++ platforms.windows;
     maintainers = with maintainers; [
+      silvanshade
       thoughtpolice
       tmarkus
     ];

--- a/pkgs/development/libraries/tbb/default.nix
+++ b/pkgs/development/libraries/tbb/default.nix
@@ -50,6 +50,9 @@ stdenv.mkDerivation rec {
       url = "https://patch-diff.githubusercontent.com/raw/uxlfoundation/oneTBB/pull/1696.patch";
       hash = "sha256-yjX2FkOK8bz29a/XSA7qXgQw9lxzx8VIgEBREW32NN4=";
     })
+    # Fix Threads::Threads target for static from https://github.com/oneapi-src/oneTBB/pull/1248
+    # This is a conflict-resolved cherry-pick of the above PR to due to formatting differences.
+    ./patches/fix-cmake-threads-threads-target-for-static.patch
   ];
 
   # Fix build with modern gcc

--- a/pkgs/development/libraries/tbb/patches/fix-cmake-threads-threads-target-for-static.patch
+++ b/pkgs/development/libraries/tbb/patches/fix-cmake-threads-threads-target-for-static.patch
@@ -1,0 +1,34 @@
+From b42f074a724a41d2369a94283a2e94190d0cbb44 Mon Sep 17 00:00:00 2001
+From: Liam Keegan <liam@keegan.ch>
+Date: Fri, 10 Nov 2023 09:08:42 +0100
+Subject: [PATCH] Fix CMake "Threads::Threads target not found" issue for
+ static builds (#1248)
+
+- add `Threads` dependency to installed CMake config for static builds only
+- based on #912 by @p12tic including reviewer comments from @ilya-lavrenov and @isaevil
+- resolves #1145
+
+Signed-off-by: Liam Keegan <liam@keegan.ch>
+(cherry picked from commit 12ceae12138af08845b3e8c369b24527346fe99e)
+---
+ CMakeLists.txt | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 16ee29ed..0bc39a52 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -265,6 +265,10 @@ else()
+             COMPONENT devel)
+     file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake
+                "include(\${CMAKE_CURRENT_LIST_DIR}/${PROJECT_NAME}Targets.cmake)\n")
++        if (NOT BUILD_SHARED_LIBS)
++            file(APPEND ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake
++                       "include(CMakeFindDependencyMacro)\nfind_dependency(Threads)\n")
++        endif()
+ 
+     write_basic_package_version_file("${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake"
+                                      COMPATIBILITY AnyNewerVersion)
+-- 
+2.49.0
+


### PR DESCRIPTION
Fixes: https://github.com/NixOS/nix/issues/13160

This is a backport of https://github.com/uxlfoundation/oneTBB/pull/1248

I had to include this as a manual patch rather than using `fetchpatch` because the patch fails to apply due to whitespace differences.

The patch does successfully apply via `patch --ignore-whitespace` but as far as I can tell there isn't an option to configure `fetchpatch` to similarly ignore whitespace.

- Built on platform(s)
  - [x] x86_64-linux
