### PR TITLE
buildMozillaMach: cleanup, reenable system-icu, retarget nss_esr version

### DIFF
--- a/pkgs/applications/networking/browsers/firefox/common.nix
+++ b/pkgs/applications/networking/browsers/firefox/common.nix
@@ -560,7 +560,7 @@ buildStdenv.mkDerivation {
         xorg.xorgproto
         zlib
         (
-          if (lib.versionAtLeast version "116") then nss_latest else nss_esr # 3.90
+          if (lib.versionAtLeast version "129") then nss_latest else nss_esr # 3.90
         )
       ]
       ++ lib.optional alsaSupport alsa-lib

--- a/pkgs/applications/networking/browsers/firefox/common.nix
+++ b/pkgs/applications/networking/browsers/firefox/common.nix
@@ -44,7 +44,6 @@ in
   lib,
   pkgs,
   stdenv,
-  fetchpatch,
   patchelf,
 
   # build time
@@ -467,7 +466,7 @@ buildStdenv.mkDerivation {
     ]
     ++ lib.optional (isElfhackPlatform stdenv) (enableFeature elfhackSupport "elf-hack")
     ++ lib.optional (!drmSupport) "--disable-eme"
-    ++ lib.optional (allowAddonSideload) "--allow-addon-sideload"
+    ++ lib.optional allowAddonSideload "--allow-addon-sideload"
     ++ lib.optionals (!stdenv.hostPlatform.isDarwin) [
       # MacOS builds use bundled versions of libraries: https://bugzilla.mozilla.org/show_bug.cgi?id=1776255
       "--enable-system-pixman"

--- a/pkgs/applications/networking/browsers/firefox/common.nix
+++ b/pkgs/applications/networking/browsers/firefox/common.nix
@@ -76,6 +76,7 @@ in
   gnum4,
   gtk3,
   icu73,
+  icu77,
   libGL,
   libGLU,
   libevent,
@@ -327,6 +328,10 @@ buildStdenv.mkDerivation {
       rm -rf obj-x86_64-pc-linux-gnu
       patchShebangs mach build
     ''
+    # https://bugzilla.mozilla.org/show_bug.cgi?id=1927380
+    + lib.optionalString (lib.versionAtLeast version "134") ''
+      sed -i "s/icu-i18n/icu-uc &/" js/moz.configure
+    ''
     + extraPostPatch;
 
   # Ignore trivial whitespace changes in patches, this fixes compatibility of
@@ -471,8 +476,7 @@ buildStdenv.mkDerivation {
       # MacOS builds use bundled versions of libraries: https://bugzilla.mozilla.org/show_bug.cgi?id=1776255
       "--enable-system-pixman"
       "--with-system-ffi"
-      # Firefox 136 fails to link with our icu76.1
-      (lib.optionalString (lib.versionOlder version "136") "--with-system-icu")
+      "--with-system-icu"
       "--with-system-jpeg"
       "--with-system-libevent"
       "--with-system-libvpx"
@@ -568,7 +572,7 @@ buildStdenv.mkDerivation {
         libdrm
       ]
     ))
-    ++ lib.optionals (lib.versionOlder version "136") [ icu73 ]
+    ++ [ (if (lib.versionAtLeast version "138") then icu77 else icu73) ]
     ++ lib.optional gssSupport libkrb5
     ++ lib.optional jemallocSupport jemalloc
     ++ extraBuildInputs;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
