### PR TITLE
lomiri.lomiri-gallery-app: 3.1.0 -> 3.1.1

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -756,7 +756,7 @@ in
   lomiri-filemanager-app = runTest ./lomiri-filemanager-app.nix;
   lomiri-mediaplayer-app = runTest ./lomiri-mediaplayer-app.nix;
   lomiri-music-app = runTest ./lomiri-music-app.nix;
-  lomiri-gallery-app = runTest ./lomiri-gallery-app.nix;
+  lomiri-gallery-app = discoverTests (import ./lomiri-gallery-app.nix);
   lomiri-system-settings = runTest ./lomiri-system-settings.nix;
   lorri = handleTest ./lorri/default.nix { };
   lxqt = handleTest ./lxqt.nix { };

--- a/nixos/tests/lomiri-gallery-app.nix
+++ b/nixos/tests/lomiri-gallery-app.nix
@@ -127,9 +127,9 @@ let
                       if buttonIsOffset then "900" else "940"
                     } 50 click 1") # open media information
                     machine.sleep(2)
-                    machine.wait_for_text("${format}") # make sure we're looking at the right file
                     machine.screenshot("lomiri-gallery_${format}_info")
                     machine.send_key("esc")
+                    machine.sleep(2)
                     machine.wait_for_text("${imageLabel}") # make sure media shows fine
               ''
           );
@@ -238,9 +238,9 @@ in
       with subtest("lomiri gallery handles mp4"):
           machine.succeed("xdotool mousemove 935 40 click 1") # open media information
           machine.sleep(2)
-          machine.wait_for_text("MP4") # make sure we're looking at the right file
           machine.screenshot("lomiri-gallery_mp4_info")
           machine.send_key("esc")
+          machine.sleep(2)
 
           machine.wait_for_text("${imageLabel}") # make sure thumbnail processing worked
 

--- a/nixos/tests/lomiri-gallery-app.nix
+++ b/nixos/tests/lomiri-gallery-app.nix
@@ -1,117 +1,240 @@
-{ lib, ... }:
 let
+  makeTest = import ./make-test-python.nix;
   imageDataDir = "gallery-app-sampledata";
   imageLabel = "Image";
