### PR TITLE
ty: init at 0.0.1-alpha.1

### DIFF
--- a/pkgs/by-name/ty/ty/package.nix
+++ b/pkgs/by-name/ty/ty/package.nix
@@ -1,0 +1,64 @@
+{
+  lib,
+  stdenv,
+  rustPlatform,
+  fetchFromGitHub,
+
+  # nativeBuildInputs
+  installShellFiles,
+
+  buildPackages,
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "ty";
+  version = "0.0.1-alpha.1";
+
+  src = fetchFromGitHub {
+    owner = "astral-sh";
+    repo = "ruff";
+    rev = "f8890b70c35b2d05a8fa21958077de2aab5ba2ad";
+    hash = "sha256-5kkUYa7fwGf+X11W//XXsEAna8fiNcl3bhALOiXjnHQ=";
+  };
+
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-zKy2hlU3Buy+SzN1lNEXb/7V6VlhbGOc78nz1/Ruk+0=";
+
+  nativeBuildInputs = [
+    installShellFiles
+  ];
+
+  dontUseCmakeConfigure = true;
+
+  cargoBuildFlags = [
+    "--package"
+    "ty"
+  ];
+
+  # Tests require python3
+  doCheck = false;
+
+  postInstall =
+    let
+      emulator = stdenv.hostPlatform.emulator buildPackages;
+    in
+    ''
+      installShellCompletion --cmd ty \
+        --bash <(${emulator} $out/bin/ty generate-shell-completion bash) \
+        --fish <(${emulator} $out/bin/ty generate-shell-completion fish) \
+        --zsh <(${emulator} $out/bin/ty generate-shell-completion zsh)
+    '';
+
+  doInstallCheck = true;
+
+  meta = {
+    description = "Extremely fast Python type checker and language server, written in Rust.";
+    homepage = "https://github.com/astral-sh/ty";
+    changelog = "https://github.com/astral-sh/ty/blob/${version}/CHANGELOG.md";
+    license = with lib.licenses; [
+      mit
+    ];
+    maintainers = with lib.maintainers; [ ryantm ];
+    mainProgram = "ty";
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
Added new package ty which is a Python LSP from the same people who brought us ruff and uv. It's still early in development. I was able to type check my codebase from the commandline. The server connected to emacs's eglot LSP interface, but it seems to have pretty limited functionality at this point. Bash completions worked. Started with the ruff build instructions and removed things we didn't need yet.

Not sure if we want to accept this yet since it is so pre-alpha, but I figured people would be interested in it, so maybe we should just put it in.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
