### PR TITLE
wpcleaner: init at 2.0.5-unstable-2025-04-25

### DIFF
--- a/pkgs/by-name/wp/wpcleaner/0001-fix-script-names-and-remove-getdown.patch
+++ b/pkgs/by-name/wp/wpcleaner/0001-fix-script-names-and-remove-getdown.patch
@@ -1,0 +1,108 @@
+diff --git a/WikipediaCleaner/resources/getdown/Bot.sh b/WikipediaCleaner/resources/getdown/Bot.sh
+index c73ff234b..471b211b0 100644
+--- a/WikipediaCleaner/resources/getdown/Bot.sh
++++ b/WikipediaCleaner/resources/getdown/Bot.sh
+@@ -9,24 +9,24 @@
+ # ===== CONNECTION =====
+ # The first part of the parameters consists in connection information.
+ # You can use the following syntax:
+-# Bot.sh en <username> <password> ...
++# wpcleaner-bot en <username> <password> ...
+ # 
+ # Or with a credentials.txt file containing the following 2 lines :
+ #   user=<username>
+ #   password=<password>
+ # Then you can use the following syntax:
+-# Bot.sh -credentials credentials.txt en ...
++# wpcleaner-bot -credentials credentials.txt en ...
+ #
+ # ===== TASKS =====
+ # The second part of the parameters consists in the tasks to ask to the bot.
+ # For example, if you want to update disambiguation warnings, you can use the following syntax:
+-# Bot.sh ... UpdateDabWarnings
++# wpcleaner-bot ... UpdateDabWarnings
+ # Or if you want to execute a set of tasks described in a task file, you can use the following syntax:
+-# Bot.sh ... DoTasks <task file>
++# wpcleaner-bot ... DoTasks <task file>
+ #
+ # ===== NOTE =====
+ # If you want to pass extra arguments to the JVM, like increasing the memory available to Java,
+ # you can create an extra.txt file in the same folder with one parameter per line.
+ # For example, to allow 8G of RAM, the line will be: -Xmx=8192M
+ 
+-java -jar libs/getdown-launcher.jar . bot "$@"
++java -cp @wpcleaner_jar@ org.wikipediacleaner.Bot "$@"
+diff --git a/WikipediaCleaner/resources/getdown/WPCleaner.sh b/WikipediaCleaner/resources/getdown/WPCleaner.sh
+index 28e3726cd..8eb8563fd 100644
+--- a/WikipediaCleaner/resources/getdown/WPCleaner.sh
++++ b/WikipediaCleaner/resources/getdown/WPCleaner.sh
+@@ -29,33 +29,18 @@
+ # You can execute this script with optional parameters that will be passed to
+ # WPCleaner. For example, if you want to automatically login to English
+ # Wikipedia, you can use the following syntax:
+-#   WPCleaner.sh en <username> <password>
++#   wpcleaner en <username> <password>
+ #
+ # Or with a credentials.txt file containing these 2 lines,
+ #   user=<username>
+ #   password=<password>
+ # you can use the following syntax to login automatically:
+-#   WPCleaner.sh -credentials credentials.txt en
+-#
+-# If you want to pass extra arguments to the JVM, like increasing the memory
+-# available to Java, create a file named 'extra.txt' in the same directory as
+-# this script, with read permissions for any user which might invoke it, with
+-# one parameter per line. For example, to allow 8G of RAM, the line would read:
+-#   -Xmx=8192M
+-
+-JAVA_APP_DIR="$(cd "$(dirname "$0")"; pwd -P)"
+-JAVA_LIB_DIR="${JAVA_APP_DIR}/libs"
+-cd "$JAVA_APP_DIR" || ( echo "Unable to open install directory." >&2; exit 1; )
++#   wpcleaner -credentials credentials.txt en
++# or create a $XDG_CONFIG_HOME/wpcleaner/credentials.txt file, it will be used automatically
+ 
+-JAVA_PARAMS="-jar ${JAVA_LIB_DIR}/getdown-launcher.jar . client"
+-
+-if [ -f credentials.txt ]; then
+-  JAVA_PARAMS="${JAVA_PARAMS} -credentials credentials.txt"
++credentials="$XDG_CONFIG_HOME/wpcleaner/credentials.txt"
++if [[ "${credentials}" ]]; then
++  java -jar @wpcleaner_jar@ -credentials ${credentials} $@
++else
++  java -jar @wpcleaner_jar@ $@
+ fi
+-
+-case $# in
+-  0) java ${JAVA_PARAMS}
+-  ;;
+-  *) java ${JAVA_PARAMS} $@
+-  ;;
+-esac
+diff --git a/WikipediaCleaner/run-task.sh b/WikipediaCleaner/run-task.sh
+index fff6ab234..1c3eed957 100755
+--- a/WikipediaCleaner/run-task.sh
++++ b/WikipediaCleaner/run-task.sh
+@@ -1,12 +1,12 @@
+ #! /bin/bash
+ 
+-wpcleaner_jar="build/dist/full/WikipediaCleaner.jar"
++wpcleaner_jar="@wpcleaner_jar@"
+ if ! [[ -f "${wpcleaner_jar}" ]]; then
+   echo "WPCleaner is missing at ${wpcleaner_jar}, please build"
+   exit 1
+ fi
+ 
+-credentials="resources/credentials.txt"
++credentials="$XDG_CONFIG_HOME/wpcleaner/credentials.txt"
+ if ! [[ -f "${credentials}" ]]; then
+   echo "Credentials file is missing at ${credentials}, please create it"
+   exit 1
+@@ -24,7 +24,7 @@ if [[ "${task}" == "" ]]; then
+   exit 1
+ fi
+ 
+-tasks_dir="resources/tasks/${language}wiki"
++tasks_dir="@tasks@/${language}wiki"
+ if ! [[ -d "${tasks_dir}" ]]; then
+   echo "Task folder not found"
+   exit 1

