### PR TITLE
cockpit: add sscg to dependencies

### DIFF
--- a/pkgs/by-name/co/cockpit/package.nix
+++ b/pkgs/by-name/co/cockpit/package.nix
@@ -32,6 +32,7 @@
   pkg-config,
   polkit,
   python3Packages,
+  sscg,
   systemd,
   udev,
   xmlto,
@@ -167,6 +168,7 @@ stdenv.mkDerivation (finalAttrs: {
       --prefix PATH : ${
         lib.makeBinPath [
           coreutils
+          sscg
           openssl
         ]
       } \


### PR DESCRIPTION
This PR adds sscg to dependencies and build inputs for cockpit. Without this PR, `journalctl -u cockpit` would show the following error message:
```
May 11 22:33:05 desktop-sicqmtd-wsl systemd[1]: Starting Cockpit Web Service...
May 11 22:33:05 desktop-sicqmtd-wsl cockpit-certificate-ensure[2129345]: /nix/store/8rpk8xwmm0j1bqnnyz764v99hzrspk0n-cockpit-337/libexec/.cockpit-certificate-helper-wrapped: line 31: sscg: command not found
May 11 22:33:05 desktop-sicqmtd-wsl cockpit-certificate-ensure[2129346]: .+..+.+.....+.........+++++++++++++++++++++++++++++++++++++++*.+...............+.+++++++++++++++++++++++++++++++++++++++*.....+......+....+...+..................+.....+.......+........+.......+............+..+....+..+....+...............+......+........+......+...+.............+........+.+......+..+...+....+...........+.......+..+..........+.....+....+..+...+.+.........+..+...+......+...+.+.....+.+........+.............+..............+.+........+......+...+.+.........+........+...+....+...+..+.......+..............+......+...+.+......+...+..+.............+...........+..........+.........+......+..............+.+..+....+...+.....+......+.........+.............+........+......+.+...............+.....+............+..........+...+...+.....+.......+...+...........+.+..+............+.+.....+.........+......+.......+............+.....++++++
May 11 22:33:05 desktop-sicqmtd-wsl cockpit-certificate-ensure[2129346]: ..+.......+........+.+..+....+.....+......+....+...+..+.+...+...........+.+.....+++++++++++++++++++++++++++++++++++++++*......+.+..............+++++++++++++++++++++++++++++++++++++++*...........+..+.........+.......++++++
May 11 22:33:05 desktop-sicqmtd-wsl cockpit-certificate-ensure[2129346]: -----
May 11 22:33:05 desktop-sicqmtd-wsl systemd[1]: Started Cockpit Web Service.
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

I tested this PR on NixOS with `services.cockpit.enable`, and I confirm this PR avoids the error message

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
