### PR TITLE
workflows: Use ARM runners

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -15,7 +15,7 @@ jobs:
   backport:
     name: Backport Pull Request
     if: github.repository_owner == 'NixOS' && github.event.pull_request.merged == true && (github.event.action != 'labeled' || startsWith(github.event.label.name, 'backport'))
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-24.04-arm
     steps:
       # Use a GitHub App to create the PR so that CI gets triggered
       # The App is scoped to Repository > Contents and Pull Requests: write for Nixpkgs

--- a/.github/workflows/check-cherry-picks.yml
+++ b/.github/workflows/check-cherry-picks.yml
@@ -12,7 +12,7 @@ permissions: {}
 jobs:
   check:
     name: cherry-pick-check
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-24.04-arm
     if: github.repository_owner == 'NixOS'
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/check-format.yml
+++ b/.github/workflows/check-format.yml
@@ -12,7 +12,7 @@ jobs:
 
   nixos:
     name: fmt-check
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-24.04-arm
     needs: get-merge-commit
     if: needs.get-merge-commit.outputs.mergedSha
     steps:

--- a/.github/workflows/check-shell.yml
+++ b/.github/workflows/check-shell.yml
@@ -16,6 +16,10 @@ jobs:
         include:
           - runner: ubuntu-24.04
             system: x86_64-linux
+          - runner: ubuntu-24.04-arm
+            system: aarch64-linux
+          - runner: macos-13
+            system: x86_64-darwin
           - runner: macos-14
             system: aarch64-darwin
 

--- a/.github/workflows/codeowners-v2.yml
+++ b/.github/workflows/codeowners-v2.yml
@@ -41,7 +41,7 @@ jobs:
   # Check that code owners is valid
   check:
     name: Check
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-24.04-arm
     needs: get-merge-commit
     if: github.repository_owner == 'NixOS' && needs.get-merge-commit.outputs.mergedSha
     steps:
@@ -89,7 +89,7 @@ jobs:
   # Request reviews from code owners
   request:
     name: Request
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-24.04-arm
     if: github.repository_owner == 'NixOS'
     steps:
       - uses: cachix/install-nix-action@526118121621777ccd86f79b04685a9319637641 # v31

--- a/.github/workflows/eval-aliases.yml
+++ b/.github/workflows/eval-aliases.yml
@@ -11,7 +11,7 @@ jobs:
 
   eval-aliases:
     name: Eval nixpkgs with aliases enabled
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-24.04-arm
     needs: [ get-merge-commit ]
     steps:
       - name: Check out the PR at the test merge commit

--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -21,7 +21,7 @@ jobs:
 
   attrs:
     name: Attributes
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-24.04-arm
     needs: get-merge-commit
     if: needs.get-merge-commit.outputs.mergedSha
     outputs:
@@ -61,7 +61,7 @@ jobs:
 
   outpaths:
     name: Outpaths
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-24.04-arm
     needs: [ attrs, get-merge-commit ]
     strategy:
       fail-fast: false
@@ -70,10 +70,10 @@ jobs:
     steps:
       - name: Enable swap
         run: |
-          sudo fallocate -l 10G /swapfile
-          sudo chmod 600 /swapfile
-          sudo mkswap /swapfile
-          sudo swapon /swapfile
+          sudo fallocate -l 10G /swap
+          sudo chmod 600 /swap
+          sudo mkswap /swap
+          sudo swapon /swap
 
       - name: Download the list of all attributes
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
@@ -110,7 +110,7 @@ jobs:
 
   process:
     name: Process
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-24.04-arm
     needs: [ outpaths, attrs, get-merge-commit ]
     outputs:
       targetRunId: ${{ steps.targetRunId.outputs.targetRunId }}
@@ -212,7 +212,7 @@ jobs:
   # Separate job to have a very tightly scoped PR write token
   tag:
     name: Tag
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-24.04-arm
     needs: [ attrs, process ]
     if: needs.process.outputs.targetRunId
     permissions:

--- a/.github/workflows/get-merge-commit.yml
+++ b/.github/workflows/get-merge-commit.yml
@@ -11,7 +11,7 @@ permissions: {}
 
 jobs:
   resolve-merge-commit:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-24.04-arm
     outputs:
       mergedSha: ${{ steps.merged.outputs.mergedSha }}
     steps:

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -16,7 +16,7 @@ permissions:
 jobs:
   labels:
     name: label-pr
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-24.04-arm
     if: "github.repository_owner == 'NixOS' && !contains(github.event.pull_request.title, '[skip treewide]')"
     steps:
       - uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # v5.0.0

--- a/.github/workflows/manual-nixos-v2.yml
+++ b/.github/workflows/manual-nixos-v2.yml
@@ -22,12 +22,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        system:
-          - x86_64-linux
-          - aarch64-linux
-    runs-on: >-
-      ${{ (matrix.system == 'x86_64-linux' && 'ubuntu-24.04')
-      || (matrix.system == 'aarch64-linux' && 'ubuntu-24.04-arm') }}
+        include:
+          - runner: ubuntu-24.04
+            system: x86_64-linux
+          - runner: ubuntu-24.04-arm
+            system: aarch64-linux
+    runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:

--- a/.github/workflows/manual-nixpkgs-v2.yml
+++ b/.github/workflows/manual-nixpkgs-v2.yml
@@ -14,7 +14,7 @@ permissions: {}
 jobs:
   nixpkgs:
     name: nixpkgs-manual-build
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:

--- a/.github/workflows/nix-parse-v2.yml
+++ b/.github/workflows/nix-parse-v2.yml
@@ -11,7 +11,7 @@ jobs:
 
   tests:
     name: nix-files-parseable-check
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-24.04-arm
     needs: get-merge-commit
     if: "needs.get-merge-commit.outputs.mergedSha && !contains(github.event.pull_request.title, '[skip treewide]')"
     steps:

--- a/.github/workflows/no-channel.yml
+++ b/.github/workflows/no-channel.yml
@@ -13,7 +13,7 @@ jobs:
       startsWith(github.event.pull_request.base.ref, 'nixos-') ||
       startsWith(github.event.pull_request.base.ref, 'nixpkgs-')
     name: "This PR is targeting a channel branch"
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-24.04-arm
     steps:
       - run: |
           cat <<EOF

--- a/.github/workflows/periodic-merge.yml
+++ b/.github/workflows/periodic-merge.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   merge:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-24.04-arm
     name: ${{ inputs.from }} → ${{ inputs.into }}
     steps:
       # Use a GitHub App to create the PR so that CI gets triggered


### PR DESCRIPTION
ARM runners are supposed to be more energy efficient than x86. Also, from limited testing, they appear to be faster for the eval jobs as well. Average run time for the "Outpaths (x86_64-linux)" job was 4m 27s earlier. In the first few runs, this job came in between 3m 9s and 3m 20s, so far. This effect did not show for other jobs, yet.

The following two exceptions are made right now:
- nixpkgs-lib-tests currently fails on the ARM runner building Nix 2.3 (it does work locally for me, though... odd)
- nixpkgs-vet is currently pinned to a x86_64-linux only binary release

Let's be good citizen, save some energy - and enjoy slightly faster eval in CI, shall we?

## Things done

Tested in https://github.com/wolfgangwalther/nixpkgs/pull/637.

- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
