### PR TITLE
python3Packages.litellm: fix litellm_enterprise module not found

### DIFF
--- a/pkgs/development/python-modules/litellm/default.nix
+++ b/pkgs/development/python-modules/litellm/default.nix
@@ -5,6 +5,7 @@
   azure-identity,
   azure-keyvault-secrets,
   backoff,
+  boto3,
   buildPythonPackage,
   click,
   cryptography,
@@ -25,17 +26,20 @@
   pydantic,
   pyjwt,
   pynacl,
+  python,
   python-dotenv,
   python-multipart,
   pythonOlder,
   pyyaml,
   requests,
   resend,
+  rich,
   rq,
   tiktoken,
   tokenizers,
   uvloop,
   uvicorn,
+  websockets,
   nixosTests,
   nix-update-script,
 }:
@@ -63,7 +67,6 @@ buildPythonPackage rec {
     importlib-metadata
     jinja2
     jsonschema
-    mcp
     openai
     pydantic
     python-dotenv
@@ -76,35 +79,50 @@ buildPythonPackage rec {
     proxy = [
       apscheduler
       backoff
+      boto3
       cryptography
       fastapi
       fastapi-sso
       gunicorn
+      mcp
       orjson
       pyjwt
+      pynacl
       python-multipart
       pyyaml
+      rich
       rq
       uvloop
       uvicorn
+      websockets
     ];
+
     extra_proxy = [
       azure-identity
       azure-keyvault-secrets
       google-cloud-kms
       prisma
-      pynacl
       resend
     ];
   };
 
-  pythonImportsCheck = [ "litellm" ];
+  pythonImportsCheck = [
+    "litellm"
+    "litellm_enterprise"
+  ];
 
   # Relax dependency check on openai, may not be needed in the future
   pythonRelaxDeps = [ "openai" ];
 
   # access network
   doCheck = false;
+
+  postFixup = ''
+    # Symlink litellm_enterprise to make it discoverable
+    pushd $out/lib/python${python.pythonVersion}/site-packages
+    ln -s enterprise/litellm_enterprise litellm_enterprise
+    popd
+  '';
 
   passthru = {
     tests = { inherit (nixosTests) litellm; };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

TLDR:

* Fixed `litellm_enterprise` module not found issue causing litellm to potentially crash on start-up.
* Added missing dependencies according to [pyproject.toml](https://github.com/BerriAI/litellm/blob/v1.69.0-stable/pyproject.toml).


#406389 introduced a potential regression for litellm users who uses it as a proxy. Litellm will crash on startup with error ` ModuleNotFoundError: No module named 'litellm_enterprise'`:

![image](https://github.com/user-attachments/assets/12ce33f1-1140-4538-8522-0903672a0cda)

This is because in recent version of litellm introduced a new sub-package `litellm-enterprise` whose source code is kept under [/enterprise folder of the same repo](https://github.com/BerriAI/litellm/tree/main/enterprise). This sub-package is also built along with the current Nix derivation, but it is never exposed into Python Paths and making it undiscoverable.

This PR attempts to fix it by doing a quick symlink. Maybe there are better ways to address this, so I am opening this PR and welcome further suggestions.

This change is tested locally:

![image](https://github.com/user-attachments/assets/7d5a293c-c87d-417c-9fdb-b8a0baaad733)


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
