### PR TITLE
dependabot-cli.withDockerImages: fix build

### DIFF
--- a/pkgs/by-name/de/dependabot-cli/package.nix
+++ b/pkgs/by-name/de/dependabot-cli/package.nix
@@ -15,23 +15,25 @@ let
 
   # vv Also update this vv
   tag = "nixpkgs-dependabot-cli-${version}";
+
   updateJobProxy = dockerTools.pullImage {
     imageName = "ghcr.io/github/dependabot-update-job-proxy/dependabot-update-job-proxy";
     # Get these hashes from
     # nix run nixpkgs#nix-prefetch-docker -- --image-name ghcr.io/github/dependabot-update-job-proxy/dependabot-update-job-proxy --image-tag latest --final-image-name dependabot-update-job-proxy --final-image-tag ${tag}
-    imageDigest = "sha256:cc4a9b7db8ddf3924b6c25cc8a74d9937bf803e64733035809862a1c0a6df984";
-    sha256 = "0wkr0rac7dp1080s4zik5yzi5967gkfylly2148ipgw50sp0sq8s";
+    imageDigest = "sha256:3030ba5ff8f556e47016fca94d81c677b5c6abde99fef228341e1537588e503a";
+    hash = "sha256-RiXUae5ONScoDu85L6BEf3T4JodBYha6v+d9kWl8oWc=";
 
     # Don't update this, it's used to refer to the imported image later
     finalImageName = "dependabot-update-job-proxy";
     finalImageTag = tag;
   };
+
   updaterGitHubActions = dockerTools.pullImage {
     imageName = "ghcr.io/dependabot/dependabot-updater-github-actions";
     # Get these hashes from
     # nix run nixpkgs#nix-prefetch-docker -- --image-name ghcr.io/dependabot/dependabot-updater-github-actions --image-tag latest --final-image-name dependabot-updater-github-actions --final-image-tag ${tag}
-    imageDigest = "sha256:6665b3e26ef97577e83f2dfd0007a73c02b003126e72c0b4b196fe570088ed93";
-    sha256 = "0q7w3yp49wb70gkjjl2syvs75hm1jkva2qslzckwxh73z0kq2z0q";
+    imageDigest = "sha256:a356576adbec11bc34b142b6ef69a5856a09dc3654bdc9f9b046c08ee2d73ff8";
+    hash = "sha256-zqydb2v39xiSBT5ayWEacD0NIH6LoFX8lkRcCKppH08=";
 
     # Don't update this, it's used to refer to the imported image later
     finalImageName = "dependabot-updater-github-actions";


### PR DESCRIPTION
This has been broken for a while as the updater doesn't do the needful thing to update them.

Detected with https://github.com/NixOS/nixpkgs-vet/pull/157 some time ago but I didn't get a chance to take a look until now.

nixos/nixpkgs#405049 was the most recent dependabot update.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).