### PR TITLE
bitnet: init at 0-unstable-2025-06-03

### DIFF
--- a/pkgs/by-name/bi/bitnet/package.nix
+++ b/pkgs/by-name/bi/bitnet/package.nix
@@ -1,0 +1,129 @@
+{
+  config,
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  fetchurl,
+  cmake,
+  makeBinaryWrapper,
+  python3,
+  # any
+  enableImpureNativeOptimizations ? false,
+  # x86
+  enableAvx ? stdenv.hostPlatform.avxSupport,
+  enableAvx2 ? stdenv.hostPlatform.avx2Support,
+  enableFma ? stdenv.hostPlatform.fmaSupport,
+  enableF16c ? stdenv.hostPlatform.avxSupport, # approximation with some false negatives
+  enableAvx512 ? stdenv.hostPlatform.avx512Support,
+  enableAvx512VBMI ? false,
+  enableAvx512VNNI ? false,
+  enableAvx512BF16 ? false,
+  # arm
+  enableSve ? false,
+  # model selection
+  modelName ? "microsoft/BitNet-b1.58-2B-4T",
+  modelRepo ? fetchurl {
+    url = "https://huggingface.co/microsoft/bitnet-b1.58-2B-4T-gguf/resolve/de6ce176e062a4c6ba0162824474c4f07490b59c/ggml-model-i2_s.gguf";
+    hash = "sha256-QiGyUv3V/SXhWEet/rXuiIhlBrpQuKNFSDdEkohMIWI=";
+  },
+}:
+
+let
+  x86 = stdenv.hostPlatform.isx86_64;
+  arm = stdenv.hostPlatform.isAarch64;
+in
+
+assert x86 || arm;
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "bitnet";
+  version = "0-unstable-2025-06-03";
+
+  src = fetchFromGitHub {
+    owner = "microsoft";
+    repo = "BitNet";
+    rev = "404980eecae38affa4871c3e419eae3f44536a95";
+    hash = "sha256-bRnrjsE+WdZXAAtDISDu8qICLI70q2TFDSZyI5mzvEY=";
+    fetchSubmodules = true;
+  };
+
+  nativeBuildInputs = [
+    cmake
+    makeBinaryWrapper
+    python3
+  ];
+
+  postPatch = ''
+    substituteInPlace setup_env.py \
+      --replace-fail '    setup_gguf()' "    print('skipped setup_gguf')" \
+      --replace-fail '    compile()' "    print('skipped compile')" \
+      --replace-fail '    prepare_model()' "    print('skipped prepare_model')"
+  '';
+
+  preConfigure = ''
+    python3 ./setup_env.py --hf-repo "${modelName}"
+  '';
+
+  cmakeFlags = [
+    (lib.cmakeBool "BITNET_ARM_TL1" arm)
+    (lib.cmakeBool "BITNET_X86_TL2" x86)
+    (lib.cmakeBool "GGML_BITNET_ARM_TL1" arm)
+    (lib.cmakeBool "GGML_BITNET_X86_TL2" x86)
+    # loongarch64 related
+    (lib.cmakeBool "GGML_LASX" false)
+    (lib.cmakeBool "GGML_LSX" false)
+    # catch-all
+    (lib.cmakeBool "GGML_NATIVE" (!(finalAttrs.NIX_ENFORCE_NO_NATIVE or true)))
+  ]
+  ++ lib.optionals (finalAttrs.NIX_ENFORCE_NO_NATIVE or true) [
+    # x86 related
+    (lib.cmakeBool "GGML_AVX" enableAvx)
+    (lib.cmakeBool "GGML_AVX2" enableAvx2)
+    (lib.cmakeBool "GGML_AVX512" enableAvx512)
+    (lib.cmakeBool "GGML_AVX512_VBMI" enableAvx512VBMI)
+    (lib.cmakeBool "GGML_AVX512_VNNI" enableAvx512VNNI)
+    (lib.cmakeBool "GGML_AVX512_BF16" enableAvx512BF16)
+    (lib.cmakeBool "GGML_FMA" enableFma)
+    (lib.cmakeBool "GGML_F16C" enableF16c)
+    # arm related
+    (lib.cmakeBool "GGML_SVE" enableSve)
+  ];
+
+  NIX_ENFORCE_NO_NATIVE = !enableImpureNativeOptimizations;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/{bin,lib}
+    cp bin/llama-cli $out/bin
+    cp 3rdparty/llama.cpp/ggml/src/libggml.so $out/lib
+    cp 3rdparty/llama.cpp/src/libllama.so $out/lib
+
+    patchelf --add-rpath $out/lib $out/bin/llama-cli
+    patchelf --shrink-rpath --allowed-rpath-prefixes ${builtins.storeDir} $out/lib/* $out/bin/*
+    wrapProgram $out/bin/llama-cli \
+      --add-flags "-m ${modelRepo}"
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Microsoft's inference framework for 1-bit LLMs";
+    homepage = "https://github.com/microsoft/BitNet";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.fliegendewurst ];
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+      "x86_64-darwin"
+      "aarch64-darwin"
+    ];
+    mainProgram = "llama-cli";
+    broken =
+      !(enableImpureNativeOptimizations || (x86 -> enableAvx) || arm)
+      && (
+        !config.allowAliases
+        || (lib.assertMsg false "bitnet must be built with with AVX support on x86 (`enableAvx = true;`), or with impure native optimizations (`enableImpureNativeOptimizations = true;`)")
+      );
+  };
+})


### PR DESCRIPTION
https://github.com/microsoft/BitNet/

Closes #349641

To try it out, use `llama-cli -cnv`.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).