### PR TITLE
duckdb: fix cross compilation

### DIFF
--- a/pkgs/by-name/du/duckdb/package.nix
+++ b/pkgs/by-name/du/duckdb/package.nix
@@ -5,15 +5,33 @@
   cmake,
   ninja,
   openssl,
-  openjdk11,
   python3,
-  unixodbc,
-  withJdbc ? false,
-  withOdbc ? false,
   versionCheckHook,
 }:
 
 let
+  canExecute = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
+  # Keep this in sync with DuckDBPlatform() in DuckDB's platform.hpp.
+  duckdbPlatform =
+    let
+      os =
+        if stdenv.hostPlatform.isWindows then
+          "windows"
+        else if stdenv.hostPlatform.isDarwin then
+          "osx"
+        else if stdenv.hostPlatform.isFreeBSD then
+          "freebsd"
+        else
+          "linux";
+      arch =
+        if stdenv.hostPlatform.isAarch64 then
+          "arm64"
+        else if stdenv.hostPlatform.is64bit then
+          "amd64"
+        else
+          "i686";
+    in
+    "${os}_${arch}${lib.optionalString stdenv.hostPlatform.isMusl "_musl"}${lib.optionalString stdenv.hostPlatform.isMinGW "_mingw"}";
   versions = lib.importJSON ./versions.json;
 in
 stdenv.mkDerivation (finalAttrs: {
@@ -40,22 +58,19 @@ stdenv.mkDerivation (finalAttrs: {
     ninja
     python3
   ];
-  buildInputs = [
-    openssl
-  ]
-  ++ lib.optionals withJdbc [ openjdk11 ]
-  ++ lib.optionals withOdbc [ unixodbc ];
+  buildInputs = [ openssl ];
 
   cmakeFlags = [
     (lib.cmakeFeature "DUCKDB_EXTENSION_CONFIGS" "${finalAttrs.src}/.github/config/in_tree_extensions.cmake")
-    (lib.cmakeBool "BUILD_ODBC_DRIVER" withOdbc)
-    (lib.cmakeBool "JDBC_DRIVER" withJdbc)
     (lib.cmakeFeature "OVERRIDE_GIT_DESCRIBE" "v${finalAttrs.version}-0-g${finalAttrs.rev}")
     # development settings
-    (lib.cmakeBool "BUILD_UNITTESTS" finalAttrs.doInstallCheck)
+    (lib.cmakeBool "BUILD_UNITTESTS" finalAttrs.finalPackage.doInstallCheck)
+  ]
+  ++ lib.optionals (!canExecute) [
+    (lib.cmakeFeature "DUCKDB_EXPLICIT_PLATFORM" duckdbPlatform)
   ];
 
-  doInstallCheck = true;
+  doInstallCheck = canExecute;
 
   nativeInstallCheckInputs = [ versionCheckHook ];
 


### PR DESCRIPTION
DuckDB normally builds and executes a target-platform probe during CMake configuration, which breaks cross compilation without an emulator. Set `DUCKDB_EXPLICIT_PLATFORM` from the nixpkgs host platform and only build or run tests when the build platform can execute host binaries. This also removes JDBC and ODBC options that DuckDB no longer recognizes.

This replaces the stale parts of the original PR: DuckDB now uses GNUInstallDirs, #444225 introduced the current source update workflow, and the Darwin deployment-target workaround is no longer needed.

Validation:

- Built `duckdb` on x86_64-linux, ran its full `installCheck` suite, and smoke-tested the CLI.
- Cross-built `pkgsCross.aarch64-multiplatform.duckdb`; the resulting AArch64 artifacts use `linux_arm64`.
- Built `python313Packages.duckdb`; 3316 tests passed, with 42 skipped and 9 expected xfails.
- Ran `nix fmt` and `git diff --check`.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux (cross-compiled from x86_64-linux)
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
