### PR TITLE
util-linux: fix mount regression

### DIFF
--- a/pkgs/by-name/ut/util-linux/fix-mount-regression.patch
+++ b/pkgs/by-name/ut/util-linux/fix-mount-regression.patch
@@ -1,0 +1,39 @@
+From 7dbfe31a83f45d5aef2b508697e9511c569ffbc8 Mon Sep 17 00:00:00 2001
+From: Karel Zak <kzak@redhat.com>
+Date: Mon, 24 Mar 2025 14:31:05 +0100
+Subject: [PATCH] libmount: fix --no-canonicalize regression
+
+Fixes: https://github.com/util-linux/util-linux/issues/3474
+Signed-off-by: Karel Zak <kzak@redhat.com>
+---
+ libmount/src/context.c | 3 ---
+ sys-utils/mount.8.adoc | 2 +-
+ 2 files changed, 1 insertion(+), 4 deletions(-)
+
+diff --git a/libmount/src/context.c b/libmount/src/context.c
+index 0323cb23d34..15a8ad3bbd0 100644
+--- a/libmount/src/context.c
++++ b/libmount/src/context.c
+@@ -530,9 +530,6 @@ int mnt_context_is_xnocanonicalize(
+ 	assert(cxt);
+ 	assert(type);
+ 
+-	if (mnt_context_is_nocanonicalize(cxt))
+-		return 1;
+-
+ 	ol = mnt_context_get_optlist(cxt);
+ 	if (!ol)
+ 		return 0;
+diff --git a/sys-utils/mount.8.adoc b/sys-utils/mount.8.adoc
+index 4f23f8d1f0e..5103b91c578 100644
+--- a/sys-utils/mount.8.adoc
++++ b/sys-utils/mount.8.adoc
+@@ -756,7 +756,7 @@ Allow to make a target directory (mountpoint) if it does not exist yet. The opti
+ *X-mount.nocanonicalize*[**=**_type_]::
+ Allows disabling of canonicalization for mount source and target paths. By default, the `mount` command resolves all paths to their absolute paths without symlinks. However, this behavior may not be desired in certain situations, such as when binding a mount over a symlink, or a symlink over a directory or another symlink. The optional argument _type_ can be either "source" or "target" (mountpoint). If no _type_ is specified, then canonicalization is disabled for both types. This mount option does not affect the conversion of source tags (e.g. LABEL= or UUID=) and fstab processing.
+ +
+-The command line option *--no-canonicalize* overrides this mount option and affects all path and tag conversions in all situations, but it does not modify flags for open_tree syscalls.
++The command-line option *--no-canonicalize* overrides this mount option and affects all path and tag conversions in all situations, but for backward compatibility, it does not modify open_tree syscall flags and does not allow the bind-mount over a symlink use case.
+ +
+ Note that *mount*(8) still sanitizes and canonicalizes the source and target paths specified on the command line by non-root users, regardless of the X-mount.nocanonicalize setting.
+ 

--- a/pkgs/by-name/ut/util-linux/package.nix
+++ b/pkgs/by-name/ut/util-linux/package.nix
@@ -48,6 +48,8 @@ stdenv.mkDerivation rec {
       ./rtcwake-search-PATH-for-shutdown.patch
       # https://github.com/util-linux/util-linux/pull/3013
       ./fix-darwin-build.patch
+      # https://github.com/util-linux/util-linux/pull/3479 (fixes https://github.com/util-linux/util-linux/issues/3474)
+      ./fix-mount-regression.patch
     ]
     ++ lib.optionals (!stdenv.hostPlatform.isLinux) [
       (fetchurl {


### PR DESCRIPTION
Add patch of https://github.com/util-linux/util-linux/commit/7dbfe31a83f45d5aef2b508697e9511c569ffbc8

This fixes the issues mentioned here:
- https://github.com/util-linux/util-linux/issues/3474
- https://github.com/k3s-io/k3s/issues/12006

Note: For k3s it should be possible to work around the issue by running k3s with `--prefer-bundled-bin`. But I was unable to get it working with nixpkgs revision dda3dcd3fe03e991015e9a74b22d35950f264a54.
Edit: actually quite obvious why `--prefer-bundled-bin` does not work. The k3s nix package does not copy over the auxiliary binaries from https://github.com/k3s-io/k3s-root/releases/download/v0.14.1/k3s-root-amd64.tar to the location where the build expects them.

CC: @numinit @NixOS/k3s 

## Things done

I did not yet have enough time to rebuild every package depending on `util-linux`.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
