### PR TITLE
swaymsg_workspace: init at 0.1.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3466,6 +3466,12 @@
     githubId = 20448408;
     keys = [ { fingerprint = "D446 E58D 87A0 31C7 EC15  88D7 B461 2924 45C6 E696"; } ];
   };
+  berezowski = {
+    email = "nix@berezowski.de";
+    github = "berezowski";
+    githubId = 2563136;
+    name = "Hubert Berezowski";
+  };
   bergey = {
     email = "bergey@teallabs.org";
     github = "bergey";

--- a/pkgs/by-name/sw/swaymsg_workspace/package.nix
+++ b/pkgs/by-name/sw/swaymsg_workspace/package.nix
@@ -1,0 +1,34 @@
+{
+  lib,
+  fetchFromGitHub,
+  rustPlatform,
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "swaymsg_workspace";
+  version = "0.1.1";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "berezowski";
+    repo = "swaymsg_workspace";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-yP8YRcedK4O0tJBeWUqAlsGWwrWWY5QjIYHk+aD/rVc=";
+  };
+
+  cargoHash = "sha256-7UiRJ5nPHK2z00EmyIvmj39zYN1I2VVbpcE0R0j3oIY=";
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Manage Sway Workspaces Utility";
+    homepage = "https://github.com/berezowski/swaymsg_workspace";
+    changelog = "https://github.com/berezowski/swaymsg_workspace/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.gpl3Plus;
+    mainProgram = "swaymsg_workspace";
+    maintainers = with lib.maintainers; [ berezowski ];
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
[swaymsg_workspace](https://github.com/berezowski/swaymsg_workspace) is a tool that improves workspace management in [Sway](https://swaywm.org/) by making workspace switching, reordering, and renaming easier—especially when using multiple monitors.

it depends on the [sway window manager nix package](https://search.nixos.org/packages?channel=24.11&show=sway&from=0&size=50&sort=relevance&type=packages&query=sway) being installed.

Integration Tests are run as part of the package bulid. So: no manual testing of ./result/bin is necessary.
If you run ```results/swaymsg_workspace-x86_64-linux/bin/swaymsg_workspace swap_with_next``` in your terminal and the current workspace swaps its position with the next one, the rest should work as well.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
