### PR TITLE
python3Packages: unbreak packages that no longer seem to be broken

### DIFF
--- a/pkgs/by-name/f3/f3d/package.nix
+++ b/pkgs/by-name/f3/f3d/package.nix
@@ -97,8 +97,5 @@ stdenv.mkDerivation rec {
     ];
     platforms = with platforms; unix;
     mainProgram = "f3d";
-    # error: use of undeclared identifier 'NSMenuItem'
-    # adding AppKit does not solve it
-    broken = with stdenv.hostPlatform; isDarwin && isx86_64;
   };
 }

--- a/pkgs/by-name/ge/geant4/package.nix
+++ b/pkgs/by-name/ge/geant4/package.nix
@@ -141,7 +141,6 @@ stdenv.mkDerivation rec {
   '';
 
   meta = with lib; {
-    broken = (stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isAarch64);
     description = "Toolkit for the simulation of the passage of particles through matter";
     longDescription = ''
       Geant4 is a toolkit for the simulation of the passage of particles through matter.

--- a/pkgs/development/python-modules/argostranslate/default.nix
+++ b/pkgs/development/python-modules/argostranslate/default.nix
@@ -1,6 +1,5 @@
 {
   lib,
-  stdenv,
   buildPythonPackage,
   fetchPypi,
   pytestCheckHook,
@@ -60,7 +59,5 @@ buildPythonPackage rec {
     homepage = "https://www.argosopentech.com";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ misuzu ];
-    # Segfaults at import
-    broken = stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isx86_64;
   };
 }

--- a/pkgs/development/python-modules/bytewax/default.nix
+++ b/pkgs/development/python-modules/bytewax/default.nix
@@ -1,6 +1,5 @@
 {
   lib,
-  stdenv,
   buildPythonPackage,
   fetchFromGitHub,
   pythonOlder,
@@ -106,7 +105,5 @@ buildPythonPackage rec {
       mslingsby
       kfollesdal
     ];
-    # mismatched type expected u8, found i8
-    broken = stdenv.hostPlatform.isAarch64;
   };
 }

--- a/pkgs/development/python-modules/cgal/default.nix
+++ b/pkgs/development/python-modules/cgal/default.nix
@@ -83,7 +83,5 @@ buildPythonPackage rec {
     homepage = "https://github.com/CGAL/cgal-swig-bindings";
     license = lib.licenses.gpl3Plus;
     maintainers = with lib.maintainers; [ pbsds ];
-    # error: no template named 'unary_function' in namespace 'boost::functional::detail'
-    broken = stdenv.hostPlatform.isDarwin;
   };
 }

--- a/pkgs/development/python-modules/clldutils/default.nix
+++ b/pkgs/development/python-modules/clldutils/default.nix
@@ -64,7 +64,5 @@ buildPythonPackage rec {
     homepage = "https://github.com/clld/clldutils";
     license = licenses.asl20;
     maintainers = with maintainers; [ melling ];
-    # TypeError: EnumSymbol.__init__() missing 2 required positional arguments: 'value' and 'description'
-    broken = true;
   };
 }

