### PR TITLE
python313Packages.alarmdecoder: 1.13.13 -> 1.13.14, python313Packages.adext: 0.4.6 -> 0.4.7

### DIFF
--- a/pkgs/development/python-modules/adext/default.nix
+++ b/pkgs/development/python-modules/adext/default.nix
@@ -10,7 +10,7 @@
 
 buildPythonPackage rec {
   pname = "adext";
-  version = "0.4.6";
+  version = "0.4.7";
   pyproject = true;
 
   disabled = pythonOlder "3.7";
@@ -19,7 +19,7 @@ buildPythonPackage rec {
     owner = "ajschmidt8";
     repo = "adext";
     tag = "v${version}";
-    hash = "sha256-K2SXZ/YW+/XM+R8F77nWWV+DyZxCc4GYdrMwUnJ5jPg=";
+    hash = "sha256-cZMA8/t24xk5b1At2LQWeDWuRfPcXBCXpl2T70YxZeA=";
   };
 
   build-system = [ setuptools-scm ];

--- a/pkgs/development/python-modules/alarmdecoder/default.nix
+++ b/pkgs/development/python-modules/alarmdecoder/default.nix
@@ -2,7 +2,6 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  fetchpatch,
   mock,
   pyftdi,
   pyopenssl,
@@ -15,23 +14,15 @@
 
 buildPythonPackage rec {
   pname = "alarmdecoder";
-  version = "1.13.13";
+  version = "1.13.14";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "nutechsoftware";
     repo = "alarmdecoder";
     rev = version;
-    hash = "sha256-dMOC8znhnCAn4fKSnT9Vw1oGzDRN72d6m8RWD1NQ6Ms=";
+    hash = "sha256-qjn6OY8N1Miuou2aCHGhAQJtOEH1kE6XM8k1TPAibGU=";
   };
-
-  patches = [
-    (fetchpatch {
-      name = "use-setuptools_scm.patch";
-      url = "https://github.com/nutechsoftware/alarmdecoder/commit/e9fc6aa76d7925bb61a3c53716f2b6e25c9ca342.patch";
-      hash = "sha256-vt48QfbkcwQmMgJckpawENVMselVx17jrCNKkZ+s95k=";
-    })
-  ];
 
   postPatch = ''
     substituteInPlace test/test_{ad2,devices,messages}.py \
@@ -61,9 +52,9 @@ buildPythonPackage rec {
   pythonImportsCheck = [ "alarmdecoder" ];
 
   meta = with lib; {
-    changelog = "https://github.com/nutechsoftware/alarmdecoder/releases/tag/${src.rev}";
     description = "Python interface for the Alarm Decoder (AD2USB, AD2SERIAL and AD2PI) devices";
     homepage = "https://github.com/nutechsoftware/alarmdecoder";
+    changelog = "https://github.com/nutechsoftware/alarmdecoder/releases/tag/${src.rev}";
     license = licenses.mit;
     maintainers = with maintainers; [ fab ];
   };


### PR DESCRIPTION
Changelog: https://github.com/nutechsoftware/alarmdecoder/releases/tag/1.13.14

Changelog: https://github.com/ajschmidt8/adext/releases/tag/v0.4.7

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
