### PR TITLE
nixos/udev: verify udev rules with udevadm

### DIFF
--- a/nixos/modules/services/hardware/udev.nix
+++ b/nixos/modules/services/hardware/udev.nix
@@ -57,7 +57,10 @@ let
         packages = lib.unique (map toString udevPackages);
 
         nativeBuildInputs = [
-          pkgs.systemdMinimal
+          # We only include the out output here to avoid needing to include all
+          # other outputs in the installer tests as well
+          # We only need the udevadm command anyway
+          pkgs.systemdMinimal.out
         ];
       }
       ''

--- a/nixos/modules/services/hardware/udev.nix
+++ b/nixos/modules/services/hardware/udev.nix
@@ -55,6 +55,10 @@ let
         preferLocalBuild = true;
         allowSubstitutes = false;
         packages = lib.unique (map toString udevPackages);
+
+        nativeBuildInputs = [
+          pkgs.systemdMinimal
+        ];
       }
       ''
         mkdir -p $out
@@ -146,6 +150,11 @@ let
           done
           exit 1
         fi
+
+        # Verify all the udev rules
+        echo "Verifying udev rules using udevadm verify..."
+        udevadm verify --resolve-names=never --no-style $out
+        echo "OK"
 
         # If auto-configuration is disabled, then remove
         # udev's 80-drivers.rules file, which contains rules for

--- a/nixos/tests/installer.nix
+++ b/nixos/tests/installer.nix
@@ -681,7 +681,7 @@ let
         {
           # The configuration of the system used to run "nixos-install".
           installer =
-            { config, ... }:
+            { config, pkgs, ... }:
             {
               imports = [
                 commonConfig
@@ -739,6 +739,11 @@ let
                   unionfs-fuse
                   xorg.lndir
                   shellcheck-minimal
+
+                  # Only the out output is included here, which is what is
+                  # required to build the NixOS udev rules
+                  # See the comment in services/hardware/udev.nix
+                  systemdMinimal.out
 
                   # add curl so that rather than seeing the test attempt to download
                   # curl's tarball, we see what it's trying to download


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Re-apply of #404323, but this time I made sure that the installer tests still pass

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
