### PR TITLE
try: 0.2.0 -> 0.2.0-unstable-2025-02-25

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7812,6 +7812,12 @@
     github = "hatch01";
     githubId = 42416805;
   };
+  ezrizhu = {
+    name = "Ezri Zhu";
+    email = "me@ezrizhu.com";
+    github = "ezrizhu";
+    githubId = 44515009;
+  };
   f--t = {
     email = "git@f-t.me";
     github = "f--t";

--- a/pkgs/by-name/tr/try/package.nix
+++ b/pkgs/by-name/tr/try/package.nix
@@ -1,37 +1,73 @@
 {
-  stdenvNoCC,
+  stdenv,
+  autoreconfHook,
   lib,
   fetchFromGitHub,
-  fuse-overlayfs,
   util-linux,
+  mergerfs,
+  attr,
   makeWrapper,
+  pandoc,
+  kmod,
+  installShellFiles,
+  versionCheckHook,
 }:
-stdenvNoCC.mkDerivation rec {
+stdenv.mkDerivation {
   pname = "try";
-  version = "0.2.0";
+  version = "0.2.0-unstable-2025-02-25";
   src = fetchFromGitHub {
     owner = "binpash";
     repo = "try";
-    rev = "v${version}";
-    hash = "sha256-2EDRVwW4XzQhd7rAM2rDuR94Fkaq4pH5RTooFEBBh5g=";
+    rev = "67052d8f20725f3cdc22ffaec33f7b7c14f1eb6b";
+    hash = "sha256-8mfCmqN50pRAeNTJUlRVrRQulWon4b2OL4Ug/ygBhB0=";
   };
-  nativeBuildInputs = [ makeWrapper ];
+  nativeBuildInputs = [
+    makeWrapper
+    autoreconfHook
+    pandoc
+    attr
+    util-linux
+    kmod
+    installShellFiles
+  ];
+  # Trigger a overlay run to load the overlayfs module, required by ./configure
+  preConfigure = ''
+    mkdir lower upper work merged
+    unshare -r --mount mount -t overlay overlay -o lowerdir=lower,upperdir=upper,workdir=work merged
+    rm -rf lower upper work merged
+  '';
   installPhase = ''
     runHook preInstall
     install -Dt $out/bin try
+    install -Dt $out/bin utils/try-commit
+    install -Dt $out/bin utils/try-summary
     wrapProgram $out/bin/try --prefix PATH : ${
       lib.makeBinPath [
-        fuse-overlayfs
         util-linux
+        mergerfs
+        attr
       ]
     }
+    installManPage man/try.1.gz
+    installShellCompletion --bash --name try.bash completions/try.bash
     runHook postInstall
   '';
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+  preVersionCheck = ''
+    export version=0.2.0
+  '';
+  versionCheckProgramArg = "-v";
   meta = with lib; {
     homepage = "https://github.com/binpash/try";
     description = "Lets you run a command and inspect its effects before changing your live system";
     mainProgram = "try";
-    maintainers = with maintainers; [ pasqui23 ];
+    maintainers = with maintainers; [
+      pasqui23
+      ezrizhu
+    ];
     license = with licenses; [ mit ];
     platforms = platforms.linux;
   };


### PR DESCRIPTION
* try has added a lot of features since 0.2.0 e.g.: 
  * https://github.com/binpash/try/pull/158
  * https://github.com/binpash/try/pull/146
  * https://github.com/binpash/try/pull/122
  * https://github.com/binpash/try/pull/168
  * https://github.com/binpash/try/pull/167
* this PR also properly calls overlay instead of using the fuse-overlayfs which is not necessary, as well as adding mergerfs as a dep
* adds version check
* installs manpage and completions

* adds myself as maintainer
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
