### PR TITLE
cudaPackages.cuda_nvcc: remove trailing escape

### DIFF
--- a/pkgs/development/cuda-modules/fixups/cuda_nvcc.nix
+++ b/pkgs/development/cuda-modules/fixups/cuda_nvcc.nix
@@ -40,7 +40,7 @@ prevAttrs: {
       substituteInPlace bin/nvcc.profile \
         --replace-fail \
           '$(TOP)/$(_NVVM_BRANCH_)' \
-          "''${!outputBin}/nvvm" \
+          "''${!outputBin}/nvvm"
     ''
     + ''
       cat << EOF >> bin/nvcc.profile


### PR DESCRIPTION
I made a bad refactor in #404973 which left a trailing escape character in the fixup function for CUDA NVCC, breaking builds when using a version of CUDA older than 12.5 (the default is 12.8). Here's the failure:

```console
cuda_nvcc> source root is cuda_nvcc-linux-x86_64-11.8.89-archive
cuda_nvcc> setting SOURCE_DATE_EPOCH to timestamp 1663785538 of file "cuda_nvcc-linux-x86_64-11.8.89-archive/LICENSE"
cuda_nvcc> Running phase: patchPhase
cuda_nvcc> substituteStream() in derivation cuda_nvcc-11.8.89: ERROR: Invalid command line argument: cat
error: build of '/nix/store/xkj8hg9r5gq40r5r2jplnmb7fkgpfs2b-cuda_nvcc-11.8.89.drv' on 'ssh-ng://nixos-ext' failed: builder for '/nix/store/xkj8hg9r5gq40r5r2jplnmb7fkgpfs2b-cuda_nvcc-11.8.89.drv' failed with exit code 1;
       last 11 log lines:
       > structuredAttrs is enabled
       > Sourcing auto-add-driver-runpath-hook
       > Using autoAddDriverRunpath
       > Sourcing fix-elf-files.sh
       > Sourcing mark-for-cudatoolkit-root-hook
       > Running phase: unpackPhase
       > unpacking source archive /nix/store/v3k6v884w16ja4cw88v1i5y0blyg38zv-cuda_nvcc-linux-x86_64-11.8.89-archive.tar.xz
       > source root is cuda_nvcc-linux-x86_64-11.8.89-archive
       > setting SOURCE_DATE_EPOCH to timestamp 1663785538 of file "cuda_nvcc-linux-x86_64-11.8.89-archive/LICENSE"
       > Running phase: patchPhase
       > substituteStream() in derivation cuda_nvcc-11.8.89: ERROR: Invalid command line argument: cat
       For full logs, run:
         nix log /nix/store/xkj8hg9r5gq40r5r2jplnmb7fkgpfs2b-cuda_nvcc-11.8.89.drv
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
