### PR TITLE
linuxPackages.rtl8821au: {unstable-2024-03-16 -> unstable-2025-04-08, fix meta.homepage}

### DIFF
--- a/pkgs/os-specific/linux/rtl8821au/default.nix
+++ b/pkgs/os-specific/linux/rtl8821au/default.nix
@@ -62,7 +62,7 @@ stdenv.mkDerivation {
 
   meta = with lib; {
     description = "rtl8821AU and rtl8812AU chipset driver with firmware";
-    homepage = "https://github.com/morrownr/8821au";
+    homepage = "https://github.com/morrownr/8821au-20210708";
     license = licenses.gpl2Only;
     platforms = lib.platforms.linux;
     maintainers = with maintainers; [ plchldr ];

--- a/pkgs/os-specific/linux/rtl8821au/default.nix
+++ b/pkgs/os-specific/linux/rtl8821au/default.nix
@@ -9,13 +9,13 @@
 
 stdenv.mkDerivation {
   pname = "rtl8821au";
-  version = "${kernel.version}-unstable-2024-03-16";
+  version = "${kernel.version}-unstable-2025-04-08";
 
   src = fetchFromGitHub {
     owner = "morrownr";
     repo = "8821au-20210708";
-    rev = "168ac48174067e17ffb9f8b15ab802f37447dacc";
-    hash = "sha256-eB9RCoU5jg5fgZkfcef9fsQ6tyD8gTPD+wYcR6PbWNw=";
+    rev = "b90b76d30709fb82705cbc2e295a7dde9372a0a8";
+    hash = "sha256-rS7UXey2x00Dn9E2l5nRiVElYNKMRjIYDa+qDCGt5ac=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
Changelog: https://github.com/morrownr/8821au-20210708/compare/168ac48174067e17ffb9f8b15ab802f37447dacc...b90b76d30709fb82705cbc2e295a7dde9372a0a8
ZHF: #403336
Hydra: https://hydra.nixos.org/build/296928763

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
