### PR TITLE
nixos/limine: greatly reduce the chance of the bootloader script rendering the system unbootable

### DIFF
--- a/nixos/modules/system/boot/loader/limine/limine-install.py
+++ b/nixos/modules/system/boot/loader/limine/limine-install.py
@@ -203,7 +203,8 @@ def copy_file(from_path: str, to_path: str):
     if not os.path.exists(dirname):
         os.makedirs(dirname)
 
-    shutil.copyfile(from_path, to_path)
+    shutil.copyfile(from_path, to_path + ".tmp")
+    os.rename(to_path + ".tmp", to_path)
 
 def option_from_config(name: str, config_path: List[str], conversion: Callable[[str], str] | None = None) -> str:
     if config(*config_path):

--- a/nixos/modules/system/boot/loader/limine/limine-install.py
+++ b/nixos/modules/system/boot/loader/limine/limine-install.py
@@ -74,6 +74,7 @@ def is_encrypted(device: str) -> bool:
 def is_fs_type_supported(fs_type: str) -> bool:
     return fs_type.startswith('vfat')
 
+paths = {}
 
 def get_copied_path_uri(path: str, target: str) -> str:
     result = ''
@@ -85,6 +86,8 @@ def get_copied_path_uri(path: str, target: str) -> str:
 
     if not os.path.exists(dest_path):
         copy_file(path, dest_path)
+    else:
+        paths[dest_path] = True
 
     path_with_prefix = os.path.join('/limine', target, dest_file)
     result = f'boot():{path_with_prefix}'
@@ -206,6 +209,8 @@ def copy_file(from_path: str, to_path: str):
     shutil.copyfile(from_path, to_path + ".tmp")
     os.rename(to_path + ".tmp", to_path)
 
+    paths[to_path] = True
+
 def option_from_config(name: str, config_path: List[str], conversion: Callable[[str], str] | None = None) -> str:
     if config(*config_path):
         return f'{name}: {conversion(config(*config_path)) if conversion else config(*config_path)}\n'
@@ -246,12 +251,10 @@ def main():
 
     if not os.path.exists(limine_dir):
         os.makedirs(limine_dir)
-
-    if os.path.exists(os.path.join(limine_dir, 'kernels')):
-        print(f'nuking {os.path.join(limine_dir, "kernels")}')
-        shutil.rmtree(os.path.join(limine_dir, 'kernels'))
-
-    os.makedirs(os.path.join(limine_dir, "kernels"))
+    else:
+        for dir, dirs, files in os.walk(limine_dir, topdown=True):
+            for file in files:
+                paths[os.path.join(dir, file)] = False
 
     profiles = [('system', get_gens())]
 
@@ -270,13 +273,6 @@ def main():
         graphics: yes
         default_entry: 2
     ''')
-
-    if os.path.exists(os.path.join(limine_dir, 'wallpapers')):
-        print(f'nuking {os.path.join(limine_dir, "wallpapers")}')
-        shutil.rmtree(os.path.join(limine_dir, 'wallpapers'))
-
-    if len(config('style', 'wallpapers')) > 0:
-        os.makedirs(os.path.join(limine_dir, 'wallpapers'))
 
     for wallpaper in config('style', 'wallpapers'):
         config_file += f'''wallpaper: {get_copied_path_uri(wallpaper, 'wallpapers')}\n'''
@@ -318,6 +314,8 @@ def main():
     with open(config_file_path, 'w') as file:
         file.truncate()
         file.write(config_file.strip())
+
+    paths[config_file_path] = True
 
     for dest_path, source_path in config('additionalFiles').items():
         dest_path = os.path.join(limine_dir, dest_path)
@@ -409,5 +407,10 @@ def main():
             raise Exception(
                 'Failed to deploy BIOS stage 1 Limine bootloader!\n' +
                 'You might want to try enabling the `boot.loader.limine.forceMbr` option.')
+
+    print("removing unused boot files...")
+    for path in paths:
+        if not paths[path]:
+            os.remove(path)
 
 main()


### PR DESCRIPTION
With this patch:
- Files will be copied atomically
- The kernels directory is not nuked (the contents are instead replaced accordingly)

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
