### PR TITLE
freelens-bin: init at 1.6.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -24158,6 +24158,11 @@
     name = "Sebastian Kowalak";
     matrix = "@scl:tchncs.de";
   };
+  skwig = {
+    name = "skwig";
+    github = "skwig";
+    githubId = 16136203;
+  };
   skyesoss = {
     name = "Skye Soss";
     matrix = "@skyesoss:matrix.org";

--- a/pkgs/by-name/fr/freelens-bin/darwin.nix
+++ b/pkgs/by-name/fr/freelens-bin/darwin.nix
@@ -1,0 +1,32 @@
+{
+  stdenvNoCC,
+  pname,
+  version,
+  src,
+  meta,
+  undmg,
+}:
+
+stdenvNoCC.mkDerivation {
+  inherit
+    pname
+    version
+    src
+    meta
+    ;
+
+  sourceRoot = ".";
+
+  nativeBuildInputs = [ undmg ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p "$out/Applications"
+    cp -R "Lens.app" "$out/Applications/Lens.app"
+
+    runHook postInstall
+  '';
+
+  dontFixup = true;
+}

--- a/pkgs/by-name/fr/freelens-bin/linux.nix
+++ b/pkgs/by-name/fr/freelens-bin/linux.nix
@@ -1,0 +1,30 @@
+{
+  pname,
+  version,
+  src,
+  meta,
+  appimageTools,
+  makeWrapper,
+}:
+let
+  appimageContents = appimageTools.extractType2 { inherit pname version src; };
+
+in
+appimageTools.wrapType2 {
+  inherit
+    pname
+    version
+    src
+    meta
+    ;
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  extraInstallCommands = ''
+    mv $out/bin/${pname} $out/bin/freelens
+    wrapProgram $out/bin/freelens --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true}}"
+    install -m 444 -D ${appimageContents}/freelens.desktop $out/share/applications/freelens.desktop
+    install -m 444 -D ${appimageContents}/usr/share/icons/hicolor/512x512/apps/freelens.png $out/share/icons/hicolor/512x512/apps/freelens.png
+    substituteInPlace $out/share/applications/freelens.desktop --replace-fail 'Exec=AppRun' 'Exec=freelens'
+  '';
+}

--- a/pkgs/by-name/fr/freelens-bin/package.nix
+++ b/pkgs/by-name/fr/freelens-bin/package.nix
@@ -1,0 +1,74 @@
+{
+  stdenv,
+  stdenvNoCC,
+  fetchurl,
+  lib,
+  appimageTools,
+  makeWrapper,
+  undmg,
+}:
+
+let
+
+  pname = "freelens-bin";
+  version = "1.6.1";
+
+  sources = {
+    x86_64-linux = {
+      url = "https://github.com/freelensapp/freelens/releases/download/v${version}/Freelens-${version}-linux-amd64.AppImage";
+      hash = "sha256-RiA9OWcs6goRPN8dGsLV3ViBe/ZWB3M7yzTmDHgB3mo=";
+    };
+    aarch64-linux = {
+      url = "https://github.com/freelensapp/freelens/releases/download/v${version}/Freelens-${version}-linux-arm64.AppImage";
+      hash = "sha256-hYkI9N8fnEIcj7bPp0lXcB89OZ0kzcd2RrJs3htg6Qo=";
+    };
+    x86_64-darwin = {
+      url = "https://github.com/freelensapp/freelens/releases/download/v${version}/Freelens-${version}-macos-amd64.dmg";
+      hash = "sha256-JXqMaw5KlronrpNYNU0YcVwRddHRrK/Y5b5NE3y5BA8=";
+    };
+    aarch64-darwin = {
+      url = "https://github.com/freelensapp/freelens/releases/download/v${version}/Freelens-${version}-macos-arm64.dmg";
+      hash = "sha256-0Eg3xBE+yjNvNjloUAJJMpY9h7ifgV+4G3a+EvbXL+Q=";
+    };
+  };
+
+  src = fetchurl {
+    inherit (sources.${stdenv.system} or (throw "Unsupported system: ${stdenv.system}")) url hash;
+  };
+
+  meta = {
+    description = "Free IDE for Kubernetes";
+    longDescription = ''
+      Freelens is a free and open-source user interface designed for managing Kubernetes clusters. It provides a standalone application compatible with macOS, Windows, and Linux operating systems, making it accessible to a wide range of users. The application aims to simplify the complexities of Kubernetes management by offering an intuitive and user-friendly interface.
+    '';
+    homepage = "https://github.com/freelensapp/freelens/";
+    license = lib.licenses.mit;
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    maintainers = with lib.maintainers; [ skwig ];
+    platforms = builtins.attrNames sources;
+    mainProgram = "freelens";
+  };
+
+in
+if stdenv.hostPlatform.isDarwin then
+  import ./darwin.nix {
+    inherit
+      stdenvNoCC
+      pname
+      version
+      src
+      meta
+      undmg
+      ;
+  }
+else
+  import ./linux.nix {
+    inherit
+      pname
+      version
+      src
+      meta
+      appimageTools
+      makeWrapper
+      ;
+  }


### PR DESCRIPTION
[freelens](https://github.com/freelensapp/freelens) is a user interface for managing Kubernetes clusters.

It is a fork of [Open Lens](https://github.com/lensapp/lens/tree/master), core of [Lens Desktop](https://k8slens.dev/), with the aim of carrying forward its open-source version. Closed source lens already is in `nixpkgs` and its `package.nix` served as heavy inspiration.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
