### PR TITLE
gpg-mdp: 0.7.4 -> 0.7.5

### DIFF
--- a/pkgs/by-name/gp/gpg-mdp/package.nix
+++ b/pkgs/by-name/gp/gpg-mdp/package.nix
@@ -1,53 +1,53 @@
 {
-  fetchurl,
-  fetchpatch,
   lib,
+  fetchFromGitHub,
   stdenv,
+  nix-update-script,
+
   ncurses,
   gnupg,
 }:
 
-let
-  version = "0.7.4";
-in
-stdenv.mkDerivation {
+stdenv.mkDerivation (finalAttrs: {
   # mdp renamed to gpg-mdp because there is a mdp package already.
   pname = "gpg-mdp";
-  inherit version;
+  version = "0.7.5";
+
   meta = {
     homepage = "https://tamentis.com/projects/mdp/";
+    changelog = "https://github.com/tamentis/mdp/releases/tag/v${finalAttrs.version}";
     license = [ lib.licenses.isc ];
     description = "Manage your passwords with GnuPG and a text editor";
   };
-  src = fetchurl {
-    url = "https://tamentis.com/projects/mdp/files/mdp-${version}.tar.gz";
-    sha256 = "04mdnx4ccpxf9m2myy9nvpl9ma4jgzmv9bkrzv2b9affzss3r34g";
+
+  src = fetchFromGitHub {
+    owner = "tamentis";
+    repo = "mdp";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-Y92y70XkUbB+lhWAzEkCB/cvfUPPKIfu0yrlCS2pKn0=";
   };
-  patches = [
-    # Pull fix pending upstream inclusion for -fno-common toolchain support:
-    #   https://github.com/tamentis/mdp/pull/9
-    (fetchpatch {
-      name = "fno-common.patch";
-      url = "https://github.com/tamentis/mdp/commit/95c77de3beb96dc7c76ff36d3f3dfb18411d7c54.patch";
-      sha256 = "1j6yvjzkx31b758yav4arhlm5ig7phl8mgx4fcwj7lm2pfvzwcsz";
-    })
-  ];
+
   buildInputs = [ ncurses ];
+
   prePatch = ''
     substituteInPlace ./configure \
-      --replace "alias echo=/bin/echo" ""
+      --replace-fail "alias echo=/bin/echo" "" \
+      --replace-fail "main()" "int main()"
 
     substituteInPlace ./src/config.c \
-      --replace "/usr/bin/gpg" "${gnupg}/bin/gpg" \
-      --replace "/usr/bin/vi" "vi"
+      --replace-fail "/usr/bin/gpg" "${lib.getExe gnupg}" \
+      --replace-fail "/usr/bin/vi" "vi"
 
     substituteInPlace ./mdp.1 \
-      --replace "/usr/bin/gpg" "${gnupg}/bin/gpg"
+      --replace-fail "/usr/bin/gpg" "${lib.getExe gnupg}"
   '';
+
   # we add symlinks to the binary and man page with the name 'gpg-mdp', in case
   # the completely unrelated program also named 'mdp' is already installed.
   postFixup = ''
     ln -s $out/bin/mdp $out/bin/gpg-mdp
     ln -s $out/share/man/man1/mdp.1.gz $out/share/man/man1/gpg-mdp.1.gz
   '';
-}
+
+  passthru.updateScript = nix-update-script { };
+})


### PR DESCRIPTION
ZHF: #403336

hydra: https://hydra.nixos.org/build/296145889

```
$ ./result/bin/mdp -h
usage: mdp [-Vh] [-c config] command [command args ...]

The mdp commands are:
   add        Add new random passwords at the end of your file.
   edit       Edit your passwords.
   generate   Generate random passwords.
   get        Get passwords by keywords or regexes.
   prompt     Interactive prompt session.

'mdp <command> -h' returns this command's usage.
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
