### PR TITLE
direwolf: refactor; direwolf-unstable: init at 1.7-unstable-2025-04-29

### DIFF
--- a/pkgs/by-name/di/direwolf-unstable/package.nix
+++ b/pkgs/by-name/di/direwolf-unstable/package.nix
@@ -1,0 +1,41 @@
+{
+  lib,
+  fetchFromGitHub,
+  direwolf,
+  nix-update-script,
+  hamlibSupport ? true,
+  gpsdSupport ? true,
+  extraScripts ? false,
+}:
+
+(direwolf.override {
+  inherit hamlibSupport gpsdSupport extraScripts;
+}).overrideAttrs
+  (oldAttrs: {
+    version = "1.7-unstable-2025-04-29";
+
+    src = fetchFromGitHub {
+      owner = "wb2osz";
+      repo = "direwolf";
+      rev = "486b3cf1f685502af7dc87b0f9c9cead6800d47b";
+      hash = "sha256-VFBkOWHGZP7GjekHL3GY3BGkVXQbtyD1YPmu0xaQ1ME=";
+    };
+
+    postPatch =
+      builtins.replaceStrings
+        [
+          "decode_aprs.c"
+          "tocalls.txt"
+          "--replace-fail /etc/udev/rules.d/"
+        ]
+        [
+          "deviceid.c"
+          "tocalls.yaml"
+          "--replace-fail /usr/lib/udev/rules.d/ $out/lib/udev/rules.d/ --replace-fail /etc/udev/rules.d/"
+        ]
+        oldAttrs.postPatch;
+
+    dontVersionCheck = true;
+
+    passthru.updateScript = nix-update-script { extraArgs = [ "--version=branch=dev" ]; };
+  })

--- a/pkgs/by-name/di/direwolf/package.nix
+++ b/pkgs/by-name/di/direwolf/package.nix
@@ -90,6 +90,7 @@ stdenv.mkDerivation (finalAttrs: {
   meta = {
     description = "Soundcard Packet TNC, APRS Digipeater, IGate, APRStt gateway";
     homepage = "https://github.com/wb2osz/direwolf/";
+    mainProgram = "direwolf";
     license = lib.licenses.gpl2;
     platforms = lib.platforms.unix;
     maintainers = with lib.maintainers; [

--- a/pkgs/by-name/di/direwolf/package.nix
+++ b/pkgs/by-name/di/direwolf/package.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "wb2osz";
     repo = "direwolf";
-    rev = version;
+    tag = version;
     hash = "sha256-Vbxc6a6CK+wrBfs15dtjfRa1LJDKKyHMrg8tqsF7EX4=";
   };
 

--- a/pkgs/by-name/di/direwolf/package.nix
+++ b/pkgs/by-name/di/direwolf/package.nix
@@ -7,7 +7,8 @@
   alsa-lib,
   gpsd,
   gpsdSupport ? false,
-  hamlib,
+  hamlib_4,
+  hamlib ? hamlib_4,
   hamlibSupport ? true,
   perl,
   portaudio,
@@ -64,23 +65,21 @@ stdenv.mkDerivation rec {
 
   postPatch = ''
     substituteInPlace conf/CMakeLists.txt \
-      --replace /etc/udev/rules.d/ $out/lib/udev/rules.d/
+      --replace-fail /etc/udev/rules.d/ $out/lib/udev/rules.d/
     substituteInPlace src/symbols.c \
-      --replace /usr/share/direwolf/symbols-new.txt $out/share/direwolf/symbols-new.txt \
-      --replace /opt/local/share/direwolf/symbols-new.txt $out/share/direwolf/symbols-new.txt
+      --replace-fail /usr/share/direwolf/symbols-new.txt $out/share/direwolf/symbols-new.txt \
+      --replace-fail /opt/local/share/direwolf/symbols-new.txt $out/share/direwolf/symbols-new.txt
     substituteInPlace src/decode_aprs.c \
-      --replace /usr/share/direwolf/tocalls.txt $out/share/direwolf/tocalls.txt \
-      --replace /opt/local/share/direwolf/tocalls.txt $out/share/direwolf/tocalls.txt
+      --replace-fail /usr/share/direwolf/tocalls.txt $out/share/direwolf/tocalls.txt \
+      --replace-fail /opt/local/share/direwolf/tocalls.txt $out/share/direwolf/tocalls.txt
     substituteInPlace cmake/cpack/direwolf.desktop.in \
-      --replace 'Terminal=false' 'Terminal=true' \
-      --replace 'Exec=@APPLICATION_DESKTOP_EXEC@' 'Exec=direwolf'
-    substituteInPlace src/dwgpsd.c \
-      --replace 'GPSD_API_MAJOR_VERSION > 11' 'GPSD_API_MAJOR_VERSION > 14'
+      --replace-fail 'Terminal=false' 'Terminal=true' \
+      --replace-fail 'Exec=@APPLICATION_DESKTOP_EXEC@' 'Exec=direwolf'
   ''
   + lib.optionalString extraScripts ''
     patchShebangs scripts/dwespeak.sh
     substituteInPlace scripts/dwespeak.sh \
-      --replace espeak ${espeak}/bin/espeak
+      --replace-fail espeak ${espeak}/bin/espeak
   '';
 
   doInstallCheck = true;

--- a/pkgs/by-name/di/direwolf/package.nix
+++ b/pkgs/by-name/di/direwolf/package.nix
@@ -16,6 +16,7 @@
   espeak,
   udev,
   udevCheckHook,
+  nix-update-script,
   extraScripts ? false,
 }:
 
@@ -83,6 +84,8 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   doInstallCheck = true;
+
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "Soundcard Packet TNC, APRS Digipeater, IGate, APRStt gateway";

--- a/pkgs/by-name/di/direwolf/package.nix
+++ b/pkgs/by-name/di/direwolf/package.nix
@@ -92,6 +92,7 @@ stdenv.mkDerivation (finalAttrs: {
     maintainers = with lib.maintainers; [
       lasandell
       sarcasticadmin
+      pandapip1
     ];
   };
 })

--- a/pkgs/by-name/di/direwolf/package.nix
+++ b/pkgs/by-name/di/direwolf/package.nix
@@ -19,14 +19,14 @@
   extraScripts ? false,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "direwolf";
   version = "1.7";
 
   src = fetchFromGitHub {
     owner = "wb2osz";
     repo = "direwolf";
-    tag = version;
+    tag = finalAttrs.version;
     hash = "sha256-Vbxc6a6CK+wrBfs15dtjfRa1LJDKKyHMrg8tqsF7EX4=";
   };
 
@@ -94,4 +94,4 @@ stdenv.mkDerivation rec {
       sarcasticadmin
     ];
   };
-}
+})

