### PR TITLE
workflows/eval: remove attrs step

### DIFF
--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -19,37 +19,10 @@ jobs:
   get-merge-commit:
     uses: ./.github/workflows/get-merge-commit.yml
 
-  attrs:
-    name: Attributes
-    runs-on: ubuntu-24.04-arm
-    needs: get-merge-commit
-    if: needs.get-merge-commit.outputs.mergedSha
-    steps:
-      - name: Check out the PR at the test merge commit
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          ref: ${{ needs.get-merge-commit.outputs.mergedSha }}
-          path: nixpkgs
-
-      - name: Install Nix
-        uses: cachix/install-nix-action@526118121621777ccd86f79b04685a9319637641 # v31
-        with:
-          extra_nix_config: sandbox = true
-
-      - name: Evaluate the list of all attributes
-        run: |
-          nix-build nixpkgs/ci -A eval.attrpathsSuperset
-
-      - name: Upload the list of all attributes
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        with:
-          name: paths
-          path: result/*
-
   outpaths:
     name: Outpaths
     runs-on: ubuntu-24.04-arm
-    needs: [ attrs, get-merge-commit ]
+    needs: [ get-merge-commit ]
     strategy:
       fail-fast: false
       matrix:
@@ -61,12 +34,6 @@ jobs:
           sudo chmod 600 /swap
           sudo mkswap /swap
           sudo swapon /swap
-
-      - name: Download the list of all attributes
-        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
-        with:
-          name: paths
-          path: paths
 
       - name: Check out the PR at the test merge commit
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -85,7 +52,6 @@ jobs:
         run: |
           nix-build nixpkgs/ci -A eval.singleSystem \
             --argstr evalSystem "$MATRIX_SYSTEM" \
-            --arg attrpathFile ./paths/paths.json \
             --arg chunkSize 10000
           # If it uses too much memory, slightly decrease chunkSize
 
@@ -98,7 +64,7 @@ jobs:
   process:
     name: Process
     runs-on: ubuntu-24.04-arm
-    needs: [ outpaths, attrs, get-merge-commit ]
+    needs: [ outpaths, get-merge-commit ]
     outputs:
       targetRunId: ${{ steps.targetRunId.outputs.targetRunId }}
     steps:
@@ -200,7 +166,7 @@ jobs:
   tag:
     name: Tag
     runs-on: ubuntu-24.04-arm
-    needs: [ attrs, process ]
+    needs: [ process ]
     if: needs.process.outputs.targetRunId
     permissions:
       pull-requests: write

--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -26,7 +26,6 @@ jobs:
     if: needs.get-merge-commit.outputs.mergedSha
     outputs:
       targetSha: ${{ steps.targetSha.outputs.targetSha }}
-      systems: ${{ steps.systems.outputs.systems }}
     steps:
       - name: Check out the PR at the test merge commit
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -47,11 +46,9 @@ jobs:
         with:
           extra_nix_config: sandbox = true
 
-      - name: Evaluate the list of all attributes and get the systems matrix
-        id: systems
+      - name: Evaluate the list of all attributes
         run: |
           nix-build nixpkgs/ci -A eval.attrpathsSuperset
-          echo "systems=$(<result/systems.json)" >> "$GITHUB_OUTPUT"
 
       - name: Upload the list of all attributes
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
@@ -66,7 +63,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        system: ${{ fromJSON(needs.attrs.outputs.systems) }}
+        system: ${{ fromJSON(needs.get-merge-commit.outputs.systems) }}
     steps:
       - name: Enable swap
         run: |

--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -24,22 +24,12 @@ jobs:
     runs-on: ubuntu-24.04-arm
     needs: get-merge-commit
     if: needs.get-merge-commit.outputs.mergedSha
-    outputs:
-      targetSha: ${{ steps.targetSha.outputs.targetSha }}
     steps:
       - name: Check out the PR at the test merge commit
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: ${{ needs.get-merge-commit.outputs.mergedSha }}
-          fetch-depth: 2
           path: nixpkgs
-
-      - name: Determine target commit
-        if: github.event_name == 'pull_request_target'
-        id: targetSha
-        run: |
-          targetSha=$(git -C nixpkgs rev-parse HEAD^1)
-          echo "targetSha=$targetSha" >> "$GITHUB_OUTPUT"
 
       - name: Install Nix
         uses: cachix/install-nix-action@526118121621777ccd86f79b04685a9319637641 # v31
@@ -143,7 +133,7 @@ jobs:
           path: prResult/*
 
       - name: Get target run id
-        if: needs.attrs.outputs.targetSha
+        if: needs.get-merge-commit.outputs.targetSha
         id: targetRunId
         run: |
           # Get the latest eval.yml workflow run for the PR's target commit
@@ -172,7 +162,7 @@ jobs:
           echo "targetRunId=$runId" >> "$GITHUB_OUTPUT"
         env:
           REPOSITORY: ${{ github.repository }}
-          TARGET_SHA: ${{ needs.attrs.outputs.targetSha }}
+          TARGET_SHA: ${{ needs.get-merge-commit.outputs.targetSha }}
           GH_TOKEN: ${{ github.token }}
 
       - uses: actions/download-artifact@v4
@@ -186,8 +176,8 @@ jobs:
       - name: Compare against the target branch
         if: steps.targetRunId.outputs.targetRunId
         run: |
-          git -C nixpkgs worktree add ../target ${{ needs.attrs.outputs.targetSha }}
-          git -C nixpkgs diff --name-only ${{ needs.attrs.outputs.targetSha }} \
+          git -C nixpkgs worktree add ../target ${{ needs.get-merge-commit.outputs.targetSha }}
+          git -C nixpkgs diff --name-only ${{ needs.get-merge-commit.outputs.targetSha }} \
             | jq --raw-input --slurp 'split("\n")[:-1]' > touched-files.json
 
           # Use the target branch to get accurate maintainer info
@@ -241,7 +231,7 @@ jobs:
       - name: Check out Nixpkgs at the base commit
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          ref: ${{ needs.attrs.outputs.targetSha }}
+          ref: ${{ needs.get-merge-commit.outputs.targetSha }}
           path: base
           sparse-checkout: ci
 

--- a/.github/workflows/get-merge-commit.yml
+++ b/.github/workflows/get-merge-commit.yml
@@ -6,6 +6,9 @@ on:
       mergedSha:
         description: "The merge commit SHA"
         value: ${{ jobs.resolve-merge-commit.outputs.mergedSha }}
+      targetSha:
+        description: "The target commit SHA"
+        value: ${{ jobs.resolve-merge-commit.outputs.targetSha }}
       systems:
         description: "The supported systems"
         value: ${{ jobs.resolve-merge-commit.outputs.systems }}
@@ -17,6 +20,7 @@ jobs:
     runs-on: ubuntu-24.04-arm
     outputs:
       mergedSha: ${{ steps.merged.outputs.mergedSha }}
+      targetSha: ${{ steps.merged.outputs.targetSha }}
       systems: ${{ steps.systems.outputs.systems }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -35,9 +39,9 @@ jobs:
               echo "mergedSha=${{ github.sha }}" >> "$GITHUB_OUTPUT"
               ;;
             pull_request_target)
-              if mergedSha=$(base/ci/get-merge-commit.sh ${{ github.repository }} ${{ github.event.number }}); then
-                echo "Checking the merge commit $mergedSha"
-                echo "mergedSha=$mergedSha" >> "$GITHUB_OUTPUT"
+              if commits=$(base/ci/get-merge-commit.sh ${{ github.repository }} ${{ github.event.number }}); then
+                echo "Checking the commits:\n$commits"
+                echo "$commits" >> "$GITHUB_OUTPUT"
               else
                 # Skipping so that no notifications are sent
                 echo "Skipping the rest..."

--- a/.github/workflows/get-merge-commit.yml
+++ b/.github/workflows/get-merge-commit.yml
@@ -6,6 +6,9 @@ on:
       mergedSha:
         description: "The merge commit SHA"
         value: ${{ jobs.resolve-merge-commit.outputs.mergedSha }}
+      systems:
+        description: "The supported systems"
+        value: ${{ jobs.resolve-merge-commit.outputs.systems }}
 
 permissions: {}
 
@@ -14,6 +17,7 @@ jobs:
     runs-on: ubuntu-24.04-arm
     outputs:
       mergedSha: ${{ steps.merged.outputs.mergedSha }}
+      systems: ${{ steps.systems.outputs.systems }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
@@ -40,4 +44,8 @@ jobs:
               fi
               ;;
           esac
-          rm -rf base
+
+      - name: Load supported systems
+        id: systems
+        run: |
+          echo "systems=$(jq -c <base/ci/supportedSystems.json)" >> "$GITHUB_OUTPUT"

--- a/ci/README.md
+++ b/ci/README.md
@@ -44,14 +44,14 @@ Why not just build the tooling right from the PRs Nixpkgs version?
 ## `get-merge-commit.sh GITHUB_REPO PR_NUMBER`
 
 Check whether a PR is mergeable and return the test merge commit as
-[computed by GitHub](https://docs.github.com/en/rest/guides/using-the-rest-api-to-interact-with-your-git-database?apiVersion=2022-11-28#checking-mergeability-of-pull-requests).
+[computed by GitHub](https://docs.github.com/en/rest/guides/using-the-rest-api-to-interact-with-your-git-database?apiVersion=2022-11-28#checking-mergeability-of-pull-requests) and its parent.
 
 Arguments:
 - `GITHUB_REPO`: The repository of the PR, e.g. `NixOS/nixpkgs`
 - `PR_NUMBER`: The PR number, e.g. `1234`
 
 Exit codes:
-- 0: The PR can be merged, the test merge commit hash is returned on stdout
+- 0: The PR can be merged, the hashes of the test merge commit and the target commit are returned on stdout
 - 1: The PR cannot be merged because it's not open anymore
 - 2: The PR cannot be merged because it has a merge conflict
 - 3: The merge commit isn't being computed, GitHub is likely having internal issues, unknown if the PR is mergeable

--- a/ci/eval/README.md
+++ b/ci/eval/README.md
@@ -11,7 +11,7 @@ nix-build ci -A eval.full \
   --arg evalSystems '["x86_64-linux" "aarch64-darwin"]'
 ```
 
-- `--max-jobs`: The maximum number of derivations to run at the same time. Only each [supported system](../supportedSystems.nix) gets a separate derivation, so it doesn't make sense to set this higher than that number.
+- `--max-jobs`: The maximum number of derivations to run at the same time. Only each [supported system](../supportedSystems.json) gets a separate derivation, so it doesn't make sense to set this higher than that number.
 - `--cores`: The number of cores to use for each job. Recommended to set this to the amount of cores on your system divided by `--max-jobs`.
 - `chunkSize`: The number of attributes that are evaluated simultaneously on a single core. Lowering this decreases memory usage at the cost of increased evaluation time. If this is too high, there won't be enough chunks to process them in parallel, and will also increase evaluation time.
 - `evalSystems`: The set of systems for which `nixpkgs` should be evaluated. Defaults to the four official platforms (`x86_64-linux`, `aarch64-linux`, `x86_64-darwin` and `aarch64-darwin`).

--- a/ci/eval/default.nix
+++ b/ci/eval/default.nix
@@ -26,14 +26,14 @@ let
           "nixos"
           "pkgs"
           ".version"
-          "ci/supportedSystems.nix"
+          "ci/supportedSystems.json"
         ]
       );
     };
 
   nix = nixVersions.nix_2_24;
 
-  supportedSystems = import ../supportedSystems.nix;
+  supportedSystems = builtins.fromJSON (builtins.readFile ../supportedSystems.json);
 
   attrpathsSuperset =
     runCommand "attrpaths-superset.json"
@@ -43,8 +43,6 @@ let
           nix
           time
         ];
-        env.supportedSystems = builtins.toJSON supportedSystems;
-        passAsFile = [ "supportedSystems" ];
       }
       ''
         export NIX_STATE_DIR=$(mktemp -d)
@@ -58,7 +56,6 @@ let
             --option restrict-eval true \
             --option allow-import-from-derivation false \
             --arg enableWarnings false > $out/paths.json
-        mv "$supportedSystemsPath" $out/systems.json
       '';
 
   singleSystem =

--- a/ci/eval/default.nix
+++ b/ci/eval/default.nix
@@ -65,7 +65,7 @@ let
       # because `--argstr system` would only be passed to the ci/default.nix file!
       evalSystem,
       # The path to the `paths.json` file from `attrpathsSuperset`
-      attrpathFile,
+      attrpathFile ? "${attrpathsSuperset}/paths.json",
       # The number of attributes per chunk, see ./README.md for more info.
       chunkSize,
       checkMeta ? true,
@@ -286,7 +286,6 @@ let
           name = evalSystem;
           path = singleSystem {
             inherit quickTest evalSystem chunkSize;
-            attrpathFile = attrpathsSuperset + "/paths.json";
           };
         }) evalSystems
       );

--- a/ci/get-merge-commit.sh
+++ b/ci/get-merge-commit.sh
@@ -55,7 +55,10 @@ done
 
 if [[ "$mergeable" == "true" ]]; then
     log "The PR can be merged"
-    jq -r .merge_commit_sha <<< "$prInfo"
+    mergedSha="$(jq -r .merge_commit_sha <<< "$prInfo")"
+    echo "mergedSha=$mergedSha"
+    targetSha="$(gh api "/repos/$repo/commits/$mergedSha" --jq '.parents[0].sha')"
+    echo "targetSha=$targetSha"
 else
     log "The PR has a merge conflict"
     exit 2

--- a/ci/supportedSystems.json
+++ b/ci/supportedSystems.json
@@ -1,0 +1,6 @@
+[
+  "aarch64-linux",
+  "aarch64-darwin",
+  "x86_64-linux",
+  "x86_64-darwin"
+]

--- a/ci/supportedSystems.nix
+++ b/ci/supportedSystems.nix
@@ -1,6 +1,0 @@
-[
-  "aarch64-linux"
-  "aarch64-darwin"
-  "x86_64-linux"
-  "x86_64-darwin"
-]

--- a/pkgs/top-level/release-haskell.nix
+++ b/pkgs/top-level/release-haskell.nix
@@ -10,7 +10,7 @@
   $ hydra-eval-jobs -I . pkgs/top-level/release-haskell.nix
 */
 {
-  supportedSystems ? import ../../ci/supportedSystems.nix,
+  supportedSystems ? builtins.fromJSON (builtins.readFile ../../ci/supportedSystems.json),
 }:
 
 let

