### PR TITLE
python3Minimal: make it truly minimal

### DIFF
--- a/pkgs/development/interpreters/python/cpython/default.nix
+++ b/pkgs/development/interpreters/python/cpython/default.nix
@@ -14,10 +14,12 @@
 
   # runtime dependencies
   bzip2,
+  withExpat ? true,
   expat,
   libffi,
   libuuid,
   libxcrypt,
+  withMpdecimal ? true,
   mpdecimal,
   ncurses,
   openssl,
@@ -91,6 +93,9 @@
 
   # tests
   testers,
+
+  # allow pythonMinimal to prevent accidental dependencies it doesn't want
+  allowedReferenceNames ? [ ],
 
 }@inputs:
 
@@ -216,16 +221,20 @@ let
   buildInputs = lib.filter (p: p != null) (
     [
       bzip2
-      expat
       libffi
       libuuid
       libxcrypt
-      mpdecimal
       ncurses
       openssl
       sqlite
       xz
       zlib
+    ]
+    ++ optionals withMpdecimal [
+      mpdecimal
+    ]
+    ++ optionals withExpat [
+      expat
     ]
     ++ optionals bluezSupport [
       bluez
@@ -420,7 +429,7 @@ stdenv.mkDerivation (finalAttrs: {
   env = {
     CPPFLAGS = concatStringsSep " " (map (p: "-I${getDev p}/include") buildInputs);
     LDFLAGS = concatStringsSep " " (map (p: "-L${getLib p}/lib") buildInputs);
-    LIBS = "${optionalString (!stdenv.hostPlatform.isDarwin) "-lcrypt"}";
+    LIBS = "${optionalString (!stdenv.hostPlatform.isDarwin && libxcrypt != null) "-lcrypt"}";
     NIX_LDFLAGS = lib.optionalString (stdenv.cc.isGNU && !stdenv.hostPlatform.isStatic) (
       {
         "glibc" = "-lgcc_s";
@@ -436,7 +445,11 @@ stdenv.mkDerivation (finalAttrs: {
   configureFlags =
     [
       "--without-ensurepip"
+    ]
+    ++ optionals withExpat [
       "--with-system-expat"
+    ]
+    ++ optionals withMpdecimal [
       "--with-system-libmpdec"
     ]
     ++ optionals (openssl != null) [
@@ -741,6 +754,19 @@ stdenv.mkDerivation (finalAttrs: {
       # These typically end up in shebangs.
       pythonOnBuildForHost
       buildPackages.bashNonInteractive
+    ];
+
+  # Optionally set allowedReferences to guarantee minimal dependencies
+  # Allows python3Minimal to stay minimal and not have deps added by accident
+  # Doesn't do anything if allowedReferenceNames is empty (was not set)
+  ${if allowedReferenceNames != [ ] then "allowedReferences" else null} =
+    # map allowed names to their derivations
+    (map (name: inputs.${name}) allowedReferenceNames) ++ [
+      # any version of python depends on libc and libgcc
+      stdenv.cc.cc.lib
+      stdenv.cc.libc
+      # allows python referring to its own store path
+      "out"
     ];
 
   separateDebugInfo = true;

--- a/pkgs/development/interpreters/python/default.nix
+++ b/pkgs/development/interpreters/python/default.nix
@@ -113,6 +113,10 @@
           sqlite = null;
           tzdata = null;
           libuuid = null;
+          bzip2 = null;
+          libxcrypt = null;
+          xz = null;
+          zlib = null;
           libffi = libffiBoot; # without test suite
           stripConfig = true;
           stripIdlelib = true;
@@ -124,6 +128,16 @@
           enableOptimizations = false;
           enableLTO = false;
           mimetypesSupport = false;
+          withExpat = false;
+          withMpdecimal = false;
+          /*
+            The actual 'allowedReferences' attribute is set inside the cpython derivation.
+            This is necessary in order to survive overrides of dependencies.
+          */
+          allowedReferenceNames = [
+            "bashNonInteractive"
+            "libffi"
+          ];
         }
         // sources.python312
       )).overrideAttrs


### PR DESCRIPTION
Make python3 minimal truly minimal by disabling some more dependencies.

This makes it easy to bootstrap python.

After this, the only remaining runtime deps for python3Minimal are:
- bash (for launching subprocesses with shell=True)
- libc
- libgcc
- libffi

All remaining deps seem to be fundamental and cannot be further reduced, except bash which could potentially be removed and replaced with `$SHELL` at runtime.

Done:
- add some more withXXX switches to the cpython package
- use new switches in python3Minimal to disable some deps
- set some other deps to null in python3Minimal
- Set `allowedReferences` to guarantee that the closure remains minimal in the future.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
