### PR TITLE
workflows: improve testability

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -14,7 +14,7 @@ permissions: {}
 jobs:
   backport:
     name: Backport Pull Request
-    if: github.repository_owner == 'NixOS' && github.event.pull_request.merged == true && (github.event.action != 'labeled' || startsWith(github.event.label.name, 'backport'))
+    if: vars.NIXPKGS_CI_APP_ID && github.event.pull_request.merged == true && (github.event.action != 'labeled' || startsWith(github.event.label.name, 'backport'))
     runs-on: ubuntu-24.04-arm
     steps:
       # Use a GitHub App to create the PR so that CI gets triggered

--- a/.github/workflows/check-cherry-picks.yml
+++ b/.github/workflows/check-cherry-picks.yml
@@ -16,7 +16,6 @@ jobs:
   check:
     name: cherry-pick-check
     runs-on: ubuntu-24.04-arm
-    if: github.repository_owner == 'NixOS'
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:

--- a/.github/workflows/check-cherry-picks.yml
+++ b/.github/workflows/check-cherry-picks.yml
@@ -1,6 +1,9 @@
 name: "Check cherry-picks"
 
 on:
+  pull_request:
+    paths:
+      - .github/workflows/check-cherry-picks.yml
   pull_request_target:
     branches:
       - 'release-**'

--- a/.github/workflows/check-format.yml
+++ b/.github/workflows/check-format.yml
@@ -1,6 +1,9 @@
 name: Check that files are formatted
 
 on:
+  pull_request:
+    paths:
+      - .github/workflows/check-format.yml
   pull_request_target:
     types: [opened, synchronize, reopened, edited]
 

--- a/.github/workflows/check-shell.yml
+++ b/.github/workflows/check-shell.yml
@@ -1,6 +1,9 @@
 name: "Check shell"
 
 on:
+  pull_request:
+    paths:
+      - .github/workflows/check-shell.yml
   pull_request_target:
     paths:
       - 'shell.nix'

--- a/.github/workflows/codeowners-v2.yml
+++ b/.github/workflows/codeowners-v2.yml
@@ -23,6 +23,9 @@
 name: Codeowners v2
 
 on:
+  pull_request:
+    paths:
+      - .github/workflows/codeowners-v2.yml
   pull_request_target:
     types: [opened, ready_for_review, synchronize, reopened, edited]
 
@@ -64,6 +67,7 @@ jobs:
         run: nix-build base/ci -A codeownersValidator
 
       - uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e # v2.0.6
+        if: vars.OWNER_RO_APP_ID
         id: app-token
         with:
           app-id: ${{ vars.OWNER_RO_APP_ID }}
@@ -77,6 +81,7 @@ jobs:
           path: pr
 
       - name: Validate codeowners
+        if: steps.app-token.outputs.token
         run: result/bin/codeowners-validator
         env:
           OWNERS_FILE: pr/${{ env.OWNERS_FILE }}
@@ -99,6 +104,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e # v2.0.6
+        if: vars.OWNER_APP_ID
         id: app-token
         with:
           app-id: ${{ vars.OWNER_APP_ID }}
@@ -111,6 +117,7 @@ jobs:
         run: nix-build ci -A requestReviews
 
       - name: Request reviews
+        if: steps.app-token.outputs.token
         run: result/bin/request-code-owner-reviews.sh ${{ github.repository }} ${{ github.event.number }} "$OWNERS_FILE"
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/eval-aliases.yml
+++ b/.github/workflows/eval-aliases.yml
@@ -29,7 +29,7 @@ jobs:
           extra_nix_config: sandbox = true
 
       - name: Ensure flake outputs on all systems still evaluate
-        run: nix --experimental-features 'nix-command flakes' flake check --all-systems --no-build ./nixpkgs
+        run: nix flake check --all-systems --no-build ./nixpkgs
 
       - name: Query nixpkgs with aliases enabled to check for basic syntax errors
         run: |

