### PR TITLE
lomiri.lomiri-mediaplayer-app: 1.1.0 -> 1.1.1

### DIFF
--- a/nixos/tests/lomiri-mediaplayer-app.nix
+++ b/nixos/tests/lomiri-mediaplayer-app.nix
@@ -54,30 +54,39 @@ in
 
     with subtest("lomiri mediaplayer launches"):
         machine.succeed("lomiri-mediaplayer-app >&2 &")
+        machine.wait_for_console_text("The name com.lomiri.content.dbus.Service was not provided")
+        machine.wait_for_console_text("The name com.lomiri.content.dbus.Service was not provided") # Emitted twice
         machine.sleep(10)
         machine.send_key("alt-f10")
-        machine.wait_for_text("Choose from")
+        machine.sleep(5)
+        machine.wait_for_text(r"(Choose|Sorry|provide|content)")
         machine.screenshot("lomiri-mediaplayer_open")
 
     machine.succeed("pkill -f lomiri-mediaplayer-app")
 
     with subtest("lomiri mediaplayer plays video"):
         machine.succeed("lomiri-mediaplayer-app /etc/${videoFile} >&2 &")
+        machine.wait_for_console_text("The name com.lomiri.content.dbus.Service was not provided") # Only once here
+        machine.wait_for_console_text("qml: onPositionChanged")
         machine.sleep(10)
         machine.send_key("alt-f10")
+        machine.sleep(5)
         machine.wait_for_text("${ocrContent}")
         machine.screenshot("lomiri-mediaplayer_playback")
 
     machine.succeed("pkill -f lomiri-mediaplayer-app")
 
     with subtest("lomiri mediaplayer localisation works"):
-        # OCR struggles with finding identifying the translated window title, and lomiri-content-hub QML isn't translated
+        # OCR struggles with finding the translated window title, and lomiri-content-hub QML isn't translated
         # Cause an error, and look for the error popup
         machine.succeed("touch invalid.mp4")
         machine.succeed("env LANG=de_DE.UTF-8 lomiri-mediaplayer-app invalid.mp4 >&2 &")
+        machine.wait_for_console_text("The name com.lomiri.content.dbus.Service was not provided")
+        machine.wait_for_console_text("Der Datenstrom enthält keine Daten")
         machine.sleep(10)
         machine.send_key("alt-f10")
-        machine.wait_for_text("Fehler")
+        machine.sleep(5)
+        machine.wait_for_text(r"(Fehler|Abspielen|fehlgeschlagen)")
         machine.screenshot("lomiri-mediaplayer_localised")
   '';
 }

--- a/pkgs/desktops/lomiri/applications/lomiri-mediaplayer-app/default.nix
+++ b/pkgs/desktops/lomiri/applications/lomiri-mediaplayer-app/default.nix
@@ -2,7 +2,6 @@
   stdenv,
   lib,
   fetchFromGitLab,
-  fetchpatch,
   gitUpdater,
   nixosTests,
   cmake,
@@ -23,49 +22,14 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "lomiri-mediaplayer-app";
-  version = "1.1.0";
+  version = "1.1.1";
 
   src = fetchFromGitLab {
     owner = "ubports";
     repo = "development/core/lomiri-mediaplayer-app";
-    rev = "refs/tags/${finalAttrs.version}";
-    hash = "sha256-Pq1TA7eoHDRRzr6zT2cmIye91uz/0YsmQ8Qp79244wg=";
+    tag = "${finalAttrs.version}";
+    hash = "sha256-A1tAXQXDwVZ3ILFcJKCtbOm1iNxPFOXQIS6p7fPbqwM=";
   };
-
-  patches = [
-    # Remove when https://gitlab.com/ubports/development/core/lomiri-mediaplayer-app/-/merge_requests/35 merged & in release
-    (fetchpatch {
-      name = "0001-lomiri-mediaplayer-app-Fix-GNUInstallDirs-usage.patch";
-      url = "https://gitlab.com/ubports/development/core/lomiri-mediaplayer-app/-/commit/baaa0ea7cba2a9f8bc7f223246857eba1cd5d8e4.patch";
-      hash = "sha256-RChPRi4zrAWJEl4Urznh5FRYuTnxCFzG+gZurrF7Ym0=";
-    })
-
-    # Remove when https://gitlab.com/ubports/development/core/lomiri-mediaplayer-app/-/merge_requests/36 merged & in release
-    (fetchpatch {
-      name = "0002-lomiri-mediaplayer-app-Drop-NO_DEFAULT_PATH-for-qmltestrunner.patch";
-      url = "https://gitlab.com/ubports/development/core/lomiri-mediaplayer-app/-/commit/3bf4ebae7eb59176af984d07ad72b67ee0bd1b8f.patch";
-      hash = "sha256-dJCW0dKe7Tq1Mg9CSdVQHamObVrPS7COXsdv41SWnHg=";
-    })
-
-    # Remove when https://gitlab.com/ubports/development/core/lomiri-mediaplayer-app/-/merge_requests/37 merged & in release
-    (fetchpatch {
-      name = "0003-lomiri-mediaplayer-app-BUILD_TESTING.patch";
-      url = "https://gitlab.com/ubports/development/core/lomiri-mediaplayer-app/-/commit/df1aadb82d73177133bc096307ec1ef1e2b0c2ed.patch";
-      hash = "sha256-dvkGjG0ptCmLDIAWzDjOzu+Q/5bgVdb/+RmE6v8fV0Q=";
-    })
-
-    # Remove when https://gitlab.com/ubports/development/core/lomiri-mediaplayer-app/-/merge_requests/38 merged & in release
-    (fetchpatch {
-      name = "0004-lomiri-mediaplayer-app-bindtextdomain.patch";
-      url = "https://gitlab.com/ubports/development/core/lomiri-mediaplayer-app/-/commit/bd927e823205214f9ea01dfb1f93171a8952ecf9.patch";
-      hash = "sha256-/lg0elv9weNnRGq1oD94/sE511EZ0TmXZsURcauQobI=";
-    })
-    (fetchpatch {
-      name = "0005-lomiri-mediaplayer-app-Fix-title-localisation.patch";
-      url = "https://gitlab.com/ubports/development/core/lomiri-mediaplayer-app/-/commit/c4cba819dd55e7e85c4ea496626bed9aa78470a5.patch";
-      hash = "sha256-EiUxaCa5ANnRSciB8IodQOGnmG4rE/g/M+K4XcyqTI8=";
-    })
-  ];
 
   postPatch = ''
     # We don't want absolute paths in desktop files
@@ -154,7 +118,9 @@ stdenv.mkDerivation (finalAttrs: {
   meta = {
     description = "Media Player application for Ubuntu Touch devices";
     homepage = "https://gitlab.com/ubports/development/apps/lomiri-mediaplayer-app";
-    changelog = "https://gitlab.com/ubports/development/apps/lomiri-mediaplayer-app/-/blob/${finalAttrs.version}/ChangeLog";
+    changelog = "https://gitlab.com/ubports/development/apps/lomiri-mediaplayer-app/-/blob/${
+      if (!builtins.isNull finalAttrs.src.tag) then finalAttrs.src.tag else finalAttrs.src.rev
+    }/ChangeLog";
     license = with lib.licenses; [
       gpl3Only
       cc-by-sa-30


### PR DESCRIPTION
https://gitlab.com/ubports/development/core/lomiri-mediaplayer-app/-/blob/1.1.1/ChangeLog

Pretty much just upstream accepting all the patches we were already applying.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
