### PR TITLE
mate.atril: 1.28.1 -> 1.28.2

### DIFF
--- a/pkgs/desktops/mate/atril/default.nix
+++ b/pkgs/desktops/mate/atril/default.nix
@@ -1,9 +1,12 @@
 {
   lib,
   stdenv,
-  fetchurl,
+  fetchFromGitHub,
   pkg-config,
+  autoreconfHook,
+  gtk-doc,
   gettext,
+  yelp-tools,
   caja,
   gtk3,
   glib,
@@ -25,22 +28,29 @@
   enableXps ? true,
   libgxps,
   enableImages ? false,
-  mateUpdateScript,
+  gitUpdater,
 }:
 
 stdenv.mkDerivation rec {
   pname = "atril";
-  version = "1.28.1";
+  version = "1.28.2";
 
-  src = fetchurl {
-    url = "https://pub.mate-desktop.org/releases/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "dMT0KXnz6tUt7yN2dEjQatf3FUIeA8m1CUBLCW3oGT4=";
+  src = fetchFromGitHub {
+    owner = "mate-desktop";
+    repo = "atril";
+    tag = "v${version}";
+    fetchSubmodules = true;
+    hash = "sha256-NnWD3Gcxn8ZZKdHzg6iclLiSwj3sBvF+BwpNtcU+dSY=";
   };
 
   nativeBuildInputs = [
+    autoreconfHook
+    gtk-doc
+    itstool
     pkg-config
     gettext
     wrapGAppsHook3
+    yelp-tools
   ];
 
   buildInputs =
@@ -48,7 +58,6 @@ stdenv.mkDerivation rec {
       caja
       gtk3
       glib
-      itstool
       libarchive
       libsecret
       libxml2
@@ -76,7 +85,10 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  passthru.updateScript = mateUpdateScript { inherit pname; };
+  passthru.updateScript = gitUpdater {
+    rev-prefix = "v";
+    odd-unstable = true;
+  };
 
   meta = with lib; {
     description = "Simple multi-page document viewer for the MATE desktop";


### PR DESCRIPTION
https://github.com/mate-desktop/atril/compare/v1.28.1...v1.28.2

Upstream is [experiencing problems](https://github.com/mate-desktop/atril/pull/632#issuecomment-2828631500) releasing tarballs, so switch to fetchFromGitHub for now.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

