### PR TITLE
legendsviewer-next: init at 1.2.5

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7306,6 +7306,13 @@
     githubId = 39825;
     name = "Dominik Honnef";
   };
+  donottellmetonottellyou = {
+    name = "Jade Masker";
+    email = "donottellmetonottellyou@gmail.com";
+    github = "donottellmetonottellyou";
+    githubId = 115233539;
+    keys = [ { fingerprint = "5C8B 7128 4AB3 000D 4AC6  6234 9B81 35A2 4A75 CB86"; } ];
+  };
   donovanglover = {
     github = "donovanglover";
     githubId = 2374245;

--- a/pkgs/by-name/le/legendsviewer-next/deps.json
+++ b/pkgs/by-name/le/legendsviewer-next/deps.json
@@ -1,0 +1,112 @@
+[
+  {
+    "pname": "Castle.Core",
+    "version": "5.1.1",
+    "hash": "sha256-oVkQB+ON7S6Q27OhXrTLaxTL0kWB58HZaFFuiw4iTrE="
+  },
+  {
+    "pname": "coverlet.collector",
+    "version": "6.0.0",
+    "hash": "sha256-IEmweTMapcPhFHpmJsPXfmMhravYOrWupgjeOvMmQ4o="
+  },
+  {
+    "pname": "Microsoft.CodeCoverage",
+    "version": "17.8.0",
+    "hash": "sha256-cv/wAXfTNS+RWEsHWNKqRDHC7LOQSSdFJ1a9cZuSfJw="
+  },
+  {
+    "pname": "Microsoft.Extensions.ApiDescription.Server",
+    "version": "6.0.5",
+    "hash": "sha256-RJjBWz+UHxkQE2s7CeGYdTZ218mCufrxl0eBykZdIt4="
+  },
+  {
+    "pname": "Microsoft.NET.Test.Sdk",
+    "version": "17.8.0",
+    "hash": "sha256-uz7QvW+NsVRsp8FR1wjnGEOkUaPX4JyieywvCN6g2+s="
+  },
+  {
+    "pname": "Microsoft.OpenApi",
+    "version": "1.6.14",
+    "hash": "sha256-dSJUic2orPGfYVgto9DieRckbtLpPyxHtf+RJ2tmKPM="
+  },
+  {
+    "pname": "Microsoft.TestPlatform.ObjectModel",
+    "version": "17.8.0",
+    "hash": "sha256-9TwGrjVvbtyetw67Udp3EMK5MX8j0RFRjduxPCs9ESw="
+  },
+  {
+    "pname": "Microsoft.TestPlatform.TestHost",
+    "version": "17.8.0",
+    "hash": "sha256-+CTYFu631uovLCO47RKe86YaAqfoLA4r73vKORJUsjg="
+  },
+  {
+    "pname": "Moq",
+    "version": "4.20.70",
+    "hash": "sha256-O+Ed1Hv8fK8MKaRh7qFGbsSPaTAj4O+yaLQ/W/ju7ks="
+  },
+  {
+    "pname": "MSTest.TestAdapter",
+    "version": "3.1.1",
+    "hash": "sha256-TLysbO9bgiztIap44o875ZPpuVAOC6ueaRTKsiVicXg="
+  },
+  {
+    "pname": "MSTest.TestFramework",
+    "version": "3.1.1",
+    "hash": "sha256-Vqu+IDuYjiR39QOJW7GHiH7CeF2cBfNIYYTXmVeeb9E="
+  },
+  {
+    "pname": "Newtonsoft.Json",
+    "version": "13.0.1",
+    "hash": "sha256-K2tSVW4n4beRPzPu3rlVaBEMdGvWSv/3Q1fxaDh4Mjo="
+  },
+  {
+    "pname": "NuGet.Frameworks",
+    "version": "6.5.0",
+    "hash": "sha256-ElqfN4CcKxT3hP2qvxxObb4mnBlYG89IMxO0Sm5oZ2g="
+  },
+  {
+    "pname": "SkiaSharp",
+    "version": "2.88.8",
+    "hash": "sha256-rD5gc4SnlRTXwz367uHm8XG5eAIQpZloGqLRGnvNu0A="
+  },
+  {
+    "pname": "SkiaSharp.NativeAssets.Linux",
+    "version": "2.88.8",
+    "hash": "sha256-fOmNbbjuTazIasOvPkd2NPmuQHVCWPnow7AxllRGl7Y="
+  },
+  {
+    "pname": "SkiaSharp.NativeAssets.macOS",
+    "version": "2.88.8",
+    "hash": "sha256-CdcrzQHwCcmOCPtS8EGtwsKsgdljnH41sFytW7N9PmI="
+  },
+  {
+    "pname": "SkiaSharp.NativeAssets.Win32",
+    "version": "2.88.8",
+    "hash": "sha256-b8Vb94rNjwPKSJDQgZ0Xv2dWV7gMVFl5GwTK/QiZPPM="
+  },
+  {
+    "pname": "Swashbuckle.AspNetCore",
+    "version": "6.9.0",
+    "hash": "sha256-fmJjAfVHzbw/31IFPFUP31g46Y1XXIc1kr6VvYW5pCc="
+  },
+  {
+    "pname": "Swashbuckle.AspNetCore.Swagger",
+    "version": "6.9.0",
+    "hash": "sha256-8KM21CWckFghGaqWahMa3V64+hUBrifAJnQ6P2VXlEk="
+  },
+  {
+    "pname": "Swashbuckle.AspNetCore.SwaggerGen",
+    "version": "6.9.0",
+    "hash": "sha256-Ni8Z9CFs+ybTX8IgDuSKA580ISQ55w032EeqWYQXwoc="
+  },
+  {
+    "pname": "Swashbuckle.AspNetCore.SwaggerUI",
+    "version": "6.9.0",
+    "hash": "sha256-V+3bEEpxSXPi9Sy1hHZEjY9qxuIpRWV5dKzaqYMSu40="
+  },
+  {
+    "pname": "System.Diagnostics.EventLog",
+    "version": "6.0.0",
+    "hash": "sha256-zUXIQtAFKbiUMKCrXzO4mOTD5EUphZzghBYKXprowSM="
+  }
+]

--- a/pkgs/by-name/le/legendsviewer-next/frontend.nix
+++ b/pkgs/by-name/le/legendsviewer-next/frontend.nix
@@ -1,0 +1,44 @@
+{
+  version,
+  src,
+  patches,
+
+  lib,
+  nodejs_22,
+
+  buildNpmPackage,
+}:
+buildNpmPackage {
+  pname = "legends-viewer-frontend";
+
+  inherit version src patches;
+
+  nodejs = nodejs_22;
+  npmDepsHash = "sha256-Hlo+G/d0glDutBwQU1Y5rfLD7IcfWtAClJPyrX5QBQg=";
+
+  postPatch = ''
+    cd "./LegendsViewer.Frontend/legends-viewer-frontend"
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out
+    cp -r ./dist $out
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Recreates Dwarf Fortress' Legends Mode from exported files";
+    homepage = "https://github.com/Kromtec/LegendsViewer-Next";
+    license = lib.licenses.mit;
+    platforms = [
+      "aarch64-darwin"
+      "x86_64-darwin"
+      "aarch64-linux"
+      "x86_64-linux"
+    ];
+    maintainers = with lib.maintainers; [ donottellmetonottellyou ];
+  };
+}

