### PR TITLE
labels: Automatically label CI changes for backport to 25.05

### DIFF
--- a/.github/labeler-no-sync.yml
+++ b/.github/labeler-no-sync.yml
@@ -22,7 +22,7 @@
         - doc/**/*
         - nixos/doc/**/*
 
-"backport release-24.11":
+"backport release-25.05":
   - any:
     - changed-files:
       - any-glob-to-any-file:


### PR DESCRIPTION
I removed the automatically applied backport label for 24.11 here, because this label would still be present on the 25.05 branch. Thus CI changes would be marked for backport to 25.05 on master and then for backport to 24.11 on the backport PR.

Recursive backporting.

## Things done

- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
