### PR TITLE
Revert "nixos/udev: verify udev rules using udevadm"

### DIFF
--- a/nixos/modules/services/hardware/udev.nix
+++ b/nixos/modules/services/hardware/udev.nix
@@ -55,10 +55,6 @@ let
         preferLocalBuild = true;
         allowSubstitutes = false;
         packages = lib.unique (map toString udevPackages);
-
-        nativeBuildInputs = [
-          pkgs.systemdMinimal
-        ];
       }
       ''
         mkdir -p $out
@@ -150,11 +146,6 @@ let
           done
           exit 1
         fi
-
-        # Verify all the udev rules
-        echo "Verifying udev rules using udevadm verify..."
-        udevadm verify --resolve-names=never --no-style $out
-        echo "OK"
 
         # If auto-configuration is disabled, then remove
         # udev's 80-drivers.rules file, which contains rules for


### PR DESCRIPTION
Reverts NixOS/nixpkgs#404323

Broke installer tests: https://hydra.nixos.org/eval/1815170

Reverting for now.