--- a/pkgs/by-name/le/legendsviewer-next/package.nix
+++ b/pkgs/by-name/le/legendsviewer-next/package.nix
@@ -1,0 +1,155 @@
+{
+  patches ? [ ],
+
+  lib,
+  dotnetCorePackages,
+  curl,
+
+  buildDotnetModule,
+  callPackage,
+  copyDesktopItems,
+  fetchFromGitHub,
+  makeDesktopItem,
+  nix-update-script,
+}:
+let
+  version = "1.2.5";
+
+  src = fetchFromGitHub {
+    owner = "Kromtec";
+    repo = "LegendsViewer-Next";
+    tag = "v${version}";
+    hash = "sha256-R84y+QdLiEoVTo+z3jaql8m2rg2nbX9aXa2m8JiYAzU=";
+  };
+
+  patches' = patches ++ [ ./remove-npm-frontend.patch ];
+
+  frontend = callPackage ./frontend.nix {
+    inherit version src;
+    patches = patches';
+  };
+in
+buildDotnetModule rec {
+  pname = "legendsviewer-next";
+  inherit version src;
+  patches = patches';
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = pname;
+      desktopName = "Legends Viewer";
+      genericName = "DF Legends Export Browser";
+      comment = meta.description;
+      icon = "${frontend}/dist/ceretelina.png";
+      tryExec = meta.mainProgram;
+      exec = meta.mainProgram;
+
+      categories = [
+        "Game"
+        "RolePlaying"
+        "Simulation"
+      ];
+      keywords = [
+        "df"
+        "dwarf"
+        "fortress"
+        "legends"
+        "viewer"
+      ];
+    })
+  ];
+
+  dotnet-sdk = dotnetCorePackages.sdk_10_0;
+  dotnet-runtime = dotnetCorePackages.aspnetcore_10_0;
+
+  # File generated with `nix-build -A package.passthru.fetch-deps`
+  nugetDeps = ./deps.json;
+
+  projectFile = "./LegendsViewer.Backend/LegendsViewer.Backend.csproj";
+  testProjectFile = "./LegendsViewer.Backend.Tests/LegendsViewer.Backend.Tests.csproj";
+  executables = [ meta.mainProgram ];
+
+  nativeBuildInputs = [
+    copyDesktopItems
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    lib=$out/lib/legendsviewer-next
+
+    mkdir -p $lib
+
+    cp ./LegendsViewer.Backend/bin/Release/*/*/* $lib
+    ln -s ${frontend} $lib/legends-viewer-frontend
+
+    runHook postInstall
+  '';
+
+  doInstallCheck = true;
+
+  nativeInstallCheckInputs = [
+    curl
+  ];
+
+  installCheckPhase = ''
+    runHook preInstallCheck
+
+    # Do not use coproc (on darwin)
+    $out/bin/LegendsViewer > /dev/null 2>&1 &
+    LEGENDSVIEWER_PID=$!
+
+    # Prevent hang on darwin
+    cleanup() {
+      kill -KILL "$LEGENDSVIEWER_PID"
+    }
+    trap cleanup EXIT
+
+    echo "Wait for server (max ~5 minutes):"
+    for i in $(seq 1 300); do
+      sleep 1
+      if curl -fsS http://localhost:15421/api/version > /dev/null; then
+        echo "Server is up!"
+        break
+      fi
+      echo "Retrying $i / 300"
+    done
+
+    echo "Version matches expected?"
+    if ! curl -fsS http://localhost:15421/api/version | grep -F "${version}"; then
+      echo "Version check failed"
+      exit 1
+    fi
+
+    echo "Static html server is up?"
+    if ! curl -fsS http://localhost:15422 | grep "<!doctype html>"; then
+      echo "Static html check failed"
+      exit 1
+    fi
+
+    # Cleanup, no longer need trap
+    cleanup
+    trap - EXIT
+
+    runHook postInstallCheck
+  '';
+
+  passthru = {
+    updateScript = nix-update-script { };
+  };
+
+  meta = {
+    description = "Recreates Dwarf Fortress' Legends Mode from exported files";
+    homepage = "https://github.com/Kromtec/LegendsViewer-Next";
+    license = lib.licenses.mit;
+    mainProgram = "LegendsViewer";
+    platforms = [
+      "aarch64-linux"
+      "x86_64-linux"
+    ];
+    maintainers = with lib.maintainers; [ donottellmetonottellyou ];
+  };
+}

