### PR TITLE
workflows/check-format: run on all files

### DIFF
--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -166,7 +166,7 @@ jobs:
   tag:
     name: Tag
     runs-on: ubuntu-24.04-arm
-    needs: [ process ]
+    needs: [ get-merge-commit, process ]
     if: needs.process.outputs.targetRunId
     permissions:
       pull-requests: write

--- a/.github/workflows/get-merge-commit.yml
+++ b/.github/workflows/get-merge-commit.yml
@@ -40,7 +40,7 @@ jobs:
               ;;
             pull_request_target)
               if commits=$(base/ci/get-merge-commit.sh ${{ github.repository }} ${{ github.event.number }}); then
-                echo "Checking the commits:\n$commits"
+                echo -e "Checking the commits:\n$commits"
                 echo "$commits" >> "$GITHUB_OUTPUT"
               else
                 # Skipping so that no notifications are sent

--- a/ci/default.nix
+++ b/ci/default.nix
@@ -63,10 +63,7 @@ let
       fs = pkgs.lib.fileset;
       nixFilesSrc = fs.toSource {
         root = ../.;
-        fileset = fs.difference (fs.unions [
-          (fs.fileFilter (file: file.hasExt "nix") ../.)
-          ../.git-blame-ignore-revs
-        ]) (fs.maybeMissing ../.git);
+        fileset = fs.difference ../. (fs.maybeMissing ../.git);
       };
     in
     {


### PR DESCRIPTION
This was run on .nix files only, but we recently added keep-sorted, editorconfig-checker and actionlint to treefmt, so CI needs to check all files instead.

Also fixes two warnings that actionlint currently reports after #406266. Resolves https://github.com/NixOS/nixpkgs/pull/406266#discussion_r2085900167.

## Things done

- [x] Tested `nix-build ci -A fmt.check` locally - passed silently before, failed after first commit, then passed again after the last.
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
