### PR TITLE
nixos/profiles/nix-builder-vm: allow the system derivation to be substituted

### DIFF
--- a/nixos/modules/profiles/nix-builder-vm.nix
+++ b/nixos/modules/profiles/nix-builder-vm.nix
@@ -126,6 +126,20 @@ in
     # TODO system.switch.enable = false;?
     system.disableInstallerTools = true;
 
+    # Allow the system derivation to be substituted, so that
+    # users are less likely to run into a state where they need
+    # the builder running to build the builder if they just want
+    # to make a tweak that only affects the macOS side of things,
+    # like changing the QEMU args.
+    #
+    # TODO(winter): Move to qemu-vm? Trying it here for now as a
+    # low impact change that'll probably improve people's experience.
+    #
+    # (I have no clue what is going on in https://github.com/nix-darwin/nix-darwin/issues/1081
+    # though, as this fix would only apply to one person in that thread... hopefully someone
+    # comes across with a reproducer if this doesn't do it.)
+    system.systemBuilderArgs.allowSubstitutes = true;
+
     nix.settings = {
       min-free = cfg.min-free;
 


### PR DESCRIPTION
Consider a user wanting to set up the Linux builder for the first time, but with a slightly more generous allocation of resources compared to the default. They'll do something like this:

```nix
{
  virtualisation.cores = 3;
    virtualisation.darwin-builder = {
        diskSize = 40 * 1024;
        memorySize = 4 * 1024;
    };
}
```

This will fail with an error like this:

```
error: a 'aarch64-linux' with features {} is required to build '/nix/store/3acpgmwqwnk8g2gc5r05ar2lvmn01b8a-builder.pl.drv', but I am a 'aarch64-darwin' with features {apple-virt, benchmark, big-parallel, nixos-test}
```

But why would they have to rebuild the NixOS system?! All they did was change the arguments passed to QEMU, and nothing those options control would affect the NixOS configuration itself... right?

`config.system.build.toplevel` is defined with `allowSubstitutes` set to `false` by default, which makes it so that the toplevel can't be substituted if Nix is trying to use it "directly." So because the above example would have to rebuild the VM runner, which references toplevel directly, Nix refuses to substitute it, unless `always-allow-substitutes = true` is set as a Nix option. (In the case where the QEMU options aren't changed at all, Nix just substitutes the runner, which sidesteps this issue as the runner itself doesn't use toplevel as an input.)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [x] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