--- a/pkgs/development/python-modules/etebase/default.nix
+++ b/pkgs/development/python-modules/etebase/default.nix
@@ -1,6 +1,5 @@
 {
   lib,
-  stdenv,
   fetchFromGitHub,
   buildPythonPackage,
   rustPlatform,
@@ -75,7 +74,6 @@ buildPythonPackage rec {
   };
 
   meta = with lib; {
-    broken = stdenv.hostPlatform.isDarwin;
     homepage = "https://www.etebase.com/";
     description = "Python client library for Etebase";
     license = licenses.bsd3;

--- a/pkgs/development/python-modules/gb-io/default.nix
+++ b/pkgs/development/python-modules/gb-io/default.nix
@@ -1,12 +1,10 @@
 {
-  stdenv,
   lib,
   fetchFromGitHub,
   buildPythonPackage,
   rustPlatform,
   cargo,
   rustc,
-  setuptools-rust,
   unittestCheckHook,
 }:
 
@@ -43,7 +41,6 @@ buildPythonPackage rec {
   pythonImportsCheck = [ "gb_io" ];
 
   meta = with lib; {
-    broken = stdenv.hostPlatform.isDarwin;
     homepage = "https://github.com/althonos/gb-io.py";
     description = "Python interface to gb-io, a fast GenBank parser written in Rust";
     license = licenses.mit;

--- a/pkgs/development/python-modules/greeclimate/default.nix
+++ b/pkgs/development/python-modules/greeclimate/default.nix
@@ -1,5 +1,4 @@
 {
-  stdenv,
   lib,
   buildPythonPackage,
   pythonOlder,
@@ -63,7 +62,6 @@ buildPythonPackage rec {
   ];
 
   meta = with lib; {
-    broken = stdenv.hostPlatform.isDarwin;
     description = "Discover, connect and control Gree based minisplit systems";
     homepage = "https://github.com/cmroche/greeclimate";
     changelog = "https://github.com/cmroche/greeclimate/blob/${src.rev}/CHANGELOG.md";

--- a/pkgs/development/python-modules/imagecodecs-lite/default.nix
+++ b/pkgs/development/python-modules/imagecodecs-lite/default.nix
@@ -1,5 +1,4 @@
 {
-  stdenv,
   lib,
   fetchPypi,
   buildPythonPackage,
@@ -29,8 +28,6 @@ buildPythonPackage rec {
   '';
 
   meta = with lib; {
-    broken =
-      (stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isAarch64) || stdenv.hostPlatform.isDarwin;
     description = "Block-oriented, in-memory buffer transformation, compression, and decompression functions";
     homepage = "https://www.lfd.uci.edu/~gohlke/";
     maintainers = [ maintainers.tbenst ];

--- a/pkgs/development/python-modules/mayavi/default.nix
+++ b/pkgs/development/python-modules/mayavi/default.nix
@@ -11,7 +11,6 @@
   pyqt5,
   pythonOlder,
   pythonAtLeast,
-  stdenv,
   traitsui,
   vtk,
   wrapQtAppsHook,
@@ -60,8 +59,5 @@ buildPythonPackage rec {
     license = licenses.bsdOriginal;
     maintainers = with maintainers; [ ];
     mainProgram = "mayavi2";
-    # Fails during stripping with:
-    # The file was not recognized as a valid object file
-    broken = stdenv.hostPlatform.isDarwin;
   };
 }

--- a/pkgs/development/python-modules/open-clip-torch/default.nix
+++ b/pkgs/development/python-modules/open-clip-torch/default.nix
@@ -95,7 +95,5 @@ buildPythonPackage rec {
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ iynaix ];
     mainProgram = "open-clip";
-    # Segfaults during pythonImportsCheck phase
-    broken = stdenv.hostPlatform.system == "x86_64-darwin";
   };
 }

--- a/pkgs/development/python-modules/osc/default.nix
+++ b/pkgs/development/python-modules/osc/default.nix
@@ -1,5 +1,4 @@
 {
-  stdenv,
   bashInteractive,
   buildPythonPackage,
   cryptography,
@@ -49,7 +48,6 @@ buildPythonPackage rec {
   preCheck = "HOME=$TOP/tmp";
 
   meta = with lib; {
-    broken = stdenv.hostPlatform.isDarwin;
     homepage = "https://github.com/openSUSE/osc";
     description = "opensuse-commander with svn like handling";
     mainProgram = "osc";

--- a/pkgs/development/python-modules/pint-pandas/default.nix
+++ b/pkgs/development/python-modules/pint-pandas/default.nix
@@ -1,5 +1,4 @@
 {
-  stdenv,
   lib,
   buildPythonPackage,
   fetchFromGitHub,
@@ -9,6 +8,7 @@
   wheel,
   pint,
   pandas,
+  packaging,
   pytestCheckHook,
 }:
 
@@ -35,12 +35,12 @@ buildPythonPackage rec {
   dependencies = [
     pint
     pandas
+    packaging
   ];
 
   nativeCheckInputs = [ pytestCheckHook ];
 
   meta = {
-    broken = stdenv.hostPlatform.isDarwin;
     description = "Pandas support for pint";
     license = lib.licenses.bsd3;
     homepage = "https://github.com/hgrecco/pint-pandas";

--- a/pkgs/development/python-modules/pylibjpeg-openjpeg/default.nix
+++ b/pkgs/development/python-modules/pylibjpeg-openjpeg/default.nix
@@ -72,9 +72,7 @@ buildPythonPackage rec {
     changelog = "https://github.com/pydicom/pylibjpeg-openjpeg/releases/tag/v${version}";
     license = [ lib.licenses.mit ];
     maintainers = with lib.maintainers; [ bcdarwin ];
-    # x86-linux: test_encode.py::TestEncodeBuffer failures
-    # darwin: numerous test failures, seemingly due to issues setting up test data
-    broken =
-      (stdenv.hostPlatform.isAarch64 && stdenv.hostPlatform.isLinux) || stdenv.hostPlatform.isDarwin;
+    # darwin: numerous test failures, test dependency pydicom is marked as unsupported
+    broken = stdenv.hostPlatform.isDarwin;
   };
 }

--- a/pkgs/development/python-modules/pysequoia/default.nix
+++ b/pkgs/development/python-modules/pysequoia/default.nix
@@ -58,7 +58,5 @@ buildPythonPackage rec {
     homepage = "https://sequoia-pgp.gitlab.io/pysequoia";
     license = licenses.asl20;
     maintainers = with maintainers; [ doronbehar ];
-    # Broken since the 0.1.20 update according to ofborg. The errors are not clear...
-    broken = stdenv.hostPlatform.isDarwin;
   };
 }

--- a/pkgs/development/python-modules/pysptk/default.nix
+++ b/pkgs/development/python-modules/pysptk/default.nix
@@ -1,6 +1,5 @@
 {
   lib,
-  stdenv,
   buildPythonPackage,
   cython,
   decorator,
@@ -8,6 +7,7 @@
   numpy,
   pythonOlder,
   scipy,
+  setuptools,
   six,
 }:
 
@@ -31,6 +31,7 @@ buildPythonPackage rec {
     decorator
     numpy
     scipy
+    setuptools
     six
   ];
 
@@ -40,7 +41,6 @@ buildPythonPackage rec {
   pythonImportsCheck = [ "pysptk" ];
 
   meta = with lib; {
-    broken = stdenv.hostPlatform.isDarwin;
     description = "Wrapper for Speech Signal Processing Toolkit (SPTK)";
     homepage = "https://pysptk.readthedocs.io/";
     license = licenses.mit;

--- a/pkgs/development/python-modules/pyvlx/default.nix
+++ b/pkgs/development/python-modules/pyvlx/default.nix
@@ -1,6 +1,5 @@
 {
   lib,
-  stdenv,
   buildPythonPackage,
   fetchFromGitHub,
   pytestCheckHook,
@@ -47,6 +46,5 @@ buildPythonPackage rec {
     changelog = "https://github.com/Julius2342/pyvlx/releases/tag/${version}";
     license = licenses.lgpl2Only;
     maintainers = with maintainers; [ fab ];
-    broken = stdenv.hostPlatform.isDarwin;
   };
 }

--- a/pkgs/development/python-modules/stups-fullstop/default.nix
+++ b/pkgs/development/python-modules/stups-fullstop/default.nix
@@ -15,7 +15,7 @@ buildPythonPackage rec {
   pname = "stups-fullstop";
   version = "1.1.31";
   format = "setuptools";
-  disabled = !isPy3k;
+  disabled = !isPy3k || pythonAtLeast "3.11"; # Uses regex patterns deprecated in 3.9, errors in 3.11+
 
   src = fetchFromGitHub {
     owner = "zalando-stups";
@@ -44,8 +44,5 @@ buildPythonPackage rec {
     homepage = "https://github.com/zalando-stups/stups-fullstop-cli";
     license = licenses.asl20;
     maintainers = [ maintainers.mschuwalow ];
-    # Uses regex patterns deprecated in 3.9:
-    #     re.error: global flags not at the start of the expression at ...
-    broken = pythonAtLeast "3.11";
   };
 }

--- a/pkgs/development/python-modules/tabcmd/default.nix
+++ b/pkgs/development/python-modules/tabcmd/default.nix
@@ -90,7 +90,6 @@ buildPythonPackage rec {
   pythonImportsCheck = [ "tabcmd" ];
 
   meta = with lib; {
-    broken = true;
     description = "Command line client for working with Tableau Server";
     homepage = "https://github.com/tableau/tabcmd";
     changelog = "https://github.com/tableau/tabcmd/releases/tag/v${version}";

--- a/pkgs/development/python-modules/type-infer/default.nix
+++ b/pkgs/development/python-modules/type-infer/default.nix
@@ -2,6 +2,7 @@
   lib,
   buildPythonPackage,
   pythonOlder,
+  pythonAtLeast,
   fetchFromGitHub,
   poetry-core,
   colorlog,
@@ -36,7 +37,7 @@ buildPythonPackage {
   inherit version;
   pyproject = true;
 
-  disabled = pythonOlder "3.8";
+  disabled = pythonOlder "3.8" || pythonAtLeast "3.13";
 
   src = fetchFromGitHub {
     owner = "mindsdb";
@@ -87,7 +88,5 @@ buildPythonPackage {
     homepage = "https://github.com/mindsdb/type_infer";
     license = licenses.gpl3Only;
     maintainers = with maintainers; [ mbalatsko ];
-    # ModuleNotFoundError: No module named 'imghdr', unrelated
-    broken = true;
   };
 }

--- a/pkgs/development/python-modules/zeroc-ice/default.nix
+++ b/pkgs/development/python-modules/zeroc-ice/default.nix
@@ -1,5 +1,4 @@
 {
-  stdenv,
   lib,
   buildPythonPackage,
   fetchPypi,
@@ -29,7 +28,6 @@ buildPythonPackage rec {
   pythonImportsCheck = [ "Ice" ];
 
   meta = with lib; {
-    broken = stdenv.hostPlatform.isDarwin;
     homepage = "https://zeroc.com/";
     license = licenses.gpl2;
     description = "Comprehensive RPC framework with support for Python, C++, .NET, Java, JavaScript and more";


### PR DESCRIPTION
Similar to #317828.

I ran the following very hacky command to generate a list of all python312Packages that were marked as `broken`, but where builds on the broken platform "succeeds" (in that it exits with status 0), for `aarch64-darwin`, `x86_64-darwin`, and `aarch64-linux`:

```bash
nix eval --system [platform] --json -f . python3Packages --apply \
  'builtins.mapAttrs (name: value: if (builtins.tryEval value).success && value != null then value.meta.broken or null else null)' | \
    jq -r 'to_entries | map(select(.value == true) | .key) | .[]' | \
    sed -E 's/(.*)/python312Packages.\1/' | \
    env NIXPKGS_ALLOW_BROKEN=1 NIXPKGS_ALLOW_UNFREE=1 parallel -j8 \
      'nix build --system [platform] -f . {} 2>/dev/null && echo "{}" || true'
```

I then provide that list to Claude Code using the following prompt:

---

<details>
<summary>Prompt</summary>

The following packages in `nixpkgs` are marked as `broken` on one of `aarch64-darwin`, `x86_64-darwin`, or `aarch64-linux` but build successfully on one or more of the platforms they were marked as `broken` on with `NIXPKGS_ALLOW_BROKEN=1`:

```
[packages]
```

Packages are sometimes marked as `broken` due to upstream issues that prevent the package from building on a given platform. However, sometimes later a fix is implemented upstream, but the `broken` status is not removed in `nixpkgs`.

For each of these packages please look at: 
* the package definition in `nixpkgs`;
* the commit where they were marked as `broken`; and
* the pull request that added that commit;

to see if you can find any explanation for why it was marked as `broken`.

(Only escalate the the next one in the list if the previous one didn’t provide you with the information you were looking for.)

If any of these give an indication that this was due to a transient upstream issue (or something similar, or was done as part of a bulk/treewide change). Test building the package on all platforms for which it is currently marked as broken (out of `aarch64-darwin`, `x86_64-darwin`, and `aarch64-linux` as relevant). Use the following command for builds:

```
env NIXPKGS_ALLOW_BROKEN=1 NIXPKGS_ALLOW_UNFREE=1 nix build -f . [package] --system [platform]
```

(Builds can sometimes take a long time, so ensure the build can run for at least 10 minutes by default.)

If it builds successfully (and the build logs don’t highlight any issues of concern that could indicate why the package is marked as `broken`)  remove the `broken` status (along with any imports that might no longer be in use like `stdenv`, though build again afterwards to confirm removing anything like that didn’t cause any unforeseen issues) and then create a commit with a message of the following form:

```
[package]: unbreak on [list of platforms]
```

(You should assume that if it builds fine on `aarch64-linux` it will also build fine on `x86_64-linux`. If both Darwin platforms should be on the list just include “Darwin” in the list. Same for “Linux”. If the package was marked as `broken` on all platforms, just used the commit message “[package]: unbreak”.)

Examples:

```
python312Packages.pytest-annotate: unbreak on Darwin
python312Packages.pynetdicom: unbreak on `aarch64-darwin`
python312Packages.nnpdf: unbreak on `aarch64-{darwin,linux}`
python312Packages.sphinx-markdown-parser: unbreak on Darwin and `aarch64-linux`
```

Sometimes a package is marked as `broken`, even if it builds successfully due to runtime issues with the package on a given platform, etc. As such, just because a package builds on a platform, does not mean it shouldn’t be marked as `broken`. If you don’t have a clear indication from doing the above, that the package should not be marked as `broken`, use web search to try and figure out why the package might be broken on certain platforms. 

If the package should remain `broken` and there is a comment in the package definition in `nixpkgs` above the line where it was marked as broken, do nothing and move on to the next package. If there is no comment, add one (line length should never exceed 100 characters) and make a commit with a message of the form:

```
[package]: add explanation for `broken` status
```

Sometimes packages are marked as `broken` when really they aren’t supported on a given platform. If that’s the case based on your findings, make the appropriate changes (e.g., remove the relevant platform(s) from `meta.broken` and exclude from `meta.platforms`), and make a commit with a message of the form:

```
[package]: mark as unsupported on [list of platforms]
```

Make a todo list to track progress.
</details>

---

While it wasn't completely hands off, with light supervision and a little bit of prodding and course correcting here or there, it mostly did all the work on its own (while I mostly did other things) and definitely caught a few things I wouldn't have.

The following packages were marked as `broken` and did build on one of the platforms that they were marked as such on, but were left that way due to being truly broken with appropriate documentation:

```
python312Packages.linien-common
python312Packages.linien-client
python312Packages.telethon-session-sqlalchemy
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
