### PR TITLE
python3Packages.cirq: 1.4.1-unstable-2024-09-21 -> 1.5.0

### DIFF
--- a/pkgs/development/python-modules/cirq-aqt/default.nix
+++ b/pkgs/development/python-modules/cirq-aqt/default.nix
@@ -13,12 +13,11 @@ buildPythonPackage rec {
 
   sourceRoot = "${src.name}/${pname}";
 
-  postPatch = ''
-    substituteInPlace requirements.txt \
-      --replace-fail "requests~=2.18" "requests"
-  '';
-
   build-system = [ setuptools ];
+
+  pythonRelaxDeps = [
+    "requests"
+  ];
 
   dependencies = [
     cirq-core

--- a/pkgs/development/python-modules/cirq-core/default.nix
+++ b/pkgs/development/python-modules/cirq-core/default.nix
@@ -37,14 +37,14 @@
 
 buildPythonPackage rec {
   pname = "cirq-core";
-  version = "1.4.1-unstable-2024-09-21";
+  version = "1.5.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "quantumlib";
     repo = "cirq";
-    rev = "3fefe2984a1203c0bf647c1ea84f4882b05f8477";
-    hash = "sha256-/WDKVxNJ8pewTLAFTyAZ/nnYcJSLubEJcn7qoJslZ3U=";
+    tag = "v${version}";
+    hash = "sha256-4FgXX4ox7BkjmLecxsvg0/JpcrHPn6hlFw5rk4bn9Cc=";
   };
 
   sourceRoot = "${src.name}/${pname}";
@@ -98,6 +98,10 @@ buildPythonPackage rec {
     ++ lib.optionals stdenv.hostPlatform.isAarch64 [
       # https://github.com/quantumlib/Cirq/issues/5924
       "test_prepare_two_qubit_state_using_sqrt_iswap"
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [
+      # test_scalar_division[scalar9-terms9-terms_expected9] result differs in the final digit
+      "test_scalar_division"
     ];
 
   meta = {

--- a/pkgs/development/python-modules/cirq-google/default.nix
+++ b/pkgs/development/python-modules/cirq-google/default.nix
@@ -6,6 +6,7 @@
   protobuf,
   freezegun,
   pytestCheckHook,
+  typedunits,
 }:
 
 buildPythonPackage rec {
@@ -25,6 +26,7 @@ buildPythonPackage rec {
     cirq-core
     google-api-core
     protobuf
+    typedunits
   ] ++ google-api-core.optional-dependencies.grpc;
 
   nativeCheckInputs = [

--- a/pkgs/development/python-modules/cirq-ionq/default.nix
+++ b/pkgs/development/python-modules/cirq-ionq/default.nix
@@ -13,12 +13,11 @@ buildPythonPackage rec {
 
   sourceRoot = "${src.name}/${pname}";
 
-  postPatch = ''
-    substituteInPlace requirements.txt \
-      --replace-fail "requests~=2.18" "requests"
-  '';
-
   build-system = [ setuptools ];
+
+  pythonRelaxDeps = [
+    "requests"
+  ];
 
   dependencies = [
     cirq-core

--- a/pkgs/development/python-modules/cirq-pasqal/default.nix
+++ b/pkgs/development/python-modules/cirq-pasqal/default.nix
@@ -13,12 +13,11 @@ buildPythonPackage rec {
 
   sourceRoot = "${src.name}/${pname}";
 
-  postPatch = ''
-    substituteInPlace requirements.txt \
-      --replace-fail "requests~=2.18" "requests"
-  '';
-
   build-system = [ setuptools ];
+
+  pythonRelaxDeps = [
+    "requests"
+  ];
 
   dependencies = [
     cirq-core

--- a/pkgs/development/python-modules/cirq-rigetti/default.nix
+++ b/pkgs/development/python-modules/cirq-rigetti/default.nix
@@ -14,7 +14,10 @@ buildPythonPackage rec {
 
   sourceRoot = "${src.name}/${pname}";
 
-  pythonRelaxDeps = [ "pyquil" ];
+  pythonRelaxDeps = [
+    "pyquil"
+    "qcs-sdk-python"
+  ];
 
   postPatch = ''
     # Remove outdated test

--- a/pkgs/development/python-modules/typedunits/default.nix
+++ b/pkgs/development/python-modules/typedunits/default.nix
@@ -1,0 +1,68 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  stdenv,
+  cython,
+  setuptools,
+  attrs,
+  numpy,
+  protobuf,
+  pyparsing,
+  pytestCheckHook,
+}:
+
+buildPythonPackage {
+  pname = "typedunits";
+  version = "0.0.1.dev20250509200845";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "quantumlib";
+    repo = "TypedUnits";
+    # PyPi ships platform- and python- specific wheels, so pin the matching source
+    rev = "95e698b10454dc8dffdb708d56199a748e6dab75";
+    hash = "sha256-mNo2s1sIMOa7zYfp6XyF8CBQ840+XvN0Ek59W6bRqeM=";
+  };
+
+  build-system = [
+    cython
+    setuptools
+  ];
+
+  dependencies = [
+    attrs
+    cython
+    numpy
+    protobuf
+    pyparsing
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  disabledTests = lib.optionals stdenv.hostPlatform.isDarwin [
+    # Rounding differences
+    "test_float_to_twelths_frac"
+  ];
+
+  disabledTestPaths = [
+    # Flaky due to host timing differences under load
+    "test_perf/test_array_with_dimension_performance.py"
+    "test_perf/test_value__array_performance.py"
+    "test_perf/test_value_performance.py"
+    "test_perf/test_value_with_dimension_performance.py"
+  ];
+
+  pythonImportsCheck = [
+    "tunits"
+  ];
+
+  meta = {
+    description = "Units and dimensions library with support for static dimensionality checking and protobuffer serialization";
+    homepage = "https://github.com/quantumlib/TypedUnits";
+    license = lib.licenses.asl20;
+    maintainers = [ lib.maintainers.sarahec ];
+  };
+}

--- a/pkgs/development/python-modules/typedunits/default.nix
+++ b/pkgs/development/python-modules/typedunits/default.nix
@@ -50,7 +50,7 @@ buildPythonPackage {
   disabledTestPaths = [
     # Flaky due to host timing differences under load
     "test_perf/test_array_with_dimension_performance.py"
-    "test_perf/test_value__array_performance.py"
+    "test_perf/test_value_array_performance.py"
     "test_perf/test_value_performance.py"
     "test_perf/test_value_with_dimension_performance.py"
   ];

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -17907,6 +17907,8 @@ self: super: with self; {
 
   typed-settings = callPackage ../development/python-modules/typed-settings { };
 
+  typedunits = callPackage ../development/python-modules/typedunits { };
+
   typeguard = callPackage ../development/python-modules/typeguard { };
 
   typepy = callPackage ../development/python-modules/typepy { };


### PR DESCRIPTION
Updates `python3Packages.cirq` to 1.5.0, including:
* `python3Packages.cirq-core`
* `python3Packages.cirq-google`
* `python3Packages.cirq-aqt`
* `python3Packages.cirq-ionq`
* `python3Packages.cirq-pasqual`
* `python3Packages.cirq-rigetti`

Initializes `python3Packages.typedunits` as it's a dependency of `python3Packages.cirq-google`

Note: The [cirq 1.5.0 release notes](https://github.com/quantumlib/Cirq/releases/tag/v1.5.0) declare `cirq-regetti` as deprecated and removed, but it's still receiving updates in the source. 

Part of #407693

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [x] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
