### PR TITLE
deskthing: init at 0.11.17

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -14868,6 +14868,12 @@
     githubId = 117918464;
     keys = [ { fingerprint = "B5ED 595C 8C7E 133C 6B68  63C8 CFEF 1E35 0351 F72D"; } ];
   };
+  malmeloo = {
+    email = "git@mikealmel.ooo";
+    github = "malmeloo";
+    githubId = 32306794;
+    name = "Mike Almeloo";
+  };
   malo = {
     email = "mbourgon@gmail.com";
     github = "malob";

--- a/pkgs/by-name/de/deskthing/package.nix
+++ b/pkgs/by-name/de/deskthing/package.nix
@@ -1,0 +1,48 @@
+{
+  lib,
+  fetchurl,
+  appimageTools,
+  makeDesktopItem,
+  imagemagick,
+}:
+let
+  pname = "deskthing";
+  version = "0.11.17";
+
+  src = fetchurl {
+    url = "https://github.com/ItsRiprod/${pname}/releases/download/v${version}/deskthing-linux-${version}-setup.AppImage";
+    hash = "sha256-BdWibxt3vHHlBzUST5fMW9H+pnejf5kcl/E8fxwg2nE=";
+  };
+
+  appimageContents = appimageTools.extract { inherit pname version src; };
+in
+appimageTools.wrapType2 {
+  inherit pname version src;
+
+  extraInstallCommands = ''
+    install -m 444 -D ${appimageContents}/${pname}.desktop -t $out/share/applications
+    substituteInPlace $out/share/applications/${pname}.desktop \
+      --replace-fail 'Exec=AppRun' 'Exec=${pname}'
+
+    # install "0x0" icon as 512x512
+    install -m 444 -D \
+      ${appimageContents}/usr/share/icons/hicolor/0x0/apps/deskthing.png \
+      $out/share/icons/hicolor/512x512/apps/deskthing.png
+  '';
+
+  extraPkgs =
+    pkgs: with pkgs; [
+      vips
+    ];
+
+  meta = {
+    homepage = "https://deskthing.app/";
+    downloadPage = "https://github.com/ItsRiprod/deskthing/releases/";
+    description = "DeskThing desktop companion app";
+    mainProgram = "deskthing";
+    platforms = [ "x86_64-linux" ];
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ malmeloo ];
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Adds [deskthing](https://deskthing.app/). Supersedes #372690.

This desktop app can (for the most part) be tested without owning a physical Car Thing:
- Launch the program
  - It will show file not found errors in the terminal, this seems to be an issue with the program itself (restarting fixes it)
- Download the Deskthing Client by going to `Downloads -> Client` (the `Client` button is a dropdown under the `Downloads` button in the header)
  - You can also follow the "setting up a client" task if you click on the `Tasks` button in the bottom left
- Restart the server (`Clients` menu then `Restart Server` in the bottom left) or the entire application (make sure to quit it entirely, simply closing the window will just put it in the background)
- Visit `http://localhost:8891/` in a web browser
- Install some apps from the `Downloads` page if you wish

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