--- a/.github/workflows/eval-aliases.yml
+++ b/.github/workflows/eval-aliases.yml
@@ -1,6 +1,9 @@
 name: Eval aliases
 
 on:
+  pull_request:
+    paths:
+      - .github/workflows/eval-aliases.yml
   pull_request_target:
 
 permissions: {}

--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -1,6 +1,9 @@
 name: Eval
 
 on:
+  pull_request:
+    paths:
+      - .github/workflows/eval.yml
   pull_request_target:
     types: [opened, ready_for_review, synchronize, reopened]
   push:
@@ -175,6 +178,7 @@ jobs:
       # See ./codeowners-v2.yml, reuse the same App because we need the same permissions
       # Can't use the token received from permissions above, because it can't get enough permissions
       - uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e # v2.0.6
+        if: vars.OWNER_APP_ID
         id: app-token
         with:
           app-id: ${{ vars.OWNER_APP_ID }}
@@ -205,6 +209,7 @@ jobs:
         run: nix-build base/ci -A requestReviews
 
       - name: Labelling pull request
+        if: ${{ github.event_name == 'pull_request_target' }}
         run: |
           # Get all currently set rebuild labels
           gh api \
@@ -259,6 +264,7 @@ jobs:
           NUMBER: ${{ github.event.number }}
 
       - name: Requesting maintainer reviews
+        if: steps.app-token.outputs.token
         run: |
           # maintainers.json contains GitHub IDs. Look up handles to request reviews from.
           # There appears to be no API to request reviews based on GitHub IDs

--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -209,7 +209,7 @@ jobs:
         run: nix-build base/ci -A requestReviews
 
       - name: Labelling pull request
-        if: ${{ github.event_name == 'pull_request_target' }}
+        if: ${{ github.event_name == 'pull_request_target' && github.repository_owner == 'NixOS' }}
         run: |
           # Get all currently set rebuild labels
           gh api \
@@ -244,7 +244,7 @@ jobs:
           NUMBER: ${{ github.event.number }}
 
       - name: Add eval summary to commit statuses
-        if: ${{ github.event_name == 'pull_request_target' }}
+        if: ${{ github.event_name == 'pull_request_target' && github.repository_owner == 'NixOS' }}
         run: |
           description=$(jq -r '
           "Package: added " + (.attrdiff.added | length | tostring) +
@@ -264,7 +264,7 @@ jobs:
           NUMBER: ${{ github.event.number }}
 
       - name: Requesting maintainer reviews
-        if: steps.app-token.outputs.token
+        if: ${{ steps.app-token.outputs.token && github.repository_owner == 'NixOS' }}
         run: |
           # maintainers.json contains GitHub IDs. Look up handles to request reviews from.
           # There appears to be no API to request reviews based on GitHub IDs

--- a/.github/workflows/get-merge-commit.yml
+++ b/.github/workflows/get-merge-commit.yml
@@ -1,6 +1,9 @@
 name: Get merge commit
 
 on:
+  pull_request:
+    paths:
+      - .github/workflows/get-merge-commit.yml
   workflow_call:
     outputs:
       mergedSha:
@@ -38,7 +41,7 @@ jobs:
             push)
               echo "mergedSha=${{ github.sha }}" >> "$GITHUB_OUTPUT"
               ;;
-            pull_request_target)
+            pull_request*)
               if commits=$(base/ci/get-merge-commit.sh ${{ github.repository }} ${{ github.event.number }}); then
                 echo -e "Checking the commits:\n$commits"
                 echo "$commits" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/lib-tests.yml
+++ b/.github/workflows/lib-tests.yml
@@ -1,6 +1,9 @@
 name: "Building Nixpkgs lib-tests"
 
 on:
+  pull_request:
+    paths:
+      - .github/workflows/lib-tests.yml
   pull_request_target:
     paths:
       - 'lib/**'

--- a/.github/workflows/manual-nixos-v2.yml
+++ b/.github/workflows/manual-nixos-v2.yml
@@ -1,6 +1,9 @@
 name: "Build NixOS manual v2"
 
 on:
