### PR TITLE
cudaPackages_11_0.autoAddCudaCompatRunpath.libcudaPath: fix the eval

### DIFF
--- a/pkgs/top-level/cuda-packages.nix
+++ b/pkgs/top-level/cuda-packages.nix
@@ -27,6 +27,7 @@
   newScope,
   pkgs,
   stdenv,
+  runCommand,
 }:
 let
   inherit (lib)
@@ -135,7 +136,10 @@ let
     [
       (
         final: _:
-        lib.packagesFromDirectoryRecursive {
+        {
+          cuda_compat = runCommand "cuda_compat" { meta.platforms = [ ]; } "false"; # Prevent missing attribute errors
+        }
+        // lib.packagesFromDirectoryRecursive {
           inherit (final) callPackage;
           directory = ../development/cuda-modules/packages;
         }


### PR DESCRIPTION
Addresses https://github.com/NixOS/nixpkgs/pull/405031#issuecomment-2875098551. Without the change direct access to the attribute fails to eval as:

    $ nix eval --impure --expr 'with import ./. {}; cudaPackages_11_0.autoAddCudaCompatRunpath.libcudaPath'
    evaluation warning: CUDA versions older than 12.0 will be removed in Nixpkgs 25.05; see the 24.11 release notes for more information
    error:
       … while evaluating the attribute 'autoAddCudaCompatRunpath.libcudaPath'
         at pkgs/development/cuda-modules/packages/autoAddCudaCompatRunpath/package.nix:16:5:
           15|   substitutions = {
           16|     libcudaPath = if cuda_compat then "${cuda_compat}/compat" else null;
             |     ^
           17|   };

       … while evaluating a branch condition
         at pkgs/development/cuda-modules/packages/autoAddCudaCompatRunpath/package.nix:16:19:
           15|   substitutions = {
           16|     libcudaPath = if cuda_compat then "${cuda_compat}/compat" else null;
             |                   ^
           17|   };

       error: expected a Boolean but found null: null
       at pkgs/development/cuda-modules/packages/autoAddCudaCompatRunpath/package.nix:16:19:
           15|   substitutions = {
           16|     libcudaPath = if cuda_compat then "${cuda_compat}/compat" else null;
             |                   ^
           17|   };


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
