### PR TITLE
lib.types.attrNamesToTrue: add

### DIFF
--- a/lib/tests/modules.sh
+++ b/lib/tests/modules.sh
@@ -160,6 +160,9 @@ checkConfigError 'A definition for option .intStrings\.badTagTypeError\.left. is
 checkConfigError 'A definition for option .nested\.right\.left. is not of type .signed integer.' config.nested.right.left ./types-attrTag.nix
 checkConfigError 'In attrTag, each tag value must be an option, but tag int was a bare type, not wrapped in mkOption.' config.opt.int ./types-attrTag-wrong-decl.nix
 
+# types.nix assertions
+checkConfigOutput '"ok"' config.check ./types.nix
+
 # types.pathInStore
 checkConfigOutput '".*/store/0lz9p8xhf89kb1c1kk6jxrzskaiygnlh-bash-5.2-p15.drv"' config.pathInStore.ok1 ./types.nix
 checkConfigOutput '".*/store/0fb3ykw9r5hpayd05sr0cizwadzq1d8q-bash-5.2-p15"' config.pathInStore.ok2 ./types.nix

--- a/lib/tests/modules/types.nix
+++ b/lib/tests/modules/types.nix
@@ -7,6 +7,15 @@ let
     types
     mkOption
     ;
+
+  m = {
+    options = {
+      enableQux = mkOption {
+        type = types.bool;
+        default = false;
+      };
+    };
+  };
 in
 {
   options = {
@@ -14,6 +23,8 @@ in
     # NB: types are tested in multiple places, so this list is far from exhaustive
     pathInStore = mkOption { type = types.lazyAttrsOf types.pathInStore; };
     attrNamesToTrue = mkOption { type = types.lazyAttrsOf types.attrNamesToTrue; };
+    attrNamesToSet = mkOption { type = types.lazyAttrsOf types.attrNamesToSet; };
+    attrNamesToSubmodules = mkOption { type = types.lazyAttrsOf (types.attrNamesToSubmodules m); };
   };
   config = {
     pathInStore.ok1 = "${storeDir}/0lz9p8xhf89kb1c1kk6jxrzskaiygnlh-bash-5.2-p15.drv";
@@ -41,6 +52,40 @@ in
       b = false;
       c = true;
     };
+    attrNamesToSet.justNames = [
+      "a"
+      "b"
+      "c"
+    ];
+    attrNamesToSet.mixed = lib.mkMerge [
+      {
+        a = { };
+        b = { };
+      }
+      [ "c" ]
+    ];
+    attrNamesToSet.trivial = {
+      a = { };
+      b = { };
+      c = { };
+    };
+    attrNamesToSubmodules.justNames = [
+      "a"
+      "b"
+      "c"
+    ];
+    attrNamesToSubmodules.mixed = lib.mkMerge [
+      {
+        a = { };
+        b.enableQux = true;
+      }
+      [ "c" ]
+    ];
+    attrNamesToSubmodules.trivial = {
+      a = { };
+      b.enableQux = true;
+      c = { };
+    };
     check =
       assert
         config.attrNamesToTrue.justNames == {
@@ -59,6 +104,42 @@ in
           a = true;
           b = false;
           c = true;
+        };
+      assert
+        config.attrNamesToSet.justNames == {
+          a = { };
+          b = { };
+          c = { };
+        };
+      assert
+        config.attrNamesToSet.mixed == {
+          a = { };
+          b = { };
+          c = { };
+        };
+      assert
+        config.attrNamesToSet.trivial == {
+          a = { };
+          b = { };
+          c = { };
+        };
+      assert
+        config.attrNamesToSubmodules.justNames == {
+          a.enableQux = false;
+          b.enableQux = false;
+          c.enableQux = false;
+        };
+      assert
+        config.attrNamesToSubmodules.mixed == {
+          a.enableQux = false;
+          b.enableQux = true;
+          c.enableQux = false;
+        };
+      assert
+        config.attrNamesToSubmodules.trivial == {
+          a.enableQux = false;
+          b.enableQux = true;
+          c.enableQux = false;
         };
       "ok";
   };

--- a/lib/tests/modules/types.nix
+++ b/lib/tests/modules/types.nix
@@ -1,4 +1,4 @@
-{ lib, ... }:
+{ config, lib, ... }:
 let
   inherit (builtins)
     storeDir
@@ -10,7 +10,10 @@ let
 in
 {
   options = {
+    check = mkOption { };
+    # NB: types are tested in multiple places, so this list is far from exhaustive
     pathInStore = mkOption { type = types.lazyAttrsOf types.pathInStore; };
+    attrNamesToTrue = mkOption { type = types.lazyAttrsOf types.attrNamesToTrue; };
   };
   config = {
     pathInStore.ok1 = "${storeDir}/0lz9p8xhf89kb1c1kk6jxrzskaiygnlh-bash-5.2-p15.drv";
@@ -21,5 +24,42 @@ in
     pathInStore.bad3 = "${storeDir}/";
     pathInStore.bad4 = "${storeDir}/.links"; # technically true, but not reasonable
     pathInStore.bad5 = "/foo/bar";
+    attrNamesToTrue.justNames = [
+      "a"
+      "b"
+      "c"
+    ];
+    attrNamesToTrue.mixed = lib.mkMerge [
+      {
+        a = true;
+        b = false;
+      }
+      [ "c" ]
+    ];
+    attrNamesToTrue.trivial = {
+      a = true;
+      b = false;
+      c = true;
+    };
+    check =
+      assert
+        config.attrNamesToTrue.justNames == {
+          a = true;
+          b = true;
+          c = true;
+        };
+      assert
+        config.attrNamesToTrue.mixed == {
+          a = true;
+          b = false;
+          c = true;
+        };
+      assert
+        config.attrNamesToTrue.trivial == {
+          a = true;
+          b = false;
+          c = true;
+        };
+      "ok";
   };
 }

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -1463,6 +1463,16 @@ let
         enabledList: lib.genAttrs enabledList (_attrName: true)
       ) (types.attrsOf types.bool);
 
