### PR TITLE
alda: run hooks in installPhase, set meta values for sub-packages

### DIFF
--- a/pkgs/by-name/al/alda/package.nix
+++ b/pkgs/by-name/al/alda/package.nix
@@ -14,7 +14,7 @@ let
   src = fetchFromGitHub {
     owner = "alda-lang";
     repo = "alda";
-    rev = "release-${version}";
+    tag = "release-${version}";
     hash = "sha256-//VfegK8wkGKSpvtsNTEQqbVJkcucNiamoNIXaEBLb8=";
   };
   license = lib.licenses.epl20;
@@ -46,6 +46,8 @@ let
       inherit license;
       homepage = "https://github.com/alda-lang/alda/tree/master/client";
       broken = !stdenv.buildPlatform.canExecute stdenv.hostPlatform;
+      maintainers = [ lib.maintainers.ericdallo ];
+      platforms = lib.platforms.unix;
     };
   };
   alda_player = stdenv.mkDerivation {
@@ -67,16 +69,22 @@ let
     gradleBuildTask = "fatJar";
 
     installPhase = ''
+      runHook preInstall
+
       mkdir -p $out/{bin,share}
       cp build/libs/alda-player-fat.jar $out/share
 
       makeWrapper ${lib.getExe jre} $out/bin/alda-player \
         --add-flags "-jar $out/share/alda-player-fat.jar"
+
+      runHook postInstall
     '';
 
     meta = {
       inherit license;
       homepage = "https://github.com/alda-lang/alda/tree/master/player";
+      maintainers = [ lib.maintainers.ericdallo ];
+      platforms = lib.platforms.unix;
     };
   };
 in
@@ -96,6 +104,6 @@ symlinkJoin {
       binaryBytecode
     ];
     maintainers = [ lib.maintainers.ericdallo ];
-    platforms = jre.meta.platforms;
+    platforms = lib.platforms.unix;
   };
 }


### PR DESCRIPTION
Follow up to #393878 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).