### PR TITLE
python3Packages.omemo: init at 1.2.0, python3Packages.twomemo: init at 1.1.0, python3Packages.oldmemo: init at 1.1.0

### DIFF
--- a/pkgs/development/python-modules/oldmemo/default.nix
+++ b/pkgs/development/python-modules/oldmemo/default.nix
@@ -1,0 +1,60 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  setuptools,
+
+  typing-extensions,
+  xeddsa,
+  doubleratchet,
+  omemo,
+  x3dh,
+  cryptography,
+  protobuf,
+
+  xmlschema,
+}:
+
+buildPythonPackage rec {
+  pname = "oldmemo";
+  version = "1.1.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "Syndace";
+    repo = "python-oldmemo";
+    tag = "v${version}";
+    hash = "sha256-iAsp42VcGsf3Nhk0I97Wi3SlpLxcA6BkVaFm1yY0HrY=";
+  };
+
+  build-system = [
+    setuptools
+  ];
+
+  dependencies = [
+    typing-extensions
+    xeddsa
+    doubleratchet
+    omemo
+    x3dh
+    cryptography
+    protobuf
+  ];
+
+  optional-dependencies.xml = [
+    xmlschema
+  ];
+
+  pythonImportsCheck = [
+    "oldmemo"
+  ];
+
+  meta = {
+    description = "Backend implementation of the `eu.siacs.conversations.axolotl` namespace for python-omemo";
+    homepage = "https://github.com/Syndace/python-oldmemo";
+    changelog = "https://github.com/Syndace/python-oldmemo/blob/${src.tag}/CHANGELOG.md";
+    license = lib.licenses.agpl3Plus;
+    maintainers = with lib.maintainers; [ themadbit ];
+  };
+}

--- a/pkgs/development/python-modules/omemo/default.nix
+++ b/pkgs/development/python-modules/omemo/default.nix
@@ -1,0 +1,74 @@
+{
+  lib,
+  fetchFromGitHub,
+  buildPythonPackage,
+
+  setuptools,
+
+  typing-extensions,
+  xeddsa,
+
+  pytestCheckHook,
+  oldmemo,
+
+  # passthru
+  omemo,
+}:
+buildPythonPackage rec {
+  pname = "omemo";
+  version = "1.2.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "Syndace";
+    repo = "python-omemo";
+    tag = "v${version}";
+    hash = "sha256-egb4UFoF/gS3LKutArnJSXxDYH/xyBLOxWec98rOT9Y=";
+  };
+
+  build-system = [
+    setuptools
+  ];
+
+  dependencies = [
+    typing-extensions
+    xeddsa
+  ];
+
+  doCheck = false;
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    oldmemo
+  ]
+  ++ oldmemo.optional-dependencies.xml;
+
+  pythonImportsCheck = [
+    "omemo"
+  ];
+
+  passthru.tests = {
+    pytest = omemo.overridePythonAttrs {
+      doCheck = true;
+    };
+  };
+
+  meta = {
+    description = "Open python implementation of the OMEMO Multi-End Message and Object Encryption protocol";
+    longDescription = ''
+      A complete implementation of XEP-0384 on protocol-level, i.e. more than just the cryptography.
+      python-omemo supports different versions of the specification through so-called backends.
+
+      A backend for OMEMO in the urn:xmpp:omemo:2 namespace (the most recent version of the specification) is available
+      in the python-twomemo Python package.
+      A backend for (legacy) OMEMO in the eu.siacs.conversations.axolotl namespace is available in the python-oldmemo
+      package.
+      Multiple backends can be loaded and used at the same time, the library manages their coexistence transparently.
+    '';
+    homepage = "https://github.com/Syndace/python-omemo";
+    changelog = "https://github.com/Syndace/python-omemo/blob/${src.tag}/CHANGELOG.md";
+    license = lib.licenses.mit;
+    teams = with lib.teams; [ ngi ];
+    maintainers = with lib.maintainers; [ themadbit ];
+  };
+}

--- a/pkgs/development/python-modules/twomemo/default.nix
+++ b/pkgs/development/python-modules/twomemo/default.nix
@@ -1,0 +1,55 @@
+{
+  lib,
+  fetchFromGitHub,
+  buildPythonPackage,
+  setuptools,
+  doubleratchet,
+  omemo,
+  x3dh,
+  xeddsa,
+  protobuf,
+  typing-extensions,
+  xmlschema,
+}:
+buildPythonPackage rec {
+  pname = "twomemo";
+  version = "1.1.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "Syndace";
+    repo = "python-twomemo";
+    tag = "v${version}";
+    hash = "sha256-jkazeFdNK0iB76oyHbQu+TLaGz+SH/30CmqXk0K6Sy8=";
+  };
+
+  strictDeps = true;
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    doubleratchet
+    omemo
+    x3dh
+    xeddsa
+    protobuf
+    typing-extensions
+  ];
+
+  optional-dependencies.xml = [
+    xmlschema
+  ];
+
+  pythonImportsCheck = [
+    "twomemo"
+  ];
+
+  meta = {
+    description = "Backend implementation of the urn:xmpp:omemo:2 namespace for python-omemo";
+    homepage = "https://github.com/Syndace/python-twomemo";
+    changelog = "https://github.com/Syndace/python-twomemo/blob/v${version}/CHANGELOG.md";
+    license = lib.licenses.mit;
+    teams = with lib.teams; [ ngi ];
+    maintainers = with lib.maintainers; [ themadbit ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10639,6 +10639,8 @@ self: super: with self; {
 
   omegaconf = callPackage ../development/python-modules/omegaconf { };
 
+  omemo = callPackage ../development/python-modules/omemo { };
+
   omemo-dr = callPackage ../development/python-modules/omemo-dr { };
 
   omnikinverter = callPackage ../development/python-modules/omnikinverter { };
@@ -18414,6 +18416,8 @@ self: super: with self; {
   twitterapi = callPackage ../development/python-modules/twitterapi { };
 
   twofish = callPackage ../development/python-modules/twofish { };
+
+  twomemo = callPackage ../development/python-modules/twomemo { };
 
   twscrape = callPackage ../development/python-modules/twscrape { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10629,6 +10629,8 @@ self: super: with self; {
 
   oldest-supported-numpy = callPackage ../development/python-modules/oldest-supported-numpy { };
 
+  oldmemo = callPackage ../development/python-modules/oldmemo { };
+
   olefile = callPackage ../development/python-modules/olefile { };
 
   oletools = callPackage ../development/python-modules/oletools { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Add two python3Packages
- omemo
- twomemo
- oldmemo
---
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
