### PR TITLE
nixdoc: modernize

### DIFF
--- a/pkgs/by-name/ni/nixdoc/package.nix
+++ b/pkgs/by-name/ni/nixdoc/package.nix
@@ -4,29 +4,29 @@
   rustPlatform,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "nixdoc";
   version = "3.1.0";
 
   src = fetchFromGitHub {
     owner = "nix-community";
     repo = "nixdoc";
-    rev = "v${version}";
-    sha256 = "sha256-7UOjmW8Ef4mEvj7SINaKWh2ZuyNMVEXB82mtuZTQiPA=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-7UOjmW8Ef4mEvj7SINaKWh2ZuyNMVEXB82mtuZTQiPA=";
   };
 
   useFetchCargoVendor = true;
   cargoHash = "sha256-Aw794yhIET8/pnlQiK2xKVbYC/Kd5MExvFTwkv4LLTc=";
 
-  meta = with lib; {
+  meta = {
     description = "Generate documentation for Nix functions";
     mainProgram = "nixdoc";
     homepage = "https://github.com/nix-community/nixdoc";
-    license = [ licenses.gpl3 ];
-    maintainers = with maintainers; [
+    license = [ lib.licenses.gpl3 ];
+    maintainers = with lib.maintainers; [
       infinisil
       hsjobeki
     ];
-    platforms = platforms.unix;
+    platforms = lib.platforms.unix;
   };
-}
+})


### PR DESCRIPTION
I mainly want to trigger a run of the manual-nixpkgs workflow here.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
