### PR TITLE
gnatprove: fix building with gcc 14

### DIFF
--- a/pkgs/development/ada-modules/gnatprove/0003-Adjust-after-category-change-for-N_Formal_Package_De.patch
+++ b/pkgs/development/ada-modules/gnatprove/0003-Adjust-after-category-change-for-N_Formal_Package_De.patch
@@ -1,0 +1,33 @@
+From 3c06fb993ae628b5069c1f3e23f11c53815e1cbe Mon Sep 17 00:00:00 2001
+From: Eric Botcazou <ebotcazou@adacore.com>
+Date: Sat, 8 Mar 2025 00:09:57 +0100
+Subject: [PATCH] Adjust after category change for N_Formal_Package_Declaration
+
+Issue: eng/toolchain/gnat#1354
+---
+ src/why/gnat2why-borrow_checker.adb | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/why/gnat2why-borrow_checker.adb b/src/why/gnat2why-borrow_checker.adb
+index a97f225b06..f3ab8be3e9 100644
+--- a/src/why/gnat2why-borrow_checker.adb
++++ b/src/why/gnat2why-borrow_checker.adb
+@@ -1693,6 +1693,7 @@ procedure Check_Declaration (Decl : Node_Id) is
+          --  Ignored constructs for pointer checking
+ 
+          when N_Formal_Object_Declaration
++            | N_Formal_Package_Declaration
+             | N_Formal_Type_Declaration
+             | N_Incomplete_Type_Declaration
+             | N_Private_Extension_Declaration
+@@ -3326,7 +3327,6 @@ procedure Check_Node (N : Node_Id) is
+             | N_Empty
+             | N_Enumeration_Representation_Clause
+             | N_Exception_Renaming_Declaration
+-            | N_Formal_Package_Declaration
+             | N_Formal_Subprogram_Declaration
+             | N_Freeze_Entity
+             | N_Freeze_Generic_Entity
+-- 
+2.48.1
+

--- a/pkgs/development/ada-modules/gnatprove/default.nix
+++ b/pkgs/development/ada-modules/gnatprove/default.nix
@@ -64,6 +64,9 @@ let
 
         # Suppress warnings on aarch64: https://github.com/AdaCore/spark2014/issues/54
         ./0002-mute-aarch64-warnings.patch
+
+        # Changes to the GNAT frontend: https://github.com/AdaCore/spark2014/issues/58
+        ./0003-Adjust-after-category-change-for-N_Formal_Package_De.patch
       ];
       commit_date = "2024-01-11";
     };
@@ -121,8 +124,8 @@ stdenv.mkDerivation {
 
   postPatch = ''
     # gnat2why/gnat_src points to the GNAT sources
-    tar xf ${gnat.cc.src} gcc-${gnat.cc.version}/gcc/ada
-    mv gcc-${gnat.cc.version}/gcc/ada gnat2why/gnat_src
+    tar xf ${gnat.cc.src} --wildcards 'gcc-*/gcc/ada'
+    mv gcc-*/gcc/ada gnat2why/gnat_src
   '';
 
   configurePhase = ''


### PR DESCRIPTION
There are two issues with gnatprove:
+ When the gnat.cc.version does not match the gcc version within the tarball, the postPatch phase could't extract the needed sources. Use wildcards to overcome this issue.

+ There was a change in the gcc-14.3 frond end affecting the build. Backporting a patch from master solves this.

#fixes https://github.com/NixOS/nixpkgs/issues/407510

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
