### PR TITLE
lux-cli: 0.3.14 -> 0.4.4

### DIFF
--- a/pkgs/by-name/lu/lux-cli/package.nix
+++ b/pkgs/by-name/lu/lux-cli/package.nix
@@ -5,40 +5,25 @@
   lib,
   libgit2,
   libgpg-error,
-  lua51Packages,
-  lua52Packages,
-  lua53Packages,
-  lua54Packages,
+  luaPackages,
   luajit,
   makeWrapper,
   nix,
   openssl,
   pkg-config,
   rustPlatform,
-  symlinkJoin,
   versionCheckHook,
 }:
-let
-  lux-lua-bundle = symlinkJoin {
-    name = "lux-lua-bundle";
-    paths = [
-      lua51Packages.lux-lua
-      lua52Packages.lux-lua
-      lua53Packages.lux-lua
-      lua54Packages.lux-lua
-    ];
-  };
-in
 rustPlatform.buildRustPackage rec {
   pname = "lux-cli";
 
-  version = "0.3.14";
+  version = "0.4.4";
 
-  src = lua52Packages.lux-lua.src;
+  src = luaPackages.lux-lua.src;
 
   buildAndTestSubdir = "lux-cli";
   useFetchCargoVendor = true;
-  cargoHash = lua52Packages.lux-lua.cargoHash;
+  cargoHash = luaPackages.lux-lua.cargoHash;
 
   nativeInstallCheckInputs = [
     versionCheckHook
@@ -78,12 +63,6 @@ rustPlatform.buildRustPackage rec {
   postBuild = ''
     cargo xtask dist-man
     cargo xtask dist-completions
-  '';
-
-  postFixup = ''
-    # Instruct Lux to search for the lux-specific shared libraries in the lux-lua bundle
-    # (temporary solution, until https://github.com/nvim-neorocks/lux/issues/655 is implemented)
-    wrapProgram $out/bin/lx --set LUX_LIB_DIR "${lux-lua-bundle}"
   '';
 
   meta = {


### PR DESCRIPTION
Closes #406049.

With version 0.4.1, lux-cli no longer needs to bundle lux-lua via `LUX_LIB_DIR`.
It can auto-detect it using pkg-config.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
