### PR TITLE
nixfmt-tree: remove `tree-root-file` default

### DIFF
--- a/pkgs/by-name/ni/nixfmt-tree/package.nix
+++ b/pkgs/by-name/ni/nixfmt-tree/package.nix
@@ -4,6 +4,8 @@
   treefmt,
   nixfmt-rfc-style,
   nixfmt-tree,
+  git,
+  writableTmpDirAsHomeHook,
 
   settings ? { },
   runtimeInputs ? [ ],
@@ -29,9 +31,6 @@ let
         # Log level for files treefmt won't format
         # The default is warn, which would be too annoying for people who just care about Nix
         on-unmatched = lib.mkOptionDefault "info";
-
-        # Assume the tree is a Git repository, will fail if it's not
-        tree-root-file = lib.mkOptionDefault ".git/index";
 
         # NOTE: The `mkIf` condition should not be needed once `runtimePackages` is removed.
         formatter.nixfmt = lib.mkIf (lib.any isNixfmt allRuntimeInputs) {
@@ -102,9 +101,6 @@ treefmtWithConfig.overrideAttrs {
           # Log level for files treefmt won't format
           on-unmatched = "info";
 
-          # Assume the tree is a Git repository, will fail if it's not
-          tree-root-file = ".git/index";
-
           # Configure nixfmt for .nix files
           formatter.nixfmt = {
             command = "nixfmt";
@@ -122,49 +118,63 @@ treefmtWithConfig.overrideAttrs {
     platforms = lib.platforms.all;
   };
 
-  passthru.tests.simple = runCommand "nixfmt-tree-test-simple" { } ''
-    export XDG_CACHE_HOME=$(mktemp -d)
-    cat > unformatted.nix <<EOF
-    let to = "be formatted"; in to
-    EOF
+  passthru.tests.simple =
+    runCommand "nixfmt-tree-test-simple"
+      {
+        nativeBuildInputs = [
+          git
+          nixfmt-tree
+          writableTmpDirAsHomeHook
+        ];
+      }
+      ''
+        git config --global user.email "nix-builder@nixos.org"
+        git config --global user.name "Nix Builder"
 
-    cat > formatted.nix <<EOF
-    let
-      to = "be formatted";
-    in
-    to
-    EOF
+        cat > unformatted.nix <<EOF
+        let to = "be formatted"; in to
+        EOF
 
-    mkdir -p repo
-    (
-      cd repo
-      mkdir .git dir
-      touch .git/index
-      cp ../unformatted.nix a.nix
-      cp ../unformatted.nix dir/b.nix
+        cat > formatted.nix <<EOF
+        let
+          to = "be formatted";
+        in
+        to
+        EOF
 
-      ${lib.getExe nixfmt-tree} dir
-      if [[ "$(<dir/b.nix)" != "$(<../formatted.nix)" ]]; then
-        echo "File dir/b.nix was not formatted properly after dir was requested to be formatted"
-        exit 1
-      elif [[ "$(<a.nix)" != "$(<../unformatted.nix)" ]]; then
-        echo "File a.nix was formatted when only dir was requested to be formatted"
-        exit 1
-      fi
+        mkdir -p repo
+        (
+          cd repo
+          mkdir dir
+          cp ../unformatted.nix a.nix
+          cp ../unformatted.nix dir/b.nix
 
-      (
-        cd dir
-        ${lib.getExe nixfmt-tree}
-      )
+          git init
+          git add .
+          git commit -m "Initial commit"
 
-      if [[ "$(<a.nix)" != "$(<../formatted.nix)" ]]; then
-        echo "File a.nix was not formatted properly after running treefmt without arguments in dir"
-        exit 1
-      fi
-    )
+          treefmt dir
+          if [[ "$(<dir/b.nix)" != "$(<../formatted.nix)" ]]; then
+            echo "File dir/b.nix was not formatted properly after dir was requested to be formatted"
+            exit 1
+          elif [[ "$(<a.nix)" != "$(<../unformatted.nix)" ]]; then
+            echo "File a.nix was formatted when only dir was requested to be formatted"
+            exit 1
+          fi
 
-    echo "Success!"
+          (
+            cd dir
+            treefmt
+          )
 
-    touch $out
-  '';
+          if [[ "$(<a.nix)" != "$(<../formatted.nix)" ]]; then
+            echo "File a.nix was not formatted properly after running treefmt without arguments in dir"
+            exit 1
+          fi
+        )
+
+        echo "Success!"
+
+        touch $out
+      '';
 }


### PR DESCRIPTION
This isn't needed since treefmt 2.3.1 (#409400). treefmt can now find the tree root by asking `git`.

Updated test to use a real `git` repo instead of stubbing `.git/index`, as otherwise treefmt can't run `git rev-parse --show-toplevel`.

cc @brianmcgee @jfly

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - `nix-build -A nixfmt-tree.tests`
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
