### PR TITLE
zinnia: fix compilation on darwin, update sourceRoot logic

### DIFF
--- a/pkgs/by-name/zi/zinnia/package.nix
+++ b/pkgs/by-name/zi/zinnia/package.nix
@@ -4,7 +4,7 @@
   fetchFromGitHub,
 }:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation (finalAttrs: {
   pname = "zinnia";
   version = "2016-08-28";
 
@@ -15,15 +15,19 @@ stdenv.mkDerivation {
     sha256 = "1izjy5qw6swg0rs2ym2i72zndb90mwrfbd1iv8xbpwckbm4899lg";
   };
 
-  setSourceRoot = ''
-    sourceRoot=$(echo */zinnia)
-  '';
+  sourceRoot = "${finalAttrs.src.name}/zinnia";
 
-  meta = with lib; {
+  patches = [
+    # Fixes the following error on darwin:
+    # svm.cpp:50:10: error: no member named 'random_shuffle' in namespace 'std'
+    ./remove-random-shuffle-usage.patch
+  ];
+
+  meta = {
     description = "Online hand recognition system with machine learning";
     homepage = "http://taku910.github.io/zinnia/";
-    license = licenses.bsd2;
-    platforms = platforms.unix;
+    license = lib.licenses.bsd2;
+    platforms = lib.platforms.unix;
     maintainers = [ ];
   };
-}
+})

--- a/pkgs/by-name/zi/zinnia/remove-random-shuffle-usage.patch
+++ b/pkgs/by-name/zi/zinnia/remove-random-shuffle-usage.patch
@@ -1,0 +1,27 @@
+diff --git a/svm.cpp b/svm.cpp
+index 3b7643e..2a34b42 100644
+--- a/svm.cpp
++++ b/svm.cpp
+@@ -10,6 +10,7 @@
+ #include <vector>
+ #include <cmath>
+ #include <algorithm>
++#include <random>
+ #include "feature.h"
+ 
+ namespace zinnia {
+@@ -43,11 +44,13 @@ bool svm_train(size_t l,
+     }
+   }
+ 
++  std::random_device rand_device;
++  std::default_random_engine rand_engine(rand_device());
+   static const size_t kMaxIteration = 2000;
+   for (size_t iter = 0; iter < kMaxIteration; ++iter) {
+     double PGmax_new = -kINF;
+     double PGmin_new = kINF;
+-    std::random_shuffle(index.begin(), index.begin() + active_size);
++    std::shuffle(index.begin(), index.begin() + active_size, rand_engine);
+ 
+     for (size_t s = 0; s < active_size; ++s) {
+       const size_t i = index[s];


### PR DESCRIPTION
ZHF: https://github.com/NixOS/nixpkgs/issues/403336

https://hydra.nixos.org/build/295797208

Related discussion about possibly dropping the package instead: https://github.com/NixOS/nixpkgs/pull/282148#issuecomment-2864572155



<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
