### PR TITLE
python3Packages.aioopenssl: disable failing network tests

### DIFF
--- a/pkgs/development/python-modules/aioopenssl/default.nix
+++ b/pkgs/development/python-modules/aioopenssl/default.nix
@@ -1,16 +1,23 @@
 {
   lib,
+  stdenv,
   buildPythonPackage,
   fetchFromGitHub,
+
+  # build-system
+  setuptools,
+
+  # dependencies
   pyopenssl,
+
+  # test
   pytestCheckHook,
 }:
 
 buildPythonPackage rec {
   pname = "aioopenssl";
   version = "0.6.0";
-
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "horazont";
@@ -19,11 +26,37 @@ buildPythonPackage rec {
     hash = "sha256-7Q+4/DlP+kUnC3YNk7woJaxLEEiuVmolUOajepM003Q=";
   };
 
-  propagatedBuildInputs = [ pyopenssl ];
+  build-system = [ setuptools ];
+
+  dependencies = [ pyopenssl ];
 
   pythonImportsCheck = [ "aioopenssl" ];
 
   nativeCheckInputs = [ pytestCheckHook ];
+
+  # Tests that fail in when built in the Darwin sandbox.
+  disabledTests = lib.optionals stdenv.hostPlatform.isDarwin [
+    # address already in use
+    "test_renegotiate"
+    # permission error (tries to bind to port not allowed by sandbox)
+    "test_abort"
+    "test_close_during_handshake"
+    "test_connect_send_recv_close"
+    "test_data_is_sent_after_handshake"
+    "test_local_addr"
+    "test_no_data_is_received_after_handshake"
+    "test_no_data_is_received_if_handshake_crashes"
+    "test_no_data_is_sent_if_handshake_crashes"
+    "test_post_handshake_exception_is_propagated"
+    "test_recv_large_data"
+    "test_renegotiation"
+    "test_send_and_receive_data"
+    "test_send_large_data"
+    "test_send_recv_large_data"
+    "test_starttls"
+  ];
+
+  __darwinAlowLocalNetworking = true;
 
   meta = {
     description = "TLS-capable transport using OpenSSL for asyncio";


### PR DESCRIPTION
Hydra: https://hydra.nixos.org/build/296397620

Building was failing in Hydra under Darwin when `test_renegotiate` failed with "address in use". Other tests were found to fail under the sandbox.

Fixes:
1. Disable `test_renegotiate` on Darwin
2. Enable `__darwinAllowLocalNetworking`
3. Modernize derivation

ZHF: #403336

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [x] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
