### PR TITLE
lomiri.lomiri-filemanager-app: 1.1.3 -> 1.1.4

### DIFF
--- a/nixos/tests/lomiri-filemanager-app.nix
+++ b/nixos/tests/lomiri-filemanager-app.nix
@@ -34,14 +34,22 @@
     machine.wait_for_x()
 
     with subtest("lomiri filemanager launches"):
-        machine.execute("lomiri-filemanager-app >&2 &")
+        machine.succeed("lomiri-filemanager-app >&2 &")
+        machine.wait_for_console_text("QFSFileEngine::open: No file name specified")
+        machine.sleep(10)
+        machine.send_key("alt-f10")
+        machine.sleep(5)
         machine.wait_for_text(r"(filemanager.ubports|alice|items|directories|files|folder)")
         machine.screenshot("lomiri-filemanager_open")
 
     machine.succeed("pkill -f lomiri-filemanager-app")
 
     with subtest("lomiri filemanager localisation works"):
-        machine.execute("env LANG=de_DE.UTF-8 lomiri-filemanager-app >&2 &")
+        machine.succeed("env LANG=de_DE.UTF-8 lomiri-filemanager-app >&2 &")
+        machine.wait_for_console_text("QFSFileEngine::open: No file name specified")
+        machine.sleep(10)
+        machine.send_key("alt-f10")
+        machine.sleep(5)
         machine.wait_for_text(r"(Elemente|Verzeichnisse|Dateien|Ordner)")
         machine.screenshot("lomiri-filemanager_localised")
   '';

--- a/pkgs/desktops/lomiri/applications/lomiri-filemanager-app/default.nix
+++ b/pkgs/desktops/lomiri/applications/lomiri-filemanager-app/default.nix
@@ -21,13 +21,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "lomiri-filemanager-app";
-  version = "1.1.3";
+  version = "1.1.4";
 
   src = fetchFromGitLab {
     owner = "ubports";
     repo = "development/apps/lomiri-filemanager-app";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-qOzQba1NJBH1hE3XYQQowfkggLlaZl6Vz8uVW7dCzWI=";
+    hash = "sha256-2NDz9XcUMEYHOLaomTVImjuQHLzZ/pat/Fe9uWe29as=";
   };
 
   postPatch = ''
@@ -81,7 +81,9 @@ stdenv.mkDerivation (finalAttrs: {
   meta = {
     description = "File Manager application for Ubuntu Touch devices";
     homepage = "https://gitlab.com/ubports/development/apps/lomiri-filemanager-app";
-    changelog = "https://gitlab.com/ubports/development/apps/lomiri-filemanager-app/-/blob/v${finalAttrs.version}/ChangeLog";
+    changelog = "https://gitlab.com/ubports/development/apps/lomiri-filemanager-app/-/blob/${
+      if (!builtins.isNull finalAttrs.src.tag) then finalAttrs.src.tag else finalAttrs.src.rev
+    }/ChangeLog";
     license = lib.licenses.gpl3Only;
     mainProgram = "lomiri-filemanager-app";
     teams = [ lib.teams.lomiri ];


### PR DESCRIPTION
https://gitlab.com/ubports/development/apps/lomiri-filemanager-app/-/blob/v1.1.4/ChangeLog

`nixosTests.lomiri-filemanager-app` was stuck for me on the second OCR… Implemented #406759, sigh…

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
