### PR TITLE
nixosTests.vscodium: Relax OCR tests again

### DIFF
--- a/nixos/tests/vscodium.nix
+++ b/nixos/tests/vscodium.nix
@@ -62,14 +62,14 @@ let
           codium_running.wait() # type: ignore[union-attr]
           with codium_running: # type: ignore[union-attr]
               # Wait until vscodium is visible. "File" is in the menu bar.
-              machine.wait_for_text('Get Started with')
+              machine.wait_for_text('(Get|Started|with|Customize|theme)')
               machine.screenshot('start_screen')
 
               test_string = 'testfile'
 
               # Create a new file
               machine.send_key('ctrl-n')
-              machine.wait_for_text('Untitled')
+              machine.wait_for_text('(Untitled|Select|language|template|dismiss)')
               machine.screenshot('empty_editor')
 
               # Type a string


### PR DESCRIPTION
Too flaky.

As long as *some text* displays on the screen everything is fine.

https://hydra.nixos.org/build/297031399/nixlog/9

Screenshots taken from the VM tests.

<img src="https://github.com/user-attachments/assets/ce10df64-ffdd-41dd-8d7d-67b05d6b0736" width=30%>
<img src="https://github.com/user-attachments/assets/61ceecd1-e5c6-4e03-adb9-0afc33c73737" width=30%>

---

Note that the nixosTests.vscodium.wayland failure on aarch64 is not a regression.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

