### PR TITLE
Revert "file: 5.45 -> 5.46", to fix Zip files regressions

### DIFF
--- a/pkgs/tools/misc/file/32-bit-time_t.patch
+++ b/pkgs/tools/misc/file/32-bit-time_t.patch
@@ -1,0 +1,38 @@
+https://github.com/file/file/commit/218fdf813fd5ccecbb8887a1b62509cd1c6dd3a1.patch
+
+From 218fdf813fd5ccecbb8887a1b62509cd1c6dd3a1 Mon Sep 17 00:00:00 2001
+From: Christos Zoulas <christos@zoulas.com>
+Date: Fri, 28 Jul 2023 14:38:25 +0000
+Subject: [PATCH] deal with 32 bit time_t
+
+---
+ src/file.h | 8 +++++---
+ 1 file changed, 5 insertions(+), 3 deletions(-)
+
+diff --git a/src/file.h b/src/file.h
+index 2e0494d2f..78f574ea1 100644
+--- a/src/file.h
++++ b/src/file.h
+@@ -27,7 +27,7 @@
+  */
+ /*
+  * file.h - definitions for file(1) program
+- * @(#)$File: file.h,v 1.247 2023/07/27 19:40:22 christos Exp $
++ * @(#)$File: file.h,v 1.248 2023/07/28 14:38:25 christos Exp $
+  */
+ 
+ #ifndef __file_h__
+@@ -159,9 +159,11 @@
+ /*
+  * Dec 31, 23:59:59 9999
+  * we need to make sure that we don't exceed 9999 because some libc
+- * implementations like muslc crash otherwise
++ * implementations like muslc crash otherwise. If you are unlucky
++ * to be running on a system with a 32 bit time_t, then it is even less.
+  */
+-#define	MAX_CTIME	CAST(time_t, 0x3afff487cfULL)
++#define	MAX_CTIME \
++    CAST(time_t, sizeof(time_t) > 4 ? 0x3afff487cfULL : 0x7fffffffULL)
+ 
+ #define FILE_BADSIZE CAST(size_t, ~0ul)
+ #define MAXDESC	64		/* max len of text description/MIME type */

--- a/pkgs/tools/misc/file/default.nix
+++ b/pkgs/tools/misc/file/default.nix
@@ -16,20 +16,33 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "file";
-  version = "5.46";
+  version = "5.45";
 
   src = fetchurl {
     urls = [
       "https://astron.com/pub/file/file-${finalAttrs.version}.tar.gz"
       "https://distfiles.macports.org/file/file-${finalAttrs.version}.tar.gz"
     ];
-    hash = "sha256-ycx3x8VgxUMTXtxVWvYJ1WGdvvARmX6YjOQKPXXYYIg=";
+    hash = "sha256-/Jf1ECm7DiyfTjv/79r2ePDgOe6HK53lwAKm0Jx4TYI=";
   };
 
   outputs = [
     "out"
     "dev"
     "man"
+  ];
+
+  patches = [
+    # Upstream patch to fix 32-bit tests.
+    #
+    # It is included in 5.46+, but we are not updating to it or a later version until:
+    #
+    # https://bugs.astron.com/view.php?id=622
+    #
+    # is resolved. See also description of the bug here:
+    #
+    # https://github.com/NixOS/nixpkgs/pull/402318#issuecomment-2881163359
+    ./32-bit-time_t.patch
   ];
 
   strictDeps = true;


### PR DESCRIPTION
## Description of changes


## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
