### PR TITLE
owl-compositor: fix XDG_RUNTIME_DIR not set on darwin 

### DIFF
--- a/pkgs/by-name/ni/nightlight/package.nix
+++ b/pkgs/by-name/ni/nightlight/package.nix
@@ -1,0 +1,39 @@
+{
+  lib,
+  fetchFromGitHub,
+  rustPlatform,
+  makeWrapper,
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "nightlight";
+  version = "0.3.1";
+
+  src = fetchFromGitHub {
+    owner = "smudge";
+    repo = "nightlight";
+    tag = "v${version}";
+    hash = "sha256-NOphjrqsnO5693Zw3NkX3c74I3PdJ8W6sxYwOEJ1yCU=";
+  };
+
+  useFetchCargoVendor = true;
+
+  cargoHash = "sha256-v5Oo1AxwvJs66l9CtVjO+WfwgsM16zSLT1SSnDi1kSo=";
+
+  checkFlags = [
+    "--skip=repl"
+    "--skip=printer::tests"
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    homepage = "https://github.com/smudge/nightlight";
+    description = "CLI tool for configuring Night Shift macOS";
+    maintainers = with lib.maintainers; [ aspauldingcode ];
+    platforms = lib.platforms.darwin;
+    license = lib.licenses.mit;
+    mainProgram = "nightlight";
+  };
+}

--- a/pkgs/by-name/ow/owl-compositor/package.nix
+++ b/pkgs/by-name/ow/owl-compositor/package.nix
@@ -54,9 +54,6 @@ stdenv.mkDerivation {
       libxkbcommon
       wayland
     ]
-    ++ lib.optionals stdenv.hostPlatform.isDarwin [
-      darwin.apple_sdk.frameworks.Cocoa
-    ]
     ++ lib.optionals (!stdenv.hostPlatform.isDarwin) [
       gnustep-back
     ];
@@ -78,7 +75,15 @@ stdenv.mkDerivation {
 
     mkdir -p $out/{Applications,bin}
     mv Owl.app $out/Applications
-    makeWrapper $out/{Applications/Owl.app${lib.optionalString stdenv.hostPlatform.isDarwin "/Contents/MacOS"},bin}/Owl
+
+    cat > $out/bin/Owl <<EOF
+    #!/bin/sh
+    export XDG_RUNTIME_DIR="/tmp/runtime-\$(id -un)"
+    mkdir -p "\$XDG_RUNTIME_DIR"
+    chmod 700 "\$XDG_RUNTIME_DIR"
+    exec "$out/Applications/Owl.app${lib.optionalString stdenv.hostPlatform.isDarwin "/Contents/MacOS"}/Owl" "\$@"
+    EOF
+    chmod +x $out/bin/Owl
 
     runHook postInstall
   '';


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
Add a check for setting XDG_RUNTIME_DIR on macOS for successfully running owl-compositor.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
