### PR TITLE
maintainers: Align systemd team and package maintenance with GitHub team

### DIFF
--- a/maintainers/team-list.nix
+++ b/maintainers/team-list.nix
@@ -1182,7 +1182,12 @@ with lib.maintainers;
   };
 
   systemd = {
-    members = [ ];
+    members = [
+      flokli
+      arianvp
+      elvishjerricco
+      aanderse
+    ];
     githubTeams = [ "systemd" ];
     scope = "Maintain systemd for NixOS.";
     shortName = "systemd";

--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -1037,10 +1037,7 @@ stdenv.mkDerivation (finalAttrs: {
       ofl
       publicDomain
     ];
-    maintainers = with lib.maintainers; [
-      flokli
-      kloenk
-    ];
+    teams = [ lib.teams.systemd ];
     pkgConfigModules = [
       "libsystemd"
       "libudev"


### PR DESCRIPTION
Pinging @kloenk as this removes them from the maintainer list. If you'd like to be re-added we can do that, but you haven't contributed to the file in a while and it seems most appropriate to just have the maintainers match the github team.