### PR TITLE
newlib: Apply patch to fix targeting MIPS

### DIFF
--- a/pkgs/development/misc/newlib/default.nix
+++ b/pkgs/development/misc/newlib/default.nix
@@ -20,14 +20,22 @@ stdenv.mkDerivation (finalAttrs: {
     sha256 = "sha256-M/EmBeAFSWWZbCXBOCs+RjsK+ReZAB9buMBjDy7IyFI=";
   };
 
-  patches = lib.optionals nanoizeNewlib [
-    # https://bugs.gentoo.org/723756
-    (fetchpatch {
-      name = "newlib-3.3.0-no-nano-cxx.patch";
-      url = "https://gitweb.gentoo.org/repo/gentoo.git/plain/sys-libs/newlib/files/newlib-3.3.0-no-nano-cxx.patch?id=9ee5a1cd6f8da6d084b93b3dbd2e8022a147cfbf";
-      sha256 = "sha256-S3mf7vwrzSMWZIGE+d61UDH+/SK/ao1hTPee1sElgco=";
-    })
-  ];
+  patches =
+    [
+      (fetchpatch {
+        name = "0001-newlib-Fix-mips-libgloss-support.patch";
+        url = "https://sourceware.org/git/?p=newlib-cygwin.git;a=patch;h=8a8fb570d7c5310a03a34b3dd6f9f8bb35ee9f40";
+        hash = "sha256-hWS/X0jf/ZFXIR39NvNDVhkR8F81k9UWpsqDhZFxO5o=";
+      })
+    ]
+    ++ lib.optionals nanoizeNewlib [
+      # https://bugs.gentoo.org/723756
+      (fetchpatch {
+        name = "newlib-3.3.0-no-nano-cxx.patch";
+        url = "https://gitweb.gentoo.org/repo/gentoo.git/plain/sys-libs/newlib/files/newlib-3.3.0-no-nano-cxx.patch?id=9ee5a1cd6f8da6d084b93b3dbd2e8022a147cfbf";
+        sha256 = "sha256-S3mf7vwrzSMWZIGE+d61UDH+/SK/ao1hTPee1sElgco=";
+      })
+    ];
 
   depsBuildBuild = [
     buildPackages.stdenv.cc


### PR DESCRIPTION
Closes #406428

I also tested the other `-embedded` / `newlib`-using examples. The ones that also FTBFS:

- `vc4` Errors out while configuring its binutils:
  ```
  *** BFD does not support target vc4-unknown-elf.
  *** Look in bfd/config.bfd for supported targets.
  make[1]: *** [Makefile:3054: configure-bfd] Error 1
  ```
- `ppc-embedded` and `ppcle-embedded` error out because their libgloss needs similar fixes, upstream doesn't seem to have commits for them yet:
  ```
  powerpc-none-eabi-cc -B/build/newlib-4.5.0.20241231/powerpc-none-eabi/newlib/ -isystem /build/newlib-4.5.0.20241231/powerpc-none-eabi/newlib/targ-include -isystem /build/newlib-4.5.0.20241231/newlib/libc/include -B/build/newlib-4.5.0.20241231/powerpc-none-eabi/libgloss/rs6000 -L/build/newlib-4.5.0.20241231/powerpc-none-eabi/libgloss/libnosys -L/build/newlib-4.5.0.20241231/libgloss/rs6000    -g -O2 -mrelocatable-lib -mno-eabi -O2 -I. -I../../.././libgloss/rs6000/.. -I./.. -c -g -O2 ../../.././libgloss/rs6000/sim-print.c
  ../../.././libgloss/rs6000/sim-print.c: In function 'print':
  ../../.././libgloss/rs6000/sim-print.c:29:3: error: implicit declaration of function 'write' [-Wimplicit-function-declaration]
     29 |   write (1, ptr, p-ptr);
        |   ^~~~~
  make[4]: *** [Makefile:150: sim-print.o] Error 1
  ```
- `i686-embedded` same as above:
  ```
    CC       i386/i386_libcygmon_a-cygmon-gmon.o
  ../.././libgloss/i386/cygmon-gmon.c: In function 'monstartup':
  ../.././libgloss/i386/cygmon-gmon.c:109:21: error: implicit declaration of function 'sbrk' [-Wimplicit-function-declaration]
    109 |   buffer = (char *) sbrk (monsize);
        |                     ^~~~
  ../.././libgloss/i386/cygmon-gmon.c:112:7: error: implicit declaration of function 'write'; did you mean 'fwrite'? [-Wimplicit-function-declaration]
    112 |       write (2, MSG , sizeof(MSG));
        |       ^~~~~
        |       fwrite
  ../.././libgloss/i386/cygmon-gmon.c:113:7: error: 'return' with no value, in function returning non-void [-Wreturn-mismatch]
    113 |       return;
        |       ^~~~~~
  ../.././libgloss/i386/cygmon-gmon.c:89:1: note: declared here
     89 | monstartup(lowpc, highpc)
        | ^~~~~~~~~~
  ../.././libgloss/i386/cygmon-gmon.c:115:3: error: implicit declaration of function 'bzero' [-Wimplicit-function-declaration]
    115 |   bzero (buffer, monsize);
        |   ^~~~~
  ../.././libgloss/i386/cygmon-gmon.c:115:3: warning: incompatible implicit declaration of built-in function 'bzero' [-Wbuiltin-declaration-mismatch]
  ../.././libgloss/i386/cygmon-gmon.c:121:7: error: 'return' with no value, in function returning non-void [-Wreturn-mismatch]
    121 |       return;
        |       ^~~~~~
  ../.././libgloss/i386/cygmon-gmon.c:89:1: note: declared here
     89 | monstartup(lowpc, highpc)
        | ^~~~~~~~~~
  ../.././libgloss/i386/cygmon-gmon.c:142:7: error: 'return' with no value, in function returning non-void [-Wreturn-mismatch]
    142 |       return;
        |       ^~~~~~
  ../.././libgloss/i386/cygmon-gmon.c:89:1: note: declared here
     89 | monstartup(lowpc, highpc)
        | ^~~~~~~~~~
  ../.././libgloss/i386/cygmon-gmon.c:153:5: error: 'return' with no value, in function returning non-void [-Wreturn-mismatch]
    153 |     return;
        |     ^~~~~~
  ../.././libgloss/i386/cygmon-gmon.c:89:1: note: declared here
     89 | monstartup(lowpc, highpc)
        | ^~~~~~~~~~
  ../.././libgloss/i386/cygmon-gmon.c:161:3: error: implicit declaration of function 'moncontrol' [-Wimplicit-function-declaration]
    161 |   moncontrol (1);
        |   ^~~~~~~~~~
  ../.././libgloss/i386/cygmon-gmon.c: In function '_mcleanup':
  ../.././libgloss/i386/cygmon-gmon.c:175:3: error: implicit declaration of function 'profil_write' [-Wimplicit-function-declaration]
    175 |   profil_write (1, sbuf, ssiz);
        |   ^~~~~~~~~~~~
  ../.././libgloss/i386/cygmon-gmon.c: At top level:
  ../.././libgloss/i386/cygmon-gmon.c:198:1: error: return type defaults to 'int' [-Wimplicit-int]
    198 | _mcount()
        | ^~~~~~~
  ../.././libgloss/i386/cygmon-gmon.c: In function '_mcount':
  ../.././libgloss/i386/cygmon-gmon.c:220:14: error: type defaults to 'int' in declaration of '_etext' [-Wimplicit-int]
    220 |       extern _etext();
        |              ^~~~~~
  ../.././libgloss/i386/cygmon-gmon.c:221:14: error: type defaults to 'int' in declaration of '_ftext' [-Wimplicit-int]
    221 |       extern _ftext();
        |              ^~~~~~
  ../.././libgloss/i386/cygmon-gmon.c:224:7: error: implicit declaration of function 'atexit' [-Wimplicit-function-declaration]
    224 |       atexit(_mcleanup);
        |       ^~~~~~
  ../.././libgloss/i386/cygmon-gmon.c:66:1: note: 'atexit' is defined in header '<stdlib.h>'; this is probably fixable by adding '#include <stdlib.h>'
     65 | #include "cygmon-gmon.h"
    +++ |+#include <stdlib.h>
     66 | 
  ../.././libgloss/i386/cygmon-gmon.c:326:3: error: 'return' with no value, in function returning non-void [-Wreturn-mismatch]
    326 |   return;               /* normal return restores saved registers */
        |   ^~~~~~
  ../.././libgloss/i386/cygmon-gmon.c:198:1: note: declared here
    198 | _mcount()
        | ^~~~~~~
  ../.././libgloss/i386/cygmon-gmon.c: At top level:
  ../.././libgloss/i386/cygmon-gmon.c:340:1: error: return type defaults to 'int' [-Wimplicit-int]
    340 | moncontrol(mode)
        | ^~~~~~~~~~
  ../.././libgloss/i386/cygmon-gmon.c: In function 'moncontrol':
  ../.././libgloss/i386/cygmon-gmon.c:346:7: error: implicit declaration of function 'profil' [-Wimplicit-function-declaration]
    346 |       profil((unsigned short *)(sbuf + sizeof(struct phdr)),
        |       ^~~~~~
  make[4]: *** [Makefile:7905: i386/i386_libcygmon_a-cygmon-gmon.o] Error 1
  ```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] `pkgsCross.mips64-embedded`
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
