### PR TITLE
nixos/btrbk: fix sudo wheel group requirement

### DIFF
--- a/nixos/modules/services/backup/btrbk.nix
+++ b/nixos/modules/services/backup/btrbk.nix
@@ -63,44 +63,58 @@ let
     else
       concatLists (mapAttrsToList (genSection name) value);
 
-  sudoRule = {
-    users = [ "btrbk" ];
-    commands = [
-      {
-        command = "${pkgs.btrfs-progs}/bin/btrfs";
-        options = [ "NOPASSWD" ];
-      }
-      {
-        command = "${pkgs.coreutils}/bin/mkdir";
-        options = [ "NOPASSWD" ];
-      }
-      {
-        command = "${pkgs.coreutils}/bin/readlink";
-        options = [ "NOPASSWD" ];
-      }
-      # for ssh, they are not the same than the one hard coded in ${pkgs.btrbk}
-      {
-        command = "/run/current-system/sw/bin/btrfs";
-        options = [ "NOPASSWD" ];
-      }
-      {
-        command = "/run/current-system/sw/bin/mkdir";
-        options = [ "NOPASSWD" ];
-      }
-      {
-        command = "/run/current-system/sw/bin/readlink";
-        options = [ "NOPASSWD" ];
-      }
-    ];
-  };
+  sudoRules = [
+    {
+      users = [ "btrbk" ];
+      commands = [
+        { command = "!ALL"; }
+      ];
+    }
+    {
+      users = [ "btrbk" ];
+      commands = [
+        {
+          command = "${pkgs.btrfs-progs}/bin/btrfs";
+          options = [ "NOPASSWD" ];
+        }
+        {
+          command = "${pkgs.coreutils}/bin/mkdir";
+          options = [ "NOPASSWD" ];
+        }
+        {
+          command = "${pkgs.coreutils}/bin/readlink";
+          options = [ "NOPASSWD" ];
+        }
+        # for ssh, they are not the same than the one hard coded in ${pkgs.btrbk}
+        {
+          command = "/run/current-system/sw/bin/btrfs";
+          options = [ "NOPASSWD" ];
+        }
+        {
+          command = "/run/current-system/sw/bin/mkdir";
+          options = [ "NOPASSWD" ];
+        }
+        {
+          command = "/run/current-system/sw/bin/readlink";
+          options = [ "NOPASSWD" ];
+        }
+      ];
+    }
+  ];
+
+  cfgSec = config.security;
 
   sudo_doas =
-    if config.security.sudo.enable || config.security.sudo-rs.enable then
+    if cfgSec.sudo.enable || cfgSec.sudo-rs.enable then
       "sudo"
-    else if config.security.doas.enable then
+    else if cfgSec.doas.enable then
       "doas"
     else
       throw "The btrbk nixos module needs either sudo or doas enabled in the configuration";
+
+  sudo_exec_wheel = cfgSec.sudo.execWheelOnly || cfgSec.sudo-rs.execWheelOnly;
+
+  sudoWheel = optional (sudo_doas == "sudo" && sudo_exec_wheel) "wheel";
 
   addDefaults = settings: { backend = "btrfs-progs-${sudo_doas}"; } // settings;
 
@@ -287,8 +301,8 @@ in
 
     environment.systemPackages = [ pkgs.btrbk ] ++ cfg.extraPackages;
 
-    security.sudo.extraRules = mkIf (sudo_doas == "sudo") [ sudoRule ];
-    security.sudo-rs.extraRules = mkIf (sudo_doas == "sudo") [ sudoRule ];
+    security.sudo.extraRules = mkIf (sudo_doas == "sudo") sudoRules;
+    security.sudo-rs.extraRules = mkIf (sudo_doas == "sudo") sudoRules;
 
     security.doas = mkIf (sudo_doas == "doas") {
       extraRules =
@@ -321,6 +335,7 @@ in
       createHome = true;
       shell = "${pkgs.bash}/bin/bash";
       group = "btrbk";
+      extraGroups = sudoWheel;
       openssh.authorizedKeys.keys = map (
         v:
         let

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -306,6 +306,7 @@ in
   btrbk-doas = runTest ./btrbk-doas.nix;
   btrbk-no-timer = runTest ./btrbk-no-timer.nix;
   btrbk-section-order = runTest ./btrbk-section-order.nix;
+  btrbk-sudo-wheel = runTest ./btrbk-sudo-wheel.nix;
   budgie = runTest ./budgie.nix;
   buildbot = runTest ./buildbot.nix;
   buildkite-agents = runTest ./buildkite-agents.nix;

--- a/nixos/tests/btrbk-sudo-wheel.nix
+++ b/nixos/tests/btrbk-sudo-wheel.nix
@@ -1,0 +1,47 @@
+{ pkgs, ... }:
+{
+  name = "btrbk-sudo-wheel";
+  meta = {
+    maintainers = [ ];
+  };
+
+  nodes.machine =
+    { ... }:
+    {
+      security.sudo = {
+        execWheelOnly = true;
+        wheelNeedsPassword = false;
+      };
+      environment.systemPackages = with pkgs; [ btrfs-progs ];
+      services.btrbk.instances.local = {
+        onCalendar = null;
+        settings.volume."/mnt" = {
+          snapshot_dir = "btrbk/local";
+          subvolume = "to_backup";
+        };
+      };
+    };
+
+  testScript = ''
+    start_all()
+
+    # Create btrfs partition at /mnt
+    machine.succeed("truncate --size=128M /data_fs")
+    machine.succeed("mkfs.btrfs /data_fs")
+    machine.succeed("mkdir /mnt")
+    machine.succeed("mount /data_fs /mnt")
+    machine.succeed("btrfs subvolume create /mnt/to_backup")
+    machine.succeed("mkdir -p /mnt/btrbk/local")
+
+    # Manually starting the service should still work.
+    machine.succeed("echo foo > /mnt/to_backup/bar")
+    machine.start_job("btrbk-local.service")
+
+    machine.fail("journalctl -b -o cat -u btrbk-local.service -g 'sudo: Permission denied'");
+
+    machine.wait_until_succeeds("cat /mnt/btrbk/local/*/bar | grep foo")
+
+    machine.fail("sudo -u btrbk cat /etc/shadow")
+    machine.fail("sudo -u btrbk cat /etc/sudoers")
+  '';
+}

--- a/pkgs/by-name/bt/btrbk/package.nix
+++ b/pkgs/by-name/bt/btrbk/package.nix
@@ -70,6 +70,7 @@ stdenv.mkDerivation (finalAttrs: {
   passthru.tests = {
     inherit (nixosTests)
       btrbk
+      btrbk-sudo-wheel
       btrbk-no-timer
       btrbk-section-order
       btrbk-doas


### PR DESCRIPTION
fix `sudo` execution failure when `security.{sudo,sudo-rs}.execWheelOnly` is enabled.

```
WARNING: ... sh: line 1: /run/wrappers/bin/sudo: Permission denied
...
!!! Aborted: Failed to fetch subvolume detail
```

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

@oxalica

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
