### PR TITLE
nbxplorer: 2.5.25 -> 2.5.26

### DIFF
--- a/pkgs/by-name/nb/nbxplorer/deps.json
+++ b/pkgs/by-name/nb/nbxplorer/deps.json
@@ -166,13 +166,13 @@
   },
   {
     "pname": "NBitcoin",
-    "version": "8.0.4",
-    "hash": "sha256-9GxJVcByg3zHl9uR01KpTkFkwKuFyr2hm0uZWWlDGeE="
+    "version": "8.0.12",
+    "hash": "sha256-OBJu6fQd0MBKSVHERI7EBtSQQvAL9T8Gr0e7Kx2q9/I="
   },
   {
     "pname": "NBitcoin.Altcoins",
-    "version": "4.0.4",
-    "hash": "sha256-fHG/dlTbEu9DjFnHpEVI6/LbVz0BSJdqkPOo6tQW0fg="
+    "version": "4.0.7",
+    "hash": "sha256-WN9uLRlIW+WGUSS4NE7ZE8kftQEaVDh7AnT1+P8g2gg="
   },
   {
     "pname": "NETStandard.Library",

--- a/pkgs/by-name/nb/nbxplorer/package.nix
+++ b/pkgs/by-name/nb/nbxplorer/package.nix
@@ -7,13 +7,13 @@
 
 buildDotnetModule rec {
   pname = "nbxplorer";
-  version = "2.5.25";
+  version = "2.5.26";
 
   src = fetchFromGitHub {
     owner = "dgarage";
     repo = "NBXplorer";
     tag = "v${version}";
-    hash = "sha256-RTkKyckdAv6+wJSlDlR+Q8fw0aZEbi4AwB+OPHI7TR4=";
+    hash = "sha256-gXLzUgFZxrDNbDjpPmVDIj2xi6I+IfkNwXBYvelRYPU=";
   };
 
   projectFile = "NBXplorer/NBXplorer.csproj";


### PR DESCRIPTION
Fixes nbxplorer crashing when parsing block 896727:
https://github.com/MetacoSA/NBitcoin/pull/1269

- [x] Built and run on `x86_64-linux`

cc @prusnak