### PR TITLE
graylog-6_2: init at 6.2.5

### DIFF
--- a/pkgs/tools/misc/graylog/6.2.nix
+++ b/pkgs/tools/misc/graylog/6.2.nix
@@ -1,0 +1,10 @@
+{ callPackage, lib, ... }:
+let
+  buildGraylog = callPackage ./graylog.nix { };
+in
+buildGraylog {
+  version = "6.2.9";
+  hash = "sha256-udq/LDIgxoesKPkFp/U68Fc6OBQdyFTG3RfSsAINp8I=";
+  maintainers = with lib.maintainers; [ bbenno ];
+  license = lib.licenses.sspl;
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3146,8 +3146,10 @@ with pkgs;
   inherit
     ({
       graylog-6_1 = callPackage ../tools/misc/graylog/6.1.nix { };
+      graylog-6_2 = callPackage ../tools/misc/graylog/6.2.nix { };
     })
     graylog-6_1
+    graylog-6_2
     ;
 
   graylogPlugins = recurseIntoAttrs (


### PR DESCRIPTION
Add Graylog 6.2 with its current version `6.2.5`. Changes since version 6.1 are described in the [changelog](https://go2docs.graylog.org/current/changelogs/changelog.html#Graylog625).
Additionally, breaking changes are summarized in the [migration guide](https://go2docs.graylog.org/current/upgrading_graylog/upgrade_to_graylog_6.2.htm).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
