### PR TITLE
taler-exchange: fix and enable strictDeps

### DIFF
--- a/pkgs/by-name/ta/taler-exchange/package.nix
+++ b/pkgs/by-name/ta/taler-exchange/package.nix
@@ -18,6 +18,7 @@
   jq,
   gettext,
   texinfo,
+  libtool,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -35,7 +36,12 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [
     autoreconfHook
+    recutils # recfix
     pkg-config
+    python3.pkgs.jinja2
+    texinfo # makeinfo
+    # jq is necessary for some tests and is checked by configure script
+    jq
   ];
 
   buildInputs = [
@@ -44,15 +50,13 @@ stdenv.mkDerivation (finalAttrs: {
     jansson
     libsodium
     libpq
+    libtool
     curl
-    recutils
     gettext
-    texinfo # Fix 'makeinfo' is missing on your system.
     libunistring
-    python3.pkgs.jinja2
-    # jq is necessary for some tests and is checked by configure script
-    jq
   ];
+
+  strictDeps = true;
 
   propagatedBuildInputs = [ gnunet ];
 
@@ -89,6 +93,10 @@ stdenv.mkDerivation (finalAttrs: {
     chmod -w Makefile.am
     popd
   '';
+
+  configureFlags = [
+    "ac_cv_path__libcurl_config=${lib.getDev curl}/bin/curl-config"
+  ];
 
   enableParallelBuilding = true;
 


### PR DESCRIPTION
Fixes regular strictDeps build, ref. #178468

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).