### PR TITLE
Link to breaking changes Discourse thread in PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -29,6 +29,7 @@ For new packages please briefly describe the package or provide a link to its ho
   - [ ] (Package updates) Added a release notes entry if the change is major or breaking
   - [ ] (Module updates) Added a release notes entry if the change is significant
   - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
+- [ ] Posted to [Breaking Changes Announcement thread](https://discourse.nixos.org/t/17574) if the change might cause breakage
 - [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
 
 <!--


### PR DESCRIPTION
As I mentioned in [the Discourse thread about the recent breaking change to PAM configuration](https://discourse.nixos.org/t/re-recent-breaking-changes-lockscreen-pam/63719/28?u=keysmashes), I think it would be a good idea to include a link to [the breaking changes announcement thread on Discourse](https://discourse.nixos.org/t/17574) in the PR template checklist.

That thread seems extremely valuable to me, since (unlike the release notes here on GitHub) you can subscribe to it and be notified about breaking changes automatically. However, it's not particularly widely-used: it saw 4 posts so far this year (which we are 35% of the way through), 32 posts last year, and 24 posts in 2023, which is pretty clearly far behind the number of breaking changes included in the release notes (at time of writing, 114 bulletpoints under "Backward Incompatibilities" in the [Nixpkgs 25.05 release notes](https://github.com/NixOS/nixpkgs/blob/c5427604c76fa5a4bf33f113fe54e4a3f64e1e8d/doc/release-notes/rl-2505.section.md), and 63 in the [NixOS 25.05 release notes](https://github.com/NixOS/nixpkgs/blob/c5427604c76fa5a4bf33f113fe54e4a3f64e1e8d/nixos/doc/manual/release-notes/rl-2505.section.md)). This limits its utility.

Perhaps the thread will be uselessly noisy if every breaking change is posted there. On the other hand, perhaps it will become more useful with a more comprehensive view of breaking changes. Perhaps it will reveal that some things marked as breaking changes are in fact not: for example, "GIMP 3.0 available as `gimp3`" doesn't strike me as breaking. Maybe we will decide that some things, like "`xdragon` package has been renamed to `dragon-drop`", may not need posting (since `warnOnInstantiate` or `throw` in `pkgs/top-level/aliases.nix` will notify the affected users directly). It's quite hard to suggest strict guidelines up-front; I think it will be quite useful to just try nudging people towards posting there and watching what happens. We can always remove the link if it makes things worse.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
