### PR TITLE
xen: patch with XSA-469

### DIFF
--- a/pkgs/by-name/xe/xen/package.nix
+++ b/pkgs/by-name/xe/xen/package.nix
@@ -16,6 +16,34 @@ buildXenPackage.override { inherit python3Packages; } {
       url = "https://xenbits.xenproject.org/xsa/xsa467.patch";
       hash = "sha256-O2IwfRo6BnXAO04xjKmOyrV6J6Q1mAVLHWNCxqIEQGU=";
     })
+    (fetchpatch {
+      url = "https://xenbits.xenproject.org/xsa/xsa469/xsa469-4.19-01.patch";
+      hash = "sha256-YUcp9QI49RM/7WCxYzpzppv+vKtyl/NvLy6rIX5hVMw=";
+    })
+    (fetchpatch {
+      url = "https://xenbits.xenproject.org/xsa/xsa469/xsa469-4.19-02.patch";
+      hash = "sha256-FTtEGAPFYxsun38hLhVMKJ1TFJOsTMK3WWPkO0R/OHg=";
+    })
+    (fetchpatch {
+      url = "https://xenbits.xenproject.org/xsa/xsa469/xsa469-4.19-03.patch";
+      hash = "sha256-UkYMSpUgFvr4GJPXLgQsCyppGkNbeiFMyCZORK5tfmA=";
+    })
+    (fetchpatch {
+      url = "https://xenbits.xenproject.org/xsa/xsa469/xsa469-4.19-04.patch";
+      hash = "sha256-lpiDPSHi+v2VfaWE9kp4+hveZKTzojD1F+RHsOtKE3A=";
+    })
+    (fetchpatch {
+      url = "https://xenbits.xenproject.org/xsa/xsa469/xsa469-4.19-05.patch";
+      hash = "sha256-EKo9a5STX0mTRopoThe3+6gCWat+3XbguLr9QgMheZs=";
+    })
+    (fetchpatch {
+      url = "https://xenbits.xenproject.org/xsa/xsa469/xsa469-4.19-06.patch";
+      hash = "sha256-HU+4apyTZNIFZ9cySOEtNh0JBJDG3LjDLwMvQYq0src=";
+    })
+    (fetchpatch {
+      url = "https://xenbits.xenproject.org/xsa/xsa469/xsa469-4.19-07.patch";
+      hash = "sha256-9S85nkQ9Nn0cMzyRe4KGrFUaLggVxXBeKhoFF4R0y78=";
+    })
   ];
   rev = "ccf400846780289ae779c62ef0c94757ff43bb60";
   hash = "sha256-s0eCBCd6ybl+kLtXCC6E1sk++w7txXn/B/Cg5acQFfY=";


### PR DESCRIPTION
Researchers at VU Amsterdam have released Training Solo, detailing several speculative attacks which bypass current protections.

One issue, which Intel has named Indirect Target Selection, is a bug in the hardware support for prediction-domain isolation.  The mitigation for this involves both microcode and software changes in Xen.

For more details, see:
1.  https://vusec.net/projects/training-solo
2.  https://www.intel.com/content/www/us/en/developer/articles/technical/software-security-guidance/advisory-guidance/indirect-target-selection.html

Another issue discussed in the Training Solo paper pertains to classic-BPF.  Xen does not have any capability similar to BPF filters, so is not believed to be affected by this issue.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
