### PR TITLE
nixpkgs-vet: init at 0.1.4

### DIFF
--- a/pkgs/by-name/ni/nixpkgs-vet/package.nix
+++ b/pkgs/by-name/ni/nixpkgs-vet/package.nix
@@ -1,0 +1,36 @@
+{
+  fetchFromGitHub,
+  lib,
+  nix,
+  nix-update-script,
+  rustPlatform,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "nixpkgs-vet";
+  version = "0.1.4";
+
+  src = fetchFromGitHub {
+    owner = "NixOS";
+    repo = "nixpkgs-vet";
+    tag = finalAttrs.version;
+    hash = "sha256-J61eOTeDMHt9f1XmKVrEMAFUgwHGmMxDoSyY3v72QVY=";
+  };
+
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-H2JAIMJeVqp8xq75eLEBKiK2pBrgC7vgXXlqbrSUifE=";
+
+  doCheck = false;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Tool to vet (check) Nixpkgs, including its pkgs/by-name directory";
+    homepage = "https://github.com/NixOS/nixpkgs-vet";
+    license = lib.licenses.mit;
+    mainProgram = "nixpkgs-vet";
+    maintainers = with lib.maintainers; [
+      philiptaron
+      willbush
+    ];
+  };
+})


### PR DESCRIPTION
This is currently run in CI, but not from nixpkgs. Instead it's pulled from the upstream repo. There is only a x86_64-linux release, though, which makes this approach inadequate for local usage on other systems.

We already use a pinned nixpkgs revision in CI, so we should move to use that for nixpkgs-vet, too.

Shamelessly added @philiptaron and @willbush as the maintainers, because they have been actively maintaining the upstream package lately. Please confirm, whether you're OK with that.

Before we can make use of this in CI, we need to merge it and then bump the pinned nixpkgs revision.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
