### PR TITLE
svt-av1-psy: limit x86_64-specific dependencies

### DIFF
--- a/pkgs/by-name/sv/svt-av1-psy/package.nix
+++ b/pkgs/by-name/sv/svt-av1-psy/package.nix
@@ -74,5 +74,6 @@ stdenv.mkDerivation (finalAttrs: {
     ];
     platforms = lib.platforms.unix;
     maintainers = with lib.maintainers; [ johnrtitor ];
+    mainProgram = "SvtAv1EncApp";
   };
 })

--- a/pkgs/by-name/sv/svt-av1-psy/package.nix
+++ b/pkgs/by-name/sv/svt-av1-psy/package.nix
@@ -32,21 +32,26 @@ stdenv.mkDerivation (finalAttrs: {
         )
       )
       {
-        USE_EXTERNAL_CPUINFO = true;
         LIBDOVI_FOUND = true;
         LIBHDR10PLUS_RS_FOUND = true;
       };
 
-  nativeBuildInputs = [
-    cmake
-    nasm
-  ];
+  nativeBuildInputs =
+    [
+      cmake
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isx86_64 [
+      nasm
+    ];
 
-  buildInputs = [
-    cpuinfo
-    libdovi
-    hdr10plus
-  ];
+  buildInputs =
+    [
+      libdovi
+      hdr10plus
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isx86_64 [
+      cpuinfo
+    ];
 
   passthru.updateScript = unstableGitUpdater {
     branch = "master";


### PR DESCRIPTION
[Upstream SVT-AV1 deprecated the `USE_EXTERNAL_CPUINFO` option and replaced it with `USE_CPUINFO`, which defaults to `AUTO`][1]. SVT-AV1 will use only use the bundled version of cpuinfo if it cannot find the system version.
[The use of cpuinfo was also disabled for aarch64][2], so limit its use to x86_64.

[1]: https://gitlab.com/AOMediaCodec/SVT-AV1/-/commit/54ac9322e79508e6ef3474d77f8e32e4ca49b923
[2]: https://gitlab.com/AOMediaCodec/SVT-AV1/-/commit/ec699561b51f3204e2df6d4c2578eea1f7bd52be

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [x] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
