### PR TITLE
pulumiPackages.pulumi-yaml: init at 1.26.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8871,6 +8871,13 @@
     name = "Fausto Núñez Alberro";
     keys = [ { fingerprint = "668E 01D1 B129 3F42 0A0F  933A C880 6451 94A2 D562"; } ];
   };
+  folliehiyuki = {
+    email = "folliekazetani@protonmail.com";
+    matrix = "@folliehiyuki:envs.net";
+    github = "folliehiyuki";
+    githubId = 67634026;
+    name = "Hoang Nguyen";
+  };
   fooker = {
     email = "fooker@lab.sh";
     github = "fooker";

--- a/pkgs/by-name/pu/pulumi/plugins/pulumi-yaml/package.nix
+++ b/pkgs/by-name/pu/pulumi/plugins/pulumi-yaml/package.nix
@@ -1,0 +1,85 @@
+{
+  lib,
+  fetchFromGitHub,
+  buildGoModule,
+  pulumi,
+  pulumi-go,
+  pulumi-random,
+  nix-update-script,
+}:
+buildGoModule (finalAttrs: {
+  pname = "pulumi-yaml";
+  version = "1.26.1";
+
+  src = fetchFromGitHub {
+    owner = "pulumi";
+    repo = "pulumi-yaml";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-q9IFB7KHurGT9f6Ri2AwwDDdZqGplvQQ0p7k4l6UQYw=";
+  };
+
+  vendorHash = "sha256-qhiD+fCMQLqmJsMbEC4xmXhayM2tv4cWmk6aSgJCjaU=";
+
+  subPackages = [
+    "cmd/pulumi-converter-yaml"
+    "cmd/pulumi-language-yaml"
+  ];
+
+  nativeCheckInputs = [
+    pulumi
+    pulumi-go
+    pulumi-random
+  ];
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X=github.com/pulumi/pulumi-yaml/pkg/version.Version=${finalAttrs.version}"
+  ];
+
+  preCheck = ''
+    unset subPackages
+
+    export PULUMI_SKIP_UPDATE_CHECK=true
+    export PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION=true
+
+    # Required for user.Current implementation with osusergo on Darwin.
+    export HOME=$TMPDIR USER=nixbld
+
+    # Expose pulumi-language-yaml program for the tests to use
+    export PATH=$PATH:"$GOPATH/bin"
+  '';
+
+  checkFlags = [
+    "-skip=^${
+      lib.concatStringsSep "$|^" [
+        # Requires pulumi-test-language program from the main pulumi repo (referenced as git submodule)
+        "TestLanguage"
+
+        # pulumi plugin install or depends on pulumi-aws plugin
+        "TestGenerateProgram"
+        "TestPluginDownloadURLUsed"
+        "TestRemoteComponent"
+        "TestRemoteComponentTagged"
+        "TestResourceOrderingWithDefaultProvider"
+
+        # Requires external schema files
+        "TestImportTemplate"
+        "TestGenerateExamples"
+      ]
+    }$"
+  ];
+
+  __darwinAllowLocalNetworking = true;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    homepage = "https://www.pulumi.com/docs/iac/languages-sdks/yaml/";
+    description = "Language host for Pulumi programs written in YAML";
+    changelog = "https://github.com/pulumi/pulumi-yaml/blob/v${finalAttrs.version}/CHANGELOG.md";
+    license = lib.licenses.asl20;
+    mainProgram = "pulumi-language-yaml";
+    maintainers = with lib.maintainers; [ folliehiyuki ];
+  };
+})


### PR DESCRIPTION
This is an official language host provider for Pulumi, allowing users to write Pulumi resources within Pulumi.yaml file directly.

https://github.com/pulumi/pulumi-yaml

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
