### PR TITLE
nvidia-container-toolkit: minor fixups

### DIFF
--- a/nixos/tests/nvidia-container-toolkit.nix
+++ b/nixos/tests/nvidia-container-toolkit.nix
@@ -90,7 +90,10 @@ in
 {
   name = "nvidia-container-toolkit";
   meta = with lib.maintainers; {
-    maintainers = [ ereslibre ];
+    maintainers = [
+      ereslibre
+      christoph-heiss
+    ];
   };
   defaults =
     { config, ... }:

--- a/pkgs/by-name/nv/nvidia-container-toolkit/package.nix
+++ b/pkgs/by-name/nv/nvidia-container-toolkit/package.nix
@@ -52,11 +52,11 @@ buildGoModule rec {
 
   postPatch = ''
     substituteInPlace internal/config/config.go \
-      --replace '/usr/bin/nvidia-container-runtime-hook' "$tools/bin/nvidia-container-runtime-hook" \
-      --replace '/sbin/ldconfig' '${lib.getBin glibc}/sbin/ldconfig'
+      --replace-fail '/usr/bin/nvidia-container-runtime-hook' "$tools/bin/nvidia-container-runtime-hook" \
+      --replace-fail '/sbin/ldconfig' '${lib.getBin glibc}/sbin/ldconfig'
 
     substituteInPlace tools/container/toolkit/toolkit.go \
-      --replace '/sbin/ldconfig' '${lib.getBin glibc}/sbin/ldconfig'
+      --replace-fail '/sbin/ldconfig' '${lib.getBin glibc}/sbin/ldconfig'
   '';
 
   subPackages = [

--- a/pkgs/by-name/nv/nvidia-container-toolkit/package.nix
+++ b/pkgs/by-name/nv/nvidia-container-toolkit/package.nix
@@ -80,6 +80,8 @@ buildGoModule rec {
     # "-X name=value"
     "-X"
     "${cliVersionPackage}.version=${version}"
+    "-X"
+    "github.com/NVIDIA/nvidia-container-toolkit/internal/info.gitCommit=${src.rev}"
   ];
 
   nativeBuildInputs = [

--- a/pkgs/by-name/nv/nvidia-container-toolkit/package.nix
+++ b/pkgs/by-name/nv/nvidia-container-toolkit/package.nix
@@ -64,6 +64,7 @@ buildGoModule rec {
 
   subPackages = [
     "cmd/nvidia-cdi-hook"
+    "cmd/nvidia-container-runtime"
     "cmd/nvidia-container-runtime.cdi"
     "cmd/nvidia-container-runtime-hook"
     "cmd/nvidia-container-runtime.legacy"
@@ -104,11 +105,13 @@ buildGoModule rec {
 
   postInstall =
     ''
-      wrapProgram $out/bin/nvidia-container-runtime-hook \
-        --prefix PATH : ${libnvidia-container}/bin
-
       mkdir -p $tools/bin
-      mv $out/bin/{nvidia-cdi-hook,nvidia-container-runtime.cdi,nvidia-container-runtime-hook,nvidia-container-runtime.legacy} $tools/bin
+      mv $out/bin/{nvidia-cdi-hook,nvidia-container-runtime,nvidia-container-runtime.cdi,nvidia-container-runtime-hook,nvidia-container-runtime.legacy} $tools/bin
+
+      for bin in nvidia-container-runtime-hook nvidia-container-runtime; do
+        wrapProgram $tools/bin/$bin \
+          --prefix PATH : ${libnvidia-container}/bin:$out/bin
+      done
     ''
     + lib.optionalString (configTemplate != null || configTemplatePath != null) ''
       mkdir -p $out/etc/nvidia-container-runtime

--- a/pkgs/by-name/nv/nvidia-container-toolkit/package.nix
+++ b/pkgs/by-name/nv/nvidia-container-toolkit/package.nix
@@ -57,6 +57,9 @@ buildGoModule rec {
 
     substituteInPlace tools/container/toolkit/toolkit.go \
       --replace-fail '/sbin/ldconfig' '${lib.getBin glibc}/sbin/ldconfig'
+
+    substituteInPlace cmd/nvidia-cdi-hook/update-ldcache/update-ldcache.go \
+      --replace-fail '/sbin/ldconfig' '${lib.getBin glibc}/sbin/ldconfig'
   '';
 
   subPackages = [

--- a/pkgs/by-name/nv/nvidia-container-toolkit/package.nix
+++ b/pkgs/by-name/nv/nvidia-container-toolkit/package.nix
@@ -127,6 +127,9 @@ buildGoModule rec {
     description = "NVIDIA Container Toolkit";
     license = licenses.asl20;
     platforms = platforms.linux;
-    maintainers = with maintainers; [ cpcloud ];
+    maintainers = with maintainers; [
+      cpcloud
+      christoph-heiss
+    ];
   };
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

1. Build the `nvidia-container-runtime` binary
2. Fix up PATH for `nvidia-container-runtime-hook`
4. Set `gitCommit` version variable

Tested this with a k3s cluster, with both consumer & datacenter Nvidia cards used with the [Nvidia k8s-device-plugin](https://github.com/NVIDIA/k8s-device-plugin).

Without the 1. & 2., the device plugin won't start due to binary dependencies issues.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
