### PR TITLE
sta: unbreak on darwin

### DIFF
--- a/pkgs/by-name/st/sta/package.nix
+++ b/pkgs/by-name/st/sta/package.nix
@@ -17,6 +17,8 @@ stdenv.mkDerivation {
     sha256 = "sha256-AiygCfBze7J1Emy6mc27Dim34eLR7VId9wodUZapIL4=";
   };
 
+  strictDeps = true;
+
   nativeBuildInputs = [ autoreconfHook ];
 
   doCheck = true;

--- a/pkgs/by-name/st/sta/package.nix
+++ b/pkgs/by-name/st/sta/package.nix
@@ -3,6 +3,7 @@
   lib,
   fetchFromGitHub,
   autoreconfHook,
+  cxxtest,
 }:
 
 stdenv.mkDerivation {
@@ -17,6 +18,24 @@ stdenv.mkDerivation {
   };
 
   nativeBuildInputs = [ autoreconfHook ];
+
+  doCheck = true;
+  nativeCheckInputs = [ cxxtest ];
+  checkInputs = [ cxxtest ];
+
+  checkPhase = ''
+    runHook preCheck
+
+    pushd test
+
+    cxxtestgen --error-printer --have-std -o tests.cpp sta_test_1.h sta_test_2.h
+    ${stdenv.cc.targetPrefix}c++ -o tester tests.cpp
+    ./tester
+
+    popd
+
+    runHook postCheck
+  '';
 
   meta = with lib; {
     description = "Simple statistics from the command line interface (CLI), fast";

--- a/pkgs/by-name/st/sta/package.nix
+++ b/pkgs/by-name/st/sta/package.nix
@@ -31,7 +31,6 @@ stdenv.mkDerivation {
     homepage = "https://github.com/simonccarter/sta";
     maintainers = [ ];
     platforms = platforms.all;
-    badPlatforms = platforms.darwin;
     mainProgram = "sta";
   };
 }


### PR DESCRIPTION
Builds and runs just fine.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [x] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
