### PR TITLE
nixosTests.{lomiri-*,teleports}: Fix OCR

### DIFF
--- a/nixos/tests/lomiri-calendar-app.nix
+++ b/nixos/tests/lomiri-calendar-app.nix
@@ -44,23 +44,33 @@
 
     with subtest("lomiri calendar launches"):
         machine.succeed("lomiri-calendar-app >&2 &")
-        machine.wait_for_text(r"(January|February|March|April|May|June|July|August|September|October|November|December)")
+        machine.sleep(10)
+        machine.send_key("alt-f10")
+        machine.sleep(2)
+        # Default page is unbearably slow to OCR on, switch to another
+        machine.succeed("xdotool mousemove 580 50 click 1")
+        machine.sleep(2)
+        machine.wait_for_text(r"(January|February|March|April|May|June|July|August|September|October|November|December|Mon|Tue|Wed|Thu|Fri|Sat|Sun)")
         machine.screenshot("lomiri-calendar")
 
     with subtest("lomiri calendar works"):
         # Switch to Agenda tab, less busy
-        machine.succeed("xdotool mousemove 300 50 click 1")
+        machine.succeed("xdotool mousemove 380 50 click 1")
+        machine.sleep(2)
 
         # Still on main page
-        machine.succeed("xdotool mousemove 500 650 click 1")
+        machine.succeed("xdotool mousemove 500 720 click 1")
+        machine.sleep(2)
         machine.wait_for_text(r"(Date|Monday|Tuesday|Wednesday|Thursday|Friday|Saturday|Sunday|All day|Name|Details|More)")
         machine.screenshot("lomiri-calendar_newevent")
 
         # On New Event page
         machine.succeed("xdotool mousemove 500 230 click 1")
+        machine.sleep(2)
         machine.send_chars("foobar")
         machine.sleep(2) # make sure they're actually in there
-        machine.succeed("xdotool mousemove 780 40 click 1")
+        machine.succeed("xdotool mousemove 1000 40 click 1")
+        machine.sleep(2)
         machine.wait_for_text("Agenda")
         machine.screenshot("lomiri-calendar_eventadded")
 
@@ -73,6 +83,9 @@
 
     with subtest("lomiri calendar localisation works"):
         machine.succeed("env LANG=de_DE.UTF-8 lomiri-calendar-app >&2 &")
+        machine.sleep(10)
+        machine.send_key("alt-f10")
+        machine.sleep(2)
         machine.wait_for_text(r"(Montag|Dienstag|Mittwoch|Donnerstag|Freitag|Samstag|Sonntag)")
         machine.screenshot("lomiri-calendar_localised")
   '';

--- a/nixos/tests/lomiri-clock-app.nix
+++ b/nixos/tests/lomiri-clock-app.nix
@@ -34,14 +34,20 @@
     machine.wait_for_x()
 
     with subtest("lomiri clock launches"):
-        machine.execute("lomiri-clock-app >&2 &")
+        machine.succeed("lomiri-clock-app >&2 &")
+        machine.sleep(10)
+        machine.send_key("alt-f10")
+        machine.sleep(5)
         machine.wait_for_text(r"(clock.ubports|City|Alarms)")
         machine.screenshot("lomiri-clock_open")
 
     machine.succeed("pkill -f lomiri-clock-app")
 
     with subtest("lomiri clock localisation works"):
-        machine.execute("env LANG=de_DE.UTF-8 lomiri-clock-app >&2 &")
+        machine.succeed("env LANG=de_DE.UTF-8 lomiri-clock-app >&2 &")
+        machine.sleep(10)
+        machine.send_key("alt-f10")
+        machine.sleep(5)
         machine.wait_for_text(r"(Stadt|Weckzeiten)")
         machine.screenshot("lomiri-clock_localised")
   '';

--- a/nixos/tests/lomiri-docviewer-app.nix
+++ b/nixos/tests/lomiri-docviewer-app.nix
@@ -46,6 +46,9 @@ in
 
     with subtest("lomiri docviewer launches"):
         machine.succeed("lomiri-docviewer-app >&2 &")
+        machine.sleep(10)
+        machine.send_key("alt-f10")
+        machine.sleep(5)
         machine.wait_for_text("No documents")
         machine.screenshot("lomiri-docviewer_open")
 
