### PR TITLE
home-assistant: 2025.5.1 -> 2025.5.2

### DIFF
--- a/pkgs/development/python-modules/aiodiscover/default.nix
+++ b/pkgs/development/python-modules/aiodiscover/default.nix
@@ -18,7 +18,7 @@
 
 buildPythonPackage rec {
   pname = "aiodiscover";
-  version = "2.6.1";
+  version = "2.7.0";
   pyproject = true;
 
   disabled = pythonOlder "3.9";
@@ -27,7 +27,7 @@ buildPythonPackage rec {
     owner = "bdraco";
     repo = "aiodiscover";
     tag = "v${version}";
-    hash = "sha256-dgmRgokHDw0ooxD8Ksxb8QKeAdUhYj/WO85EC57MeNg=";
+    hash = "sha256-zJOsf4oZbZgaiaaPM0HfR0GNwxvGoR6fgkJB5ZFY0O8=";
   };
 
   build-system = [ poetry-core ];

--- a/pkgs/development/python-modules/deebot-client/default.nix
+++ b/pkgs/development/python-modules/deebot-client/default.nix
@@ -20,7 +20,7 @@
 
 buildPythonPackage rec {
   pname = "deebot-client";
-  version = "13.1.0";
+  version = "13.2.0";
   pyproject = true;
 
   disabled = pythonOlder "3.13";
@@ -29,12 +29,12 @@ buildPythonPackage rec {
     owner = "DeebotUniverse";
     repo = "client.py";
     tag = version;
-    hash = "sha256-EIhefThzHC9hpI4bGkTu+TskdzajI7cc90DhrfDlbcs=";
+    hash = "sha256-0DGOdfr6vqtgYwabhJWfxV2kACzixiCnqPNssPHyLhw=";
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
     inherit pname version src;
-    hash = "sha256-WYWrfNigmu18yEa2QstJ5RfjLWS/Tckem48j8JK2NHk=";
+    hash = "sha256-A/axIsDfpWNLQXeExshzlJfKWh5yFZYqxDQYPn1+fHg=";
   };
 
   pythonRelaxDeps = [

--- a/pkgs/development/python-modules/ical/default.nix
+++ b/pkgs/development/python-modules/ical/default.nix
@@ -17,7 +17,7 @@
 
 buildPythonPackage rec {
   pname = "ical";
-  version = "9.2.2";
+  version = "9.2.4";
   pyproject = true;
 
   disabled = pythonOlder "3.11";
@@ -26,7 +26,7 @@ buildPythonPackage rec {
     owner = "allenporter";
     repo = "ical";
     tag = version;
-    hash = "sha256-eh8XOKn7Xo4JprMwVVdsBWdXajn2URYVR5tz2y2wKrg=";
+    hash = "sha256-R9BuCLuVYuUvrmF/arEDsUPPUeSLjpqiEJ/ovvGIsYQ=";
   };
 
   build-system = [ setuptools ];

--- a/pkgs/development/python-modules/pysensibo/default.nix
+++ b/pkgs/development/python-modules/pysensibo/default.nix
@@ -9,14 +9,14 @@
 
 buildPythonPackage rec {
   pname = "pysensibo";
-  version = "1.1.0";
+  version = "1.2.1";
   pyproject = true;
 
   disabled = pythonOlder "3.11";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-yITcVEBtqH1B+MyhQweOzmdgPgWrueAkczp/UsT4J/4=";
+    hash = "sha256-Otk5W3VTbOAeZOVnXvW8VSxU1nHa8zUvmvduRTdlwVs=";
   };
 
   build-system = [ poetry-core ];

--- a/pkgs/development/python-modules/pysmartthings/default.nix
+++ b/pkgs/development/python-modules/pysmartthings/default.nix
@@ -18,7 +18,7 @@
 
 buildPythonPackage rec {
   pname = "pysmartthings";
-  version = "3.2.1";
+  version = "3.2.2";
   pyproject = true;
 
   disabled = pythonOlder "3.12";
@@ -27,7 +27,7 @@ buildPythonPackage rec {
     owner = "andrewsayre";
     repo = "pysmartthings";
     tag = "v${version}";
-    hash = "sha256-KgwNXIzQWae91R0qmInlm6m+NwrSJgP9SY80WSneTY4=";
+    hash = "sha256-tQ+AQDHwr9JO4AQ+2ZAGQbSrfnuzPUEi2F19wLijv1Y=";
   };
 
   build-system = [ poetry-core ];

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -2,7 +2,7 @@
 # Do not edit!
 
 {
-  version = "2025.5.1";
+  version = "2025.5.2";
   components = {
     "3_day_blinds" =
       ps: with ps; [

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -194,6 +194,16 @@ let
         doCheck = false; # no tests
       });
 
+      plexapi = super.plexapi.overrideAttrs (oldAttrs: rec {
+        version = "4.15.16";
+        src = fetchFromGitHub {
+          owner = "pkkid";
+          repo = "python-plexapi";
+          tag = version;
+          hash = "sha256-NwGGNN6LC3gvE8zoVL5meNWMbqZjJ+6PcU2ebJTfJmU=";
+        };
+      });
+
       # Pinned due to API changes in 0.1.0
       poolsense = super.poolsense.overridePythonAttrs (oldAttrs: rec {
         version = "0.0.8";
@@ -367,7 +377,7 @@ let
   extraBuildInputs = extraPackages python.pkgs;
 
   # Don't forget to run update-component-packages.py after updating
-  hassVersion = "2025.5.1";
+  hassVersion = "2025.5.2";
 
 in
 python.pkgs.buildPythonApplication rec {
@@ -388,13 +398,13 @@ python.pkgs.buildPythonApplication rec {
     owner = "home-assistant";
     repo = "core";
     tag = version;
-    hash = "sha256-/ItMm6/SV0MazK16NfW53XPcIV7ERUUabjcwHBC4c7Y=";
+    hash = "sha256-el5s82R4MuTjUnMVXRQj4PhPxJxHoL6Jqvc6XRnJl8w=";
   };
 
   # Secondary source is pypi sdist for translations
   sdist = fetchPypi {
     inherit pname version;
-    hash = "sha256-zllQ0h1Ws+HNyfBvAAoKtovQtwkr0fNNtnF2pAjRrqM=";
+    hash = "sha256-lddnAM3fja9enPYRSonwSe1aG8t55jSJQNveWPwrhOE=";
   };
 
   build-system = with python.pkgs; [

--- a/pkgs/servers/home-assistant/frontend.nix
+++ b/pkgs/servers/home-assistant/frontend.nix
@@ -8,7 +8,7 @@ buildPythonPackage rec {
   # the frontend version corresponding to a specific home-assistant version can be found here
   # https://github.com/home-assistant/home-assistant/blob/master/homeassistant/components/frontend/manifest.json
   pname = "home-assistant-frontend";
-  version = "20250509.0";
+  version = "20250516.0";
   format = "wheel";
 
   src = fetchPypi {
@@ -16,7 +16,7 @@ buildPythonPackage rec {
     pname = "home_assistant_frontend";
     dist = "py3";
     python = "py3";
-    hash = "sha256-tlBdUA3Gj7P6KTjY2UNnWjQqpnwgvAlXC09P7QFR0r0=";
+    hash = "sha256-KyZE9SmEoAKgaZMRvs83BK73Yo3fqD8O+vMBO4JE+Ng=";
   };
 
   # there is nothing to strip in this package

--- a/pkgs/servers/home-assistant/pytest-homeassistant-custom-component.nix
+++ b/pkgs/servers/home-assistant/pytest-homeassistant-custom-component.nix
@@ -18,7 +18,7 @@
 
 buildPythonPackage rec {
   pname = "pytest-homeassistant-custom-component";
-  version = "0.13.244";
+  version = "0.13.245";
   pyproject = true;
 
   disabled = pythonOlder "3.13";
@@ -27,7 +27,7 @@ buildPythonPackage rec {
     owner = "MatthewFlamm";
     repo = "pytest-homeassistant-custom-component";
     rev = "refs/tags/${version}";
-    hash = "sha256-jYKPkhOKxi3Ue4Q/FHaBn/3p8b1VYsje1/awvOCBDfk=";
+    hash = "sha256-l/NStiw2tajXydNv9EDqRZ1ku2CeRdDOsHDFIEA9vdM=";
   };
 
   build-system = [ setuptools ];

--- a/pkgs/servers/home-assistant/stubs.nix
+++ b/pkgs/servers/home-assistant/stubs.nix
@@ -10,7 +10,7 @@
 
 buildPythonPackage rec {
   pname = "homeassistant-stubs";
-  version = "2025.5.1";
+  version = "2025.5.2";
   pyproject = true;
 
   disabled = python.version != home-assistant.python.version;
@@ -19,7 +19,7 @@ buildPythonPackage rec {
     owner = "KapJI";
     repo = "homeassistant-stubs";
     tag = version;
-    hash = "sha256-esKI8bqTI2ov5i0vrUDTjCPWKp7PG/Pay/lvYbvMQkU=";
+    hash = "sha256-jvXsGWVXviwC2KjMuRPdLy2uY5fkqsMALG1RZ3XvzvU=";
   };
 
   build-system = [

--- a/pkgs/servers/home-assistant/tests.nix
+++ b/pkgs/servers/home-assistant/tests.nix
@@ -63,6 +63,17 @@ let
   };
 
   extraDisabledTests = {
+    sensor = [
+      # Failed: Translation not found for sensor
+      "test_validate_unit_change_convertible"
+      "test_validate_statistics_unit_change_no_device_class"
+      "test_validate_statistics_state_class_removed"
+      "test_validate_statistics_state_class_removed_issue_cleaned_up"
+      "test_validate_statistics_unit_change_no_conversion"
+      "test_validate_statistics_unit_change_equivalent_units_2"
+      "test_update_statistics_issues"
+      "test_validate_statistics_mean_type_changed"
+    ];
     shell_command = [
       # tries to retrieve file from github
       "test_non_text_stdout_capture"
@@ -75,6 +86,10 @@ let
       # AssertionError: assert 'unknown_error' == 'template_error'
       "test_render_template_with_timeout"
     ];
+    zeroconf = [
+      # multicast socket bind, not possible in the sandbox
+      "test_subscribe_discovery"
+    ];
   };
 
   extraPytestFlagsArray = {
@@ -84,7 +99,7 @@ let
     ];
     bmw_connected_drive = [
       # outdated snapshot
-      "--deselect tests/components/bmw_connected_drive/test_select.py::test_entity_state_attrs"
+      "--deselect tests/components/bmw_connected_drive/test_binary_sensor.py::test_entity_state_attrs"
     ];
     dnsip = [
       # Tries to resolve DNS entries
@@ -103,6 +118,14 @@ let
     modem_callerid = [
       # aioserial mock produces wrong state
       "--deselect tests/components/modem_callerid/test_init.py::test_setup_entry"
+    ];
+    openai_conversation = [
+      # outdated snapshot
+      "--deselect tests/components/openai_conversation/test_conversation.py::test_function_call"
+    ];
+    technove = [
+      # outdated snapshot
+      "--deselect tests/components/technove/test_switch.py::test_switches"
     ];
   };
 in


### PR DESCRIPTION
https://github.com/home-assistant/core/releases/tag/2025.5.2

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