--- a/pkgs/by-name/di/direwolf/package.nix
+++ b/pkgs/by-name/di/direwolf/package.nix
@@ -84,12 +84,12 @@ stdenv.mkDerivation (finalAttrs: {
 
   doInstallCheck = true;
 
-  meta = with lib; {
+  meta = {
     description = "Soundcard Packet TNC, APRS Digipeater, IGate, APRStt gateway";
     homepage = "https://github.com/wb2osz/direwolf/";
-    license = licenses.gpl2;
-    platforms = platforms.unix;
-    maintainers = with maintainers; [
+    license = lib.licenses.gpl2;
+    platforms = lib.platforms.unix;
+    maintainers = with lib.maintainers; [
       lasandell
       sarcasticadmin
     ];

--- a/pkgs/by-name/di/direwolf/package.nix
+++ b/pkgs/by-name/di/direwolf/package.nix
@@ -16,6 +16,7 @@
   espeak,
   udev,
   udevCheckHook,
+  versionCheckHook,
   nix-update-script,
   extraScripts ? false,
 }:
@@ -59,6 +60,7 @@ stdenv.mkDerivation (finalAttrs: {
       perl
       espeak
     ];
+  nativeInstallCheckInputs = [ versionCheckHook ];
 
   preConfigure = lib.optionals (!extraScripts) ''
     echo "" > scripts/CMakeLists.txt
@@ -84,6 +86,8 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   doInstallCheck = true;
+
+  versionCheckProgramArg = [ "-u" ];
 
   passthru.updateScript = nix-update-script { };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10959,10 +10959,6 @@ with pkgs;
 
   dfasma = libsForQt5.callPackage ../applications/audio/dfasma { };
 
-  direwolf = callPackage ../applications/radio/direwolf {
-    hamlib = hamlib_4;
-  };
-
   djv = callPackage ../by-name/dj/djv/package.nix { openexr = openexr_2; };
 
   djview4 = djview;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

~~`versionCheckHook` was not added due to the lack of a `--version` subcommand. See https://github.com/wb2osz/direwolf/issues/570~~ A workaround was found

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
