### PR TITLE
serenityos-emoji-font: init at 0-unstable-2025-05-31

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -26030,6 +26030,12 @@
     githubId = 45292658;
     name = "Julius Schmitt";
   };
+  voidnoi = {
+    email = "voidnoi@proton.me";
+    github = "VoidNoi";
+    githubId = 83523507;
+    name = "voidnoi";
+  };
   vojta001 = {
     email = "vojtech.kane@gmail.com";
     github = "vojta001";

--- a/pkgs/by-name/se/serenityos-emoji-font/package.nix
+++ b/pkgs/by-name/se/serenityos-emoji-font/package.nix
@@ -1,0 +1,112 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchFromGitHub,
+  fetchzip,
+  python3Packages,
+  fetchpatch2,
+  parallel,
+}:
+let
+
+  pixart2svg = stdenvNoCC.mkDerivation {
+    name = "pixart2svg";
+    version = "0-unstable-2021-07-18";
+
+    src = fetchzip {
+      name = "pixart2svg";
+      url = "https://gist.github.com/m13253/66284bc244deeff0f0f8863c206421c7/archive/f9454958dc0a33cea787cc6fbd7e8e34ba6eb23b.zip";
+      hash = "sha256-lNA3qWK/bnUcMM/jrCGEgaX+HAk/DjKJnkE8niYmBDU=";
+    };
+
+    patches =
+      let
+        urlFor =
+          name:
+          "https://raw.githubusercontent.com/linusg/serenityos-emoji-font/11c84f33777a5d5bbe97ef2ffe8b74af7d72d27f/patches/${name}.patch";
+      in
+      [
+        (fetchpatch2 {
+          url = urlFor "0001-pixart2svg-rgba";
+          extraPrefix = "./";
+          hash = "sha256-/4a6btqp/6yiBnFhr4vI+SWfOopUjzDfOeW1Fs6Z5yU=";
+        })
+        (fetchpatch2 {
+          url = urlFor "0002-pixart2svg-no-style";
+          extraPrefix = "./";
+          hash = "sha256-FVurs+bEOat74d2egl21JS5ywdkFKKIsqXSFGSJI8MI=";
+        })
+        (fetchpatch2 {
+          url = urlFor "0003-pixart2svg-imageio-deprecation-warning";
+          extraPrefix = "./";
+          hash = "sha256-Vo3JIcXof+AtuEbsczNS3CUaBUEncCR0pnIuY4uF7R4=";
+        })
+      ];
+
+    installPhase = ''
+      mkdir -p $out
+      cp ./pixart2svg.py $out
+    '';
+  };
+
+in
+stdenvNoCC.mkDerivation {
+  name = "serenityos-emoji-font";
+  version = "0-unstable-2025-05-31";
+
+  src = fetchFromGitHub {
+    name = "serenity";
+    owner = "SerenityOS";
+    repo = "serenity";
+    rev = "35fd7a6770144259a05d41dfffbc8092495c4bf2";
+    hash = "sha256-i48egESwQKhcEAObSg2zqubgNdkXE5FlNa+Jukvg2X8=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs =
+    [
+      pixart2svg
+      parallel
+    ]
+    ++ (with python3Packages; [
+      imageio
+      nanoemoji
+      numpy
+    ]);
+
+  buildPhase = ''
+    runHook preBuild
+
+    mkdir -p svgfiles
+
+    total=$(ls -1 Base/res/emoji/*.png | wc -l)
+
+    parallel -j$NIX_BUILD_CORES \
+      echo [{#}/$total] Converting {/} \; python3 ${pixart2svg}/pixart2svg.py {} svgfiles/{/.}.svg \
+      ::: Base/res/emoji/*.png;
+
+    nanoemoji --family "SerenityOS Emoji" --output_file "SerenityOS-Emoji.ttf" --color_format glyf_colr_1 svgfiles/*.svg
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/share/fonts/truetype
+    cp build/SerenityOS-Emoji.ttf $out/share/fonts/truetype
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "SerenityOS pixel art emojis as a TTF";
+    homepage = "https://emoji.serenityos.org/";
+    license = lib.licenses.bsd2;
+    maintainers = with lib.maintainers; [
+      voidnoi
+    ];
+    platforms = lib.platforms.all;
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
Add SerenityOS pixel art emoji font
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
