### PR TITLE
python3Packages.aiocache: disable time-sensitive tests

### DIFF
--- a/pkgs/development/python-modules/aiocache/default.nix
+++ b/pkgs/development/python-modules/aiocache/default.nix
@@ -53,12 +53,19 @@ buildPythonPackage rec {
     "ignore::DeprecationWarning"
     # TypeError: object MagicMock can't be used in 'await' expression
     "--deselect=tests/ut/backends/test_redis.py::TestRedisBackend::test_close"
+    # Tests can time out and leave redis/valkey in an unusable state for later tests
+    "-x"
   ];
 
   disabledTests =
     [
       # Test calls apache benchmark and fails, no usable output
       "test_concurrency_error_rates"
+      # susceptible to timing out / short ttl
+      "test_cached_stampede"
+      "test_locking_dogpile_lease_expiration"
+      "test_set_ttl_handle"
+      "test_set_cancel_previous_ttl_handle"
     ]
     ++ lib.optionals (pythonAtLeast "3.13") [
       # https://github.com/aio-libs/aiocache/issues/863
@@ -68,6 +75,8 @@ buildPythonPackage rec {
   disabledTestPaths = [
     # Benchmark and performance tests are not relevant for Nixpkgs
     "tests/performance/"
+    # Full of timing-sensitive tests
+    "tests/ut/backends/test_redis.py"
   ];
 
   __darwinAllowLocalNetworking = true;

--- a/pkgs/development/python-modules/aiocache/default.nix
+++ b/pkgs/development/python-modules/aiocache/default.nix
@@ -12,7 +12,6 @@
   pytest-mock,
   pytestCheckHook,
   pythonAtLeast,
-  pythonOlder,
   redis,
   redisTestHook,
   setuptools,
@@ -22,8 +21,6 @@ buildPythonPackage rec {
   pname = "aiocache";
   version = "0.12.3";
   pyproject = true;
-
-  disabled = pythonOlder "3.8";
 
   src = fetchFromGitHub {
     owner = "aio-libs";
@@ -77,11 +74,11 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "aiocache" ];
 
-  meta = with lib; {
-    description = "Python API Rate Limit Decorator";
+  meta = {
+    description = "Asyncio cache supporting multiple backends (memory, redis, memcached, etc.)";
     homepage = "https://github.com/aio-libs/aiocache";
     changelog = "https://github.com/aio-libs/aiocache/releases/tag/v${version}";
-    license = licenses.bsd3;
-    maintainers = with maintainers; [ fab ];
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ fab ];
   };
 }


### PR DESCRIPTION
Hydra: https://hydra.nixos.org/build/296397297
Supersedes: #406045

`aiocache` contains a number of timing-sensitive tests that can fail ~~when compiled under Python 3.13 on Darwin~~ namely, those with a limited time to live which may be exceeded under load. When one of these tests fails, it tends to take down `valkey` and cause a cascade of failures, potentially hanging the test process.

Fixes:
1. Disable known time-sensitive tests ~~on Darwin~~.
2. Add the `-x` flag to `pytest` to stop on the first failure.

ZHF: #403336

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
