### PR TITLE
gnunet: fix and enable strictDeps

### DIFF
--- a/pkgs/applications/networking/p2p/gnunet/default.nix
+++ b/pkgs/applications/networking/p2p/gnunet/default.nix
@@ -12,6 +12,7 @@
 
   # runtime deps
   adns,
+  bashNonInteractive,
   curl,
   gettext,
   gmp,
@@ -48,7 +49,7 @@ stdenv.mkDerivation (finalAttrs: {
   enableParallelBuilding = true;
 
   nativeBuildInputs = [
-    libtool
+    gettext # msgfmt
     makeWrapper
     meson
     ninja
@@ -57,8 +58,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   buildInputs = [
     adns
+    bashNonInteractive
     curl
-    gettext
     gmp
     gnutls
     jansson
@@ -71,12 +72,15 @@ stdenv.mkDerivation (finalAttrs: {
     libopus
     libpulseaudio
     libsodium
+    libtool
     libunistring
     libxml2
     ncurses
     sqlite
     zlib
   ] ++ lib.optional postgresqlSupport libpq;
+
+  strictDeps = true;
 
   preConfigure = ''
     # Brute force: since nix-worker chroots don't provide
@@ -122,5 +126,7 @@ stdenv.mkDerivation (finalAttrs: {
     maintainers = with lib.maintainers; [ pstn ];
     platforms = lib.platforms.unix;
     changelog = "https://git.gnunet.org/gnunet.git/tree/ChangeLog?h=v${finalAttrs.version}";
+    # meson: "Can not run test applications in this cross environment." (for dane_verify_crt_raw)
+    broken = !stdenv.buildPlatform.canExecute stdenv.hostPlatform;
   };
 })


### PR DESCRIPTION
Fixes regular strictDeps build, ref. #178468

bash is required for some scripts

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).