### PR TITLE
Revert "[Backport release-24.11] wlx-overlay-s: 25.3.0 -> 25.4.2"

### DIFF
--- a/pkgs/by-name/wl/wlx-overlay-s/package.nix
+++ b/pkgs/by-name/wl/wlx-overlay-s/package.nix
@@ -26,17 +26,17 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "wlx-overlay-s";
-  version = "25.4.2";
+  version = "25.3.0";
 
   src = fetchFromGitHub {
     owner = "galister";
     repo = "wlx-overlay-s";
     rev = "v${version}";
-    hash = "sha256-lWUfhiHRxu72p9ZG2f2fZH6WZECm/fOKcK05MLZV+MI=";
+    hash = "sha256-m2YVXF9bEjovZOWa+X1CYHAUaAsUI4dBMG2ni3jP9L4=";
   };
 
   useFetchCargoVendor = true;
-  cargoHash = "sha256-em5sWSty2/pZp2jTwBnLUIBgPOcoMpwELwj984XYf+k=";
+  cargoHash = "sha256-y4pWUQFPR0jOTdukQZe4d1v0DFDfQtAg0Bi4V4ue5+Y=";
 
   nativeBuildInputs = [
     makeWrapper


### PR DESCRIPTION
Reverts NixOS/nixpkgs#398193

Fixes https://github.com/NixOS/nixpkgs/issues/406898