### PR TITLE
workflows/eval-aliases: split from eval

### DIFF
--- a/.github/workflows/eval-aliases.yml
+++ b/.github/workflows/eval-aliases.yml
@@ -1,0 +1,33 @@
+name: Eval aliases
+
+on:
+  pull_request_target:
+
+permissions: {}
+
+jobs:
+  get-merge-commit:
+    uses: ./.github/workflows/get-merge-commit.yml
+
+  eval-aliases:
+    name: Eval nixpkgs with aliases enabled
+    runs-on: ubuntu-24.04
+    needs: [ get-merge-commit ]
+    steps:
+      - name: Check out the PR at the test merge commit
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ needs.get-merge-commit.outputs.mergedSha }}
+          path: nixpkgs
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@526118121621777ccd86f79b04685a9319637641 # v31
+        with:
+          extra_nix_config: sandbox = true
+
+      - name: Ensure flake outputs on all systems still evaluate
+        run: nix --experimental-features 'nix-command flakes' flake check --all-systems --no-build ./nixpkgs
+
+      - name: Query nixpkgs with aliases enabled to check for basic syntax errors
+        run: |
+          time nix-env -I ./nixpkgs -f ./nixpkgs -qa '*' --option restrict-eval true --option allow-import-from-derivation false >/dev/null

--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -59,29 +59,6 @@ jobs:
           name: paths
           path: result/*
 
-  eval-aliases:
-    name: Eval nixpkgs with aliases enabled
-    runs-on: ubuntu-24.04
-    needs: [ get-merge-commit ]
-    steps:
-      - name: Check out the PR at the test merge commit
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          ref: ${{ needs.get-merge-commit.outputs.mergedSha }}
-          path: nixpkgs
-
-      - name: Install Nix
-        uses: cachix/install-nix-action@526118121621777ccd86f79b04685a9319637641 # v31
-        with:
-          extra_nix_config: sandbox = true
-
-      - name: Ensure flake outputs on all systems still evaluate
-        run: nix --experimental-features 'nix-command flakes' flake check --all-systems --no-build ./nixpkgs
-
-      - name: Query nixpkgs with aliases enabled to check for basic syntax errors
-        run: |
-          time nix-env -I ./nixpkgs -f ./nixpkgs -qa '*' --option restrict-eval true --option allow-import-from-derivation false >/dev/null
-
   outpaths:
     name: Outpaths
     runs-on: ubuntu-24.04


### PR DESCRIPTION
The eval-aliases job is independent of all the other eval jobs. By splitting it into a separate workflow, we avoid running it in two cases:

1. When turning a PR "ready to review". In this case, the main eval workflow needs to run to be able to tag reviewers - but not eval-aliases.

2. On branches like master, staging, etc. We only need to run eval there to have a result to compare against in PRs. eval-aliases doesn't contribute to that.

Thus, this will avoid wasting resources.

## Things done

- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
