### PR TITLE
rnnoise-plugin: split outputs

### DIFF
--- a/pkgs/by-name/rn/rnnoise-plugin/package.nix
+++ b/pkgs/by-name/rn/rnnoise-plugin/package.nix
@@ -13,7 +13,13 @@
 stdenv.mkDerivation rec {
   pname = "rnnoise-plugin";
   version = "1.10";
-  outputs = [ "out" "ladspa" "lv2" "lxvst" "vst3" ];
+  outputs = [
+    "out"
+    "ladspa"
+    "lv2"
+    "lxvst"
+    "vst3"
+  ];
 
   src = fetchFromGitHub {
     owner = "werman";

--- a/pkgs/by-name/rn/rnnoise-plugin/package.nix
+++ b/pkgs/by-name/rn/rnnoise-plugin/package.nix
@@ -13,6 +13,7 @@
 stdenv.mkDerivation rec {
   pname = "rnnoise-plugin";
   version = "1.10";
+  outputs = [ "out" "ladspa" "lv2" "lxvst" "vst3" ];
 
   src = fetchFromGitHub {
     owner = "werman";
@@ -42,6 +43,15 @@ stdenv.mkDerivation rec {
     ++ lib.optionals stdenv.hostPlatform.isLinux [
       webkitgtk_4_0
     ];
+
+  # Move each plugin into a dedicated output, leaving a symlink in $out for backwards compatibility
+  postInstall = ''
+    for plugin in ladspa lv2 lxvst vst3; do
+      mkdir -p ''${!plugin}/lib
+      mv $out/lib/$plugin ''${!plugin}/lib/$plugin
+      ln -s ''${!plugin}/lib/$plugin $out/lib/$plugin
+    done
+  '';
 
   meta = with lib; {
     description = "Real-time noise suppression plugin for voice based on Xiph's RNNoise";


### PR DESCRIPTION
Split `rnnoise-plugin` with per-plugin-type derivation outputs.

The build remains monolithic, and the default output functionally identical (using symlinks from `lib/*` to the individual outputs)

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
