### PR TITLE
pygame{,-ce}: migrate to sdl2-compat

### DIFF
--- a/pkgs/development/python-modules/gym/default.nix
+++ b/pkgs/development/python-modules/gym/default.nix
@@ -74,6 +74,10 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
+  preCheck = ''
+    export SDL_VIDEODRIVER=dummy
+  '';
+
   disabledTests =
     [
       # TypeError: Converting from sequence to b2Vec2, expected int/float arguments index 0

--- a/pkgs/development/python-modules/gymnasium/default.nix
+++ b/pkgs/development/python-modules/gymnasium/default.nix
@@ -89,6 +89,10 @@ buildPythonPackage rec {
     "tests/wrappers/test_record_video.py"
   ];
 
+  preCheck = ''
+    export SDL_VIDEODRIVER=dummy
+  '';
+
   disabledTests = [
     # Fails since jax 0.6.0
     # Fixed on master https://github.com/Farama-Foundation/Gymnasium/commit/94019feee1a0f945b9569cddf62780f4e1a224a5

--- a/pkgs/development/python-modules/pygame-ce/default.nix
+++ b/pkgs/development/python-modules/pygame-ce/default.nix
@@ -18,10 +18,10 @@
   libpng,
   libX11,
   portmidi,
-  SDL2_classic,
-  SDL2_classic_image,
-  SDL2_classic_mixer,
-  SDL2_classic_ttf,
+  SDL2,
+  SDL2_image,
+  SDL2_mixer,
+  SDL2_ttf,
   numpy,
 
   pygame-gui,
@@ -59,6 +59,8 @@ buildPythonPackage rec {
         ]) buildInputs
       );
     })
+    # https://github.com/libsdl-org/sdl2-compat/issues/476
+    ./skip-rle-tests.patch
   ];
 
   postPatch =
