### PR TITLE
heimdall: Bring back the other platforms

### DIFF
--- a/pkgs/by-name/he/heimdall/0001-Install-the-macOS-bundle-to-the-install-prefix.patch
+++ b/pkgs/by-name/he/heimdall/0001-Install-the-macOS-bundle-to-the-install-prefix.patch
@@ -1,0 +1,22 @@
+From d0382de78c43c47b8ae3326d979cbbd028b66735 Mon Sep 17 00:00:00 2001
+From: Tim Schumacher <timschumi@gmx.de>
+Date: Fri, 13 Jun 2025 00:29:46 +0200
+Subject: [PATCH] Install the macOS bundle to the install prefix
+
+---
+ heimdall-frontend/CMakeLists.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/heimdall-frontend/CMakeLists.txt b/heimdall-frontend/CMakeLists.txt
+index 6ccb9b1..6fa3054 100644
+--- a/heimdall-frontend/CMakeLists.txt
++++ b/heimdall-frontend/CMakeLists.txt
+@@ -83,4 +83,4 @@ target_link_libraries(heimdall-frontend z)
+ install (TARGETS heimdall-frontend
+         RUNTIME    DESTINATION ${CMAKE_INSTALL_PREFIX}/bin
+         LIBRARY    DESTINATION ${CMAKE_INSTALL_LIBDIR}
+-        BUNDLE DESTINATION /Applications)
++        BUNDLE DESTINATION ${CMAKE_INSTALL_PREFIX}/Applications)
+-- 
+2.49.0
+

--- a/pkgs/by-name/he/heimdall/package.nix
+++ b/pkgs/by-name/he/heimdall/package.nix
@@ -61,7 +61,9 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Cross-platform open-source tool suite used to flash firmware onto Samsung Galaxy devices";
     homepage = "https://git.sr.ht/~grimler/Heimdall";
     license = lib.licenses.mit;
-    mainProgram = if enableGUI then "heimdall-frontend" else "heimdall";
+    mainProgram =
+      (if enableGUI then "heimdall-frontend" else "heimdall")
+      + lib.optionalString stdenv.hostPlatform.isWindows ".exe";
     maintainers = with lib.maintainers; [
       surfaceflinger
     ];

--- a/pkgs/by-name/he/heimdall/package.nix
+++ b/pkgs/by-name/he/heimdall/package.nix
@@ -23,6 +23,10 @@ stdenv.mkDerivation (finalAttrs: {
 
   passthru.updateScript = gitUpdater { rev-prefix = "v"; };
 
+  patches = [
+    ./0001-Install-the-macOS-bundle-to-the-install-prefix.patch
+  ];
+
   outputs = [
     "out"
     "udev"

--- a/pkgs/by-name/he/heimdall/package.nix
+++ b/pkgs/by-name/he/heimdall/package.nix
@@ -58,7 +58,6 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   meta = {
-    broken = enableGUI && !stdenv.hostPlatform.isLinux;
     description = "Cross-platform open-source tool suite used to flash firmware onto Samsung Galaxy devices";
     homepage = "https://git.sr.ht/~grimler/Heimdall";
     license = lib.licenses.mit;

--- a/pkgs/by-name/he/heimdall/package.nix
+++ b/pkgs/by-name/he/heimdall/package.nix
@@ -66,6 +66,7 @@ stdenv.mkDerivation (finalAttrs: {
       + lib.optionalString stdenv.hostPlatform.isWindows ".exe";
     maintainers = with lib.maintainers; [
       surfaceflinger
+      timschumi
     ];
     platforms = with lib.platforms; unix ++ windows;
   };


### PR DESCRIPTION
This redoes everything that was missed or explicitly removed in #406611.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