--- a/pkgs/top-level/release-outpaths.nix
+++ b/pkgs/top-level/release-outpaths.nix
@@ -13,7 +13,7 @@
   attrNamesOnly ? false,
 
   # Set this to `null` to build for builtins.currentSystem only
-  systems ? import ../../ci/supportedSystems.nix,
+  systems ? builtins.fromJSON (builtins.readFile ../../ci/supportedSystems.json),
 }:
 let
   lib = import (path + "/lib");

--- a/pkgs/top-level/release.nix
+++ b/pkgs/top-level/release.nix
@@ -19,7 +19,7 @@
   system ? builtins.currentSystem,
   officialRelease ? false,
   # The platform doubles for which we build Nixpkgs.
-  supportedSystems ? import ../../ci/supportedSystems.nix,
+  supportedSystems ? builtins.fromJSON (builtins.readFile ../../ci/supportedSystems.json),
   # The platform triples for which we build bootstrap tools.
   bootstrapConfigs ? [
     "aarch64-apple-darwin"


### PR DESCRIPTION
Previously, the attrs step consisted of:
- 7s queue time
- 1m 15s run time

Only 25s of this were spent preparing the attr paths. A bit more than a minute was just spent for queuing, checking out the repo, downloading nix, downloading dependencies, uploading the artifacts - and then downloading them again in the next step. All of that can be avoided if we collect the attrs as part of the outpaths job.

By running the attrs step as part of each outpaths step the attrs will be collected 4x, but:
- We save a minute for each eval run to complete.
- We save a job, giving us more free runners and *possibly* less queue times for other jobs in the repo.
- We reduce complexity in the workflow file.

## Things done

- [x] Tested in my fork: https://github.com/wolfgangwalther/nixpkgs/actions/runs/14959442805?pr=641
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
