### PR TITLE
nixos/pdns-recursor: deprecate settings, add yaml-settings

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2505.section.md
+++ b/nixos/doc/manual/release-notes/rl-2505.section.md
@@ -267,6 +267,13 @@
   [not recommended by upstream](https://docs.nextcloud.com/server/30/admin_manual/installation/system_requirements.html)
   and thus doesn't qualify as default.
 
+- PowerDNS Recursor has been updated to version 5.1.2, which comes with a new YAML configuration format (`recursor.yml`)
+  and deprecates the previous format (`recursor.conf`). Accordingly, the NixOS option `services.pdns-recursor.settings`
+  has been renamed to [old-settings](#opt-services.pdns-recursor.old-settings) and will be provided for backward compatibility
+  until the next NixOS release. Users are asked to migrate their settings to the new [yaml-settings](#opt-services.pdns-recursor.old-settings)
+  option following this [guide](https://doc.powerdns.com/recursor/appendices/yamlconversion.html).
+  Note that options other than `services.pdns-recursor.settings` are unaffacted by this change.
+
 - Nextcloud's default FPM pool settings have been increased according to upstream recommentations. It's advised
   to review the new defaults and description of
   [](#opt-services.nextcloud.poolSettings).

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1018,7 +1018,7 @@ in
   paperless = handleTest ./paperless.nix { };
   parsedmarc = handleTest ./parsedmarc { };
   password-option-override-ordering = handleTest ./password-option-override-ordering.nix { };
-  pdns-recursor = handleTest ./pdns-recursor.nix { };
+  pdns-recursor = runTest ./pdns-recursor.nix;
   pds = handleTest ./pds.nix { };
   peerflix = handleTest ./peerflix.nix { };
   peering-manager = handleTest ./web-apps/peering-manager.nix { };

--- a/nixos/tests/pdns-recursor.nix
+++ b/nixos/tests/pdns-recursor.nix
@@ -1,20 +1,25 @@
-import ./make-test-python.nix (
-  { pkgs, ... }:
-  {
-    name = "powerdns-recursor";
+{ lib, pkgs, ... }:
 
-    nodes.server =
-      { ... }:
-      {
-        services.pdns-recursor.enable = true;
-        services.pdns-recursor.exportHosts = true;
-        networking.hosts."192.0.2.1" = [ "example.com" ];
-      };
+{
+  name = "powerdns-recursor";
+  meta.maintainers = with lib.maintainers; [ rnhmjoj ];
 
-    testScript = ''
+  nodes.server = {
+    services.pdns-recursor.enable = true;
+    services.pdns-recursor.exportHosts = true;
+    services.pdns-recursor.old-settings.dnssec-log-bogus = true;
+    networking.hosts."192.0.2.1" = [ "example.com" ];
+  };
+
+  testScript = ''
+    with subtest("pdns-recursor is running"):
       server.wait_for_unit("pdns-recursor")
       server.wait_for_open_port(53)
+
+    with subtest("can resolve names"):
       assert "192.0.2.1" in server.succeed("host example.com localhost")
-    '';
-  }
-)
+
+    with subtest("old-settings have been merged in"):
+      server.succeed("${lib.getExe pkgs.yq-go} -e .dnssec.log_bogus /etc/pdns-recursor/recursor.yml")
+  '';
+}


### PR DESCRIPTION
Alternative to #377801 without any breaking change.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- Tested
  - [x] `nixosTests.pdns-recursor`
  - [x] `nixosTests.ncdns`
  - [x] using both `old-settings` and `yaml-settings`
  - [x] running `pdns-recursor` for real
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
