### PR TITLE
picture-of-the-day: init at 1.4.3

### DIFF
--- a/pkgs/by-name/pi/picture-of-the-day/package.nix
+++ b/pkgs/by-name/pi/picture-of-the-day/package.nix
@@ -1,0 +1,78 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitea,
+  pkg-config,
+  wrapGAppsHook4,
+  gettext,
+  gobject-introspection,
+  blueprint-compiler,
+  desktop-file-utils,
+  appstream-glib,
+  glib,
+  gtk4,
+  libadwaita,
+  libsoup_3,
+  nix-update-script,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "picture-of-the-day";
+  version = "1.4.5";
+
+  src = fetchFromGitea {
+    domain = "codeberg.org";
+    owner = "swsnr";
+    repo = "picture-of-the-day";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-ajLqT4t2xn9BfQJ3rGg/9TrdWgImwsmYGPI7wTVelTw=";
+  };
+
+  cargoHash = "sha256-NOczmWOVS34Yh+WUQ/RcnP+rBDQcaT8Encw+lZKGNlo=";
+
+  nativeBuildInputs = [
+    pkg-config
+    wrapGAppsHook4
+    gettext
+    gobject-introspection
+    blueprint-compiler
+    appstream-glib
+  ];
+
+  buildInputs = [
+    glib
+    gtk4
+    libadwaita
+    libsoup_3
+  ];
+
+  installPhase = ''
+    install -Dm0644 de.swsnr.pictureoftheday.desktop $out/share/applications/de.swsnr.pictureoftheday.desktop
+    install -Dm0644 resources/de.swsnr.pictureoftheday.metainfo.xml $out/share/metainfo/de.swsnr.pictureoftheday.metainfo.xml
+
+    install -Dm0644 -t $out/share/icons/hicolor/scalable/apps/ resources/icons/scalable/apps/de.swsnr.pictureoftheday.svg
+    install -Dm0644 resources/icons/symbolic/apps/de.swsnr.pictureoftheday-symbolic.svg \
+      $out/share/icons/hicolor/symbolic/apps/de.swsnr.pictureoftheday-symbolic-symbolic.svg
+
+    install -Dm0644 schemas/de.swsnr.pictureoftheday.gschema.xml $out/share/glib-2.0/schemas/de.swsnr.picture-of-the-day.gschema.xml
+    glib-compile-schemas --strict $out/share/glib-2.0/schemas
+  '';
+
+  checkFlags = [
+    # requires networking
+    "--skip=images::sources::apod::tests::fetch_apod"
+    "--skip=images::sources::bing::tests::fetch_daily_images"
+    "--skip=images::sources::epod::tests::fetch_picture_of_the_day"
+    "--skip=images::sources::epod::tests::scrape_page_with_asset_link_and_photographer"
+    "--skip=images::sources::epod::tests::scrape_page_without_asset_link_and_copyright"
+    "--skip=images::sources::wikimedia::tests::featured_image"
+  ];
+
+  meta = {
+    description = "Your daily GNOME wallpaper";
+    homepage = "https://codeberg.org/swsnr/picture-of-the-day";
+    changelog = "https://codeberg.org/swsnr/picture-of-the-day/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mpl20;
+    maintainers = [ lib.maintainers.awwpotato ];
+    mainProgram = "picture-of-the-day";
+  };
+})


### PR DESCRIPTION
https://codeberg.org/swsnr/picture-of-the-day
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