--- a/pkgs/by-name/wp/wpcleaner/0002-dont-build-javadoc.patch
+++ b/pkgs/by-name/wp/wpcleaner/0002-dont-build-javadoc.patch
@@ -1,0 +1,13 @@
+diff --git a/WikipediaCleaner/build.xml b/WikipediaCleaner/build.xml
+index 9437c1dd6..37a33509f 100644
+--- a/WikipediaCleaner/build.xml
++++ b/WikipediaCleaner/build.xml
+@@ -172,7 +172,7 @@
+   </taskdef>
+ 
+   <!-- Build WPCleaner -->
+-  <target name="main" description="Build WPCleaner" depends="init,clean,main-i18n,javadoc">
++  <target name="main" description="Build WPCleaner" depends="init,clean,main-i18n">
+ 
+     <!-- Initialize -->
+     <input message="Please enter Password for keystore:" addproperty="WPCleaner.keystore.password" />

--- a/pkgs/by-name/wp/wpcleaner/package.nix
+++ b/pkgs/by-name/wp/wpcleaner/package.nix
@@ -1,0 +1,123 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  makeDesktopItem,
+  copyDesktopItems,
+  makeBinaryWrapper,
+  jdk17,
+  ant,
+  stripJavaArchivesHook,
+  gettext,
+}:
+
+let
+  wpcleanerJar = "$out/share/wpcleaner/WikipediaCleaner.jar";
+  clientScript = "$out/bin/wpcleaner";
+  botScript = "$out/bin/wpcleaner-bot";
+  runTaskScript = "$out/bin/wpcleaner-run-task";
+  extraJavaArgs = [
+    "-Dawt.useSystemAAFontSettings=lcd"
+    "-Xms1g"
+    "-Xmx8g"
+  ];
+in
+stdenv.mkDerivation {
+  pname = "wpcleaner";
+  version = "2.0.5-unstable-2025-04-25";
+  src = fetchFromGitHub {
+    owner = "WPCleaner";
+    repo = "wpcleaner";
+    rev = "7fd357cf26349658183517658139870dd45eaedc";
+    hash = "sha256-iaAP/5Z+ghvMAn4ke7lhRqKov/3jXr0LMwbPDZ052j0=";
+  };
+
+  dontConfigure = true;
+
+  patches = [
+    # The names of the scripts are too generic (e.g. Bot.sh) and the scripts
+    # run the jar through getdown, which is a tool which checks if there is a
+    # new version of the jar automatically and update itself if it is the case,
+    # therefore we want to disable it.
+    ./0001-fix-script-names-and-remove-getdown.patch
+    # Building the documentation requires internet access to docs.oracle.com,
+    # which is not available at build time and is not useful to the user.
+    ./0002-dont-build-javadoc.patch
+  ];
+
+  nativeBuildInputs = [
+    jdk17
+    ant
+    gettext
+    makeBinaryWrapper
+    copyDesktopItems
+    stripJavaArchivesHook
+  ];
+
+  buildInputs = [ jdk17 ];
+
+  buildPhase = ''
+    runHook preBuild
+
+    cd WikipediaCleaner
+    echo "" | ant
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm744 build/dist/full/WikipediaCleaner.jar ${wpcleanerJar}
+    install -Dm744 resources/getdown/WPCleaner.sh ${clientScript}
+    install -Dm744 resources/getdown/Bot.sh ${botScript}
+    install -Dm744 run-task.sh ${runTaskScript}
+
+    substituteInPlace \
+      ${clientScript} ${botScript} ${runTaskScript} \
+      --subst-var-by wpcleaner_jar "${wpcleanerJar}" \
+      --subst-var-by tasks "$out/share/wpcleaner/tasks"
+
+    wrapProgram ${clientScript} \
+      --prefix PATH : ${lib.makeBinPath [ jdk17 ]} \
+      --prefix JAVA_JDK_OPTIONS " " "${lib.strings.concatStringsSep " " extraJavaArgs}"
+    wrapProgram ${botScript} \
+      --prefix PATH : ${lib.makeBinPath [ jdk17 ]} \
+      --prefix JAVA_JDK_OPTIONS " " "${lib.strings.concatStringsSep " " extraJavaArgs}"
+    wrapProgram ${runTaskScript} \
+      --prefix PATH : ${lib.makeBinPath [ jdk17 ]} \
+      --prefix JAVA_JDK_OPTIONS " " "${lib.strings.concatStringsSep " " extraJavaArgs}"
+
+    cp -r resources/tasks $out/share/wpcleaner
+    install -Dm644 resources/commons-nuvola-web-broom-64px.png $out/share/icons/hicolor/64x64/apps/wpcleaner.png
+
+    runHook postInstall
+  '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "wpcleaner";
+      desktopName = "WPCleaner";
+      comment = "Perform maintenance on Wikipedia";
+      icon = "wpcleaner";
+      exec = "wpcleaner";
+      categories = [ "Utility" ];
+      keywords = [ "Wikipedia" ];
+    })
+  ];
+
+  meta = {
+    description = "An utility for performing maintenance on Wikipedia";
+    longDescription = ''
+      WPCleaner is a tool designed to help with various maintenance tasks, especially repairing
+      links to disambiguation pages, checking Wikipedia, fixing spelling and typography, and
+      helping with translation of articles coming from other wikis.
+    '';
+    homepage = "https://wpcleaner.toolforge.org/";
+    downloadPage = "https://github.com/WPCleaner/wpcleaner";
+    license = lib.licenses.asl20;
+    mainProgram = "wpcleaner";
+    platforms = lib.platforms.all;
+    maintainers = with lib.maintainers; [ jeancaspar ];
+  };
+}


### PR DESCRIPTION
<https://wpcleaner.toolforge.org/>

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
