### PR TITLE
nixos/image/repart: Use own assertions / warnings.

### DIFF
--- a/lib/asserts.nix
+++ b/lib/asserts.nix
@@ -1,5 +1,16 @@
 { lib }:
 
+let
+  inherit (lib.strings)
+    concatStringsSep
+    ;
+  inherit (lib.lists)
+    filter
+    ;
+  inherit (lib.trivial)
+    showWarnings
+    ;
+in
 rec {
 
   /**
@@ -131,4 +142,61 @@ rec {
       "each element in ${name} must be one of ${lib.generators.toPretty { } xs}, but is: ${
         lib.generators.toPretty { } vals
       }";
+
+  /**
+    Wrap a value with logic that throws an error when assertions
+    fail and emits any warnings.
+
+    # Inputs
+
+    `assertions`
+
+    : A list of assertions. If any of their `assertion` attrs is `false`, their `message` attrs will be emitted in a `throw`.
+
+    `warnings`
+
+    : A list of strings to emit as warnings. This function does no filtering on this list.
+
+    `val`
+
+    : A value to return, wrapped in `warn`, if a `throw` is not necessary.
+
+    # Type
+
+    ```
+    checkAssertWarn :: [ { assertion :: Bool; message :: String } ] -> [ String ] -> Any -> Any
+    ```
+
+    # Examples
+    :::{.example}
+    ## `lib.asserts.checkAssertWarn` usage example
+    ```nix
+    checkAssertWarn
+      [ { assertion = false; message = "Will fail"; } ]
+      [ ]
+      null
+    stderr>        error:
+    stderr>        Failed assertions:
+    stderr>        - Will fail
+
+    checkAssertWarn
+      [ { assertion = true; message = "Will not fail"; } ]
+      [ "Will warn" ]
+      null
+    stderr> evaluation warning: Will warn
+    null
+    ```
+
+    :::
+  */
+  checkAssertWarn =
+    assertions: warnings: val:
+    let
+      failedAssertions = map (x: x.message) (filter (x: !x.assertion) assertions);
+    in
+    if failedAssertions != [ ] then
+      throw "\nFailed assertions:\n${concatStringsSep "\n" (map (x: "- ${x}") failedAssertions)}"
+    else
+      showWarnings warnings val;
+
 }

--- a/nixos/modules/system/activation/top-level.nix
+++ b/nixos/modules/system/activation/top-level.nix
@@ -77,14 +77,7 @@ let
   );
 
   # Handle assertions and warnings
-
-  failedAssertions = map (x: x.message) (filter (x: !x.assertion) config.assertions);
-
-  baseSystemAssertWarn =
-    if failedAssertions != [ ] then
-      throw "\nFailed assertions:\n${concatStringsSep "\n" (map (x: "- ${x}") failedAssertions)}"
-    else
-      showWarnings config.warnings baseSystem;
+  baseSystemAssertWarn = lib.asserts.checkAssertWarn config.assertions config.warnings baseSystem;
 
   # Replace runtime dependencies
   system =


### PR DESCRIPTION
This fixes some infinite recursion problems that are easy to trigger with the repart image builder. See commit message for details.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
