### PR TITLE
nixos/stage-2-init: support nosuid/nodev mount options for /nix/store

### DIFF
--- a/doc/release-notes/rl-2511.section.md
+++ b/doc/release-notes/rl-2511.section.md
@@ -9,7 +9,7 @@
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
 
-- Create the first release note entry in this section!
+- The `boot.readOnlyNixStore` has been removed. Control over bind mount options on `/nix/store` is now offered by the `boot.nixStoreMountOpts` option.
 
 ## Other Notable Changes {#sec-nixpkgs-release-25.11-notable-changes}
 

--- a/nixos/modules/system/boot/stage-2.nix
+++ b/nixos/modules/system/boot/stage-2.nix
@@ -17,7 +17,8 @@ let
     replacements = {
       shell = "${pkgs.bash}/bin/bash";
       systemConfig = null; # replaced in ../activation/top-level.nix
-      inherit (config.boot) readOnlyNixStore systemdExecutable;
+      inherit (config.boot) systemdExecutable;
+      nixStoreMountOpts = lib.concatStringsSep " " (map lib.escapeShellArg config.boot.nixStoreMountOpts);
       inherit (config.system.nixos) distroName;
       inherit useHostResolvConf;
       inherit (config.system.build) earlyMountScript;
@@ -57,8 +58,25 @@ in
         description = ''
           If set, NixOS will enforce the immutability of the Nix store
           by making {file}`/nix/store` a read-only bind
-          mount.  Nix will automatically make the store writable when
+          mount. Nix will automatically make the store writable when
           needed.
+        '';
+      };
+
+      nixStoreMountOpts = mkOption {
+        type = types.listOf types.nonEmptyStr;
+        default = [
+          "ro"
+          "nodev"
+          "nosuid"
+        ];
+        description = ''
+          Defines the mount options used on a bind mount for the {file}`/nix/store`.
+          This affects the whole system except the nix store daemon, which will undo the bind mount.
+
+          `ro` enforces immutability of the Nix store.
+          The store daemon should already not put device mappers or suid binaries in the store,
+          meaning `nosuid` and `nodev` enforce what should already be the case.
         '';
       };
 
@@ -85,6 +103,9 @@ in
   config = {
 
     system.build.bootStage2 = bootStage2;
-
+    boot.nixStoreMountOpts = [
+      "nodev"
+      "nosuid"
+    ] ++ lib.optional config.boot.readOnlyNixStore "ro";
   };
 }

