### PR TITLE
lomiri.lomiri-calculator-app: 4.0.2 -> 4.1.0

### DIFF
--- a/nixos/tests/lomiri-calculator-app.nix
+++ b/nixos/tests/lomiri-calculator-app.nix
@@ -34,7 +34,11 @@
     machine.wait_for_x()
 
     with subtest("lomiri calculator launches"):
-        machine.execute("lomiri-calculator-app >&2 &")
+        machine.succeed("lomiri-calculator-app >&2 &")
+        machine.wait_for_console_text("Database upgraded to") # only on first run
+        machine.sleep(10)
+        machine.send_key("alt-f10")
+        machine.sleep(5)
         machine.wait_for_text("Calculator")
         machine.screenshot("lomiri-calculator")
 
@@ -48,7 +52,11 @@
     machine.succeed("pkill -f lomiri-calculator-app")
 
     with subtest("lomiri calculator localisation works"):
-        machine.execute("env LANG=de_DE.UTF-8 lomiri-calculator-app >&2 &")
+        machine.succeed("env LANG=de_DE.UTF-8 lomiri-calculator-app >&2 &")
+        machine.wait_for_console_text("using main qml file from") # less precise, but the app doesn't exactly log a whole lot
+        machine.sleep(10)
+        machine.send_key("alt-f10")
+        machine.sleep(5)
         machine.wait_for_text("Rechner")
         machine.screenshot("lomiri-calculator_localised")
 

--- a/nixos/tests/lomiri-calculator-app.nix
+++ b/nixos/tests/lomiri-calculator-app.nix
@@ -43,6 +43,12 @@
         machine.screenshot("lomiri-calculator")
 
     with subtest("lomiri calculator works"):
+        # Seems like on slower hardware, we might be using the app too quickly after its startup, with the math library
+        # not being set up properly yet:
+        # qml: [LOG]: Unable to calculate formula : "22*16", math.js: TypeError: Cannot call method 'evaluate' of null
+        # OfBorg aarch64 CI is *incredibly slow*, hence the long duration.
+        machine.sleep(60)
+
         machine.send_key("tab") # Fix focus
 
         machine.send_chars("22*16\n")

--- a/pkgs/desktops/lomiri/applications/lomiri-calculator-app/default.nix
+++ b/pkgs/desktops/lomiri/applications/lomiri-calculator-app/default.nix
@@ -2,7 +2,6 @@
   stdenv,
   lib,
   fetchFromGitLab,
-  fetchpatch,
   gitUpdater,
   nixosTests,
   cmake,
@@ -16,36 +15,14 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "lomiri-calculator-app";
-  version = "4.0.2";
+  version = "4.1.0";
 
   src = fetchFromGitLab {
     owner = "ubports";
     repo = "development/apps/lomiri-calculator-app";
-    rev = "v${finalAttrs.version}";
-    hash = "sha256-NyLEis+rIx2ELUiGrGCeFX/tlt43UgPBkb9aUs1tkgk=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-RLg2B8LtYE3b7dRRvhPqIA4RAlwNO585q+02wBEedj8=";
   };
-
-  patches = [
-    # Remove when version > 4.0.2
-    (fetchpatch {
-      name = "0001-lomiri-calculator-app-Fix-GNUInstallDirs-variable-concatenations.patch";
-      url = "https://gitlab.com/ubports/development/apps/lomiri-calculator-app/-/commit/0bd6ef6c3470bcecf90a88e1e5568a5ce5ad6d06.patch";
-      hash = "sha256-2FCLZ/LY3xTPGDmX+M8LiqlbcNQJu5hulkOf+V+3hWY=";
-    })
-
-    # Remove when version > 4.0.2
-    # Must apply separately because merge has hunk with changes to new file before hunk that inits said file
-    (fetchpatch {
-      name = "0002-lomiri-calculator-app-Migrate-to-C++-app.patch";
-      url = "https://gitlab.com/ubports/development/apps/lomiri-calculator-app/-/commit/035e5b8000ad1c8149a6b024fa8fed2667fbb659.patch";
-      hash = "sha256-2BTFOrH/gjIzXBmnTPMi+mPpUA7e/+6O/E3pdxhjZYQ=";
-    })
-    (fetchpatch {
-      name = "0003-lomiri-calculator-app-Call-i18n.bindtextdomain.patch";
-      url = "https://gitlab.com/ubports/development/apps/lomiri-calculator-app/-/commit/7cb5e56958e41a8f7a51e00d81d9b2bc24de32b0.patch";
-      hash = "sha256-k/Civ0+SCNDDok9bUdb48FKC+LPlM13ASFP6CbBvBVs=";
-    })
-  ];
 
   postPatch =
     # We don't want absolute paths in desktop files
@@ -99,7 +76,9 @@ stdenv.mkDerivation (finalAttrs: {
   meta = {
     description = "Powerful and easy to use calculator for Ubuntu Touch, with calculations history and formula validation";
     homepage = "https://gitlab.com/ubports/development/apps/lomiri-calculator-app";
-    changelog = "https://gitlab.com/ubports/development/apps/lomiri-calculator-app/-/blob/v${finalAttrs.version}/ChangeLog";
+    changelog = "https://gitlab.com/ubports/development/apps/lomiri-calculator-app/-/blob/${
+      if (!builtins.isNull finalAttrs.src.tag) then finalAttrs.src.tag else finalAttrs.src.rev
+    }/ChangeLog";
     license = lib.licenses.gpl3Only;
     mainProgram = "lomiri-calculator-app";
     teams = [ lib.teams.lomiri ];


### PR DESCRIPTION
https://gitlab.com/ubports/development/apps/lomiri-calculator-app/-/blob/v4.1.0/ChangeLog

Only relevant changes are ones that I had previously submitted upstream and which were already applied onto the previous version on our side.

`nixosTests.lomiri-calculator-app` was stuck for me on OCR. I prolly missed that in #406759…

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
