### PR TITLE
sgdboop: init at 1.3.1

### DIFF
--- a/pkgs/by-name/sg/sgdboop/hide_desktop_entry.patch
+++ b/pkgs/by-name/sg/sgdboop/hide_desktop_entry.patch
@@ -1,0 +1,22 @@
+From a4ca664abfac0b7efa7dbc48c6438bc1a5333962 Mon Sep 17 00:00:00 2001
+From: Fazzi <faaris.ansari@proton.me>
+Date: Sat, 24 May 2025 20:55:50 +0100
+Subject: [PATCH] desktopFile: hide entry from app launchers
+
+---
+ linux-release/com.steamgriddb.SGDBoop.desktop | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/linux-release/com.steamgriddb.SGDBoop.desktop b/linux-release/com.steamgriddb.SGDBoop.desktop
+index 9c84cdb..9899682 100644
+--- a/linux-release/com.steamgriddb.SGDBoop.desktop
++++ b/linux-release/com.steamgriddb.SGDBoop.desktop
+@@ -4,7 +4,7 @@ Comment=Apply Steam assets from SteamGridDB
+ Exec=SGDBoop %U
+ Terminal=false
+ Type=Application
+-NoDisplay=false
++NoDisplay=true
+ Icon=com.steamgriddb.SGDBoop
+ MimeType=x-scheme-handler/sgdb
+ Categories=Utility

--- a/pkgs/by-name/sg/sgdboop/package.nix
+++ b/pkgs/by-name/sg/sgdboop/package.nix
@@ -1,0 +1,60 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  curl,
+  pkg-config,
+  wrapGAppsHook3,
+}:
+stdenv.mkDerivation rec {
+  pname = "sgdboop";
+  version = "1.3.1";
+
+  src = fetchFromGitHub {
+    owner = "SteamGridDB";
+    repo = "SGDBoop";
+    tag = "v${version}";
+    hash = "sha256-FpVQQo2N/qV+cFhYZ1FVm+xlPHSVMH4L+irnQEMlUQs=";
+  };
+
+  patches = [
+    # Hide the app from app launchers, as it is not meant to be run directly
+    # Remove when https://github.com/SteamGridDB/SGDBoop/pull/112 is merged
+    ./hide_desktop_entry.patch
+  ];
+
+  makeFlags = [
+    # The flatpak install just copies things to /app - otherwise wants to do things with XDG
+    "FLATPAK_ID=fake"
+  ];
+
+  postPatch = ''
+    substituteInPlace Makefile \
+      --replace-fail "/app/" "$out/"
+  '';
+
+  postInstall = ''
+    rm -r "$out/share/metainfo"
+  '';
+
+  nativeBuildInputs = [
+    pkg-config
+    wrapGAppsHook3
+  ];
+
+  buildInputs = [
+    curl
+  ];
+
+  meta = {
+    description = "Applying custom artwork to Steam, using SteamGridDB";
+    homepage = "https://github.com/SteamGridDB/SGDBoop/";
+    license = lib.licenses.zlib;
+    maintainers = with lib.maintainers; [
+      saturn745
+      fazzi
+    ];
+    mainProgram = "SGDBoop";
+    platforms = lib.platforms.linux;
+  };
+}


### PR DESCRIPTION
Just a revive of #341468 by @Saturn745, which itself is based on @puffnfresh's original PR #269369, which went stale.
Please let me know if you want to update your original PR instead and I will gladly close this.

There may be some issues with commit author attributions that I'm unsure how to solve. Considering there were two people working on it before this I don't know how I can make sure everyone involved is given attribution.

Simply packages SGDBoop. As of version 1.3.0 the dependency on `iup` was removed and hence i removed the PR relating to it and its dependencies (`canvasdraw` and `imtoolkit`). So now the PR is very simple and only needs to add the one package.

Fixes #220937 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
