### PR TITLE
python3Packages.anthropic: 0.49.0 -> 0.51.0

### DIFF
--- a/pkgs/development/python-modules/anthropic/default.nix
+++ b/pkgs/development/python-modules/anthropic/default.nix
@@ -6,7 +6,6 @@
   # build-system
   hatch-fancy-pypi-readme,
   hatchling,
-  pythonAtLeast,
 
   # dependencies
   anyio,
@@ -31,15 +30,20 @@
 
 buildPythonPackage rec {
   pname = "anthropic";
-  version = "0.49.0";
+  version = "0.51.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "anthropics";
     repo = "anthropic-sdk-python";
     tag = "v${version}";
-    hash = "sha256-vbK8rqCekWbgLAU7YlHUhfV+wB7Q3Rpx0OUYvq3WYWw=";
+    hash = "sha256-gD3qZpPKtKZtuoGqnKVgFp0gCxpL0Aq5NGFCMk+z3cQ=";
   };
+
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail '"hatchling==1.26.3"' '"hatchling>=1.26.3"'
+  '';
 
   build-system = [
     hatchling
@@ -71,15 +75,10 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "anthropic" ];
 
-  disabledTests =
-    [
-      # Test require network access
-      "test_copy_build_request"
-    ]
-    ++ lib.optionals (pythonAtLeast "3.13") [
-      # Fails on RuntimeWarning: coroutine method 'aclose' of 'AsyncStream._iter_events' was never awaited
-      "test_multi_byte_character_multiple_chunks[async]"
-    ];
+  disabledTests = [
+    # Test require network access
+    "test_copy_build_request"
+  ];
 
   disabledTestPaths = [
     # Test require network access

--- a/pkgs/development/python-modules/anthropic/default.nix
+++ b/pkgs/development/python-modules/anthropic/default.nix
@@ -1,33 +1,38 @@
 {
   lib,
-  anyio,
   buildPythonPackage,
-  dirty-equals,
-  distro,
   fetchFromGitHub,
-  google-auth,
+
+  # build-system
   hatch-fancy-pypi-readme,
   hatchling,
+  pythonAtLeast,
+
+  # dependencies
+  anyio,
+  distro,
   httpx,
   jiter,
-  nest-asyncio,
   pydantic,
-  pytest-asyncio,
-  pytestCheckHook,
-  pythonAtLeast,
-  pythonOlder,
-  respx,
   sniffio,
   tokenizers,
   typing-extensions,
+
+  # optional dependencies
+  google-auth,
+
+  # test
+  dirty-equals,
+  nest-asyncio,
+  pytest-asyncio,
+  pytestCheckHook,
+  respx,
 }:
 
 buildPythonPackage rec {
   pname = "anthropic";
   version = "0.49.0";
   pyproject = true;
-
-  disabled = pythonOlder "3.8";
 
   src = fetchFromGitHub {
     owner = "anthropics";
@@ -46,8 +51,8 @@ buildPythonPackage rec {
     distro
     httpx
     jiter
-    sniffio
     pydantic
+    sniffio
     tokenizers
     typing-extensions
   ];
@@ -58,8 +63,8 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [
     dirty-equals
-    pytest-asyncio
     nest-asyncio
+    pytest-asyncio
     pytestCheckHook
     respx
   ];
@@ -87,11 +92,14 @@ buildPythonPackage rec {
     "ignore::DeprecationWarning"
   ];
 
-  meta = with lib; {
+  meta = {
     description = "Anthropic's safety-first language model APIs";
     homepage = "https://github.com/anthropics/anthropic-sdk-python";
     changelog = "https://github.com/anthropics/anthropic-sdk-python/releases/tag/${src.tag}";
-    license = licenses.mit;
-    maintainers = with maintainers; [ natsukium ];
+    license = lib.licenses.mit;
+    maintainers = [
+      lib.maintainers.natsukium
+      lib.maintainers.sarahec
+    ];
   };
 }


### PR DESCRIPTION
Hydra: https://hydra.nixos.org/build/296945155

New error in Hydra:
```sh
_____________________ TestAsyncAnthropic.test_get_platform _____________________
tests/test_client.py:1862: in test_get_platform
    raise AssertionError("calling get_platform using asyncify resulted in a hung process")
E   AssertionError: calling get_platform using asyncify resulted in a hung process
```

EDIT: The python 3.13 problems were fixed in release 0.51.0, so I'm filing an update 

1. Confirmed error only happens on Python 3.13 and Darwin
2. Updated package to release 0.51.0 which fixes these problems.
3. ~~Disabled the test under those conditions~~
4. Cleaned up `pythonOlder` and `with lib;`
5. Added self as maintainer

Release notes: https://github.com/anthropics/anthropic-sdk-python/releases/tag/v0.51.0

diff: https://github.com/anthropics/anthropic-sdk-python/compare/v0.49.0...v0.51.0

ZHF: #403336 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [x] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
