### PR TITLE
stdenv.mkDerivation: warn when overriding version without also overriding src

### DIFF
--- a/pkgs/applications/editors/neovim/build-neovim-plugin.nix
+++ b/pkgs/applications/editors/neovim/build-neovim-plugin.nix
@@ -26,6 +26,7 @@ let
 
   luaDrv = originalLuaDrv.overrideAttrs (oa: {
     version = attrs.version or oa.version;
+    __intentionallyOverridingVersion = true;
     rockspecVersion = oa.rockspecVersion;
 
     extraConfig = ''
@@ -43,6 +44,7 @@ let
           lua.pkgs.luarocksMoveDataFolder
         ];
         version = "${originalLuaDrv.version}-unstable-${oa.version}";
+        __intentionallyOverridingVersion = true;
       }
     )
   );

--- a/pkgs/applications/video/obs-studio/default.nix
+++ b/pkgs/applications/video/obs-studio/default.nix
@@ -67,6 +67,7 @@ let
 
   cef = cef-binary.overrideAttrs (oldAttrs: {
     version = "127.3.5";
+    __intentionallyOverridingVersion = true; # `cef-binary` uses the overridden `srcHash` values in its source FOD
     gitRevision = "114ea2a";
     chromiumVersion = "127.0.6533.120";
 

--- a/pkgs/by-name/bo/bolt-launcher/package.nix
+++ b/pkgs/by-name/bo/bolt-launcher/package.nix
@@ -23,6 +23,7 @@
 let
   cef = cef-binary.overrideAttrs (oldAttrs: {
     version = "126.2.18";
+    __intentionallyOverridingVersion = true; # `cef-binary` uses the overridden `srcHash` values in its source FOD
     gitRevision = "3647d39";
     chromiumVersion = "126.0.6478.183";
 

--- a/pkgs/by-name/li/linux-wallpaperengine/package.nix
+++ b/pkgs/by-name/li/linux-wallpaperengine/package.nix
@@ -33,6 +33,7 @@
 let
   cef = cef-binary.overrideAttrs (oldAttrs: {
     version = "120.1.10";
+    __intentionallyOverridingVersion = true; # `cef-binary` uses the overridden `srcHash` values in its source FOD
     gitRevision = "3ce3184";
     chromiumVersion = "120.0.6099.129";
 

--- a/pkgs/development/lua-modules/overrides.nix
+++ b/pkgs/development/lua-modules/overrides.nix
@@ -111,6 +111,7 @@ in
         rev = lib.last (lib.splitString "-" (lib.last rel));
       in
       "${date}-${rev}";
+    __intentionallyOverridingVersion = true;
 
     meta.broken = luaOlder "5.1" || luaAtLeast "5.5";
 


### PR DESCRIPTION
With the addition of `finalAttrs`, lots of packages have started to use this pattern:

```nix
stdenv.mkDerivation (finalAttrs: {
  version = "1.0.0";
  src = fetchurl {
    url = "https://example.com/foo/${finalAttrs.version}.tar.gz";
  };
})
```

in the hopes that when a user overrides `version` with `overrideAttrs`, the source's URL will get modified too. Unfortunately, this doesn't have any effect due to how most of our FODs are named, basically behaving no differently to using `rec` in package definitions to reuse attributes.

This change hopes to improve the user experience a bit by adding a warning when `overrideAttrs` is used in this way, which will help no matter if the package is using `finalAttrs` or `rec`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [x] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
