### PR TITLE
opensnitch{,-ui}: modernize, adopt

### DIFF
--- a/pkgs/by-name/op/opensnitch-ui/package.nix
+++ b/pkgs/by-name/op/opensnitch-ui/package.nix
@@ -1,29 +1,23 @@
 {
-  python311Packages,
-  fetchFromGitHub,
-  nix-update-script,
+  python3Packages,
   qt5,
   lib,
+  opensnitch,
 }:
 
-python311Packages.buildPythonApplication rec {
+python3Packages.buildPythonApplication {
   pname = "opensnitch-ui";
-  version = "1.6.9";
 
-  src = fetchFromGitHub {
-    owner = "evilsocket";
-    repo = "opensnitch";
-    rev = "refs/tags/v${version}";
-    hash = "sha256-c+VAlm32/NXvUr5i0AY/zuTrFIQLtPxNNeSiQTMoJAY=";
-  };
+  inherit (opensnitch) src version;
+  sourceRoot = "${opensnitch.src.name}/ui";
 
   postPatch = ''
-    substituteInPlace ui/opensnitch/utils/__init__.py \
-      --replace /usr/lib/python3/dist-packages/data ${python311Packages.pyasn}/${python311Packages.python.sitePackages}/pyasn/data
+    substituteInPlace opensnitch/utils/__init__.py \
+      --replace-fail /usr/lib/python3/dist-packages/data ${python3Packages.pyasn}/${python3Packages.python.sitePackages}/pyasn/data
   '';
 
   nativeBuildInputs = [
-    python311Packages.pyqt5
+    python3Packages.pyqt5
     qt5.wrapQtAppsHook
   ];
 
@@ -31,7 +25,7 @@ python311Packages.buildPythonApplication rec {
     qt5.qtwayland
   ];
 
-  propagatedBuildInputs = with python311Packages; [
+  dependencies = with python3Packages; [
     grpcio-tools
     notify2
     packaging
@@ -50,16 +44,12 @@ python311Packages.buildPythonApplication rec {
     sed -i 's/^import ui_pb2/from . import ui_pb2/' opensnitch/ui_pb2*
   '';
 
-  preConfigure = ''
-    cd ui
-  '';
-
   preCheck = ''
     export PYTHONPATH=opensnitch:$PYTHONPATH
   '';
 
   postInstall = ''
-    mv $out/${python311Packages.python.sitePackages}/usr/* $out/
+    mv $out/${python3Packages.python.sitePackages}/usr/* $out/
   '';
 
   dontWrapQtApps = true;
@@ -68,14 +58,15 @@ python311Packages.buildPythonApplication rec {
   # All tests are sandbox-incompatible and disabled for now
   doCheck = false;
 
-  passthru.updateScript = nix-update-script { };
-
-  meta = with lib; {
+  meta = {
     description = "Application firewall";
     mainProgram = "opensnitch-ui";
     homepage = "https://github.com/evilsocket/opensnitch/wiki";
-    license = licenses.gpl3Only;
-    maintainers = with maintainers; [ onny ];
-    platforms = platforms.linux;
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [
+      onny
+      grimmauld
+    ];
+    platforms = lib.platforms.linux;
   };
 }

--- a/pkgs/by-name/op/opensnitch/package.nix
+++ b/pkgs/by-name/op/opensnitch/package.nix
@@ -13,9 +13,12 @@
   testers,
   opensnitch,
   nixosTests,
+  opensnitch-ui,
+  nix-update-script,
 }:
 let
   # Override protoc-gen-go-grpc to use the compatible version
+  # Should be droppable on opensnitch 1.7.0
   protoc-gen-go-grpc' = protoc-gen-go-grpc.overrideAttrs (oldAttrs: rec {
     version = "1.3.0";
 
@@ -29,20 +32,20 @@ let
     vendorHash = "sha256-y+/hjYUTFZuq55YAZ5M4T1cwIR+XFQBmWVE+Cg1Y7PI=";
   });
 in
-buildGoModule rec {
+buildGoModule (finalAttrs: {
   pname = "opensnitch";
   version = "1.6.9";
 
   src = fetchFromGitHub {
     owner = "evilsocket";
     repo = "opensnitch";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-c+VAlm32/NXvUr5i0AY/zuTrFIQLtPxNNeSiQTMoJAY=";
   };
 
   postPatch = ''
     # Allow configuring Version at build time
-    substituteInPlace daemon/core/version.go --replace "const " "var "
+    substituteInPlace daemon/core/version.go --replace-fail "const " "var "
   '';
 
   modRoot = "daemon";
@@ -71,18 +74,18 @@ buildGoModule rec {
     mkdir -p $out/etc/opensnitchd $out/lib/systemd/system
     cp system-fw.json $out/etc/opensnitchd/
     substitute default-config.json $out/etc/opensnitchd/default-config.json \
-      --replace "/var/log/opensnitchd.log" "/dev/stdout"
+      --replace-fail "/var/log/opensnitchd.log" "/dev/stdout"
     # Do not mkdir rules path
     sed -i '8d' opensnitchd.service
     # Fixup hardcoded paths
     substitute opensnitchd.service $out/lib/systemd/system/opensnitchd.service \
-      --replace "/usr/local/bin/opensnitchd" "$out/bin/opensnitchd"
+      --replace-fail "/usr/local/bin/opensnitchd" "$out/bin/opensnitchd"
   '';
 
   ldflags = [
     "-s"
     "-w"
-    "-X github.com/evilsocket/opensnitch/daemon/core.Version=${version}"
+    "-X github.com/evilsocket/opensnitch/daemon/core.Version=${finalAttrs.version}"
   ];
 
   postInstall = ''
@@ -90,20 +93,33 @@ buildGoModule rec {
       --prefix PATH : ${lib.makeBinPath [ iptables ]}
   '';
 
-  passthru.tests = {
-    inherit (nixosTests) opensnitch;
-    version = testers.testVersion {
-      package = opensnitch;
-      command = "opensnitchd -version";
+  passthru = {
+    tests = {
+      inherit (nixosTests) opensnitch;
+      inherit opensnitch-ui;
+      version = testers.testVersion {
+        package = opensnitch;
+        command = "opensnitchd -version";
+      };
+    };
+
+    updater = nix-update-script {
+      extraArgs = [
+        "--version-regex"
+        "^v([0-9.]+)$"
+      ];
     };
   };
 
-  meta = with lib; {
+  meta = {
     description = "Application firewall";
     mainProgram = "opensnitchd";
     homepage = "https://github.com/evilsocket/opensnitch/wiki";
-    license = licenses.gpl3Only;
-    maintainers = with maintainers; [ onny ];
-    platforms = platforms.linux;
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [
+      onny
+      grimmauld
+    ];
+    platforms = lib.platforms.linux;
   };
-}
+})


### PR DESCRIPTION
I use opensnitch on all my systems, and getting the 1.6.9 update merged was a little painful.

This includes:
- `replace` -> `replace-fail`
- remove `with lib;`
- adopt by me
- use sources from `opensnitch` in `opensnitch-ui`
- `cd` -> `sourceRoot`
- unpin python 3.11
- move the update script to `opensnitch`, blacklist the release candidates
- `rec` -> `finalAttrs` (for go module)

followup to https://github.com/NixOS/nixpkgs/pull/402907#pullrequestreview-2837604743

cc @onny @winterqt 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
