### PR TITLE
hobbes: 0-unstable-2023-06-03 -> 0-unstable-2025-04-23

### DIFF
--- a/pkgs/by-name/ho/hobbes/package.nix
+++ b/pkgs/by-name/ho/hobbes/package.nix
@@ -3,7 +3,6 @@
   stdenv,
   llvmPackages,
   fetchFromGitHub,
-  fetchpatch,
   cmake,
   llvm_12,
   ncurses,
@@ -14,33 +13,19 @@
 }:
 llvmPackages.stdenv.mkDerivation {
   pname = "hobbes";
-  version = "0-unstable-2023-06-03";
+  version = "0-unstable-2025-04-23";
 
   src = fetchFromGitHub {
     owner = "morganstanley";
     repo = "hobbes";
-    rev = "88a712b85bc896a4c87e60c12321445f1cdcfd00";
-    hash = "sha256-2v0yk35/cLKTjX0Qbc8cjc7Y6bamRSa9GpPvGoxL2Cw=";
+    rev = "0829030be03d47f91075cbebd0c9565f44bf9911";
+    hash = "sha256-GZ26XL4++2MWQED2tVWeJ8HFcFQUXnXZ3+JCgdlAXNo=";
   };
 
-  patches = [
-    # fix build for LLVM-12+
-    # https://github.com/morganstanley/hobbes/pull/452
-    (fetchpatch {
-      name = "include-cstdint.patch";
-      url = "https://github.com/morganstanley/hobbes/commit/924b71fca06c61e606792cc8db8521fb499d4237.patch";
-      hash = "sha256-/VsWtTYc3LBOnm4Obgx/MOqaaWZhUc8yzmkygtNz+mY=";
-    })
+  CXXFLAGS = [
+    "-Wno-error=missing-template-arg-list-after-template-kw"
+    "-Wno-error=deprecated-copy"
   ];
-
-  # only one warning generated. try to remove on next update
-  env.CXXFLAGS = "-Wno-error=deprecated-copy";
-
-  # TODO: re-enable Python tests once they work on Python 3
-  # currently failing with "I don't know how to decode the primitive type: b'bool'"
-  postPatch = ''
-    rm test/Python.C
-  '';
 
   nativeBuildInputs = [
     cmake


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
ZHF: #403336
Hydra: https://hydra.nixos.org/build/296329961

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