@@ -57,6 +60,9 @@ in
 
     with subtest("lomiri docviewer txt works"):
         machine.succeed("lomiri-docviewer-app /etc/docviewer-sampletext.txt >&2 &")
+        machine.sleep(10)
+        machine.send_key("alt-f10")
+        machine.sleep(5)
         machine.wait_for_text("${exampleText}")
         machine.screenshot("lomiri-docviewer_txt")
 
@@ -64,6 +70,9 @@ in
 
     with subtest("lomiri docviewer odt works"):
         machine.succeed("lomiri-docviewer-app /root/docviewer-sampletext.odt >&2 &")
+        machine.sleep(10)
+        machine.send_key("alt-f10")
+        machine.sleep(5)
         machine.wait_for_text("${exampleText}")
         machine.screenshot("lomiri-docviewer_odt")
 
@@ -71,6 +80,9 @@ in
 
     with subtest("lomiri docviewer pdf works"):
         machine.succeed("lomiri-docviewer-app /root/docviewer-sampletext.pdf >&2 &")
+        machine.sleep(10)
+        machine.send_key("alt-f10")
+        machine.sleep(5)
         machine.wait_for_text("${exampleText}")
         machine.screenshot("lomiri-docviewer_pdf")
 
@@ -78,6 +90,9 @@ in
 
     with subtest("lomiri docviewer localisation works"):
         machine.succeed("env LANG=de_DE.UTF-8 lomiri-docviewer-app >&2 &")
+        machine.sleep(10)
+        machine.send_key("alt-f10")
+        machine.sleep(5)
         machine.wait_for_text("Keine Dokumente")
         machine.screenshot("lomiri-docviewer_localised")
   '';

--- a/nixos/tests/lomiri-gallery-app.nix
+++ b/nixos/tests/lomiri-gallery-app.nix
@@ -59,8 +59,15 @@
       machine.succeed("mkdir /root/Pictures /root/Videos")
       # Setup example data, OCR-friendly:
       # - White square, black text
+      # - Small text for display OCR
+      # - Big text for gallery preview OCR
       # - uppercase extension
-      machine.succeed("magick -size 500x500 -background white -fill black canvas:white -pointsize 70 -annotate +100+300 '${imageLabel}' /root/Pictures/output.PNG")
+      machine.succeed(
+          "magick -size 500x500 -background white -fill black canvas:white "
+          + "-pointsize 20 -annotate +100+100 '${imageLabel}' "
+          + "-pointsize 50 -annotate +100+300 '${imageLabel}' "
+          + "/root/Pictures/output.PNG"
+      )
 
       # Different image formats
       machine.succeed("magick /root/Pictures/output.PNG /root/Pictures/output.JPG")

--- a/nixos/tests/lomiri-mediaplayer-app.nix
+++ b/nixos/tests/lomiri-mediaplayer-app.nix
@@ -1,6 +1,6 @@
 { lib, ... }:
 let
-  ocrContent = "Video Test";
+  ocrContent = "Feed";
   videoFile = "test.webm";
 in
 {
@@ -25,8 +25,8 @@ in
               ];
             }
             ''
