### PR TITLE
plex-desktop: adding StartupWMClass to .desktop file

### DIFF
--- a/pkgs/by-name/pl/plex-desktop/package.nix
+++ b/pkgs/by-name/pl/plex-desktop/package.nix
@@ -13,6 +13,7 @@
   libva,
   libxkbcommon,
   libxml2_13,
+  makeDesktopItem,
   makeShellWrapper,
   minizip,
   nss,
@@ -39,6 +40,15 @@ let
     license = lib.licenses.unfree;
     platforms = [ "x86_64-linux" ];
     mainProgram = "plex-desktop";
+  };
+  desktopItem = makeDesktopItem {
+    name = "plex-desktop";
+    desktopName = "Plex";
+    exec = "plex-desktop";
+    icon = "${plex-desktop}/meta/gui/icon.png";
+    terminal = false;
+    categories = [ "AudioVideo" ];
+    startupWMClass = "Plex";
   };
   plex-desktop = stdenv.mkDerivation {
     inherit pname version meta;
@@ -133,11 +143,8 @@ buildFHSEnv {
 
   extraInstallCommands = ''
     mkdir -p $out/share/applications $out/share/icons/hicolor/scalable/apps
-    install -m 444 -D ${plex-desktop}/meta/gui/plex-desktop.desktop $out/share/applications/plex-desktop.desktop
-    substituteInPlace $out/share/applications/plex-desktop.desktop \
-      --replace-fail \
-      'Icon=''${SNAP}/meta/gui/icon.png' \
-      'Icon=${plex-desktop}/meta/gui/icon.png'
+    install -m 444 -D ${desktopItem}/share/applications/plex-desktop.desktop $out/share/applications/plex-desktop.desktop
+    install -m 444 -D ${plex-desktop}/meta/gui/icon.png $out/share/icons/hicolor/scalable/apps/plex-desktop.png
   '';
 
   runScript = writeShellScript "plex-desktop.sh" ''

--- a/pkgs/by-name/pl/plex-desktop/package.nix
+++ b/pkgs/by-name/pl/plex-desktop/package.nix
@@ -45,7 +45,7 @@ let
     name = "plex-desktop";
     desktopName = "Plex";
     exec = "plex-desktop";
-    icon = "${plex-desktop}/meta/gui/icon.png";
+    icon = "plex-desktop";
     terminal = false;
     categories = [ "AudioVideo" ];
     startupWMClass = "Plex";


### PR DESCRIPTION
<!--
Adding StartupWMClass to plex-desktop's .desktop file allows GNOME to correctly associate the window with its .desktop file, improving behavior in the dock and preventing duplicate icons.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
