### PR TITLE
pidginPackages.pidgin-sipe: fix compilation error with libxml2

### DIFF
--- a/pkgs/applications/networking/instant-messengers/pidgin/pidgin-plugins/sipe/0001-fix-libxml-error-signature.patch
+++ b/pkgs/applications/networking/instant-messengers/pidgin/pidgin-plugins/sipe/0001-fix-libxml-error-signature.patch
@@ -1,0 +1,21 @@
+diff --git a/src/core/sipe-xml.c b/src/core/sipe-xml.c
+index cfc5311..c38f6e8 100644
+--- a/src/core/sipe-xml.c
++++ b/src/core/sipe-xml.c
+@@ -29,6 +29,7 @@
+ #include <time.h>
+ 
+ #include "libxml/parser.h"
++#include "libxml/xmlerror.h"
+ #include "libxml/c14n.h"
+ #include "libxml/xmlversion.h"
+ 
+@@ -154,7 +155,7 @@ static void callback_error(void *user_data, const char *msg, ...)
+ 	g_free(errmsg);
+ }
+ 
+-static void callback_serror(void *user_data, xmlErrorPtr error)
++static void callback_serror(void *user_data, const xmlError *error)
+ {
+ 	struct _parser_data *pd = user_data;
+ 

--- a/pkgs/applications/networking/instant-messengers/pidgin/pidgin-plugins/sipe/default.nix
+++ b/pkgs/applications/networking/instant-messengers/pidgin/pidgin-plugins/sipe/default.nix
@@ -31,6 +31,7 @@ stdenv.mkDerivation rec {
       url = "https://repo.or.cz/siplcs.git/patch/583a734e63833f03d11798b7b0d59a17d08ae60f";
       sha256 = "Ai6Czpy/FYvBi4GZR7yzch6OcouJgfreI9HcojhGVV4=";
     })
+    ./0001-fix-libxml-error-signature.patch
   ];
 
   nativeBuildInputs = [ intltool ];


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Added a patch to fix the signature in the libxml2 error handling. Without this fix, the build fails.

ZHF: #403336
Hydra: https://hydra.nixos.org/build/296201087

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
