### PR TITLE
exactaudiocopy: 1.6.0 -> 1.8.0 (and fix build issue

### DIFF
--- a/pkgs/by-name/ex/exactaudiocopy/package.nix
+++ b/pkgs/by-name/ex/exactaudiocopy/package.nix
@@ -20,9 +20,9 @@ let
     sha256 = "8291d33104ebab2619ba8d85744083e241330a286f5bd7d54c7b0eb08f2b84c1";
   };
 
-  cygwin_dll = fetchurl {
-    url = "https://cygwin.com/snapshots/x86/cygwin1-20220301.dll.xz";
-    sha256 = "0zxn0r5q69fhciy0mrplhxj1hxwy3sq4k1wdy6n6kyassm4zyz1x";
+  cygwin = fetchurl {
+    url = "https://mirrors.kernel.org/sourceware/cygwin/x86_64/release/cygwin/cygwin-3.6.1-1-x86_64.tar.xz";
+    sha256 = "45d1c76a15426209c20a8d4df813e94fbd17bd5d85ad4d742515ff432400143e";
   };
 
   patched_eac = stdenv.mkDerivation {
@@ -40,9 +40,11 @@ let
       cd $_tmp
       7z x -aoa ${eac_exe}
       chmod -R 755 .
-      cp ${cygwin_dll} cygwin1.dll.xz
-      xz --decompress cygwin1.dll.xz
-      mv cygwin1.dll CDRDAO/
+      cp ${cygwin} cygwin1.tar.xz
+      tar xf cygwin1.tar.xz
+      mv usr/bin/cygwin1.dll CDRDAO/
+      rm -rf usr
+      rm cygwin1.tar.xz
       cp -r * $out
       7z x EAC.exe
       convert .rsrc/1033/ICON/29.ico -thumbnail 128x128 -alpha on -background none -flatten "$out/eac.ico.128.png"

--- a/pkgs/by-name/ex/exactaudiocopy/package.nix
+++ b/pkgs/by-name/ex/exactaudiocopy/package.nix
@@ -13,11 +13,11 @@
 
 let
   pname = "exact-audio-copy";
-  version = "1.6.0";
+  version = "1.8.0";
 
   eac_exe = fetchurl {
     url = "http://www.exactaudiocopy.de/eac-${lib.versions.majorMinor version}.exe";
-    sha256 = "8291d33104ebab2619ba8d85744083e241330a286f5bd7d54c7b0eb08f2b84c1";
+    sha256 = "205530cfbfdff82343858f38b0e709e586051fb8900ecd513d7992a3c1ef031b";
   };
 
   cygwin = fetchurl {


### PR DESCRIPTION
switched from the deprecated cygwin snapshots url to a binary from the kernel mirror (and bumped the version used in the process.) (fixes #390665)

updated from exactaudiocopy 1.6 to 1.8 (not sure if this should be a seperate pr?)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
