### PR TITLE
lib.path.append: Accept string for first argument

### DIFF
--- a/lib/path/default.nix
+++ b/lib/path/default.nix
@@ -175,7 +175,7 @@ in
     Append a subpath string to a path.
 
     Like `path + ("/" + string)` but safer, because it errors instead of returning potentially surprising results.
-    More specifically, it checks that the first argument is a [path value type](https://nixos.org/manual/nix/stable/language/values.html#type-path"),
+    More specifically, it checks that the first argument is a [path value type](https://nixos.org/manual/nix/stable/language/values.html#type-path") or a string,
     and that the second argument is a [valid subpath string](#function-library-lib.path.subpath.isValid).
 
     Laws:
@@ -217,7 +217,7 @@ in
     => /foo/bar
 
     # first argument needs to be a path value type
-    append "/foo" "bar"
+    append 0 "bar"
     => <error>
 
     # second argument needs to be a valid subpath string
@@ -238,8 +238,12 @@ in
     path:
     # The subpath string to append
     subpath:
-    assert assertMsg (isPath path)
-      ''lib.path.append: The first argument is of type ${builtins.typeOf path}, but a path was expected'';
+    # Note: strings are paths in Nix:
+    # - `outPath` on derivations and Flake inputs is a string, not a path.
+    # - `builtins.path`, bizarrely, returns a string instead of a path (not
+    #   that the documentation makes this clear).
+    assert assertMsg (isPath path || isString path)
+      ''lib.path.append: The first argument is of type ${builtins.typeOf path}, but a path or string was expected'';
     assert assertMsg (isValid subpath) ''
       lib.path.append: Second argument is not a valid subpath string:
           ${subpathInvalidReason subpath}'';

--- a/lib/path/tests/unit.nix
+++ b/lib/path/tests/unit.nix
@@ -30,7 +30,7 @@ let
       expected = /foo/bar;
     };
     testAppendExample4 = {
-      expr = (builtins.tryEval (append "/foo" "bar")).success;
+      expr = (builtins.tryEval (append { } "bar")).success;
       expected = false;
     };
     testAppendExample5 = {
@@ -323,6 +323,10 @@ let
     testSubpathComponentsExample3 = {
       expr = (builtins.tryEval (subpath.components "/foo")).success;
       expected = false;
+    };
+    testAppendString = {
+      expr = append "/puppy" "doggy";
+      expected = "/puppy/doggy";
     };
   };
 in


### PR DESCRIPTION
`lib.path.append` is equivalent to `+` except it produces error messages if you feed it non-paths. This is frustrating for users, because many APIs in Nix do not represent paths as path-type values.

Notably:
- `outPath` on derivations and Flake inputs is a string, not a path.
- `builtins.path`, bizarrely, returns a string instead of a path (not that the documentation makes this clear).

Using path-type values often leads to duplicate copies of Nix store paths; the only workaround is to use `builtins.toString` to produce paths.

See: https://github.com/NixOS/nix/issues/9428
See: #406885


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
