### PR TITLE
python3Packages.unsloth: 2025.4.1 -> 2025.5.9

### DIFF
--- a/pkgs/development/python-modules/trl/default.nix
+++ b/pkgs/development/python-modules/trl/default.nix
@@ -16,14 +16,14 @@
 
 buildPythonPackage rec {
   pname = "trl";
-  version = "0.15.2";
+  version = "0.17.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "huggingface";
     repo = "trl";
     tag = "v${version}";
-    hash = "sha256-HsSmFXFqDOWVLa6VXdPZVS9C3bjYcsliR0TwNpPiQx4=";
+    hash = "sha256-kRZhtrKGNTJ9TJypRG9dABNn00w77dwx+JxT+2PUrfY=";
   };
 
   build-system = [
@@ -46,7 +46,7 @@ buildPythonPackage rec {
   meta = {
     description = "Train transformer language models with reinforcement learning";
     homepage = "https://github.com/huggingface/trl";
-    changelog = "https://github.com/huggingface/trl/releases/tag/v${version}";
+    changelog = "https://github.com/huggingface/trl/releases/tag/${src.tag}";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ hoh ];
   };

--- a/pkgs/development/python-modules/unsloth-zoo/default.nix
+++ b/pkgs/development/python-modules/unsloth-zoo/default.nix
@@ -13,6 +13,7 @@
   datasets,
   hf-transfer,
   huggingface-hub,
+  msgspec,
   packaging,
   peft,
   psutil,
@@ -26,14 +27,14 @@
 
 buildPythonPackage rec {
   pname = "unsloth-zoo";
-  version = "2025.4.1";
+  version = "2025.5.11";
   pyproject = true;
 
   # no tags on GitHub
   src = fetchPypi {
     pname = "unsloth_zoo";
     inherit version;
-    hash = "sha256-mRs/NMCNJWT52S7mtbQI332IQR6+/IaL29XmtMOz3fE=";
+    hash = "sha256-QRKcFkNlr7pICEy3il+za6hDYjvsSxHIBM6VaB1c5mk=";
   };
 
   # pyproject.toml requires an obsolete version of protobuf,
@@ -41,6 +42,7 @@ buildPythonPackage rec {
   # Upstream issue: https://github.com/unslothai/unsloth-zoo/pull/68
   pythonRelaxDeps = [
     "protobuf"
+    "transformers"
   ];
 
   patches = [
@@ -59,6 +61,7 @@ buildPythonPackage rec {
     datasets
     hf-transfer
     huggingface-hub
+    msgspec
     packaging
     peft
     psutil

--- a/pkgs/development/python-modules/unsloth-zoo/dont-require-unsloth.patch
+++ b/pkgs/development/python-modules/unsloth-zoo/dont-require-unsloth.patch
@@ -1,14 +1,26 @@
 diff --git a/unsloth_zoo/__init__.py b/unsloth_zoo/__init__.py
+index a629854..06014b1 100644
 --- a/unsloth_zoo/__init__.py
 +++ b/unsloth_zoo/__init__.py
-@@ -17,14 +17,10 @@
- __version__ = "2025.3.17"
+@@ -17,8 +17,6 @@
+ __version__ = "2025.5.11"
  
  from importlib.util import find_spec
 -if find_spec("unsloth") is None:
 -    raise ImportError("Please install Unsloth via `pip install unsloth`!")
  pass
  del find_spec
+ 
+@@ -28,13 +26,14 @@ def get_device_type():
+         return "cuda"
+     elif hasattr(torch, "xpu") and torch.xpu.is_available():
+         return "xpu"
++    else:
++        # Allow import during tests
++        return None
+     raise NotImplementedError("Unsloth currently only works on NVIDIA GPUs and Intel GPUs.")
+ pass
+ DEVICE_TYPE : str = get_device_type()
  
  import os
 -if not ("UNSLOTH_IS_PRESENT" in os.environ):

--- a/pkgs/development/python-modules/unsloth/default.nix
+++ b/pkgs/development/python-modules/unsloth/default.nix
@@ -31,14 +31,14 @@
 
 buildPythonPackage rec {
   pname = "unsloth";
-  version = "2025.4.1";
+  version = "2025.5.9";
   pyproject = true;
 
   # Tags on the GitHub repo don't match
   src = fetchPypi {
     pname = "unsloth";
     inherit version;
-    hash = "sha256-9LtDGfdWH7R3U/xi+aK3V4zA+vs83S6Cp0F2NQKvSdY=";
+    hash = "sha256-ud4+6BmyNvtvJz56dhS9SIXxTDw740rSfxxoi5itw4U=";
   };
 
   build-system = [
@@ -73,6 +73,7 @@ buildPythonPackage rec {
   # Upstream issue: https://github.com/unslothai/unsloth-zoo/pull/68
   pythonRelaxDeps = [
     "protobuf"
+    "transformers"
   ];
 
   # The source repository contains no test


### PR DESCRIPTION
Blog notes: https://unsloth.ai/blog/tts

> You can now train Text-to-Speech (TTS) models in Unsloth! Fine-tuning TTS models enables them to adapt to your specific dataset, use case, or desired vocal style and tone. The goal is to customize these models for tasks such as voice cloning, speaking style adaptation, tone modulation, multilingual support, and other specialized applications.

Updated `unsloth` and `unsloth-zoo`.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
