### PR TITLE
llvmPackages: llvmPackages_19 -> llvmPackages_21

### DIFF
--- a/doc/release-notes/rl-2511.section.md
+++ b/doc/release-notes/rl-2511.section.md
@@ -14,6 +14,8 @@
   If a newer C++ library feature is not available on the default deployment target, you will need to increase the deployment target.
   See the Darwin platform documentation for more details.
 
+- LLVM has been updated from 19 to 21.
+
 ## Backward Incompatibilities {#sec-nixpkgs-release-25.11-incompatibilities}
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->

--- a/pkgs/development/compilers/llvm/20/libclc/use-default-paths.patch
+++ b/pkgs/development/compilers/llvm/20/libclc/use-default-paths.patch
@@ -1,22 +1,22 @@
-From e8b910246d0c7c3d9fff994f71c6f8a48ec09a50 Mon Sep 17 00:00:00 2001
-From: Tristan Ross <tristan.ross@midstall.com>
-Date: Sat, 24 Aug 2024 19:56:24 -0700
-Subject: [PATCH] [libclc] use default paths with find_program when possible
-
----
- libclc/CMakeLists.txt | 4 ++--
- 1 file changed, 1 insertions(+), 1 deletions(-)
-
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 02bb859ae8590b..6bcd8ae52a5794 100644
+index b0e7aac6f8f3..af17e62588fe 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -55,7 +55,7 @@ if( LIBCLC_STANDALONE_BUILD OR CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DI
+@@ -57,7 +57,7 @@ if( LIBCLC_STANDALONE_BUILD OR CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DI
    # Import required tools
    if( NOT EXISTS ${LIBCLC_CUSTOM_LLVM_TOOLS_BINARY_DIR} )
      foreach( tool IN ITEMS clang llvm-as llvm-link opt )
 -      find_program( LLVM_TOOL_${tool} ${tool} PATHS ${LLVM_TOOLS_BINARY_DIR} NO_DEFAULT_PATH )
-+      find_program( LLVM_TOOL_${tool} ${tool} PATHS ${LLVM_TOOLS_BINARY_DIR} )
++    find_program( LLVM_TOOL_${tool} ${tool} PATHS ${LLVM_TOOLS_BINARY_DIR} )
        set( ${tool}_exe ${LLVM_TOOL_${tool}} )
        set( ${tool}_target )
      endforeach()
+@@ -93,7 +93,7 @@ if( EXISTS ${LIBCLC_CUSTOM_LLVM_TOOLS_BINARY_DIR} )
+   # and custom tools.
+   foreach( tool IN ITEMS clang llvm-as llvm-link opt )
+     find_program( LLVM_CUSTOM_TOOL_${tool} ${tool}
+-      PATHS ${LIBCLC_CUSTOM_LLVM_TOOLS_BINARY_DIR} NO_DEFAULT_PATH )
++      PATHS ${LIBCLC_CUSTOM_LLVM_TOOLS_BINARY_DIR} )
+     set( ${tool}_exe ${LLVM_CUSTOM_TOOL_${tool}} )
+     set( ${tool}_target )
+   endforeach()

--- a/pkgs/development/compilers/llvm/common/patches.nix
+++ b/pkgs/development/compilers/llvm/common/patches.nix
@@ -93,6 +93,10 @@
   ];
   "libclc/use-default-paths.patch" = [
     {
+      after = "20";
+      path = ../20;
+    }
+    {
       after = "19";
       before = "20";
       path = ../19;

--- a/pkgs/development/compilers/rust/1_89.nix
+++ b/pkgs/development/compilers/rust/1_89.nix
@@ -20,8 +20,8 @@
   pkgsTargetTarget,
   makeRustPlatform,
   wrapRustcWith,
-  llvmPackages_20,
-  llvm_20,
+  llvmPackages,
+  llvm,
   wrapCCWith,
   overrideCC,
   fetchpatch,
@@ -29,7 +29,7 @@
 let
   llvmSharedFor =
     pkgSet:
-    pkgSet.llvmPackages_20.libllvm.override (
+    pkgSet.llvmPackages.libllvm.override (
       {
         enableSharedLibraries = true;
       }
@@ -37,7 +37,7 @@ let
         # Force LLVM to compile using clang + LLVM libs when targeting pkgsLLVM
         stdenv = pkgSet.stdenv.override {
           allowedRequisites = null;
-          cc = pkgSet.pkgsBuildHost.llvmPackages_20.clangUseLLVM;
+          cc = pkgSet.pkgsBuildHost.llvmPackages.clangUseLLVM;
         };
       }
     );
@@ -51,11 +51,10 @@ import ./default.nix
     llvmSharedForHost = llvmSharedFor pkgsBuildHost;
     llvmSharedForTarget = llvmSharedFor pkgsBuildTarget;
 
+    inherit llvmPackages;
+
     # For use at runtime
     llvmShared = llvmSharedFor pkgsHostTarget;
-
-    # Expose llvmPackages used for rustc from rustc via passthru for LTO in Firefox
-    llvmPackages = llvmPackages_20;
 
     # Note: the version MUST be the same version that we are building. Upstream
     # ensures that each released compiler can compile itself:
@@ -87,8 +86,8 @@ import ./default.nix
 
   (
     builtins.removeAttrs args [
-      "llvmPackages_20"
-      "llvm_20"
+      "llvmPackages"
+      "llvm"
       "wrapCCWith"
       "overrideCC"
       "pkgsHostTarget"

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5363,7 +5363,7 @@ with pkgs;
   libllvm = llvmPackages.libllvm;
   llvm-manpages = llvmPackages.llvm-manpages;
 
-  llvmPackages = llvmPackages_19;
+  llvmPackages = llvmPackages_21;
 
   inherit
     (rec {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5526,9 +5526,7 @@ with pkgs;
   wrapRustcWith = { rustc-unwrapped, ... }@args: callPackage ../build-support/rust/rustc-wrapper args;
   wrapRustc = rustc-unwrapped: wrapRustcWith { inherit rustc-unwrapped; };
 
-  rust_1_89 = callPackage ../development/compilers/rust/1_89.nix {
-    llvm_20 = llvmPackages_20.libllvm;
-  };
+  rust_1_89 = callPackage ../development/compilers/rust/1_89.nix { };
   rust = rust_1_89;
 
   mrustc = callPackage ../development/compilers/mrustc { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

Bump the global LLVM version. Tested builds:

- `firefox`
- `mesa`
- `rustc`


- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
