### PR TITLE
linuxPackages.v86d: fix build

### DIFF
--- a/pkgs/os-specific/linux/v86d/default.nix
+++ b/pkgs/os-specific/linux/v86d/default.nix
@@ -16,11 +16,11 @@ stdenv.mkDerivation {
   src = fetchFromGitHub {
     owner = "mjanusz";
     repo = "v86d";
-    rev = "v86d-${pversion}";
+    tag = "v86d-${pversion}";
     hash = "sha256-95LRzVbO/DyddmPwQNNQ290tasCGoQk7FDHlst6LkbA=";
   };
 
-  patchPhase = ''
+  postPatch = ''
     patchShebangs configure
   '';
 
@@ -40,17 +40,21 @@ stdenv.mkDerivation {
   ];
 
   configurePhase = ''
+    runHook preConfigure
+
     ./configure $configureFlags
+
+    runHook postConfigure
   '';
 
   buildInputs = [ klibc ];
 
-  meta = with lib; {
+  meta = {
     description = "Daemon to run x86 code in an emulated environment";
     mainProgram = "v86d";
     homepage = "https://github.com/mjanusz/v86d";
-    license = licenses.gpl2Only;
-    maintainers = with maintainers; [ codyopel ];
+    license = lib.licenses.gpl2Only;
+    maintainers = with lib.maintainers; [ codyopel ];
     platforms = [
       "i686-linux"
       "x86_64-linux"

--- a/pkgs/os-specific/linux/v86d/default.nix
+++ b/pkgs/os-specific/linux/v86d/default.nix
@@ -24,6 +24,9 @@ stdenv.mkDerivation {
     patchShebangs configure
   '';
 
+  # GCC 14 makes this an error by default, remove when fixed upstream
+  env.NIX_CFLAGS_COMPILE = "-Wno-implicit-function-declaration -Wno-implicit-int";
+
   configureFlags = [
     "--with-klibc"
     "--with-x86emu"


### PR DESCRIPTION
## Changes

- Fix build with GCC 14
- Small improvements
  - use `tag` in `src`
  - specify phase hooks
  - remove `with lib;` in `meta`

ZHF: #403336

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
