### PR TITLE
nixf-diagnose: init at 0.1.2

### DIFF
--- a/pkgs/by-name/ni/nixf-diagnose/package.nix
+++ b/pkgs/by-name/ni/nixf-diagnose/package.nix
@@ -1,0 +1,31 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  nixf,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "nixf-diagnose";
+  version = "0.1.2";
+
+  src = fetchFromGitHub {
+    owner = "inclyc";
+    repo = "nixf-diagnose";
+    tag = finalAttrs.version;
+    hash = "sha256-gkeU3EwAl9810eRRp5/ddf1h0qpV6FrBBdntNBpBtsM=";
+  };
+
+  env.NIXF_TIDY_PATH = lib.getExe nixf;
+
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-nrr2/lTWPyH7MsG2hSMJjbFCpHsKWINEP8jwSYPhocg=";
+
+  meta = {
+    description = "CLI wrapper for nixf-tidy with fancy diagnostic output";
+    mainProgram = "nixf-diagnose";
+    homepage = "https://github.com/inclyc/nixf-diagnose";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ inclyc ];
+  };
+})


### PR DESCRIPTION
This is a lightweight CLI frontend for `nixf`, which provides fancy interface prompts in the terminal indicating whether Nix files contain errors (linter + syntax checker). In the discussion at https://github.com/NixOS/nixpkgs/issues/332695, we talked about how `nixf-tidy` needs a good user interface to display errors, and this package fulfills that requirement while also aiming to promote the adoption of linter checks within `nixpkgs`.

### Usage Instructions:

Assume you have a Nix file with nits:

```nix
/* /tmp/a.nix */
rec {
  a = 1;
  b = 2
}
```

Run the following command:

```
> nixf-diagnose /tmp/a.nix
```

```
Error: expected ;
   ╭─[/tmp/a.nix:4:8]
   │
 4 │   b = 2
   ·        │ 
   ·        ╰─ expected ;
───╯
Warning: attrset is not necessary to be `rec`ursive
   ╭─[/tmp/a.nix:2:1]
   │
 2 │ rec {
   · ─┬─  
   ·  ╰─── attrset is not necessary to be `rec`ursive
───╯
```

For more description, see https://github.com/inclyc/nixf-diagnose

### Binary / Closure size?

There is no need to pull the entire `nixd` as a dependency. If you only use the `nixf-diagnose` executable, it occupies approximately 2.2 MiB of disk space. Specifically:

- This executable: 1.5 Mib
- nixf library: 754.45 Kib


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

CC @infinisil @wolfgangwalther @Aleksanaa @flokli 
