### PR TITLE
python3Packages.labelbox: 6.6.0 -> 6.10.0

### DIFF
--- a/pkgs/development/python-modules/labelbox/default.nix
+++ b/pkgs/development/python-modules/labelbox/default.nix
@@ -29,14 +29,14 @@
 }:
 
 let
-  version = "6.6.0";
+  version = "6.10.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "Labelbox";
     repo = "labelbox-python";
     tag = "v.${version}";
-    hash = "sha256-aMJJZ9ONnjFK/J4pyLTFQox/cC8ij85IYNlJTFrfV2I=";
+    hash = "sha256-EstHsY9yFeUhQAx3pgvKk/o3EMkr3JeHDDg/p6meDIE=";
   };
 
   lbox-clients = buildPythonPackage {
@@ -48,11 +48,23 @@ let
 
     build-system = [ hatchling ];
 
+    postPatch = ''
+      substituteInPlace pyproject.toml \
+        --replace "--durations=20 --cov=lbox.example" "--durations=20"
+    '';
+
     dependencies = [
       google-api-core
       requests
     ];
 
+    nativeCheckInputs = [
+      pytestCheckHook
+    ];
+
+    doCheck = true;
+
+    __darwinAllowLocalNetworking = true;
   };
 in
 buildPythonPackage rec {
@@ -112,6 +124,10 @@ buildPythonPackage rec {
     "tests/data"
     "tests/unit/test_label_data_type.py"
   ];
+
+  doCheck = true;
+
+  __darwinAllowLocalNetworking = true;
 
   pythonImportsCheck = [ "labelbox" ];
 

--- a/pkgs/development/python-modules/labelbox/default.nix
+++ b/pkgs/development/python-modules/labelbox/default.nix
@@ -20,7 +20,6 @@
   pytest-xdist,
   pytestCheckHook,
   python-dateutil,
-  pythonOlder,
   requests,
   shapely,
   strenum,
@@ -29,12 +28,9 @@
   typing-extensions,
 }:
 
-buildPythonPackage rec {
-  pname = "labelbox";
+let
   version = "6.6.0";
   pyproject = true;
-
-  disabled = pythonOlder "3.8";
 
   src = fetchFromGitHub {
     owner = "Labelbox";
@@ -42,6 +38,27 @@ buildPythonPackage rec {
     tag = "v.${version}";
     hash = "sha256-aMJJZ9ONnjFK/J4pyLTFQox/cC8ij85IYNlJTFrfV2I=";
   };
+
+  lbox-clients = buildPythonPackage {
+    inherit src version pyproject;
+
+    pname = "lbox-clients";
+
+    sourceRoot = "${src.name}/libs/lbox-clients";
+
+    build-system = [ hatchling ];
+
+    dependencies = [
+      google-api-core
+      requests
+    ];
+
+  };
+in
+buildPythonPackage rec {
+  inherit src version pyproject;
+
+  pname = "labelbox";
 
   sourceRoot = "${src.name}/libs/labelbox";
 
@@ -54,6 +71,7 @@ buildPythonPackage rec {
 
   dependencies = [
     google-api-core
+    lbox-clients
     pydantic
     python-dateutil
     requests
@@ -97,11 +115,11 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "labelbox" ];
 
-  meta = with lib; {
+  meta = {
     description = "Platform API for LabelBox";
     homepage = "https://github.com/Labelbox/labelbox-python";
     changelog = "https://github.com/Labelbox/labelbox-python/releases/tag/v.${src.tag}";
-    license = licenses.asl20;
-    maintainers = with maintainers; [ rakesh4g ];
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ rakesh4g ];
   };
 }


### PR DESCRIPTION
### Hydra failure
Hydra: https://hydra.nixos.org/build/296410296

A bulk update in #375144 caused the build to break:
```sh
Checking runtime dependencies for labelbox-6.6.0-py3-none-any.whl
  - lbox-clients not installed
```

`lbox-clients` is a submodule in the original source and is not versioned independently.

Fix: Build `lbox-clients` in a `let` statement from the same source as `labelbox`.

### Update

Updated 6.6.0 -> 6.10.0

Changelogs:
* https://github.com/Labelbox/labelbox-python/releases/tag/v.6.10.0 
* https://github.com/Labelbox/labelbox-python/releases/tag/v.6.9.0
* https://github.com/Labelbox/labelbox-python/releases/tag/v.6.8.0
* https://github.com/Labelbox/labelbox-python/releases/tag/v.6.8.0

diff: https://github.com/Labelbox/labelbox-python/compare/v.6.6.0...v.6.10.0

ZHF: #403336

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [Nixpkgs 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/doc/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/doc/manual/release-notes/rl-2505.section.md) Nixpkgs Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
- [NixOS 25.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2511.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) NixOS Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
