### PR TITLE
bic: 1.0.0 -> 1.0.0-unstable-2022-02-16

### DIFF
--- a/pkgs/by-name/bi/bic/package.nix
+++ b/pkgs/by-name/bi/bic/package.nix
@@ -5,44 +5,59 @@
   readline,
   autoreconfHook,
   autoconf-archive,
+  gcc,
   gmp,
   flex,
   bison,
+  libffi,
+  makeWrapper,
+  pkg-config,
 }:
 
 stdenv.mkDerivation rec {
   pname = "bic";
-  version = "1.0.0";
+  version = "1.0.0-unstable-2022-02-16";
 
   src = fetchFromGitHub {
     owner = "hexagonal-sun";
     repo = "bic";
-    rev = "v${version}";
-    sha256 = "1ws46h1ngzk14dspmsggj9535yl04v9wh8v4gb234n34rdkdsyyw";
+    rev = "b224d2776fdfe84d02eb96a21880a9e4ceeb3065";
+    hash = "sha256-6na7/kCXhHN7utbvXvTWr3QG4YhDww9AkilyKf71HlM=";
   };
 
   buildInputs = [
     readline
+    gcc
     gmp
   ];
+
   nativeBuildInputs = [
     autoreconfHook
     autoconf-archive
     bison
     flex
+    gcc
+    libffi
+    makeWrapper
+    pkg-config
   ];
 
-  meta = with lib; {
+  postInstall = ''
+    wrapProgram $out/bin/bic \
+      --prefix PATH : ${lib.makeBinPath [ gcc ]}
+  '';
+
+  meta = {
     description = "C interpreter and API explorer";
     mainProgram = "bic";
     longDescription = ''
       bic This a project that allows developers to explore and test C-APIs using a
       read eval print loop, also known as a REPL.
     '';
-    license = with licenses; [ gpl2Plus ];
+    license = with lib.licenses; [ gpl2Plus ];
     homepage = "https://github.com/hexagonal-sun/bic";
-    platforms = platforms.unix;
-    maintainers = with maintainers; [ hexagonal-sun ];
+    platforms = lib.platforms.unix;
+    maintainers = with lib.maintainers; [ hexagonal-sun ];
     # never built on aarch64-darwin since first introduction in nixpkgs
     broken = stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isAarch64;
   };


### PR DESCRIPTION
Diff : https://github.com/hexagonal-sun/bic/compare/v1.0.0...master

https://hydra.nixos.org/build/296275132

ZHF: https://github.com/NixOS/nixpkgs/issues/403336

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
