### PR TITLE
uucp: patch code for GCC 14 compilation

### DIFF
--- a/pkgs/by-name/uu/uucp/package.nix
+++ b/pkgs/by-name/uu/uucp/package.nix
@@ -28,6 +28,10 @@ stdenv.mkDerivation (finalAttrs: {
       --replace-fail '(void) exit (0)' '(void) (0)'
   '';
 
+  patches = [
+    ./socklen_t.patch
+  ];
+
   # Regenerate `configure`; the checked in version was generated in 2002 and
   # contains snippets like `main(){return(0);}` that modern compilers dislike.
   nativeBuildInputs = [ autoreconfHook ];

--- a/pkgs/by-name/uu/uucp/socklen_t.patch
+++ b/pkgs/by-name/uu/uucp/socklen_t.patch
@@ -1,0 +1,26 @@
+diff --git a/unix/portnm.c b/unix/portnm.c
+index 9eda4ab..019337c 100644
+--- a/unix/portnm.c
++++ b/unix/portnm.c
+@@ -32,7 +32,7 @@ zsysdep_port_name (ftcp_port)
+ 
+ #if HAVE_TCP
+   {
+-    size_t clen;
++    socklen_t clen;
+     struct sockaddr s;
+ 
+     clen = sizeof (struct sockaddr);
+diff --git a/unix/tcp.c b/unix/tcp.c
+index 1bbcec7..af52cab 100644
+--- a/unix/tcp.c
++++ b/unix/tcp.c
+@@ -395,7 +395,7 @@ ftcp_open (qconn, ibaud, fwait, fuser)
+   while (! FGOT_SIGNAL ())
+     {
+       sockaddr_storage speer;
+-      size_t clen;
++      socklen_t clen;
+       int onew;
+       pid_t ipid;
+ 


### PR DESCRIPTION
The original code uses `size_t` for two variables that hold the sizes of structs, but the function they get passed to requires pointer to `socklen_t`, which is type `unsigned int *`. As far as I can tell, using `socklen_t` has been the standard for at least a couple decades. Stricter GCC 14 rules made this code not compile

ZHF: https://github.com/NixOS/nixpkgs/issues/403336

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
