### PR TITLE
labels: no CI label for OWNERS changes

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -39,7 +39,7 @@
     - changed-files:
       - any-glob-to-any-file:
         - .github/**/*
-        - ci/**/*
+        - ci/**/*.*
 
 "6.topic: coq":
   - any:


### PR DESCRIPTION
We can use the same "hack" as in labeler-no-sync.yml, because OWNERS is the only file without extension in that directory structure.

This makes it easier to search for CI related PRs via label.

## Things done

- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
