### PR TITLE
kdeltachat: pin libdeltachat at 1.155.6

### DIFF
--- a/pkgs/applications/networking/instant-messengers/kdeltachat/default.nix
+++ b/pkgs/applications/networking/instant-messengers/kdeltachat/default.nix
@@ -1,6 +1,7 @@
 {
   lib,
   mkDerivation,
+  fetchFromGitHub,
   fetchFromSourcehut,
   cmake,
   extra-cmake-modules,
@@ -11,8 +12,25 @@
   qtimageformats,
   qtmultimedia,
   qtwebengine,
+  rustPlatform,
 }:
 
+let
+  libdeltachat' = libdeltachat.overrideAttrs rec {
+    version = "1.155.6";
+    src = fetchFromGitHub {
+      owner = "chatmail";
+      repo = "core";
+      tag = "v${version}";
+      hash = "sha256-d7EmmyLSJjFIZM1j6LP8f4WnXiptNTAqOdJD/oPL02Y=";
+    };
+    cargoDeps = rustPlatform.fetchCargoVendor {
+      pname = "deltachat-core-rust";
+      inherit version src;
+      hash = "sha256-E01aEzNi06LQntrlA+342a8Nl5API6v7HbdmuKpfajs=";
+    };
+  };
+in
 mkDerivation {
   pname = "kdeltachat";
   version = "unstable-2024-01-14";
@@ -32,7 +50,7 @@ mkDerivation {
 
   buildInputs = [
     kirigami2
-    libdeltachat
+    libdeltachat'
     qtimageformats
     qtmultimedia
     qtwebengine

--- a/pkgs/by-name/kd/kdeltachat/package.nix
+++ b/pkgs/by-name/kd/kdeltachat/package.nix
@@ -1,18 +1,14 @@
 {
   lib,
-  mkDerivation,
   fetchFromGitHub,
   fetchFromSourcehut,
   cmake,
   extra-cmake-modules,
   pkg-config,
-  kirigami2,
   libdeltachat,
-  qtbase,
-  qtimageformats,
-  qtmultimedia,
-  qtwebengine,
+  libsForQt5,
   rustPlatform,
+  stdenv,
 }:
 
 let
@@ -30,8 +26,16 @@ let
       hash = "sha256-E01aEzNi06LQntrlA+342a8Nl5API6v7HbdmuKpfajs=";
     };
   };
+  inherit (libsForQt5)
+    kirigami2
+    qtbase
+    qtimageformats
+    qtmultimedia
+    qtwebengine
+    wrapQtAppsHook
+    ;
 in
-mkDerivation {
+stdenv.mkDerivation {
   pname = "kdeltachat";
   version = "unstable-2024-01-14";
 
@@ -46,6 +50,7 @@ mkDerivation {
     cmake
     extra-cmake-modules
     pkg-config
+    wrapQtAppsHook
   ];
 
   buildInputs = [

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13019,8 +13019,6 @@ with pkgs;
 
   kaidan = kdePackages.callPackage ../applications/networking/instant-messengers/kaidan { };
 
-  kdeltachat = libsForQt5.callPackage ../applications/networking/instant-messengers/kdeltachat { };
-
   kexi = libsForQt5.callPackage ../applications/office/kexi { };
 
   kgraphviewer = libsForQt5.callPackage ../applications/graphics/kgraphviewer { };


### PR DESCRIPTION
Otherwise kdeltachat fails to build with

    /build/source/message.cpp: In member function 'void DcMessage::setFile(QString)':
    /build/source/message.cpp:93:12: error: 'dc_msg_set_file' was not declared in this scope; did you mean 'dc_msg_get_file'?
       93 |     return dc_msg_set_file(m_message, utf8File.constData(), NULL);
          |            ^~~~~~~~~~~~~~~
          |            dc_msg_get_file


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
