### PR TITLE
geolite-legacy: 20240720 -> 20250129, add updateScript

### DIFF
--- a/pkgs/by-name/ge/geolite-legacy/package.nix
+++ b/pkgs/by-name/ge/geolite-legacy/package.nix
@@ -10,19 +10,19 @@
 
 stdenv.mkDerivation rec {
   pname = "geolite-legacy";
-  version = "20240720";
+  version = "20250129";
 
   # We use Arch Linux package as a snapshot, because upstream database is updated in-place.
   geoip = fetchzip {
     url = "https://archive.archlinux.org/packages/g/geoip-database/geoip-database-${version}-1-any.pkg.tar.zst";
-    hash = "sha256-9rPp1Lu6Q4+Cb4N4e/ezHacpLuUwbGQefEPuSrH8O6o=";
+    hash = "sha256-/aT/ndml7a3P9/1CM3KhB4/L+F0CDHpHj/NnKWOv2G0=";
     nativeBuildInputs = [ zstd ];
     stripRoot = false;
   };
 
   extra = fetchzip {
     url = "https://archive.archlinux.org/packages/g/geoip-database-extra/geoip-database-extra-${version}-1-any.pkg.tar.zst";
-    hash = "sha256-sb06yszstKalc+b9rSuStRuY3YRebAL1Q4jEJkbGiMI=";
+    hash = "sha256-qFJKeLEWag5Wvzye5heDs79ai0pkJndmZgS8Ip5T3G4=";
     nativeBuildInputs = [ zstd ];
     stripRoot = false;
   };


### PR DESCRIPTION
## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review`

---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 5 packages built:</summary>
  <ul>
    <li>geoipWithDatabase</li>
    <li>geolite-legacy</li>
    <li>gswatcher</li>
    <li>ipv6calc</li>
    <li>netsniff-ng</li>
  </ul>
</details>

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc