### PR TITLE
{_cuda.extensions,pkgsCuda,pkgsForCudaArch}: init

### DIFF
--- a/doc/languages-frameworks/cuda.section.md
+++ b/doc/languages-frameworks/cuda.section.md
@@ -95,6 +95,22 @@ final: prev: {
 }
 ```
 
+## Extending CUDA package sets {#cuda-extending-cuda-package-sets}
+
+CUDA package sets are scopes, so they provide the usual `overrideScope` attribute for overriding package attributes (see the note about `cudaMajorMinorVersion` and `_cuda` in [Configuring CUDA package sets](#cuda-configuring-cuda-package-sets)).
+
+Inspired by `pythonPackagesExtensions`, the `_cuda.extensions` attribute is a list of extensions applied to every version of the CUDA package set, allowing modification of all versions of the CUDA package set without having to know what they are or find a way to enumerate and modify them explicitly. As an example, disabling `cuda_compat` across all CUDA package sets can be accomplished with this overlay:
+
+```nix
+final: prev: {
+  _cuda = prev._cuda.extend (
+    _: prevAttrs: {
+      extensions = prevAttrs.extensions ++ [ (_: _: { cuda_compat = null; }) ];
+    }
+  );
+}
+```
+
 ## Using cudaPackages {#cuda-using-cudapackages}
 
 ::: {.caution}

--- a/doc/languages-frameworks/cuda.section.md
+++ b/doc/languages-frameworks/cuda.section.md
@@ -1,18 +1,18 @@
 # CUDA {#cuda}
 
-Compute Unified Device Architecture (CUDA) is a parallel computing platform and application programming interface (API) model created by NVIDIA. It's commonly used to accelerate computationally intensive problems and has been widely adopted for High Performance Computing (HPC) and Machine Learning (ML) applications.
+Compute Unified Device Architecture (CUDA) is a parallel computing platform and application programming interface (API) model created by NVIDIA. It's commonly used to accelerate computationally intensive problems and has been widely adopted for high-performance computing (HPC) and machine learning (ML) applications.
 
 ## User Guide {#cuda-user-guide}
 
 Packages provided by NVIDIA which require CUDA are typically stored in CUDA package sets.
 
-Nixpkgs provides a number of CUDA package sets, each based on a different CUDA release. Top-level attributes providing access to CUDA package sets follow these naming conventions:
+Nixpkgs provides a number of CUDA package sets, each based on a different CUDA release. Top-level attributes that provide access to CUDA package sets follow these naming conventions:
 
 - `cudaPackages_x_y`: A major-minor-versioned package set for a specific CUDA release, where `x` and `y` are the major and minor versions of the CUDA release.
 - `cudaPackages_x`: A major-versioned alias to the major-minor-versioned CUDA package set with the latest widely supported major CUDA release.
 - `cudaPackages`: An unversioned alias to the major-versioned alias for the latest widely supported CUDA release. The package set referenced by this alias is also referred to as the "default" CUDA package set.
 
-While versioned package sets are available (e.g., `cudaPackages_12_2`), it is recommended to use the unversioned `cudaPackages` attribute, as versioned attributes are periodically removed.
+It is recommended to use the unversioned `cudaPackages` attribute. While versioned package sets are available (e.g., `cudaPackages_12_2`), they are periodically removed.
 
 Here are two examples to illustrate the naming conventions:
 
@@ -53,17 +53,17 @@ The majority of CUDA packages are unfree, so either `allowUnfreePredicate` or `a
 
 The `cudaSupport` configuration option is used by packages to conditionally enable CUDA-specific functionality. This configuration option is commonly used by packages which can be built with or without CUDA support.
 
-The `cudaCapabilities` configuration option specifies a list of CUDA capabilities. Packages may use this option to control device code generation to take advantage of architecture-specific functionality, speed up compile times by producing less device code, or slim package closures. As an example, one can build for Ada Lovelace GPUs with `cudaCapabilities = [ "8.9" ];`. If `cudaCapabilities` is not provided, the default value is calculated per-package set, derived from a list of GPUs supported by that version of CUDA. Please consult [supported GPUs](https://en.wikipedia.org/wiki/CUDA#GPUs_supported) for specific cards. Library maintainers should consult [NVCC Docs](https://docs.nvidia.com/cuda/cuda-compiler-driver-nvcc/) and its release notes.
+The `cudaCapabilities` configuration option specifies a list of CUDA capabilities. Packages may use this option to control device code generation to take advantage of architecture-specific functionality, speed up compile times by producing less device code, or slim package closures. For example, you can build for Ada Lovelace GPUs with `cudaCapabilities = [ "8.9" ];`. If `cudaCapabilities` is not provided, the default value is calculated per-package set, derived from a list of GPUs supported by that CUDA version. Please consult [supported GPUs](https://en.wikipedia.org/wiki/CUDA#GPUs_supported) for specific cards. Library maintainers should consult [NVCC Docs](https://docs.nvidia.com/cuda/cuda-compiler-driver-nvcc/) and its release notes.
 
 ::: {.caution}
-Certain CUDA capabilities are not targeted by default, including capabilities belonging to the Jetson family of devices (like `8.7`, which corresponds to the Jetson Orin) or non-baseline feature-sets (like `9.0a`, which corresponds to the Hopper exclusive feature set). If you need to target these capabilities, you must explicitly set `cudaCapabilities` to include them.
+Certain CUDA capabilities are not targeted by default, including capabilities belonging to the Jetson family of devices (e.g. `8.7`, which corresponds to the Jetson Orin) or non-baseline feature-sets (e.g. `9.0a`, which corresponds to the Hopper exclusive feature set). If you need to target these capabilities, you must explicitly set `cudaCapabilities` to include them.
 :::
 
 The `cudaForwardCompat` boolean configuration option determines whether PTX support for future hardware is enabled.
 
 ### Modifying CUDA package sets {#cuda-modifying-cuda-package-sets}
 
-CUDA package sets are created by `callPackage`-ing `pkgs/top-level/cuda-packages.nix` with an explicit argument for `cudaMajorMinorVersion`, a string of the form `"<major>.<minor>"` (e.g., `"12.2"`), which informs the CUDA package set tooling which version of CUDA to use. The majority of the CUDA package set tooling is available through the top-level attribute set `_cuda`, a fixed-point defined outside the CUDA package sets.
+CUDA package sets are created by using `callPackage` on `pkgs/top-level/cuda-packages.nix` with an explicit argument for `cudaMajorMinorVersion`, a string of the form `"<major>.<minor>"` (e.g., `"12.2"`), which informs the CUDA package set tooling which version of CUDA to use. The majority of the CUDA package set tooling is available through the top-level attribute set `_cuda`, a fixed-point defined outside the CUDA package sets.
 
 ::: {.caution}
 The `cudaMajorMinorVersion` and `_cuda` attributes are not part of the CUDA package set fixed-point, but are instead provided by `callPackage` from the top-level in the construction of the package set. As such, they must be modified via the package set's `override` attribute.
@@ -77,7 +77,7 @@ As indicated by the underscore prefix, `_cuda` is an implementation detail and n
 The `_cuda` attribute set fixed-point should be modified through its `extend` attribute.
 :::
 
-The `_cuda.fixups` attribute set is a mapping from package name (`pname`) to a `callPackage`-able expression which will be provided to `overrideAttrs` on the result of our generic builder.
+The `_cuda.fixups` attribute set is a mapping from package name (`pname`) to a `callPackage`-compatible expression which will be provided to `overrideAttrs` on the result of our generic builder.
 
 ::: {.caution}
 Fixups are chosen from `_cuda.fixups` by `pname`. As a result, packages with multiple versions (e.g., `cudnn`, `cudnn_8_9`, etc.) all share a single fixup function (i.e., `_cuda.fixups.cudnn`, which is `pkgs/development/cuda-modules/fixups/cudnn.nix`).
@@ -101,9 +101,9 @@ final: prev: {
 
 ### Extending CUDA package sets {#cuda-extending-cuda-package-sets}
 
-CUDA package sets are scopes, so they provide the usual `overrideScope` attribute for overriding package attributes (see the note about `cudaMajorMinorVersion` and `_cuda` in [Configuring CUDA package sets](#cuda-modifying-cuda-package-sets)).
+CUDA package sets are scopes and provide the usual `overrideScope` attribute for overriding package attributes (see the note about `cudaMajorMinorVersion` and `_cuda` in [Configuring CUDA package sets](#cuda-modifying-cuda-package-sets)).
 
-Inspired by `pythonPackagesExtensions`, the `_cuda.extensions` attribute is a list of extensions applied to every version of the CUDA package set, allowing modification of all versions of the CUDA package set without having to know what they are or find a way to enumerate and modify them explicitly. As an example, disabling `cuda_compat` across all CUDA package sets can be accomplished with this overlay:
+Inspired by `pythonPackagesExtensions`, the `_cuda.extensions` attribute is a list of extensions applied to every version of the CUDA package set, allowing modification of all versions of the CUDA package set without needing to know their names or explicitly enumerate and modify them. As an example, disabling `cuda_compat` across all CUDA package sets can be accomplished with this overlay:
 
 ```nix
 final: prev: {
@@ -132,7 +132,7 @@ To use one or more CUDA packages in an expression, give the expression a `cudaPa
 <package-expression>
 ```
 
-In your package's derivation arguments, it is _strongly_ recommended the following are set:
+In your package's derivation arguments, it is _strongly_ recommended that the following are set:
 
 ```nix
 {
@@ -152,12 +152,12 @@ When using `callPackage`, you can choose to pass in a different variant, e.g. wh
 ```
 
 ::: {.caution}
-Overriding the CUDA package set used by a package may cause inconsistencies, since the override affects niether the direct nor transitive dependencies of the package. As a result, it is easy to end up with a package which uses a different CUDA package set than its dependencies. If at all possible, it is recommended to change the default CUDA package set globally, to ensure a consistent environment.
+Overriding the CUDA package set for a package may cause inconsistencies, because the override does not affect its direct or transitive dependencies. As a result, it is easy to end up with a package that use a different CUDA package set than its dependencies. If possible, it is recommended that you change the default CUDA package set globally, to ensure a consistent environment.
 :::
 
 ### Nixpkgs CUDA variants {#cuda-nixpkgs-cuda-variants}
 
-Nixpkgs CUDA variants are provided primarily for the convenience of selecting CUDA-enabled packages by attribute path. As an example, the `pkgsForCudaArch` collection of CUDA Nixpkgs variants allows one to access an instantiation of OpenCV with CUDA support for an Ada Lovelace GPU with the attribute path `pkgsForCudaArch.sm_89.opencv`, without needing to modify the `config` provided when importing Nixpkgs.
+Nixpkgs CUDA variants are provided primarily for the convenience of selecting CUDA-enabled packages by attribute path. As an example, the `pkgsForCudaArch` collection of CUDA Nixpkgs variants allows you to access an instantiation of OpenCV with CUDA support for an Ada Lovelace GPU with the attribute path `pkgsForCudaArch.sm_89.opencv`, without needing to modify the `config` provided when importing Nixpkgs.
 
 ::: {.caution}
 Nixpkgs variants are not free: they require re-evaluating Nixpkgs. Where possible, import Nixpkgs once, with the desired configuration.
@@ -165,7 +165,7 @@ Nixpkgs variants are not free: they require re-evaluating Nixpkgs. Where possibl
 
 #### Using `cudaPackages.pkgs` {#cuda-using-cudapackages-pkgs}
 
-Each CUDA package set has a `pkgs` attribute, which is a variant of Nixpkgs where the enclosing CUDA package set is made the default CUDA package set. This was done primarily to avoid package set leakage, wherein a member of a non-default CUDA package set has a (potentially transitive) dependency on a member of the default CUDA package set.
+Each CUDA package set has a `pkgs` attribute, which is a variant of Nixpkgs in which the enclosing CUDA package set becomes the default. This was done primarily to avoid package set leakage, wherein a member of a non-default CUDA package set has a (potentially transitive) dependency on a member of the default CUDA package set.
 
 ::: {.note}
 Package set leakage is a common problem in Nixpkgs and is not limited to CUDA package sets.
@@ -175,7 +175,7 @@ As an added benefit of `pkgs` being configured this way, building a package with
 
 #### Using `pkgsCuda` {#cuda-using-pkgscuda}
 
-The `pkgsCuda` attribute set is a variant of Nixpkgs configured with `cudaSupport = true;` and `rocmSupport = false`. It is a convenient way access a variant of Nixpkgs configured with the default set of CUDA capabilities.
+The `pkgsCuda` attribute set is a variant of Nixpkgs configured with `cudaSupport = true;` and `rocmSupport = false`. It is a convenient way to access a variant of Nixpkgs configured with the default set of CUDA capabilities.
 
 #### Using `pkgsForCudaArch` {#cuda-using-pkgsforcudaarch}
 
@@ -196,7 +196,7 @@ In `pkgsForCudaArch`, the `cudaForwardCompat` option is set to `false` because e
 ::: {.caution}
 Not every version of CUDA supports every architecture!
 
-To illustrate: support for Blackwell (e.g., `sm_100`) was only added in CUDA 12.8. Assume our Nixpkgs' default CUDA package set is to CUDA 12.6. Then the Nixpkgs variant available through `pkgsForCudaArch.sm_100` is useless, since packages like `pkgsForCudaArch.sm_100.opencv` and `pkgsForCudaArch.sm_100.python3Packages.torch` will try to generate code for `sm_100`, an architecture unknown to CUDA 12.6. In such a case, you should use `pkgsForCudaArch.sm_100.cudaPackages_12_8.pkgs` instead (see [Using cudaPackages.pkgs](#cuda-using-cudapackages-pkgs) for more details).
+To illustrate: support for Blackwell (e.g., `sm_100`) was added in CUDA 12.8. Assume our Nixpkgs' default CUDA package set is to CUDA 12.6. Then the Nixpkgs variant available through `pkgsForCudaArch.sm_100` is useless, since packages like `pkgsForCudaArch.sm_100.opencv` and `pkgsForCudaArch.sm_100.python3Packages.torch` will try to generate code for `sm_100`, an architecture unknown to CUDA 12.6. In that case, you should use `pkgsForCudaArch.sm_100.cudaPackages_12_8.pkgs` instead (see [Using cudaPackages.pkgs](#cuda-using-cudapackages-pkgs) for more details).
 :::
 
 The `pkgsForCudaArch` attribute set makes it possible to access packages built for a specific architecture without needing to manually call `pkgs.extend` and supply a new `config`. As an example, `pkgsForCudaArch.sm_89.python3Packages.torch` provides PyTorch built for Ada Lovelace GPUs.

--- a/doc/languages-frameworks/cuda.section.md
+++ b/doc/languages-frameworks/cuda.section.md
@@ -2,6 +2,8 @@
 
 Compute Unified Device Architecture (CUDA) is a parallel computing platform and application programming interface (API) model created by NVIDIA. It's commonly used to accelerate computationally intensive problems and has been widely adopted for High Performance Computing (HPC) and Machine Learning (ML) applications.
 
+## User Guide {#cuda-user-guide}
+
 Packages provided by NVIDIA which require CUDA are typically stored in CUDA package sets.
 
 Nixpkgs provides a number of CUDA package sets, each based on a different CUDA release. Top-level attributes providing access to CUDA package sets follow these naming conventions:
@@ -19,7 +21,7 @@ Here are two examples to illustrate the naming conventions:
 
 All CUDA package sets include common CUDA packages like `libcublas`, `cudnn`, `tensorrt`, and `nccl`.
 
-## Configuring Nixpkgs for CUDA {#cuda-configuring-nixpkgs-for-cuda}
+### Configuring Nixpkgs for CUDA {#cuda-configuring-nixpkgs-for-cuda}
 
 CUDA support is not enabled by default in Nixpkgs. To enable CUDA support, make sure Nixpkgs is imported with a configuration similar to the following:
 
@@ -59,7 +61,7 @@ Certain CUDA capabilities are not targeted by default, including capabilities be
 
 The `cudaForwardCompat` boolean configuration option determines whether PTX support for future hardware is enabled.
 
-## Configuring CUDA package sets {#cuda-configuring-cuda-package-sets}
+### Modifying CUDA package sets {#cuda-modifying-cuda-package-sets}
 
 CUDA package sets are created by `callPackage`-ing `pkgs/top-level/cuda-packages.nix` with an explicit argument for `cudaMajorMinorVersion`, a string of the form `"<major>.<minor>"` (e.g., `"12.2"`), which informs the CUDA package set tooling which version of CUDA to use. The majority of the CUDA package set tooling is available through the top-level attribute set `_cuda`, a fixed-point defined outside the CUDA package sets.
 
@@ -97,9 +99,9 @@ final: prev: {
 }
 ```
 
-## Extending CUDA package sets {#cuda-extending-cuda-package-sets}
+### Extending CUDA package sets {#cuda-extending-cuda-package-sets}
 
-CUDA package sets are scopes, so they provide the usual `overrideScope` attribute for overriding package attributes (see the note about `cudaMajorMinorVersion` and `_cuda` in [Configuring CUDA package sets](#cuda-configuring-cuda-package-sets)).
+CUDA package sets are scopes, so they provide the usual `overrideScope` attribute for overriding package attributes (see the note about `cudaMajorMinorVersion` and `_cuda` in [Configuring CUDA package sets](#cuda-modifying-cuda-package-sets)).
 
 Inspired by `pythonPackagesExtensions`, the `_cuda.extensions` attribute is a list of extensions applied to every version of the CUDA package set, allowing modification of all versions of the CUDA package set without having to know what they are or find a way to enumerate and modify them explicitly. As an example, disabling `cuda_compat` across all CUDA package sets can be accomplished with this overlay:
 
@@ -113,7 +115,7 @@ final: prev: {
 }
 ```
 
-## Using `cudaPackages` {#cuda-using-cudapackages}
+### Using `cudaPackages` {#cuda-using-cudapackages}
 
 ::: {.caution}
 A non-trivial amount of CUDA package discoverability and usability relies on the various setup hooks used by a CUDA package set. As a result, users will likely encounter issues trying to perform builds within a `devShell` without manually invoking phases.
@@ -153,7 +155,15 @@ When using `callPackage`, you can choose to pass in a different variant, e.g. wh
 Overriding the CUDA package set used by a package may cause inconsistencies, since the override affects niether the direct nor transitive dependencies of the package. As a result, it is easy to end up with a package which uses a different CUDA package set than its dependencies. If at all possible, it is recommended to change the default CUDA package set globally, to ensure a consistent environment.
 :::
 
-## Using `cudaPackages.pkgs` {#cuda-using-cudapackages-pkgs}
+### Nixpkgs CUDA variants {#cuda-nixpkgs-cuda-variants}
+
+Nixpkgs CUDA variants are provided primarily for the convenience of selecting CUDA-enabled packages by attribute path. As an example, the `pkgsForCudaArch` collection of CUDA Nixpkgs variants allows one to access an instantiation of OpenCV with CUDA support for an Ada Lovelace GPU with the attribute path `pkgsForCudaArch.sm_89.opencv`, without needing to modify the `config` provided when importing Nixpkgs.
+
+::: {.caution}
+Nixpkgs variants are not free: they require re-evaluating Nixpkgs. Where possible, import Nixpkgs once, with the desired configuration.
+:::
+
+#### Using `cudaPackages.pkgs` {#cuda-using-cudapackages-pkgs}
 
 Each CUDA package set has a `pkgs` attribute, which is a variant of Nixpkgs where the enclosing CUDA package set is made the default CUDA package set. This was done primarily to avoid package set leakage, wherein a member of a non-default CUDA package set has a (potentially transitive) dependency on a member of the default CUDA package set.
 
@@ -163,11 +173,11 @@ Package set leakage is a common problem in Nixpkgs and is not limited to CUDA pa
 
 As an added benefit of `pkgs` being configured this way, building a package with a non-default version of CUDA is as simple as accessing an attribute. As an example, `cudaPackages_12_8.pkgs.opencv` provides OpenCV built against CUDA 12.8.
 
-## Using `pkgsCuda` {#cuda-using-pkgscuda}
+#### Using `pkgsCuda` {#cuda-using-pkgscuda}
 
 The `pkgsCuda` attribute set is a variant of Nixpkgs configured with `cudaSupport = true;` and `rocmSupport = false`. It is a convenient way access a variant of Nixpkgs configured with the default set of CUDA capabilities.
 
-## Using `pkgsForCudaArch` {#cuda-using-pkgsforcudaarch}
+#### Using `pkgsForCudaArch` {#cuda-using-pkgsforcudaarch}
 
 The `pkgsForCudaArch` attribute set maps CUDA architectures (e.g., `sm_89` for Ada Lovelace or `sm_90a` for architecture-specific Hopper) to Nixpkgs variants configured to support exactly that architecture. As an example, `pkgsForCudaArch.sm_89` is a Nixpkgs variant extending `pkgs` and setting the following values in `config`:
 
@@ -191,7 +201,7 @@ To illustrate: support for Blackwell (e.g., `sm_100`) was only added in CUDA 12.
 
 The `pkgsForCudaArch` attribute set makes it possible to access packages built for a specific architecture without needing to manually call `pkgs.extend` and supply a new `config`. As an example, `pkgsForCudaArch.sm_89.python3Packages.torch` provides PyTorch built for Ada Lovelace GPUs.
 
-## Running Docker or Podman containers with CUDA support {#cuda-docker-podman}
+### Running Docker or Podman containers with CUDA support {#cuda-docker-podman}
 
 It is possible to run Docker or Podman containers with CUDA support. The recommended mechanism to perform this task is to use the [NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/index.html).
 
@@ -236,7 +246,7 @@ $ nix run nixpkgs#jq -- -r '.devices[].name' < /var/run/cdi/nvidia-container-too
 all
 ```
 
-### Specifying what devices to expose to the container {#cuda-specifying-what-devices-to-expose-to-the-container}
+#### Specifying what devices to expose to the container {#cuda-specifying-what-devices-to-expose-to-the-container}
 
 You can choose what devices are exposed to your containers by using the identifier on the generated CDI specification. Like follows:
 
@@ -257,7 +267,7 @@ GPU 1: NVIDIA GeForce RTX 2080 SUPER (UUID: <REDACTED>)
 By default, the NVIDIA Container Toolkit will use the GPU index to identify specific devices. You can change the way to identify what devices to expose by using the `hardware.nvidia-container-toolkit.device-name-strategy` NixOS attribute.
 :::
 
-### Using docker-compose {#cuda-using-docker-compose}
+#### Using docker-compose {#cuda-using-docker-compose}
 
 It's possible to expose GPU's to a `docker-compose` environment as well. With a `docker-compose.yaml` file like follows:
 

--- a/doc/redirects.json
+++ b/doc/redirects.json
@@ -23,9 +23,6 @@
   "cuda": [
     "index.html#cuda"
   ],
-  "cuda-configuring-cuda-package-sets": [
-    "index.html#cuda-configuring-cuda-package-sets"
-  ],
   "cuda-configuring-nixpkgs-for-cuda": [
     "index.html#cuda-configuring-nixpkgs-for-cuda"
   ],
@@ -37,6 +34,13 @@
   ],
   "cuda-extending-cuda-package-sets": [
     "index.html#cuda-extending-cuda-package-sets"
+  ],
+  "cuda-modifying-cuda-package-sets": [
+    "index.html#cuda-modifying-cuda-package-sets",
+    "index.html#cuda-configuring-cuda-package-sets"
+  ],
+  "cuda-nixpkgs-cuda-variants": [
+    "index.html#cuda-nixpkgs-cuda-variants"
   ],
   "cuda-package-set-maintenance": [
     "index.html#cuda-package-set-maintenance",
@@ -71,6 +75,9 @@
   "cuda-updating-the-cuda-toolkit": [
     "index.html#cuda-updating-the-cuda-toolkit",
     "index.html#updating-the-cuda-toolkit"
+  ],
+  "cuda-user-guide": [
+    "index.html#cuda-user-guide"
   ],
   "cuda-using-cudapackages": [
     "index.html#cuda-using-cudapackages"

--- a/doc/redirects.json
+++ b/doc/redirects.json
@@ -35,6 +35,9 @@
   "cuda-docker-podman": [
     "index.html#cuda-docker-podman"
   ],
+  "cuda-extending-cuda-package-sets": [
+    "index.html#cuda-extending-cuda-package-sets"
+  ],
   "cuda-package-set-maintenance": [
     "index.html#cuda-package-set-maintenance",
     "index.html#adding-a-new-cuda-release"

--- a/doc/redirects.json
+++ b/doc/redirects.json
@@ -75,9 +75,18 @@
   "cuda-using-cudapackages": [
     "index.html#cuda-using-cudapackages"
   ],
+  "cuda-using-cudapackages-pkgs": [
+    "index.html#cuda-using-cudapackages-pkgs"
+  ],
   "cuda-using-docker-compose": [
     "index.html#cuda-using-docker-compose",
     "index.html#using-docker-compose"
+  ],
+  "cuda-using-pkgscuda": [
+    "index.html#cuda-using-pkgscuda"
+  ],
+  "cuda-using-pkgsforcudaarch": [
+    "index.html#cuda-using-pkgsforcudaarch"
   ],
   "cuda-writing-tests": [
     "index.html#cuda-writing-tests"

--- a/doc/redirects.json
+++ b/doc/redirects.json
@@ -20,6 +20,65 @@
   "cmake-ctest-variables": [
     "index.html#cmake-ctest-variables"
   ],
+  "cuda": [
+    "index.html#cuda"
+  ],
+  "cuda-configuring-cuda-package-sets": [
+    "index.html#cuda-configuring-cuda-package-sets"
+  ],
+  "cuda-configuring-nixpkgs-for-cuda": [
+    "index.html#cuda-configuring-nixpkgs-for-cuda"
+  ],
+  "cuda-contributing": [
+    "index.html#cuda-contributing"
+  ],
+  "cuda-docker-podman": [
+    "index.html#cuda-docker-podman"
+  ],
+  "cuda-package-set-maintenance": [
+    "index.html#cuda-package-set-maintenance",
+    "index.html#adding-a-new-cuda-release"
+  ],
+  "cuda-passthru-testers": [
+    "index.html#cuda-passthru-testers"
+  ],
+  "cuda-passthru-tests": [
+    "index.html#cuda-passthru-tests"
+  ],
+  "cuda-specifying-what-devices-to-expose-to-the-container": [
+    "index.html#cuda-specifying-what-devices-to-expose-to-the-container",
+    "index.html#specifying-what-devices-to-expose-to-the-container"
+  ],
+  "cuda-updating-redistributables": [
+    "index.html#cuda-updating-redistributables",
+    "index.html#updating-cuda-redistributables"
+  ],
+  "cuda-updating-cutensor": [
+    "index.html#cuda-updating-cutensor",
+    "index.html#updating-cutensor"
+  ],
+  "cuda-updating-supported-compilers-and-gpus": [
+    "index.html#cuda-updating-supported-compilers-and-gpus",
+    "index.html#updating-supported-compilers-and-gpus"
+  ],
+  "cuda-updating-the-cuda-package-set": [
+    "index.html#cuda-updating-the-cuda-package-set",
+    "index.html#updating-the-cuda-package-set"
+  ],
+  "cuda-updating-the-cuda-toolkit": [
+    "index.html#cuda-updating-the-cuda-toolkit",
+    "index.html#updating-the-cuda-toolkit"
+  ],
+  "cuda-using-cudapackages": [
+    "index.html#cuda-using-cudapackages"
+  ],
+  "cuda-using-docker-compose": [
+    "index.html#cuda-using-docker-compose",
+    "index.html#using-docker-compose"
+  ],
+  "cuda-writing-tests": [
+    "index.html#cuda-writing-tests"
+  ],
   "ex-build-helpers-extendMkDerivation": [
     "index.html#ex-build-helpers-extendMkDerivation"
   ],
@@ -2752,56 +2811,6 @@
   ],
   "building-a-crystal-package": [
     "index.html#building-a-crystal-package"
-  ],
-  "cuda": [
-    "index.html#cuda"
-  ],
-  "cuda-contributing": [
-    "index.html#cuda-contributing"
-  ],
-  "cuda-docker-podman": [
-    "index.html#cuda-docker-podman"
-  ],
-  "cuda-package-set-maintenance": [
-    "index.html#cuda-package-set-maintenance",
-    "index.html#adding-a-new-cuda-release"
-  ],
-  "cuda-passthru-testers": [
-    "index.html#cuda-passthru-testers"
-  ],
-  "cuda-passthru-tests": [
-    "index.html#cuda-passthru-tests"
-  ],
-  "cuda-specifying-what-devices-to-expose-to-the-container": [
-    "index.html#cuda-specifying-what-devices-to-expose-to-the-container",
-    "index.html#specifying-what-devices-to-expose-to-the-container"
-  ],
-  "cuda-updating-redistributables": [
-    "index.html#cuda-updating-redistributables",
-    "index.html#updating-cuda-redistributables"
-  ],
-  "cuda-updating-cutensor": [
-    "index.html#cuda-updating-cutensor",
-    "index.html#updating-cutensor"
-  ],
-  "cuda-updating-supported-compilers-and-gpus": [
-    "index.html#cuda-updating-supported-compilers-and-gpus",
-    "index.html#updating-supported-compilers-and-gpus"
-  ],
-  "cuda-updating-the-cuda-package-set": [
-    "index.html#cuda-updating-the-cuda-package-set",
-    "index.html#updating-the-cuda-package-set"
-  ],
-  "cuda-updating-the-cuda-toolkit": [
-    "index.html#cuda-updating-the-cuda-toolkit",
-    "index.html#updating-the-cuda-toolkit"
-  ],
-  "cuda-using-docker-compose": [
-    "index.html#cuda-using-docker-compose",
-    "index.html#using-docker-compose"
-  ],
-  "cuda-writing-tests": [
-    "index.html#cuda-writing-tests"
   ],
   "cuelang": [
     "index.html#cuelang"

--- a/pkgs/development/cuda-modules/_cuda/default.nix
+++ b/pkgs/development/cuda-modules/_cuda/default.nix
@@ -22,6 +22,7 @@ lib.fixedPoints.makeExtensible (final: {
     inherit (final) bootstrapData db;
     inherit lib;
   };
+  extensions = [ ]; # Extensions applied to every CUDA package set.
   fixups = import ./fixups { inherit lib; };
   lib = import ./lib {
     _cuda = final;

--- a/pkgs/development/cuda-modules/_cuda/fixups/nsight_systems.nix
+++ b/pkgs/development/cuda-modules/_cuda/fixups/nsight_systems.nix
@@ -2,6 +2,7 @@
   boost178,
   cuda_cudart,
   cudaOlder,
+  e2fsprogs,
   gst_all_1,
   lib,
   nss,
@@ -77,6 +78,7 @@ in
     (qt.qtwayland or qt.full)
     boost178
     cuda_cudart.stubs
+    e2fsprogs
     gst_all_1.gst-plugins-base
     gst_all_1.gstreamer
     nss

--- a/pkgs/top-level/cuda-packages.nix
+++ b/pkgs/top-level/cuda-packages.nix
@@ -209,6 +209,7 @@ let
     ++ lib.optionals config.allowAliases [
       (import ../development/cuda-modules/aliases.nix { inherit lib; })
     ]
+    ++ _cuda.extensions
   );
 
   cudaPackages = customisation.makeScope newScope (

--- a/pkgs/top-level/cuda-packages.nix
+++ b/pkgs/top-level/cuda-packages.nix
@@ -25,7 +25,7 @@
   _cuda,
   cudaMajorMinorVersion,
   lib,
-  newScope,
+  pkgs,
   stdenv,
   runCommand,
 }:
@@ -51,6 +51,36 @@ let
     lib.intersectLists jetsonCudaCapabilities (config.cudaCapabilities or [ ]) != [ ];
   redistSystem = _cuda.lib.getRedistSystem hasJetsonCudaCapability stdenv.hostPlatform.system;
 
+  # We must use an instance of Nixpkgs where the CUDA package set we're building is the default; if we do not, members
+  # of the versioned, non-default package sets may rely on (transitively) members of the default, unversioned CUDA
+  # package set.
+  # See `Using cudaPackages.pkgs` in doc/languages-frameworks/cuda.section.md for more information.
+  pkgs' =
+    let
+      cudaPackagesUnversionedName = "cudaPackages";
+      cudaPackagesMajorVersionName = cudaLib.mkVersionedName cudaPackagesUnversionedName (
+        versions.major cudaMajorMinorVersion
+      );
+      cudaPackagesMajorMinorVersionName = cudaLib.mkVersionedName cudaPackagesUnversionedName cudaMajorMinorVersion;
+    in
+    # If the CUDA version of pkgs matches our CUDA version, we are constructing the default package set and can use
+    # pkgs without modification.
+    if pkgs.cudaPackages.cudaMajorMinorVersion == cudaMajorMinorVersion then
+      pkgs
+    else
+      pkgs.extend (
+        final: _: {
+          __attrsFailEvaluation = true;
+          recurseForDerivations = false;
+          # The CUDA package set will be available as cudaPackages_x_y, so we need only update the aliases for the
+          # minor-versioned and unversioned package sets.
+          # cudaPackages_x = cudaPackages_x_y
+          ${cudaPackagesMajorVersionName} = final.${cudaPackagesMajorMinorVersionName};
+          # cudaPackages = cudaPackages_x
+          ${cudaPackagesUnversionedName} = final.${cudaPackagesMajorVersionName};
+        }
+      );
+
   passthruFunction = final: {
     # NOTE:
     # It is important that _cuda is not part of the package set fixed-point. As described by
@@ -64,21 +94,13 @@ let
 
     inherit cudaMajorMinorVersion;
 
+    pkgs = pkgs';
+
     cudaNamePrefix = "cuda${cudaMajorMinorVersion}";
 
     cudaMajorVersion = versions.major cudaMajorMinorVersion;
     cudaOlder = strings.versionOlder cudaMajorMinorVersion;
     cudaAtLeast = strings.versionAtLeast cudaMajorMinorVersion;
-
-    # Maintain a reference to the final cudaPackages.
-    # Without this, if we use `final.callPackage` and a package accepts `cudaPackages` as an
-    # argument, it's provided with `cudaPackages` from the top-level scope, which is not what we
-    # want. We want to provide the `cudaPackages` from the final scope -- that is, the *current*
-    # scope. However, we also want to prevent `pkgs/top-level/release-attrpaths-superset.nix` from
-    # recursing more than one level here.
-    cudaPackages = final // {
-      __attrsFailEvaluation = true;
-    };
 
     flags =
       cudaLib.formatCapabilities {
@@ -212,7 +234,7 @@ let
     ++ _cuda.extensions
   );
 
-  cudaPackages = customisation.makeScope newScope (
+  cudaPackages = customisation.makeScope pkgs'.newScope (
     fixedPoints.extends composedExtension passthruFunction
   );
 in

--- a/pkgs/top-level/variants.nix
+++ b/pkgs/top-level/variants.nix
@@ -95,6 +95,27 @@ self: super: {
     };
   });
 
+  # `pkgsForCudaArch` maps each CUDA capability in _cuda.db.cudaCapabilityToInfo to a Nixpkgs variant configured for
+  # that target system. For example, `pkgsForCudaArch.sm_90a.python3Packages.torch` refers to PyTorch built for the
+  # Hopper architecture, leveraging architecture-specific features.
+  # NOTE: Not every package set is supported on every architecture!
+  # See `Using pkgsForCudaArch` in doc/languages-frameworks/cuda.section.md for more information.
+  pkgsForCudaArch = lib.listToAttrs (
+    lib.map (cudaCapability: {
+      name = self._cuda.lib.mkRealArchitecture cudaCapability;
+      value = nixpkgsFun {
+        config = super.config // {
+          cudaSupport = true;
+          rocmSupport = false;
+          # Not supported by architecture-specific feature sets, so disable for all.
+          # Users can choose to build for family-specific feature sets if they wish.
+          cudaForwardCompat = false;
+          cudaCapabilities = [ cudaCapability ];
+        };
+      };
+    }) (lib.attrNames self._cuda.db.cudaCapabilityToInfo)
+  );
+
   pkgsExtraHardening = nixpkgsFun {
     overlays = [
       (

--- a/pkgs/top-level/variants.nix
+++ b/pkgs/top-level/variants.nix
@@ -95,6 +95,15 @@ self: super: {
     };
   });
 
+  # Full package set with cuda on rocm off
+  # Mostly useful for asserting pkgs.pkgsCuda.torchWithCuda == pkgs.torchWithCuda and similar
+  pkgsCuda = nixpkgsFun {
+    config = super.config // {
+      cudaSupport = true;
+      rocmSupport = false;
+    };
+  };
+
   # `pkgsForCudaArch` maps each CUDA capability in _cuda.db.cudaCapabilityToInfo to a Nixpkgs variant configured for
   # that target system. For example, `pkgsForCudaArch.sm_90a.python3Packages.torch` refers to PyTorch built for the
   # Hopper architecture, leveraging architecture-specific features.


### PR DESCRIPTION
This PR:

- Includes CUDA language section documentation fixups and new sections (including a CUDA User Guide!)
- Introduces and documents `_cuda.extensions`, `pkgsCuda`, and `pkgsForCudaArch`
- Fixes package set leakage in versioned, non-default instances of the CUDA package set (e.g., `cudaPackages_11_8`, `cudaPackages_12_2`, etc.) and documents `cudaPackages.pkgs`

> [!NOTE]
>
> There is a increase to evaluation time for attributes which draw from the non-default CUDA package set due to the implementation of the fix for package set leakage.

As an example, consider `catboost`, which requires `cudaPackages_11`, and saw a slight slowdown from about `0.49` seconds to about `0.55` seconds:

<details><summary>Before</summary>

```json
{
  "cpuTime": 0.4951170086860657,
  "envs": {
    "bytes": 14589216,
    "elements": 1034109,
    "number": 789543
  },
  "gc": {
    "cycles": 1,
    "heapSize": 402915328,
    "totalBytes": 182882816
  },
  "list": {
    "bytes": 1729208,
    "concats": 22189,
    "elements": 216151
  },
  "nrAvoided": 846465,
  "nrExprs": 217900,
  "nrFunctionCalls": 711585,
  "nrLookups": 381381,
  "nrOpUpdateValuesCopied": 4538315,
  "nrOpUpdates": 45631,
  "nrPrimOpCalls": 417981,
  "nrThunks": 908748,
  "sets": {
    "bytes": 89235808,
    "elements": 5467638,
    "number": 109600
  },
  "sizes": {
    "Attr": 16,
    "Bindings": 16,
    "Env": 8,
    "Value": 24
  },
  "symbols": {
    "bytes": 464088,
    "number": 44826
  },
  "time": {
    "cpu": 0.4951170086860657,
    "gc": 0.002,
    "gcFraction": 0.004039449190621771
  },
  "values": {
    "bytes": 52030200,
    "number": 2167925
  }
}
```

</details>

<details><summary>After</summary>

```json
{
  "cpuTime": 0.5533679723739624,
  "envs": {
    "bytes": 22146784,
    "elements": 1569057,
    "number": 1199291
  },
  "gc": {
    "cycles": 1,
    "heapSize": 402915328,
    "totalBytes": 275970768
  },
  "list": {
    "bytes": 2658768,
    "concats": 31839,
    "elements": 332346
  },
  "nrAvoided": 1285255,
  "nrExprs": 217978,
  "nrFunctionCalls": 1073751,
  "nrLookups": 590551,
  "nrOpUpdateValuesCopied": 6945741,
  "nrOpUpdates": 65022,
  "nrPrimOpCalls": 644075,
  "nrThunks": 1375075,
  "sets": {
    "bytes": 135716224,
    "elements": 8314615,
    "number": 167649
  },
  "sizes": {
    "Attr": 16,
    "Bindings": 16,
    "Env": 8,
    "Value": 24
  },
  "symbols": {
    "bytes": 464266,
    "number": 44837
  },
  "time": {
    "cpu": 0.5533679723739624,
    "gc": 0.002,
    "gcFraction": 0.003614231577985893
  },
  "values": {
    "bytes": 77944752,
    "number": 3247698
  }
}
```

</details>

The largest measured increase in evaluation time comes from `pkgs/top-level/release-cuda.nix`, which instantiates *every* CUDA package set, jumping from about `7.7` seconds to about `25.6` seconds:

<details><summary>Before</summary>

```json
{
  "cpuTime": 7.651072025299072,
  "envs": {
    "bytes": 438816984,
    "elements": 31661704,
    "number": 23190419
  },
  "gc": {
    "cycles": 9,
    "heapSize": 1829953536,
    "totalBytes": 3203691584
  },
  "list": {
    "bytes": 60658712,
    "concats": 1043070,
    "elements": 7582339
  },
  "nrAvoided": 24049709,
  "nrExprs": 1224124,
  "nrFunctionCalls": 20635918,
  "nrLookups": 10945781,
  "nrOpUpdateValuesCopied": 47363986,
  "nrOpUpdates": 1770862,
  "nrPrimOpCalls": 9565514,
  "nrThunks": 27756355,
  "sets": {
    "bytes": 1151189808,
    "elements": 67027422,
    "number": 4921941
  },
  "sizes": {
    "Attr": 16,
    "Bindings": 16,
    "Env": 8,
    "Value": 24
  },
  "symbols": {
    "bytes": 937835,
    "number": 81382
  },
  "time": {
    "cpu": 7.651072025299072,
    "gc": 2.613,
    "gcFraction": 0.34152076877068227
  },
  "values": {
    "bytes": 977363952,
    "number": 40723498
  }
}
```

</details>

<details><summary>After</summary>

```json
{
  "cpuTime": 25.631572723388672,
  "envs": {
    "bytes": 1542351136,
    "elements": 110687785,
    "number": 82106107
  },
  "gc": {
    "cycles": 13,
    "heapSize": 7483875328,
    "totalBytes": 12488948416
  },
  "list": {
    "bytes": 194446808,
    "concats": 3671610,
    "elements": 24305851
  },
  "nrAvoided": 87539852,
  "nrExprs": 1224245,
  "nrFunctionCalls": 75285426,
  "nrLookups": 35311482,
  "nrOpUpdateValuesCopied": 236831655,
  "nrOpUpdates": 6330797,
  "nrPrimOpCalls": 35780617,
  "nrThunks": 94455780,
  "sets": {
    "bytes": 4987623664,
    "elements": 298972000,
    "number": 12754479
  },
  "sizes": {
    "Attr": 16,
    "Bindings": 16,
    "Env": 8,
    "Value": 24
  },
  "symbols": {
    "bytes": 937946,
    "number": 81387
  },
  "time": {
    "cpu": 25.631572723388672,
    "gc": 7.534,
    "gcFraction": 0.2939343629556241
  },
  "values": {
    "bytes": 3475471944,
    "number": 144811331
  }
}
```

</details>

Given the small number of packages which use a non-default version of the CUDA package set:

- `catboost`: https://github.com/NixOS/nixpkgs/blob/846783c12b7a8da2fc4f0636bb1025bc03a71730/pkgs/top-level/all-packages.nix#L7802
- `dcgm`: https://github.com/NixOS/nixpkgs/blob/846783c12b7a8da2fc4f0636bb1025bc03a71730/pkgs/by-name/dc/dcgm/package.nix#L9-L10
- Old releases of `magma`: https://github.com/NixOS/nixpkgs/blob/846783c12b7a8da2fc4f0636bb1025bc03a71730/pkgs/development/libraries/science/math/magma/generic.nix#L45-L46
- `python3Packages.paddlepaddle`: https://github.com/NixOS/nixpkgs/blob/846783c12b7a8da2fc4f0636bb1025bc03a71730/pkgs/development/python-modules/paddlepaddle/default.nix#L13
- `python3Packages.tensorflow-build`: https://github.com/NixOS/nixpkgs/blob/846783c12b7a8da2fc4f0636bb1025bc03a71730/pkgs/top-level/python-packages.nix#L17604
- `python3Packages.tensorrt`: https://github.com/NixOS/nixpkgs/blob/846783c12b7a8da2fc4f0636bb1025bc03a71730/pkgs/top-level/python-packages.nix#L17671

I don't believe this increase to be a cause for concern for most users.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
