### PR TITLE
yacreader: fix darwin build

### DIFF
--- a/pkgs/applications/graphics/yacreader/darwin-unarr-use-pkg-config.patch
+++ b/pkgs/applications/graphics/yacreader/darwin-unarr-use-pkg-config.patch
@@ -1,0 +1,13 @@
+diff --git a/compressed_archive/unarr/unarr-wrapper.pri b/compressed_archive/unarr/unarr-wrapper.pri
+index 0115267..5d3d6f5 100644
+--- a/compressed_archive/unarr/unarr-wrapper.pri
++++ b/compressed_archive/unarr/unarr-wrapper.pri
+@@ -6,7 +6,7 @@ HEADERS += $$PWD/extract_delegate.h \
+ 
+ SOURCES += $$PWD/compressed_archive.cpp
+ 
+-if(mingw|unix):!macx:!contains(QT_CONFIG, no-pkg-config):packagesExist(libunarr) {
++if(mingw|unix):!contains(QT_CONFIG, no-pkg-config):packagesExist(libunarr) {
+   message(Using system provided unarr installation found by pkg-config.)
+   CONFIG += link_pkgconfig
+   PKGCONFIG += libunarr

--- a/pkgs/applications/graphics/yacreader/default.nix
+++ b/pkgs/applications/graphics/yacreader/default.nix
@@ -2,11 +2,10 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  libsForQt5,
-  poppler,
-  pkg-config,
-  libunarr,
   libGLU,
+  libunarr,
+  libsForQt5,
+  pkg-config,
 }:
 
 stdenv.mkDerivation rec {
@@ -15,28 +14,63 @@ stdenv.mkDerivation rec {
 
   src = fetchFromGitHub {
     owner = "YACReader";
-    repo = pname;
-    rev = version;
-    sha256 = "sha256-5vCjr8WRwa7Q/84Itgg07K1CJKGnWA1z53et2IxxReE=";
+    repo = "yacreader";
+    tag = version;
+    hash = "sha256-5vCjr8WRwa7Q/84Itgg07K1CJKGnWA1z53et2IxxReE=";
   };
+
+  patches = [
+    # make the unarr backend logic use pkg-config even on Darwin
+    ./darwin-unarr-use-pkg-config.patch
+  ];
+
+  qmakeFlags = [
+    # force unarr backend on all platforms
+    "CONFIG+=unarr"
+  ];
 
   nativeBuildInputs = [
     libsForQt5.qmake
-    pkg-config
+    libsForQt5.qttools # for translations
     libsForQt5.wrapQtAppsHook
+    pkg-config
   ];
-  buildInputs = [
-    libunarr
-    libGLU
-    libsForQt5.poppler
-    libsForQt5.qtmultimedia
-    libsForQt5.qtscript
-  ];
-  propagatedBuildInputs = [
-    libsForQt5.qtquickcontrols2
-    libsForQt5.qtgraphicaleffects
-    libsForQt5.qtdeclarative
-  ];
+
+  buildInputs =
+    [
+      libGLU
+      libsForQt5.poppler
+      libsForQt5.qtgraphicaleffects # imported, but not declared as a dependency
+      libsForQt5.qtmultimedia
+      libsForQt5.qtquickcontrols2
+      libunarr
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [
+      libsForQt5.qtmacextras # can be removed when using qt6
+    ];
+
+  # custom Darwin install instructions taken from the upsteam compileOSX.sh script
+  installPhase = lib.optionalString stdenv.hostPlatform.isDarwin ''
+    runHook preInstall
+
+    mkdir -p "$out"/Applications
+
+    cp -r YACReader/YACReader.app "$out"/Applications/
+    cp -r YACReaderLibrary/YACReaderLibrary.app "$out"/Applications/
+    cp -r YACReaderLibraryServer/YACReaderLibraryServer.app "$out"/Applications/
+
+    cp -r release/server "$out"/Applications/YACReaderLibrary.app/Contents/MacOS/
+    cp -r release/server "$out"/Applications/YACReaderLibraryServer.app/Contents/MacOS/
+    cp -r release/languages "$out"/Applications/YACReader.app/Contents/MacOS/
+    cp -r release/languages "$out"/Applications/YACReaderLibrary.app/Contents/MacOS/
+    cp -r release/languages "$out"/Applications/YACReaderLibraryServer.app/Contents/MacOS/
+
+    makeWrapper "$out"/Applications/YACReader.app/Contents/MacOS/YACReader "$out/bin/YACReader"
+    makeWrapper "$out"/Applications/YACReaderLibrary.app/Contents/MacOS/YACReaderLibrary "$out/bin/YACReaderLibrary"
+    makeWrapper "$out"/Applications/YACReaderLibraryServer.app/Contents/MacOS/YACReaderLibraryServer "$out/bin/YACReaderLibraryServer"
+
+    runHook postInstall
+  '';
 
   meta = {
     description = "Comic reader for cross-platform reading and managing your digital comic collection";


### PR DESCRIPTION
ZHF: https://github.com/NixOS/nixpkgs/issues/403336

https://hydra.nixos.org/build/297110220

This PR actually adds support for building the package on darwin.
I think the build has been failing on darwin ever since the package was added...

I have not used the software before, but I was able to open some `cbz` archives.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
