### PR TITLE
treewide: use `ctestCheckHook` (part 1)

### DIFF
--- a/pkgs/applications/misc/prusa-slicer/default.nix
+++ b/pkgs/applications/misc/prusa-slicer/default.nix
@@ -35,6 +35,7 @@
   heatshrink,
   catch2,
   webkitgtk_4_0,
+  ctestCheckHook,
   withSystemd ? lib.meta.availableOn stdenv.hostPlatform systemd,
   systemd,
   wxGTK-override ? null,
@@ -205,16 +206,12 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   doCheck = true;
-
-  checkPhase = ''
-    runHook preCheck
-
-    ctest \
-      --force-new-ctest-process \
-      -E 'libslic3r_tests|sla_print_tests'
-
-    runHook postCheck
-  '';
+  nativeCheckInputs = [ ctestCheckHook ];
+  checkFlags = [
+    "--force-new-ctest-process"
+    "-E"
+    "libslic3r_tests|sla_print_tests"
+  ];
 
   meta =
     with lib;

--- a/pkgs/by-name/al/alembic/package.nix
+++ b/pkgs/by-name/al/alembic/package.nix
@@ -60,11 +60,7 @@ stdenv.mkDerivation rec {
   '';
 
   doCheck = true;
-  checkPhase = ''
-    runHook preCheck
-    ctest -j 1
-    runHook postCheck
-  '';
+  enableParallelChecking = false;
 
   meta = with lib; {
     description = "Open framework for storing and sharing scene data";

--- a/pkgs/by-name/cc/ccache/package.nix
+++ b/pkgs/by-name/cc/ccache/package.nix
@@ -95,10 +95,10 @@ stdenv.mkDerivation (finalAttrs: {
   disabledTests =
     [
       "test.trim_dir" # flaky on hydra (possibly filesystem-specific?)
+      "test.fileclone" # flaky on hydra, also seems to fail on zfs
     ]
     ++ lib.optionals stdenv.hostPlatform.isDarwin [
       "test.basedir"
-      "test.fileclone" # flaky on hydra (possibly filesystem-specific?)
       "test.multi_arch"
       "test.nocpp2"
     ];

--- a/pkgs/by-name/cc/ccache/package.nix
+++ b/pkgs/by-name/cc/ccache/package.nix
@@ -15,6 +15,8 @@
   doctest,
   xcodebuild,
   makeWrapper,
+  ctestCheckHook,
+  writableTmpDirAsHomeHook,
   nix-update-script,
 }:
 
@@ -82,31 +84,24 @@ stdenv.mkDerivation (finalAttrs: {
     # test/run requires the compgen function which is available in
     # bashInteractive, but not bash.
     bashInteractive
+    ctestCheckHook
+    writableTmpDirAsHomeHook
   ] ++ lib.optional stdenv.hostPlatform.isDarwin xcodebuild;
 
   checkInputs = [
     doctest
   ];
 
-  checkPhase =
-    let
-      badTests =
-        [
-          "test.trim_dir" # flaky on hydra (possibly filesystem-specific?)
-        ]
-        ++ lib.optionals stdenv.hostPlatform.isDarwin [
-          "test.basedir"
-          "test.fileclone" # flaky on hydra (possibly filesystem-specific?)
-          "test.multi_arch"
-          "test.nocpp2"
-        ];
-    in
-    ''
-      runHook preCheck
-      export HOME=$(mktemp -d)
-      ctest --output-on-failure -E '^(${lib.concatStringsSep "|" badTests})$'
-      runHook postCheck
-    '';
+  disabledTests =
+    [
+      "test.trim_dir" # flaky on hydra (possibly filesystem-specific?)
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [
+      "test.basedir"
+      "test.fileclone" # flaky on hydra (possibly filesystem-specific?)
+      "test.multi_arch"
+      "test.nocpp2"
+    ];
 
   passthru = {
     # A derivation that provides gcc and g++ commands, but that

--- a/pkgs/by-name/ez/eztrace/package.nix
+++ b/pkgs/by-name/ez/eztrace/package.nix
@@ -9,6 +9,7 @@
   libbfd,
   libopcodes,
   otf2,
+  ctestCheckHook,
   versionCheckHook,
 }:
 
@@ -54,8 +55,6 @@ stdenv.mkDerivation (finalAttrs: {
 
   cmakeFlags = [
     (lib.cmakeBool "EZTRACE_ENABLE_MEMORY" true)
-    # This test is somewhat flaky and fails once per several rebuilds.
-    (lib.cmakeFeature "CMAKE_CTEST_ARGUMENTS" "--exclude-regex;memory_tests")
   ];
 
   nativeBuildInputs = [
@@ -72,8 +71,13 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   doCheck = true;
+  disabledTests = [
+    # This test is somewhat flaky and fails once per several rebuilds.
+    "memory_tests"
+  ];
   nativeCheckInputs = [
     otf2 # `otf2-print` needed by compiler_instrumentation_tests,pthread_tests,posixio_tests
+    ctestCheckHook
   ];
 
   postInstall = ''

--- a/pkgs/by-name/op/openscad-unstable/package.nix
+++ b/pkgs/by-name/op/openscad-unstable/package.nix
@@ -41,6 +41,7 @@
   xorg,
   mimalloc,
   opencsg,
+  ctestCheckHook,
 }:
 # clang consume much less RAM than GCC
 clangStdenv.mkDerivation rec {
@@ -142,12 +143,16 @@ clangStdenv.mkDerivation rec {
 
   nativeCheckInputs = [
     mesa.llvmpipeHook
+    ctestCheckHook
   ];
 
-  checkPhase = ''
+  dontUseNinjaCheck = true;
+  checkFlags = [
+    "-E"
     # some fontconfig issues cause pdf output to have wrong font
-    ctest -j$NIX_BUILD_CORES -E pdfexporttest.\*
-  '';
+    "pdfexporttest"
+  ];
+
   meta = with lib; {
     description = "3D parametric model compiler (unstable)";
     longDescription = ''

--- a/pkgs/by-name/si/sirius/package.nix
+++ b/pkgs/by-name/si/sirius/package.nix
@@ -6,6 +6,7 @@
   pkg-config,
   mpi,
   mpiCheckPhaseHook,
+  ctestCheckHook,
   gfortran,
   blas,
   lapack,
@@ -152,16 +153,14 @@ stdenv.mkDerivation rec {
   # Can not run parallel checks generally as it requires exactly multiples of 4 MPI ranks
   # Even cpu_serial tests had to be disabled as they require scalapack routines in the sandbox
   # and run into the same problem as MPI tests
-  checkPhase = ''
-    runHook preCheck
-
-    ctest --output-on-failure --label-exclude integration_test
-
-    runHook postCheck
-  '';
+  checkFlags = [
+    "--label-exclude"
+    "integration_test"
+  ];
 
   nativeCheckInputs = [
     mpiCheckPhaseHook
+    ctestCheckHook
   ];
 
   meta = with lib; {

--- a/pkgs/development/compilers/halide/default.nix
+++ b/pkgs/development/compilers/halide/default.nix
@@ -22,6 +22,7 @@
   wasmSupport ? false,
   wabt,
   doCheck ? true,
+  ctestCheckHook,
 }:
 
 assert blas.implementation == "openblas" && lapack.implementation == "openblas";
@@ -102,15 +103,9 @@ stdenv.mkDerivation (finalAttrs: {
     "correctness_cross_compilation"
     "correctness_simd_op_check_hvx"
   ];
-  # ninja's setup-hook doesn't let us specify custom flags for the checkPhase, see
-  # https://discourse.nixos.org/t/building-only-specific-targets-with-cmake/31545/4
-  # so we resort to overriding the whole checkPhase
+
   dontUseNinjaCheck = true;
-  checkPhase = ''
-    runHook preCheck
-    ctest --exclude-regex '^(${lib.strings.concatStringsSep "|" finalAttrs.disabledTests})$'
-    runHook postCheck
-  '';
+  nativeCheckInputs = [ ctestCheckHook ];
 
   postInstall =
     lib.optionalString pythonSupport ''

--- a/pkgs/development/libraries/eccodes/default.nix
+++ b/pkgs/development/libraries/eccodes/default.nix
@@ -9,6 +9,7 @@
   libpng,
   gfortran,
   perl,
+  ctestCheckHook,
   enablePython ? false,
   pythonPackages,
   enablePosixThreads ? false,
@@ -65,11 +66,12 @@ stdenv.mkDerivation rec {
   ];
 
   doCheck = true;
-
-  # Only do tests that don't require downloading 120MB of testdata
-  checkPhase = ''
-    ctest -R "eccodes_t_(definitions|calendar|unit_tests|md5|uerra|grib_2nd_order_numValues|julian)" -VV
-  '';
+  nativeCheckInputs = [ ctestCheckHook ];
+  checkFlags = [
+    "-R"
+    # Only do tests that don't require downloading 120MB of testdata
+    "eccodes_t_(definitions|calendar|unit_tests|md5|uerra|grib_2nd_order_numValues|julian)"
+  ];
 
   meta = with lib; {
     homepage = "https://confluence.ecmwf.int/display/ECC/";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Follow-up to https://github.com/NixOS/nixpkgs/pull/379426. Cleaning up low rebuild count packages to go straight to master. Best reviewed commit-by-commit.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
