### PR TITLE
pstoedit: fix build on darwin, tidy

### DIFF
--- a/pkgs/by-name/ps/pstoedit/package.nix
+++ b/pkgs/by-name/ps/pstoedit/package.nix
@@ -23,6 +23,11 @@ stdenv.mkDerivation rec {
     hash = "sha256-VYi0MtLGsq2YKLRJFepYE/+aOjMSpB+g3kw43ayd9y8=";
   };
 
+  postPatch = ''
+    # don't use gnu-isms like link.h on macos
+    substituteInPlace src/pstoedit.cpp --replace-fail '#ifndef _MSC_VER' '#if !defined(_MSC_VER) && !defined(__APPLE__)'
+  '';
+
   outputs = [
     "out"
     "dev"

--- a/pkgs/by-name/ps/pstoedit/package.nix
+++ b/pkgs/by-name/ps/pstoedit/package.nix
@@ -50,12 +50,6 @@ stdenv.mkDerivation rec {
       libiconv
     ];
 
-  # '@LIBPNG_LDFLAGS@' is no longer substituted by autoconf (the code is commented out)
-  # so we need to remove it from the pkg-config file as well
-  preConfigure = ''
-    substituteInPlace config/pstoedit.pc.in --replace '@LIBPNG_LDFLAGS@' ""
-  '';
-
   postInstall = ''
     wrapProgram $out/bin/pstoedit \
       --prefix PATH : ${lib.makeBinPath [ ghostscript ]}


### PR DESCRIPTION
ZHF #403336

Chiefly this fixes build on darwin by cribbing a fix from homebrew @ https://github.com/Homebrew/homebrew-core/blob/3dbe9808b957c02b5c1185712c979590940d9f1d/Formula/p/pstoedit.rb#L27C16-L27C32

Also removes an old pkg-config substitution that doesn't appear to match anything anymore.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
