### PR TITLE
release-notes: make Mattermost shorter

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2505.section.md
+++ b/nixos/doc/manual/release-notes/rl-2505.section.md
@@ -24,20 +24,6 @@
 
 - The `intel` video driver for X.org (from the xf86-video-intel package, which was previously removed because it was non-functional) has been fixed and the driver has been re-introduced.
 
-- The Mattermost module ([`services.mattermost`](#opt-services.mattermost.enable)) and packages (`mattermost` and `mmctl`) have been substantially updated:
-  - [](#opt-services.mattermost.preferNixConfig) now defaults to true if you advance [](#opt-system.stateVersion) to 25.05. This means that if you have [](#opt-services.mattermost.mutableConfig) set, NixOS will override your settings to those that you define in the module. It is recommended to leave this at the default, even if you used a mutable config before, because it will ensure that your Mattermost data directories are correct. If you moved your data directories, you may want to review the module changes before upgrading.
-  - Mattermost telemetry reporting is now disabled by default, though security update notifications are enabled. Look at [`services.mattermost.telemetry`](#opt-services.mattermost.telemetry.enableDiagnostics) for options to control this behavior.
-  - `pkgs.mattermost` has been updated from 9.11 to 10.5 to track the latest extended support release, since 9.11 will become end-of-life during the lifetime of NixOS 25.05.
-  - `pkgs.mattermostLatest` is now an option to track the latest (non-prerelease) Mattermost release. We test upgrade migrations from ESR releases (`pkgs.mattermost`) to `pkgs.mattermostLatest`.
-  - The Mattermost frontend is now built from source and can be overridden.
-    - Note that the Mattermost derivation containing both the webapp and server is now wrapped to allow them to be built independently, so overrides to both webapp and server look like `mattermost.overrideAttrs (prev: { webapp = prev.webapp.override { ... }; server = prev.server.override { ... }; })` now.
-  - `services.mattermost.listenAddress` has been split into [](#opt-services.mattermost.host) and [](#opt-services.mattermost.port). If your `listenAddress` contained a port, you will need to edit your configuration.
-  - Mattermost now supports peer authentication on both MySQL and Postgres database backends. Updating [](#opt-system.stateVersion) to 25.05 or later will result in peer authentication being used by default if the Mattermost server would otherwise be connecting to localhost. This is the recommended configuration.
-  - The Mattermost module will produce eval warnings if a database password would end up in the Nix store, and recommend alternatives such as peer authentication or using the environment file.
-  - We now support `mmctl` for Mattermost administration if both [](#opt-services.mattermost.socket.enable) and [](#opt-services.mattermost.socket.export) are set, which export the Mattermost control socket path into the system environment.
-  - A new `pkgs.mattermost.buildPlugin` function has been added, which allows plugins to be built from source, including webapp frontends with a supported package-lock.json. See the Mattermost NixOS test and [manual](https://nixos.org/manual/nixpkgs/unstable/#sec-mattermost-plugins-build) for an example.
-  - Note that the Mattermost module will create an account _without_ a well-known UID if the username differs from the default (`mattermost`). If you used Mattermost with a nonstandard username, you may want to review the module changes before upgrading.
-
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
 
 ## New Modules {#sec-release-25.05-new-modules}
@@ -360,6 +346,12 @@
   Read the [release blog post](https://prometheus.io/blog/2024/11/14/prometheus-3-0/) and
   [migration guide](https://prometheus.io/docs/prometheus/3.1/migration/).
 
+- The Mattermost module ([`services.mattermost`](#opt-services.mattermost.enable)) and packages (`mattermost` and `mmctl`) have been substantially updated:
+  - `services.mattermost.listenAddress` has been split into [](#opt-services.mattermost.host) and [](#opt-services.mattermost.port). If your `listenAddress` contained a port, you will need to edit your configuration. This will be the only truly breaking change in this release for most configurations.
+  - [](#opt-services.mattermost.preferNixConfig) now defaults to true if you advance [](#opt-system.stateVersion) to 25.05. This means that if you have [](#opt-services.mattermost.mutableConfig) set, NixOS will override settings set in the Admin Console to those that you define in the module configuration. It is recommended to leave this at the default, even if you used a fully mutable configuration before, because it will ensure that your Mattermost data directories are correct. If you moved your data directories, you may want to review the module changes before upgrading.
+  - Mattermost now supports peer authentication on both MySQL and Postgres database backends. Updating [](#opt-system.stateVersion) to 25.05 or later will result in peer authentication being used by default if the Mattermost server would otherwise be connecting to localhost. This is the recommended configuration.
+  - Note that the Mattermost module will create an account _without_ a well-known UID if the username differs from the default (`mattermost`). If you used Mattermost with a nonstandard username, you may want to review the module changes before upgrading.
+
 - `kanata` was updated to v1.8.0, which introduces several breaking changes.
   See the release notes of
   [v1.7.0](https://github.com/jtroo/kanata/releases/tag/v1.7.0) and
@@ -613,6 +605,15 @@
   containing the final arguments including overrides.
   This allows packaging configuration to be overridden in a consistent manner by
   providing an alternative to `rec {}` syntax.
+
+- [Mattermost](#opt-services.mattermost.enable), a self-hosted chat collaboration platform supporting calls, playbooks, and boards, has been updated. It now has multiple versions, disabled telemetry, and a native frontend build in nixpkgs, removing all upstream prebuilt blobs.
+  - A new `pkgs.mattermost.buildPlugin` function has been added, which allows plugins to be built from source, including webapp frontends with a supported package-lock.json. See the Mattermost NixOS test and [manual](https://nixos.org/manual/nixpkgs/unstable/#sec-mattermost-plugins-build) for an example.
+  - Mattermost telemetry reporting is now disabled by default, though security update notifications are enabled. Look at [`services.mattermost.telemetry`](#opt-services.mattermost.telemetry.enableDiagnostics) for options to control this behavior.
+  - The Mattermost frontend is now built from source and can be overridden. Note that the Mattermost derivation containing both the webapp and server is now wrapped to allow them to be built independently, so overrides to both webapp and server look like `mattermost.overrideAttrs (prev: { webapp = prev.webapp.override { ... }; server = prev.server.override { ... }; })` now.
+  - `pkgs.mattermost` has been updated from 9.11 to 10.5 to track the latest extended support release, since 9.11 will become end-of-life during the lifetime of NixOS 25.05.
+  - `pkgs.mattermostLatest` is now an option to track the latest (non-prerelease) Mattermost release. We test upgrade migrations from ESR releases (`pkgs.mattermost`) to `pkgs.mattermostLatest`.
+  - The Mattermost module will produce eval warnings if a database password would end up in the Nix store, and recommend alternatives such as peer authentication or using the environment file.
+  - We now support `mmctl` for Mattermost administration if both [](#opt-services.mattermost.socket.enable) and [](#opt-services.mattermost.socket.export) are set, which export the Mattermost control socket path into the system environment.
 
 - KDE Partition Manager `partitionmanager`'s support for ReiserFS is removed.
   ReiserFS has not been actively maintained for many years. It has been marked as obsolete since Linux 6.6, and


### PR DESCRIPTION
I looked at the release notes and this was half of the 25.05 highlights when it's mostly upgrade notes. I didn't really want mostly technical details to be that prominent, even though it's a big update.

All the upgrade notes should be in Backward Incompatibilities, not the highlights, so move things around. Mention it in the highlights, still.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
