### PR TITLE
ci/eval/compare: manage the "by: package-maintainer" label

### DIFF
--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -154,9 +154,12 @@ jobs:
             --arg beforeResultDir ./targetResult \
             --arg afterResultDir "$(realpath prResult)" \
             --arg touchedFilesJson ./touched-files.json \
+            --arg githubAuthorId "$AUTHOR_ID" \
             -o comparison
 
           cat comparison/step-summary.md >> "$GITHUB_STEP_SUMMARY"
+        env:
+          AUTHOR_ID: ${{ github.event.pull_request.user.id }}
 
       - name: Upload the combined results
         if: steps.targetRunId.outputs.targetRunId
@@ -211,10 +214,10 @@ jobs:
       - name: Labelling pull request
         if: ${{ github.event_name == 'pull_request_target' && github.repository_owner == 'NixOS' }}
         run: |
-          # Get all currently set rebuild labels
+          # Get all currently set labels that we manage
           gh api \
             /repos/"$REPOSITORY"/issues/"$NUMBER"/labels \
-            --jq '.[].name | select(startswith("10.rebuild"))' \
+            --jq '.[].name | select(startswith("10.rebuild") or . == "11.by: package-maintainer")' \
             | sort > before
 
           # And the labels that should be there

--- a/ci/eval/compare/default.nix
+++ b/ci/eval/compare/default.nix
@@ -10,6 +10,7 @@
   beforeResultDir,
   afterResultDir,
   touchedFilesJson,
+  githubAuthorId,
   byName ? false,
 }:
 let
@@ -114,7 +115,15 @@ let
           # Adds "10.rebuild-*-stdenv" label if the "stdenv" attribute was changed
           ++ lib.mapAttrsToList (kernel: _: "10.rebuild-${kernel}-stdenv") (
             lib.filterAttrs (_: kernelRebuilds: kernelRebuilds ? "stdenv") rebuildsByKernel
-          );
+          )
+          # Adds the "11.by: package-maintainer" label if all of the packages directly
+          # changed are maintained by the PR's author. (https://github.com/NixOS/ofborg/blob/df400f44502d4a4a80fa283d33f2e55a4e43ee90/ofborg/src/tagger.rs#L83-L88)
+          ++ lib.optional (
+            maintainers ? ${githubAuthorId}
+            && lib.all (lib.flip lib.elem maintainers.${githubAuthorId}) (
+              lib.flatten (lib.attrValues maintainers)
+            )
+          ) "11.by: package-maintainer";
       }
     );
 


### PR DESCRIPTION
While OfBorg is still adding these, it takes a much longer time to do so compared to the eval action. Since we're adding rebuild labels, I think it'd be nice to just do it within the eval action.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [x] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
