### PR TITLE
[24.11] pocket-casts: 0.9.0 -> 0.10.3

### DIFF
--- a/pkgs/by-name/po/pocket-casts/package.nix
+++ b/pkgs/by-name/po/pocket-casts/package.nix
@@ -10,16 +10,16 @@
 
 buildNpmPackage rec {
   pname = "pocket-casts";
-  version = "0.10.2";
+  version = "0.10.3";
 
   src = fetchFromGitHub {
     owner = "felicianotech";
     repo = "pocket-casts-desktop-app";
     rev = "v${version}";
-    hash = "sha256-qXwLnAp8GxOBnPy5uM/Y4dKlALRLo9Hs2p8/WSJcAyE=";
+    hash = "sha256-IhH5nZ2kXVW2D8cMmVyMX4xZLnzfMAp2gwQgZgHOItY=";
   };
 
-  npmDepsHash = "sha256-HU+jfp+Rmw78wTSA0m9Q6EW6+bw84+MEnnSaPnKqqIo=";
+  npmDepsHash = "sha256-oLZ81SA+eO20sUc2cwba3cc6vu1Qf/lNkIfzK2CQdrw=";
 
   env.ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
 

--- a/pkgs/by-name/po/pocket-casts/package.nix
+++ b/pkgs/by-name/po/pocket-casts/package.nix
@@ -10,16 +10,16 @@
 
 buildNpmPackage rec {
   pname = "pocket-casts";
-  version = "0.9.0";
+  version = "0.10.2";
 
   src = fetchFromGitHub {
     owner = "felicianotech";
     repo = "pocket-casts-desktop-app";
     rev = "v${version}";
-    hash = "sha256-5xn2uAjqIyWKQAruHLyho72HCYpbxyWlcTQ3LXXZy6M=";
+    hash = "sha256-qXwLnAp8GxOBnPy5uM/Y4dKlALRLo9Hs2p8/WSJcAyE=";
   };
 
-  npmDepsHash = "sha256-nfTn2rs0XGraebI0rKlTECccc7KpRXf/+qOjj/5GPAw=";
+  npmDepsHash = "sha256-HU+jfp+Rmw78wTSA0m9Q6EW6+bw84+MEnnSaPnKqqIo=";
 
   env.ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
 
@@ -44,8 +44,8 @@ buildNpmPackage rec {
   ];
 
   postInstall = ''
-    install -Dm644 $out/lib/node_modules/pocket-casts/icon.png $out/share/pixmaps/pocket-casts.png
-    install -Dm644 $out/lib/node_modules/pocket-casts/icon-x360.png $out/share/pixmaps/pocket-casts-x360.png
+    install -Dm444 $out/lib/node_modules/pocket-casts/img/icon-x512.png $out/share/icons/hicolor/512x512/apps/pocket-casts.png
+    install -Dm444 $out/lib/node_modules/pocket-casts/img/icon-x360.png $out/share/icons/hicolor/360x360/apps/pocket-casts.png
 
     makeWrapper ${electron}/bin/electron $out/bin/pocket-casts \
       --add-flags $out/lib/node_modules/pocket-casts/main.js

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2982,7 +2982,7 @@ with pkgs;
   patool = with python3Packages; toPythonApplication patool;
 
   pocket-casts = callPackage ../by-name/po/pocket-casts/package.nix {
-    electron = electron_33;
+    electron = electron_35;
   };
 
   pueue = darwin.apple_sdk_11_0.callPackage ../applications/misc/pueue {


### PR DESCRIPTION
Backport of #406671 as Electron 33 has reached end-of-life.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
