### PR TITLE
tests.stdenv.structuredAttrsByDefault.test-cc-wrapper-substitutions: fix on darwin

### DIFF
--- a/pkgs/build-support/pkg-config-wrapper/default.nix
+++ b/pkgs/build-support/pkg-config-wrapper/default.nix
@@ -59,7 +59,7 @@ stdenv.mkDerivation {
   dontUnpack = true;
 
   # Additional flags passed to pkg-config.
-  addFlags = optional stdenv.targetPlatform.isStatic "--static";
+  env.addFlags = optionalString stdenv.targetPlatform.isStatic "--static";
 
   installPhase =
     ''

--- a/pkgs/build-support/remove-references-to/default.nix
+++ b/pkgs/build-support/remove-references-to/default.nix
@@ -34,8 +34,10 @@ stdenv.mkDerivation {
     substituteAll ${./darwin-sign-fixup.sh} $out/nix-support/setup-hooks.sh
   '';
 
-  inherit (builtins) storeDir;
-  shell = lib.getBin shell + (shell.shellPath or "");
-  signingUtils = if darwinCodeSign then signingUtils else null;
+  env = {
+    inherit (builtins) storeDir;
+    shell = lib.getBin shell + (shell.shellPath or "");
+  } // lib.optionalAttrs darwinCodeSign { inherit signingUtils; };
+
   meta.mainProgram = "remove-references-to";
 }

--- a/pkgs/development/interpreters/lua-5/5.2.darwin.patch
+++ b/pkgs/development/interpreters/lua-5/5.2.darwin.patch
@@ -7,7 +7,7 @@ index d2c7db4..dc107b3 100644
  TO_BIN= lua luac
  TO_INC= lua.h luaconf.h lualib.h lauxlib.h lua.hpp
 -TO_LIB= liblua.a
-+TO_LIB= liblua.${version}.dylib
++TO_LIB= liblua.${pkgversion}.dylib
  TO_MAN= lua.1 luac.1
  
  # Lua version and release.
@@ -15,7 +15,7 @@ index d2c7db4..dc107b3 100644
  	cd src && $(INSTALL_DATA) $(TO_INC) $(INSTALL_INC)
  	cd src && $(INSTALL_DATA) $(TO_LIB) $(INSTALL_LIB)
  	cd doc && $(INSTALL_DATA) $(TO_MAN) $(INSTALL_MAN)
-+	ln -s -f liblua.${version}.dylib $(INSTALL_LIB)/liblua.${luaversion}.dylib
++	ln -s -f liblua.${pkgversion}.dylib $(INSTALL_LIB)/liblua.${luaversion}.dylib
 +	ln -s -f liblua.${luaversion}.dylib $(INSTALL_LIB)/liblua.dylib
  
  uninstall:
@@ -29,7 +29,7 @@ index 7b4b2b7..25001e5 100644
  PLATS= aix ansi bsd freebsd generic linux macosx mingw posix solaris
  
 -LUA_A=	liblua.a
-+LUA_A=	liblua.${version}.dylib
++LUA_A=	liblua.${pkgversion}.dylib
  CORE_O=	lapi.o lcode.o lctype.o ldebug.o ldo.o ldump.o lfunc.o lgc.o llex.o \
  	lmem.o lobject.o lopcodes.o lparser.o lstate.o lstring.o ltable.o \
  	ltm.o lundump.o lvm.o lzio.o
@@ -39,14 +39,14 @@ index 7b4b2b7..25001e5 100644
  $(LUA_A): $(BASE_O)
 -	$(AR) $@ $(BASE_O)
 -	$(RANLIB) $@
-+	$(CC) -dynamiclib -install_name $(out)/lib/liblua.${version}.dylib \
-+		-compatibility_version ${version} -current_version ${version} \
-+		-o liblua.${version}.dylib $^
++	$(CC) -dynamiclib -install_name $(out)/lib/liblua.${pkgversion}.dylib \
++		-compatibility_version ${pkgversion} -current_version ${pkgversion} \
++		-o liblua.${pkgversion}.dylib $^
  
  $(LUA_T): $(LUA_O) $(LUA_A)
 -	$(CC) -o $@ $(LDFLAGS) $(LUA_O) $(LUA_A) $(LIBS)
 +	$(CC) -fno-common $(MYLDFLAGS) \
-+		-o $@ $(LUA_O) $(LUA_A) -L. -llua.${version} $(LIBS)
++		-o $@ $(LUA_O) $(LUA_A) -L. -llua.${pkgversion} $(LIBS)
  
  $(LUAC_T): $(LUAC_O) $(LUA_A)
  	$(CC) -o $@ $(LDFLAGS) $(LUAC_O) $(LUA_A) $(LIBS)

--- a/pkgs/development/interpreters/lua-5/5.4.darwin.patch
+++ b/pkgs/development/interpreters/lua-5/5.4.darwin.patch
@@ -5,7 +5,7 @@
  TO_BIN= lua luac
  TO_INC= lua.h luaconf.h lualib.h lauxlib.h lua.hpp
 -TO_LIB= liblua.a
-+TO_LIB= liblua.${version}.dylib
++TO_LIB= liblua.${pkgversion}.dylib
  TO_MAN= lua.1 luac.1
  
  # Lua version and release.
@@ -13,7 +13,7 @@
  	cd src && $(INSTALL_DATA) $(TO_INC) $(INSTALL_INC)
  	cd src && $(INSTALL_DATA) $(TO_LIB) $(INSTALL_LIB)
  	cd doc && $(INSTALL_DATA) $(TO_MAN) $(INSTALL_MAN)
-+	ln -s -f liblua.${version}.dylib $(INSTALL_LIB)/liblua.${luaversion}.dylib
++	ln -s -f liblua.${pkgversion}.dylib $(INSTALL_LIB)/liblua.${luaversion}.dylib
 +	ln -s -f liblua.${luaversion}.dylib $(INSTALL_LIB)/liblua.dylib
  
  uninstall:
@@ -25,7 +25,7 @@
  PLATS= guess aix bsd c89 freebsd generic linux linux-readline macosx mingw posix solaris
  
 -LUA_A=	liblua.a
-+LUA_A=	liblua.${version}.dylib
++LUA_A=	liblua.${pkgversion}.dylib
  CORE_O=	lapi.o lcode.o lctype.o ldebug.o ldo.o ldump.o lfunc.o lgc.o llex.o lmem.o lobject.o lopcodes.o lparser.o lstate.o lstring.o ltable.o ltm.o lundump.o lvm.o lzio.o
  LIB_O=	lauxlib.o lbaselib.o lcorolib.o ldblib.o liolib.o lmathlib.o loadlib.o loslib.o lstrlib.o ltablib.o lutf8lib.o linit.o
  BASE_O= $(CORE_O) $(LIB_O) $(MYOBJS)
@@ -35,14 +35,14 @@
  $(LUA_A): $(BASE_O)
 -	$(AR) $@ $(BASE_O)
 -	$(RANLIB) $@
-+	$(CC) -dynamiclib -install_name $(out)/lib/liblua.${version}.dylib \
-+		-compatibility_version ${version} -current_version ${version} \
-+		-o liblua.${version}.dylib $^
++	$(CC) -dynamiclib -install_name $(out)/lib/liblua.${pkgversion}.dylib \
++		-compatibility_version ${pkgversion} -current_version ${pkgversion} \
++		-o liblua.${pkgversion}.dylib $^
  
  $(LUA_T): $(LUA_O) $(LUA_A)
 -	$(CC) -o $@ $(LDFLAGS) $(LUA_O) $(LUA_A) $(LIBS)
 +	$(CC) -fno-common $(MYLDFLAGS) \
-+		-o $@ $(LUA_O) $(LUA_A) -L. -llua.${version} $(LIBS)
++		-o $@ $(LUA_O) $(LUA_A) -L. -llua.${pkgversion} $(LIBS)
  
  $(LUAC_T): $(LUAC_O) $(LUA_A)
  	$(CC) -o $@ $(LDFLAGS) $(LUAC_O) $(LUA_A) $(LIBS)

--- a/pkgs/development/interpreters/lua-5/interpreter.nix
+++ b/pkgs/development/interpreters/lua-5/interpreter.nix
@@ -99,6 +99,11 @@ stdenv.mkDerivation (
         cat ${./lua-dso.make} >> src/Makefile
       '';
 
+    env = {
+      inherit luaversion;
+      pkgversion = version;
+    };
+
     # see configurePhase for additional flags (with space)
     makeFlags = [
       "INSTALL_TOP=${placeholder "out"}"

--- a/pkgs/os-specific/darwin/signing-utils/default.nix
+++ b/pkgs/os-specific/darwin/signing-utils/default.nix
@@ -20,6 +20,8 @@ stdenv.mkDerivation {
   '';
 
   # Substituted variables
-  inherit sigtool;
-  codesignAllocate = "${cctools}/bin/${cctools.targetPrefix}codesign_allocate";
+  env = {
+    inherit sigtool;
+    codesignAllocate = "${cctools}/bin/${cctools.targetPrefix}codesign_allocate";
+  };
 }


### PR DESCRIPTION
Some `__structuredAttrs` fixes that benefit both Darwin and everyone else. :)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin (only `tests.stdenv.structuredAttrsByDefault.test-cc-wrapper-substitutions`, not anything else yet)
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [x] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
