### PR TITLE
gcc-arm-embedded: fix hardcoded library paths on x86_64-darwin

### DIFF
--- a/pkgs/by-name/gc/gcc-arm-embedded-13/package.nix
+++ b/pkgs/by-name/gc/gcc-arm-embedded-13/package.nix
@@ -4,6 +4,10 @@
   fetchurl,
   ncurses5,
   libxcrypt-legacy,
+  xz,
+  zstd,
+  makeBinaryWrapper,
+  darwin,
 }:
 
 stdenv.mkDerivation rec {
@@ -38,6 +42,11 @@ stdenv.mkDerivation rec {
     ./info-fix.patch
   ];
 
+  nativeBuildInputs = lib.optionals (stdenv.isDarwin && stdenv.isx86_64) [
+    makeBinaryWrapper
+    darwin.sigtool
+  ];
+
   dontConfigure = true;
   dontBuild = true;
   dontPatchELF = true;
@@ -50,20 +59,32 @@ stdenv.mkDerivation rec {
     rm $out/bin/{arm-none-eabi-gdb-py,arm-none-eabi-gdb-add-index-py} || :
   '';
 
-  preFixup = lib.optionalString stdenv.isLinux ''
-    find $out -type f | while read f; do
-      patchelf "$f" > /dev/null 2>&1 || continue
-      patchelf --set-interpreter $(cat ${stdenv.cc}/nix-support/dynamic-linker) "$f" || true
-      patchelf --set-rpath ${
-        lib.makeLibraryPath [
-          "$out"
-          stdenv.cc.cc
-          ncurses5
-          libxcrypt-legacy
-        ]
-      } "$f" || true
-    done
-  '';
+  preFixup =
+    lib.optionalString stdenv.isLinux ''
+      find $out -type f | while read f; do
+        patchelf "$f" > /dev/null 2>&1 || continue
+        patchelf --set-interpreter $(cat ${stdenv.cc}/nix-support/dynamic-linker) "$f" || true
+        patchelf --set-rpath ${
+          lib.makeLibraryPath [
+            "$out"
+            stdenv.cc.cc
+            ncurses5
+            libxcrypt-legacy
+          ]
+        } "$f" || true
+      done
+    ''
+    + lib.optionalString (stdenv.isDarwin && stdenv.isx86_64) ''
+      find "$out" -executable -type f | while read executable; do
+        ( \
+          install_name_tool \
+            -change "/usr/local/opt/zstd/lib/libzstd.1.dylib" "${lib.getLib zstd}/lib/libzstd.1.dylib" \
+            -change "/usr/local/opt/xz/lib/liblzma.5.dylib" "${lib.getLib xz}/lib/liblzma.5.dylib" \
+            "$executable" \
+          && codesign -f -s - "$executable" \
+        ) || true
+      done
+    '';
 
   meta = with lib; {
     description = "Pre-built GNU toolchain from ARM Cortex-M & Cortex-R processors";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Packages that use `gcc-arm-embedded` are currently failing to build on `x86_64-darwin` due to unpatched paths to `zstd` and `xz`.

Example error:
```
dyld[23869]: Library not loaded: /usr/local/opt/zstd/lib/libzstd.1.dylib
  Referenced from: <E36D2C99-6E55-3C79-B1A0-B74BE74E79B9> /nix/store/jha0fn8gmikj4p348xp9qj2mph4qgnms-gcc-arm-embedded-13.3.rel1/libexec/gcc/arm-none-eabi/13.3.1/cc1
  Reason: tried: '/usr/local/opt/zstd/lib/libzstd.1.dylib' (no such file), '/usr/lib/libzstd.1.dylib' (no such file, not in dyld cache)
dyld[23868]: Library not loaded: /usr/local/opt/zstd/lib/libzstd.1.dylib
  Referenced from: <E36D2C99-6E55-3C79-B1A0-B74BE74E79B9> /nix/store/jha0fn8gmikj4p348xp9qj2mph4qgnms-gcc-arm-embedded-13.3.rel1/libexec/gcc/arm-none-eabi/13.3.1/cc1
  Reason: tried: '/usr/local/opt/zstd/lib/libzstd.1.dylib' (no such file), '/usr/lib/libzstd.1.dylib' (no such file, not in dyld cache)
arm-none-eabi-gcc: indyld[23873]: Library not loaded: /usr/local/opt/zstd/lib/libzstd.1.dylib
  Referenced from: <E36D2C99-6E55-3C79-B1A0-B74BE74E79B9> /nix/store/jha0fn8gmikj4p348xp9qj2mph4qgnms-gcc-arm-embedded-13.3.rel1/libexec/gcc/arm-none-eabi/13.3.1/cc1
  Reason: tried: '/usr/local/opt/zstd/lib/libzstd.1.dylib' (no such file), '/usr/lib/libzstd.1.dylib' (no such file, not in dyld cache)
ternal compiler error: Abort trap: 6 signal terminated program cc1
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
