### PR TITLE
mpd: 0.24.2 -> 0.24.3

### DIFF
--- a/pkgs/servers/mpd/default.nix
+++ b/pkgs/servers/mpd/default.nix
@@ -50,8 +50,9 @@
   pcre2,
   libgcrypt,
   expat,
-  # Services
-  yajl,
+  nlohmann_json,
+  zlib,
+  libupnp,
   # Client support
   libmpdclient,
   # Tag support
@@ -116,16 +117,15 @@ let
     qobuz = [
       curl
       libgcrypt
-      yajl
-    ];
-    soundcloud = [
-      curl
-      yajl
+      nlohmann_json
     ];
     # Client support
     libmpdclient = [ libmpdclient ];
     # Tag support
-    id3tag = [ libid3tag ];
+    id3tag = [
+      libid3tag
+      zlib
+    ];
     # Misc
     dbus = [ dbus ];
     expat = [ expat ];
@@ -134,7 +134,6 @@ let
     sqlite = [ sqlite ];
     syslog = [ ];
     systemd = [ systemd ];
-    yajl = [ yajl ];
     zeroconf = [
       avahi
       dbus
@@ -197,13 +196,13 @@ let
     in
     stdenv.mkDerivation rec {
       pname = "mpd";
-      version = "0.24.2";
+      version = "0.24.3";
 
       src = fetchFromGitHub {
         owner = "MusicPlayerDaemon";
         repo = "MPD";
         rev = "v${version}";
-        sha256 = "sha256-6wEFgiMsEoWvmfH609d+UZY7jzqDoNmXalpHBipqTN0=";
+        sha256 = "sha256-lbYQ3fHq1Z6i3zVdLiO9q+3t2BkREwvgOHUVfTJniNg=";
       };
 
       buildInputs = [
@@ -214,6 +213,7 @@ let
         #
         #    Run-time dependency GTest found: YES 1.10.0
         gtest
+        libupnp
       ] ++ concatAttrVals features_ featureDependencies;
 
       nativeBuildInputs = [
@@ -225,25 +225,13 @@ let
       depsBuildBuild = [ buildPackages.stdenv.cc ];
 
       postPatch =
-        ''
-          # Basically a revert of https://github.com/MusicPlayerDaemon/MPD/commit/0aeda01ba6d22a8d9fc583faa67ffc6473869a43
-          # We use a yajl fork that fixed this issue in the pkg-config manifest
-          substituteInPlace \
-            src/lib/yajl/Callbacks.hxx \
-            src/lib/yajl/Handle.hxx \
-            --replace-fail "<yajl_parse.h>" "<yajl/yajl_parse.h>"
-          substituteInPlace \
-            src/lib/yajl/Gen.hxx \
-            --replace-fail "<yajl_gen.h>" "<yajl/yajl_gen.h>"
-        ''
-        +
-          lib.optionalString
-            (stdenv.hostPlatform.isDarwin && lib.versionOlder stdenv.hostPlatform.darwinSdkVersion "12.0")
-            ''
-              substituteInPlace src/output/plugins/OSXOutputPlugin.cxx \
-                --replace kAudioObjectPropertyElement{Main,Master} \
-                --replace kAudioHardwareServiceDeviceProperty_Virtual{Main,Master}Volume
-            '';
+        lib.optionalString
+          (stdenv.hostPlatform.isDarwin && lib.versionOlder stdenv.hostPlatform.darwinSdkVersion "12.0")
+          ''
+            substituteInPlace src/output/plugins/OSXOutputPlugin.cxx \
+              --replace kAudioObjectPropertyElement{Main,Master} \
+              --replace kAudioHardwareServiceDeviceProperty_Virtual{Main,Master}Volume
+          '';
 
       # Otherwise, the meson log says:
       #
@@ -272,7 +260,8 @@ let
         ++ map (x: "-D${x}=enabled") features_
         ++ map (x: "-D${x}=disabled") (lib.subtractLists features_ knownFeatures)
         ++ lib.optional (builtins.elem "zeroconf" features_) "-Dzeroconf=avahi"
-        ++ lib.optional (builtins.elem "systemd" features_) "-Dsystemd_system_unit_dir=etc/systemd/system";
+        ++ lib.optional (builtins.elem "systemd" features_) "-Dsystemd_system_unit_dir=etc/systemd/system"
+        ++ lib.optional (builtins.elem "qobuz" features_) "-Dnlohmann_json=enabled";
 
       passthru.tests.nixos = nixosTests.mpd;
 
@@ -321,9 +310,7 @@ in
         "id3tag"
         "expat"
         "pcre"
-        "yajl"
         "sqlite"
-        "soundcloud"
         "qobuz"
       ]
       ++ lib.optionals stdenv.hostPlatform.isLinux [


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Changelogs: https://raw.githubusercontent.com/MusicPlayerDaemon/MPD/v0.24.3/NEWS
Resolves: #406166

Removed `yajl` and `soundcloud` plugins as these got removed entirely from MPD, removed obsolete patch along with it. Added `nlohmann_json` (`qobuz`) and `zlib` (`id3tag`). Added `libupnp` to `buildInputs` as Ninja warns this is a runtime dependency.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

cc @astsmtl @tobim
