### PR TITLE
update-source-version: escape ampersand in new url

### DIFF
--- a/pkgs/common-updater/scripts/update-source-version
+++ b/pkgs/common-updater/scripts/update-source-version
@@ -230,10 +230,10 @@ if [[ -n "$newUrl" ]]; then
     fi
 
     # Escape regex metacharacter that may appear in URLs
-    oldUrlEscaped=$(echo "$oldUrl" | sed -re 's|[${}.+?\[]|\\&|g')
-    newUrlEscaped=$(echo "$newUrl" | sed -re 's|&|\\&|g')
+    oldUrlEscaped=$(echo "$oldUrl" | sed -e 's|[*.^$[\|]|\\&|g')
+    newUrlEscaped=$(echo "$newUrl" | sed -e 's|[&\|]|\\&|g')
 
-    sed -i.cmp "$nixFile" -re "s|\"$oldUrlEscaped\"|\"$newUrlEscaped\"|"
+    sed -i.cmp "$nixFile" -e "s|\"$oldUrlEscaped\"|\"$newUrlEscaped\"|"
     if cmp -s "$nixFile" "$nixFile.cmp"; then
         die "Failed to replace source URL '$oldUrl' to '$newUrl' in '$attr'!"
     fi

--- a/pkgs/common-updater/scripts/update-source-version
+++ b/pkgs/common-updater/scripts/update-source-version
@@ -229,10 +229,11 @@ if [[ -n "$newUrl" ]]; then
         die "Couldn't evaluate source url from '$attr.$sourceKey'!"
     fi
 
-    # Escape regex metacharacter that are allowed in store path names
-    oldUrlEscaped=$(echo "$oldUrl" | sed -re 's|[${}.+?]|\\&|g')
+    # Escape regex metacharacter that may appear in URLs
+    oldUrlEscaped=$(echo "$oldUrl" | sed -re 's|[${}.+?\[]|\\&|g')
+    newUrlEscaped=$(echo "$newUrl" | sed -re 's|&|\\&|g')
 
-    sed -i.cmp "$nixFile" -re "s|\"$oldUrlEscaped\"|\"$newUrl\"|"
+    sed -i.cmp "$nixFile" -re "s|\"$oldUrlEscaped\"|\"$newUrlEscaped\"|"
     if cmp -s "$nixFile" "$nixFile.cmp"; then
         die "Failed to replace source URL '$oldUrl' to '$newUrl' in '$attr'!"
     fi


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Escape the ampersand in new URL, which is a regex character that represents the entire matched text.

As pointed out by https://github.com/NixOS/nixpkgs/pull/407147#pullrequestreview-2841493917, I also changed the comments so that they make sense.

I didn't escape other metacharacters of BRE syntax because I think they probably won't appear in a URL.

(Sorry for opening another PR. I failed to realize the necessity of escaping the ampersand before my previous PR got merged.)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
