### PR TITLE
jasper-gtk-theme: init at 0-unstable-2025-04-02

### DIFF
--- a/pkgs/by-name/ja/jasper-gtk-theme/package.nix
+++ b/pkgs/by-name/ja/jasper-gtk-theme/package.nix
@@ -1,0 +1,102 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchFromGitHub,
+  gnome-themes-extra,
+  gtk-engine-murrine,
+  jdupes,
+  sassc,
+  themeVariants ? [ ], # default: teal
+  colorVariants ? [ ], # default: all
+  sizeVariants ? [ ], # default: standard
+  tweaks ? [ ],
+}:
+
+let
+  pname = "jasper-gtk-theme";
+
+in
+lib.checkListOfEnum "${pname}: theme variants"
+  [
+    "default"
+    "purple"
+    "pink"
+    "red"
+    "orange"
+    "yellow"
+    "green"
+    "blue"
+    "grey"
+    "all"
+  ]
+  themeVariants
+  lib.checkListOfEnum
+  "${pname}: color variants"
+  [ "standard" "light" "dark" ]
+  colorVariants
+  lib.checkListOfEnum
+  "${pname}: size variants"
+  [ "standard" "compact" ]
+  sizeVariants
+  lib.checkListOfEnum
+  "${pname}: tweaks"
+  [
+    "nord"
+    "dracula"
+    "black"
+    "macos"
+  ]
+  tweaks
+
+  stdenvNoCC.mkDerivation
+  rec {
+    inherit pname;
+    version = "0-unstable-2025-04-02";
+
+    src = fetchFromGitHub {
+      owner = "vinceliuice";
+      repo = "Jasper-gtk-theme";
+      rev = "71cb99a6618d839b1058cb8e6660a3b2f63aca70";
+      hash = "sha256-ZWPUyVszDPUdzttAJuIA9caDpP4SQ7mIbCoczxwvsus=";
+    };
+
+    nativeBuildInputs = [
+      jdupes
+      sassc
+    ];
+
+    buildInputs = [
+      gnome-themes-extra
+    ];
+
+    propagatedUserEnvPkgs = [
+      gtk-engine-murrine
+    ];
+
+    postPatch = ''
+      patchShebangs install.sh
+    '';
+
+    installPhase = ''
+      runHook preInstall
+
+      name= HOME="$TMPDIR" ./install.sh \
+        ${lib.optionalString (themeVariants != [ ]) "--theme " + builtins.toString themeVariants} \
+        ${lib.optionalString (colorVariants != [ ]) "--color " + builtins.toString colorVariants} \
+        ${lib.optionalString (sizeVariants != [ ]) "--size " + builtins.toString sizeVariants} \
+        ${lib.optionalString (tweaks != [ ]) "--tweaks " + builtins.toString tweaks} \
+        --dest $out/share/themes
+
+      jdupes --quiet --link-soft --recurse $out/share
+
+      runHook postInstall
+    '';
+
+    meta = {
+      description = "Modern and clean Gtk theme";
+      homepage = "https://github.com/vinceliuice/Jasper-gtk-theme";
+      license = lib.licenses.gpl3Only;
+      platforms = lib.platforms.unix;
+      maintainers = [ lib.maintainers.romildo ];
+    };
+  }


### PR DESCRIPTION
Add the [Jasper GTK theme](https://www.pling.com/p/1891521/).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
