### PR TITLE
nixos/shadowsocks: add `package` option

### DIFF
--- a/nixos/modules/services/networking/shadowsocks.nix
+++ b/nixos/modules/services/networking/shadowsocks.nix
@@ -29,8 +29,15 @@ let
 
   configFile = pkgs.writeText "shadowsocks.json" (builtins.toJSON opts);
 
+  executablesMap = {
+    "${getName pkgs.shadowsocks-libev}" = {
+      server = "ss-server";
+    };
+    "${getName pkgs.shadowsocks-rust}" = {
+      server = "ssserver";
+    };
+  };
 in
-
 {
 
   ###### interface
@@ -47,14 +54,25 @@ in
         '';
       };
 
+      package = mkPackageOption pkgs "Shadowsocks" {
+        default = "shadowsocks-libev";
+      };
+
       localAddress = mkOption {
-        type = types.coercedTo types.str singleton (types.listOf types.str);
+        type =
+          with types;
+          oneOf [
+            str
+            (listOf str)
+          ];
+        # Keeped for compatibility
         default = [
           "[::0]"
           "0.0.0.0"
         ];
         description = ''
           Local addresses to which the server binds.
+          Note: shadowsocks-rust accepts only string parameter.
         '';
       };
 
@@ -163,14 +181,19 @@ in
           (noPasswd && !noPasswdFile) || (!noPasswd && noPasswdFile);
         message = "Option `password` or `passwordFile` must be set and cannot be set simultaneously";
       }
+      {
+        # Ensure localAddress is a string if package is shadowsocks-rust
+        assertion = !(getName cfg.package == "shadowsocks-rust" && !lib.strings.isString cfg.localAddress);
+        message = "Option `localAddress` must be a string when using shadowsocks-rust.";
+      }
     ];
 
-    systemd.services.shadowsocks-libev = {
-      description = "shadowsocks-libev Daemon";
+    systemd.services.${getName cfg.package} = {
+      description = "${getName cfg.package} Daemon";
       after = [ "network.target" ];
       wantedBy = [ "multi-user.target" ];
       path = [
-        pkgs.shadowsocks-libev
+        cfg.package
       ]
       ++ optional (cfg.plugin != null) cfg.plugin
       ++ optional (cfg.passwordFile != null) pkgs.jq;
@@ -179,7 +202,9 @@ in
         ${optionalString (cfg.passwordFile != null) ''
           cat ${configFile} | jq --arg password "$(cat "${cfg.passwordFile}")" '. + { password: $password }' > /tmp/shadowsocks.json
         ''}
-        exec ss-server -c ${if cfg.passwordFile != null then "/tmp/shadowsocks.json" else configFile}
+        exec ${(executablesMap.${getName cfg.package}).server} -c ${
+          if cfg.passwordFile != null then "/tmp/shadowsocks.json" else configFile
+        }
       '';
     };
   };

--- a/nixos/tests/shadowsocks/common.nix
+++ b/nixos/tests/shadowsocks/common.nix
@@ -1,11 +1,13 @@
 {
   name,
+  package,
   plugin ? null,
   pluginOpts ? "",
 }:
 
 import ../make-test-python.nix (
   { pkgs, lib, ... }:
+
   {
     inherit name;
     meta = {
@@ -27,9 +29,10 @@ import ../make-test-python.nix (
         networking.firewall.allowedUDPPorts = [ 8488 ];
         services.shadowsocks = {
           enable = true;
+          package = package;
           encryptionMethod = "chacha20-ietf-poly1305";
           password = "pa$$w0rd";
-          localAddress = [ "0.0.0.0" ];
+          localAddress = "0.0.0.0";
           port = 8488;
           fastOpen = false;
           mode = "tcp_and_udp";
@@ -78,7 +81,7 @@ import ../make-test-python.nix (
     testScript = ''
       start_all()
 
-      server.wait_for_unit("shadowsocks-libev.service")
+      server.wait_for_unit("${lib.getName package}.service")
       server.wait_for_unit("nginx.service")
       client.wait_for_unit("shadowsocks-client.service")
 

--- a/nixos/tests/shadowsocks/default.nix
+++ b/nixos/tests/shadowsocks/default.nix
@@ -5,12 +5,26 @@
 }:
 
 {
-  "basic" = import ./common.nix {
-    name = "basic";
+  "basic-libev" = import ./common.nix {
+    name = "basic-libev";
+    package = pkgs.shadowsocks-libev;
   };
 
-  "v2ray-plugin" = import ./common.nix {
-    name = "v2ray-plugin";
+  "basic-rust" = import ./common.nix {
+    name = "basic-rust";
+    package = pkgs.shadowsocks-rust;
+  };
+
+  "v2ray-plugin-libev" = import ./common.nix {
+    name = "v2ray-plugin-libev";
+    package = pkgs.shadowsocks-libev;
+    plugin = "${pkgs.shadowsocks-v2ray-plugin}/bin/v2ray-plugin";
+    pluginOpts = "host=nixos.org";
+  };
+
+  "v2ray-plugin-rust" = import ./common.nix {
+    name = "v2ray-plugin-rust";
+    package = pkgs.shadowsocks-rust;
     plugin = "${pkgs.shadowsocks-v2ray-plugin}/bin/v2ray-plugin";
     pluginOpts = "host=nixos.org";
   };


### PR DESCRIPTION
Related issues: 
- https://github.com/NixOS/nixpkgs/issues/384226
- https://github.com/NixOS/nixpkgs/issues/284530

Changes:
- add `package` option to services.shadowsocks and related changes
- add tests with `pkgs.shadowsocks-rust`
- add postfix 'libev' to original tests


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [X] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
