### PR TITLE
nixos/pam: Google Authenticator 2FA support over XRDP

### DIFF
--- a/nixos/modules/security/pam.nix
+++ b/nixos/modules/security/pam.nix
@@ -249,6 +249,23 @@ let
               to provide Google Authenticator token to log in.
             '';
           };
+          allowNullOTP = lib.mkOption {
+            type = lib.types.bool;
+            default = false;
+            description = ''
+              Whether to allow login for accounts that have no OTP set
+              (i.e., accounts with no OTP configured or no existing
+              {file}`~/.google_authenticator`).
+            '';
+          };
+          forwardPass = lib.mkOption {
+            type = lib.types.bool;
+            default = false;
+            description = ''
+              The authentication provides a single field requiring
+              the user's password followed by the one-time password (OTP).
+            '';
+          };
         };
 
         otpwAuth = lib.mkOption {
@@ -1048,6 +1065,8 @@ let
                       modulePath = "${pkgs.google-authenticator}/lib/security/pam_google_authenticator.so";
                       settings = {
                         no_increment_hotp = true;
+                        forward_pass = cfg.googleAuthenticator.forwardPass;
+                        nullok = cfg.googleAuthenticator.allowNullOTP;
                       };
                     }
                     {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

XRDP currently does not decouple the first and second authentication factor request so both the password and the OTP should be passed in the single password field.

The current PAM configuration for Google Authenticator does not allow this by causing invalid verification on PAM side.

The proposed fix adds the `forward_pass` parameter on a service (i.e., `xrdp_sesman`) PAM module when `google-authenticator` is enabled.

In this manner, the Google Authenticator module can actually work by providing `[password][6digitsOTP]`.

Added `nullok` setting in order to allow the addition or removal of specific users from 2FA: in a system with more than one user, if user A would like to keep the 2FA, and the user B no, the user B can remove `.google-authenticator` file and the 2FA won't be enforced just for him/her.

It can be manually verified by adding the following in `configuration.nix`:
```nix
  security.pam.services.xrdp-sesman.text = ''
    # Account management.
    account required ${pkgs.pam}/lib/security/pam_unix.so

    # Authentication management.
    auth optional ${pkgs.pam}/lib/security/pam_unix.so likeauth nullok 
    auth required ${pkgs.google-authenticator}/lib/security/pam_google_authenticator.so no_increment_hotp forward_pass nullok
    auth sufficient ${pkgs.pam}/lib/security/pam_unix.so likeauth nullok try_first_pass
    auth required ${pkgs.pam}/lib/security/pam_deny.so

    # Password management.
    password sufficient ${pkgs.pam}/lib/security/pam_unix.so nullok yescrypt

    # Session management.
    session required ${pkgs.pam}/lib/security/pam_env.so conffile=/etc/pam/environment readenv=0
    session required ${pkgs.pam}/lib/security/pam_unix.so
    session required ${pkgs.pam}/lib/security/pam_loginuid.so
    session optional ${pkgs.systemd}/lib/security/pam_systemd.so
    session required ${pkgs.pam}/lib/security/pam_limits.so conf=${pkgs.pam}/etc/security/limits.conf
  '';
```

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
