### PR TITLE
{SDL2_classic, sdl2-compat}: add passthru.sdlLibs

### DIFF
--- a/pkgs/by-name/mo/moonlight-qt/package.nix
+++ b/pkgs/by-name/mo/moonlight-qt/package.nix
@@ -6,8 +6,8 @@
   qt6,
   pkg-config,
   vulkan-headers,
-  SDL2_classic,
-  SDL2_classic_ttf,
+  SDL2,
+  SDL2_ttf,
   ffmpeg,
   libopus,
   libplacebo,
@@ -51,8 +51,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   buildInputs =
     [
-      (SDL2_classic.override { drmSupport = stdenv.hostPlatform.isLinux; })
-      SDL2_classic_ttf
+      SDL2
+      SDL2_ttf
       ffmpeg
       libopus
       libplacebo

--- a/pkgs/by-name/sd/SDL2_classic_image/package.nix
+++ b/pkgs/by-name/sd/SDL2_classic_image/package.nix
@@ -1,13 +1,5 @@
 {
-  SDL2_image,
   SDL2_classic,
-  enableSTB ? true,
+  enableSTB ? null,
 }:
-
-(SDL2_image.override {
-  SDL2 = SDL2_classic;
-  inherit enableSTB;
-}).overrideAttrs
-  {
-    pname = "SDL2_classic_image";
-  }
+if enableSTB == null then SDL2_classic.sdlLibs.SDL2_image else SDL2_classic.sdlLibs.SDL2_image.override { }

--- a/pkgs/by-name/sd/SDL2_classic_image/package.nix
+++ b/pkgs/by-name/sd/SDL2_classic_image/package.nix
@@ -2,4 +2,4 @@
   SDL2_classic,
   enableSTB ? null,
 }:
-if enableSTB == null then SDL2_classic.sdlLibs.SDL2_image else SDL2_classic.sdlLibs.SDL2_image.override { }
+if enableSTB == null then SDL2_classic.sdlLibs.SDL2_image else SDL2_classic.sdlLibs.SDL2_image.override { inherit enableSTB; }

--- a/pkgs/by-name/sd/SDL2_classic_mixer/package.nix
+++ b/pkgs/by-name/sd/SDL2_classic_mixer/package.nix
@@ -1,11 +1,1 @@
-{
-  SDL2_mixer,
-  SDL2_classic,
-}:
-
-(SDL2_mixer.override {
-  SDL2 = SDL2_classic;
-}).overrideAttrs
-  {
-    pname = "SDL2_classic_mixer";
-  }
+{ SDL2_classic }: SDL2_classic.sdlLibs.SDL2_mixer

--- a/pkgs/by-name/sd/SDL2_classic_ttf/package.nix
+++ b/pkgs/by-name/sd/SDL2_classic_ttf/package.nix
@@ -1,11 +1,1 @@
-{
-  SDL2_ttf,
-  SDL2_classic,
-}:
-
-(SDL2_ttf.override {
-  SDL2 = SDL2_classic;
-}).overrideAttrs
-  {
-    pname = "SDL2_classic_ttf";
-  }
+{ SDL2_classic }: SDL2_classic.sdlLibs.SDL2_ttf

--- a/pkgs/by-name/sd/sdl2-compat/package.nix
+++ b/pkgs/by-name/sd/sdl2-compat/package.nix
@@ -11,6 +11,7 @@
   SDL2_sound,
   SDL2_mixer,
   SDL2_image,
+  SDL2_Pango,
   sdl3,
   stdenv,
   testers,
@@ -71,18 +72,22 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   passthru = {
-    tests =
-      {
-        pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+    sdlLibs = {
+      inherit
+        SDL2_ttf
+        SDL2_net
+        SDL2_gfx
+        SDL2_sound
+        SDL2_mixer
+        SDL2_image
+        SDL2_Pango
+        ;
+    };
 
-        inherit
-          SDL2_ttf
-          SDL2_net
-          SDL2_gfx
-          SDL2_sound
-          SDL2_mixer
-          SDL2_image
-          ;
+    tests =
+      finalAttrs.passthru.sdlLibs
+      // {
+        pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
       }
       // lib.optionalAttrs stdenv.hostPlatform.isLinux {
         inherit monado;

--- a/pkgs/development/python-modules/pygame-ce/default.nix
+++ b/pkgs/development/python-modules/pygame-ce/default.nix
@@ -19,9 +19,6 @@
   libX11,
   portmidi,
   SDL2_classic,
-  SDL2_classic_image,
-  SDL2_classic_mixer,
-  SDL2_classic_ttf,
   numpy,
 
   pygame-gui,
@@ -99,9 +96,9 @@ buildPythonPackage rec {
     libpng
     portmidi
     SDL2_classic
-    (SDL2_classic_image.override { enableSTB = false; })
-    SDL2_classic_mixer
-    SDL2_classic_ttf
+    (SDL2_classic.sdlLibs.SDL2_image.override { enableSTB = false; })
+    SDL2_classic.sdlLibs.SDL2_mixer
+    SDL2_classic.sdlLibs.SDL2_ttf
   ];
 
   nativeCheckInputs = [

--- a/pkgs/development/python-modules/pygame/default.nix
+++ b/pkgs/development/python-modules/pygame/default.nix
@@ -21,9 +21,6 @@
   libpng,
   libX11,
   portmidi,
-  SDL2_classic_image,
-  SDL2_classic_mixer,
-  SDL2_classic_ttf,
 }:
 
 buildPythonPackage rec {
@@ -87,9 +84,9 @@ buildPythonPackage rec {
     libX11
     portmidi
     SDL2_classic
-    (SDL2_classic_image.override { enableSTB = false; })
-    SDL2_classic_mixer
-    SDL2_classic_ttf
+    (SDL2_classic.sdlLibs.SDL2_image.override { enableSTB = false; })
+    SDL2_classic.sdlLibs.SDL2_mixer
+    SDL2_classic.sdlLibs.SDL2_ttf
   ];
 
   preConfigure = ''


### PR DESCRIPTION
This is an attempt to make defining SDL2 libraries less painful. Currently, mismatched SDL2 libraries against SDL2 itself can cause issues. Using the `passthru.sdlLibs` ensures a consistent SDL library base.

Suggested in https://github.com/NixOS/nixpkgs/issues/405245#issuecomment-2880739544

cc @pbsds @marcin-serwin 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
