### PR TITLE
haskellPackages.postgres-websockets: fix at run-time

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -2695,6 +2695,20 @@ self: super:
   tasty-autocollect = dontCheck super.tasty-autocollect;
 
   postgres-websockets = lib.pipe super.postgres-websockets [
+    (appendPatches [
+      (pkgs.fetchpatch {
+        # Needed for the patch below to apply.
+        name = "remove-protolude.patch";
+        url = "https://github.com/diogob/postgres-websockets/commit/8027c0f6dc0c5fe6bab4e3e7730db8653b2c51cc.patch";
+        hash = "sha256-gefVUR+tJLrmpwnc1hf4GjLbGVe1GwNmLn5YU7qW/HY=";
+      })
+      (pkgs.fetchpatch {
+        # Can be removed with the next update.
+        name = "fix-connection-closing-when-no-write-mode-is-present.patch";
+        url = "https://github.com/diogob/postgres-websockets/commit/577a2f0bf4750c682c2c3c63e37d90e0ec6f95eb.patch";
+        hash = "sha256-7PCVbfNiJhWfmQrEjaVqbmCL5jffhofOto1RF2FVYJo=";
+      })
+    ])
     (addTestToolDepends [
       pkgs.postgresql
       pkgs.postgresqlTestHook


### PR DESCRIPTION
Reason for the failure is still unclear and it was not possible to reproduce upstream, yet.

https://github.com/diogob/postgres-websockets/pull/101#issuecomment-2881016449

I will want to have that fix in 25.05 eventually, too, but I figured merging into haskell-updates and then backporting after branch-off might be better, to reduce the merge conflicts in main.yml, which was recently sorted and now added to.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
