### PR TITLE
jetbrains.jdk: 21.0.4 -> 21.0.6, jetbrains.jcef: 867 -> 1014

### DIFF
--- a/pkgs/development/compilers/jetbrains-jdk/default.nix
+++ b/pkgs/development/compilers/jetbrains-jdk/default.nix
@@ -41,21 +41,21 @@ let
 in
 jdk.overrideAttrs (oldAttrs: rec {
   pname = "jetbrains-jdk" + lib.optionalString withJcef "-jcef";
-  javaVersion = "21.0.4";
-  build = "598.4";
+  javaVersion = "21.0.6";
+  build = "895.109";
   # To get the new tag:
   # git clone https://github.com/jetbrains/jetbrainsruntime
   # cd jetbrainsruntime
   # git checkout jbr-release-${javaVersion}b${build}
   # git log --simplify-by-decoration --decorate=short --pretty=short | grep "jbr-" --color=never | cut -d "(" -f2 | cut -d ")" -f1 | awk '{print $2}' | sort -t "-" -k 2 -g | tail -n 1 | tr -d ","
-  openjdkTag = "jbr-21.0.4+8";
+  openjdkTag = "jbr-21.0.6+7";
   version = "${javaVersion}-b${build}";
 
   src = fetchFromGitHub {
     owner = "JetBrains";
     repo = "JetBrainsRuntime";
     rev = "jb${version}";
-    hash = "sha256-YF5Z1A4qmD9Z4TE6f2i8wv9ZD+NqHGY5Q0oIVQiC3Bg=";
+    hash = "sha256-Neh0PGer4JnNaForBKRlGPLft5cae5GktreyPRNjFCk=";
   };
 
   BOOT_JDK = jdk.home;

--- a/pkgs/development/compilers/jetbrains-jdk/jcef.nix
+++ b/pkgs/development/compilers/jetbrains-jdk/jcef.nix
@@ -105,11 +105,11 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "jcef-jetbrains";
-  rev = "34dfd656652c24da31b89c39d0885f284722eeaa";
+  rev = "7a7b9383b3bf39c850feb0d103c6b829e2f48a6b";
   # This is the commit number
-  # Currently from the branch: https://github.com/JetBrains/jcef/tree/242
+  # Currently from the branch: https://github.com/JetBrains/jcef/tree/251
   # Run `git rev-list --count HEAD`
-  version = "867";
+  version = "1014";
 
   nativeBuildInputs = [
     cmake
@@ -135,7 +135,7 @@ stdenv.mkDerivation rec {
     owner = "jetbrains";
     repo = "jcef";
     inherit rev;
-    hash = "sha256-JlTGKqvgdBpBs2xtFMTVJ/ZksT1uME/8a2g7niH2sq8=";
+    hash = "sha256-ZMxx5mwmsBiUneULHFUDOrJQ8yKuK9bfPz89vN31ql4=";
   };
   cef-bin =
     let
@@ -215,8 +215,6 @@ stdenv.mkDerivation rec {
       runHook preInstall
 
       export JCEF_ROOT_DIR=$(realpath ..)
-      export THRIFT_DIR="$JCEF_ROOT_DIR"/third_party/thrift
-      export THRIFT_JAR=libthrift-0.19.0.jar
       export OUT_NATIVE_DIR=$JCEF_ROOT_DIR/jcef_build/native/${buildType}
       export JB_TOOLS_DIR=$(realpath ../jb/tools)
       export JB_TOOLS_OS_DIR=$JB_TOOLS_DIR/linux
@@ -278,11 +276,6 @@ stdenv.mkDerivation rec {
     + ''
 
       cd ../jcef
-      cp "$THRIFT_DIR"/"$THRIFT_JAR" .
-      cp "$JB_TOOLS_DIR"/common/thrift-module-info.java module-info.java
-      javac --patch-module org.apache.thrift=$THRIFT_JAR module-info.java
-      jar uf $THRIFT_JAR module-info.class
-      rm module-info.class module-info.java
       cp "$OUT_CLS_DIR"/jcef.jar .
       mkdir lib
       cp -R "$OUT_NATIVE_DIR"/* lib
@@ -303,7 +296,6 @@ stdenv.mkDerivation rec {
     jmod create --module-path . --class-path jogl-all.jar --libs lib $out/jmods/jogl.all.jmod
     cd ../jcef
     jmod create --module-path . --class-path jcef.jar --libs lib $out/jmods/jcef.jmod
-    jmod create --module-path . --class-path $THRIFT_JAR $out/jmods/org.apache.thrift.jmod
 
     # stripJavaArchivesHook gets rid of jar file timestamps, but not of jmod file timestamps
     # We have to manually call strip-nondeterminism to do this for jmod files too


### PR DESCRIPTION
jetbrains-jdk: 21.0.4 -> 21.0.6
jcef-jetbrains: 242 -> 251

This should be the JDK & JCEF used in JetBrains 2025.1 which might resolve issues like:
https://github.com/NixOS/nixpkgs/issues/401540

Note: I removed the thrift jar stuff because it was removed upstream.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