+
+  makeFormatTest =
+    {
+      file,
+      buttonIsOffset ? null,
+      customTest ? null,
+    }:
+
+    makeTest (
+      { pkgs, lib, ... }:
+
+      assert lib.asserts.assertMsg (
+        buttonIsOffset != null || customTest != null
+      ) "Must either clarify button position, or define custom test code";
+
+      let
+        format = lib.lists.last (lib.strings.splitString "." file);
+      in
+
+      {
+        name = "lomiri-gallery-app-standalone-format-${format}";
+        meta.maintainers = lib.teams.lomiri.members;
+
+        nodes.machine =
+          { config, pkgs, ... }:
+          {
+            imports = [ ./common/x11.nix ];
+
+            services.xserver.enable = true;
+
+            environment = {
+              etc."${imageDataDir}".source =
+                pkgs.runCommand imageDataDir
+                  {
+                    nativeBuildInputs = with pkgs; [
+                      ffmpeg # make a video from the image
+                      (imagemagick.override { ghostscriptSupport = true; }) # add label for OCR
+                    ];
+                  }
+                  ''
+                    mkdir -p $out/{Pictures,Videos}
+
+                    # Setup example data, OCR-friendly:
+                    # - White square, black text
+                    # - Small text for display OCR
+                    # - Big text for gallery preview OCR
+                    # - uppercase extension
+                    magick -size 500x500 -background white -fill black canvas:white \
+                      -pointsize 20 -annotate +100+100 '${imageLabel}' \
+                      -pointsize 70 -annotate +100+300 '${imageLabel}' \
+                      $out/Pictures/output.PNG
+
+                    # Different image formats
+                    magick $out/Pictures/output.PNG $out/Pictures/output.JPG
+                    magick $out/Pictures/output.PNG $out/Pictures/output.BMP
+                    magick $out/Pictures/output.PNG $out/Pictures/output.GIF
+
+                    # Video for dispatching
+                    ffmpeg -loop 1 -r 1 -i $out/Pictures/output.PNG -t 100 -pix_fmt yuv420p $out/Videos/output.MP4
+                  '';
+              systemPackages =
+                with pkgs;
+                [
+                  mpv # URI dispatching for video support
+                  xdotool # mouse movement
+                ]
+                ++ (with pkgs.lomiri; [
+                  suru-icon-theme
+                  lomiri-gallery-app
+                  lomiri-thumbnailer # finds new images & generates thumbnails
+                ]);
+              variables = {
+                UITK_ICON_THEME = "suru";
+              };
+            };
+
+            i18n.supportedLocales = [ "all" ];
+
+            fonts = {
+              packages = with pkgs; [
+                # Intended font & helps with OCR
+                ubuntu-classic
+              ];
+            };
+          };
+
+        enableOCR = true;
+
+        testScript =
+          ''
+            machine.wait_for_x()
+
+            machine.succeed("mkdir /root/${builtins.dirOf file}")
+            machine.succeed("cp -vr /etc/${imageDataDir}/${file} /root/${builtins.dirOf file}")
+
+            with subtest("lomiri gallery finds files"):
+                machine.succeed("lomiri-gallery-app >&2 &")
+                machine.wait_for_console_text("qq= AlbumsOverview") # logged when album page actually gets loaded
+                machine.sleep(10)
+                machine.send_key("alt-f10")
+                machine.sleep(5)
+                machine.wait_for_text(r"(Albums|Events|Photos|${imageLabel})")
+
+                machine.succeed("xdotool mousemove 30 40 click 1") # burger menu for categories
+                machine.sleep(2)
+                machine.succeed("xdotool mousemove 30 180 click 1") # photos
+                machine.sleep(2)
+                machine.screenshot("lomiri-gallery_photos")
+
+            machine.succeed("xdotool mousemove 80 140 click 1") # select first one
+            machine.sleep(2)
+            machine.succeed("xdotool mousemove 80 140 click 1") # enable top-bar
+            machine.sleep(2)
+
+          ''
+          + (
+            if (customTest != null) then
+              customTest
+            else
+              ''
+                with subtest("lomiri gallery handles ${format}"):
+                    machine.succeed("xdotool mousemove ${
+                      if buttonIsOffset then "900" else "940"
+                    } 50 click 1") # open media information
+                    machine.sleep(2)
+                    machine.wait_for_text("${format}") # make sure we're looking at the right file
+                    machine.screenshot("lomiri-gallery_${format}_info")
+                    machine.send_key("esc")
+                    machine.wait_for_text("${imageLabel}") # make sure media shows fine
+              ''
+          );
+
+      }
+    );
+  makeFormatTests =
+    detailsList:
+    builtins.listToAttrs (
+      builtins.map (
+        {
+          name,
+          file,
+          buttonIsOffset ? null,
+          customTest ? null,
+        }:
+        {
+          name = "format-${name}";
+          value = makeFormatTest {
+            inherit
+              file
+              buttonIsOffset
+              customTest
+              ;
+          };
+        }
+      ) detailsList
+    );
 in
 {
-  name = "lomiri-gallery-app-standalone";
-  meta.maintainers = lib.teams.lomiri.members;
-
-  nodes.machine =
-    { config, pkgs, ... }:
+  basic = makeTest (
+    { lib, ... }:
     {
-      imports = [ ./common/x11.nix ];
+      name = "lomiri-gallery-app-standalone-basic";
+      meta.maintainers = lib.teams.lomiri.members;
 
-      services.xserver.enable = true;
+      nodes.machine =
+        { config, pkgs, ... }:
+        {
+          imports = [ ./common/x11.nix ];
 
-      environment = {
-        etc."${imageDataDir}".source =
-          pkgs.runCommand imageDataDir
-            {
-              nativeBuildInputs = with pkgs; [
-                ffmpeg # make a video from the image
-                (imagemagick.override { ghostscriptSupport = true; }) # add label for OCR
-              ];
-            }
-            ''
-              mkdir -p $out/{Pictures,Videos}
+          services.xserver.enable = true;
 
-              # Setup example data, OCR-friendly:
-              # - White square, black text
-              # - Small text for display OCR
-              # - Big text for gallery preview OCR
-              # - uppercase extension
-              magick -size 500x500 -background white -fill black canvas:white \
-                -pointsize 20 -annotate +100+100 '${imageLabel}' \
-                -pointsize 70 -annotate +100+300 '${imageLabel}' \
-                $out/Pictures/output.PNG
+          environment = {
+            systemPackages =
+              with pkgs;
+              [
+                xdotool # mouse movement
+              ]
+              ++ (with pkgs.lomiri; [
+                suru-icon-theme
+                lomiri-gallery-app
+              ]);
+            variables = {
+              UITK_ICON_THEME = "suru";
+            };
+          };
 
-              # Different image formats
-              magick $out/Pictures/output.PNG $out/Pictures/output.JPG
-              magick $out/Pictures/output.PNG $out/Pictures/output.BMP
-              magick $out/Pictures/output.PNG $out/Pictures/output.GIF
+          i18n.supportedLocales = [ "all" ];
 
-              # Video for dispatching
-              ffmpeg -loop 1 -r 1 -i $out/Pictures/output.PNG -t 100 -pix_fmt yuv420p $out/Videos/output.MP4
-            '';
-        systemPackages =
-          with pkgs;
-          [
-            mpv # URI dispatching for video support
-            xdotool # mouse movement
-          ]
-          ++ (with pkgs.lomiri; [
-            suru-icon-theme
-            lomiri-gallery-app
-            lomiri-thumbnailer # finds new images & generates thumbnails
-          ]);
-        variables = {
-          UITK_ICON_THEME = "suru";
+          fonts = {
+            packages = with pkgs; [
+              # Intended font & helps with OCR
+              ubuntu-classic
+            ];
+          };
         };
-      };
 
-      i18n.supportedLocales = [ "all" ];
+      enableOCR = true;
 
-      fonts = {
-        packages = with pkgs; [
-          # Intended font & helps with OCR
-          ubuntu-classic
-        ];
-      };
-    };
+      testScript = ''
+        machine.wait_for_x()
 
-  enableOCR = true;
+        with subtest("lomiri gallery launches"):
+            machine.succeed("lomiri-gallery-app >&2 &")
+            machine.wait_for_console_text("qq= AlbumsOverview") # logged when album page actually gets loaded
+            machine.sleep(10)
+            machine.send_key("alt-f10")
+            machine.sleep(5)
+            machine.wait_for_text(r"(Albums|Events|Photos)")
+            machine.screenshot("lomiri-gallery_open")
 
-  testScript =
-    ''
-      machine.wait_for_x()
+        machine.succeed("pgrep -afx lomiri-gallery-app >&2")
+        machine.succeed("pkill -efx lomiri-gallery-app >&2")
+        machine.wait_until_fails("pgrep -afx lomiri-gallery-app >&2")
 
-      with subtest("lomiri gallery launches"):
-          machine.succeed("lomiri-gallery-app >&2 &")
-          machine.wait_for_console_text("qq= AlbumsOverview") # logged when album page actually gets loaded
-          machine.sleep(10)
-          machine.send_key("alt-f10")
-          machine.sleep(5)
-          machine.wait_for_text(r"(Albums|Events|Photos)")
-          machine.screenshot("lomiri-gallery_open")
 
-      machine.succeed("pgrep -afx lomiri-gallery-app >&2")
-      machine.succeed("pkill -efx lomiri-gallery-app >&2")
-      machine.wait_until_fails("pgrep -afx lomiri-gallery-app >&2")
-
-      machine.succeed("cp -vr /etc/${imageDataDir}/* /root")
-
-      with subtest("lomiri gallery finds files"):
-          machine.succeed("lomiri-gallery-app >&2 &")
-          machine.wait_for_console_text("qq= AlbumsOverview") # logged when album page actually gets loaded
-          machine.sleep(10)
-          machine.send_key("alt-f10")
-          machine.sleep(5)
-          machine.wait_for_text(r"(Albums|Events|Photos|${imageLabel})")
-
-          machine.succeed("xdotool mousemove 30 40 click 1") # burger menu for categories
-          machine.sleep(2)
-          machine.succeed("xdotool mousemove 30 180 click 1") # photos
-          machine.sleep(2)
-          machine.wait_for_text("${imageLabel}") # should see thumbnail of at least one of them
-          machine.screenshot("lomiri-gallery_photos")
-
-      machine.succeed("xdotool mousemove 80 140 click 1") # select newest one
-      machine.sleep(2)
-      machine.succeed("xdotool mousemove 80 140 click 1") # enable top-bar
-      machine.sleep(2)
-
-      # MP4 gets special treatment
+        with subtest("lomiri gallery localisation works"):
+            machine.succeed("env LANG=de_DE.UTF-8 lomiri-gallery-app >&2 &")
+            machine.wait_for_console_text("qq= AlbumsOverview") # logged when album page actually gets loaded
+            machine.sleep(10)
+            machine.send_key("alt-f10")
+            machine.sleep(5)
+            machine.wait_for_text(r"(Alben|Ereignisse|Fotos)")
+            machine.screenshot("lomiri-gallery_localised")
+      '';
+    }
+  );
+}
+// makeFormatTests [
+  {
+    name = "mp4";
+    file = "Videos/output.MP4";
+    # MP4 gets special treatment
+    customTest = ''
       with subtest("lomiri gallery handles mp4"):
           machine.succeed("xdotool mousemove 935 40 click 1") # open media information
           machine.sleep(2)
@@ -129,57 +252,26 @@ in
 
           machine.send_key("q")
           machine.wait_until_fails("pgrep mpv") # wait for video to stop
-
-      machine.send_key("right")
-    ''
-    +
-      lib.concatMapStringsSep
-        ''
-          machine.send_key("right")
-        ''
-        (format: ''
-          with subtest("lomiri gallery handles ${format.ext}"):
-              machine.succeed("xdotool mousemove ${
-                if format.buttonIsOffset then "900" else "940"
-              } 50 click 1") # open media information
-              machine.sleep(2)
-              machine.wait_for_text("${format.ext}") # make sure we're looking at the right file
-              machine.screenshot("lomiri-gallery_${format.ext}_info")
-              machine.send_key("esc")
-              machine.wait_for_text("${imageLabel}") # make sure media shows fine
-        '')
-        [
-          {
-            ext = "GIF";
-            buttonIsOffset = false;
-          }
-          {
-            ext = "BMP";
-            buttonIsOffset = true;
-          }
-          {
-            ext = "JPG";
-            buttonIsOffset = true;
-          }
-          {
-            ext = "PNG";
-            buttonIsOffset = true;
-          }
-        ]
-    + ''
-
-      machine.succeed("pgrep -afx lomiri-gallery-app >&2")
-      machine.succeed("pkill -efx lomiri-gallery-app >&2")
-      machine.wait_until_fails("pgrep -afx lomiri-gallery-app >&2")
-
-
-      with subtest("lomiri gallery localisation works"):
-          machine.succeed("env LANG=de_DE.UTF-8 lomiri-gallery-app >&2 &")
-          machine.wait_for_console_text("qq= AlbumsOverview") # logged when album page actually gets loaded
-          machine.sleep(10)
-          machine.send_key("alt-f10")
-          machine.sleep(5)
-          machine.wait_for_text(r"(Alben|Ereignisse|Fotos)")
-          machine.screenshot("lomiri-gallery_localised")
     '';
-}
+  }
+  {
+    name = "gif";
+    file = "Pictures/output.GIF";
+    buttonIsOffset = false;
+  }
+  {
+    name = "bmp";
+    file = "Pictures/output.BMP";
+    buttonIsOffset = true;
+  }
+  {
+    name = "jpg";
+    file = "Pictures/output.JPG";
+    buttonIsOffset = true;
+  }
+  {
+    name = "png";
+    file = "Pictures/output.PNG";
+    buttonIsOffset = true;
+  }
+]

