### PR TITLE
linuxPackages.nvidia_x11.persistenced: remove dates from man pages

### DIFF
--- a/pkgs/os-specific/linux/nvidia-x11/persistenced.nix
+++ b/pkgs/os-specific/linux/nvidia-x11/persistenced.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation {
   nativeBuildInputs = [ m4 ];
   buildInputs = [ libtirpc ];
 
-  inherit (nvidia_x11) makeFlags;
+  makeFlags = nvidia_x11.makeFlags ++ [ "DATE=true" ];
 
   installFlags = [ "PREFIX=$(out)" ];
 


### PR DESCRIPTION
The make target for nvidia-persistenced builds a man page which includes the current date into the footer, causing irreproducible builds. Overriding the `date` utility with the `true` utility removes the date from the footer entirely, because:

* `DATE` overrides the `date` utility here: https://github.com/NVIDIA/nvidia-persistenced/blob/8c620178a92c835ab921811938bea8a4d41ba49e/utils.mk#L112,
* which is then used to render a date string here: https://github.com/NVIDIA/nvidia-persistenced/blob/8c620178a92c835ab921811938bea8a4d41ba49e/Makefile#L178
* which is finally included in the man page here: https://github.com/NVIDIA/nvidia-persistenced/blob/8c620178a92c835ab921811938bea8a4d41ba49e/nvidia-persistenced.1.m4#L15

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
