### PR TITLE
uvwasi: init at 0.0.21

### DIFF
--- a/pkgs/by-name/uv/uvwasi/package.nix
+++ b/pkgs/by-name/uv/uvwasi/package.nix
@@ -1,0 +1,57 @@
+{
+  lib,
+  cmake,
+  fetchFromGitHub,
+  fetchpatch2,
+  libuv,
+  nix-update-script,
+  stdenv,
+  testers,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "uvwasi";
+  version = "0.0.21";
+
+  src = fetchFromGitHub {
+    owner = "nodejs";
+    repo = "uvwasi";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-po2Pwqf97JXGKY8WysvyR1vSkqQ4XIF0VQG+83yV9nM=";
+  };
+
+  # Patch was sent upstream: https://github.com/nodejs/uvwasi/pull/302.
+  postPatch = ''
+    substituteInPlace CMakeLists.txt \
+      --replace-fail 'DESTINATION ''${CMAKE_INSTALL_INCLUDEDIR}/uvwasi' 'DESTINATION ''${CMAKE_INSTALL_INCLUDEDIR}'
+  '';
+
+  outputs = [
+    "out"
+  ];
+
+  nativeBuildInputs = [
+    cmake
+  ];
+  buildInputs = [
+    libuv
+  ];
+
+  passthru = {
+    updateScript = nix-update-script { };
+
+    tests.pkg-config = testers.hasPkgConfigModules {
+      package = finalAttrs.finalPackage;
+      moduleNames = [ "uvwasi" ];
+    };
+  };
+
+  meta = {
+    description = "WASI syscall API built atop libuv";
+    homepage = "https://github.com/nodejs/uvwasi";
+    changelog = "https://github.com/nodejs/uvwasi/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ aduh95 ];
+    platforms = lib.platforms.all;
+  };
+})


### PR DESCRIPTION
As part of #401454, I trying to use more shared libs in the hope of reducing build time for nodejs packages. 
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
