### PR TITLE
nixosTests.{lomiri-camera-app,morph-browser,teleports}: Fix OCR

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -764,7 +764,7 @@ in
   lomiri = discoverTests (import ./lomiri.nix);
   lomiri-calculator-app = runTest ./lomiri-calculator-app.nix;
   lomiri-calendar-app = runTest ./lomiri-calendar-app.nix;
-  lomiri-camera-app = runTest ./lomiri-camera-app.nix;
+  lomiri-camera-app = discoverTests (import ./lomiri-camera-app.nix);
   lomiri-clock-app = runTest ./lomiri-clock-app.nix;
   lomiri-docviewer-app = runTest ./lomiri-docviewer-app.nix;
   lomiri-filemanager-app = runTest ./lomiri-filemanager-app.nix;

--- a/nixos/tests/lomiri-camera-app.nix
+++ b/nixos/tests/lomiri-camera-app.nix
@@ -1,173 +1,286 @@
-{ lib, ... }:
-{
-  name = "lomiri-camera-app-standalone";
-  meta.maintainers = lib.teams.lomiri.members;
-
-  nodes.machine =
-    { config, pkgs, ... }:
-    {
-      imports = [ ./common/x11.nix ];
-
-      services.xserver.enable = true;
-
-      environment = {
-        systemPackages =
-          with pkgs;
-          [
-            feh # view photo result
-            ffmpeg # fake webcam stream
-            gnome-text-editor # somewhere to paste QR result
-            (imagemagick.override { ghostscriptSupport = true; }) # add label for OCR
-            qrtool # generate QR code
-            xdotool # clicking on QR button
-          ]
-          ++ (with pkgs.lomiri; [
-            suru-icon-theme
-            lomiri-camera-app
-          ]);
-        variables = {
-          UITK_ICON_THEME = "suru";
-        };
-      };
-
-      i18n.supportedLocales = [ "all" ];
-
-      fonts = {
-        packages = with pkgs; [
-          # Intended font & helps with OCR
-          ubuntu-classic
+let
+  makeTest = import ./make-test-python.nix;
+  feedLabel = "Image";
+  feedQrContent = "Test";
+  feedImageFile = "feed.png";
+  makeFeedImage =
+    pkgs:
+    pkgs.runCommand feedImageFile
+      {
+        nativeBuildInputs = with pkgs; [
+          (imagemagick.override { ghostscriptSupport = true; }) # add label for OCR
+          qrtool # generate QR code
         ];
-      };
+      }
+      ''
+        qrtool encode '${feedQrContent}' -s 20 -m 10 > qr.png
 
-      # Fake camera
-      boot.extraModulePackages = with config.boot.kernelPackages; [ v4l2loopback ];
-    };
+        # Horizontal flip, add text, flip back. Camera displays image mirrored, so need reversed text for OCR
+        magick qr.png \
+          -flop \
+          -pointsize 30 -fill black -annotate +100+100 '${feedLabel}' \
+          -flop \
+          $out
+      '';
+in
+{
+  basic = makeTest (
+    { lib, ... }:
+    {
+      name = "lomiri-camera-app-basic";
+      meta.maintainers = lib.teams.lomiri.members;
 
-  enableOCR = true;
+      nodes.machine =
+        { config, pkgs, ... }:
+        {
+          imports = [ ./common/x11.nix ];
 
-  testScript =
-    let
-      qrLabel = "Feed";
-      qrContent = "Test";
-    in
-    ''
-      machine.wait_for_x()
+          services.xserver.enable = true;
 
-      with subtest("lomiri camera launches"):
-          machine.succeed("lomiri-camera-app >&2 &")
-          # emitted twice
-          machine.wait_for_console_text("updateViewfinderResolution: viewfinder resolutions is not known yet")
-          machine.wait_for_console_text("updateViewfinderResolution: viewfinder resolutions is not known yet")
+          environment = {
+            systemPackages = with pkgs.lomiri; [
+              suru-icon-theme
+              lomiri-camera-app
+            ];
+            variables = {
+              UITK_ICON_THEME = "suru";
+            };
+          };
+
+          i18n.supportedLocales = [ "all" ];
+
+          fonts = {
+            packages = with pkgs; [
+              # Intended font & helps with OCR
+              ubuntu-classic
+            ];
+          };
+        };
+
+      enableOCR = true;
+
+      testScript =
+        let
+          qrLabel = "Feed";
+          qrContent = "Test";
+        in
+        ''
+          machine.wait_for_x()
+
+          with subtest("lomiri camera launches"):
+              machine.succeed("lomiri-camera-app >&2 &")
+              # emitted twice
+              machine.wait_for_console_text("updateViewfinderResolution: viewfinder resolutions is not known yet")
+              machine.wait_for_console_text("updateViewfinderResolution: viewfinder resolutions is not known yet")
+              machine.sleep(10)
+              machine.send_key("alt-f10")
+              machine.sleep(5)
+              machine.wait_for_text("Cannot access")
+              machine.screenshot("lomiri-camera_open")
+
+          machine.succeed("pgrep -afx lomiri-camera-app >&2")
+          machine.succeed("pkill -efx lomiri-camera-app >&2")
+          machine.wait_until_fails("pgrep -afx lomiri-camera-app >&2")
+
+          # Sometimes, GStreamer errors out on camera init with: CameraBin error: "Failed to allocate required memory."
+          # Adding more VM memory didn't affect this. Maybe flaky in general?
+          # Current assumption: Camera access gets requested in a weird/still-in-use state, so sleep abit
           machine.sleep(10)
-          machine.send_key("alt-f10")
-          machine.sleep(5)
-          machine.wait_for_text("Cannot access")
-          machine.screenshot("lomiri-camera_open")
 
-      machine.succeed("pkill -f lomiri-camera-app")
+          with subtest("lomiri camera localisation works"):
+              machine.succeed("env LANG=de_DE.UTF-8 lomiri-camera-app >&2 &")
+              # emitted twice
+              machine.wait_for_console_text("updateViewfinderResolution: viewfinder resolutions is not known yet")
+              machine.wait_for_console_text("updateViewfinderResolution: viewfinder resolutions is not known yet")
+              machine.sleep(10)
+              machine.send_key("alt-f10")
+              machine.sleep(5)
+              machine.wait_for_text("Zugriff auf")
+              machine.screenshot("lomiri-camera_localised")
+        '';
+    }
+  );
 
-      # Setup fake v4l2 camera
-      machine.succeed("modprobe v4l2loopback video_nr=10 card_label=Video-Loopback exclusive_caps=1")
-      machine.succeed("qrtool encode '${qrContent}' -s 20 -m 10 > qr.png")
-      # Horizontal flip, add text, flip back. Camera displays image mirrored, so need reversed text for OCR
-      machine.succeed("magick qr.png -flop -pointsize 30 -fill black -annotate +100+100 '${qrLabel}' -flop output.png")
-      machine.succeed("ffmpeg -re -loop 1 -i output.png -vf format=yuv420p -f v4l2 /dev/video10 -loglevel fatal >&2 &")
+  v4l2-photo = makeTest (
+    { lib, ... }:
+    {
+      name = "lomiri-camera-app-v4l2-photo";
+      meta.maintainers = lib.teams.lomiri.members;
 
-      with subtest("lomiri camera uses camera"):
-          machine.succeed("lomiri-camera-app >&2 &")
-          # emitted twice
-          machine.wait_for_console_text("No flash control support")
-          machine.wait_for_console_text("No flash control support")
-          machine.sleep(10)
-          machine.send_key("alt-f10")
-          machine.sleep(5)
-          machine.wait_for_text("${qrLabel}")
-          machine.screenshot("lomiri-camera_feed")
+      nodes.machine =
+        { config, pkgs, ... }:
+        {
+          imports = [ ./common/x11.nix ];
 
-          machine.succeed("xdotool mousemove 510 670 click 1") # take photo
-          machine.wait_until_succeeds("ls /root/Pictures/camera.ubports | grep '\\.jpg$'")
+          services.xserver.enable = true;
 
-          # Check that the image is correct
-          machine.send_key("ctrl-alt-right")
-          machine.succeed("magick /root/Pictures/camera.ubports/IMG_00000001.jpg -flop photo_flip.png")
-          machine.succeed("feh photo_flip.png >&2 &")
-          machine.sleep(10)
-          machine.wait_for_text("${qrLabel}")
-          machine.screenshot("lomiri-camera_photo")
+          environment = {
+            etc."${feedImageFile}".source = makeFeedImage pkgs;
+            systemPackages =
+              with pkgs;
+              [
+                feh # view photo result
+                ffmpeg # fake webcam stream
+                imagemagick # unflip webcam photo
+                xdotool # clicking on camera button
+              ]
+              ++ (with pkgs.lomiri; [
+                suru-icon-theme
+                lomiri-camera-app
+              ]);
+            variables = {
+              UITK_ICON_THEME = "suru";
+            };
+          };
 
-      machine.succeed("pkill -f feh")
-      machine.send_key("ctrl-alt-left")
-      machine.succeed("pkill -f lomiri-camera-app")
+          i18n.supportedLocales = [ "all" ];
 
-      # Sometimes no camera feed, GStreamer errors out with: CameraBin error: "Failed to allocate required memory."
-      # Adding more VM memory didn't affect this. Maybe flaky in general?
-      # Current assumption: Camera access gets requested in a weird/still-in-use state, so sleep abit
-      machine.sleep(10)
+          fonts = {
+            packages = with pkgs; [
+              # Intended font & helps with OCR
+              ubuntu-classic
+            ];
+          };
 
-      with subtest("lomiri barcode scanner uses camera"):
-          machine.succeed("lomiri-camera-app --mode=barcode-reader >&2 &")
-          # emitted twice
-          machine.wait_for_console_text("No flash control support")
-          machine.wait_for_console_text("No flash control support")
-          machine.sleep(10)
-          machine.send_key("alt-f10")
-          machine.sleep(5)
-          machine.wait_for_text("${qrLabel}")
-          machine.succeed("xdotool mousemove 510 670 click 1") # open up QR decode result
+          # Fake camera
+          boot.extraModulePackages = with config.boot.kernelPackages; [ v4l2loopback ];
+        };
 
-          # OCR is struggling to recognise the text. Click the clipboard button and paste the result somewhere else
-          machine.sleep(5)
-          machine.screenshot("lomiri-barcode_decode")
-          machine.succeed("xdotool mousemove 540 590 click 1")
-          machine.sleep(5)
+      enableOCR = true;
 
-          # Need to make a new window without closing camera app, otherwise clipboard content gets lost?
-          machine.send_key("ctrl-alt-right")
-          machine.succeed("gnome-text-editor >&2 &")
-          machine.sleep(10)
-          machine.send_key("alt-f10")
-          machine.sleep(5)
-          machine.wait_for_text("New")
+      testScript = ''
+        machine.wait_for_x()
 
-          # Font size up to help with OCR
-          machine.send_key("ctrl-kp_add")
-          machine.send_key("ctrl-kp_add")
-          machine.send_key("ctrl-kp_add")
-          machine.send_key("ctrl-kp_add")
-          machine.send_key("ctrl-kp_add")
-          machine.send_key("ctrl-kp_add")
-          machine.send_key("ctrl-kp_add")
-          machine.send_key("ctrl-kp_add")
-          machine.send_key("ctrl-kp_add")
-          machine.send_key("ctrl-kp_add")
-          machine.send_key("ctrl-kp_add")
-          machine.send_key("ctrl-kp_add")
-          machine.send_key("ctrl-kp_add")
-          machine.send_key("ctrl-kp_add")
-          machine.send_key("ctrl-kp_add")
-          machine.send_key("ctrl-kp_add")
+        # Setup fake v4l2 camera
+        machine.succeed("modprobe v4l2loopback video_nr=10 card_label=Video-Loopback exclusive_caps=1")
+        machine.succeed("ffmpeg -re -loop 1 -i /etc/${feedImageFile} -vf format=yuv420p -f v4l2 /dev/video10 -loglevel fatal >&2 &")
 
-          machine.send_key("ctrl-v")
-          machine.wait_for_text("${qrContent}")
+        with subtest("lomiri camera uses camera"):
+            machine.succeed("lomiri-camera-app >&2 &")
+            # emitted twice
+            machine.wait_for_console_text("No flash control support")
+            machine.wait_for_console_text("No flash control support")
+            machine.sleep(10)
+            machine.send_key("alt-f10")
+            machine.sleep(5)
+            machine.wait_for_text("${feedLabel}")
+            machine.screenshot("lomiri-camera_feed")
 
-      machine.succeed("pkill -f gnome-text-editor")
-      machine.send_key("ctrl-alt-left")
-      machine.succeed("pkill -f lomiri-camera-app")
+            machine.succeed("xdotool mousemove 510 670 click 1") # take photo
+            machine.wait_until_succeeds("ls /root/Pictures/camera.ubports | grep '\\.jpg$'")
 
-      # Sometimes no camera feed, GStreamer errors out with: CameraBin error: "Failed to allocate required memory."
-      # Adding more VM memory didn't affect this. Maybe flaky in general?
-      # Current assumption: Camera access gets requested in a weird/still-in-use state, so sleep abit
-      machine.sleep(10)
+            # Check that the image is correct
+            machine.send_key("ctrl-alt-right")
+            machine.succeed("magick /root/Pictures/camera.ubports/IMG_00000001.jpg -flop photo_flip.png")
+            machine.succeed("feh photo_flip.png >&2 &")
+            machine.sleep(10)
+            machine.send_key("alt-f10")
+            machine.sleep(5)
+            machine.wait_for_text("${feedLabel}")
+            machine.screenshot("lomiri-camera_photo")
+      '';
+    }
+  );
 
-      with subtest("lomiri camera localisation works"):
-          machine.succeed("env LANG=de_DE.UTF-8 lomiri-camera-app >&2 &")
-          # emitted twice
-          machine.wait_for_console_text("No flash control support")
-          machine.wait_for_console_text("No flash control support")
-          machine.sleep(10)
-          machine.send_key("alt-f10")
-          machine.sleep(5)
-          machine.wait_for_text("Kamera")
-          machine.screenshot("lomiri-camera_localised")
-    '';
+  v4l2-qr = makeTest (
+    { lib, ... }:
+    {
+      name = "lomiri-camera-app-v4l2-qr";
+      meta.maintainers = lib.teams.lomiri.members;
+
+      nodes.machine =
+        { config, pkgs, ... }:
+        {
+          imports = [ ./common/x11.nix ];
+
+          services.xserver.enable = true;
+
+          environment = {
+            etc."${feedImageFile}".source = makeFeedImage pkgs;
+            systemPackages =
+              with pkgs;
+              [
+                ffmpeg # fake webcam stream
+                gnome-text-editor # somewhere to paste QR result
+                xdotool # clicking on QR button
+              ]
+              ++ (with pkgs.lomiri; [
+                suru-icon-theme
+                lomiri-camera-app
+              ]);
+            variables = {
+              UITK_ICON_THEME = "suru";
+            };
+          };
+
+          i18n.supportedLocales = [ "all" ];
+
+          fonts = {
+            packages = with pkgs; [
+              # Intended font & helps with OCR
+              ubuntu-classic
+            ];
+          };
+
+          # Fake camera
+          boot.extraModulePackages = with config.boot.kernelPackages; [ v4l2loopback ];
+        };
+
+      enableOCR = true;
+
+      testScript = ''
+        machine.wait_for_x()
+
+        # Setup fake v4l2 camera
+        machine.succeed("modprobe v4l2loopback video_nr=10 card_label=Video-Loopback exclusive_caps=1")
+        machine.succeed("ffmpeg -re -loop 1 -i /etc/${feedImageFile} -vf format=yuv420p -f v4l2 /dev/video10 -loglevel fatal >&2 &")
+
+        with subtest("lomiri barcode scanner uses camera"):
+            machine.succeed("lomiri-camera-app --mode=barcode-reader >&2 &")
+            # emitted twice
+            machine.wait_for_console_text("No flash control support")
+            machine.wait_for_console_text("No flash control support")
+            machine.sleep(10)
+            machine.send_key("alt-f10")
+            machine.sleep(5)
+            machine.wait_for_text("${feedLabel}")
+            machine.succeed("xdotool mousemove 510 670 click 1") # open up QR decode result
+
+            # OCR is struggling to recognise the text. Click the clipboard button and paste the result somewhere else
+            machine.sleep(5)
+            machine.screenshot("lomiri-barcode_decode")
+            machine.succeed("xdotool mousemove 540 590 click 1")
+            machine.sleep(5)
+
+            # Need to make a new window without closing camera app, otherwise clipboard content gets lost?
+            machine.send_key("ctrl-alt-right")
+            machine.succeed("gnome-text-editor >&2 &")
+            machine.sleep(10)
+            machine.send_key("alt-f10")
+            machine.sleep(5)
+            machine.wait_for_text("New")
+
+            # Font size up to help with OCR
+            machine.send_key("ctrl-kp_add")
+            machine.send_key("ctrl-kp_add")
+            machine.send_key("ctrl-kp_add")
+            machine.send_key("ctrl-kp_add")
+            machine.send_key("ctrl-kp_add")
+            machine.send_key("ctrl-kp_add")
+            machine.send_key("ctrl-kp_add")
+            machine.send_key("ctrl-kp_add")
+            machine.send_key("ctrl-kp_add")
+            machine.send_key("ctrl-kp_add")
+            machine.send_key("ctrl-kp_add")
+            machine.send_key("ctrl-kp_add")
+            machine.send_key("ctrl-kp_add")
+            machine.send_key("ctrl-kp_add")
+            machine.send_key("ctrl-kp_add")
+            machine.send_key("ctrl-kp_add")
+
+            machine.send_key("ctrl-v")
+            machine.wait_for_text("${feedQrContent}")
+      '';
+    }
+  );
 }

--- a/nixos/tests/lomiri-camera-app.nix
+++ b/nixos/tests/lomiri-camera-app.nix
@@ -55,6 +55,8 @@
 
       with subtest("lomiri camera launches"):
           machine.succeed("lomiri-camera-app >&2 &")
+          # emitted twice
+          machine.wait_for_console_text("updateViewfinderResolution: viewfinder resolutions is not known yet")
           machine.wait_for_console_text("updateViewfinderResolution: viewfinder resolutions is not known yet")
           machine.sleep(10)
           machine.send_key("alt-f10")
@@ -73,7 +75,9 @@
 
       with subtest("lomiri camera uses camera"):
           machine.succeed("lomiri-camera-app >&2 &")
-          machine.wait_for_console_text("updateViewfinderResolution: For target resolution")
+          # emitted twice
+          machine.wait_for_console_text("No flash control support")
+          machine.wait_for_console_text("No flash control support")
           machine.sleep(10)
           machine.send_key("alt-f10")
           machine.sleep(5)
@@ -95,9 +99,16 @@
       machine.send_key("ctrl-alt-left")
       machine.succeed("pkill -f lomiri-camera-app")
 
+      # Sometimes no camera feed, GStreamer errors out with: CameraBin error: "Failed to allocate required memory."
+      # Adding more VM memory didn't affect this. Maybe flaky in general?
+      # Current assumption: Camera access gets requested in a weird/still-in-use state, so sleep abit
+      machine.sleep(10)
+
       with subtest("lomiri barcode scanner uses camera"):
           machine.succeed("lomiri-camera-app --mode=barcode-reader >&2 &")
-          machine.wait_for_console_text("updateViewfinderResolution: For target resolution")
+          # emitted twice
+          machine.wait_for_console_text("No flash control support")
+          machine.wait_for_console_text("No flash control support")
           machine.sleep(10)
           machine.send_key("alt-f10")
           machine.sleep(5)
@@ -143,9 +154,16 @@
       machine.send_key("ctrl-alt-left")
       machine.succeed("pkill -f lomiri-camera-app")
 
+      # Sometimes no camera feed, GStreamer errors out with: CameraBin error: "Failed to allocate required memory."
+      # Adding more VM memory didn't affect this. Maybe flaky in general?
+      # Current assumption: Camera access gets requested in a weird/still-in-use state, so sleep abit
+      machine.sleep(10)
+
       with subtest("lomiri camera localisation works"):
           machine.succeed("env LANG=de_DE.UTF-8 lomiri-camera-app >&2 &")
-          machine.wait_for_console_text("updateViewfinderResolution: For target resolution")
+          # emitted twice
+          machine.wait_for_console_text("No flash control support")
+          machine.wait_for_console_text("No flash control support")
           machine.sleep(10)
           machine.send_key("alt-f10")
           machine.sleep(5)

--- a/nixos/tests/lomiri-camera-app.nix
+++ b/nixos/tests/lomiri-camera-app.nix
@@ -201,7 +201,7 @@ in
               with pkgs;
               [
                 ffmpeg # fake webcam stream
-                gnome-text-editor # somewhere to paste QR result
+                xclip # inspect QR contents copied into clipboard
                 xdotool # clicking on QR button
               ]
               ++ (with pkgs.lomiri; [
@@ -246,40 +246,11 @@ in
             machine.wait_for_text("${feedLabel}")
             machine.succeed("xdotool mousemove 510 670 click 1") # open up QR decode result
 
-            # OCR is struggling to recognise the text. Click the clipboard button and paste the result somewhere else
+            # OCR is struggling to recognise the text. Click the clipboard button, check what got copied
             machine.sleep(5)
             machine.screenshot("lomiri-barcode_decode")
             machine.succeed("xdotool mousemove 540 590 click 1")
-            machine.sleep(5)
-
-            # Need to make a new window without closing camera app, otherwise clipboard content gets lost?
-            machine.send_key("ctrl-alt-right")
-            machine.succeed("gnome-text-editor >&2 &")
-            machine.sleep(10)
-            machine.send_key("alt-f10")
-            machine.sleep(5)
-            machine.wait_for_text("New")
-
-            # Font size up to help with OCR
-            machine.send_key("ctrl-kp_add")
-            machine.send_key("ctrl-kp_add")
-            machine.send_key("ctrl-kp_add")
-            machine.send_key("ctrl-kp_add")
-            machine.send_key("ctrl-kp_add")
-            machine.send_key("ctrl-kp_add")
-            machine.send_key("ctrl-kp_add")
-            machine.send_key("ctrl-kp_add")
-            machine.send_key("ctrl-kp_add")
-            machine.send_key("ctrl-kp_add")
-            machine.send_key("ctrl-kp_add")
-            machine.send_key("ctrl-kp_add")
-            machine.send_key("ctrl-kp_add")
-            machine.send_key("ctrl-kp_add")
-            machine.send_key("ctrl-kp_add")
-            machine.send_key("ctrl-kp_add")
-
-            machine.send_key("ctrl-v")
-            machine.wait_for_text("${feedQrContent}")
+            machine.wait_until_succeeds("env DISPLAY=:0 xclip -selection clipboard -o | grep -q '${feedQrContent}'")
       '';
     }
   );

--- a/nixos/tests/morph-browser.nix
+++ b/nixos/tests/morph-browser.nix
@@ -36,7 +36,10 @@
     machine.wait_for_x()
 
     with subtest("morph browser launches"):
-        machine.execute("morph-browser >&2 &")
+        machine.succeed("morph-browser >&2 &")
+        machine.sleep(10)
+        machine.send_key("alt-f10")
+        machine.sleep(5)
         machine.wait_for_text(r"Web Browser|New|sites|Bookmarks")
         machine.screenshot("morph_open")
 
@@ -47,8 +50,14 @@
 
     machine.succeed("pkill -f morph-browser")
 
+    # Get rid of saved tabs, to show localised start page
+    machine.succeed("rm -r /root/.local/share/morph-browser")
+
     with subtest("morph browser localisation works"):
-        machine.execute("env LANG=de_DE.UTF-8 morph-browser >&2 &")
+        machine.succeed("env LANG=de_DE.UTF-8 morph-browser >&2 &")
+        machine.sleep(10)
+        machine.send_key("alt-f10")
+        machine.sleep(5)
         machine.wait_for_text(r"Web-Browser|Neuer|Seiten|Lesezeichen")
         machine.screenshot("morph_localised")
   '';

--- a/nixos/tests/teleports.nix
+++ b/nixos/tests/teleports.nix
@@ -36,7 +36,7 @@
     with subtest("teleports launches"):
         machine.succeed("teleports >&2 &")
         machine.wait_for_console_text("authorizationStateWaitPhoneNumber")
-        machine.send_key("alt-f10")
+        # Not fullscreening, because main app colour makes OCR stuck
         machine.sleep(2)
         machine.wait_for_text(r"(TELEports|Phone Number)")
         machine.screenshot("teleports_open")
@@ -46,7 +46,7 @@
     with subtest("teleports localisation works"):
         machine.succeed("env LANG=de_DE.UTF-8 teleports >&2 &")
         machine.wait_for_console_text("authorizationStateWaitPhoneNumber")
-        machine.send_key("alt-f10")
+        # Not fullscreening, because main app colour makes OCR stuck
         machine.sleep(2)
         machine.wait_for_text("Telefonnummer")
         machine.screenshot("teleports_localised")

--- a/pkgs/desktops/lomiri/applications/lomiri-camera-app/default.nix
+++ b/pkgs/desktops/lomiri/applications/lomiri-camera-app/default.nix
@@ -132,7 +132,13 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   passthru = {
-    tests.vm = nixosTests.lomiri-camera-app;
+    tests = {
+      inherit (nixosTests.lomiri-camera-app)
+        basic
+        v4l2-photo
+        v4l2-qr
+        ;
+    };
     updateScript = gitUpdater { rev-prefix = "v"; };
   };
 


### PR DESCRIPTION
Round 2 >.>…

- `nixosTests.lomiri-camera-app`:
  The initial submission worked at the time of writing, but on a recent run, OCR got stuck on the QR scanner mode check and output had the following message:
    ```
    CameraBin error: "Failed to allocate required memory."
    ```
    This error is from GStreamer, presumably when access to the camera was attempted. I've added some maybe-placebo sleeps. Since the error only happened the second time we're launching the app with a valid camera, I'm assuming that we were just badly timing the second camera access. I'm hoping that the additional delay with fix that.

  Also, the messages we were looking for all get printed twice. In the case of `updateViewfinderResolution: For target resolution`, the print amount was… random? Either 2 or 3, not sure why.
  Look for a different message, and double up all of the checks to make sure we're not finding old ones.

- `nixosTests.morph-browser`:
  Missed this one in the previous OCR fix round, made it more reliable now.

- `nixosTests.teleports`:
  Making the app fullscreen actually makes OCR *worse* now, because the background colour gets messed up by one of the preprocessing steps and causes long OCR times.
  IceWM background got made nicer for OCR, so keep the window at the default size.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