-              magick -size 400x400 canvas:white -pointsize 40 -fill black -annotate +100+100 '${ocrContent}' output.png
-              ffmpeg -re -loop 1 -i output.png -c:v libvpx -b:v 100K -t 120 $out -loglevel fatal
+              magick -size 600x600 canvas:white -pointsize 20 -fill black -annotate +100+100 '${ocrContent}' output.png
+              ffmpeg -re -loop 1 -i output.png -c:v libvpx -b:v 200K -t 120 $out -loglevel fatal
             '';
         systemPackages = with pkgs.lomiri; [
           suru-icon-theme
@@ -54,6 +54,8 @@ in
 
     with subtest("lomiri mediaplayer launches"):
         machine.succeed("lomiri-mediaplayer-app >&2 &")
+        machine.sleep(10)
+        machine.send_key("alt-f10")
         machine.wait_for_text("Choose from")
         machine.screenshot("lomiri-mediaplayer_open")
 
@@ -61,6 +63,8 @@ in
 
     with subtest("lomiri mediaplayer plays video"):
         machine.succeed("lomiri-mediaplayer-app /etc/${videoFile} >&2 &")
+        machine.sleep(10)
+        machine.send_key("alt-f10")
         machine.wait_for_text("${ocrContent}")
         machine.screenshot("lomiri-mediaplayer_playback")
 
@@ -71,6 +75,8 @@ in
         # Cause an error, and look for the error popup
         machine.succeed("touch invalid.mp4")
         machine.succeed("env LANG=de_DE.UTF-8 lomiri-mediaplayer-app invalid.mp4 >&2 &")
+        machine.sleep(10)
+        machine.send_key("alt-f10")
         machine.wait_for_text("Fehler")
         machine.screenshot("lomiri-mediaplayer_localised")
   '';

--- a/nixos/tests/lomiri-music-app.nix
+++ b/nixos/tests/lomiri-music-app.nix
@@ -140,8 +140,10 @@ in
 
     with subtest("lomiri music launches"):
         machine.succeed("lomiri-music-app >&2 &")
-        machine.wait_for_text("favorite music")
+        machine.sleep(10)
         machine.send_key("alt-f10")
+        machine.sleep(2)
+        machine.wait_for_text("favorite music")
         machine.screenshot("lomiri-music")
 
     with subtest("lomiri music plays music"):
@@ -187,6 +189,9 @@ in
 
     with subtest("lomiri music localisation works"):
         machine.succeed("env LANG=de_DE.UTF-8 lomiri-music-app .mp4 >&2 &")
+        machine.sleep(10)
+        machine.send_key("alt-f10")
+        machine.sleep(2)
         machine.wait_for_text("Titel")
         machine.screenshot("lomiri-music_localised")
   '';

--- a/nixos/tests/lomiri-system-settings.nix
+++ b/nixos/tests/lomiri-system-settings.nix
@@ -109,7 +109,11 @@
       machine.wait_for_x()
 
       with subtest("lomiri system settings launches"):
-          machine.execute("lomiri-system-settings >&2 &")
+          machine.succeed("lomiri-system-settings >&2 &")
+          machine.wait_for_console_text("qml: Plugin about does not exist")
+          machine.sleep(10)
+          machine.send_key("alt-f10")
+          machine.sleep(5)
           machine.wait_for_text("System Settings")
           machine.screenshot("lss_open")
 
@@ -137,7 +141,11 @@
       machine.execute("pkill -f lomiri-system-settings")
 
       with subtest("lomiri system settings localisation works"):
-          machine.execute("env LANG=de_DE.UTF-8 lomiri-system-settings >&2 &")
+          machine.succeed("env LANG=de_DE.UTF-8 lomiri-system-settings >&2 &")
+          machine.wait_for_console_text("qml: Plugin about does not exist")
+          machine.sleep(10)
+          machine.send_key("alt-f10")
+          machine.sleep(5)
           machine.wait_for_text("Systemeinstellungen")
           machine.screenshot("lss_localised_open")
 

--- a/nixos/tests/teleports.nix
+++ b/nixos/tests/teleports.nix
@@ -34,14 +34,20 @@
     machine.wait_for_x()
 
     with subtest("teleports launches"):
-        machine.execute("teleports >&2 &")
+        machine.succeed("teleports >&2 &")
+        machine.wait_for_console_text("authorizationStateWaitPhoneNumber")
+        machine.send_key("alt-f10")
+        machine.sleep(2)
         machine.wait_for_text(r"(TELEports|Phone Number)")
         machine.screenshot("teleports_open")
 
     machine.succeed("pkill -f teleports")
 
     with subtest("teleports localisation works"):
-        machine.execute("env LANG=de_DE.UTF-8 teleports >&2 &")
+        machine.succeed("env LANG=de_DE.UTF-8 teleports >&2 &")
+        machine.wait_for_console_text("authorizationStateWaitPhoneNumber")
+        machine.send_key("alt-f10")
+        machine.sleep(2)
         machine.wait_for_text("Telefonnummer")
         machine.screenshot("teleports_localised")
   '';


### PR DESCRIPTION
Something caused the OCR processes in these to be significantly slower than before. I'm guessing a recent update to `icewm`, since the wallpaper and various elements of the test environment look different now?

Adjust the tests to pass in an acceptable time again.

Related (though not necessary): All OCR tasks get run sequentially instead of in parallel, so instead of a ~22mins long `tesseract` run causing the overall OCR runtime to get pulled up to the longest task(s), multiple slow ones add up to >1h for a single `_perform_ocr_on_screenshot` run. See #406517 for a solution to that.

Kind of half-redoing #398413, but just enough that OCR doesn't get stuck anymore on my more powerful hardware.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