--- a/nixos/modules/system/boot/stage-2.nix
+++ b/nixos/modules/system/boot/stage-2.nix
@@ -39,6 +39,16 @@ let
 in
 
 {
+  imports = [
+    (lib.mkRemovedOptionModule
+      [
+        "boot"
+        "readOnlyNixStore"
+      ]
+      "Please use the `boot.nixStoreMountOpts' option to define mount options for the Nix store, including 'ro'"
+    )
+  ];
+
   options = {
 
     boot = {
@@ -49,17 +59,6 @@ in
         type = types.lines;
         description = ''
           Shell commands to be executed just before systemd is started.
-        '';
-      };
-
-      readOnlyNixStore = mkOption {
-        type = types.bool;
-        default = true;
-        description = ''
-          If set, NixOS will enforce the immutability of the Nix store
-          by making {file}`/nix/store` a read-only bind
-          mount. Nix will automatically make the store writable when
-          needed.
         '';
       };
 
@@ -103,9 +102,5 @@ in
   config = {
 
     system.build.bootStage2 = bootStage2;
-    boot.nixStoreMountOpts = [
-      "nodev"
-      "nosuid"
-    ] ++ lib.optional config.boot.readOnlyNixStore "ro";
   };
 }

--- a/nixos/tests/boot-stage2.nix
+++ b/nixos/tests/boot-stage2.nix
@@ -10,7 +10,24 @@ import ./make-test-python.nix (
         lib,
         ...
       }:
+      let
+        # Prints the user's UID. Can't just do a shell script
+        # because setuid is ignored for interpreted programs.
+        uid = pkgs.writeCBin "uid" ''
+          #include <unistd.h>
+          #include <stdio.h>
+          int main(void) {
+            printf("%d\n", geteuid());
+            return 0;
+          }
+        '';
+      in
       {
+        users.users.alice = {
+          isNormalUser = true;
+          uid = 1000;
+        };
+
         virtualisation = {
           emptyDiskImages = [ 256 ];
 
@@ -32,6 +49,10 @@ import ./make-test-python.nix (
           };
         };
 
+        environment.systemPackages = [ pkgs.xxd ];
+
+        system.extraDependencies = [ uid ];
+
         boot = {
           initrd = {
             # Format the upper Nix store.
@@ -50,6 +71,19 @@ import ./make-test-python.nix (
               mount -t overlay overlay \
                 -o lowerdir=/mnt-root/nix/store/ro,upperdir=/mnt-root/nix/store/rw,workdir=/mnt-root/nix/store/work \
                 /mnt-root/nix/store
+
+              # Be very rude and try to put suid files and/or devices into the store.
+              evil=/mnt-root/nix/store/evil
+              mkdir -p $evil/bin $evil/dev
+
+              echo "making evil suid..." >&2
+              cp /mnt-root/${builtins.unsafeDiscardStringContext "${uid}"}/bin/uid $evil/bin/suid
+              chmod 4755 $evil/bin/suid
+              [ -u $evil/bin/suid ] || exit 1
+
+              echo "making evil devzero..." >&2
+              mknod -m 666 $evil/dev/zero c 1 5
+              [ -c $evil/dev/zero ] || exit 1
             '';
 
             kernelModules = [ "overlay" ];
@@ -70,6 +104,28 @@ import ./make-test-python.nix (
       for opt in ["ro", "nosuid", "nodev"]:
         with subtest(f"testing store mount option: {opt}"):
           machine.succeed(f'[[ "$(findmnt --direction backward --first-only --noheadings --output OPTIONS /nix/store)" =~ (^|,){opt}(,|$) ]]')
+
+      # should still be suid
+      machine.succeed('[ -u /nix/store/evil/bin/suid ]')
+      # runs as alice and is not root
+      machine.succeed('[ "$(sudo -u alice /nix/store/evil/bin/suid)" == 1000 ]')
+      # can be remounted and runs as root
+      machine.succeed('mount -o remount,suid,bind /nix/store && mount >&2')
+      machine.succeed('[ "$(sudo -u alice /nix/store/evil/bin/suid)" == 0 ]')
+      # double checking we can undo it
+      machine.succeed('mount -o remount,nosuid,bind /nix/store && mount >&2')
+      machine.succeed('[ "$(sudo -u alice /nix/store/evil/bin/suid)" == 1000 ]')
+
+      # should still be a character device
+      machine.succeed('[ -c /nix/store/evil/dev/zero ]')
+      # should not work
+      machine.fail('[ "$(dd if=/nix/store/evil/dev/zero bs=1 count=1 | xxd -pl1)" == 00 ]')
+      # can be remounted and works
+      machine.succeed('mount -o remount,dev,bind /nix/store && mount >&2')
+      machine.succeed('[ "$(dd if=/nix/store/evil/dev/zero bs=1 count=1 | xxd -pl1)" == 00 ]')
+      # double checking we can undo it
+      machine.succeed('mount -o remount,nodev,bind /nix/store && mount >&2')
+      machine.fail('[ "$(dd if=/nix/store/evil/dev/zero bs=1 count=1 | xxd -pl1)" == 00 ]')
     '';
 
     meta.maintainers = with pkgs.lib.maintainers; [ numinit ];

--- a/nixos/tests/boot-stage2.nix
+++ b/nixos/tests/boot-stage2.nix
@@ -66,6 +66,10 @@ import ./make-test-python.nix (
       machine.wait_for_unit("multi-user.target")
       machine.succeed("test /etc/post-boot-ran")
       machine.fail("touch /nix/store/should-not-work");
+
+      for opt in ["ro", "nosuid", "nodev"]:
+        with subtest(f"testing store mount option: {opt}"):
+          machine.succeed(f'[[ "$(findmnt --direction backward --first-only --noheadings --output OPTIONS /nix/store)" =~ (^|,){opt}(,|$) ]]')
     '';
 
     meta.maintainers = with pkgs.lib.maintainers; [ numinit ];


### PR DESCRIPTION
This is part of security-in-depth.
No suid binaries or devices should ever be in the nix store. If they are, something is seriously wrong.
Disallowing this from a file system level should be non-breaking.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
