### PR TITLE
dangerzone: init at 0.9.1

### DIFF
--- a/pkgs/build-support/fetchMazetteDeps/default.nix
+++ b/pkgs/build-support/fetchMazetteDeps/default.nix
@@ -1,0 +1,52 @@
+{
+  stdenv,
+  lib,
+  mazette,
+}:
+
+{
+  mazettefile,
+  lockfile,
+  hash,
+}:
+
+let
+  hash_ =
+    if hash != "" then
+      {
+        outputHashAlgo = null;
+        outputHash = hash;
+      }
+    else
+      {
+        outputHashAlgo = "sha256";
+        outputHash = lib.fakeSha256;
+      };
+in
+stdenv.mkDerivation (
+  {
+    name = "mazette-cache";
+    outputHashMode = "recursive";
+
+    dontUnpack = true;
+    dontInstall = true;
+    dontFixup = true;
+
+    nativeBuildInputs = [ mazette ];
+
+    inherit mazettefile lockfile;
+
+    buildPhase = ''
+      runHook preBuild
+
+      export XDG_CACHE_HOME=$NIX_BUILD_TOP/.cache
+      mkdir -p $XDG_CACHE_HOME
+      cp $mazettefile $lockfile .
+      mazette install
+      mv $XDG_CACHE_HOME $out
+
+      runHook postBuild
+    '';
+  }
+  // hash_
+)

