### PR TITLE
nixos/dotool: init module

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -197,6 +197,7 @@
   ./programs/digitalbitbox/default.nix
   ./programs/direnv.nix
   ./programs/dmrconfig.nix
+  ./programs/dotool.nix
   ./programs/droidcam.nix
   ./programs/dublin-traceroute.nix
   ./programs/ecryptfs.nix

--- a/nixos/modules/programs/dotool.nix
+++ b/nixos/modules/programs/dotool.nix
@@ -1,0 +1,33 @@
+{
+  lib,
+  pkgs,
+  config,
+  ...
+}:
+
+let
+  cfg = config.programs.dotool;
+in
+{
+  meta.maintainers = with lib.maintainers; [ dtomvan ];
+
+  options.programs.dotool = {
+    enable = lib.mkEnableOption "Simulate keyboard/mouse with dotool";
+    allowedUsers = lib.mkOption {
+      description = "List of users which are allowed to use dotool without root permissions";
+      type = with lib.types; listOf (passwdEntry str);
+      default = [ ];
+      example = [ "alice" ];
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    hardware.uinput.enable = true;
+    environment.systemPackages = [ pkgs.dotool ];
+    services.udev.packages = [ pkgs.dotool-udev-rules ];
+    # in theory the dotool-udev-rules allows any user in input to use rootless
+    # dotool, but in practice is the /dev/uinput gated behind the uinput group
+    users.groups.input.members = cfg.allowedUsers;
+    users.groups.uinput.members = cfg.allowedUsers;
+  };
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -456,6 +456,7 @@ in
   dokuwiki = runTest ./dokuwiki.nix;
   dolibarr = runTest ./dolibarr.nix;
   domination = runTest ./domination.nix;
+  dotool = runTest ./dotool.nix;
   dovecot = runTest ./dovecot.nix;
   drawterm = discoverTests (import ./drawterm.nix);
   draupnir = runTest ./matrix/draupnir.nix;

--- a/nixos/tests/dotool.nix
+++ b/nixos/tests/dotool.nix
@@ -1,28 +1,63 @@
-{ lib, ... }:
-{
-  name = "dotool";
-  meta.maintainers = with lib.maintainers; [ dtomvan ];
-
-  enableOCR = true;
-
-  nodes.machine = {
+{ lib, pkgs, ... }:
+let
+  mkMachine = enable: {
     imports = [ ./common/user-account.nix ];
 
     programs.dotool = {
-      enable = true;
+      # On the red machine, make sure that the default is false
+      enable = lib.mkIf enable true;
       allowedUsers = [ "alice" ];
     };
 
     services.getty.autologinUser = "alice";
   };
+in
+{
+  name = "dotool";
+  meta.maintainers = with lib.maintainers; [ dtomvan ];
+
+  # The idea is to test wether or not the dotool module actually grants extra
+  # permissions or not. Just `nix-shell -p dotool` should not work without
+  # root because of security concerns.
+  nodes = {
+    red = mkMachine false // {
+      # install dotool without module
+      environment.systemPackages = with pkgs; [ dotool ];
+    };
+    green = mkMachine true;
+  };
+
+  enableOCR = true;
 
   testScript = ''
     start_all()
 
-    machine.wait_for_unit("multi-user.target")
-    machine.wait_for_text("alice")
-    machine.succeed("echo 'type echo \"Hello world\" > /tmp/output' | sudo -u alice -i dotool")
-    machine.succeed("echo 'key enter' | sudo -u alice -i dotool")
-    machine.wait_until_succeeds("grep -F 'Hello world' /tmp/output")
+    output = "/tmp/output"
+    message = "Hello world"
+
+    def begin(machine):
+      machine.wait_for_unit("multi-user.target")
+      machine.wait_for_text("alice")
+      machine.fail(f"stat {output}")
+
+    def find_message(machine):
+      machine.wait_until_succeeds(f"grep -F '{message}' {output}")
+
+    def run_dotool(account):
+      return f"echo $'type echo \"{message}\" > {output}\nkey enter' | sudo -u {account} -i dotool"
+
+    begin(green)
+    with subtest("dotool works with the module enabled"):
+      green.succeed(run_dotool("alice"))
+      find_message(green)
+
+    begin(red)
+    with subtest("dotool fails with the module disabled"):
+      red.fail(run_dotool("alice"))
+      red.fail(f"stat {output}")
+
+    with subtest("root can always use dotool"):
+      red.succeed(run_dotool("root"))
+      find_message(red)
   '';
 }

--- a/nixos/tests/dotool.nix
+++ b/nixos/tests/dotool.nix
@@ -1,0 +1,28 @@
+{ lib, ... }:
+{
+  name = "dotool";
+  meta.maintainers = with lib.maintainers; [ dtomvan ];
+
+  enableOCR = true;
+
+  nodes.machine = {
+    imports = [ ./common/user-account.nix ];
+
+    programs.dotool = {
+      enable = true;
+      allowedUsers = [ "alice" ];
+    };
+
+    services.getty.autologinUser = "alice";
+  };
+
+  testScript = ''
+    start_all()
+
+    machine.wait_for_unit("multi-user.target")
+    machine.wait_for_text("alice")
+    machine.succeed("echo 'type echo \"Hello world\" > /tmp/output' | sudo -u alice -i dotool")
+    machine.succeed("echo 'key enter' | sudo -u alice -i dotool")
+    machine.wait_until_succeeds("grep -F 'Hello world' /tmp/output")
+  '';
+}

--- a/pkgs/by-name/do/dotool-udev-rules/package.nix
+++ b/pkgs/by-name/do/dotool-udev-rules/package.nix
@@ -1,0 +1,26 @@
+{
+  stdenv,
+  dotool,
+}:
+
+## Usage
+# In NixOS, set programs.dotool.enable = true;
+
+stdenv.mkDerivation {
+  pname = "dotool-udev-rules";
+  inherit (dotool) version src;
+
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    install -D 80-dotool.rules $out/lib/udev/rules.d/80-dotool.rules
+
+    runHook postInstall
+  '';
+
+  meta = dotool.meta // {
+    description = "UDev rules for dotool";
+  };
+}

--- a/pkgs/by-name/do/dotool-udev-rules/package.nix
+++ b/pkgs/by-name/do/dotool-udev-rules/package.nix
@@ -4,7 +4,11 @@
 }:
 
 ## Usage
-# In NixOS, set programs.dotool.enable = true;
+# In NixOS, set:
+# programs.dotool = {
+#   enable = true;
+#   allowedUsers = [ "alice" ];
+# };
 
 stdenv.mkDerivation {
   pname = "dotool-udev-rules";

--- a/pkgs/by-name/do/dotool-udev-rules/package.nix
+++ b/pkgs/by-name/do/dotool-udev-rules/package.nix
@@ -1,5 +1,6 @@
 {
   stdenv,
+  nixosTests,
   dotool,
 }:
 
@@ -23,6 +24,10 @@ stdenv.mkDerivation {
 
     runHook postInstall
   '';
+
+  passthru.tests = {
+    inherit (nixosTests) dotool;
+  };
 
   meta = dotool.meta // {
     description = "UDev rules for dotool";


### PR DESCRIPTION
- **dotool-udev-rules: init at 1.5**
- **nixos/dotool: init module**
- **nixos/dotool: add test**

Fixes #358258

This PR adds the ability to use `dotool` without root under NixOS:

```nix
programs.dotool = {
  enable = true;
  allowedUsers = [ "alice" ];
};
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
