### PR TITLE
uwu-colors: init at 0.4.0

### DIFF
--- a/pkgs/by-name/uw/uwu-colors/package.nix
+++ b/pkgs/by-name/uw/uwu-colors/package.nix
@@ -1,0 +1,28 @@
+{
+  lib,
+  fetchFromGitea,
+  rustPlatform,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "uwu-colors";
+  version = "0.4.0";
+
+  src = fetchFromGitea {
+    domain = "codeberg.org";
+    owner = "q60";
+    repo = "uwu_colors";
+    tag = finalAttrs.version;
+    hash = "sha256-qzqfLTww0m1rv/7oJZrHMk63CtOk4RzY+Owx0oqlVzI=";
+  };
+
+  cargoHash = "sha256-R/IZUFr8Cir34c+C7Kq6FTFEERiInGMF8yFcC0uQ7Us=";
+
+  meta = {
+    description = "Simple LSP server made to display colors via textDocument/documentColor";
+    mainProgram = "uwu_colors";
+    homepage = "https://codeberg.org/q60/uwu_colors";
+    license = lib.licenses.unlicense;
+    maintainers = with lib.maintainers; [ vel ];
+  };
+})


### PR DESCRIPTION
a simple albeit useful language server that i made after color swatches were introduced in helix. there was no such LSP server for generic use between different languages, so i made one. some folks that use this piece of software asked for more packaging options and i decided to make this a nix package. and there's a bunch of people who don't like flakes and prefer nix packages over them

links:
- https://codeberg.org/q60/uwu_colors
- https://github.com/q60/uwu_colors (serves as a mirror and as an easier way for people to contribute)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

i really hope i haven't missed something in the contribution guidelines. however after reading yet again, i don't really understanding package naming conventions and made this into a `kebab-case` one. i've literally forgotten everything...
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
