### PR TITLE
[python3Packages.]uv: Remove dependencies on `cmake` and `pkg-config`

### DIFF
--- a/pkgs/by-name/uv/uv/package.nix
+++ b/pkgs/by-name/uv/uv/package.nix
@@ -8,9 +8,7 @@
   rust-jemalloc-sys,
 
   # nativeBuildInputs
-  cmake,
   installShellFiles,
-  pkg-config,
 
   buildPackages,
   versionCheckHook,
@@ -36,13 +34,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     rust-jemalloc-sys
   ];
 
-  nativeBuildInputs = [
-    cmake
-    installShellFiles
-    pkg-config
-  ];
-
-  dontUseCmakeConfigure = true;
+  nativeBuildInputs = [ installShellFiles ];
 
   cargoBuildFlags = [
     "--package"
@@ -64,9 +56,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     ''
   );
 
-  nativeInstallCheckInputs = [
-    versionCheckHook
-  ];
+  nativeInstallCheckInputs = [ versionCheckHook ];
   versionCheckProgramArg = "--version";
   doInstallCheck = true;
 

--- a/pkgs/by-name/uv/uv/package.nix
+++ b/pkgs/by-name/uv/uv/package.nix
@@ -74,6 +74,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
       mit
     ];
     maintainers = with lib.maintainers; [
+      bengsparks
       GaetanLepage
       prince213
     ];

--- a/pkgs/development/python-modules/uv/default.nix
+++ b/pkgs/development/python-modules/uv/default.nix
@@ -3,6 +3,7 @@
   installShellFiles,
   rustPlatform,
   pkgs,
+  versionCheckHook,
 }:
 
 buildPythonPackage {
@@ -27,6 +28,8 @@ buildPythonPackage {
     rustPlatform.cargoSetupHook
     rustPlatform.maturinBuildHook
   ];
+
+  nativeCheckInputs = [ versionCheckHook ];
 
   pyproject = true;
   pythonImportsCheck = [ "uv" ];

--- a/pkgs/development/python-modules/uv/default.nix
+++ b/pkgs/development/python-modules/uv/default.nix
@@ -1,7 +1,6 @@
 {
   buildPythonPackage,
   installShellFiles,
-  pkg-config,
   rustPlatform,
   pkgs,
 }:
@@ -12,7 +11,6 @@ buildPythonPackage {
     version
     src
     cargoDeps
-    dontUseCmakeConfigure
     meta
     cargoBuildFlags
     postInstall
@@ -25,9 +23,7 @@ buildPythonPackage {
   '';
 
   nativeBuildInputs = [
-    pkgs.cmake
     installShellFiles
-    pkg-config
     rustPlatform.cargoSetupHook
     rustPlatform.maturinBuildHook
   ];


### PR DESCRIPTION
There are no references to `cmake` in the entire project, but these dependencies have been included in the package since it was first added in https://github.com/NixOS/nixpkgs/commit/29a6185988047c3e01e7a2410dcf2a742b82fc73. The relevant PR https://github.com/NixOS/nixpkgs/pull/289151 does not include a rationale for this, and even back then, the repository at the time did not include `CMakeLists.txt` or `*.cmake` files. 
Perhaps this was due to historical reasons, but nowadays there is no need for it :)

I've also added `versionCheckHook` to the Python package, so that `inherit (pkgs.uv) versionCheckProgramArg;` actually does something for the package. 
Finally I've added myself to the maintainer list of `uv`, as I get to use `uv` from nixpkgs at work, and also responsible for the `uv-build` package, which `inherit`s a fair amount from `uv`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
