### PR TITLE
ath{10,11,12}k-firmware: init

### DIFF
--- a/doc/release-notes/rl-2505.section.md
+++ b/doc/release-notes/rl-2505.section.md
@@ -382,6 +382,8 @@
   - Many androidenv packages are now searchable on [search.nixos.org](https://search.nixos.org).
   - We now use the latest Google repositories, which should improve aarch64-darwin compatibility. The SDK now additionally evaluates on aarch64-linux, though not all packages are functional.
 
+- Extra firmware for Qualcomm Atheros ath10k, ath11k, and ath12k devices is now supported, as the ath10k-firmware, ath11k-firmware, and ath12k-firmware packages. Note that you may need to add this to `hardware.firmware` if you would like to use the latest from Linaro (as opposed to the versions packaged in linux-firmware).
+
 - `dwarf-fortress` audio now works again. Additionally, the `dfhack` and `dwarf-fortress-full` packages are now exposed at toplevel, making it easier to install and play Dwarf Fortress. Note that `dwarf-fortress-full` is the Nixpkgs equivalent of the Dwarf Fortress Lazy Pack.
 
 - `gerbera` now has wavpack support.

--- a/pkgs/by-name/at/ath10k-firmware/package.nix
+++ b/pkgs/by-name/at/ath10k-firmware/package.nix
@@ -1,0 +1,11 @@
+{
+  ath11k-firmware,
+}:
+
+ath11k-firmware.mkAthFirmware {
+  athVersion = "ath10k";
+  rev = "ca0916244fb9ae75242585f3bb8397c5732b910c";
+  hash = "sha256-akcdhbRAvGGFs/cje09swpzBRScwhTA7loTsUDi2uC4=";
+  updateFilename = ./package.nix;
+  position = "pkgs/by-name/at/ath10k-firmware:10";
+}

--- a/pkgs/by-name/at/ath11k-firmware/package.nix
+++ b/pkgs/by-name/at/ath11k-firmware/package.nix
@@ -1,0 +1,77 @@
+{
+  lib,
+  fetchFromGitLab,
+  qca-swiss-army-knife,
+  stdenvNoCC,
+  nix-update-script,
+}:
+
+let
+  mkAthFirmware =
+    {
+      athVersion,
+      rev,
+      hash,
+      updateFilename,
+      position ? null,
+    }:
+
+    stdenvNoCC.mkDerivation (finalPackage: {
+      pname = "${athVersion}-firmware";
+      version = lib.substring 0 8 finalPackage.src.rev;
+      inherit athVersion;
+      src = fetchFromGitLab {
+        domain = "git.codelinaro.org";
+        owner = "clo/ath-firmware";
+        repo = "${athVersion}-firmware";
+        inherit rev hash;
+      };
+
+      nativeBuildInputs = [ qca-swiss-army-knife ];
+
+      dontBuild = true;
+      dontInstall = true;
+      doDist = true;
+
+      distPhase = ''
+        runHook preDist
+        mkdir -p $out/lib/firmware/$athVersion
+        touch $out/lib/firmware/WHENCE
+        $athVersion-fw-repo --install $out/lib/firmware
+        if [ ! -s $out/lib/firmware/WHENCE ]; then
+          rm -f $out/lib/firmware/WHENCE
+        fi
+        runHook postDist
+      '';
+
+      passthru = {
+        inherit mkAthFirmware;
+        updateScript = nix-update-script {
+          extraArgs = [
+            "--version=branch=main"
+            "--override-filename"
+            updateFilename
+          ];
+        };
+      };
+
+      meta =
+        {
+          description = "Firmware for ${athVersion} wireless chipsets, maintained by Linaro";
+          homepage = "https://git.codelinaro.org/clo/ath-firmware/${athVersion}-firmware";
+          license = lib.licenses.unfreeRedistributableFirmware;
+          maintainers = with lib.maintainers; [ numinit ];
+          platforms = with lib.platforms; linux;
+        }
+        // lib.optionalAttrs (position != null) {
+          inherit position;
+        };
+    });
+
+in
+mkAthFirmware {
+  athVersion = "ath11k";
+  rev = "1e7cd757828d414f71da82f480696540473bd475";
+  hash = "sha256-QXZHcbMNX0f2RQBrCCYRS3dLU1q/02J3HjnWuv8Oaaw=";
+  updateFilename = ./package.nix;
+}

--- a/pkgs/by-name/at/ath12k-firmware/package.nix
+++ b/pkgs/by-name/at/ath12k-firmware/package.nix
@@ -1,0 +1,11 @@
+{
+  ath11k-firmware,
+}:
+
+ath11k-firmware.mkAthFirmware {
+  athVersion = "ath12k";
+  rev = "aea9e010506e1960dee1ab2fb87e55390c485cc6";
+  hash = "sha256-2+QM2BH7XupXXMwrJg0whwHYC3WC8Km6zt3iewmBq3Q=";
+  updateFilename = ./package.nix;
+  position = "pkgs/by-name/at/ath12k-firmware:10";
+}

--- a/pkgs/by-name/qc/qca-swiss-army-knife/package.nix
+++ b/pkgs/by-name/qc/qca-swiss-army-knife/package.nix
@@ -1,0 +1,45 @@
+{
+  lib,
+  fetchFromGitHub,
+  nix-update-script,
+  python3,
+  stdenvNoCC,
+}:
+
+stdenvNoCC.mkDerivation (finalPackage: {
+  pname = "qca-swiss-army-knife";
+  version = lib.substring 0 8 finalPackage.src.rev;
+  src = fetchFromGitHub {
+    owner = "qca";
+    repo = "qca-swiss-army-knife";
+    rev = "e53ea71655c9f8a23f4bed7731fca53f0e96cdbd";
+    hash = "sha256-OtK17Wk+jKKBf1Me6pduiZUXxkK31kGva/Bf/shFU6Q=";
+  };
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  buildInputs = [ python3 ];
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/bin
+    cp tools/scripts/ath{10,11,12}k/* $out/bin/
+    chmod +x $out/bin/*
+    runHook postInstall
+  '';
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [
+      "--version-branch=master"
+    ];
+  };
+
+  meta = {
+    description = "Firmware utilities for ath10k and later chipsets";
+    homepage = "https://github.com/qca/qca-swiss-army-knife";
+    license = lib.licenses.isc;
+    maintainers = with lib.maintainers; [ numinit ];
+    platforms = with lib.platforms; linux;
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Package firmware for newer Qualcomm wireless chipsets supported by Linaro.

(Note that these versions may, and do, diverge from what's already in linux-firmware, and may be required to use certain newer wifi devices).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
