### PR TITLE
rime-wanxiang: init at 6.7.8

### DIFF
--- a/pkgs/by-name/ri/rime-wanxiang/package.nix
+++ b/pkgs/by-name/ri/rime-wanxiang/package.nix
@@ -1,0 +1,91 @@
+{
+  lib,
+  fetchFromGitHub,
+  stdenvNoCC,
+  librime,
+  rime-data,
+  nix-update-script,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "rime-wanxiang";
+  version = "6.7.8";
+
+  src = fetchFromGitHub {
+    owner = "amzxyz";
+    repo = "rime_wanxiang";
+    tag = "v" + finalAttrs.version;
+    hash = "sha256-U5aM8LMBh0ncGPIllhioJCS1/5SncWYg8e+C5tXDST0=";
+  };
+
+  nativeBuildInputs = [
+    librime
+  ];
+
+  buildInputs = [
+    rime-data
+  ];
+
+  dontConfigure = true;
+
+  buildPhase = ''
+    runHook preBuild
+
+    for s in *.schema.yaml; do
+        rime_deployer --compile "$s" . ${rime-data}/share/rime-data ./build
+    done
+
+    rm build/*.txt
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    dst=$out/share/rime-data
+    mkdir -p $dst
+
+    rm -r .github custom LICENSE squirrel.yaml weasel.yaml *.md *.trime.yaml
+    mv default.yaml wanxiang_suggested_default.yaml
+
+    cp -pr -t $dst *
+
+    runHook postInstall
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Feature-rich pinyin schema for Rime, basic edition";
+    longDescription = ''
+      万象拼音基础版 is a basic quanpin and shuangpin input schema for Rime based on
+      [万象 dictionaries and grammar models](https://github.com/amzxyz/RIME-LMDG),
+      supporting traditional shuangpin as well as tonal schemata such as 自然龙 and
+      龙码.
+
+      The schema requires to work the grammar model `wanxiang-lts-zh-hans.gram`.
+      However, this file is
+      [released](https://github.com/amzxyz/RIME-LMDG/releases/tag/LTS) by
+      carelessly overriding the old versions
+      (see the [discussion](https://github.com/amzxyz/RIME-LMDG/issues/22)). So
+      we can't pack it into Nixpkgs, which demands reproducibility. You have to
+      download it yourself and place it in the user directory of Rime.
+
+      The upstream `default.yaml` is included as
+      `wanxiang_suggested_default.yaml`. To enable it, please modify your
+      `default.custom.yaml` as such:
+
+      ```yaml
+      patch:
+        __include: wanxiang_suggested_default:/
+      ```
+    '';
+    homepage = "https://github.com/amzxyz/rime_wanxiang";
+    downloadPage = "https://github.com/amzxyz/rime_wanxiang/releases";
+    changelog = "https://github.com/amzxyz/rime_wanxiang/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.cc-by-40;
+    maintainers = with lib.maintainers; [ rc-zb ];
+    platforms = lib.platforms.all;
+  };
+})


### PR DESCRIPTION
Add [万象拼音基础版](https://github.com/amzxyz/rime_wanxiang) as rime-wanxiang. This is a feature-rich pinyin schema for the Rime input method framework.

The schema requires to work the grammar model `wanxiang-lts-zh-hans.gram`. However, this file is [released](https://github.com/amzxyz/RIME-LMDG/releases/tag/LTS) by carelessly overriding the old versions (see amzxyz/RIME-LMDG#22), which makes it impossible to reproduce over time. So I decide just not to include it, and prompt the user to download it themselves.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