--- a/pkgs/by-name/da/dangerzone/package.nix
+++ b/pkgs/by-name/da/dangerzone/package.nix
@@ -1,0 +1,125 @@
+{
+  fetchFromGitHub,
+  fetchMazetteDeps,
+  fetchurl,
+  jq,
+  lib,
+  mazette,
+  podman,
+  python3Packages,
+  stdenv,
+  writableTmpDirAsHomeHook,
+}:
+
+let
+  version = "0.9.1";
+  src = fetchFromGitHub {
+    owner = "freedomofpress";
+    repo = "dangerzone";
+    tag = "v${version}";
+    hash = "sha256-BcBsFphIQ7JGOTeobGbbQopEptNWYxl3GOtRmDZDwAg=";
+  };
+  # note: the container SHA256 hashes are taken directly from upstream
+  container =
+    if stdenv.hostPlatform.isx86 then
+      fetchurl {
+        url = "https://github.com/freedomofpress/dangerzone/releases/download/v0.9.1/container-0.9.1-i686.tar";
+        sha256 = "ff210840ef3ba595aac3af5848829437c0fbf83cb775ea6fa200184986e3cc72";
+        meta.sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+      }
+    else if stdenv.hostPlatform.isAarch64 then
+      fetchurl {
+        url = "https://github.com/freedomofpress/dangerzone/releases/download/v0.9.1/container-0.9.1-arm64.tar";
+        sha256 = "3e3396162c4b251165b936c0ccffbb59d7d387b8649b9e2bbde488921a6539b5";
+        meta.sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+      }
+    else
+      throw "unsuppported platform ${stdenv.hostPlatform.system}";
+  mazette-cache = fetchMazetteDeps {
+    mazettefile = "${src}/pyproject.toml";
+    lockfile = "${src}/mazette.lock";
+    hash = "sha256-3IaQPl5llLZrMXiI3RdsqtYgAGb/Tv1HbISRzOv3C28=";
+  };
+in
+python3Packages.buildPythonApplication {
+  pname = "dangerzone";
+  inherit version;
+  pyproject = true;
+
+  inherit src;
+
+  patches = [
+    ./paths.patch
+  ];
+
+  nativeBuildInputs = [
+    jq
+    mazette
+  ];
+
+  nativeCheckInputs = [
+    podman
+    python3Packages.numpy
+    python3Packages.pytest-mock
+    python3Packages.pytest-qt
+    python3Packages.pytest-subprocess
+    python3Packages.pytestCheckHook
+    python3Packages.strip-ansi
+    writableTmpDirAsHomeHook
+  ];
+
+  build-system = [
+    python3Packages.poetry-core
+  ];
+
+  dependencies = [
+    python3Packages.click
+    python3Packages.colorama
+    python3Packages.markdown
+    python3Packages.packaging
+    python3Packages.platformdirs
+    python3Packages.pymupdf
+    python3Packages.pyside6
+    python3Packages.pyxdg
+    python3Packages.requests
+  ];
+
+  # podman doesn't work in the build sandbox, so we have to skip any tests which use it
+  disabledTests = [
+    "TestContainer"
+    "TestCliConversion"
+    "test_hancom_office"
+  ];
+  disabledTestPaths = [
+    "tests/gui" # flaky
+    "tests/test_large_set.py" # excessively long duration
+  ];
+
+  postBuild = ''
+    ln -s ${container} share/container.tar
+    tar xf ${container} --to-stdout index.json | jq -r '.manifests.[].annotations.["org.opencontainers.image.ref.name"]' > share/image-id.txt
+    XDG_CACHE_HOME=${mazette-cache} mazette install
+  '';
+
+  postInstall = ''
+    mkdir -p $out/share/dangerzone
+    cp -r share/* $out/share/dangerzone/
+    mkdir -p $out/share/applications
+    cp install/linux/press.freedom.dangerzone.desktop $out/share/applications/
+    mkdir -p $out/share/icons/hicolor/64x64
+    cp install/linux/press.freedom.dangerzone.png $out/share/icons/hicolor/64x64/
+  '';
+
+  meta = {
+    description = "Convert potentially dangerous documents or images to safe PDFs";
+    homepage = "https://dangerzone.rocks/";
+    license = lib.licenses.agpl3Plus;
+    platforms = [
+      "aarch64-linux"
+      "x86_64-linux"
+      "i686-linux"
+    ];
+    maintainers = [ lib.maintainers.keysmashes ];
+    sourceProvenance = [ lib.sourceTypes.fromSource lib.sourceTypes.binaryNativeCode ];
+  };
+}

--- a/pkgs/by-name/da/dangerzone/paths.patch
+++ b/pkgs/by-name/da/dangerzone/paths.patch
@@ -1,0 +1,21 @@
+diff --git a/dangerzone/util.py b/dangerzone/util.py
+index 6cae64377b..f626089f2f 100644
+--- a/dangerzone/util.py
++++ b/dangerzone/util.py
+@@ -26,7 +26,7 @@
+             app_path = bin_path.parent.parent
+             prefix = app_path / "Resources" / "share"
+         elif platform.system() == "Linux":
+-            prefix = Path(sys.prefix) / "share" / "dangerzone"
++            prefix = Path(__file__).parent.parent.parent.parent.parent / "share" / "dangerzone"
+         elif platform.system() == "Windows":
+             exe_path = Path(sys.executable)
+             dz_install_path = exe_path.parent
+@@ -54,6 +54,7 @@
+     #
+     # [1] https://tesseract-ocr.github.io/tessdoc/Installation.html
+     tessdata_dirs = [
++        get_resource_path("tessdata"),
+         Path("/usr/share/tessdata/"),  # on some Debian
+         Path("/usr/share/tesseract/tessdata/"),  # on Fedora
+         Path("/usr/share/tesseract-ocr/tessdata/"),  # ? (documented)

--- a/pkgs/by-name/ma/mazette/package.nix
+++ b/pkgs/by-name/ma/mazette/package.nix
@@ -1,0 +1,43 @@
+{
+  fetchFromGitHub,
+  lib,
+  python3Packages,
+}:
+
+python3Packages.buildPythonApplication {
+  pname = "mazette";
+  version = "0.2.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "freedomofpress";
+    repo = "mazette";
+    tag = "0.2.0";
+    hash = "sha256-m0D6VP98uIOmG1YTG5S3omcXWVO3nOdFetasf6SZ+RQ=";
+  };
+
+  build-system = [
+    python3Packages.hatchling
+  ];
+
+  dependencies = [
+    python3Packages.colorama
+    python3Packages.platformdirs
+    python3Packages.requests
+    python3Packages.semver
+    python3Packages.toml
+  ];
+
+  meta = {
+    description = "Manage assets from GitHub releases";
+    homepage = "https://github.com/freedomofpress/mazette";
+    license = [
+      lib.licenses.asl20
+      lib.licenses.mit
+    ];
+    platforms = lib.platforms.linux;
+    maintainers = [ lib.maintainers.keysmashes ];
+    sourceProvenance = [ lib.sourceTypes.fromSource ];
+    mainProgram = "mazette";
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -516,6 +516,8 @@ with pkgs;
 
   fetchMavenArtifact = callPackage ../build-support/fetchmavenartifact { };
 
+  fetchMazetteDeps = callPackage ../build-support/fetchMazetteDeps { };
+
   fetchpijul = callPackage ../build-support/fetchpijul { };
 
   inherit (callPackages ../build-support/node/fetch-yarn-deps { })


### PR DESCRIPTION
[Dangerzone](https://dangerzone.rocks/) is an application to defang potentially-dangerous documents/images and convert them to safe PDFs.

This requires Podman set up on the system (otherwise it will display a big error message about Podman not being available).

Please note that the SHA256 hashes of the containers are copy-pasted from `checksums-0.9.0.txt` provided by upstream (which I have verified the PGP signature of), I have therefore deliberately not converted them to SRI format.

Closes #189761

Potential improvements (I am unlikely to tackle any of these immediately unless a committer indicates that this will not be merged unless they are done):

- ~~perhaps we could avoid running (and patching to the point of totally rewriting) `download-tessdata.py` with a little work to parse `ocr-languages.json` directly in `postBuild`~~ I've now packaged the new tool `mazette` which dangerzone uses to download tesseract data, and written a `fetchMazetteDeps` to populate its cache in a FOD (like `fetchYarnDeps`) – feedback on this welcomed
- it would be nice to build the container from source rather than downloading it – but on the other hand, there's upstream work ongoing to decouple container updates from application updates, so that work would likely be wasted
  - does downloading the container imply `sourceProvenance = [ lib.sourceTypes.binaryNativeCode ]`?
- getting the GUI tests working would be quite nice, currently they seem to cause python to abort
- packaging for Darwin? but I don't have a Darwin machine I can test on
- the app has a [hardcoded list of directories](https://github.com/freedomofpress/dangerzone/blob/c99c424f87bf35085fa39b7b36d5f94dc047c201/dangerzone/gui/logic.py#L115-L120) it searches for desktop entries in rather than using `$XDG_DATA_DIRS`, so it's unlikely to be able to find any applications to open the PDFs it produces – I think this should be fixed upstream rather than by patching it in nixpkgs

For my own reference: patches are from change `pzsmqmxp`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
