### PR TITLE
evolution-ews: fix patch compiler errors

### DIFF
--- a/pkgs/by-name/ev/evolution-ews/hardcode-gsettings.patch
+++ b/pkgs/by-name/ev/evolution-ews/hardcode-gsettings.patch
@@ -7,7 +7,7 @@ index 32817df..da65217 100644
  
  	/* cannot save, when evolution is not installed */
 -	if (!e_ews_common_utils_gsettings_schema_exists ("org.gnome.evolution.mail"))
-+	if (!true)
++	if (!TRUE)
  		return FALSE;
  
  	if (!old_categories || !new_categories)
@@ -40,7 +40,7 @@ index 7374c36..7da2023 100644
  
  	/* cannot save, when evolution is not installed */
 -	if (!e_ews_common_utils_gsettings_schema_exists ("org.gnome.evolution.mail"))
-+	if (!true)
++	if (!TRUE)
  		return FALSE;
  
  	if (!old_categories || !new_categories)
@@ -73,7 +73,7 @@ index cec5417..2e744a0 100644
  	ICalTimezone *zone = NULL;
  
 -	if (e_ews_common_utils_gsettings_schema_exists ("org.gnome.evolution.calendar")) {
-+	if (true) {
++	if (TRUE) {
  		GSettings *settings;
  
 -		settings = g_settings_new ("org.gnome.evolution.calendar");
@@ -101,7 +101,7 @@ index 3458c10..7d21784 100644
  	gchar *location = NULL;
  
 -	if (e_ews_common_utils_gsettings_schema_exists ("org.gnome.evolution.calendar")) {
-+	if (true) {
++	if (TRUE) {
  		GSettings *settings;
  
 -		settings = g_settings_new ("org.gnome.evolution.calendar");


### PR DESCRIPTION
Found while updating my system to 25.05.

```
/build/evolution-ews-3.56.1/src/common/e-ews-common-utils.c:211:13: error: 'true' undeclared (first use in this function)
  211 |         if (true) {
      |             ^~~~
/build/evolution-ews-3.56.1/src/common/e-ews-common-utils.c:15:1: note: 'true' is defined in header '<stdbool.h>'; this is probably fixable by adding '#include <stdbool.h>'
   14 | #include "e-ews-common-utils.h"
  +++ |+#include <stdbool.h>
   15 |
/build/evolution-ews-3.56.1/src/common/e-ews-common-utils.c:211:13: note: each undeclared identifier is reported only once for each function it appears in
  211 |         if (true) {
      |             ^~~~
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
