### PR TITLE
Add home-assistant custom component rct-power

### DIFF
--- a/pkgs/development/python-modules/rctclient/default.nix
+++ b/pkgs/development/python-modules/rctclient/default.nix
@@ -1,0 +1,37 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  click,
+  setuptools,
+  pytestCheckHook,
+}:
+
+buildPythonPackage rec {
+  pname = "rctclient";
+  version = "0.0.4";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "svalouch";
+    repo = "python-rctclient";
+    tag = "v${version}";
+    hash = "sha256-QPla5h8wSM9Ynj44Uwc1a2yAnu8TXbyBWzVHQeW6jnI=";
+  };
+
+  build-system = [ setuptools ];
+
+  optional-dependencies.cli = [ click ];
+
+  pythonImportsCheck = [ "rctclient" ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  meta = with lib; {
+    description = "Python implementation of the RCT Power GmbH Serial Communication Protocol";
+    homepage = "https://github.com/svalouch/python-rctclient";
+    changelog = "https://github.com/svalouch/python-rctclient/releases/tag/${src.tag}";
+    license = with licenses; [ gpl3Only ];
+    maintainers = with maintainers; [ _9R ];
+  };
+}

--- a/pkgs/servers/home-assistant/custom-components/rct_power/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/rct_power/package.nix
@@ -1,0 +1,33 @@
+{
+  lib,
+  fetchFromGitHub,
+  buildHomeAssistantComponent,
+  rctclient,
+}:
+
+buildHomeAssistantComponent rec {
+  owner = "weltenwort";
+  domain = "rct_power";
+  version = "v0.14.1";
+
+  src = fetchFromGitHub {
+    owner = "weltenwort";
+    repo = "home-assistant-rct-power-integration";
+    tag = version;
+    hash = "sha256-wM66MyRhBsMfUr+KlqV4jSuXcnKfW0fkbDAyuU2crsc=";
+  };
+
+  dependencies = [
+    rctclient
+  ];
+
+  doCheck = false; # no tests
+
+  meta = with lib; {
+    changelog = "https://github.com/weltenwort/home-assistant-rct-power-integration/releases/tag/${src.tag}";
+    description = "Custom integration for RCT Power Inverters";
+    homepage = "https://github.com/weltenwort/home-assistant-rct-power-integration";
+    maintainers = with maintainers; [ _9R ];
+    license = licenses.mit;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -14831,6 +14831,8 @@ self: super: with self; {
 
   rcssmin = callPackage ../development/python-modules/rcssmin { };
 
+  rctclient = callPackage ../development/python-modules/rctclient { };
+
   rdbtools = callPackage ../development/python-modules/rdbtools { };
 
   rdflib = callPackage ../development/python-modules/rdflib { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

This PR inits the home-assistant custom component rct-power to monitor/interact with rct power inverter and power storage devices.
It also adds the rctclient python3 module that is a dependency of the rct-power home-assistant integration.

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
