### PR TITLE
lib.types.attrNamesToTrue: unpublish temporarily

### DIFF
--- a/lib/types.nix
+++ b/lib/types.nix
@@ -1456,12 +1456,6 @@ let
           nestedTypes.finalType = finalType;
         };
 
-      # A list of attrnames is coerced into an attrset of bools by
-      # setting the values to true.
-      attrNamesToTrue = coercedTo (types.listOf types.str) (
-        enabledList: lib.genAttrs enabledList (_attrName: true)
-      ) (types.attrsOf types.bool);
-
       # Augment the given type with an additional type check function.
       addCheck = elemType: check: elemType // { check = x: elemType.check x && check x; };
 

--- a/nixos/doc/manual/development/option-types.section.md
+++ b/nixos/doc/manual/development/option-types.section.md
@@ -135,29 +135,6 @@ merging is handled.
     problems.
     :::
 
-`types.attrNamesToTrue`
-
-:   Either a list of attribute names, or an attribute set of
-    booleans. A list will be coerced into an attribute set with those
-    names, whose values are set to `true`. This is useful when it is
-    convenient to be able to write definitions as a simple list, but
-    still need to be able to override and disable individual values.
-
-    ::: {#ex-types-attrNamesToTrue .example}
-    ### `types.attrNamesToTrue`
-    ```
-    {
-      foo = [ "bar" ];
-    }
-    ```
-
-    ```
-    {
-      foo.bar = true;
-    }
-    ```
-    :::
-
 `types.pkgs`
 
 :   A type for the top level Nixpkgs package set.

--- a/nixos/modules/system/boot/kernel.nix
+++ b/nixos/modules/system/boot/kernel.nix
@@ -25,6 +25,12 @@ let
     ${concatStringsSep "\n" config.boot.kernelModules}
   '';
 
+  # A list of attrnames is coerced into an attrset of bools by
+  # setting the values to true.
+  attrNamesToTrue = types.coercedTo (types.listOf types.str) (
+    enabledList: lib.genAttrs enabledList (_attrName: true)
+  ) (types.attrsOf types.bool);
+
 in
 
 {
@@ -196,7 +202,7 @@ in
     };
 
     boot.kernelModules = mkOption {
-      type = types.attrNamesToTrue;
+      type = attrNamesToTrue;
       default = { };
       description = ''
         The set of kernel modules to be loaded in the second stage of
@@ -211,7 +217,7 @@ in
     };
 
     boot.initrd.availableKernelModules = mkOption {
-      type = types.attrNamesToTrue;
+      type = attrNamesToTrue;
       default = { };
       example = [
         "sata_nv"
@@ -238,7 +244,7 @@ in
     };
 
     boot.initrd.kernelModules = mkOption {
-      type = types.attrNamesToTrue;
+      type = attrNamesToTrue;
       default = { };
       description = ''
         Set of modules that are always loaded by the initrd.

--- a/nixos/modules/system/boot/modprobe.nix
+++ b/nixos/modules/system/boot/modprobe.nix
@@ -7,6 +7,16 @@
 
 with lib;
 
+let
+
+  # A list of attrnames is coerced into an attrset of bools by
+  # setting the values to true.
+  attrNamesToTrue = types.coercedTo (types.listOf types.str) (
+    enabledList: lib.genAttrs enabledList (_attrName: true)
+  ) (types.attrsOf types.bool);
+
+in
+
 {
 
   ###### interface
@@ -25,7 +35,7 @@ with lib;
       };
 
     boot.blacklistedKernelModules = mkOption {
-      type = types.attrNamesToTrue;
+      type = attrNamesToTrue;
       default = { };
       example = [
         "cirrusfb"

--- a/nixos/modules/tasks/filesystems.nix
+++ b/nixos/modules/tasks/filesystems.nix
@@ -13,6 +13,12 @@ let
   # https://wiki.archlinux.org/index.php/fstab#Filepath_spaces
   escape = string: builtins.replaceStrings [ " " "\t" ] [ "\\040" "\\011" ] string;
 
+  # A list of attrnames is coerced into an attrset of bools by
+  # setting the values to true.
+  attrNamesToTrue = types.coercedTo (types.listOf types.str) (
+    enabledList: lib.genAttrs enabledList (_attrName: true)
+  ) (types.attrsOf types.bool);
+
   addCheckDesc =
     desc: elemType: check:
     types.addCheck elemType check // { description = "${elemType.description} (with check: ${desc})"; };
@@ -326,7 +332,7 @@ in
           zfs = lib.mkForce false;
         }
       '';
-      type = types.attrNamesToTrue;
+      type = attrNamesToTrue;
       description = ''
         Names of supported filesystem types, or an attribute set of file system types
         and their state. The set form may be used together with `lib.mkForce` to


### PR DESCRIPTION
 Thank you for making this change @ElvishJerricco.
Unfortunately, and I take blame for this, this change to the module system was not reviewed and approved by the module system maintainers. I'm supportive of this change, but extending it on the staging-next branch is not the right place.
This commit is also here to make sure that we don't run into conflicts or other git trouble with the staging workflow.

I'll take care of the PR to add this properly now.

Review:
It looks alright, but it didn't have tests yet, and it should be considered in a broader context where the existence of this type creates an incentive to be used in cases where the `<attr> = false;` case is undesirable. I'd like to complement this with an type that has `<attr> = {};` only.

My apologies for the lack of a timely and clear review. Often we recommend to define the type outside the module system until approved. This commit puts us back in that state.

`attrNamesToTrue` was introduced in 98652f9a901aac50c1d7780ea3507439803a3408


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
