### PR TITLE
rspamd: disable blas by default

### DIFF
--- a/pkgs/by-name/rs/rspamd/package.nix
+++ b/pkgs/by-name/rs/rspamd/package.nix
@@ -24,7 +24,9 @@
   xxHash,
   zstd,
   libarchive,
-  withBlas ? true,
+  # Enabling blas support breaks bayes filter training from dovecot in nixos-mailserver tests
+  # https://gitlab.com/simple-nixos-mailserver/nixos-mailserver/-/issues/321
+  withBlas ? false,
   withLuaJIT ? stdenv.hostPlatform.isx86_64,
   nixosTests,
 }:


### PR DESCRIPTION

We run integration tests in the nixos-mailserver project and identified
the commit enable blas breaking rspamc learn_ham/spam calls from within
dovecot sieve scripts using the pipe command.

https://gitlab.com/simple-nixos-mailserver/nixos-mailserver/-/issues/321

```
Debug: sieve: action pipe: running program: sa-learn-spam.sh
Debug: program exec:/nix/store/3yv9zxi9ls8w4vmp4sxmil30jj8n08kk-sieve-pipe-bins/sa-learn-spam.sh: Created
Debug: program exec:/nix/store/3yv9zxi9ls8w4vmp4sxmil30jj8n08kk-sieve-pipe-bins/sa-learn-spam.sh: Pass environment: USER=user1@example.com
Debug: program exec:/nix/store/3yv9zxi9ls8w4vmp4sxmil30jj8n08kk-sieve-pipe-bins/sa-learn-spam.sh: Pass environment: HOME=/var/vmail
Debug: program exec:/nix/store/3yv9zxi9ls8w4vmp4sxmil30jj8n08kk-sieve-pipe-bins/sa-learn-spam.sh: Pass environment: HOST=server
Debug: program exec:/nix/store/3yv9zxi9ls8w4vmp4sxmil30jj8n08kk-sieve-pipe-bins/sa-learn-spam.sh: Establishing connection
Debug: program exec:/nix/store/3yv9zxi9ls8w4vmp4sxmil30jj8n08kk-sieve-pipe-bins/sa-learn-spam.sh: Forked child process
Debug: program exec:/nix/store/3yv9zxi9ls8w4vmp4sxmil30jj8n08kk-sieve-pipe-bins/sa-learn-spam.sh (1945): Connected to program
Debug: program exec:/nix/store/3yv9zxi9ls8w4vmp4sxmil30jj8n08kk-sieve-pipe-bins/sa-learn-spam.sh (1945): Finished streaming payload to program
Debug: program exec:/nix/store/3yv9zxi9ls8w4vmp4sxmil30jj8n08kk-sieve-pipe-bins/sa-learn-spam.sh (1945): Finished input to program
Debug: program exec:/nix/store/3yv9zxi9ls8w4vmp4sxmil30jj8n08kk-sieve-pipe-bins/sa-learn-spam.sh (1945): Disconnected
Debug: program exec:/nix/store/3yv9zxi9ls8w4vmp4sxmil30jj8n08kk-sieve-pipe-bins/sa-learn-spam.sh (1945): Waiting for program to finish after 8 msecs (timeout = 9992 msecs)
Debug: program exec:/nix/store/3yv9zxi9ls8w4vmp4sxmil30jj8n08kk-sieve-pipe-bins/sa-learn-spam.sh (1945): Execution timed out after 10000 milliseconds: Sending TERM signal
Debug: program exec:/nix/store/3yv9zxi9ls8w4vmp4sxmil30jj8n08kk-sieve-pipe-bins/sa-learn-spam.sh (1945): Child process ended
Error: program exec:/nix/store/3yv9zxi9ls8w4vmp4sxmil30jj8n08kk-sieve-pipe-bins/sa-learn-spam.sh (1945): Forcibly terminated with signal 15
Debug: program exec:/nix/store/3yv9zxi9ls8w4vmp4sxmil30jj8n08kk-sieve-pipe-bins/sa-learn-spam.sh (1945): Destroy
Error: sieve: failed to pipe message to program `sa-learn-spam.sh': refer to server log for more information. [2025-05-09 23:31:40]
```

The root cause is still unknown.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
