### PR TITLE
Revert "freerdp: drop freerdp 2.x, move to by-name"

### DIFF
--- a/pkgs/by-name/fr/freerdp2/package.nix
+++ b/pkgs/by-name/fr/freerdp2/package.nix
@@ -1,0 +1,227 @@
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  cmake,
+  docbook-xsl-nons,
+  libxslt,
+  pkg-config,
+  alsa-lib,
+  faac,
+  faad2,
+  fetchpatch,
+  ffmpeg,
+  glib,
+  openh264,
+  openssl,
+  pcre2,
+  zlib,
+  libX11,
+  libXcursor,
+  libXdamage,
+  libXdmcp,
+  libXext,
+  libXi,
+  libXinerama,
+  libXrandr,
+  libXrender,
+  libXtst,
+  libXv,
+  libxkbcommon,
+  libxkbfile,
+  wayland,
+  wayland-scanner,
+  gst_all_1,
+  libunwind,
+  orc,
+  cairo,
+  libusb1,
+  libpulseaudio,
+  cups,
+  pcsclite,
+  systemd,
+  libjpeg_turbo,
+  buildServer ? true,
+  nocaps ? false,
+  withUnfree ? false,
+
+  # tries to compile and run generate_argument_docbook.c
+  withManPages ? stdenv.buildPlatform.canExecute stdenv.hostPlatform,
+}:
+
+let
+  cmFlag = flag: if flag then "ON" else "OFF";
+  disabledTests =
+    [
+      # this one is probably due to our sandbox
+      {
+        dir = "libfreerdp/crypto/test";
+        file = "Test_x509_cert_info.c";
+      }
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [
+      {
+        dir = "winpr/libwinpr/sysinfo/test";
+        file = "TestGetComputerName.c";
+      }
+    ];
+
+  inherit (lib) optionals;
+
+in
+stdenv.mkDerivation rec {
+  pname = "freerdp";
+  version = "2.11.7";
+
+  src = fetchFromGitHub {
+    owner = "FreeRDP";
+    repo = "FreeRDP";
+    rev = version;
+    hash = "sha256-w+xyMNFmKylSheK0yAGl8J6MXly/HUjjAfR9Qq3s/kA=";
+  };
+
+  patches = [
+    # GCC 14 compatibility
+    (fetchpatch {
+      url = "https://github.com/FreeRDP/FreeRDP/commit/5b14b7cbdd36414f1838047f21502654bd32ebb1.patch";
+      hash = "sha256-EWLfmjGJGWA/sY2E2DnFKhPbzhOVbXZPCrV8i1XuSeY=";
+    })
+    (fetchpatch {
+      url = "https://github.com/FreeRDP/FreeRDP/commit/efa899d3deb8595a29fabb2a2251722f9d7e0d7f.patch";
+      hash = "sha256-hjqNexYq+3iO2L2L9wT2tWbHz0BEtl/y7jgQT4kpNIM=";
+    })
+    (fetchpatch {
+      url = "https://github.com/FreeRDP/FreeRDP/commit/0c20fac8f1deeeca3df93a6619542e5d9176f0f0.patch";
+      hash = "sha256-cEzNPteucoI5KoGEM3C6mg2kW9uWImPebZEV6nssexY=";
+    })
+  ];
+
+  postPatch =
+    ''
+      export HOME=$TMP
+
+      # skip NIB file generation on darwin
+      sed -z 's/NIB file generation.*//' -i client/Mac{,/cli}/CMakeLists.txt
+
+      # failing test(s)
+      ${lib.concatMapStringsSep "\n" (e: ''
+        substituteInPlace ${e.dir}/CMakeLists.txt \
+          --replace ${e.file} ""
+        rm ${e.dir}/${e.file}
+      '') disabledTests}
+
+      substituteInPlace "libfreerdp/freerdp.pc.in" \
+        --replace "Requires:" "Requires: @WINPR_PKG_CONFIG_FILENAME@"
+    ''
+    + lib.optionalString (pcsclite != null) ''
+      substituteInPlace "winpr/libwinpr/smartcard/smartcard_pcsc.c" \
+        --replace "libpcsclite.so" "${lib.getLib pcsclite}/lib/libpcsclite.so"
+    ''
+    + lib.optionalString nocaps ''
+      substituteInPlace "libfreerdp/locale/keyboard_xkbfile.c" \
+        --replace "RDP_SCANCODE_CAPSLOCK" "RDP_SCANCODE_LCONTROL"
+    '';
+
+  buildInputs =
+    [
+      cairo
+      cups
+      faad2
+      ffmpeg
+      glib
+      gst_all_1.gst-plugins-base
+      gst_all_1.gst-plugins-good
+      gst_all_1.gstreamer
+      libX11
+      libXcursor
+      libXdamage
+      libXdmcp
+      libXext
+      libXi
+      libXinerama
+      libXrandr
+      libXrender
+      libXtst
+      libXv
+      libjpeg_turbo
+      libpulseaudio
+      libunwind
+      libusb1
+      libxkbcommon
+      libxkbfile
+      openh264
+      openssl
+      orc
+      pcre2
+      pcsclite
+      zlib
+    ]
+    ++ optionals stdenv.hostPlatform.isLinux [
+      alsa-lib
+      systemd
+      wayland
+    ]
+    ++ optionals withUnfree [
+      faac
+    ];
+
+  nativeBuildInputs = [
+    cmake
+    libxslt
+    docbook-xsl-nons
+    pkg-config
+    wayland-scanner
+  ];
+
+  doCheck = true;
+
+  # https://github.com/FreeRDP/FreeRDP/issues/8526#issuecomment-1357134746
+  cmakeFlags =
+    [
+      "-Wno-dev"
+      "-DCMAKE_INSTALL_LIBDIR=lib"
+      "-DDOCBOOKXSL_DIR=${docbook-xsl-nons}/xml/xsl/docbook"
+    ]
+    ++ lib.mapAttrsToList (k: v: "-D${k}=${cmFlag v}") {
+      BUILD_TESTING = false; # false is recommended by upstream
+      WITH_CAIRO = (cairo != null);
+      WITH_CUPS = (cups != null);
+      WITH_FAAC = (withUnfree && faac != null);
+      WITH_FAAD2 = (faad2 != null);
+      WITH_JPEG = (libjpeg_turbo != null);
+      WITH_OPENH264 = (openh264 != null);
+      WITH_OSS = false;
+      WITH_MANPAGES = withManPages;
+      WITH_PCSC = (pcsclite != null);
+      WITH_PULSE = (libpulseaudio != null);
+      WITH_SERVER = buildServer;
+      WITH_VAAPI = false; # false is recommended by upstream
+      WITH_X11 = true;
+    };
+
+  env.NIX_CFLAGS_COMPILE = toString (
+    lib.optionals stdenv.hostPlatform.isDarwin [
+      "-include AudioToolbox/AudioToolbox.h"
+    ]
+    ++ lib.optionals stdenv.cc.isClang [
+      "-Wno-error=incompatible-function-pointer-types"
+    ]
+  );
+
+  NIX_LDFLAGS = lib.optionals stdenv.hostPlatform.isDarwin [
+    "-framework AudioToolbox"
+  ];
+
+  meta = with lib; {
+    description = "Remote Desktop Protocol Client";
+    longDescription = ''
+      FreeRDP is a client-side implementation of the Remote Desktop Protocol (RDP)
+      following the Microsoft Open Specifications.
+    '';
+    homepage = "https://www.freerdp.com/";
+    changelog = "https://github.com/FreeRDP/FreeRDP/releases/tag/${src.rev}";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ peterhoeg ];
+    platforms = platforms.unix;
+  };
+}


### PR DESCRIPTION
This partially reverts commit 3703bd3dd59165a12d4c677d4fd510c1c2c3401e of PR #392754.

It keeps the move to by-name and makes freerdp2 require an explicit version number.

**IDEALLY this is not required!!** 

If #407726 works, this can just be closed fully. I'd rather not reintroduce a dependency that had security issues and is over a year old at this point. cc @drupol 

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
