### PR TITLE
shader-slang: 2025.6.1 -> 2025.8.1

### DIFF
--- a/pkgs/by-name/sh/shader-slang/1-find-packages.patch
+++ b/pkgs/by-name/sh/shader-slang/1-find-packages.patch
@@ -1,8 +1,8 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index dc281211..c36b9bcb 100644
+index a933d0ab64..fced38bc32 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -154,6 +154,8 @@ advanced_option(
+@@ -160,6 +160,8 @@ advanced_option(
      "Build using system unordered dense"
      OFF
  )
@@ -11,7 +11,7 @@ index dc281211..c36b9bcb 100644
  
  option(
      SLANG_SPIRV_HEADERS_INCLUDE_DIR
-@@ -289,6 +291,34 @@ if(${SLANG_USE_SYSTEM_UNORDERED_DENSE})
+@@ -386,6 +388,34 @@ if(${SLANG_USE_SYSTEM_UNORDERED_DENSE})
      find_package(unordered_dense CONFIG QUIET)
  endif()
  
@@ -47,10 +47,10 @@ index dc281211..c36b9bcb 100644
  
  # webgpu_dawn is only available as a fetched shared library, since Dawn's nested source
 diff --git a/external/CMakeLists.txt b/external/CMakeLists.txt
-index 43105a5f..8b9c0f14 100644
+index 55d9e4941d..ff8a244651 100644
 --- a/external/CMakeLists.txt
 +++ b/external/CMakeLists.txt
-@@ -73,19 +73,24 @@ if(NOT ${SLANG_USE_SYSTEM_SPIRV_HEADERS})
+@@ -117,6 +117,7 @@ if(NOT ${SLANG_USE_SYSTEM_SPIRV_HEADERS})
  endif()
  
  if(SLANG_ENABLE_SLANG_GLSLANG)
@@ -58,9 +58,10 @@ index 43105a5f..8b9c0f14 100644
      # SPIRV-Tools
      set(SPIRV_TOOLS_BUILD_STATIC ON)
      set(SPIRV_WERROR OFF)
-     set(SPIRV_HEADER_DIR "${CMAKE_CURRENT_LIST_DIR}/spirv-headers/")
-     set(SPIRV_SKIP_TESTS ON)
-     add_subdirectory(spirv-tools EXCLUDE_FROM_ALL ${system})
+@@ -138,11 +139,14 @@ if(SLANG_ENABLE_SLANG_GLSLANG)
+             ${system}
+         )
+     endif()
 +endif()
  
 +if(NOT ${SLANG_USE_SYSTEM_GLSLANG})
@@ -69,7 +70,12 @@ index 43105a5f..8b9c0f14 100644
      set(ENABLE_OPT ON)
      set(ENABLE_PCH OFF)
 +    set(ALLOW_EXTERNAL_SPIRV_TOOLS ${SLANG_USE_SYSTEM_SPIRV_TOOLS})
-     add_subdirectory(glslang EXCLUDE_FROM_ALL ${system})
+     if(NOT SLANG_OVERRIDE_GLSLANG_PATH)
+         add_subdirectory(glslang EXCLUDE_FROM_ALL ${system})
+     else()
+@@ -154,6 +158,7 @@ if(SLANG_ENABLE_SLANG_GLSLANG)
+         )
+     endif()
  endif()
 +endif()
  

--- a/pkgs/by-name/sh/shader-slang/package.nix
+++ b/pkgs/by-name/sh/shader-slang/package.nix
@@ -144,6 +144,7 @@ stdenv.mkDerivation (finalAttrs: {
   meta = {
     description = "Shading language that makes it easier to build and maintain large shader codebases in a modular and extensible fashion";
     homepage = "https://github.com/shader-slang/slang";
+    changelog = "https://github.com/shader-slang/slang/releases/tag/v${finalAttrs.version}";
     license = with lib.licenses; [
       asl20
       llvm-exception

--- a/pkgs/by-name/sh/shader-slang/package.nix
+++ b/pkgs/by-name/sh/shader-slang/package.nix
@@ -27,13 +27,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "shader-slang";
-  version = "2025.6.1";
+  version = "2025.8.1";
 
   src = fetchFromGitHub {
     owner = "shader-slang";
     repo = "slang";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-yNPAJX7OxxQLXDm3s7Hx5QA9fxy1qbAMp4LKYVqxMVM=";
+    hash = "sha256-PScbMkJJ4rh8I8ID709GKtLmd5+4Z2x2BlFEdWpoesI=";
     fetchSubmodules = true;
   };
 


### PR DESCRIPTION
Changelogs:

- https://github.com/shader-slang/slang/releases/tag/v2025.8.1
- https://github.com/shader-slang/slang/releases/tag/v2025.8
- https://github.com/shader-slang/slang/releases/tag/v2025.7.1
- https://github.com/shader-slang/slang/releases/tag/v2025.7
- https://github.com/shader-slang/slang/releases/tag/v2025.6.4
- https://github.com/shader-slang/slang/releases/tag/v2025.6.3
- https://github.com/shader-slang/slang/releases/tag/v2025.6.2


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
