### PR TITLE
element-{desktop,web-unwrapped}: {fix,modernize} update script

### DIFF
--- a/pkgs/by-name/el/element-desktop/update.sh
+++ b/pkgs/by-name/el/element-desktop/update.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env nix-shell
-#!nix-shell -i bash -p nix wget prefetch-yarn-deps nix-prefetch-github jq
+#!nix-shell -i bash -p nix coreutils prefetch-yarn-deps jq curl
 
 if [ "$#" -gt 1 ] || [[ "$1" == -* ]]; then
   echo "Regenerates packaging data for the element packages."
@@ -12,54 +12,49 @@ version="$1"
 set -euo pipefail
 
 if [ -z "$version" ]; then
-  version="$(wget -q -O- "https://api.github.com/repos/element-hq/element-desktop/releases?per_page=1" | jq -r '.[0].tag_name')"
+  version="$(curl -fsSL "https://api.github.com/repos/element-hq/element-desktop/releases/latest" | jq -r '.tag_name')"
 fi
 
 # strip leading "v"
 version="${version#v}"
 
-# Element Web
-web_src="https://raw.githubusercontent.com/element-hq/element-web/v$version"
-web_src_hash=$(nix-prefetch-github element-hq element-web --rev v${version} | jq -r .hash)
-
 cd "$(dirname "${BASH_SOURCE[0]}")" || exit 1
 
-web_tmpdir=$(mktemp -d)
-trap 'rm -rf "$web_tmpdir"' EXIT
+nixflags=(
+  --extra-experimental-features
+  "nix-command flakes"
+)
 
-pushd $web_tmpdir
-wget -q "$web_src/yarn.lock"
-web_yarn_hash=$(prefetch-yarn-deps yarn.lock)
-popd
+# HACK: prefetch-yarn-deps hashes may output extra clutter on stdout (!) so
+# we'll need to get the last line, last word
+fixupHash() {
+  local sorta_yarn_hash="$(tail -n1 <<< "$1")"
+  local almost_yarn_hash="${sorta_yarn_hash##* }"
+  local yarn_hash="$(nix "${nixflags[@]}" hash convert --hash-algo sha256 "$almost_yarn_hash")"
 
-# Element Desktop
-desktop_src="https://raw.githubusercontent.com/element-hq/element-desktop/v$version"
-desktop_src_hash=$(nix-prefetch-github element-hq element-desktop --rev v${version} | jq -r .hash)
+  printf "%s" "$yarn_hash"
+}
 
-desktop_tmpdir=$(mktemp -d)
-trap 'rm -rf "$desktop_tmpdir"' EXIT
+getHashes() {
+  variant="$1"
+  output="$2"
 
-pushd $desktop_tmpdir
-wget -q "$desktop_src/yarn.lock"
-desktop_yarn_hash=$(prefetch-yarn-deps yarn.lock)
-popd
+  local url="github:element-hq/element-$variant/v$version"
+  local src="$(nix "${nixflags[@]}" flake prefetch --json "$url")"
+  local src_hash="$(jq -r ".hash" <<< "$src")"
+  local src_path="$(jq -r ".storePath" <<< "$src")"
+  local yarn_hash="$(fixupHash "$(prefetch-yarn-deps "$src_path/yarn.lock")")"
 
-cat > ../element-web-unwrapped/element-web-pin.nix << EOF
+  cat > "$output" << EOF
 {
   "version" = "$version";
   "hashes" = {
-    "webSrcHash" = "$web_src_hash";
-    "webYarnHash" = "$web_yarn_hash";
+    "${variant}SrcHash" = "$src_hash";
+    "${variant}YarnHash" = "$yarn_hash";
   };
 }
 EOF
+}
 
-cat > element-desktop-pin.nix << EOF
-{
-  "version" = "$version";
-  "hashes" = {
-    "desktopSrcHash" = "$desktop_src_hash";
-    "desktopYarnHash" = "$desktop_yarn_hash";
-  };
-}
-EOF
+getHashes web ../element-web-unwrapped/element-web-pin.nix
+getHashes desktop element-desktop-pin.nix


### PR DESCRIPTION

- Does not fetch `-rc` versions anymore
- Fixes weird output by `prefetch-yarn-deps` (see https://github.com/NixOS/nixpkgs/pull/407704#issue-3069691545)
- Doesn't create any temporary files anymore, since everything is
  prefetched local builds will be faster too
- DRY

Tested it to output same hashes as #407704 (expect for one hash that wasn't
`nix hash convert`'ed on their end, it's equivalent though)

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