--- a/pkgs/by-name/le/legendsviewer-next/remove-npm-frontend.patch
+++ b/pkgs/by-name/le/legendsviewer-next/remove-npm-frontend.patch
@@ -1,0 +1,21 @@
+diff --git a/LegendsViewer.Frontend/LegendsViewer.Frontend.csproj b/LegendsViewer.Frontend/LegendsViewer.Frontend.csproj
+index 3275f9c..aac315e 100644
+--- a/LegendsViewer.Frontend/LegendsViewer.Frontend.csproj
++++ b/LegendsViewer.Frontend/LegendsViewer.Frontend.csproj
+@@ -21,16 +21,8 @@
+ 	</PropertyGroup>
+ 
+ 	<!-- Always run npm install -->
+-	<Target Name="OnPackageChange" BeforeTargets="BeforeBuild">
+-		<Message Importance="high" Text="Installing npm packages..." />
+-		<Exec Command="npm install" WorkingDirectory="$(SpaRoot)" />
+-	</Target>
+ 
+ 	<!-- Always run npm run build -->
+-	<Target Name="OnSourceChange" BeforeTargets="BeforeBuild">
+-		<Message Importance="high" Text="Compiling WebApp..." />
+-		<Exec Command="npm run build" WorkingDirectory="$(SpaRoot)" />
+-	</Target>
+ 
+ 	<Target Name="CopyFilesAfterBuild" BeforeTargets="BeforeBuild;IncrementalClean">
+ 		<ItemGroup>


### PR DESCRIPTION
## Add legendsviewer-next

### Commits

- maintainers: add donottellmetnottellyou
- legendsviewer-next: init at 1.2.5

### Description

![World Overview Screenshot](https://github.com/user-attachments/assets/36b6e193-2e54-479f-9b86-add8e683c19b)
[LegendsViewer-Next](https://github.com/Kromtec/LegendsViewer-Next) is a cross-platform revamp (by the same author) of the [original Windows-only LegendsViewer](https://github.com/Kromtec/LegendsViewer), a legends-mode explorer for the indie game [Dwarf Fortress](https://search.nixos.org/packages?channel=25.11&query=dwarf#show=dwarf-fortress). LegendsViewer-Next supports world information overviews, maps, populations, war/battle death tolls, favorites, and has a very user-friendly interface.

LegendsViewer-Next hosts a web app on port 15422 with the api on port 15421. Its configuration on Linux is stored at `~/.config/LegendsViewer`, currently only `bookmarks.json`.

### Tests

Currently, there is one installCheckPhase test, which makes sure the frontend serves an html document and the backend reports the correct version, and both are working.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - ~~[ ] `sandbox = relaxed`~~
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - ~~[NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))~~
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - ~~or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)~~
  - ~~made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages~~
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - ~~[ ] (Package updates) Added a release notes entry if the change is major or breaking~~
  - ~~[ ] (Module updates) Added a release notes entry if the change is significant~~
  - ~~[ ] (Module addition) Added a release notes entry if adding a new NixOS module~~
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