--- a/nixos/tests/lomiri-gallery-app.nix
+++ b/nixos/tests/lomiri-gallery-app.nix
@@ -1,4 +1,8 @@
 { lib, ... }:
+let
+  imageDataDir = "gallery-app-sampledata";
+  imageLabel = "Image";
+in
 {
   name = "lomiri-gallery-app-standalone";
   meta.maintainers = lib.teams.lomiri.members;
@@ -11,11 +15,38 @@
       services.xserver.enable = true;
 
       environment = {
+        etc."${imageDataDir}".source =
+          pkgs.runCommand imageDataDir
+            {
+              nativeBuildInputs = with pkgs; [
+                ffmpeg # make a video from the image
+                (imagemagick.override { ghostscriptSupport = true; }) # add label for OCR
+              ];
+            }
+            ''
+              mkdir -p $out/{Pictures,Videos}
+
+              # Setup example data, OCR-friendly:
+              # - White square, black text
+              # - Small text for display OCR
+              # - Big text for gallery preview OCR
+              # - uppercase extension
+              magick -size 500x500 -background white -fill black canvas:white \
+                -pointsize 20 -annotate +100+100 '${imageLabel}' \
+                -pointsize 70 -annotate +100+300 '${imageLabel}' \
+                $out/Pictures/output.PNG
+
+              # Different image formats
+              magick $out/Pictures/output.PNG $out/Pictures/output.JPG
+              magick $out/Pictures/output.PNG $out/Pictures/output.BMP
+              magick $out/Pictures/output.PNG $out/Pictures/output.GIF
+
+              # Video for dispatching
+              ffmpeg -loop 1 -r 1 -i $out/Pictures/output.PNG -t 100 -pix_fmt yuv420p $out/Videos/output.MP4
+            '';
         systemPackages =
           with pkgs;
           [
-            ffmpeg # make a video from the image
-            (imagemagick.override { ghostscriptSupport = true; }) # example image creation
             mpv # URI dispatching for video support
             xdotool # mouse movement
           ]
@@ -42,44 +73,30 @@
   enableOCR = true;
 
   testScript =
-    let
-      imageLabel = "Image";
-    in
     ''
       machine.wait_for_x()
 
       with subtest("lomiri gallery launches"):
           machine.succeed("lomiri-gallery-app >&2 &")
-          machine.sleep(2)
+          machine.wait_for_console_text("qq= AlbumsOverview") # logged when album page actually gets loaded
+          machine.sleep(10)
+          machine.send_key("alt-f10")
+          machine.sleep(5)
           machine.wait_for_text(r"(Albums|Events|Photos)")
           machine.screenshot("lomiri-gallery_open")
 
-      machine.succeed("pkill -f lomiri-gallery-app")
+      machine.succeed("pgrep -afx lomiri-gallery-app >&2")
+      machine.succeed("pkill -efx lomiri-gallery-app >&2")
+      machine.wait_until_fails("pgrep -afx lomiri-gallery-app >&2")
 
-      machine.succeed("mkdir /root/Pictures /root/Videos")
-      # Setup example data, OCR-friendly:
-      # - White square, black text
-      # - Small text for display OCR
-      # - Big text for gallery preview OCR
-      # - uppercase extension
-      machine.succeed(
-          "magick -size 500x500 -background white -fill black canvas:white "
-          + "-pointsize 20 -annotate +100+100 '${imageLabel}' "
-          + "-pointsize 50 -annotate +100+300 '${imageLabel}' "
-          + "/root/Pictures/output.PNG"
-      )
+      machine.succeed("cp -vr /etc/${imageDataDir}/* /root")
 
-      # Different image formats
-      machine.succeed("magick /root/Pictures/output.PNG /root/Pictures/output.JPG")
-      machine.succeed("magick /root/Pictures/output.PNG /root/Pictures/output.BMP")
-      machine.succeed("magick /root/Pictures/output.PNG /root/Pictures/output.GIF")
-
-      # Video for dispatching
-      machine.succeed("ffmpeg -loop 1 -r 1 -i /root/Pictures/output.PNG -t 100 -pix_fmt yuv420p /root/Videos/output.MP4")
-
-      with subtest("lomiri gallery handles files"):
+      with subtest("lomiri gallery finds files"):
           machine.succeed("lomiri-gallery-app >&2 &")
-          machine.sleep(2)
+          machine.wait_for_console_text("qq= AlbumsOverview") # logged when album page actually gets loaded
+          machine.sleep(10)
+          machine.send_key("alt-f10")
+          machine.sleep(5)
           machine.wait_for_text(r"(Albums|Events|Photos|${imageLabel})")
 
           machine.succeed("xdotool mousemove 30 40 click 1") # burger menu for categories
@@ -89,74 +106,79 @@
           machine.wait_for_text("${imageLabel}") # should see thumbnail of at least one of them
           machine.screenshot("lomiri-gallery_photos")
 
-          machine.succeed("xdotool mousemove 80 140 click 1") # select newest one
+      machine.succeed("xdotool mousemove 80 140 click 1") # select newest one
+      machine.sleep(2)
+      machine.succeed("xdotool mousemove 80 140 click 1") # enable top-bar
+      machine.sleep(2)
+
+      # MP4 gets special treatment
+      with subtest("lomiri gallery handles mp4"):
+          machine.succeed("xdotool mousemove 935 40 click 1") # open media information
           machine.sleep(2)
-          machine.succeed("xdotool mousemove 80 140 click 1") # enable top-bar
-          machine.sleep(2)
+          machine.wait_for_text("MP4") # make sure we're looking at the right file
+          machine.screenshot("lomiri-gallery_mp4_info")
+          machine.send_key("esc")
 
-          with subtest("lomiri gallery handles mp4"):
-              machine.succeed("xdotool mousemove 870 50 click 1") # open media information
+          machine.wait_for_text("${imageLabel}") # make sure thumbnail processing worked
+
+          machine.succeed("xdotool mousemove 510 380 click 1") # dispatch to system's video handler
+          machine.wait_until_succeeds("pgrep -u root -f mpv") # wait for video to start
+          machine.sleep(10)
+          machine.succeed("pgrep -u root -f mpv") # should still be playing
+          machine.screenshot("lomiri-gallery_mp4_dispatch")
+
+          machine.send_key("q")
+          machine.wait_until_fails("pgrep mpv") # wait for video to stop
+
+      machine.send_key("right")
+    ''
+    +
+      lib.concatMapStringsSep
+        ''
+          machine.send_key("right")
+        ''
+        (format: ''
+          with subtest("lomiri gallery handles ${format.ext}"):
+              machine.succeed("xdotool mousemove ${
+                if format.buttonIsOffset then "900" else "940"
+              } 50 click 1") # open media information
               machine.sleep(2)
-              machine.wait_for_text("MP4") # make sure we're looking at the right file
-              machine.screenshot("lomiri-gallery_mp4_info")
+              machine.wait_for_text("${format.ext}") # make sure we're looking at the right file
+              machine.screenshot("lomiri-gallery_${format.ext}_info")
               machine.send_key("esc")
-
-              machine.wait_for_text("${imageLabel}") # make sure thumbnail rendering worked
-
-              machine.succeed("xdotool mousemove 450 350 click 1") # dispatch to system's video handler
-              machine.wait_until_succeeds("pgrep -u root -f mpv") # wait for video to start
-              machine.sleep(10)
-              machine.succeed("pgrep -u root -f mpv") # should still be playing
-              machine.screenshot("lomiri-gallery_mp4_dispatch")
-
-              machine.send_key("q")
-              machine.wait_until_fails("pgrep mpv") # wait for video to stop
-
-              machine.send_key("right")
-
-          with subtest("lomiri gallery handles gif"):
-              machine.succeed("xdotool mousemove 870 50 click 1") # open media information
-              machine.sleep(2)
-              machine.wait_for_text("GIF") # make sure we're looking at the right file
-              machine.screenshot("lomiri-gallery_gif_info")
-              machine.send_key("esc")
-
               machine.wait_for_text("${imageLabel}") # make sure media shows fine
-              machine.send_key("right")
+        '')
+        [
+          {
+            ext = "GIF";
+            buttonIsOffset = false;
+          }
+          {
+            ext = "BMP";
+            buttonIsOffset = true;
+          }
+          {
+            ext = "JPG";
+            buttonIsOffset = true;
+          }
+          {
+            ext = "PNG";
+            buttonIsOffset = true;
+          }
+        ]
+    + ''
 
-          with subtest("lomiri gallery handles bmp"):
-              machine.succeed("xdotool mousemove 840 50 click 1") # open media information (extra icon, different location)
-              machine.sleep(2)
-              machine.wait_for_text("BMP") # make sure we're looking at the right file
-              machine.screenshot("lomiri-gallery_bmp_info")
-              machine.send_key("esc")
+      machine.succeed("pgrep -afx lomiri-gallery-app >&2")
+      machine.succeed("pkill -efx lomiri-gallery-app >&2")
+      machine.wait_until_fails("pgrep -afx lomiri-gallery-app >&2")
 
-              machine.wait_for_text("${imageLabel}") # make sure media shows fine
-              machine.send_key("right")
-
-          with subtest("lomiri gallery handles jpg"):
-              machine.succeed("xdotool mousemove 840 50 click 1") # open media information (extra icon, different location)
-              machine.sleep(2)
-              machine.wait_for_text("JPG") # make sure we're looking at the right file
-              machine.screenshot("lomiri-gallery_jpg_info")
-              machine.send_key("esc")
-
-              machine.wait_for_text("${imageLabel}") # make sure media shows fine
-              machine.send_key("right")
-
-          with subtest("lomiri gallery handles png"):
-              machine.succeed("xdotool mousemove 840 50 click 1") # open media information (extra icon, different location)
-              machine.sleep(2)
-              machine.wait_for_text("PNG") # make sure we're looking at the right file
-              machine.screenshot("lomiri-gallery_png_info")
-              machine.send_key("esc")
-
-              machine.wait_for_text("${imageLabel}") # make sure media shows fine
-
-      machine.succeed("pkill -f lomiri-gallery-app")
 
       with subtest("lomiri gallery localisation works"):
           machine.succeed("env LANG=de_DE.UTF-8 lomiri-gallery-app >&2 &")
+          machine.wait_for_console_text("qq= AlbumsOverview") # logged when album page actually gets loaded
+          machine.sleep(10)
+          machine.send_key("alt-f10")
+          machine.sleep(5)
           machine.wait_for_text(r"(Alben|Ereignisse|Fotos)")
           machine.screenshot("lomiri-gallery_localised")
     '';

--- a/pkgs/desktops/lomiri/applications/lomiri-gallery-app/default.nix
+++ b/pkgs/desktops/lomiri/applications/lomiri-gallery-app/default.nix
@@ -103,7 +103,16 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   passthru = {
-    tests.vm = nixosTests.lomiri-gallery-app;
+    tests = {
+      inherit (nixosTests.lomiri-gallery-app)
+        basic
+        format-mp4
+        format-gif
+        format-bmp
+        format-jpg
+        format-png
+        ;
+    };
     updateScript = gitUpdater { rev-prefix = "v"; };
   };
 

--- a/pkgs/desktops/lomiri/applications/lomiri-gallery-app/default.nix
+++ b/pkgs/desktops/lomiri/applications/lomiri-gallery-app/default.nix
@@ -2,7 +2,6 @@
   stdenv,
   lib,
   fetchFromGitLab,
-  fetchpatch,
   gitUpdater,
   nixosTests,
   cmake,
@@ -25,28 +24,14 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "lomiri-gallery-app";
-  version = "3.1.0";
+  version = "3.1.1";
 
   src = fetchFromGitLab {
     owner = "ubports";
     repo = "development/apps/lomiri-gallery-app";
-    rev = "v${finalAttrs.version}";
-    hash = "sha256-uKGPic9XYUj0rLA05i6GjLM+n17MYgiFJMWnLXHKmIU=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-5/mZszPEsSZqgioJ+Mc7+0gEcpUKr7n/LgyXJ20P2Zg=";
   };
-
-  patches = [
-    # Remove when https://gitlab.com/ubports/development/apps/lomiri-gallery-app/-/merge_requests/152 merged & in release
-    (fetchpatch {
-      name = "0001-lomiri-gallery-app-bindtextdomain.patch";
-      url = "https://gitlab.com/ubports/development/apps/lomiri-gallery-app/-/commit/592eff118cb5056886b73e6698f8941c7a16f2e0.patch";
-      hash = "sha256-aR/Lnzvq4RuRLI75mMd4xTGMAcijm1adSAGVFZZ++No=";
-    })
-    (fetchpatch {
-      name = "0002-lomiri-gallery-app-C++ify-i18n.patch";
-      url = "https://gitlab.com/ubports/development/apps/lomiri-gallery-app/-/commit/a7582abbe0acef4d49c77a4395bc22dbd1707ef3.patch";
-      hash = "sha256-qzqTXqIYX+enoOwwV9d9fxe7tVYLuh1WkL8Ij/Qx0H0=";
-    })
-  ];
 
   postPatch = ''
     # Make splash path in desktop file relative
@@ -125,7 +110,9 @@ stdenv.mkDerivation (finalAttrs: {
   meta = {
     description = "Photo gallery application for Ubuntu Touch devices";
     homepage = "https://gitlab.com/ubports/development/apps/lomiri-gallery-app";
-    changelog = "https://gitlab.com/ubports/development/apps/lomiri-gallery-app/-/blob/v${finalAttrs.version}/ChangeLog";
+    changelog = "https://gitlab.com/ubports/development/apps/lomiri-gallery-app/-/blob/${
+      if (!builtins.isNull finalAttrs.src.tag) then finalAttrs.src.tag else finalAttrs.src.rev
+    }/ChangeLog";
     license = with lib.licenses; [
       gpl3Only
       cc-by-sa-30

--- a/pkgs/desktops/lomiri/services/lomiri-thumbnailer/default.nix
+++ b/pkgs/desktops/lomiri/services/lomiri-thumbnailer/default.nix
@@ -188,7 +188,13 @@ stdenv.mkDerivation (finalAttrs: {
   passthru = {
     tests = {
       # gallery app delegates to thumbnailer, tests various formats
-      gallery-app = nixosTests.lomiri-gallery-app;
+      inherit (nixosTests.lomiri-gallery-app)
+        format-mp4
+        format-gif
+        format-bmp
+        format-jpg
+        format-png
+        ;
 
       # music app relies on thumbnailer to extract embedded cover art
       music-app = nixosTests.lomiri-music-app;


### PR DESCRIPTION
https://gitlab.com/ubports/development/apps/lomiri-gallery-app/-/blob/v3.1.1/ChangeLog

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
