### PR TITLE
f3d: Add openusd plugin

### DIFF
--- a/pkgs/by-name/f3/f3d/package.nix
+++ b/pkgs/by-name/f3/f3d/package.nix
@@ -6,6 +6,9 @@
   cmake,
   help2man,
   gzip,
+  libXt,
+  openusd,
+  tbb,
   # There is a f3d overridden with EGL enabled vtk in top-level/all-packages.nix
   # compiling with EGL enabled vtk will result in f3d running in headless mode
   # See https://github.com/NixOS/nixpkgs/pull/324022. This may change later.
@@ -17,6 +20,7 @@
   fontconfig,
   withManual ? !stdenv.hostPlatform.isDarwin,
   withPythonBinding ? false,
+  withUsd ? openusd.meta.available,
 }:
 
 stdenv.mkDerivation rec {
@@ -66,6 +70,11 @@ stdenv.mkDerivation rec {
       python3Packages.python
       # Using C++ header files, not Python import
       python3Packages.pybind11
+    ]
+    ++ lib.optionals withUsd [
+      libXt
+      openusd
+      tbb
     ];
 
   cmakeFlags =
@@ -84,6 +93,9 @@ stdenv.mkDerivation rec {
     ]
     ++ lib.optionals withPythonBinding [
       "-DF3D_BINDINGS_PYTHON=ON"
+    ]
+    ++ lib.optionals withUsd [
+      "-DF3D_PLUGIN_BUILD_USD=ON"
     ];
 
   meta = with lib; {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This enables support for usd files.

example model (have to unpack as gh doesn't support usdz attachments):
[cube.zip](https://github.com/user-attachments/files/20228325/cube.zip)

Because this pulls in a lot of deps, I have made it optional, but we can include it unconditionally too or have it disabled by default.

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review`

---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 13 packages built:</summary>
  <ul>
    <li>exhibit</li>
    <li>f3d</li>
    <li>f3d.man</li>
    <li>f3d_egl</li>
    <li>f3d_egl.man</li>
    <li>python312Packages.f3d</li>
    <li>python312Packages.f3d.man</li>
    <li>python312Packages.f3d_egl</li>
    <li>python312Packages.f3d_egl.man</li>
    <li>python313Packages.f3d</li>
    <li>python313Packages.f3d.man</li>
    <li>python313Packages.f3d_egl</li>
    <li>python313Packages.f3d_egl.man</li>
  </ul>
</details>


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
