### PR TITLE
quickjs: 2024-01-13 -> 2025-04-26

### DIFF
--- a/pkgs/by-name/qu/quickjs/package.nix
+++ b/pkgs/by-name/qu/quickjs/package.nix
@@ -8,11 +8,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "quickjs";
-  version = "2024-01-13";
+  version = "2025-04-26";
 
   src = fetchurl {
     url = "https://bellard.org/quickjs/quickjs-${finalAttrs.version}.tar.xz";
-    hash = "sha256-PEv4+JW/pUvrSGyNEhgRJ3Hs/FrDvhA2hR70FWghLgM=";
+    hash = "sha256-LyAHTCUWbvb3gfOBxQ1XtQLLhdRw1jmrzOu+95VMg78=";
   };
 
   outputs = [
@@ -38,6 +38,7 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   postBuild = ''
+    make doc/version.texi
     pushd doc
     makeinfo *texi
     popd
@@ -61,7 +62,6 @@ stdenv.mkDerivation (finalAttrs: {
     ''
       set +o pipefail
       qjs     --help 2>&1 | grep "QuickJS version"
-      qjscalc --help 2>&1 | grep "QuickJS version"
       set -o pipefail
     ''
 
@@ -93,10 +93,6 @@ stdenv.mkDerivation (finalAttrs: {
       ES2023 specification including modules, asynchronous generators, proxies
       and BigInt.
 
-      It optionally supports mathematical extensions such as big decimal
-      floating point numbers (BigDecimal), big binary floating point numbers
-      (BigFloat) and operator overloading.
-
       Main Features:
 
       - Small and easily embeddable: just a few C files, no external
@@ -112,8 +108,6 @@ stdenv.mkDerivation (finalAttrs: {
       - Can compile Javascript sources to executables with no external dependency.
       - Garbage collection using reference counting (to reduce memory usage and
         have deterministic behavior) with cycle removal.
-      - Mathematical extensions: BigDecimal, BigFloat, operator overloading,
-        bigint mode, math mode.
       - Command line interpreter with contextual colorization implemented in
         Javascript.
       - Small built-in standard library with C library wrappers.


### PR DESCRIPTION
Fixes CVE-2025-46687.

https://bellard.org/quickjs/Changelog


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


## `nixpkgs-review` result (no new failures)

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review pr 407469`

---
### `x86_64-linux`
<details>
  <summary>:x: 1 package failed to build:</summary>
  <ul>
    <li>edbrowse</li>
  </ul>
</details>
<details>
  <summary>:white_check_mark: 2 packages built:</summary>
  <ul>
    <li>quickjs</li>
    <li>quickjs.info</li>
  </ul>
</details>
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
