### PR TITLE
buckets: 0.75.0 -> 0.80.0

### DIFF
--- a/pkgs/by-name/bu/buckets/package.nix
+++ b/pkgs/by-name/bu/buckets/package.nix
@@ -18,16 +18,16 @@ let
     .${system};
 
   # Get hash in sri format
-  # nix-prefetch-url <url> | xargs nix hash to-sri --type sha256 --extra-experimental-features nix-command
+  # nix-prefetch-url <url> | xargs nix hash convert --hash-algo sha256
   hash =
     {
-      x86_64-linux = "sha256-Gj/VDsV+ks8bhsFwU47+oBmsYOa0lQMHZeqQ3/IHm9E=";
-      aarch64-linux = "sha256-9pIT7iiarHBtHRdX5lqdfmJLJLMkugqZdprBZm5g1A8=";
+      x86_64-linux = "sha256-DK5+VT4+OCcJ4Bbv6GGs6R332GMsD1gNEmcz0iaJb1c=";
+      aarch64-linux = "sha256-Qu2YHGu0EPFaXjlUwJ7On8tOA9rqX/k8UnwADuRxoUk=";
     }
     .${system};
 
   pname = "buckets";
-  version = "0.75.0";
+  version = "0.80.0";
   src = fetchurl {
     url = "https://github.com/buckets/application/releases/download/v${version}/Buckets-linux-latest-${platform}-${version}.AppImage";
     inherit hash;


### PR DESCRIPTION
This updates the version of buckets to 0.80.0

The change log is here https://github.com/buckets/application/releases
This version has a breaking change adding a payee field to the DB. Files saved in this version will not be compatible with previous versions.

@r-ryantm bot automatically created a pull request with the update https://github.com/NixOS/nixpkgs/pull/407456, but the commit was missing the updated hash for the ARM64 arch, which I have added to this PR.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