@@ -98,10 +100,10 @@ buildPythonPackage rec {
     libjpeg
     libpng
     portmidi
-    SDL2_classic
-    (SDL2_classic_image.override { enableSTB = false; })
-    SDL2_classic_mixer
-    SDL2_classic_ttf
+    SDL2
+    (SDL2_image.override { enableSTB = false; })
+    SDL2_mixer
+    SDL2_ttf
   ];
 
   nativeCheckInputs = [
@@ -114,7 +116,7 @@ buildPythonPackage rec {
 
   env =
     {
-      SDL_CONFIG = lib.getExe' (lib.getDev SDL2_classic) "sdl2-config";
+      SDL_CONFIG = lib.getExe' (lib.getDev SDL2) "sdl2-config";
     }
     // lib.optionalAttrs stdenv.cc.isClang {
       NIX_CFLAGS_COMPILE = "-Wno-error=incompatible-function-pointer-types";

--- a/pkgs/development/python-modules/pygame-ce/skip-rle-tests.patch
+++ b/pkgs/development/python-modules/pygame-ce/skip-rle-tests.patch
@@ -1,0 +1,20 @@
+diff --git a/test/surface_test.py b/test/surface_test.py
+index 4e4b5d4..ffc7ffb 100644
+--- a/test/surface_test.py
++++ b/test/surface_test.py
+@@ -375,6 +375,7 @@ class SurfaceTypeTest(unittest.TestCase):
+         self.assertTrue(s1.get_flags() & pygame.RLEACCELOK)
+         self.assertTrue(not s2.get_flags() & pygame.RLEACCELOK)
+ 
++    @unittest.skipIf(True, "https://github.com/libsdl-org/sdl2-compat/issues/476")
+     def test_solarwolf_rle_usage(self):
+         """Test for error/crash when calling set_colorkey() followed
+         by convert twice in succession. Code originally taken
+@@ -403,6 +404,7 @@ class SurfaceTypeTest(unittest.TestCase):
+         finally:
+             pygame.display.quit()
+ 
++    @unittest.skipIf(True, "https://github.com/libsdl-org/sdl2-compat/issues/476")
+     def test_solarwolf_rle_usage_2(self):
+         """Test for RLE status after setting alpha"""
+ 

--- a/pkgs/development/python-modules/pygame/0001-Use-SDL_HasSurfaceRLE-when-available.patch
+++ b/pkgs/development/python-modules/pygame/0001-Use-SDL_HasSurfaceRLE-when-available.patch
@@ -1,0 +1,54 @@
+From fb4a3d427898ed0a1fcf1e6795584a5a66a9cb3b Mon Sep 17 00:00:00 2001
+From: Marcin Serwin <marcin@serwin.dev>
+Date: Thu, 15 May 2025 18:24:56 +0200
+Subject: [PATCH 1/2] Use SDL_HasSurfaceRLE when available
+
+The hack does not work with sdl2-compat due to a different surface
+internals.
+
+Signed-off-by: Marcin Serwin <marcin@serwin.dev>
+---
+ src_c/surface.c | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/src_c/surface.c b/src_c/surface.c
+index 958ce43f..ee9991fb 100644
+--- a/src_c/surface.c
++++ b/src_c/surface.c
+@@ -63,6 +63,7 @@ typedef struct pg_bufferinternal_s {
+     Py_ssize_t mem[6];      /* Enough memory for dim 3 shape and strides  */
+ } pg_bufferinternal;
+ 
++#if !SDL_VERSION_ATLEAST(2, 0, 14)
+ /* copy of SDL Blit mapping definitions to enable pointer casting hack
+    for checking state of the SDL_COPY_RLE_DESIRED flag */
+ #define PGS_COPY_RLE_DESIRED 0x00001000
+@@ -97,6 +98,9 @@ typedef struct pg_BlitMap {
+     Uint32 src_palette_version;
+ } pg_BlitMap;
+ /* end PGS_COPY_RLE_DESIRED hack definitions */
++#else
++#define pg_HasSurfaceRLE SDL_HasSurfaceRLE
++#endif
+ 
+ int
+ pgSurface_Blit(pgSurfaceObject *dstobj, pgSurfaceObject *srcobj,
+@@ -2212,6 +2216,7 @@ surf_scroll(PyObject *self, PyObject *args, PyObject *keywds)
+     Py_RETURN_NONE;
+ }
+ 
++#if !SDL_VERSION_ATLEAST(2, 0, 14)
+ int
+ pg_HasSurfaceRLE(SDL_Surface *surface)
+ {
+@@ -2230,6 +2235,7 @@ pg_HasSurfaceRLE(SDL_Surface *surface)
+ 
+     return SDL_TRUE;
+ }
++#endif
+ 
+ static int
+ _PgSurface_SrcAlpha(SDL_Surface *surf)
+-- 
+2.49.0
+

--- a/pkgs/development/python-modules/pygame/0002-Don-t-assume-that-touch-devices-support-get_num_fing.patch
+++ b/pkgs/development/python-modules/pygame/0002-Don-t-assume-that-touch-devices-support-get_num_fing.patch
@@ -1,0 +1,29 @@
+From ca46aa2bea7a67fbac55d7228026623def0aca9d Mon Sep 17 00:00:00 2001
+From: Marcin Serwin <marcin@serwin.dev>
+Date: Fri, 16 May 2025 17:39:24 +0200
+Subject: [PATCH 2/2] Don't assume that touch devices support get_num_fingers
+
+Signed-off-by: Marcin Serwin <marcin@serwin.dev>
+---
+ test/touch_test.py | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/test/touch_test.py b/test/touch_test.py
+index 259a2c70..e8e58161 100644
+--- a/test/touch_test.py
++++ b/test/touch_test.py
+@@ -30,7 +30,10 @@ class TouchTest(unittest.TestCase):
+ 
+     @unittest.skipIf(not has_touchdevice, "no touch devices found")
+     def test_num_fingers(self):
+-        touch.get_num_fingers(touch.get_device(0))
++        # sdl2-compat reports pens/styli as touch devices but they don't
++        # support get_num_fingers, they can be distinguished by negative id
++        if touch.get_device(0) >= 0:
++            touch.get_num_fingers(touch.get_device(0))
+ 
+     def test_num_fingers__invalid(self):
+         self.assertRaises(TypeError, touch.get_num_fingers, "test")
+-- 
+2.49.0
+

--- a/pkgs/development/python-modules/pygame/adapt-to-sdl3-format-message.patch
+++ b/pkgs/development/python-modules/pygame/adapt-to-sdl3-format-message.patch
@@ -1,0 +1,14 @@
+diff --git a/src_c/surface.c b/src_c/surface.c
+index ee9991fb..32c007bd 100644
+--- a/src_c/surface.c
++++ b/src_c/surface.c
+@@ -733,7 +733,8 @@ _raise_create_surface_error(void)
+ {
+     const char *msg = SDL_GetError();
+ 
+-    if (strcmp(msg, "Unknown pixel format") == 0)
++    if (strcmp(msg, "Unknown pixel format") == 0 ||
++        strcmp(msg, "Parameter 'format' is invalid") == 0)
+         return RAISE(PyExc_ValueError, "Invalid mask values");
+     return RAISE(pgExc_SDLError, msg);
+ }

--- a/pkgs/development/python-modules/pygame/default.nix
+++ b/pkgs/development/python-modules/pygame/default.nix
@@ -12,7 +12,7 @@
   setuptools,
 
   # nativeBuildInputs
-  SDL2_classic,
+  SDL2,
   pkg-config,
 
   # buildInputs
@@ -21,9 +21,9 @@
   libpng,
   libX11,
   portmidi,
-  SDL2_classic_image,
-  SDL2_classic_mixer,
-  SDL2_classic_ttf,
+  SDL2_image,
+  SDL2_mixer,
+  SDL2_ttf,
 }:
 
 buildPythonPackage rec {
@@ -62,6 +62,14 @@ buildPythonPackage rec {
 
     # mixer queue test returns busy queue when it shouldn't
     ./skip-mixer-test.patch
+    # https://github.com/libsdl-org/sdl2-compat/issues/476
+    ./skip-rle-tests.patch
+    # https://github.com/libsdl-org/sdl2-compat/issues/489
+    ./adapt-to-sdl3-format-message.patch
+
+    # https://github.com/pygame/pygame/pull/4497
+    ./0001-Use-SDL_HasSurfaceRLE-when-available.patch
+    ./0002-Don-t-assume-that-touch-devices-support-get_num_fing.patch
   ];
 
   postPatch = ''
@@ -76,7 +84,7 @@ buildPythonPackage rec {
   ];
 
   nativeBuildInputs = [
-    SDL2_classic
+    SDL2
     pkg-config
   ];
 
@@ -86,10 +94,10 @@ buildPythonPackage rec {
     libpng
     libX11
     portmidi
-    SDL2_classic
-    (SDL2_classic_image.override { enableSTB = false; })
-    SDL2_classic_mixer
-    SDL2_classic_ttf
+    SDL2
+    (SDL2_image.override { enableSTB = false; })
+    SDL2_mixer
+    SDL2_ttf
   ];
 
   preConfigure = ''

--- a/pkgs/development/python-modules/pygame/skip-rle-tests.patch
+++ b/pkgs/development/python-modules/pygame/skip-rle-tests.patch
@@ -1,0 +1,20 @@
+diff --git a/test/surface_test.py b/test/surface_test.py
+index 4e4b5d4..ffc7ffb 100644
+--- a/test/surface_test.py
++++ b/test/surface_test.py
+@@ -375,6 +375,7 @@ class SurfaceTypeTest(unittest.TestCase):
+         self.assertTrue(s1.get_flags() & pygame.RLEACCELOK)
+         self.assertTrue(not s2.get_flags() & pygame.RLEACCELOK)
+ 
++    @unittest.skipIf(True, "https://github.com/libsdl-org/sdl2-compat/issues/476")
+     def test_solarwolf_rle_usage(self):
+         """Test for error/crash when calling set_colorkey() followed
+         by convert twice in succession. Code originally taken
+@@ -403,6 +404,7 @@ class SurfaceTypeTest(unittest.TestCase):
+         finally:
+             pygame.display.quit()
+ 
++    @unittest.skipIf(True, "https://github.com/libsdl-org/sdl2-compat/issues/476")
+     def test_solarwolf_rle_usage_2(self):
+         """Test for RLE status after setting alpha"""
+ 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

cc @NixOS/sdl 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
