### PR TITLE
workflows/check-format: add actionlint

### DIFF
--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -219,7 +219,7 @@ jobs:
           # Use the target branch to get accurate maintainer info
           nix-build target/ci -A eval.compare \
             --arg beforeResultDir ./targetResult \
-            --arg afterResultDir $(realpath prResult) \
+            --arg afterResultDir "$(realpath prResult)" \
             --arg touchedFilesJson ./touched-files.json \
             -o comparison
 

--- a/.github/workflows/lint-actions.sh
+++ b/.github/workflows/lint-actions.sh
@@ -1,7 +1,0 @@
-#!/usr/bin/env nix-shell
-#!nix-shell -i bash -p bash actionlint shellcheck -I nixpkgs=../..
-set -euo pipefail
-
-SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
-cd "$SCRIPT_DIR/../.."
-actionlint

--- a/ci/default.nix
+++ b/ci/default.nix
@@ -44,6 +44,8 @@ let
         # By default it's info, which is too noisy since we have many unmatched files
         settings.on-unmatched = "debug";
 
+        programs.actionlint.enable = true;
+
         programs.keep-sorted.enable = true;
 
         # This uses nixfmt-rfc-style underneath,


### PR DESCRIPTION
I added a lint-action.sh script in .github/workflows a while ago while fixing some warnings. But I haven't run it myself ever since. This needs to be part of CI to make any use of it.

Immediately had a shellcheck error reported and fixed it, too.

## Things done

- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
