### PR TITLE
librdf_rasqal: remove pcre

### DIFF
--- a/pkgs/development/libraries/librdf/rasqal.nix
+++ b/pkgs/development/libraries/librdf/rasqal.nix
@@ -5,17 +5,17 @@
   librdf_raptor2,
   gmp,
   pkg-config,
-  pcre,
   libxml2,
   perl,
+  testers,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "rasqal";
   version = "0.9.33";
 
   src = fetchurl {
-    url = "http://download.librdf.org/source/rasqal-${version}.tar.gz";
+    url = "http://download.librdf.org/source/rasqal-${finalAttrs.version}.tar.gz";
     sha256 = "0z6rrwn4jsagvarg8d5zf0j352kjgi33py39jqd29gbhcnncj939";
   };
 
@@ -23,17 +23,27 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     gmp
-    pcre
     libxml2
   ];
 
   propagatedBuildInputs = [ librdf_raptor2 ];
+
+  confiugureFlags = [
+    # uses 'regex.h' as a fallback, which is preferrable
+    "--disable-pcre"
+  ];
 
   postInstall = "rm -rvf $out/share/gtk-doc";
 
   nativeCheckInputs = [ perl ];
   doCheck = false; # fails with "No testsuite plan file sparql-query-plan.ttl could be created in build/..."
   doInstallCheck = false; # fails with "rasqal-config does not support (--help|--version)"
+
+  passthru.tests = {
+    # rasqal-config --version just checks the pkg-config module.
+    # That check is broken, checking the pkg-config ourselves is a good replacement.
+    pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+  };
 
   meta = {
     description = "Library that handles Resource Description Framework (RDF)";
@@ -44,5 +54,6 @@ stdenv.mkDerivation rec {
     ];
     maintainers = with lib.maintainers; [ marcweber ];
     platforms = lib.platforms.unix;
+    pkgConfigModules = [ "rasqal" ];
   };
-}
+})


### PR DESCRIPTION
Upstream declared the fallback to `regex.h` sufficient for functionality [1].

Fedora also disabled pcre for rasqal back in 2023 [2].

[1] https://github.com/dajobe/rasqal/issues/12#issuecomment-1713075496
[2] https://src.fedoraproject.org/rpms/rasqal/c/89316c895ce79ce3441686eb45f9a8b3943b0933?branch=rawhide


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
