### PR TITLE
nixos/containers: mtu setting for veths

### DIFF
--- a/nixos/modules/virtualisation/nixos-containers.nix
+++ b/nixos/modules/virtualisation/nixos-containers.nix
@@ -27,6 +27,10 @@ let
       renderExtraVeth = (
         name: cfg: ''
           echo "Bringing ${name} up"
+          ${optionalString (cfg.mtu != null) ''
+            echo "Setting MTU for ${name}"
+            ip link set dev ${name} mtu ${builtins.toString cfg.mtu}
+          ''}
           ip link set dev ${name} up
           ${optionalString (cfg.localAddress != null) ''
             echo "Setting ip for ${name}"
@@ -56,11 +60,16 @@ let
       # Initialise the container side of the veth pair.
       if [[ -n "''${HOST_ADDRESS-}" ]]   || [[ -n "''${HOST_ADDRESS6-}" ]]  ||
          [[ -n "''${LOCAL_ADDRESS-}" ]]  || [[ -n "''${LOCAL_ADDRESS6-}" ]] ||
-         [[ -n "''${HOST_BRIDGE-}" ]]    || [[ -n "''${LOCAL_MAC_ADDRESS-}" ]]; then
+         [[ -n "''${HOST_BRIDGE-}" ]]    || [[ -n "''${LOCAL_MAC_ADDRESS-}" ]] ||
+         [[ -n "''${NET_MTU-}" ]]; then
         ip link set host0 name eth0
 
         if [[ -n "''${LOCAL_MAC_ADDRESS-}" ]]; then
           ip link set dev eth0 address "$LOCAL_MAC_ADDRESS"
+        fi
+
+        if [[ -n "''${NET_MTU-}" ]]; then
+          ip link set dev eth0 mtu "$NET_MTU"
         fi
 
         ip link set dev eth0 up
@@ -206,8 +215,9 @@ let
       --bind="/nix/var/nix/profiles/per-container/$INSTANCE:/nix/var/nix/profiles$NIX_BIND_OPT" \
       --bind="/nix/var/nix/gcroots/per-container/$INSTANCE:/nix/var/nix/gcroots$NIX_BIND_OPT" \
       ${optionalString (!cfg.ephemeral) "--link-journal=try-guest"} \
-      --setenv PRIVATE_NETWORK="''${PRIVATE_NETWORK-}" \
       --setenv PRIVATE_USERS="''${PRIVATE_USERS-}" \
+      --setenv PRIVATE_NETWORK="''${PRIVATE_NETWORK-}" \
+      --setenv NET_MTU="''${NET_MTU-}" \
       --setenv HOST_BRIDGE="''${HOST_BRIDGE-}" \
       --setenv HOST_ADDRESS="''${HOST_ADDRESS-}" \
       --setenv LOCAL_ADDRESS="''${LOCAL_ADDRESS-}" \
@@ -236,7 +246,8 @@ let
     machinectl terminate "$INSTANCE" 2> /dev/null || true
 
     if [[ -n "''${HOST_ADDRESS-}" ]]  || [[ -n "''${LOCAL_ADDRESS-}" ]] ||
-       [[ -n "''${HOST_ADDRESS6-}" ]] || [[ -n "''${LOCAL_ADDRESS6-}" ]]; then
+       [[ -n "''${HOST_ADDRESS6-}" ]] || [[ -n "''${LOCAL_ADDRESS6-}" ]] ||
+       [[ -n "''${NET_MTU-}" ]]; then
       ip link del dev "ve-$INSTANCE" 2> /dev/null || true
       ip link del dev "vb-$INSTANCE" 2> /dev/null || true
     fi
@@ -269,6 +280,9 @@ let
         else
           ''
             echo "Bring ${name} up"
+            ${optionalString (cfg.mtu != null) ''
+              ip link set dev "${name}" mtu ${builtins.toString cfg.mtu}
+            ''}
             ip link set dev "${name}" up
             # Set IPs and routes for ${name}
             ${optionalString (cfg.hostAddress != null) ''
@@ -287,9 +301,13 @@ let
     in
     ''
       if [[ -n "''${HOST_ADDRESS-}" ]]  || [[ -n "''${LOCAL_ADDRESS-}" ]] ||
-         [[ -n "''${HOST_ADDRESS6-}" ]] || [[ -n "''${LOCAL_ADDRESS6-}" ]]; then
+         [[ -n "''${HOST_ADDRESS6-}" ]] || [[ -n "''${LOCAL_ADDRESS6-}" ]] ||
+         [[ -n "''${NET_MTU-}" ]]; then
         if [[ -z "''${HOST_BRIDGE-}" ]]; then
           ifaceHost=ve-$INSTANCE
+          if [[ -n "''${NET_MTU-}" ]]; then
+            ip link set dev "$ifaceHost" mtu "$NET_MTU"
+          fi
           ip link set dev "$ifaceHost" up
 
           ${ipcall cfg "ip addr" "HOST_ADDRESS" "hostAddress"}
@@ -449,6 +467,16 @@ let
         is specified by protocol, hostPort and containerPort. By default,
         protocol is tcp and hostPort and containerPort are assumed to be
         the same if containerPort is not explicitly given.
+      '';
+    };
+
+    mtu = mkOption {
+      type = types.nullOr types.int;
+      default = null;
+      example = 1500;
+      description = ''
+        The MTU to be assigned to the interface.
+        (Not used when hostBridge is set.)
       '';
     };
 
@@ -1122,6 +1150,9 @@ in
                   ''}
                   ${optionalString (length cfg.forwardPorts > 0) ''
                     HOST_PORT=${concatStringsSep "," (map mkPortStr cfg.forwardPorts)}
+                  ''}
+                  ${optionalString (cfg.mtu != null) ''
+                    NET_MTU=${builtins.toString cfg.mtu}
                   ''}
                   ${optionalString (cfg.hostAddress != null) ''
                     HOST_ADDRESS=${cfg.hostAddress}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -390,6 +390,7 @@ in
   containers-ip = runTest ./containers-ip.nix;
   containers-ipv6-slaac = runTest ./containers-ipv6-slaac.nix;
   containers-macvlans = runTest ./containers-macvlans.nix;
+  containers-mtu = runTest ./containers-mtu.nix;
   containers-names = runTest ./containers-names.nix;
   containers-nested = runTest ./containers-nested.nix;
   containers-physical_interfaces = runTest ./containers-physical_interfaces.nix;

--- a/nixos/tests/containers-mtu.nix
+++ b/nixos/tests/containers-mtu.nix
@@ -1,0 +1,120 @@
+let
+  nullOr = value: default: if value != null then value else default;
+  defaultContainer =
+    args:
+    {
+      # save some time compared to sequential starting
+      # these containers eat basically zero resources anyway
+      autoStart = true;
+      privateNetwork = true;
+      config = {
+        networking.firewall.enable = false;
+      };
+    }
+    // args;
+
+in
+{ lib, ... }:
+{
+  name = "containers-mtu";
+  meta = {
+    maintainers = with lib.maintainers; [
+      benaryorg
+    ];
+  };
+
+  nodes.machine.containers = {
+    # minimum MTU sizes for IPv6 and IPv4 are 1280 and 68 respectively
+    # maximum are quite a bit higher but testing for the usual 9000 suffices to confirm that the MTU is in fact set
+    # default should use the ubiquitious 1500 since it being absent will default to whatever Linux decides to use
+    small6 = defaultContainer {
+      mtu = 1280;
+      hostAddress6 = "fc00::1";
+      localAddress6 = "fd17:4ab0:cdf3::1";
+    };
+    small4 = defaultContainer {
+      mtu = 68;
+      hostAddress = "169.254.0.1";
+      localAddress = "10.0.0.1";
+    };
+    regular6 = defaultContainer {
+      mtu = 1500;
+      hostAddress6 = "fc00::1";
+      localAddress6 = "fd17:4ab0:cdf3::2";
+    };
+    regular4 = defaultContainer {
+      mtu = 1500;
+      hostAddress = "169.254.0.1";
+      localAddress = "10.0.0.2";
+    };
+    default6 = defaultContainer {
+      hostAddress6 = "fc00::1";
+      localAddress6 = "fd17:4ab0:cdf3::3";
+    };
+    default4 = defaultContainer {
+      hostAddress = "169.254.0.1";
+      localAddress = "10.0.0.3";
+    };
+    large6 = defaultContainer {
+      mtu = 9000;
+      hostAddress6 = "fc00::1";
+      localAddress6 = "fd17:4ab0:cdf3::4";
+    };
+    large4 = defaultContainer {
+      mtu = 9000;
+      hostAddress = "169.254.0.1";
+      localAddress = "10.0.0.4";
+    };
+  };
+
+  testScript =
+    { nodes, ... }:
+    ''
+      def ping_host(ip, size=0):
+          # 4 pings to avoid a single random packet being lost from failing the entire test suite
+          # default of size 0 to ensure that reachability pings always work
+          return f"ping -n -i 0.2 -c 4 -s {size} -M probe {ip}"
+
+      machine.start()
+      machine.wait_for_unit("default.target")
+
+      containers: list[tuple[str, str, int]] = ${
+        lib.pipe nodes.machine.containers [
+          # just using builtins.toJSON all the way would've been easier but make the Python type checker angy
+          (lib.mapAttrsToList (
+            name: config: [
+              name
+              (nullOr config.localAddress6 config.localAddress)
+              (nullOr config.mtu 1500)
+            ]
+          ))
+          (builtins.map (builtins.map builtins.toJSON))
+          (builtins.map (builtins.concatStringsSep ", "))
+          (builtins.map (tuple: "    (${tuple})"))
+          (builtins.concatStringsSep ",\n")
+          (list: "[\n${list}\n]")
+        ]
+      }
+      for container, ip, mtu in containers:
+          print(f"{container}: {ip} ({mtu})")
+          assert container in machine.succeed("nixos-container list")
+
+          with subtest(f"{container} is reachable"):
+              machine.wait_until_succeeds(ping_host(ip), timeout=16)
+
+          # IPv6: 40 bytes IPv6 header, 4 byte ICMPv6 header, 4 byte Echo Request header
+          # IPv4: 20 bytes IPv4 header, 4 byte ICMP header, 4 byte Echo Request header
+          header_size: int = 48 if ":" in ip else 28
+          with subtest(f"{container} MTU bounds check"):
+              # 1 below MTU
+              machine.succeed(ping_host(ip, mtu - header_size - 1))
+              # exact MTU
+              machine.succeed(ping_host(ip, mtu - header_size))
+              # 1 above MTU
+              machine.fail(ping_host(ip, mtu - header_size + 1))
+
+          with subtest(f"Stop container {container}"):
+              machine.succeed(f"nixos-container stop {container}")
+              machine.fail(ping_host(ip) + " -W 1")
+    '';
+}


### PR DESCRIPTION
Allowing to specify the MTU for veths makes it possible to use jumbo frames, as well as to forego MSS clamping in setups where either is needed. To be noted here is that the MTU for veths is in fact relevant, unlike the loopback interface (which is weird about MTUs), or e.g. the link speed which seems to be purely CPU bound for veths. Since MTUs are a relatively common thing (VPNs being ubiquitous these days) which can cause connectivity issues when MSS clamping isn't performed (something that works *most* of the time, but which many people may not be aware of) this options seems warranted.

Since the conditions for setting up the interface in most places are that an address is provided either on the host side or the guest side, this change enables using that mechanic but without an address. This can be useful in environment where the interface is configured via a network manager on both sides of the pair. Basically; setting the MTU alone is now sufficient to have the NixOS scripts handle the interface, but not configure addresses or routes on it, in case a user wants to manage those settings themselves. For everyone using the address built-in mechanics it merely allows to specify the MTU.

The envvar for private users in the nspawn call is moved up so that the network options are grouped together.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
