### PR TITLE
fider: 0.24.0 -> 0.26.0

### DIFF
--- a/pkgs/by-name/fi/fider/frontend.nix
+++ b/pkgs/by-name/fi/fider/frontend.nix
@@ -1,6 +1,4 @@
 {
-  lib,
-  esbuild,
   buildNpmPackage,
 
   pname,
@@ -12,8 +10,6 @@
 buildNpmPackage {
   inherit version src npmDepsHash;
   pname = "${pname}-frontend";
-
-  nativeBuildInputs = [ esbuild ];
 
   buildPhase = ''
     runHook preBuild
@@ -37,6 +33,5 @@ buildNpmPackage {
 
   env = {
     PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD = 1;
-    ESBUILD_BINARY_PATH = lib.getExe esbuild;
   };
 }

--- a/pkgs/by-name/fi/fider/package.nix
+++ b/pkgs/by-name/fi/fider/package.nix
@@ -3,21 +3,19 @@
   stdenvNoCC,
   fetchFromGitHub,
   callPackage,
-  esbuild,
-  buildGoModule,
   nixosTests,
   nix-update-script,
 }:
 
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "fider";
-  version = "0.24.0";
+  version = "0.26.0";
 
   src = fetchFromGitHub {
     owner = "getfider";
     repo = "fider";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-nzOplwsE0ppmxbTrNAgePnIQIAD/5Uu4gXlebFKWGfc=";
+    hash = "sha256-uABRIR/3D+//qYu/396qqVizP0kLmAA8auYd83rABhE=";
   };
 
   dontConfigure = true;
@@ -32,8 +30,8 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   #   vendorHash = "...";
   #   npmDepsHash = "...";
   # })
-  vendorHash = "sha256-CfopU72fpXiTaBtdf9A57Wb+flDu2XEtTISxImeJLL0=";
-  npmDepsHash = "sha256-gnboT5WQzftOCZ2Ouuza7bqpxJf+Zs7OWC8OHMZNHvw=";
+  vendorHash = "sha256-4ilOdUblpwteY0ZInitSuzuB8mU1ltYgRJjla6LiziU=";
+  npmDepsHash = "sha256-c8CFMMmFcLZkJL50bfLlk2HP9B/rexNZ2WWJkV0x4Rk=";
 
   server = callPackage ./server.nix {
     inherit (finalAttrs)
@@ -50,31 +48,6 @@ stdenvNoCC.mkDerivation (finalAttrs: {
       src
       npmDepsHash
       ;
-    # We specify the esbuild override here instead of in frontend.nix so end users can
-    # again easily override it if necessary, for example when changing to an unreleased
-    # version of fider requiring a newer esbuild than specified here:
-    # pkgs.fider.overrideAttrs (prev: {
-    #   frontend = prev.frontend.override {
-    #     esbuild = ...;
-    #   };
-    # })
-    esbuild = esbuild.override {
-      buildGoModule =
-        args:
-        buildGoModule (
-          args
-          // rec {
-            version = "0.14.38";
-            src = fetchFromGitHub {
-              owner = "evanw";
-              repo = "esbuild";
-              tag = "v${version}";
-              hash = "sha256-rvMi1oC7qGidvi4zrm9KCMMntu6LJGVOGN6VmU2ivQE=";
-            };
-            vendorHash = "sha256-QPkBR+FscUc3jOvH7olcGUhM6OW4vxawmNJuRQxPuGs=";
-          }
-        );
-    };
   };
 
   installPhase = ''


### PR DESCRIPTION
Changelogs:

- https://github.com/getfider/fider/releases/tag/v0.26.0
- https://github.com/getfider/fider/releases/tag/v0.25.0


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