+  pull_request:
+    paths:
+      - .github/workflows/manual-nixos-v2.yml
   pull_request_target:
     branches:
       - master

--- a/.github/workflows/manual-nixos-v2.yml
+++ b/.github/workflows/manual-nixos-v2.yml
@@ -41,7 +41,6 @@ jobs:
           extra_nix_config: sandbox = true
 
       - uses: cachix/cachix-action@0fc020193b5a1fa3ac4575aa3a7d3aa6a35435ad # v16
-        if: github.repository_owner == 'NixOS'
         with:
           # This cache is for the nixpkgs repo checks and should not be trusted or used elsewhere.
           name: nixpkgs-ci

--- a/.github/workflows/manual-nixpkgs-v2.yml
+++ b/.github/workflows/manual-nixpkgs-v2.yml
@@ -28,7 +28,6 @@ jobs:
           extra_nix_config: sandbox = true
 
       - uses: cachix/cachix-action@0fc020193b5a1fa3ac4575aa3a7d3aa6a35435ad # v16
-        if: github.repository_owner == 'NixOS'
         with:
           # This cache is for the nixpkgs repo checks and should not be trusted or used elsewhere.
           name: nixpkgs-ci

--- a/.github/workflows/manual-nixpkgs-v2.yml
+++ b/.github/workflows/manual-nixpkgs-v2.yml
@@ -1,6 +1,9 @@
 name: "Build Nixpkgs manual v2"
 
 on:
+  pull_request:
+    paths:
+      - .github/workflows/manual-nixpkgs-v2.yml
   pull_request_target:
     branches:
       - master

--- a/.github/workflows/nix-parse-v2.yml
+++ b/.github/workflows/nix-parse-v2.yml
@@ -1,6 +1,9 @@
 name: "Check whether nix files are parseable v2"
 
 on:
+  pull_request:
+    paths:
+      - .github/workflows/nix-parse-v2.yml
   pull_request_target:
 
 permissions: {}

--- a/.github/workflows/nixpkgs-vet.yml
+++ b/.github/workflows/nixpkgs-vet.yml
@@ -6,6 +6,9 @@
 name: Vet nixpkgs
 
 on:
+  pull_request:
+    paths:
+      - .github/workflows/nixpkgs-vet.yml
   pull_request_target:
     # This workflow depends on the base branch of the PR, but changing the base branch is not included in the default trigger events, which would be `opened`, `synchronize` or `reopened`.
     # Instead it causes an `edited` event, so we need to add it explicitly here.

--- a/.github/workflows/no-channel.yml
+++ b/.github/workflows/no-channel.yml
@@ -1,6 +1,9 @@
 name: "No channel PR"
 
 on:
+  pull_request:
+    paths:
+      - .github/workflows/no-channel.yml
   pull_request_target:
     # Re-run should be triggered when the base branch is updated, instead of silently failing
     types: [opened, synchronize, reopened, edited]


### PR DESCRIPTION
Currently, testing your changes for workflows is a bit annoying, because it always has to happen in your fork. Additionally, some jobs are just disabled for forks, which is another hurdle.

This PR tries two things:
- Adds another `pull_request` event to most workflows, where sensible. This only triggers when the workflow itself is changed. Since the workflow runs in the context of the head commit, it has two main differences: (1) It runs the workflow files from the PR, aka the latest changes and (2) it doesn't have access to the secrets. Thus, I added conditionals where needed to skip some steps if no secret is available. The latter improves testability in PRs, but also in forks, where those secrets might not be set as well.
- Removes some of the "repo owner == NixOS" conditions, which prevent jobs from running in forks. All potentially failing jobs / steps should be conditioned on the availability of secrets anyway. Unfortunately labels and code-owners won't work that way, so still can't be tested easily.

## Things done

Not tested, yet - still need to confirm this actually works.

- [x] Tested in my fork
- [x] Tested in this PR (hopefully it works)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
