### PR TITLE
pdftk: use minimal jre

### DIFF
--- a/pkgs/by-name/pd/pdftk/package.nix
+++ b/pkgs/by-name/pd/pdftk/package.nix
@@ -3,12 +3,21 @@
   stdenv,
   fetchFromGitLab,
   gradle_8,
-  jre,
+  jre_headless,
+  jre_minimal,
   runtimeShell,
 }:
 let
   # "Deprecated Gradle features were used in this build, making it incompatible with Gradle 9.0."
   gradle = gradle_8;
+
+  jre = jre_minimal.override {
+    modules = [
+      "java.base"
+      "java.desktop"
+    ];
+    jdk = jre_headless;
+  };
 in
 stdenv.mkDerivation rec {
   pname = "pdftk";


### PR DESCRIPTION
@lheckemann 

## Things done

I've used the upstream test files to execute form_fill and ran the upstream test suite with the following test only relevant points:
- I bumped org.jacoco to support our jdk
- coverage generation failed but all tests passed

```
 ➜ PATH=/nix/store/szhsh4rdf2v4xqn5p2xgnkwwa6ch5486-openjdk-headless-minimal-jre-21.0.7+6/bin:/nix/store/qagnl38l96xcbx17ll0v9zswhcl1nqw6-openjdk-21.0.7+6/lib/openjdk/bin:$PATH strace -ff -o 1000 ant -lib apache-ivy-2.5.3/ -lib ./lib test
Buildfile: /home/sandro/src/gitlab.com/pdftk-java/pdftk/build.xml
Trying to override old definition of task javac

test-resolve:
[ivy:retrieve] :: Apache Ivy 2.5.3 - 20241223125031 :: https://ant.apache.org/ivy/ ::
[ivy:retrieve] :: loading settings :: url = jar:file:/home/sandro/src/gitlab.com/pdftk-java/pdftk/apache-ivy-2.5.3/ivy-2.5.3.jar!/org/apache/ivy/core/settings/ivysettings.xml
[ivy:retrieve] :: resolving dependencies :: com.gitlab.pdftk_java#pdftk;working@magnesium
[ivy:retrieve]  confs: [test]
[ivy:retrieve]  found org.bouncycastle#bcprov-jdk18on;1.71 in public
[ivy:retrieve]  found org.apache.commons#commons-lang3;3.12.0 in public
[ivy:retrieve]  found junit#junit;4.12 in public
[ivy:retrieve]  found org.hamcrest#hamcrest-core;1.3 in public
[ivy:retrieve]  found com.github.stefanbirkner#system-rules;1.19.0 in public
[ivy:retrieve]  found junit#junit-dep;4.11 in public
[ivy:retrieve]  [4.11] junit#junit-dep;[4.9,)
[ivy:retrieve]  found org.jacoco#org.jacoco.ant;0.8.13 in public
[ivy:retrieve]  found org.jacoco#org.jacoco.core;0.8.13 in public
[ivy:retrieve]  found org.ow2.asm#asm;9.8 in public
[ivy:retrieve]  found org.ow2.asm#asm-commons;9.8 in public
[ivy:retrieve]  found org.ow2.asm#asm-tree;9.8 in public
[ivy:retrieve]  found org.jacoco#org.jacoco.report;0.8.13 in public
[ivy:retrieve]  found org.jacoco#org.jacoco.agent;0.8.13 in public
[ivy:retrieve] :: resolution report :: resolve 1617ms :: artifacts dl 52ms
[ivy:retrieve]  :: evicted modules:
[ivy:retrieve]  junit#junit;4.11 by [junit#junit;4.12] in [test]
        ---------------------------------------------------------------------
        |                  |            modules            ||   artifacts   |
        |       conf       | number| search|dwnlded|evicted|| number|dwnlded|
        ---------------------------------------------------------------------
        |       test       |   14  |   1   |   0   |   1   ||   12  |   0   |
        ---------------------------------------------------------------------
[ivy:retrieve] :: retrieving :: com.gitlab.pdftk_java#pdftk
[ivy:retrieve]  confs: [test]
[ivy:retrieve]  0 artifacts copied, 12 already retrieved (0kB/15ms)

compile:
    [javac] Compiling 1 source file to /home/sandro/src/gitlab.com/pdftk-java/pdftk/build/classes
    [javac] warning: [options] bootstrap class path not set in conjunction with -source 8
    [javac] warning: [options] source value 8 is obsolete and will be removed in a future release
    [javac] warning: [options] target value 8 is obsolete and will be removed in a future release
    [javac] warning: [options] To suppress warnings about obsolete options, use -Xlint:-options.
    [javac] 4 warnings

test-compile:

test-run:
[jacoco:coverage] Enhancing junit with coverage
    [junit] Testsuite: com.gitlab.pdftk_java.AnnotationsTest
    [junit] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.597 sec
    [junit]
    [junit] Testcase: dump_text took 0.465 sec
    [junit] Testcase: dump_links took 0.079 sec
    [junit] Testsuite: com.gitlab.pdftk_java.AttachFilesTest
    [junit] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.35 sec
    [junit]
    [junit] Testcase: attach_to_page took 0.259 sec
    [junit] Testcase: no_attachment took 0.006 sec
    [junit] Testcase: attach_one_file took 0.016 sec
    [junit] Testcase: attach_relation took 0.041 sec
    [junit] Testcase: same_file_twice took 0.022 sec
    [junit] Testsuite: com.gitlab.pdftk_java.BurstTest
    [junit] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.088 sec
    [junit]
    [junit] Testcase: burst_issue18 took 0.067 sec
    [junit] Testcase: burst_issue90 took 0.019 sec
    [junit] Testsuite: com.gitlab.pdftk_java.CatTest
    [junit] Tests run: 11, Failures: 8, Errors: 0, Skipped: 0, Time elapsed: 1.366 sec
    [junit]
    [junit] Testcase: cat_rotate_page_no_op took 0.137 sec
    [junit]     FAILED
    [junit] pdftocairo error
    [junit] junit.framework.AssertionFailedError: pdftocairo error
    [junit]     at com.gitlab.pdftk_java.BlackBox.assertPdfEqualsAsSVG(BlackBox.java:111)
    [junit]     at com.gitlab.pdftk_java.CatTest.cat_rotate_page_no_op(CatTest.java:21)
    [junit]     at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
    [junit]
    [junit] Testcase: cat_rotate_range took 0.135 sec
    [junit]     FAILED
    [junit] pdftocairo error
    [junit] junit.framework.AssertionFailedError: pdftocairo error
    [junit]     at com.gitlab.pdftk_java.BlackBox.assertPdfEqualsAsSVG(BlackBox.java:111)
    [junit]     at com.gitlab.pdftk_java.CatTest.cat_rotate_range(CatTest.java:40)
    [junit]     at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
    [junit]
    [junit] Testcase: cat_rotate_page took 0.008 sec
    [junit] Testcase: cat_include_exclude_range took 0.166 sec
    [junit]     FAILED
    [junit] pdftocairo error
    [junit] junit.framework.AssertionFailedError: pdftocairo error
    [junit]     at com.gitlab.pdftk_java.BlackBox.assertPdfEqualsAsSVG(BlackBox.java:111)
    [junit]     at com.gitlab.pdftk_java.CatTest.cat_include_exclude_range(CatTest.java:54)
    [junit]     at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
    [junit]
    [junit] Testcase: cat took 0.187 sec
    [junit]     FAILED
    [junit] pdftocairo error
    [junit] junit.framework.AssertionFailedError: pdftocairo error
    [junit]     at com.gitlab.pdftk_java.BlackBox.assertPdfEqualsAsSVG(BlackBox.java:111)
    [junit]     at com.gitlab.pdftk_java.CatTest.cat(CatTest.java:14)
    [junit]     at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
    [junit]
    [junit] Testcase: cat_even took 0.198 sec
    [junit]     FAILED
    [junit] pdftocairo error
    [junit] junit.framework.AssertionFailedError: pdftocairo error
    [junit]     at com.gitlab.pdftk_java.BlackBox.assertPdfEqualsAsSVG(BlackBox.java:111)
    [junit]     at com.gitlab.pdftk_java.CatTest.cat_even(CatTest.java:61)
    [junit]     at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
    [junit]
    [junit] Testcase: cat_handles took 0.138 sec
    [junit] Testcase: cat_rotate_range_no_op took 0.102 sec
    [junit]     FAILED
    [junit] pdftocairo error
    [junit] junit.framework.AssertionFailedError: pdftocairo error
    [junit]     at com.gitlab.pdftk_java.BlackBox.assertPdfEqualsAsSVG(BlackBox.java:111)
    [junit]     at com.gitlab.pdftk_java.CatTest.cat_rotate_range_no_op(CatTest.java:28)
    [junit]     at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
    [junit]
    [junit] Testcase: cat_odd took 0.144 sec
    [junit]     FAILED
    [junit] pdftocairo error
    [junit] junit.framework.AssertionFailedError: pdftocairo error
    [junit]     at com.gitlab.pdftk_java.BlackBox.assertPdfEqualsAsSVG(BlackBox.java:111)
    [junit]     at com.gitlab.pdftk_java.CatTest.cat_odd(CatTest.java:68)
    [junit]     at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
    [junit]
    [junit] Testcase: duplicate_stdin took 0.008 sec
    [junit] Testcase: cat_exclude_range took 0.112 sec
    [junit]     FAILED
    [junit] pdftocairo error
    [junit] junit.framework.AssertionFailedError: pdftocairo error
    [junit]     at com.gitlab.pdftk_java.BlackBox.assertPdfEqualsAsSVG(BlackBox.java:111)
    [junit]     at com.gitlab.pdftk_java.CatTest.cat_exclude_range(CatTest.java:47)
    [junit]     at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
    [junit]
    [junit] TEST com.gitlab.pdftk_java.CatTest FAILED
    [junit] Testsuite: com.gitlab.pdftk_java.CommandParserTest
    [junit] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.021 sec
    [junit] ------------- Standard Error -----------------
    [junit] Error: No input files.  Exiting.
    [junit] Errors encountered.  No output created.
    [junit] Error: Unexpected data in output section:
    [junit]       cat
    [junit] Exiting.
    [junit] Errors encountered.  No output created.
    [junit] Error: Multiple output filenames given:
    [junit]    - and -
    [junit] Exiting.
    [junit] Errors encountered.  No output created.
    [junit] ------------- ---------------- ---------------
    [junit]
    [junit] Testcase: TestNoOperationCat took 0.004 sec
    [junit] Testcase: TestNoOperationFilter took 0.003 sec
    [junit] Testcase: TestNoInput took 0 sec
    [junit] Testcase: TestOperationAfterOutput took 0.002 sec
    [junit] Testcase: TestEmpty took 0 sec
    [junit] Testcase: TestNoOutput took 0.002 sec
    [junit] Testcase: TestNoInputNoOp took 0 sec
    [junit] Testcase: TestTwoOutputs took 0.002 sec
    [junit] Testsuite: com.gitlab.pdftk_java.CryptoTest
    [junit] Tests run: 5, Failures: 2, Errors: 0, Skipped: 0, Time elapsed: 0.636 sec
    [junit] ------------- Standard Error -----------------
    [junit] Warning: Using a password on the command line interface can be insecure.
    [junit] Use the keyword PROMPT to supply a password via standard input instead.
    [junit] Error: Failed to open input PDF file:
    [junit]    /tmp/junit12829661427099199932/encrypted.pdf
    [junit]    OWNER OR USER PASSWORD REQUIRED, but not given
    [junit] Errors encountered.  No output created.
    [junit] Done.  Input errors, so no output created.
    [junit] Warning: Using a password on the command line interface can be insecure.
    [junit] Use the keyword PROMPT to supply a password via standard input instead.
    [junit] Warning: Using a password on the command line interface can be insecure.
    [junit] Use the keyword PROMPT to supply a password via standard input instead.
    [junit] Warning: Using a password on the command line interface can be insecure.
    [junit] Use the keyword PROMPT to supply a password via standard input instead.
    [junit] Warning: Using a password on the command line interface can be insecure.
    [junit] Use the keyword PROMPT to supply a password via standard input instead.
    [junit] Warning: Using a password on the command line interface can be insecure.
    [junit] Use the keyword PROMPT to supply a password via standard input instead.
    [junit] Warning: Using a password on the command line interface can be insecure.
    [junit] Use the keyword PROMPT to supply a password via standard input instead.
    [junit] Warning: Using a password on the command line interface can be insecure.
    [junit] Use the keyword PROMPT to supply a password via standard input instead.
    [junit] Warning: Using a password on the command line interface can be insecure.
    [junit] Use the keyword PROMPT to supply a password via standard input instead.
    [junit] Error: Failed to open input PDF file:
    [junit]    /tmp/junit2801568040500523787/encrypted.pdf
    [junit]    OWNER OR USER PASSWORD REQUIRED, but incorrect
    [junit] Errors encountered.  No output created.
    [junit] Done.  Input errors, so no output created.
    [junit] ------------- ---------------- ---------------
    [junit]
    [junit] Testcase: no_password_fails took 0.338 sec
    [junit] Testcase: idempotent_aes took 0.151 sec
    [junit]     FAILED
    [junit] pdftocairo error
    [junit] junit.framework.AssertionFailedError: pdftocairo error
    [junit]     at com.gitlab.pdftk_java.BlackBox.assertPdfEqualsAsSVG(BlackBox.java:111)
    [junit]     at com.gitlab.pdftk_java.CryptoTest.idempotent_aes(CryptoTest.java:20)
    [junit]     at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
    [junit]
    [junit] Testcase: idempotent_rc4 took 0.117 sec
    [junit]     FAILED
    [junit] pdftocairo error
    [junit] junit.framework.AssertionFailedError: pdftocairo error
    [junit]     at com.gitlab.pdftk_java.BlackBox.assertPdfEqualsAsSVG(BlackBox.java:111)
    [junit]     at com.gitlab.pdftk_java.CryptoTest.idempotent_rc4(CryptoTest.java:29)
    [junit]     at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
    [junit]
    [junit] Testcase: set_password took 0.007 sec
    [junit] Testcase: wrong_password_fails took 0.016 sec
    [junit] TEST com.gitlab.pdftk_java.CryptoTest FAILED
    [junit] Testsuite: com.gitlab.pdftk_java.DataFieldsTest
    [junit] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.041 sec
    [junit]
    [junit] Testcase: escape_unicode took 0.018 sec
    [junit] Testcase: ignore_field_with_successor_names took 0.012 sec
    [junit] Testcase: dump_data_fields_utf8_options took 0.008 sec
    [junit] Testsuite: com.gitlab.pdftk_java.DataTest
    [junit] Tests run: 14, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.532 sec
    [junit] ------------- Standard Error -----------------
    [junit] pdftk Warning: data info record not valid -- skipped; data:
    [junit] InfoBegin
    [junit] InfoKey: Title
    [junit] InfoValue: null
    [junit] pdftk Warning: unexpected case 1 in LoadDataFile(); continuing
    [junit] pdftk Warning: data info record not valid -- skipped; data:
    [junit] InfoBegin
    [junit] InfoKey: Author
    [junit] InfoValue: null
    [junit] pdftk Warning: unexpected case 1 in LoadDataFile(); continuing
    [junit] pdftk Warning: page media record not valid -- skipped; data:
    [junit] PageMediaBegin
    [junit] PageMediaNumber: 3
    [junit] PageMediaRotation: 45
    [junit] PageMediaRect: 1 1 611 791
    [junit] PageMediaDimensions: 610 790
    [junit] PageMediaCropRect: 2 2 610 792
    [junit] pdftk Error in UpdateInfo(): page 42 not found;
    [junit] Warning: no Info added to output PDF.
    [junit] pdftk Warning: unexpected PageMedia case in LoadDataFile(); continuing
    [junit] pdftk Warning: page media record not valid -- skipped; data:
    [junit] PageMediaBegin
    [junit] PageMediaNumber: 3
    [junit] PageMediaRotation: 359
    [junit] pdftk Warning: page label record not valid -- skipped; data:
    [junit] PageLabelBegin
    [junit] PageLabelNewIndex: 0
    [junit] PageLabelStart: 3
    [junit] PageLabelNumStyle: LowercaseRomanNumerals
    [junit] pdftk Warning: page label record not valid -- skipped; data:
    [junit] PageLabelBegin
    [junit] PageLabelNewIndex: 3
    [junit] PageLabelStart: 0
    [junit] PageLabelNumStyle: LowercaseRomanNumerals
    [junit] pdftk Warning: PageLabelNumStyle: invalid value NotAStyle
    [junit] pdftk Warning: unexpected PageLabel case in LoadDataFile(); continuing
    [junit] pdftk Warning: page label record not valid -- skipped; data:
    [junit] PageLabelBegin
    [junit] PageLabelNewIndex: 3
    [junit] PageLabelStart: 3
    [junit] PageLabelNumStyle: null
    [junit] ------------- ---------------- ---------------
    [junit]
    [junit] Testcase: dump_data_invalid_outlines took 0.009 sec
    [junit] Testcase: update_page_media_replace took 0.069 sec
    [junit] Testcase: update_info_incomplete_record took 0.018 sec
    [junit] Testcase: dump_data took 0.009 sec
    [junit] Testcase: update_page_labels_new took 0.057 sec
    [junit] Testcase: update_page_media_badrotation took 0.033 sec
    [junit] Testcase: update_page_labels_replace took 0.087 sec
    [junit] Testcase: update_page_media_badpage took 0.034 sec
    [junit] Testcase: update_page_media_badrect took 0.029 sec
    [junit] Testcase: update_page_labels_badindex took 0.034 sec
    [junit] Testcase: update_page_labels_badstart took 0.032 sec
    [junit] Testcase: update_page_labels_badstyle took 0.031 sec
    [junit] Testcase: idempotent took 0.065 sec
    [junit] Testcase: dump_data_xml took 0.009 sec
    [junit] Testsuite: com.gitlab.pdftk_java.FormTest
    [junit] Tests run: 9, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.771 sec
    [junit] ------------- Standard Error -----------------
    [junit] WARNING: The creator of the input PDF:
    [junit]    test/files/issue88.pdf
    [junit]    has set an owner password (which is not required to handle this PDF).
    [junit]    You did not supply this password. Please respect any copyright.
    [junit] true
    [junit] null
    [junit] ------------- ---------------- ---------------
    [junit]
    [junit] Testcase: fill_from_fdf took 0.181 sec
    [junit] Testcase: fill_from_fdf_utf8_options took 0.082 sec
    [junit] Testcase: generate_fdf_utf8_options took 0.018 sec
    [junit] Testcase: dump_data_fields took 0.007 sec
    [junit] Testcase: generate_fdf_issue88 took 0.266 sec
    [junit] Testcase: replace_font_cff took 0.1 sec
    [junit] Testcase: replace_font_ttf took 0.092 sec
    [junit] Testcase: dump_data_fields_utf8_options took 0.007 sec
    [junit] Testcase: generate_fdf took 0.008 sec
    [junit] Testsuite: com.gitlab.pdftk_java.MultipleTest
    [junit] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.095 sec
    [junit]
    [junit] Testcase: can_fill_cat_form took 0.057 sec
    [junit] Testcase: cat_renames_clashing_forms took 0.037 sec
    [junit] Testsuite: com.gitlab.pdftk_java.ReaderTest
    [junit] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.005 sec
    [junit] ------------- Standard Error -----------------
    [junit] Error: Invalid PDF: Invalid reference on Kids: 3
    [junit] Error: Failed to open input PDF file:
    [junit]    test/files/CVE-2007-0103_AcrobatReader
    [junit] Errors encountered.  No output created.
    [junit] Done.  Input errors, so no output created.
    [junit] ------------- ---------------- ---------------
    [junit]
    [junit] Testcase: mergerequest21 took 0.004 sec
    [junit] Testsuite: com.gitlab.pdftk_java.StampTest
    [junit] Tests run: 8, Failures: 8, Errors: 0, Skipped: 0, Time elapsed: 1.14 sec
    [junit]
    [junit] Testcase: multibackground_stdin took 0.155 sec
    [junit]     FAILED
    [junit] pdftocairo error
    [junit] junit.framework.AssertionFailedError: pdftocairo error
    [junit]     at com.gitlab.pdftk_java.BlackBox.assertPdfEqualsAsSVG(BlackBox.java:111)
    [junit]     at com.gitlab.pdftk_java.StampTest.operation_stdin(StampTest.java:27)
    [junit]     at com.gitlab.pdftk_java.StampTest.multibackground_stdin(StampTest.java:57)
    [junit]     at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
    [junit]
    [junit] Testcase: stamp_stdin took 0.114 sec
    [junit]     FAILED
    [junit] pdftocairo error
    [junit] junit.framework.AssertionFailedError: pdftocairo error
    [junit]     at com.gitlab.pdftk_java.BlackBox.assertPdfEqualsAsSVG(BlackBox.java:111)
    [junit]     at com.gitlab.pdftk_java.StampTest.operation_stdin(StampTest.java:27)
    [junit]     at com.gitlab.pdftk_java.StampTest.stamp_stdin(StampTest.java:62)
    [junit]     at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
    [junit]
    [junit] Testcase: stdin_multistamp took 0.127 sec
    [junit]     FAILED
    [junit] pdftocairo error
    [junit] junit.framework.AssertionFailedError: pdftocairo error
    [junit]     at com.gitlab.pdftk_java.BlackBox.assertPdfEqualsAsSVG(BlackBox.java:111)
    [junit]     at com.gitlab.pdftk_java.StampTest.stdin_operation(StampTest.java:17)
    [junit]     at com.gitlab.pdftk_java.StampTest.stdin_multistamp(StampTest.java:47)
    [junit]     at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
    [junit]
    [junit] Testcase: stdin_multibackground took 0.132 sec
    [junit]     FAILED
    [junit] pdftocairo error
    [junit] junit.framework.AssertionFailedError: pdftocairo error
    [junit]     at com.gitlab.pdftk_java.BlackBox.assertPdfEqualsAsSVG(BlackBox.java:111)
    [junit]     at com.gitlab.pdftk_java.StampTest.stdin_operation(StampTest.java:17)
    [junit]     at com.gitlab.pdftk_java.StampTest.stdin_multibackground(StampTest.java:37)
    [junit]     at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
    [junit]
    [junit] Testcase: stdin_background took 0.142 sec
    [junit]     FAILED
    [junit] pdftocairo error
    [junit] junit.framework.AssertionFailedError: pdftocairo error
    [junit]     at com.gitlab.pdftk_java.BlackBox.assertPdfEqualsAsSVG(BlackBox.java:111)
    [junit]     at com.gitlab.pdftk_java.StampTest.stdin_operation(StampTest.java:17)
    [junit]     at com.gitlab.pdftk_java.StampTest.stdin_background(StampTest.java:32)
    [junit]     at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
    [junit]
    [junit] Testcase: multistamp_stdin took 0.166 sec
    [junit]     FAILED
    [junit] pdftocairo error
    [junit] junit.framework.AssertionFailedError: pdftocairo error
    [junit]     at com.gitlab.pdftk_java.BlackBox.assertPdfEqualsAsSVG(BlackBox.java:111)
    [junit]     at com.gitlab.pdftk_java.StampTest.operation_stdin(StampTest.java:27)
    [junit]     at com.gitlab.pdftk_java.StampTest.multistamp_stdin(StampTest.java:67)
    [junit]     at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
    [junit]
    [junit] Testcase: background_stdin took 0.164 sec
    [junit]     FAILED
    [junit] pdftocairo error
    [junit] junit.framework.AssertionFailedError: pdftocairo error
    [junit]     at com.gitlab.pdftk_java.BlackBox.assertPdfEqualsAsSVG(BlackBox.java:111)
    [junit]     at com.gitlab.pdftk_java.StampTest.operation_stdin(StampTest.java:27)
    [junit]     at com.gitlab.pdftk_java.StampTest.background_stdin(StampTest.java:52)
    [junit]     at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
    [junit]
    [junit] Testcase: stdin_stamp took 0.125 sec
    [junit]     FAILED
    [junit] pdftocairo error
    [junit] junit.framework.AssertionFailedError: pdftocairo error
    [junit]     at com.gitlab.pdftk_java.BlackBox.assertPdfEqualsAsSVG(BlackBox.java:111)
    [junit]     at com.gitlab.pdftk_java.StampTest.stdin_operation(StampTest.java:17)
    [junit]     at com.gitlab.pdftk_java.StampTest.stdin_stamp(StampTest.java:42)
    [junit]     at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
    [junit]
    [junit] TEST com.gitlab.pdftk_java.StampTest FAILED
    [junit] Tests FAILED

coverage-report:
[jacoco:report] Loading execution data file /home/sandro/src/gitlab.com/pdftk-java/pdftk/jacoco.exec

BUILD FAILED
/home/sandro/src/gitlab.com/pdftk-java/pdftk/build.xml:74: Error while creating report

Total time: 14 seconds
```

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
