### PR TITLE
feluda: init at 1.6.2

### DIFF
--- a/pkgs/by-name/fe/feluda/package.nix
+++ b/pkgs/by-name/fe/feluda/package.nix
@@ -1,0 +1,57 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  versionCheckHook,
+  nix-update-script,
+  pkg-config,
+  openssl,
+  stdenv,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "feluda";
+  version = "1.6.2";
+
+  src = fetchFromGitHub {
+    owner = "anistark";
+    repo = "feluda";
+    tag = finalAttrs.version;
+    hash = "sha256-R8x4lN4BtVbpSHll0KVdzX7IDhArsZiJFo6qNsFrgnA=";
+  };
+
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-F5flqmoH9QykmCvuqxLhsdpm3AYhwhCG4O1oRkEOY8U=";
+
+  nativeBuildInputs = lib.optionals stdenv.hostPlatform.isLinux [
+    pkg-config
+  ];
+
+  # Needed to get openssl-sys to use pkg-config.
+  OPENSSL_NO_VENDOR = 1;
+  OPENSSL_LIB_DIR = "${lib.getLib openssl}/lib";
+  OPENSSL_DIR = "${lib.getDev openssl}";
+
+  buildInputs = lib.optionals stdenv.hostPlatform.isLinux [
+    openssl
+  ];
+
+  checkFlags = [
+    # Require internet access.
+    "--skip=licenses::tests::test_fetch_license_for_go_dependency"
+    "--skip=licenses::tests::test_fetch_license_for_python_dependency"
+  ];
+
+  passthru.updateScript = nix-update-script { };
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  meta = {
+    description = "Detect license usage restrictions in your project";
+    homepage = "https://github.com/anistark/feluda";
+    changelog = "https://github.com/anistark/feluda/releases/tag/${finalAttrs.version}";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ adda ];
+    mainProgram = "feluda";
+  };
+})


### PR DESCRIPTION
This PR adds a package for `feluda`, a tool to detect licence usage restrictions in your project.

The tool needs the respective language(s) tooling used in the project to check the licences, especially those of the dependencies. Should this be written somewhere as a usage note or something similar? I am not sure where.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
