### PR TITLE
adw-gtk3: 5.10 -> 6.2

### DIFF
--- a/pkgs/by-name/ad/adw-gtk3/package.nix
+++ b/pkgs/by-name/ad/adw-gtk3/package.nix
@@ -5,34 +5,27 @@
   nix-update-script,
   meson,
   ninja,
-  sassc,
+  dart-sass,
 }:
 
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "adw-gtk3";
-  version = "5.10";
+  version = "6.2";
 
   src = fetchFromGitHub {
     owner = "lassekongo83";
     repo = "adw-gtk3";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-0OZk27b0kujzWtRX5uvelTMivL19g6sNB1IY6BsrO10=";
+    hash = "sha256-YYaqSEnIYHHkY4L3UhFBkR3DehoB6QADhSGOP/9NKx8=";
   };
 
   nativeBuildInputs = [
     meson
     ninja
-    sassc
+    dart-sass
   ];
 
-  postPatch = ''
-    chmod +x gtk/src/adw-gtk3-dark/gtk-3.0/install-dark-theme.sh
-    patchShebangs gtk/src/adw-gtk3-dark/gtk-3.0/install-dark-theme.sh
-  '';
-
-  passthru = {
-    updateScript = nix-update-script { };
-  };
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "Theme from libadwaita ported to GTK-3";

--- a/pkgs/by-name/ad/adw-gtk3/package.nix
+++ b/pkgs/by-name/ad/adw-gtk3/package.nix
@@ -32,6 +32,9 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     homepage = "https://github.com/lassekongo83/adw-gtk3";
     license = lib.licenses.lgpl21Only;
     platforms = lib.platforms.unix;
-    maintainers = with lib.maintainers; [ ciferkey ];
+    maintainers = with lib.maintainers; [
+      ciferkey
+      Gliczy
+    ];
   };
 })

--- a/pkgs/by-name/ad/adw-gtk3/package.nix
+++ b/pkgs/by-name/ad/adw-gtk3/package.nix
@@ -28,7 +28,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   passthru.updateScript = nix-update-script { };
 
   meta = {
-    description = "Theme from libadwaita ported to GTK-3";
+    description = "Unofficial GTK 3 port of libadwaita";
     homepage = "https://github.com/lassekongo83/adw-gtk3";
     license = lib.licenses.lgpl21Only;
     platforms = lib.platforms.unix;

--- a/pkgs/by-name/ad/adw-gtk3/package.nix
+++ b/pkgs/by-name/ad/adw-gtk3/package.nix
@@ -35,6 +35,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     maintainers = with lib.maintainers; [
       ciferkey
       Gliczy
+      normalcea
     ];
   };
 })


### PR DESCRIPTION
https://github.com/lassekongo83/adw-gtk3/compare/v5.10...v6.2

Upstream has replaced sassc with dart-sass.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
