### PR TITLE
oniux: init at 0.4.0

### DIFF
--- a/pkgs/by-name/on/oniux/package.nix
+++ b/pkgs/by-name/on/oniux/package.nix
@@ -1,0 +1,35 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitLab,
+  nix-update-script,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "oniux";
+  version = "0.4.0";
+
+  src = fetchFromGitLab {
+    domain = "gitlab.torproject.org";
+    owner = "tpo/core";
+    repo = "oniux";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-wWB/ch8DB2tO4+NuNDaGv8K4AbV5/MbyY01oRGai86A=";
+  };
+
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-tUOxs9bTcXS3Gq6cHYe+eAGAEYSRvf3JVGugBImbvJM=";
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    homepage = "https://gitlab.torproject.org/tpo/core/oniux";
+    description = "Isolate Applications over Tor using Linux Namespaces";
+    maintainers = with lib.maintainers; [ tnias ];
+    platforms = lib.platforms.linux;
+    license = with lib.licenses; [
+      asl20
+      mit
+    ];
+    mainProgram = "oniux";
+  };
+})


### PR DESCRIPTION
> oniux: a small command-line utility providing Tor network isolation for third-party applications using Linux namespaces. Built on Arti, and onionmasq, oniux drop-ships any Linux program into its own network namespace to route it through Tor and strips away the potential for data leaks. If your work, activism, or research demands rock-solid traffic isolation, oniux delivers it.
> 
> https://blog.torproject.org/introducing-oniux-tor-isolation-using-linux-namespaces/

- Repository: https://gitlab.torproject.org/tpo/core/oniux

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

I tested basic functionality by running this:
```bash
curl -sSf https://check.torproject.org | grep -q "Congratulations. This browser is configured to use Tor." && printf FAIL || printf PASS; echo ": without oniux check.torproject.org"
./result/bin/oniux curl -sSf https://check.torproject.org | grep -q "Congratulations. This browser is configured to use Tor." && printf PASS || printf FAIL; echo ": with oniux check.torproject.org"
```

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
