### PR TITLE
csend: init at 0.1.1

### DIFF
--- a/pkgs/by-name/cs/csend/package.nix
+++ b/pkgs/by-name/cs/csend/package.nix
@@ -1,0 +1,35 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "csend";
+  version = "0.1.1";
+
+  src = fetchFromGitHub {
+    owner = "matthewdeaves";
+    repo = "csend";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-v0vTdbMquB4xC/8bJ8nlSaRoxUGb0LWiPD344z7ljYA=";
+  };
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/bin
+    mv build/posix/csend_posix $out/bin
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Peer-to-peer (P2P) chat application designed to run on both modern POSIX-compliant systems";
+    longDescription = "A peer-to-peer (P2P) chat application designed to run on both modern POSIX-compliant systems (Linux, macOS) and vintage Classic Macintosh computers (System 7.5.3/MacTCP, built with Retro68). Features UDP-based peer discovery and TCP-based text messaging using a simple custom protocol. Includes Docker support for the POSIX version";
+    homepage = "https://github.com/matthewdeaves/csend";
+    # https://github.com/matthewdeaves/csend/issues/44
+    license = lib.licenses.unfree;
+    maintainers = with lib.maintainers; [ matthewcroughan ];
+    mainProgram = "csend_posix";
+    platforms = lib.platforms.unix;
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

This runs, and it would be good to get the other side (m68k side) compiled with the retro68 toolchain, but it's not clear how to package that and place it into nixpkgs for now, since they have their own flake and nix expressions here:

https://github.com/autc04/Retro68?tab=readme-ov-file#using-retro68-with-nix

The license is marked as unfree because no license has been created by the author yet https://github.com/matthewdeaves/csend/issues/44

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
