### PR TITLE
rustc: ensure standard library docs are installed

### DIFF
--- a/pkgs/development/compilers/rust/rustc.nix
+++ b/pkgs/development/compilers/rust/rustc.nix
@@ -153,11 +153,8 @@ stdenv.mkDerivation (finalAttrs: {
       # std is built for all platforms in --target.
       "--target=${
         concatStringsSep "," (
-          [
-            stdenv.targetPlatform.rust.rustcTargetSpec
-          ]
           # Other targets that don't need any extra dependencies to build.
-          ++ optionals (!fastCross) [
+          optionals (!fastCross) [
             "wasm32-unknown-unknown"
             "wasm32v1-none"
             "bpfel-unknown-none"
@@ -174,6 +171,13 @@ stdenv.mkDerivation (finalAttrs: {
           # build.rs scripts.
           ++ optionals (stdenv.hostPlatform != stdenv.targetPlatform && !fastCross) [
             stdenv.hostPlatform.rust.rustcTargetSpec
+          ]
+          ++ [
+            # `make install` only keeps the docs of the last target in the list.
+            # If the `targetPlatform` is not the last entry, we may end up without
+            # `alloc` or `std` docs (if the last target is `no_std`).
+            # More information: https://github.com/rust-lang/rust/issues/140922
+            stdenv.targetPlatform.rust.rustcTargetSpec
           ]
         )
       }"


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Fixes https://github.com/NixOS/nixpkgs/issues/405914

This change should be backported to 25.05 to ensure `rustc.doc` includes the standard library.

Upstream's installation script installs the `docs` component for every target that is built.
Unfortunately, installing the docs for a target removes the previous target's docs, ultimately leaving only the docs of the last target in the list.
In our case, that is a `no_std` target, for which no `alloc` or `std` docs are built, thus leaving `rustc.doc` without any standard library docs.
Moving stdenv's `targetPlatform` to the end of the list ensures we get standard library docs.

Ideally upstream Rust finds a way to ensure multiple targets can be installed without interference in the docs component (e.g., by installing each target's docs in its own subdirectory), but until then, this is a viable workaround.
Upstream issue: https://github.com/rust-lang/rust/issues/140922

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
