### PR TITLE
python3Packages.aiocache: disable testing on Darwin due to redisTestHook not connecting

### DIFF
--- a/pkgs/development/python-modules/ploomber-extension/default.nix
+++ b/pkgs/development/python-modules/ploomber-extension/default.nix
@@ -10,6 +10,8 @@
   ploomber-core,
   pytestCheckHook,
   pytest-jupyter,
+  redisTestHook,
+  valkey,
 }:
 
 buildPythonPackage rec {
@@ -38,6 +40,8 @@ buildPythonPackage rec {
   nativeCheckInputs = [
     pytestCheckHook
     pytest-jupyter
+    redisTestHook
+    valkey
   ];
 
   pythonImportsCheck = [ "ploomber_extension" ];


### PR DESCRIPTION
Hydra: https://hydra.nixos.org/build/296397297

~~Hydra build error: the test `TestCachedStampede.test_cached_stampede[redis_cache]` failed on x86_64-darwin due to timing differences.~~

**UPDATE** As of 14-May-2025 any attempt to test with Redis/Valkey leads to a hang when building Python 3.13, on Darwin, with a sandbox. Thus, disabling tests on Darwin for now.

```sh
starting redis
waiting for redis to be ready
Could not connect to Valkey at /private/tmp/nix-build-python3.13-pyrate-limiter-3.7.0.drv-0/run/redis.sock: No such file or directory
Could not connect to Valkey at /private/tmp/nix-build-python3.13-pyrate-limiter-3.7.0.drv-0/run/redis.sock: No such file or directory
Could not connect to Valkey at /private/tmp/nix-build-python3.13-pyrate-limiter-3.7.0.drv-0/run/redis.sock: No such file or directory
Could not connect to Valkey at /private/tmp/nix-build-python3.13-pyrate-limiter-3.7.0.drv-0/run/redis.sock: No such file or directory
```

Fixes:
1. Disabled ~~the test~~ testing on Darwin only
2. Fixed the package description (it was describing a different package!)

ZHF: #403336

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [x] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
