### PR TITLE
git-bug: 0.8.1 -> 0.9.0

### DIFF
--- a/pkgs/by-name/gi/git-bug/package.nix
+++ b/pkgs/by-name/gi/git-bug/package.nix
@@ -7,13 +7,13 @@
 
 buildGoModule rec {
   pname = "git-bug";
-  version = "0.8.1";
+  version = "0.9.0";
 
   src = fetchFromGitHub {
     owner = "git-bug";
     repo = "git-bug";
     rev = "v${version}";
-    sha256 = "sha256-lfvHoXbanisq6MaVXlwKmW8YTeWjx6E6b4N9xICemKc=";
+    sha256 = "sha256-w4PrcWLqkxwtyccf2OZAqFlLXNsZZNOTyny26VZr9Cg=";
   };
 
   vendorHash = "sha256-z9StU5cvZlDkmC7TE6JOhpxAx5oSTxAQTBh1LEksKww=";
@@ -28,9 +28,9 @@ buildGoModule rec {
   ];
 
   ldflags = [
-    "-X github.com/MichaelMure/git-bug/commands.GitCommit=v${version}"
-    "-X github.com/MichaelMure/git-bug/commands.GitLastTag=${version}"
-    "-X github.com/MichaelMure/git-bug/commands.GitExactTag=${version}"
+    "-X github.com/git-bug/git-bug/commands.GitCommit=v${version}"
+    "-X github.com/git-bug/git-bug/commands.GitLastTag=${version}"
+    "-X github.com/git-bug/git-bug/commands.GitExactTag=${version}"
   ];
 
   postInstall = ''


### PR DESCRIPTION
This change updates the package to 0.9.0 and corrects the linker flags
passed to the compiler.

