### PR TITLE
xplorer: use cargo-tauri.hook, fix icon loading

### DIFF
--- a/pkgs/by-name/xp/xplorer/package.nix
+++ b/pkgs/by-name/xp/xplorer/package.nix
@@ -1,91 +1,75 @@
 {
   lib,
-  cmake,
-  dbus,
+  rustPlatform,
+
   fetchFromGitHub,
   fetchYarnDeps,
+
+  cargo-tauri_1,
+  cmake,
+  nodejs,
+  pkg-config,
+  wrapGAppsHook3,
+  yarn,
+  yarnConfigHook,
+
+  dbus,
   freetype,
   gtk3,
   libsoup_2_4,
-  stdenvNoCC,
-  yarnConfigHook,
-  yarnBuildHook,
-  nodejs,
   openssl,
-  pkg-config,
-  rustPlatform,
   webkitgtk_4_0,
 }:
 
-let
-
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "xplorer";
-  version = "unstable-2023-03-19";
+  version = "0.3.1-unstable-2023-03-19";
 
   src = fetchFromGitHub {
     owner = "kimlimjustin";
     repo = "xplorer";
     rev = "8d69a281cbceda277958796cb6b77669fb062ee3";
-    sha256 = "sha256-VFRdkSfe2mERaYYtZlg9dvH1loGWVBGwiTRj4AoNEAo=";
+    hash = "sha256-VFRdkSfe2mERaYYtZlg9dvH1loGWVBGwiTRj4AoNEAo=";
   };
 
-  frontend-build = stdenvNoCC.mkDerivation (finalAttrs: {
-    inherit version src;
-    pname = "xplorer-ui";
-
-    offlineCache = fetchYarnDeps {
-      yarnLock = src + "/yarn.lock";
-      sha256 = "sha256-H37vD0GTSsWV5UH7C6UANDWnExTGh8yqajLn3y7P2T8=";
-    };
-    nativeBuildInputs = [
-      yarnConfigHook
-      yarnBuildHook
-      nodejs
-    ];
-    yarnBuildScript = "prebuild";
-    installPhase = ''
-      cp -r out $out
-    '';
-  });
-in
-
-rustPlatform.buildRustPackage {
-  inherit version src pname;
-
-  sourceRoot = "${src.name}/src-tauri";
+  cargoRoot = "src-tauri";
+  buildAndTestSubdir = "src-tauri";
 
   cargoHash = "sha256-D7qgmxDYQEgOkEYKDSLA875bXeTKDvAntF7kB4esn24=";
 
-  # copy the frontend static resources to final build directory
-  # Also modify tauri.conf.json so that it expects the resources at the new location
-  postPatch = ''
-    mkdir -p frontend-build
-    cp -R ${frontend-build}/src frontend-build
-
-    substituteInPlace tauri.conf.json --replace '"distDir": "../out/src",' '"distDir": "frontend-build/src",'
-  '';
+  yarnOfflineCache = fetchYarnDeps {
+    inherit (finalAttrs) src;
+    hash = "sha256-H37vD0GTSsWV5UH7C6UANDWnExTGh8yqajLn3y7P2T8=";
+  };
 
   nativeBuildInputs = [
+    cargo-tauri_1.hook
     cmake
+    nodejs
     pkg-config
+    wrapGAppsHook3
+    yarn
+    yarnConfigHook
   ];
+
   buildInputs = [
     dbus
-    openssl
     freetype
-    libsoup_2_4
     gtk3
+    libsoup_2_4
+    openssl
     webkitgtk_4_0
   ];
+
+  preBuild = ''
+    # upstream doesn't run this automatically
+    yarn --offline run prebuild
+  '';
 
   checkFlags = [
     # tries to mutate the parent directory
     "--skip=test_file_operation"
   ];
-
-  postInstall = ''
-    mv $out/bin/app $out/bin/xplorer
-  '';
 
   meta = with lib; {
     description = "Customizable, modern file manager";
@@ -94,4 +78,4 @@ rustPlatform.buildRustPackage {
     maintainers = with maintainers; [ dit7ya ];
     mainProgram = "xplorer";
   };
-}
+})


### PR DESCRIPTION
Things done:
- combine the frontend build logic into the main derivation
- use `cargo-tauri.hook`
  - this also generates a `.desktop` file automatically and installs the icons used by the `.desktop` file
  - it makes the `mv $out/bin/app $out/bin/xplorer` unnecessary
- use `wrapGAppsHook3` to fix icon loading
- update hashes from `sha256 =` to `hash =`
- substitute `pname` in `src`
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
