### PR TITLE
app2unit: init at 0-unstable-2025-05-09

### DIFF
--- a/pkgs/by-name/ap/app2unit/package.nix
+++ b/pkgs/by-name/ap/app2unit/package.nix
@@ -1,0 +1,37 @@
+{
+  lib,
+  stdenvNoCC,
+  dash,
+  fetchFromGitHub,
+}:
+stdenvNoCC.mkDerivation {
+  pname = "app2unit";
+  version = "0-unstable-2025-05-09";
+
+  src = fetchFromGitHub {
+    owner = "Vladimir-csp";
+    repo = "app2unit";
+    rev = "7b9672a2dc16bdfbe7b7b7c27043529ca3bcb6ae";
+    sha256 = "03dnx5v75530fwppfgpjl6xzzmdbk73ymrlix129d9n5sqrz9wgk";
+  };
+
+  installPhase = ''
+    install -Dt $out/bin app2unit
+    ln -s $out/bin/app2unit $out/bin/app2unit-open
+  '';
+
+  dontPatchShebangs = true;
+  postFixup = ''
+    substituteInPlace $out/bin/app2unit \
+      --replace-fail '#!/bin/sh' '#!${lib.getExe dash}'
+  '';
+
+  meta = {
+    description = "Launches Desktop Entries as Systemd user units";
+    homepage = "https://github.com/Vladimir-csp/app2unit";
+    license = lib.licenses.gpl3;
+    mainProgram = "app2unit";
+    maintainers = with lib.maintainers; [ fazzi ];
+    platforms = lib.platforms.linux;
+  };
+}


### PR DESCRIPTION
adds a new package, `app2unit`, used as a fast replacement to `uwsm-open`. Made by the author of uwsm as well.

The script runs with dash, which uses the same replacement as `xdg-terminal-exec` (also made by the same author): https://github.com/NixOS/nixpkgs/blob/ff7250b1f886b5a94c26fba2132455dd8a357990/pkgs/by-name/xd/xdg-terminal-exec/package.nix#L34-L38

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
