### PR TITLE
cudaPackages: multiplex builder always provides attributes

### DIFF
--- a/pkgs/development/cuda-modules/cudnn/shims.nix
+++ b/pkgs/development/cuda-modules/cudnn/shims.nix
@@ -1,13 +1,12 @@
 # Shims to mimic the shape of ../modules/generic/manifests/{feature,redistrib}/release.nix
 {
-  lib,
   package,
   # redistArch :: String
   # String is "unsupported" if the given architecture is unsupported.
   redistArch,
 }:
 {
-  featureRelease = lib.optionalAttrs (redistArch != "unsupported") {
+  featureRelease = {
     inherit (package) minCudaVersion maxCudaVersion;
     ${redistArch}.outputs = {
       lib = true;

--- a/pkgs/development/cuda-modules/tensorrt/shims.nix
+++ b/pkgs/development/cuda-modules/tensorrt/shims.nix
@@ -1,13 +1,12 @@
 # Shims to mimic the shape of ../modules/generic/manifests/{feature,redistrib}/release.nix
 {
-  lib,
   package,
   # redistArch :: String
   # String is `"unsupported"` if the given architecture is unsupported.
   redistArch,
 }:
 {
-  featureRelease = lib.optionalAttrs (redistArch != "unsupported") {
+  featureRelease = {
     inherit (package) cudnnVersion minCudaVersion maxCudaVersion;
     ${redistArch}.outputs = {
       bin = true;


### PR DESCRIPTION
#405707 broke evaluation of at least one attribute on Darwin (`python3Packages.jax-cuda12-pjrt`) because the multiplex builder would only add attributes for packages on supported platforms and access to `cudaPackages` was not guarded by platform checks.

As a quick fix, this PR changes the behavior of the multiplex builder so that it will add attributes for packages supporting the current CUDA version, even if they are unsupported on the current platform.

Tested with

```console
nix-build ci -A eval.full   --max-jobs 24   --cores 16   --arg chunkSize 10000   --arg evalSystems '["x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin"]'
```

EDIT: 

The above didn't error on `master`, so I don't know that it's a good indication that this fixes the eval error.

However, I did verify manually:

```console
[connorbaker@nixos-desktop:~/nixpkgs]$ git switch master
Switched to branch 'master'
Your branch is up to date with 'origin/master'.

[connorbaker@nixos-desktop:~/nixpkgs]$ nix eval --system aarch64-darwin .#python312Packages.jax-cuda12-pjrt
«error: attribute 'cudnn' missing»

[connorbaker@nixos-desktop:~/nixpkgs]$ git switch fix/cuda-darwin-eval 
Switched to branch 'fix/cuda-darwin-eval'

[connorbaker@nixos-desktop:~/nixpkgs]$ nix eval --system aarch64-darwin .#python312Packages.jax-cuda12-pjrt
«error: Package ‘python3.12-jax-cuda12-pjrt-0.6.0’ in /nix/store/1jnd81lxfm8rqk1zy25syqhpnpy2bklm-source/pkgs/development/python-modules/jax-cuda12-pjrt/default.nix:96 is not available on the requested hostPlatform:
  hostPlatform.config = "arm64-apple-darwin"
  package.meta.platforms = [
    "aarch64-linux"
    "armv5tel-linux"
    "armv6l-linux"
    "armv7a-linux"
    "armv7l-linux"
    "i686-linux"
    "loongarch64-linux"
    "m68k-linux"
    "microblaze-linux"
    "microblazeel-linux"
    "mips-linux"
    "mips64-linux"
    "mips64el-linux"
    "mipsel-linux"
    "powerpc64-linux"
    "powerpc64le-linux"
    "riscv32-linux"
    "riscv64-linux"
    "s390-linux"
    "s390x-linux"
    "x86_64-linux"
  ]
  package.meta.badPlatforms = [ ]
, refusing to evaluate.

a) To temporarily allow packages that are unsupported for this system, you can use an environment variable
   for a single invocation of the nix tools.

     $ export NIXPKGS_ALLOW_UNSUPPORTED_SYSTEM=1
     
   Note: When using `nix shell`, `nix build`, `nix develop`, etc with a flake,
         then pass `--impure` in order to allow use of environment variables.
    
b) For `nixos-rebuild` you can set
  { nixpkgs.config.allowUnsupportedSystem = true; }
in configuration.nix to override this.

c) For `nix-env`, `nix-build`, `nix-shell` or any other Nix command you can add
  { allowUnsupportedSystem = true; }
to ~/.config/nixpkgs/config.nix.
»
```


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
