### PR TITLE
Revert "code-cursor: use chromium's inbuilt x11wayland renderer by default"

### DIFF
--- a/pkgs/by-name/co/code-cursor/package.nix
+++ b/pkgs/by-name/co/code-cursor/package.nix
@@ -163,7 +163,7 @@ stdenvNoCC.mkDerivation {
 
       wrapProgram $out/bin/cursor \
         --add-flags "--update=false" \
-        --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=x11 --enable-features=WaylandWindowDecorations --enable-wayland-ime=true}} --no-update" \
+        --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true}} --no-update" \
         --add-flags ${lib.escapeShellArg commandLineArgs}
     ''}
 


### PR DESCRIPTION
This reverts commit 8ceaa4acec7ac3111b118bc7245a18450d9033af.

This is just bad and not intended behaviour.

`x11` is the default, and setting this to "auto" means Electron will choose the platform to run automatically (potentially switching to use Wayland backend).

if an user does not want to run this app on Wayland they should unset `NIXOS_OZONE_WL` instead.

General distro wide (NixOS) expectation is that `NIXOS_OZONE_WL` will make all electron apps use Wayland backend. and this contradicts that.

If the idea is to force X11, due to upstream not having proper Wayland support, this whole line should be removed instead. https://github.com/NixOS/nixpkgs/pull/401864/files#r2083493979
