### PR TITLE
rquickshare: fix darwin build

### DIFF
--- a/doc/hooks/tauri.section.md
+++ b/doc/hooks/tauri.section.md
@@ -35,18 +35,21 @@ rustPlatform.buildRustPackage (finalAttrs: {
     hash = "...";
   };
 
-  nativeBuildInputs = [
-    # Pull in our main hook
-    cargo-tauri.hook
+  nativeBuildInputs =
+    [
+      # Pull in our main hook
+      cargo-tauri.hook
 
-    # Setup npm
-    nodejs
-    npmHooks.npmConfigHook
+      # Setup npm
+      nodejs
+      npmHooks.npmConfigHook
 
-    # Make sure we can find our libraries
-    pkg-config
-    wrapGAppsHook4
-  ];
+      # Make sure we can find our libraries
+      pkg-config
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isLinux [
+      wrapGAppsHook4
+    ];
 
   buildInputs =
     [ openssl ]

--- a/pkgs/by-name/rq/rquickshare/package.nix
+++ b/pkgs/by-name/rq/rquickshare/package.nix
@@ -69,37 +69,45 @@ rustPlatform.buildRustPackage rec {
   useFetchCargoVendor = true;
   cargoRoot = "app/${app-type}/src-tauri";
   buildAndTestSubdir = cargoRoot;
-  cargoPatches = [ ./remove-duplicate-versions-of-sys-metrics.patch ];
+  cargoPatches = [
+    ./remove-duplicate-versions-of-sys-metrics.patch
+    ./remove-code-signing-darwin.patch
+  ];
   cargoHash = app-type-either "sha256-XfN+/oC3lttDquLfoyJWBaFfdjW/wyODCIiZZksypLM=" "sha256-4vBHxuKg4P9H0FZYYNUT+AVj4Qvz99q7Bhd7x47UC2w=";
 
-  nativeBuildInputs = [
-    proper-cargo-tauri.hook
+  nativeBuildInputs =
+    [
+      proper-cargo-tauri.hook
 
-    # Setup pnpm
-    nodejs
-    pnpm_9.configHook
+      # Setup pnpm
+      nodejs
+      pnpm_9.configHook
 
-    # Make sure we can find our libraries
-    perl
-    pkg-config
-    protobuf
-    wrapGAppsHook4
-  ];
+      # Make sure we can find our libraries
+      perl
+      pkg-config
+      protobuf
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isLinux [
+      wrapGAppsHook4
+    ];
 
   buildInputs =
     [ openssl ]
-    ++ lib.optionals stdenv.hostPlatform.isLinux [
-      glib-networking
-      libayatana-appindicator
-    ]
-    ++ lib.optionals (app-type == "main") [
-      webkitgtk_4_1
-      libsoup_3
-    ]
-    ++ lib.optionals (app-type == "legacy") [
-      webkitgtk_4_0
-      libsoup_2_4
-    ];
+    ++ lib.optionals stdenv.hostPlatform.isLinux (
+      [
+        glib-networking
+        libayatana-appindicator
+      ]
+      ++ lib.optionals (app-type == "main") [
+        webkitgtk_4_1
+        libsoup_3
+      ]
+      ++ lib.optionals (app-type == "legacy") [
+        webkitgtk_4_0
+        libsoup_2_4
+      ]
+    );
 
   passthru =
     # Don't set an update script for the legacy version

--- a/pkgs/by-name/rq/rquickshare/remove-code-signing-darwin.patch
+++ b/pkgs/by-name/rq/rquickshare/remove-code-signing-darwin.patch
@@ -1,0 +1,12 @@
+diff --git a/app/main/src-tauri/tauri.conf.json b/app/main/src-tauri/tauri.conf.json
+index 1114b19..c4cc8f4 100644
+--- a/app/main/src-tauri/tauri.conf.json
++++ b/app/main/src-tauri/tauri.conf.json
+@@ -23,7 +23,6 @@
+     "macOS": {
+       "frameworks": [],
+       "exceptionDomain": "",
+-      "signingIdentity": "-",
+       "providerShortName": null,
+       "entitlements": null
+     },


### PR DESCRIPTION
The package was broken on darwin due to non-optionally requiring Linux-specific packages. Fix was to make these optional.
It was also required to remove the ad-hoc identity signing setting from tauri config to make the build succeed on Mac.

Also in a separate commit updated `tauri.section.md` documentation to have the `wrapGAppsHook4` be only added for Linux.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
