### PR TITLE
catppuccin-plymouth: fix variant selection

### DIFF
--- a/pkgs/by-name/ca/catppuccin-plymouth/package.nix
+++ b/pkgs/by-name/ca/catppuccin-plymouth/package.nix
@@ -1,9 +1,9 @@
-{
-  stdenvNoCC,
-  lib,
-  fetchFromGitHub,
-  unstableGitUpdater,
-  variant ? "macchiato",
+{ stdenvNoCC
+, lib
+, fetchFromGitHub
+, unstableGitUpdater
+, variant ? "macchiato"
+,
 }:
 
 let

--- a/pkgs/by-name/ca/catppuccin-plymouth/package.nix
+++ b/pkgs/by-name/ca/catppuccin-plymouth/package.nix
@@ -15,9 +15,9 @@ let
     "mocha"
   ];
 in
-lib.checkListOfEnum "${pname}: color variant" validVariants [ variant ]
+assert lib.assertOneOf "${pname}: color variant" variant validVariants;
 
-  stdenvNoCC.mkDerivation
+stdenvNoCC.mkDerivation
   (finalAttrs: {
     inherit pname;
     version = "0-unstable-2024-10-19";

--- a/pkgs/by-name/ca/catppuccin-plymouth/package.nix
+++ b/pkgs/by-name/ca/catppuccin-plymouth/package.nix
@@ -1,9 +1,9 @@
-{ stdenvNoCC
-, lib
-, fetchFromGitHub
-, unstableGitUpdater
-, variant ? "macchiato"
-,
+{
+  stdenvNoCC,
+  lib,
+  fetchFromGitHub,
+  unstableGitUpdater,
+  variant ? "macchiato",
 }:
 
 let
@@ -17,40 +17,39 @@ let
 in
 assert lib.assertOneOf "${pname}: color variant" variant validVariants;
 
-stdenvNoCC.mkDerivation
-  (finalAttrs: {
-    inherit pname;
-    version = "0-unstable-2024-10-19";
+stdenvNoCC.mkDerivation (finalAttrs: {
+  inherit pname;
+  version = "0-unstable-2024-10-19";
 
-    src = fetchFromGitHub {
-      owner = "catppuccin";
-      repo = "plymouth";
-      rev = "e0f58d6fcf3dbc2d35dfc4fec394217fbfa92666";
-      hash = "sha256-He6ER1QNrJCUthFoBBGHBINouW/tozxQy3R79F5tsuo=";
-    };
+  src = fetchFromGitHub {
+    owner = "catppuccin";
+    repo = "plymouth";
+    rev = "e0f58d6fcf3dbc2d35dfc4fec394217fbfa92666";
+    hash = "sha256-He6ER1QNrJCUthFoBBGHBINouW/tozxQy3R79F5tsuo=";
+  };
 
-    sourceRoot = "${finalAttrs.src.name}/themes/catppuccin-${variant}";
+  sourceRoot = "${finalAttrs.src.name}/themes/catppuccin-${variant}";
 
-    installPhase = ''
-      runHook preInstall
+  installPhase = ''
+    runHook preInstall
 
-      sed -i 's:\(^ImageDir=\)/usr:\1'"$out"':' catppuccin-${variant}.plymouth
-      mkdir -p $out/share/plymouth/themes/catppuccin-${variant}
-      cp * $out/share/plymouth/themes/catppuccin-${variant}
+    sed -i 's:\(^ImageDir=\)/usr:\1'"$out"':' catppuccin-${variant}.plymouth
+    mkdir -p $out/share/plymouth/themes/catppuccin-${variant}
+    cp * $out/share/plymouth/themes/catppuccin-${variant}
 
-      runHook postInstall
-    '';
+    runHook postInstall
+  '';
 
-    passthru.updateScript = unstableGitUpdater { };
+  passthru.updateScript = unstableGitUpdater { };
 
-    meta = {
-      description = "Soothing pastel theme for Plymouth";
-      homepage = "https://github.com/catppuccin/plymouth";
-      license = lib.licenses.mit;
-      platforms = lib.platforms.linux;
-      maintainers = with lib.maintainers; [
-        johnrtitor
-        spectre256
-      ];
-    };
-  })
+  meta = {
+    description = "Soothing pastel theme for Plymouth";
+    homepage = "https://github.com/catppuccin/plymouth";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [
+      johnrtitor
+      spectre256
+    ];
+  };
+})


### PR DESCRIPTION
The package previously had an issue where it defined valid variants but did not properly connect the validation to the derivation. This resulted in only the default "macchiato" variant being accessible.

Fixed by replacing `lib.checkListOfEnum` with `assert lib.assertOneOf` to properly validate and allow selection of all defined variants: "latte", "frappe", "macchiato" and "mocha".

Tested by successfully building the package with each variant.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