+      # Tests: lib/tests/modules.sh, lib/tests/modules/types.nix
+      # Docs: nixos/doc/manual/development/option-types.section.md
+      # Docs: https://nixos.org/manual/nixos/unstable/#sec-option-types-basic
+      attrNamesToSet = attrNamesToSubmodules { };
+      attrNamesToSubmodules =
+        m:
+        coercedTo (types.listOf types.str) (enabledList: lib.genAttrs enabledList (_attrName: { })) (
+          types.attrsOf (types.submodule m)
+        );
+
       # Augment the given type with an additional type check function.
       addCheck = elemType: check: elemType // { check = x: elemType.check x && check x; };
 

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -1456,8 +1456,9 @@ let
           nestedTypes.finalType = finalType;
         };
 
-      # A list of attrnames is coerced into an attrset of bools by
-      # setting the values to true.
+      # Tests: lib/tests/modules/types.nix
+      # Docs: nixos/doc/manual/development/option-types.section.md
+      # Docs: https://nixos.org/manual/nixos/unstable/#sec-option-types-basic
       attrNamesToTrue = coercedTo (types.listOf types.str) (
         enabledList: lib.genAttrs enabledList (_attrName: true)
       ) (types.attrsOf types.bool);

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -1456,6 +1456,12 @@ let
           nestedTypes.finalType = finalType;
         };
 
+      # A list of attrnames is coerced into an attrset of bools by
+      # setting the values to true.
+      attrNamesToTrue = coercedTo (types.listOf types.str) (
+        enabledList: lib.genAttrs enabledList (_attrName: true)
+      ) (types.attrsOf types.bool);
+
       # Augment the given type with an additional type check function.
       addCheck = elemType: check: elemType // { check = x: elemType.check x && check x; };
 

--- a/nixos/doc/manual/development/option-types.section.md
+++ b/nixos/doc/manual/development/option-types.section.md
@@ -135,6 +135,29 @@ merging is handled.
     problems.
     :::
 
+`types.attrNamesToTrue`
+
+:   Either a list of attribute names, or an attribute set of
+    booleans. A list will be coerced into an attribute set with those
+    names, whose values are set to `true`. This is useful when it is
+    convenient to be able to write definitions as a simple list, but
+    still need to be able to override and disable individual values.
+
+    ::: {#ex-types-attrNamesToTrue .example}
+    ### `types.attrNamesToTrue`
+    ```
+    {
+      foo = [ "bar" ];
+    }
+    ```
+
+    ```
+    {
+      foo.bar = true;
+    }
+    ```
+    :::
+
 `types.pkgs`
 
 :   A type for the top level Nixpkgs package set.

--- a/nixos/doc/manual/development/option-types.section.md
+++ b/nixos/doc/manual/development/option-types.section.md
@@ -143,6 +143,9 @@ merging is handled.
     convenient to be able to write definitions as a simple list, but
     still need to be able to override and disable individual values.
 
+    If configurability of the items is needed or `false` is not a
+    desirable value, prefer `types.attrNamesToSubmodule` or `types.attrNamesToSet`.
+
     ::: {#ex-types-attrNamesToTrue .example}
     ### `types.attrNamesToTrue`
     ```
@@ -157,6 +160,53 @@ merging is handled.
     }
     ```
     :::
+
+`types.attrNamesToSet`
+
+:   Either a list of attribute names, or an attribute set of `{ }`.
+    This is similar to `types.attrNamesToTrue`, but `false` is not a permitted
+    value. This is useful when that's not an expected value, and by using this
+    type, you have the option to upgrade the type to `types.attrNamesToSubmodule`
+    without breaking anything.
+
+    ::: {#ex-types-attrNamesToSet .example}
+    ### `types.attrNamesToSet`
+    ```
+    {
+      foo = [ "bar" ];
+    }
+    ```
+
+    ```
+    {
+      foo.bar = { };
+    }
+    ```
+    :::
+
+`types.attrNamesToSubmodule` *`submodule`*
+
+:   Either a list of attribute names, or an attribute set of submodules.
+    This is similar to `types.attrNamesToSet`, but the values are submodules
+    instead of empty sets. This is useful when the values of this type are
+    optionally configurable.
+
+    ::: {#ex-types-attrNamesToSubmodule .example}
+    ### `types.attrNamesToSubmodule`
+    ```
+    {
+      foo = [ "bar" ];
+    }
+    ```
+
+    ```
+    {
+      foo.bar = { };
+      foo.baz.enableQux = true;
+    }
+    ```
+    :::
+
 
 `types.pkgs`
 


### PR DESCRIPTION
This introduces a useful type that was added by @ElvishJerricco as part of a staging PR.
I'm reopening it here so that it can be reviewed by module system maintainers without blocking anything.

## Context

- Original PR: #375975
  - (cherry picked from commit 98652f9a901aac50c1d7780ea3507439803a3408)
- Temporary partial revert: https://github.com/NixOS/nixpkgs/pull/407572


## TODO after staging merge

- [ ] Revert the revert


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
