### PR TITLE
Roon server 1534

### DIFF
--- a/pkgs/by-name/ro/roon-server/package.nix
+++ b/pkgs/by-name/ro/roon-server/package.nix
@@ -16,7 +16,7 @@
   stdenv,
 }:
 let
-  version = "2.50.1528";
+  version = "2.51.1534";
   urlVersion = builtins.replaceStrings [ "." ] [ "0" ] version;
 in
 stdenv.mkDerivation {
@@ -25,7 +25,7 @@ stdenv.mkDerivation {
 
   src = fetchurl {
     url = "https://download.roonlabs.com/updates/production/RoonServer_linuxx64_${urlVersion}.tar.bz2";
-    hash = "sha256-8Dxxjj/5JSuXeTxTV2l37ZAmf6BDdhykPSinmgZeEVY=";
+    hash = "sha256-x9zbWJ4lrqfC1CPquGsdgzhO3WBzd46dlZy6APqJbcg=";
   };
 
   dontConfigure = true;

--- a/pkgs/by-name/ro/roon-server/package.nix
+++ b/pkgs/by-name/ro/roon-server/package.nix
@@ -16,7 +16,7 @@
   stdenv,
 }:
 let
-  version = "2.49.1525";
+  version = "2.50.1528";
   urlVersion = builtins.replaceStrings [ "." ] [ "0" ] version;
 in
 stdenv.mkDerivation {
@@ -25,7 +25,7 @@ stdenv.mkDerivation {
 
   src = fetchurl {
     url = "https://download.roonlabs.com/updates/production/RoonServer_linuxx64_${urlVersion}.tar.bz2";
-    hash = "sha256-DYxybP7luRmR4HL6QYBeWU4ZWqlHEO2EgLeqxmFD87A=";
+    hash = "sha256-8Dxxjj/5JSuXeTxTV2l37ZAmf6BDdhykPSinmgZeEVY=";
   };
 
   dontConfigure = true;


### PR DESCRIPTION
This builds on https://github.com/NixOS/nixpkgs/pull/402667 which was twice approved but not merged 

https://community.roonlabs.com/t/roon-2-51-and-arc-1-66-are-live/299274

## Things done

- Built on platform(s)
  - [ x] x86_64-linux
- [ x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ x] Tested basic functionality of all binary files (usually in `./result/bin/`)

Tested core functionality with clients on windows, android, iOS

Reviews requested from @lovesegfault @Ramblurr @SailorSnoW and perhaps @DirectXMan12