### PR TITLE
python313Packages.hdf5plugin: 5.0.0 -> 5.1.0

### DIFF
--- a/pkgs/development/python-modules/hdf5plugin/default.nix
+++ b/pkgs/development/python-modules/hdf5plugin/default.nix
@@ -5,30 +5,64 @@
   setuptools,
   py-cpuinfo,
   h5py,
+  pkgconfig,
+  c-blosc2,
+  charls,
+  lz4,
+  zlib,
+  zstd,
 }:
 
 buildPythonPackage rec {
   pname = "hdf5plugin";
-  version = "5.0.0";
+  version = "5.1.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "silx-kit";
     repo = "hdf5plugin";
     tag = "v${version}";
-    hash = "sha256-6lEU8ZGJKazDqloel5QcaXAbNGzV1fAbAjYC/hFUOdI=";
+    hash = "sha256-12OWsNZfKToNLyokNrwgPc7WRISJI4nRA0J/zwgCZwI=";
   };
 
   build-system = [
     setuptools
     py-cpuinfo
+    pkgconfig # only needed if HDF5PLUGIN_SYSTEM_LIBRARIES is used
   ];
 
   dependencies = [ h5py ];
 
+  buildInputs = [
+    #c-blosc
+    c-blosc2
+    # bzip2_1_1
+    charls
+    lz4
+    # snappy
+    # zfp
+    zlib
+    zstd
+  ];
+
+  # opt-in to use use system libs instead
+  env.HDF5PLUGIN_SYSTEM_LIBRARIES = lib.concatStringsSep "," [
+    #"blosc" # AssertionError: 4000 not less than 4000
+    "blosc2"
+    # "bz2" # only works with bzip2_1_1
+    "charls"
+    "lz4"
+    # "snappy" # snappy tests fail
+    # "sperr" # not packaged?
+    # "zfp" #  pkgconfig: (lib)zfp not found
+    "zlib"
+    "zstd"
+  ];
+
   checkPhase = ''
     python test/test.py
   '';
+
   pythonImportsCheck = [ "hdf5plugin" ];
 
   preBuild = ''

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6127,7 +6127,9 @@ self: super: with self; {
 
   hdbscan = callPackage ../development/python-modules/hdbscan { };
 
-  hdf5plugin = callPackage ../development/python-modules/hdf5plugin { };
+  hdf5plugin = callPackage ../development/python-modules/hdf5plugin {
+    inherit (pkgs) zstd lz4;
+  };
 
   hdfs = callPackage ../development/python-modules/hdfs { };
 


### PR DESCRIPTION
release: https://github.com/silx-kit/hdf5plugin/releases/tag/v5.1.0

Of note is that they added a environment variable to build filters with system libraries. This PR configures the ones I could get working.
Closes https://github.com/NixOS/nixpkgs/pull/406580

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
